### PR TITLE
[IMP] context menu: Choose visibility based on the env

### DIFF
--- a/src/components/context_menu/context_menu_registry.ts
+++ b/src/components/context_menu/context_menu_registry.ts
@@ -12,7 +12,7 @@ interface BaseContextMenuItem {
   name: string;
   description: string;
   isEnabled?: (cell: Cell | null) => boolean;
-  isVisible?: (type: ContextMenuType) => boolean;
+  isVisible?: (type: ContextMenuType, env: SpreadsheetEnv) => boolean;
 }
 
 export interface ActionContextMenuItem extends BaseContextMenuItem {

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -520,6 +520,6 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
     };
     this.contextMenu.menuItems = contextMenuRegistry
       .getAll()
-      .filter((item) => !item.isVisible || item.isVisible(type));
+      .filter((item) => !item.isVisible || item.isVisible(type, this.env));
   }
 }


### PR DESCRIPTION
It might be usefull for a context menu item to have
access to the environnement to decide of its visibility.

This would be used in the Odoo integration where a
menu item "Re-insert pivot" is added. This menu
item does not need to be visible is there is no pivot.
The `env` would allow to check this via the gettters.

Note that the similar `isVisible` function of the top menu
also takes the environnement as parameter.