### PR TITLE
[FIX] conditional_formatting: use workbook instead of state

### DIFF
--- a/src/ui/side_panel/conditional_formatting.ts
+++ b/src/ui/side_panel/conditional_formatting.ts
@@ -12,7 +12,7 @@ const { xml, css } = owl.tags;
 
 const TEMPLATE = xml/* xml */ `
 <div class="o-cf">
-    <div class="o-cf-preview-list" t-foreach="model.state.activeSheet.conditionalFormats" t-as="cf" t-key="cf_index">
+    <div class="o-cf-preview-list" t-foreach="model.workbook.activeSheet.conditionalFormats" t-as="cf" t-key="cf_index">
         <div t-on-click="onRuleClick(cf)">
             <t t-call="${PREVIEW_TEMPLATE}">
                 <t t-set="currentStyle" t-value="cf.style"/>

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,7 +1,10 @@
-import { Component, hooks, tags } from "@odoo/owl";
+import { Component, hooks, tags, useState } from "@odoo/owl";
 import { functionMap, functions } from "../src/functions/index";
 import { GridModel } from "../src/model";
 import { Grid } from "../src/ui/grid";
+import { SidePanel } from "../src/ui/side_panel/side_panel";
+import { SidePanelRegistry } from "../src/ui/side_panel/registry";
+import { fillPanelRegistry } from "../src/ui/side_panel/import_registry";
 import "./canvas.mock";
 
 const { xml } = tags;
@@ -60,14 +63,26 @@ export class GridParent extends Component<any, any> {
   static template = xml`
     <div class="parent">
       <Grid model="model" t-ref="grid"/>
+      <SidePanel t-if="sidePanel.isOpen"
+             t-on-closeSidePanel="sidePanel.isOpen = false"
+             model="model"
+             title="sidePanel.title"
+             Body="sidePanel.Body"
+             Footer="sidePanel.Footer"/>
     </div>`;
 
-  static components = { Grid };
+  static components = { Grid, SidePanel };
   model: GridModel;
   grid: any = useRef("grid");
+  sidePanel = useState({ isOpen: false } as {
+    isOpen: boolean;
+    title?: string;
+    Body?: any;
+    Footer?: any;
+  });
   constructor(model: GridModel) {
     super();
-
+    fillPanelRegistry();
     const uvz = model.updateVisibleZone;
     model.updateVisibleZone = function(width?: number, height?: number) {
       // we simulate here a vizible zone of 1000x1000px
@@ -82,10 +97,20 @@ export class GridParent extends Component<any, any> {
 
   mounted() {
     this.model.on("update", this, this.render);
+    this.model.on("openSidePanel", this, this.openSidePanel);
   }
 
   willUnmount() {
     this.model.off("update", this);
+    this.model.off("openSidePanel", this);
+  }
+
+  openSidePanel(ev) {
+    const component = SidePanelRegistry.get(ev.panelName);
+    this.sidePanel.title = component.title;
+    this.sidePanel.Body = component.Body;
+    this.sidePanel.Footer = component.Footer;
+    this.sidePanel.isOpen = true;
   }
 }
 

--- a/tests/ui/grid_test.ts
+++ b/tests/ui/grid_test.ts
@@ -56,6 +56,12 @@ describe("Grid component", () => {
     });
   });
 
+  test("Can open the Conditional Format side panel", async () => {
+    model.trigger("openSidePanel", { panelName: "ConditionalFormattingPanel" });
+    await nextTick();
+    expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
+  });
+
   describe("keybindings", () => {
     test("pressing ENTER put current cell in edit mode", async () => {
       // note: this behavious is not like excel. Maybe someone will want to


### PR DESCRIPTION
Since 86da8b87764739b7b911df939e22e0d6e53592cb, we should use workbook in
conditional formatting.