### PR TITLE
[FIX] sidepanel: title should be fixed

### DIFF
--- a/src/components/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel.ts
@@ -22,6 +22,8 @@ const TEMPLATE = xml/* xml */ `
 
 const CSS = css/* scss */ `
   .o-sidePanel {
+    display: flex;
+    flex-direction: column;
     overflow-x: hidden;
     background-color: white;
     .o-sidePanelHeader {
@@ -42,9 +44,12 @@ const CSS = css/* scss */ `
         &:hover {
           border-radius: 50%;
           background-color: WhiteSmoke;
+        }
       }
     }
     .o-sidePanelBody {
+      overflow: auto;
+      width: 100%;
       padding: 6px;
     }
     .o-sidePanelFooter {


### PR DESCRIPTION
before this commit, when we have more conditional formatting rules than the hight
of the screen, all the sidepanel becomes scrollable, including the title.
With this commit the title the title stays fixed.

closes issue #344