### PR TITLE
[IMP] layout: position sidepanel at the right of the grid

### DIFF
--- a/src/components/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel.ts
@@ -1,7 +1,6 @@
 import * as owl from "@odoo/owl";
 import { sidePanelRegistry, SidePanelContent } from "./side_panel_registry";
 import { SpreadsheetEnv } from "../../types";
-import { TOPBAR_HEIGHT, SCROLLBAR_WIDTH, BOTTOMBAR_HEIGHT } from "../../constants";
 
 const { Component } = owl;
 const { xml, css } = owl.tags;
@@ -23,15 +22,8 @@ const TEMPLATE = xml/* xml */ `
 
 const CSS = css/* scss */ `
   .o-sidePanel {
-    position: absolute;
-    top: ${TOPBAR_HEIGHT}px;
-    right: ${SCROLLBAR_WIDTH}px;
-    bottom: ${BOTTOMBAR_HEIGHT}px;
     overflow-x: hidden;
     background-color: white;
-    min-width: 200px;
-    max-width: 350px;
-    border: 1px solid darkgray;
     .o-sidePanelHeader {
       padding: 6px;
       height: 41px;

--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -17,19 +17,20 @@ const { useSubEnv } = owl.hooks;
 
 const TEMPLATE = xml/* xml */ `
   <div class="o-spreadsheet" t-on-save-requested="save">
-    <TopBar t-on-click="focusGrid"/>
-    <Grid model="model" t-ref="grid"/>
-    <BottomBar />
+    <TopBar t-on-click="focusGrid" class="o-two-columns"/>
+    <Grid model="model" t-ref="grid" t-att-class="{'o-two-columns': !sidePanel.isOpen}"/>
     <SidePanel t-if="sidePanel.isOpen"
            t-on-close-side-panel="sidePanel.isOpen = false"
            component="sidePanel.component"
            panelProps="sidePanel.panelProps"/>
+    <BottomBar class="o-two-columns"/>
   </div>`;
 
 const CSS = css/* scss */ `
   .o-spreadsheet {
     display: grid;
     grid-template-rows: ${TOPBAR_HEIGHT}px auto ${BOTTOMBAR_HEIGHT + 1}px;
+    grid-template-columns: auto 350px;
     * {
       font-family: "Roboto", "RobotoDraft", Helvetica, Arial, sans-serif;
     }
@@ -39,6 +40,10 @@ const CSS = css/* scss */ `
     *:after {
       box-sizing: content-box;
     }
+  }
+
+  .o-two-columns {
+    grid-column: 1 / 3;
   }
 
   .o-icon {

--- a/tests/components/__snapshots__/spreadsheet_test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet_test.ts.snap
@@ -5,7 +5,7 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
   class="o-spreadsheet"
 >
   <div
-    class="o-spreadsheet-topbar"
+    class="o-spreadsheet-topbar o-two-columns"
   >
     <!-- Menus -->
     <div
@@ -303,7 +303,7 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
     </div>
   </div>
   <div
-    class="o-grid"
+    class="o-grid o-two-columns"
   >
     <canvas
       height="150"
@@ -349,7 +349,7 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
     </div>
   </div>
   <div
-    class="o-spreadsheet-bottom-bar"
+    class="o-spreadsheet-bottom-bar o-two-columns"
   >
     <span
       class="o-add-sheet"


### PR DESCRIPTION
Without this commit, the sidepanel was positioned on top of the grid,
with a weird look because the vertical scrollbar was on the right of the
sidepanel. This commit simply use the grid css layout from the
spreadsheet component to position the sidepanel on the right.