### PR TITLE
[FIX] context menu: Show full menu item on hover

### DIFF
--- a/src/components/context_menu/context_menu.ts
+++ b/src/components/context_menu/context_menu.ts
@@ -69,7 +69,11 @@ const CSS = css/* scss */ `
       cursor: pointer;
 
       &:hover {
-        background-color: rgba(0, 0, 0, 0.08);
+        background-color: #ebebeb;
+        overflow: visible;
+        display: inline-block;
+        min-width: 100%;
+        width: auto;
       }
 
       &.disabled {


### PR DESCRIPTION
Purpose
=======
Currently, when a menu item description is too long, the end
is displayed as an ellipsis. And the user can't see the end of
the menu.
It's ok in o-spreadsheet since we control internally their length
(and we currently don't have any long menus items).

However, when o-spreadsheet is used as a library (such as in
Odoo) some additional menu items might be added.
We have this situation when we want to display pivot names
as menu items. Descriptions are like "{model display name} (#id)".
In particular, the model display name can have an arbitrary lenght.

Specification
=============
Display the full menu item description when hovered.
Make sure the background color (light grey) is also applied to the part
of the menu item which overflows.