### PR TITLE
[FIX] composer: clicking on the composer does not duplicate text

### DIFF
--- a/src/ui/composer.ts
+++ b/src/ui/composer.ts
@@ -295,7 +295,7 @@ export class Composer extends Component<any, any> {
 
   onClick(ev: MouseEvent) {
     ev.stopPropagation();
-    this.processContent();
+    this.processContent(ev);
     this.processTokenAtCursor();
     this.model.setSelectingRange(false);
   }
@@ -308,7 +308,7 @@ export class Composer extends Component<any, any> {
   // Private
   // ---------------------------------------------------------------------------
 
-  processContent(ev: KeyboardEvent | undefined = undefined) {
+  processContent(ev: KeyboardEvent | MouseEvent | undefined = undefined) {
     this.shouldProcessInputEvents = false;
     let value = this.model.state.currentContent;
     this.tokenAtCursor = undefined;

--- a/tests/ui/composer_test.ts
+++ b/tests/ui/composer_test.ts
@@ -98,6 +98,18 @@ describe("composer", () => {
     await nextTick();
     expect(composer.textContent).toBe("=C8");
   });
+  test("clicking on the composer while typing text (not formula) does not duplicates text", async () => {
+    const model = new GridModel();
+    const parent = new GridParent(model);
+    await parent.mount(fixture);
+    fixture.querySelector("canvas")!.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    await nextTick();
+    let composer = fixture.getElementsByClassName("o-composer")[0] as HTMLElement;
+    expect(composer.textContent).toBe("a");
+    composer.dispatchEvent(new MouseEvent("click"));
+    await nextTick();
+    expect(composer.textContent).toBe("a");
+  });
 });
 
 describe("composer highlights color", () => {


### PR DESCRIPTION
When inputting text (not a formula in the composer) and clicking, it
was duplicating the content.
Now it does not duplicate anymore.