### PR TITLE
[FIX] core: Expand XC to overlapping merges

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -208,7 +208,7 @@ export class CorePlugin extends BasePlugin {
   /**
    * Converts a zone to a XC coordinate system
    *
-   * The conversion also treats merges a one single cell
+   * The conversion also treats merges as one single cell
    *
    * Examples:
    * {top:0,left:0,right:0,bottom:0} ==> A1
@@ -216,12 +216,19 @@ export class CorePlugin extends BasePlugin {
    *
    * if A1:B2 is a merge:
    * {top:0,left:0,right:1,bottom:1} ==> A1
+   * {top:1,left:0,right:1,bottom:2} ==> A1:B3
+   *
+   * if A1:B2 and A4:B5 are merges:
+   * {top:1,left:0,right:1,bottom:3} ==> A1:A5
    */
   zoneToXC(zone: Zone): string {
+    zone = this.getters.expandZone(zone);
     const topLeft = toXC(zone.left, zone.top);
     const botRight = toXC(zone.right, zone.bottom);
-
-    if (topLeft != botRight && !this.workbook.mergeCellMap[topLeft]) {
+    if (
+      topLeft != botRight &&
+      this.getters.getMainCell(topLeft) !== this.getters.getMainCell(botRight)
+    ) {
       return topLeft + ":" + botRight;
     }
 

--- a/tests/plugins/core_test.ts
+++ b/tests/plugins/core_test.ts
@@ -130,6 +130,43 @@ describe("core", () => {
     const model = new Model();
     expect(model.getters.getCell(-1, -1)).toBe(null);
   });
+
+  test("single cell XC conversion", () => {
+    const model = new Model({});
+    expect(model.getters.zoneToXC(/*A1*/ { top: 0, left: 0, right: 0, bottom: 0 })).toBe("A1");
+  });
+
+  test("multi cell zone XC conversion", () => {
+    const model = new Model({});
+    expect(model.getters.zoneToXC(/*A1:B2*/ { top: 0, left: 0, right: 1, bottom: 1 })).toBe(
+      "A1:B2"
+    );
+  });
+
+  test("xc is expanded to overlapping merges", () => {
+    const model = new Model({
+      sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:B2"] }],
+    });
+    expect(model.getters.zoneToXC(/*A2:B3*/ { top: 1, bottom: 2, left: 0, right: 1 })).toBe(
+      "A1:B3"
+    );
+  });
+
+  test("zone is across two merges", () => {
+    const model = new Model({
+      sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:B2", "A4:B5"] }],
+    });
+    expect(model.getters.zoneToXC(/*A2:B4*/ { top: 1, bottom: 3, left: 0, right: 1 })).toBe(
+      "A1:B5"
+    );
+  });
+
+  test("merge is considered as one single cell", () => {
+    const model = new Model({
+      sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:B2"] }],
+    });
+    expect(model.getters.zoneToXC(/*A2:B2*/ { top: 1, bottom: 1, left: 0, right: 1 })).toBe("A1");
+  });
 });
 
 describe("history", () => {


### PR DESCRIPTION
Given the following merge:
A1:A2

And the following zone:
Z = {top:1, bottom:2, left:0, right:0} (i.e. A2:A3)

Apply the getter `zoneToXC` on the mentionned zone:
Result: A1
Expected: A1:A3. (or at least A2:A3, I'm not sure)