### PR TITLE
[IMP] functions: add time format

### DIFF
--- a/src/functions/module_date.ts
+++ b/src/functions/module_date.ts
@@ -1,6 +1,6 @@
 import { args } from "./arguments";
 import { FunctionDescription } from "../types";
-import { toNativeDate, InternalDate, parseDate } from "../functions/dates";
+import { toNativeDate, InternalDate, parseDateTime } from "../functions/dates";
 import { toNumber, toString, visitAny } from "./helpers";
 import { _lt } from "../translation";
 
@@ -60,7 +60,7 @@ export const DATEVALUE: FunctionDescription = {
   returns: ["NUMBER"],
   compute: function (date_string: any): number {
     const _dateString = toString(date_string);
-    const result = parseDate(_dateString);
+    const result = parseDateTime(_dateString);
     if (result === null) {
       throw new Error(_lt(`DATEVALUE parameter '${_dateString}' cannot be parsed to date/time.`));
     }

--- a/src/plugins/evaluation.ts
+++ b/src/plugins/evaluation.ts
@@ -7,7 +7,6 @@ import { Mode, ModelConfig } from "../model";
 import { Cell, Command, CommandDispatcher, EvalContext, Getters, Workbook } from "../types";
 import { _lt } from "../translation";
 
-
 function* makeObjectIterator(obj: Object) {
   for (let i in obj) {
     yield obj[i];
@@ -19,7 +18,6 @@ function* makeSetIterator(set: Set<any>) {
     yield elem;
   }
 }
-
 
 const functionMap = functionRegistry.mapping;
 

--- a/tests/functions/dates_test.ts
+++ b/tests/functions/dates_test.ts
@@ -1,10 +1,4 @@
-import {
-  parseDate,
-  parseTime,
-  toNativeDate,
-  formatDate,
-  formatTime,
-} from "../../src/functions/dates";
+import { parseDateTime, toNativeDate, formatDateTime } from "../../src/functions/dates";
 
 const CURRENT_YEAR = new Date().getFullYear();
 
@@ -14,29 +8,29 @@ const CURRENT_YEAR = new Date().getFullYear();
 
 describe("date helpers: can detect and parse various dates", () => {
   test("can properly convert various dates in a large time span", () => {
-    expect(parseDate("1/1/1000")!.value).toBe(-328716);
-    expect(parseDate("1/1/2000")!.value).toBe(36526);
-    expect(parseDate("1/1/3000")!.value).toBe(401769);
-    expect(parseDate("1/1/4000")!.value).toBe(767011);
+    expect(parseDateTime("1/1/1000")!.value).toBe(-328716);
+    expect(parseDateTime("1/1/2000")!.value).toBe(36526);
+    expect(parseDateTime("1/1/3000")!.value).toBe(401769);
+    expect(parseDateTime("1/1/4000")!.value).toBe(767011);
   });
 
   test("parse various dates in m/d/yyyy format", () => {
-    expect(parseDate("12/30/1899")).toEqual({
+    expect(parseDateTime("12/30/1899")).toEqual({
       value: 0,
       format: "m/d/yyyy",
       jsDate: new Date(1899, 11, 30),
     });
-    expect(parseDate("12/31/1899")).toEqual({
+    expect(parseDateTime("12/31/1899")).toEqual({
       value: 1,
       format: "m/d/yyyy",
       jsDate: new Date(1899, 11, 31),
     });
-    expect(parseDate("1/1/1900")).toEqual({
+    expect(parseDateTime("1/1/1900")).toEqual({
       value: 2,
       format: "m/d/yyyy",
       jsDate: new Date(1900, 0, 1),
     });
-    expect(parseDate("4/20/2020")).toEqual({
+    expect(parseDateTime("4/20/2020")).toEqual({
       value: 43941,
       format: "m/d/yyyy",
       jsDate: new Date(2020, 3, 20),
@@ -44,22 +38,22 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test("parse various dates in yyyy/m/d format", () => {
-    expect(parseDate("1899/12/30")).toEqual({
+    expect(parseDateTime("1899/12/30")).toEqual({
       value: 0,
       format: "yyyy/m/d",
       jsDate: new Date(1899, 11, 30),
     });
-    expect(parseDate("1899/12/31")).toEqual({
+    expect(parseDateTime("1899/12/31")).toEqual({
       value: 1,
       format: "yyyy/m/d",
       jsDate: new Date(1899, 11, 31),
     });
-    expect(parseDate("1900/1/1")).toEqual({
+    expect(parseDateTime("1900/1/1")).toEqual({
       value: 2,
       format: "yyyy/m/d",
       jsDate: new Date(1900, 0, 1),
     });
-    expect(parseDate("2020/4/20")).toEqual({
+    expect(parseDateTime("2020/4/20")).toEqual({
       value: 43941,
       format: "yyyy/m/d",
       jsDate: new Date(2020, 3, 20),
@@ -67,12 +61,12 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test("can detect and parse mm/dd/yyyy dates ", () => {
-    expect(parseDate("03/20/2010")).toEqual({
+    expect(parseDateTime("03/20/2010")).toEqual({
       value: 40257,
       format: "mm/dd/yyyy",
       jsDate: new Date(2010, 2, 20),
     });
-    expect(parseDate("10/03/2010")).toEqual({
+    expect(parseDateTime("10/03/2010")).toEqual({
       value: 40454,
       format: "mm/dd/yyyy",
       jsDate: new Date(2010, 9, 3),
@@ -80,12 +74,12 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test("can detect and parse yyyy/mm/dd dates ", () => {
-    expect(parseDate("2010/03/20")).toEqual({
+    expect(parseDateTime("2010/03/20")).toEqual({
       value: 40257,
       format: "yyyy/mm/dd",
       jsDate: new Date(2010, 2, 20),
     });
-    expect(parseDate("2010/10/03")).toEqual({
+    expect(parseDateTime("2010/10/03")).toEqual({
       value: 40454,
       format: "yyyy/mm/dd",
       jsDate: new Date(2010, 9, 3),
@@ -93,22 +87,22 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test("can detect and parse m/d and mm/dd dates ", () => {
-    const d1 = parseDate("1/3")!;
+    const d1 = parseDateTime("1/3")!;
     expect(d1.jsDate!).toEqual(new Date(CURRENT_YEAR, 0, 3));
     expect(d1.format).toBe("m/d");
 
-    const d2 = parseDate("1/03")!;
+    const d2 = parseDateTime("1/03")!;
     expect(d2.jsDate!).toEqual(new Date(CURRENT_YEAR, 0, 3));
     expect(d2.format).toBe("mm/dd");
   });
 
   test("can detect and parse m-d-yyyy dates ", () => {
-    expect(parseDate("3-2-2010")).toEqual({
+    expect(parseDateTime("3-2-2010")).toEqual({
       value: 40239,
       format: "m-d-yyyy",
       jsDate: new Date(2010, 2, 2),
     });
-    expect(parseDate("10-23-2010")).toEqual({
+    expect(parseDateTime("10-23-2010")).toEqual({
       value: 40474,
       format: "m-d-yyyy",
       jsDate: new Date(2010, 9, 23),
@@ -116,12 +110,12 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test("can detect and parse yyyy-m-d dates ", () => {
-    expect(parseDate("2010-3-2")).toEqual({
+    expect(parseDateTime("2010-3-2")).toEqual({
       value: 40239,
       format: "yyyy-m-d",
       jsDate: new Date(2010, 2, 2),
     });
-    expect(parseDate("2010-10-23")).toEqual({
+    expect(parseDateTime("2010-10-23")).toEqual({
       value: 40474,
       format: "yyyy-m-d",
       jsDate: new Date(2010, 9, 23),
@@ -129,12 +123,12 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test("can detect and parse yyyy-mm-dd dates ", () => {
-    expect(parseDate("2010-03-20")).toEqual({
+    expect(parseDateTime("2010-03-20")).toEqual({
       value: 40257,
       format: "yyyy-mm-dd",
       jsDate: new Date(2010, 2, 20),
     });
-    expect(parseDate("2010-10-03")).toEqual({
+    expect(parseDateTime("2010-10-03")).toEqual({
       value: 40454,
       format: "yyyy-mm-dd",
       jsDate: new Date(2010, 9, 3),
@@ -142,22 +136,22 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test("can detect and parse m-d and mm-dd dates ", () => {
-    const d1 = parseDate("1-3")!;
+    const d1 = parseDateTime("1-3")!;
     expect(d1.jsDate!).toEqual(new Date(CURRENT_YEAR, 0, 3));
     expect(d1.format).toBe("m-d");
 
-    const d2 = parseDate("1-03")!;
+    const d2 = parseDateTime("1-03")!;
     expect(d2.jsDate!).toEqual(new Date(CURRENT_YEAR, 0, 3));
     expect(d2.format).toBe("mm-dd");
   });
 
   test('can detect and parse "mm dd yyyy" dates ', () => {
-    expect(parseDate("03 20 2010")).toEqual({
+    expect(parseDateTime("03 20 2010")).toEqual({
       value: 40257,
       format: "mm dd yyyy",
       jsDate: new Date(2010, 2, 20),
     });
-    expect(parseDate("10 03 2010")).toEqual({
+    expect(parseDateTime("10 03 2010")).toEqual({
       value: 40454,
       format: "mm dd yyyy",
       jsDate: new Date(2010, 9, 3),
@@ -165,12 +159,12 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test('can detect and parse "yyyy mm dd" dates ', () => {
-    expect(parseDate("2010 03 20")).toEqual({
+    expect(parseDateTime("2010 03 20")).toEqual({
       value: 40257,
       format: "yyyy mm dd",
       jsDate: new Date(2010, 2, 20),
     });
-    expect(parseDate("2010 10 03")).toEqual({
+    expect(parseDateTime("2010 10 03")).toEqual({
       value: 40454,
       format: "yyyy mm dd",
       jsDate: new Date(2010, 9, 3),
@@ -178,27 +172,27 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test("can detect and parse 'm d' and 'mm dd' dates ", () => {
-    const d1 = parseDate("1 3")!;
+    const d1 = parseDateTime("1 3")!;
     expect(d1.jsDate!).toEqual(new Date(CURRENT_YEAR, 0, 3));
     expect(d1.format).toBe("m d");
 
-    const d2 = parseDate("1 03")!;
+    const d2 = parseDateTime("1 03")!;
     expect(d2.jsDate!).toEqual(new Date(CURRENT_YEAR, 0, 3));
     expect(d2.format).toBe("mm dd");
   });
 
   test("does not parse invalid dates", () => {
-    expect(parseDate("100/100/2099")).toBeNull();
-    expect(parseDate("20/10/2020")).toBeNull(); // 20 is not a valid month
-    expect(parseDate("02/29/2020")).not.toBeNull();
-    expect(parseDate("02/30/2020")).toBeNull();
-    expect(parseDate("02/28/2021")).not.toBeNull();
-    expect(parseDate("02/29/2021")).toBeNull();
-    expect(parseDate("01/33/2021")).toBeNull();
+    expect(parseDateTime("100/100/2099")).toBeNull();
+    expect(parseDateTime("20/10/2020")).toBeNull(); // 20 is not a valid month
+    expect(parseDateTime("02/29/2020")).not.toBeNull();
+    expect(parseDateTime("02/30/2020")).toBeNull();
+    expect(parseDateTime("02/28/2021")).not.toBeNull();
+    expect(parseDateTime("02/29/2021")).toBeNull();
+    expect(parseDateTime("01/33/2021")).toBeNull();
   });
 
   test("can infer a year if not given completely", () => {
-    const getYear = (str) => toNativeDate(parseDate(str)!).getFullYear();
+    const getYear = (str) => toNativeDate(parseDateTime(str)!).getFullYear();
 
     expect(getYear("1/1/0")).toBe(2000);
     expect(getYear("1/1/8")).toBe(2008);
@@ -210,48 +204,48 @@ describe("date helpers: can detect and parse various dates", () => {
   });
 
   test("refuse various strings", () => {
-    expect(parseDate("1/1/1920/3")).toBe(null);
-    expect(parseDate("1.2/10/2020")).toBe(null);
+    expect(parseDateTime("1/1/1920/3")).toBe(null);
+    expect(parseDateTime("1.2/10/2020")).toBe(null);
   });
 });
 
-describe("formatDate", () => {
+describe("formatDateTime", () => {
   test("month day year, with / as separator", () => {
-    expect(formatDate(parseDate("01/02/1954")!)).toBe("01/02/1954");
-    expect(formatDate(parseDate("1/2/3")!)).toBe("1/2/2003");
-    expect(formatDate(parseDate("01/02/1954")!, "m/d/yyyy")).toBe("1/2/1954");
-    expect(formatDate(parseDate("01/02/1954")!, "mm/dd/yyyy")).toBe("01/02/1954");
-    expect(formatDate(parseDate("01/02/1954")!, "mm/dd")).toBe("01/02");
-    expect(formatDate(parseDate("01/02/1954")!, "m/d")).toBe("1/2");
+    expect(formatDateTime(parseDateTime("01/02/1954")!)).toBe("01/02/1954");
+    expect(formatDateTime(parseDateTime("1/2/3")!)).toBe("1/2/2003");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "m/d/yyyy")).toBe("1/2/1954");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "mm/dd/yyyy")).toBe("01/02/1954");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "mm/dd")).toBe("01/02");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "m/d")).toBe("1/2");
   });
 
   test("month day year, with - as separator", () => {
-    expect(formatDate(parseDate("01/02/1954")!, "m-d-yyyy")).toBe("1-2-1954");
-    expect(formatDate(parseDate("01/02/1954")!, "mm-dd-yyyy")).toBe("01-02-1954");
-    expect(formatDate(parseDate("01/02/1954")!, "mm-dd")).toBe("01-02");
-    expect(formatDate(parseDate("01/02/1954")!, "m-d")).toBe("1-2");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "m-d-yyyy")).toBe("1-2-1954");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "mm-dd-yyyy")).toBe("01-02-1954");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "mm-dd")).toBe("01-02");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "m-d")).toBe("1-2");
   });
 
   test("month day year, with ' ' as separator", () => {
-    expect(formatDate(parseDate("01/02/1954")!, "m d yyyy")).toBe("1 2 1954");
-    expect(formatDate(parseDate("01/02/1954")!, "mm dd yyyy")).toBe("01 02 1954");
-    expect(formatDate(parseDate("01/02/1954")!, "mm dd")).toBe("01 02");
-    expect(formatDate(parseDate("01/02/1954")!, "m d")).toBe("1 2");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "m d yyyy")).toBe("1 2 1954");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "mm dd yyyy")).toBe("01 02 1954");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "mm dd")).toBe("01 02");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "m d")).toBe("1 2");
   });
 
   test("year month day, with / as separator", () => {
-    expect(formatDate(parseDate("01/02/1954")!, "yyyy/m/d")).toBe("1954/1/2");
-    expect(formatDate(parseDate("01/02/1954")!, "yyyy/mm/dd")).toBe("1954/01/02");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "yyyy/m/d")).toBe("1954/1/2");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "yyyy/mm/dd")).toBe("1954/01/02");
   });
 
   test("year month day, with - as separator", () => {
-    expect(formatDate(parseDate("01/02/1954")!, "yyyy-m-d")).toBe("1954-1-2");
-    expect(formatDate(parseDate("01/02/1954")!, "yyyy-mm-dd")).toBe("1954-01-02");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "yyyy-m-d")).toBe("1954-1-2");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "yyyy-mm-dd")).toBe("1954-01-02");
   });
 
   test("year month day, with ' ' as separator", () => {
-    expect(formatDate(parseDate("01/02/1954")!, "yyyy m d")).toBe("1954 1 2");
-    expect(formatDate(parseDate("01/02/1954")!, "yyyy mm dd")).toBe("1954 01 02");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "yyyy m d")).toBe("1954 1 2");
+    expect(formatDateTime(parseDateTime("01/02/1954")!, "yyyy mm dd")).toBe("1954 01 02");
   });
 });
 
@@ -261,38 +255,38 @@ describe("formatDate", () => {
 
 describe("date helpers: can detect and parse various times", () => {
   test("can detect and parse 'hh:mm' times", () => {
-    expect(parseTime("00:00")).toEqual({
+    expect(parseDateTime("00:00")).toEqual({
       value: 0,
       format: "hh:mm",
       jsDate: new Date(1899, 11, 30, 0, 0, 0),
     });
-    expect(parseTime("6:00")).toEqual({
+    expect(parseDateTime("6:00")).toEqual({
       value: 0.25,
       format: "hh:mm",
       jsDate: new Date(1899, 11, 30, 6, 0, 0),
     });
-    expect(parseTime("12:09")).toEqual({
+    expect(parseDateTime("12:09")).toEqual({
       value: 0.50625,
       format: "hh:mm",
       jsDate: new Date(1899, 11, 30, 12, 9, 0),
     });
-    expect(parseTime("12:9")).toEqual({
+    expect(parseDateTime("12:9")).toEqual({
       // @compatibility: on google sheets, return string
       value: 0.50625,
       format: "hh:mm",
       jsDate: new Date(1899, 11, 30, 12, 9, 0),
     });
-    expect(parseTime("00012:09")).toEqual({
+    expect(parseDateTime("00012:09")).toEqual({
       value: 0.50625,
       format: "hh:mm",
       jsDate: new Date(1899, 11, 30, 12, 9, 0),
     });
-    expect(parseTime("12:00000009")).toEqual({
+    expect(parseDateTime("12:00000009")).toEqual({
       value: 0.50625,
       format: "hh:mm",
       jsDate: new Date(1899, 11, 30, 12, 9, 0),
     });
-    expect(parseTime("11:69")).toEqual({
+    expect(parseDateTime("11:69")).toEqual({
       value: 0.50625,
       format: "hh:mm",
       jsDate: new Date(1899, 11, 30, 12, 9, 0),
@@ -300,27 +294,27 @@ describe("date helpers: can detect and parse various times", () => {
   });
 
   test("can detect and parse 'hh:mm:ss' times", () => {
-    expect(parseTime("12:00:00")).toEqual({
+    expect(parseDateTime("12:00:00")).toEqual({
       value: 0.5,
       format: "hh:mm:ss",
       jsDate: new Date(1899, 11, 30, 12, 0, 0),
     });
-    expect(parseTime("12:08:06")).toEqual({
+    expect(parseDateTime("12:08:06")).toEqual({
       value: 0.505625,
       format: "hh:mm:ss",
       jsDate: new Date(1899, 11, 30, 12, 8, 6),
     });
-    expect(parseTime("12:8:6")).toEqual({
+    expect(parseDateTime("12:8:6")).toEqual({
       value: 0.505625,
       format: "hh:mm:ss",
       jsDate: new Date(1899, 11, 30, 12, 8, 6),
     });
-    expect(parseTime("12:008:006")).toEqual({
+    expect(parseDateTime("12:008:006")).toEqual({
       value: 0.505625,
       format: "hh:mm:ss",
       jsDate: new Date(1899, 11, 30, 12, 8, 6),
     });
-    expect(parseTime("11:59:546")).toEqual({
+    expect(parseDateTime("11:59:546")).toEqual({
       value: 0.505625,
       format: "hh:mm:ss",
       jsDate: new Date(1899, 11, 30, 12, 8, 6),
@@ -328,76 +322,76 @@ describe("date helpers: can detect and parse various times", () => {
   });
 
   test("can detect and parse 'hh:mm a' times", () => {
-    expect(parseTime("0 AM")).toEqual({
+    expect(parseDateTime("0 AM")).toEqual({
       value: 0,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 0, 0, 0),
     });
-    expect(parseTime("12 AM")).toEqual({
+    expect(parseDateTime("12 AM")).toEqual({
       value: 0,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 0, 0, 0),
     });
-    expect(parseTime("24 AM")).toEqual({
+    expect(parseDateTime("24 AM")).toEqual({
       // @compatibility: on google sheets, return string
       value: 0.5,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 12, 0, 0),
     });
-    expect(parseTime("6AM")).toEqual({
+    expect(parseDateTime("6AM")).toEqual({
       value: 0.25,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 6, 0, 0),
     });
-    expect(parseTime("6   AM")).toEqual({
+    expect(parseDateTime("6   AM")).toEqual({
       value: 0.25,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 6, 0, 0),
     });
 
-    expect(parseTime("0 PM")).toEqual({
+    expect(parseDateTime("0 PM")).toEqual({
       value: 0.5,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 12, 0, 0),
     });
-    expect(parseTime("12 PM")).toEqual({
+    expect(parseDateTime("12 PM")).toEqual({
       value: 0.5,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 12, 0, 0),
     });
-    expect(parseTime("6PM")).toEqual({
+    expect(parseDateTime("6PM")).toEqual({
       value: 0.75,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 18, 0, 0),
     });
-    expect(parseTime("6   PM")).toEqual({
+    expect(parseDateTime("6   PM")).toEqual({
       value: 0.75,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 18, 0, 0),
     });
 
-    expect(parseTime("0:09 AM")).toEqual({
+    expect(parseDateTime("0:09 AM")).toEqual({
       value: 0.00625,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 0, 9, 0),
     });
-    expect(parseTime("12:09 AM")).toEqual({
+    expect(parseDateTime("12:09 AM")).toEqual({
       value: 0.00625,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 0, 9, 0),
     });
-    expect(parseTime("00012:00000009    AM")).toEqual({
+    expect(parseDateTime("00012:00000009    AM")).toEqual({
       value: 0.00625,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 0, 9, 0),
     });
 
-    expect(parseTime("11:69 AM")).toEqual({
+    expect(parseDateTime("11:69 AM")).toEqual({
       value: 0.50625,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 12, 9, 0),
     });
-    expect(parseTime("18:00 AM")).toEqual({
+    expect(parseDateTime("18:00 AM")).toEqual({
       value: 0.25,
       format: "hh:mm a",
       jsDate: new Date(1899, 11, 30, 6, 0, 0),
@@ -405,42 +399,42 @@ describe("date helpers: can detect and parse various times", () => {
   });
 
   test("can detect and parse 'hh:mm:ss a' times", () => {
-    expect(parseTime("12:00:00 AM")).toEqual({
+    expect(parseDateTime("12:00:00 AM")).toEqual({
       value: 0,
       format: "hh:mm:ss a",
       jsDate: new Date(1899, 11, 30, 0, 0, 0),
     });
-    expect(parseTime("00:00:00 AM")).toEqual({
+    expect(parseDateTime("00:00:00 AM")).toEqual({
       value: 0,
       format: "hh:mm:ss a",
       jsDate: new Date(1899, 11, 30, 0, 0, 0),
     });
-    expect(parseTime("12:00:00 PM")).toEqual({
+    expect(parseDateTime("12:00:00 PM")).toEqual({
       value: 0.5,
       format: "hh:mm:ss a",
       jsDate: new Date(1899, 11, 30, 12, 0, 0),
     });
-    expect(parseTime("0:00:00 PM")).toEqual({
+    expect(parseDateTime("0:00:00 PM")).toEqual({
       value: 0.5,
       format: "hh:mm:ss a",
       jsDate: new Date(1899, 11, 30, 12, 0, 0),
     });
-    expect(parseTime("12:08:06 AM")).toEqual({
+    expect(parseDateTime("12:08:06 AM")).toEqual({
       value: 0.005625,
       format: "hh:mm:ss a",
       jsDate: new Date(1899, 11, 30, 0, 8, 6),
     });
-    expect(parseTime("12:8:6 AM")).toEqual({
+    expect(parseDateTime("12:8:6 AM")).toEqual({
       value: 0.005625,
       format: "hh:mm:ss a",
       jsDate: new Date(1899, 11, 30, 0, 8, 6),
     });
-    expect(parseTime("12:008:006 AM")).toEqual({
+    expect(parseDateTime("12:008:006 AM")).toEqual({
       value: 0.005625,
       format: "hh:mm:ss a",
       jsDate: new Date(1899, 11, 30, 0, 8, 6),
     });
-    expect(parseTime("11:59:546   AM")).toEqual({
+    expect(parseDateTime("11:59:546   AM")).toEqual({
       value: 0.505625,
       format: "hh:mm:ss a",
       jsDate: new Date(1899, 11, 30, 12, 8, 6),
@@ -448,32 +442,32 @@ describe("date helpers: can detect and parse various times", () => {
   });
 
   test("can detect and parse 'hhhh:mm:ss' times", () => {
-    expect(parseTime("30:00")).toEqual({
+    expect(parseDateTime("30:00")).toEqual({
       value: 1.25,
       format: "hhhh:mm:ss",
       jsDate: new Date(1899, 11, 31, 6, 0, 0),
     });
-    expect(parseTime("24:08:06")).toEqual({
+    expect(parseDateTime("24:08:06")).toEqual({
       value: 1.005625,
       format: "hhhh:mm:ss",
       jsDate: new Date(1899, 11, 31, 0, 8, 6),
     });
-    expect(parseTime("36 AM")).toEqual({
+    expect(parseDateTime("36 AM")).toEqual({
       value: 1,
       format: "hhhh:mm:ss",
       jsDate: new Date(1899, 11, 31, 0, 0, 0),
     });
-    expect(parseTime("24 PM")).toEqual({
+    expect(parseDateTime("24 PM")).toEqual({
       value: 1,
       format: "hhhh:mm:ss",
       jsDate: new Date(1899, 11, 31, 0, 0, 0),
     });
-    expect(parseTime("36:09 AM")).toEqual({
+    expect(parseDateTime("36:09 AM")).toEqual({
       value: 1.00625,
       format: "hhhh:mm:ss",
       jsDate: new Date(1899, 11, 31, 0, 9, 0),
     });
-    expect(parseTime("23:59:60 PM")).toEqual({
+    expect(parseDateTime("23:59:60 PM")).toEqual({
       value: 1,
       format: "hhhh:mm:ss",
       jsDate: new Date(1899, 11, 31, 0, 0, 0),
@@ -481,80 +475,607 @@ describe("date helpers: can detect and parse various times", () => {
   });
 });
 
-describe("formatTime", () => {
+describe("formatDateTime", () => {
   test("hours minutes 'hh:mm'", () => {
-    expect(formatTime(parseTime("0:0")!)).toBe("00:00");
-    expect(formatTime(parseTime("6:0")!)).toBe("06:00");
-    expect(formatTime(parseTime("12:9")!)).toBe("12:09");
-    expect(formatTime(parseTime("00012:09")!)).toBe("12:09");
-    expect(formatTime(parseTime("12:00000009")!)).toBe("12:09");
-    expect(formatTime(parseTime("11:69")!)).toBe("12:09");
+    expect(formatDateTime(parseDateTime("0:0")!)).toBe("00:00");
+    expect(formatDateTime(parseDateTime("6:0")!)).toBe("06:00");
+    expect(formatDateTime(parseDateTime("12:9")!)).toBe("12:09");
+    expect(formatDateTime(parseDateTime("00012:09")!)).toBe("12:09");
+    expect(formatDateTime(parseDateTime("12:00000009")!)).toBe("12:09");
+    expect(formatDateTime(parseDateTime("11:69")!)).toBe("12:09");
 
-    expect(formatTime(parseTime("12:08:06")!, "hh:mm")).toBe("12:08");
-    expect(formatTime(parseTime("05:09 PM")!, "hh:mm")).toBe("17:09");
-    expect(formatTime(parseTime("012:008:006 AM")!, "hh:mm")).toBe("00:08");
-    expect(formatTime(parseTime("30:00:00")!, "hh:mm")).toBe("06:00");
+    expect(formatDateTime(parseDateTime("12:08:06")!, "hh:mm")).toBe("12:08");
+    expect(formatDateTime(parseDateTime("05:09 PM")!, "hh:mm")).toBe("17:09");
+    expect(formatDateTime(parseDateTime("012:008:006 AM")!, "hh:mm")).toBe("00:08");
+    expect(formatDateTime(parseDateTime("30:00:00")!, "hh:mm")).toBe("06:00");
   });
 
   test("hours minutes seconds 'hh:mm:ss'", () => {
-    expect(formatTime(parseTime("12:0:0")!)).toBe("12:00:00");
-    expect(formatTime(parseTime("12:8:6")!)).toBe("12:08:06");
-    expect(formatTime(parseTime("0012:008:006")!)).toBe("12:08:06");
-    expect(formatTime(parseTime("11:59:546")!)).toBe("12:08:06");
+    expect(formatDateTime(parseDateTime("12:0:0")!)).toBe("12:00:00");
+    expect(formatDateTime(parseDateTime("12:8:6")!)).toBe("12:08:06");
+    expect(formatDateTime(parseDateTime("0012:008:006")!)).toBe("12:08:06");
+    expect(formatDateTime(parseDateTime("11:59:546")!)).toBe("12:08:06");
 
-    expect(formatTime(parseTime("12:08")!, "hh:mm:ss")).toBe("12:08:00");
-    expect(formatTime(parseTime("05:09 PM")!, "hh:mm:ss")).toBe("17:09:00");
-    expect(formatTime(parseTime("012:008:006 AM")!, "hh:mm:ss")).toBe("00:08:06");
-    expect(formatTime(parseTime("30:00:00")!, "hh:mm:ss")).toBe("06:00:00");
+    expect(formatDateTime(parseDateTime("12:08")!, "hh:mm:ss")).toBe("12:08:00");
+    expect(formatDateTime(parseDateTime("05:09 PM")!, "hh:mm:ss")).toBe("17:09:00");
+    expect(formatDateTime(parseDateTime("012:008:006 AM")!, "hh:mm:ss")).toBe("00:08:06");
+    expect(formatDateTime(parseDateTime("30:00:00")!, "hh:mm:ss")).toBe("06:00:00");
   });
 
   test("hours minutes meridian 'hh:mm a", () => {
-    expect(formatTime(parseTime("0 AM")!)).toBe("12:00 AM");
-    expect(formatTime(parseTime("0 PM")!)).toBe("12:00 PM");
-    expect(formatTime(parseTime("6AM")!)).toBe("06:00 AM");
-    expect(formatTime(parseTime("6    AM")!)).toBe("06:00 AM");
-    expect(formatTime(parseTime("7PM")!)).toBe("07:00 PM");
-    expect(formatTime(parseTime("7    PM")!)).toBe("07:00 PM");
-    expect(formatTime(parseTime("12 AM")!)).toBe("12:00 AM");
-    expect(formatTime(parseTime("12 PM")!)).toBe("12:00 PM");
-    expect(formatTime(parseTime("13 AM")!)).toBe("01:00 AM"); // @compatibility: on google sheets, parsing impposible
-    expect(formatTime(parseTime("13 PM")!)).toBe("01:00 PM"); // @compatibility: on google sheets, parsing impposible
-    expect(formatTime(parseTime("24 AM")!)).toBe("12:00 PM"); // @compatibility: on google sheets, parsing impposible
-    expect(formatTime(parseTime("0:09 AM")!)).toBe("12:09 AM");
-    expect(formatTime(parseTime("12:9 AM")!)).toBe("12:09 AM");
-    expect(formatTime(parseTime("00012:0009 AM")!)).toBe("12:09 AM");
-    expect(formatTime(parseTime("11:69 AM")!)).toBe("12:09 PM");
-    expect(formatTime(parseTime("18:00 AM")!)).toBe("06:00 AM");
+    expect(formatDateTime(parseDateTime("0 AM")!)).toBe("12:00 AM");
+    expect(formatDateTime(parseDateTime("0 PM")!)).toBe("12:00 PM");
+    expect(formatDateTime(parseDateTime("6AM")!)).toBe("06:00 AM");
+    expect(formatDateTime(parseDateTime("6    AM")!)).toBe("06:00 AM");
+    expect(formatDateTime(parseDateTime("7PM")!)).toBe("07:00 PM");
+    expect(formatDateTime(parseDateTime("7    PM")!)).toBe("07:00 PM");
+    expect(formatDateTime(parseDateTime("12 AM")!)).toBe("12:00 AM");
+    expect(formatDateTime(parseDateTime("12 PM")!)).toBe("12:00 PM");
+    expect(formatDateTime(parseDateTime("13 AM")!)).toBe("01:00 AM"); // @compatibility: on google sheets, parsing impposible
+    expect(formatDateTime(parseDateTime("13 PM")!)).toBe("01:00 PM"); // @compatibility: on google sheets, parsing impposible
+    expect(formatDateTime(parseDateTime("24 AM")!)).toBe("12:00 PM"); // @compatibility: on google sheets, parsing impposible
+    expect(formatDateTime(parseDateTime("0:09 AM")!)).toBe("12:09 AM");
+    expect(formatDateTime(parseDateTime("12:9 AM")!)).toBe("12:09 AM");
+    expect(formatDateTime(parseDateTime("00012:0009 AM")!)).toBe("12:09 AM");
+    expect(formatDateTime(parseDateTime("11:69 AM")!)).toBe("12:09 PM");
+    expect(formatDateTime(parseDateTime("18:00 AM")!)).toBe("06:00 AM");
 
-    expect(formatTime(parseTime("12:08")!, "hh:mm a")).toBe("12:08 PM");
-    expect(formatTime(parseTime("12:08:06")!, "hh:mm a")).toBe("12:08 PM");
-    expect(formatTime(parseTime("012:008:006 AM")!, "hh:mm a")).toBe("12:08 AM");
-    expect(formatTime(parseTime("30:00:00")!, "hh:mm a")).toBe("06:00 AM");
+    expect(formatDateTime(parseDateTime("12:08")!, "hh:mm a")).toBe("12:08 PM");
+    expect(formatDateTime(parseDateTime("12:08:06")!, "hh:mm a")).toBe("12:08 PM");
+    expect(formatDateTime(parseDateTime("012:008:006 AM")!, "hh:mm a")).toBe("12:08 AM");
+    expect(formatDateTime(parseDateTime("30:00:00")!, "hh:mm a")).toBe("06:00 AM");
   });
 
   test("hours minutes seconds meridian 'hh:mm:ss a", () => {
-    expect(formatTime(parseTime("00:00:00 AM")!)).toBe("12:00:00 AM");
-    expect(formatTime(parseTime("00:00:00 PM")!)).toBe("12:00:00 PM");
-    expect(formatTime(parseTime("12:00:00 AM")!)).toBe("12:00:00 AM");
-    expect(formatTime(parseTime("012:008:006 AM")!)).toBe("12:08:06 AM");
-    expect(formatTime(parseTime("11:59:546   AM")!)).toBe("12:08:06 PM");
+    expect(formatDateTime(parseDateTime("00:00:00 AM")!)).toBe("12:00:00 AM");
+    expect(formatDateTime(parseDateTime("00:00:00 PM")!)).toBe("12:00:00 PM");
+    expect(formatDateTime(parseDateTime("12:00:00 AM")!)).toBe("12:00:00 AM");
+    expect(formatDateTime(parseDateTime("012:008:006 AM")!)).toBe("12:08:06 AM");
+    expect(formatDateTime(parseDateTime("11:59:546   AM")!)).toBe("12:08:06 PM");
 
-    expect(formatTime(parseTime("12:08")!, "hh:mm:ss a")).toBe("12:08:00 PM");
-    expect(formatTime(parseTime("12:08:06")!, "hh:mm:ss a")).toBe("12:08:06 PM");
-    expect(formatTime(parseTime("05:09 PM")!, "hh:mm:ss a")).toBe("05:09:00 PM");
-    expect(formatTime(parseTime("30:00:00")!, "hh:mm:ss a")).toBe("06:00:00 AM");
+    expect(formatDateTime(parseDateTime("12:08")!, "hh:mm:ss a")).toBe("12:08:00 PM");
+    expect(formatDateTime(parseDateTime("12:08:06")!, "hh:mm:ss a")).toBe("12:08:06 PM");
+    expect(formatDateTime(parseDateTime("05:09 PM")!, "hh:mm:ss a")).toBe("05:09:00 PM");
+    expect(formatDateTime(parseDateTime("30:00:00")!, "hh:mm:ss a")).toBe("06:00:00 AM");
   });
 
   test("duration 'hhhh:mm:ss", () => {
-    expect(formatTime(parseTime("30:00")!)).toBe("30:00:00");
-    expect(formatTime(parseTime("24:08:06")!)).toBe("24:08:06");
-    expect(formatTime(parseTime("36:09 AM")!)).toBe("24:09:00"); // @compatibility: on google sheets, parsing impposible
-    expect(formatTime(parseTime("24 PM")!)).toBe("24:00:00"); // @compatibility: on google sheets, parsing impposible
-    expect(formatTime(parseTime("11:59:546   PM")!)).toBe("24:08:06");
+    expect(formatDateTime(parseDateTime("30:00")!)).toBe("30:00:00");
+    expect(formatDateTime(parseDateTime("24:08:06")!)).toBe("24:08:06");
+    expect(formatDateTime(parseDateTime("36:09 AM")!)).toBe("24:09:00"); // @compatibility: on google sheets, parsing impposible
+    expect(formatDateTime(parseDateTime("24 PM")!)).toBe("24:00:00"); // @compatibility: on google sheets, parsing impposible
+    expect(formatDateTime(parseDateTime("11:59:546   PM")!)).toBe("24:08:06");
 
-    expect(formatTime(parseTime("12:08")!, "hhhh:mm:ss")).toBe("12:08:00");
-    expect(formatTime(parseTime("12:08:06")!, "hhhh:mm:ss")).toBe("12:08:06");
-    expect(formatTime(parseTime("05:09 PM")!, "hhhh:mm:ss")).toBe("17:09:00");
-    expect(formatTime(parseTime("012:008:006 AM")!, "hhhh:mm:ss")).toBe("0:08:06");
+    expect(formatDateTime(parseDateTime("12:08")!, "hhhh:mm:ss")).toBe("12:08:00");
+    expect(formatDateTime(parseDateTime("12:08:06")!, "hhhh:mm:ss")).toBe("12:08:06");
+    expect(formatDateTime(parseDateTime("05:09 PM")!, "hhhh:mm:ss")).toBe("17:09:00");
+    expect(formatDateTime(parseDateTime("012:008:006 AM")!, "hhhh:mm:ss")).toBe("0:08:06");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Test on date and time
+// -----------------------------------------------------------------------------
+
+describe("date helpers: can detect and parse various datetimes (with '/' separator)", () => {
+  // m/d/yyyy
+
+  test("can detect and parse 'm/d/yyyy hh:mm' datetime", () => {
+    expect(parseDateTime("4/20/2020 12:09")).toEqual({
+      value: 43941.50625,
+      format: "m/d/yyyy hh:mm",
+      jsDate: new Date(2020, 3, 20, 12, 9, 0),
+    });
+  });
+
+  test("can detect and parse 'm/d/yyyy hh:mm:ss' datetime", () => {
+    expect(parseDateTime("4/20/2020 12:08:06")).toEqual({
+      value: 43941.505625,
+      format: "m/d/yyyy hh:mm:ss",
+      jsDate: new Date(2020, 3, 20, 12, 8, 6),
+    });
+  });
+
+  test("can detect and parse 'm/d/yyyy hh:mm a' datetime", () => {
+    expect(parseDateTime("4/20/2020 12:09 AM")).toEqual({
+      value: 43941.00625,
+      format: "m/d/yyyy hh:mm a",
+      jsDate: new Date(2020, 3, 20, 0, 9, 0),
+    });
+    expect(parseDateTime("4/20/2020 6 PM")).toEqual({
+      value: 43941.75,
+      format: "m/d/yyyy hh:mm a",
+      jsDate: new Date(2020, 3, 20, 18, 0, 0),
+    });
+  });
+
+  test("can detect and parse 'm/d/yyyy hh:mm:ss a' datetime", () => {
+    expect(parseDateTime("4/20/2020 12:08:06 AM")).toEqual({
+      value: 43941.005625,
+      format: "m/d/yyyy hh:mm:ss a",
+      jsDate: new Date(2020, 3, 20, 0, 8, 6),
+    });
+  });
+
+  // yyyy/m/d
+
+  test("can detect and parse 'yyyy/m/d hh:mm' datetime", () => {
+    expect(parseDateTime("2020/4/20 12:09")).toEqual({
+      value: 43941.50625,
+      format: "yyyy/m/d hh:mm",
+      jsDate: new Date(2020, 3, 20, 12, 9, 0),
+    });
+  });
+
+  test("can detect and parse 'yyyy/m/d hh:mm:ss' datetime", () => {
+    expect(parseDateTime("2020/4/20 12:08:06")).toEqual({
+      value: 43941.505625,
+      format: "yyyy/m/d hh:mm:ss",
+      jsDate: new Date(2020, 3, 20, 12, 8, 6),
+    });
+  });
+
+  test("can detect and parse 'yyyy/m/d hh:mm a' datetime", () => {
+    expect(parseDateTime("2020/4/20 12:09 AM")).toEqual({
+      value: 43941.00625,
+      format: "yyyy/m/d hh:mm a",
+      jsDate: new Date(2020, 3, 20, 0, 9, 0),
+    });
+    expect(parseDateTime("2020/4/20 6 PM")).toEqual({
+      value: 43941.75,
+      format: "yyyy/m/d hh:mm a",
+      jsDate: new Date(2020, 3, 20, 18, 0, 0),
+    });
+  });
+
+  test("can detect and parse 'yyyy/m/d hh:mm:ss a' datetime", () => {
+    expect(parseDateTime("2020/4/20 12:08:06 AM")).toEqual({
+      value: 43941.005625,
+      format: "yyyy/m/d hh:mm:ss a",
+      jsDate: new Date(2020, 3, 20, 0, 8, 6),
+    });
+  });
+
+  // mm/dd/yyyy
+
+  test("can detect and parse 'mm/dd/yyyy hh:mm' datetime", () => {
+    expect(parseDateTime("03/20/2010 12:09")).toEqual({
+      value: 40257.50625,
+      format: "mm/dd/yyyy hh:mm",
+      jsDate: new Date(2010, 2, 20, 12, 9, 0),
+    });
+  });
+
+  test("can detect and parse 'mm/dd/yyyy hh:mm:ss' datetime", () => {
+    expect(parseDateTime("03/20/2010 12:08:06")).toEqual({
+      value: 40257.505625,
+      format: "mm/dd/yyyy hh:mm:ss",
+      jsDate: new Date(2010, 2, 20, 12, 8, 6),
+    });
+  });
+
+  test("can detect and parse 'mm/dd/yyyy hh:mm a' datetime", () => {
+    expect(parseDateTime("03/20/2010 12:09 AM")).toEqual({
+      value: 40257.00625,
+      format: "mm/dd/yyyy hh:mm a",
+      jsDate: new Date(2010, 2, 20, 0, 9, 0),
+    });
+    expect(parseDateTime("03/20/2010 6 PM")).toEqual({
+      value: 40257.75,
+
+      format: "mm/dd/yyyy hh:mm a",
+      jsDate: new Date(2010, 2, 20, 18, 0, 0),
+    });
+  });
+
+  test("can detect and parse 'mm/dd/yyyy hh:mm:ss a' datetime", () => {
+    expect(parseDateTime("03/20/2010 12:08:06 AM")).toEqual({
+      value: 40257.005625,
+      format: "mm/dd/yyyy hh:mm:ss a",
+      jsDate: new Date(2010, 2, 20, 0, 8, 6),
+    });
+  });
+
+  // yyyy/mm/dd
+
+  test("can detect and parse 'yyyy/mm/dd hh:mm' datetime", () => {
+    expect(parseDateTime("2010/03/20 12:09")).toEqual({
+      value: 40257.50625,
+      format: "yyyy/mm/dd hh:mm",
+      jsDate: new Date(2010, 2, 20, 12, 9, 0),
+    });
+  });
+
+  test("can detect and parse 'yyyy/mm/dd hh:mm:ss' datetime", () => {
+    expect(parseDateTime("2010/03/20 12:08:06")).toEqual({
+      value: 40257.505625,
+      format: "yyyy/mm/dd hh:mm:ss",
+      jsDate: new Date(2010, 2, 20, 12, 8, 6),
+    });
+  });
+
+  test("can detect and parse 'yyyy/mm/dd hh:mm a' datetime", () => {
+    expect(parseDateTime("2010/03/20 12:09 AM")).toEqual({
+      value: 40257.00625,
+      format: "yyyy/mm/dd hh:mm a",
+      jsDate: new Date(2010, 2, 20, 0, 9, 0),
+    });
+    expect(parseDateTime("2010/03/20 6 PM")).toEqual({
+      value: 40257.75,
+      format: "yyyy/mm/dd hh:mm a",
+      jsDate: new Date(2010, 2, 20, 18, 0, 0),
+    });
+  });
+
+  test("can detect and parse 'yyyy/mm/dd hh:mm:ss a' datetime", () => {
+    expect(parseDateTime("2010/03/20 12:08:06 AM")).toEqual({
+      value: 40257.005625,
+      format: "yyyy/mm/dd hh:mm:ss a",
+      jsDate: new Date(2010, 2, 20, 0, 8, 6),
+    });
+  });
+
+  // m/d
+
+  test("can detect and parse 'm/d hh:mm' datetime", () => {
+    const d = parseDateTime("1/3 12:09")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 12, 9, 0));
+    expect(d.format).toBe("m/d hh:mm");
+  });
+
+  test("can detect and parse 'm/d hh:mm:ss' datetime", () => {
+    const d = parseDateTime("1/3 12:08:06")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 12, 8, 6));
+    expect(d.format).toBe("m/d hh:mm:ss");
+  });
+
+  test("can detect and parse 'm/d hh:mm a' datetime", () => {
+    const d1 = parseDateTime("1/3 12:09 AM")!;
+    expect(d1.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 0, 9, 0));
+    expect(d1.format).toBe("m/d hh:mm a");
+
+    const d2 = parseDateTime("1/3 6 PM")!;
+    expect(d2.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 18, 0, 0));
+    expect(d2.format).toBe("m/d hh:mm a");
+  });
+
+  test("can detect and parse 'm/d hh:mm:ss a' datetime", () => {
+    const d = parseDateTime("1/3 12:08:06 AM")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 0, 8, 6));
+    expect(d.format).toBe("m/d hh:mm:ss a");
+  });
+
+  // mm/dd
+
+  test("can detect and parse 'mm/dd hh:mm' datetime", () => {
+    const d = parseDateTime("1/03 12:09")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 12, 9, 0));
+    expect(d.format).toBe("mm/dd hh:mm");
+  });
+
+  test("can detect and parse 'mm/dd hh:mm:ss' datetime", () => {
+    const d = parseDateTime("1/03 12:08:06")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 12, 8, 6));
+    expect(d.format).toBe("mm/dd hh:mm:ss");
+  });
+
+  test("can detect and parse 'mm/dd hh:mm a' datetime", () => {
+    const d1 = parseDateTime("1/03 12:09 AM")!;
+    expect(d1.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 0, 9, 0));
+    expect(d1.format).toBe("mm/dd hh:mm a");
+
+    const d2 = parseDateTime("1/03 6 PM")!;
+    expect(d2.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 18, 0, 0));
+    expect(d2.format).toBe("mm/dd hh:mm a");
+  });
+
+  test("can detect and parse 'mm/dd hh:mm:ss a' datetime", () => {
+    const d = parseDateTime("1/03 12:08:06 AM")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 0, 8, 6));
+    expect(d.format).toBe("mm/dd hh:mm:ss a");
+  });
+});
+
+describe("date helpers: can detect and parse various datetime (with ' ' separator)", () => {
+  // m d yyyy
+
+  test("can detect and parse 'm d yyyy hh:mm' datetime", () => {
+    expect(parseDateTime("4 20 2020 12:09")).toEqual({
+      value: 43941.50625,
+      format: "m d yyyy hh:mm",
+      jsDate: new Date(2020, 3, 20, 12, 9, 0),
+    });
+  });
+
+  test("can detect and parse 'm d yyyy hh:mm:ss' datetime", () => {
+    expect(parseDateTime("4 20 2020 12:08:06")).toEqual({
+      value: 43941.505625,
+      format: "m d yyyy hh:mm:ss",
+      jsDate: new Date(2020, 3, 20, 12, 8, 6),
+    });
+  });
+
+  test("can detect and parse 'm d yyyy hh:mm a' datetime", () => {
+    expect(parseDateTime("4 20 2020 12:09 AM")).toEqual({
+      value: 43941.00625,
+      format: "m d yyyy hh:mm a",
+      jsDate: new Date(2020, 3, 20, 0, 9, 0),
+    });
+    expect(parseDateTime("4 20 2020 6 PM")).toEqual({
+      value: 43941.75,
+      format: "m d yyyy hh:mm a",
+      jsDate: new Date(2020, 3, 20, 18, 0, 0),
+    });
+  });
+
+  test("can detect and parse 'm d yyyy hh:mm:ss a' datetime", () => {
+    expect(parseDateTime("4 20 2020 12:08:06 AM")).toEqual({
+      value: 43941.005625,
+      format: "m d yyyy hh:mm:ss a",
+      jsDate: new Date(2020, 3, 20, 0, 8, 6),
+    });
+  });
+
+  // yyyy m d
+
+  test("can detect and parse 'yyyy m d hh:mm' datetime", () => {
+    expect(parseDateTime("2020 4 20 12:09")).toEqual({
+      value: 43941.50625,
+      format: "yyyy m d hh:mm",
+      jsDate: new Date(2020, 3, 20, 12, 9, 0),
+    });
+  });
+
+  test("can detect and parse 'yyyy m d hh:mm:ss' datetime", () => {
+    expect(parseDateTime("2020 4 20 12:08:06")).toEqual({
+      value: 43941.505625,
+      format: "yyyy m d hh:mm:ss",
+      jsDate: new Date(2020, 3, 20, 12, 8, 6),
+    });
+  });
+
+  test("can detect and parse 'yyyy m d hh:mm a' datetime", () => {
+    expect(parseDateTime("2020 4 20 12:09 AM")).toEqual({
+      value: 43941.00625,
+      format: "yyyy m d hh:mm a",
+      jsDate: new Date(2020, 3, 20, 0, 9, 0),
+    });
+    expect(parseDateTime("2020 4 20 6 PM")).toEqual({
+      value: 43941.75,
+      format: "yyyy m d hh:mm a",
+      jsDate: new Date(2020, 3, 20, 18, 0, 0),
+    });
+  });
+
+  test("can detect and parse 'yyyy m d hh:mm:ss a' datetime", () => {
+    expect(parseDateTime("2020 4 20 12:08:06 AM")).toEqual({
+      value: 43941.005625,
+      format: "yyyy m d hh:mm:ss a",
+      jsDate: new Date(2020, 3, 20, 0, 8, 6),
+    });
+  });
+
+  // mm dd yyyy
+
+  test("can detect and parse 'mm dd yyyy hh:mm' datetime", () => {
+    expect(parseDateTime("03 20 2010 12:09")).toEqual({
+      value: 40257.50625,
+      format: "mm dd yyyy hh:mm",
+      jsDate: new Date(2010, 2, 20, 12, 9, 0),
+    });
+  });
+
+  test("can detect and parse 'mm dd yyyy hh:mm:ss' datetime", () => {
+    expect(parseDateTime("03 20 2010 12:08:06")).toEqual({
+      value: 40257.505625,
+      format: "mm dd yyyy hh:mm:ss",
+      jsDate: new Date(2010, 2, 20, 12, 8, 6),
+    });
+  });
+
+  test("can detect and parse 'mm dd yyyy hh:mm a' datetime", () => {
+    expect(parseDateTime("03 20 2010 12:09 AM")).toEqual({
+      value: 40257.00625,
+      format: "mm dd yyyy hh:mm a",
+      jsDate: new Date(2010, 2, 20, 0, 9, 0),
+    });
+    expect(parseDateTime("03 20 2010 6 PM")).toEqual({
+      value: 40257.75,
+      format: "mm dd yyyy hh:mm a",
+      jsDate: new Date(2010, 2, 20, 18, 0, 0),
+    });
+  });
+
+  test("can detect and parse 'mm dd yyyy hh:mm:ss a' datetime", () => {
+    expect(parseDateTime("03 20 2010 12:08:06 AM")).toEqual({
+      value: 40257.005625,
+      format: "mm dd yyyy hh:mm:ss a",
+      jsDate: new Date(2010, 2, 20, 0, 8, 6),
+    });
+  });
+
+  // yyyy mm dd
+
+  test("can detect and parse 'yyyy mm dd hh:mm' datetime", () => {
+    expect(parseDateTime("2010 03 20 12:09")).toEqual({
+      value: 40257.50625,
+      format: "yyyy mm dd hh:mm",
+      jsDate: new Date(2010, 2, 20, 12, 9, 0),
+    });
+  });
+
+  test("can detect and parse 'yyyy mm dd hh:mm:ss' datetime", () => {
+    expect(parseDateTime("2010 03 20 12:08:06")).toEqual({
+      value: 40257.505625,
+      format: "yyyy mm dd hh:mm:ss",
+      jsDate: new Date(2010, 2, 20, 12, 8, 6),
+    });
+  });
+
+  test("can detect and parse 'yyyy mm dd hh:mm a' datetime", () => {
+    expect(parseDateTime("2010 03 20 12:09 AM")).toEqual({
+      value: 40257.00625,
+      format: "yyyy mm dd hh:mm a",
+      jsDate: new Date(2010, 2, 20, 0, 9, 0),
+    });
+    expect(parseDateTime("2010 03 20 6 PM")).toEqual({
+      value: 40257.75,
+      format: "yyyy mm dd hh:mm a",
+      jsDate: new Date(2010, 2, 20, 18, 0, 0),
+    });
+  });
+
+  test("can detect and parse 'yyyy mm dd hh:mm:ss a' datetime", () => {
+    expect(parseDateTime("2010 03 20 12:08:06 AM")).toEqual({
+      value: 40257.005625,
+      format: "yyyy mm dd hh:mm:ss a",
+      jsDate: new Date(2010, 2, 20, 0, 8, 6),
+    });
+  });
+
+  // m d
+
+  test("can detect and parse 'm d hh:mm' datetime", () => {
+    const d = parseDateTime("1 3 12:09")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 12, 9, 0));
+    expect(d.format).toBe("m d hh:mm");
+  });
+
+  test("can detect and parse 'm d hh:mm:ss' datetime", () => {
+    const d = parseDateTime("1 3 12:08:06")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 12, 8, 6));
+    expect(d.format).toBe("m d hh:mm:ss");
+  });
+
+  test("can detect and parse 'm d hh:mm a' datetime", () => {
+    const d1 = parseDateTime("1 3 12:09 AM")!;
+    expect(d1.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 0, 9, 0));
+    expect(d1.format).toBe("m d hh:mm a");
+
+    const d2 = parseDateTime("1 3 6 PM")!;
+    expect(d2.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 18, 0, 0));
+    expect(d2.format).toBe("m d hh:mm a");
+  });
+
+  test("can detect and parse 'm d hh:mm:ss a' datetime", () => {
+    const d = parseDateTime("1 3 12:08:06 AM")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 0, 8, 6));
+    expect(d.format).toBe("m d hh:mm:ss a");
+  });
+
+  // mm dd
+
+  test("can detect and parse 'mm dd hh:mm' datetime", () => {
+    const d = parseDateTime("1 03 12:09")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 12, 9, 0));
+    expect(d.format).toBe("mm dd hh:mm");
+  });
+
+  test("can detect and parse 'mm dd hh:mm:ss' datetime", () => {
+    const d = parseDateTime("1 03 12:08:06")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 12, 8, 6));
+    expect(d.format).toBe("mm dd hh:mm:ss");
+  });
+
+  test("can detect and parse 'mm dd hh:mm a' datetime", () => {
+    const d1 = parseDateTime("1 03 12:09 AM")!;
+    expect(d1.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 0, 9, 0));
+    expect(d1.format).toBe("mm dd hh:mm a");
+
+    const d2 = parseDateTime("1 03 6 PM")!;
+    expect(d2.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 18, 0, 0));
+    expect(d2.format).toBe("mm dd hh:mm a");
+  });
+
+  test("can detect and parse 'mm dd hh:mm:ss a' datetime", () => {
+    const d = parseDateTime("1 03 12:08:06 AM")!;
+    expect(d.jsDate).toEqual(new Date(CURRENT_YEAR, 0, 3, 0, 8, 6));
+    expect(d.format).toBe("mm dd hh:mm:ss a");
+  });
+});
+
+describe("formatDateTime", () => {
+  test("increment time test on datetime format with 'm/d/yyyy'", () => {
+    expect(formatDateTime(parseDateTime("12/5/2020 11:69")!)).toBe("12/5/2020 12:09");
+    expect(formatDateTime(parseDateTime("12/5/2020 23:69")!)).toBe("12/6/2020 00:09:00");
+    expect(formatDateTime(parseDateTime("12/5/2020 25 AM")!)).toBe("12/5/2020 01:00 PM");
+    expect(formatDateTime(parseDateTime("12/5/2020 25:70 PM")!)).toBe("12/6/2020 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'yyyy/m/d'", () => {
+    expect(formatDateTime(parseDateTime("2020/12/5 11:69")!)).toBe("2020/12/5 12:09");
+    expect(formatDateTime(parseDateTime("2020/12/5 23:69")!)).toBe("2020/12/6 00:09:00");
+    expect(formatDateTime(parseDateTime("2020/12/5 25 AM")!)).toBe("2020/12/5 01:00 PM");
+    expect(formatDateTime(parseDateTime("2020/12/5 25:70 PM")!)).toBe("2020/12/6 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'mm/dd/yyyy'", () => {
+    expect(formatDateTime(parseDateTime("12/05/2020 11:69")!)).toBe("12/05/2020 12:09");
+    expect(formatDateTime(parseDateTime("12/05/2020 23:69")!)).toBe("12/06/2020 00:09:00");
+    expect(formatDateTime(parseDateTime("12/05/2020 25 AM")!)).toBe("12/05/2020 01:00 PM");
+    expect(formatDateTime(parseDateTime("12/05/2020 25:70 PM")!)).toBe("12/06/2020 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'yyyy/mm/dd'", () => {
+    expect(formatDateTime(parseDateTime("2020/12/05 11:69")!)).toBe("2020/12/05 12:09");
+    expect(formatDateTime(parseDateTime("2020/12/05 23:69")!)).toBe("2020/12/06 00:09:00");
+    expect(formatDateTime(parseDateTime("2020/12/05 25 AM")!)).toBe("2020/12/05 01:00 PM");
+    expect(formatDateTime(parseDateTime("2020/12/05 25:70 PM")!)).toBe("2020/12/06 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'm/d'", () => {
+    expect(formatDateTime(parseDateTime("12/5 11:69")!)).toBe("12/5 12:09");
+    expect(formatDateTime(parseDateTime("12/5 23:69")!)).toBe("12/6 00:09:00");
+    expect(formatDateTime(parseDateTime("12/5 25 AM")!)).toBe("12/5 01:00 PM");
+    expect(formatDateTime(parseDateTime("12/5 25:70 PM")!)).toBe("12/6 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'mm/dd'", () => {
+    expect(formatDateTime(parseDateTime("12/05 11:69")!)).toBe("12/05 12:09");
+    expect(formatDateTime(parseDateTime("12/05 23:69")!)).toBe("12/06 00:09:00");
+    expect(formatDateTime(parseDateTime("12/05 25 AM")!)).toBe("12/05 01:00 PM");
+    expect(formatDateTime(parseDateTime("12/05 25:70 PM")!)).toBe("12/06 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'm d yyyy'", () => {
+    expect(formatDateTime(parseDateTime("12 5 2020 11:69")!)).toBe("12 5 2020 12:09");
+    expect(formatDateTime(parseDateTime("12 5 2020 23:69")!)).toBe("12 6 2020 00:09:00");
+    expect(formatDateTime(parseDateTime("12 5 2020 25 AM")!)).toBe("12 5 2020 01:00 PM");
+    expect(formatDateTime(parseDateTime("12 5 2020 25:70 PM")!)).toBe("12 6 2020 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'yyyy m d'", () => {
+    expect(formatDateTime(parseDateTime("2020 12 5 11:69")!)).toBe("2020 12 5 12:09");
+    expect(formatDateTime(parseDateTime("2020 12 5 23:69")!)).toBe("2020 12 6 00:09:00");
+    expect(formatDateTime(parseDateTime("2020 12 5 25 AM")!)).toBe("2020 12 5 01:00 PM");
+    expect(formatDateTime(parseDateTime("2020 12 5 25:70 PM")!)).toBe("2020 12 6 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'mm dd yyyy'", () => {
+    expect(formatDateTime(parseDateTime("12 05 2020 11:69")!)).toBe("12 05 2020 12:09");
+    expect(formatDateTime(parseDateTime("12 05 2020 23:69")!)).toBe("12 06 2020 00:09:00");
+    expect(formatDateTime(parseDateTime("12 05 2020 25 AM")!)).toBe("12 05 2020 01:00 PM");
+    expect(formatDateTime(parseDateTime("12 05 2020 25:70 PM")!)).toBe("12 06 2020 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'yyyy mm dd'", () => {
+    expect(formatDateTime(parseDateTime("2020 12 05 11:69")!)).toBe("2020 12 05 12:09");
+    expect(formatDateTime(parseDateTime("2020 12 05 23:69")!)).toBe("2020 12 06 00:09:00");
+    expect(formatDateTime(parseDateTime("2020 12 05 25 AM")!)).toBe("2020 12 05 01:00 PM");
+    expect(formatDateTime(parseDateTime("2020 12 05 25:70 PM")!)).toBe("2020 12 06 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'm d'", () => {
+    expect(formatDateTime(parseDateTime("12 5 11:69")!)).toBe("12 5 12:09");
+    expect(formatDateTime(parseDateTime("12 5 23:69")!)).toBe("12 6 00:09:00");
+    expect(formatDateTime(parseDateTime("12 5 25 AM")!)).toBe("12 5 01:00 PM");
+    expect(formatDateTime(parseDateTime("12 5 25:70 PM")!)).toBe("12 6 02:10:00");
+  });
+
+  test("increment time test on datetime format with 'mm dd'", () => {
+    expect(formatDateTime(parseDateTime("12 05 11:69")!)).toBe("12 05 12:09");
+    expect(formatDateTime(parseDateTime("12 05 23:69")!)).toBe("12 06 00:09:00");
+    expect(formatDateTime(parseDateTime("12 05 25 AM")!)).toBe("12 05 01:00 PM");
+    expect(formatDateTime(parseDateTime("12 05 25:70 PM")!)).toBe("12 06 02:10:00");
   });
 });

--- a/tests/functions/module_date_test.ts
+++ b/tests/functions/module_date_test.ts
@@ -1,5 +1,5 @@
 import { evaluateCell, evaluateGrid } from "../helpers";
-import { parseDate } from "../../src/functions/dates";
+import { parseDateTime } from "../../src/functions/dates";
 
 describe("date", () => {
   //----------------------------------------------------------------------------
@@ -43,29 +43,29 @@ describe("date", () => {
 
     const gridResult = evaluateGrid(grid);
     expect(gridResult.A2).toBe("#ERROR");
-    expect(gridResult.A3).toEqual(parseDate("1/1/1900"));
-    expect(gridResult.A4).toEqual(parseDate("12/5/2028"));
-    expect(gridResult.A6).toEqual(parseDate("1/5/2029"));
-    expect(gridResult.A7).toEqual(parseDate("7/26/2028"));
-    expect(gridResult.A8).toEqual(parseDate("12/5/2028"));
-    expect(gridResult.A10).toEqual(parseDate("12/5/2028"));
-    expect(gridResult.A11).toEqual(parseDate("12/5/2028"));
-    expect(gridResult.A12).toEqual(parseDate("12/5/2028"));
-    expect(gridResult.A14).toEqual(parseDate("12/5/2019"));
-    expect(gridResult.A15).toEqual(parseDate("12/5/1919"));
-    expect(gridResult.A16).toEqual(parseDate("12/5/3750"));
-    expect(gridResult.A17).toEqual(parseDate("12/5/3799"));
-    expect(gridResult.A18).toEqual(parseDate("12/5/1900"));
-    expect(gridResult.A19).toEqual(parseDate("11/30/1911"));
+    expect(gridResult.A3).toEqual(parseDateTime("1/1/1900"));
+    expect(gridResult.A4).toEqual(parseDateTime("12/5/2028"));
+    expect(gridResult.A6).toEqual(parseDateTime("1/5/2029"));
+    expect(gridResult.A7).toEqual(parseDateTime("7/26/2028"));
+    expect(gridResult.A8).toEqual(parseDateTime("12/5/2028"));
+    expect(gridResult.A10).toEqual(parseDateTime("12/5/2028"));
+    expect(gridResult.A11).toEqual(parseDateTime("12/5/2028"));
+    expect(gridResult.A12).toEqual(parseDateTime("12/5/2028"));
+    expect(gridResult.A14).toEqual(parseDateTime("12/5/2019"));
+    expect(gridResult.A15).toEqual(parseDateTime("12/5/1919"));
+    expect(gridResult.A16).toEqual(parseDateTime("12/5/3750"));
+    expect(gridResult.A17).toEqual(parseDateTime("12/5/3799"));
+    expect(gridResult.A18).toEqual(parseDateTime("12/5/1900"));
+    expect(gridResult.A19).toEqual(parseDateTime("11/30/1911"));
     expect(gridResult.A20).toBe("#ERROR");
-    expect(gridResult.A21).toEqual(parseDate("2/5/1998"));
-    expect(gridResult.A22).toEqual(parseDate("2/5/3797"));
+    expect(gridResult.A21).toEqual(parseDateTime("2/5/1998"));
+    expect(gridResult.A22).toEqual(parseDateTime("2/5/3797"));
     expect(gridResult.A24).toBe("#ERROR");
-    expect(gridResult.A25).toEqual(parseDate("12/5/9999"));
+    expect(gridResult.A25).toEqual(parseDateTime("12/5/9999"));
     expect(gridResult.A26).toBe("#ERROR");
     expect(gridResult.A27).toBe("#ERROR");
-    expect(gridResult.A28).toEqual(parseDate("12/5/1900"));
-    expect(gridResult.A29).toEqual(parseDate("11/25/1998"));
+    expect(gridResult.A28).toEqual(parseDateTime("12/5/1900"));
+    expect(gridResult.A29).toEqual(parseDateTime("11/25/1998"));
     expect(gridResult.A30).toBe("#ERROR");
   });
 
@@ -79,10 +79,10 @@ describe("date", () => {
     };
 
     const gridResult = evaluateGrid(grid);
-    expect(gridResult.A33).toEqual(parseDate("12/5/2028"));
-    expect(gridResult.A34).toEqual(parseDate("12/1/2028"));
-    expect(gridResult.A35).toEqual(parseDate("12/1/1901"));
-    expect(gridResult.A36).toEqual(parseDate("12/1/1905"));
+    expect(gridResult.A33).toEqual(parseDateTime("12/5/2028"));
+    expect(gridResult.A34).toEqual(parseDateTime("12/1/2028"));
+    expect(gridResult.A35).toEqual(parseDateTime("12/1/1901"));
+    expect(gridResult.A36).toEqual(parseDateTime("12/1/1905"));
   });
 
   //----------------------------------------------------------------------------
@@ -160,12 +160,12 @@ describe("date", () => {
       A6: '=EDATE("7/21/1969", 1.9)',
     };
     const gridResult = evaluateGrid(grid);
-    expect(gridResult.A1).toEqual(parseDate("7/20/1969"));
-    expect(gridResult.A2).toEqual(parseDate("8/21/1969"));
-    expect(gridResult.A3).toEqual(parseDate("5/22/1969"));
-    expect(gridResult.A4).toEqual(parseDate("6/23/1968"));
-    expect(gridResult.A5).toEqual(parseDate("5/24/2072"));
-    expect(gridResult.A6).toEqual(parseDate("8/21/1969"));
+    expect(gridResult.A1).toEqual(parseDateTime("7/20/1969"));
+    expect(gridResult.A2).toEqual(parseDateTime("8/21/1969"));
+    expect(gridResult.A3).toEqual(parseDateTime("5/22/1969"));
+    expect(gridResult.A4).toEqual(parseDateTime("6/23/1968"));
+    expect(gridResult.A5).toEqual(parseDateTime("5/24/2072"));
+    expect(gridResult.A6).toEqual(parseDateTime("8/21/1969"));
   });
 
   test("EDATE: casting tests on cell arguments", () => {
@@ -174,8 +174,8 @@ describe("date", () => {
       A8: '=EDATE("7/21/1969", True)',
     };
     const gridResult = evaluateGrid(grid);
-    expect(gridResult.A7).toEqual(parseDate("8/21/1969"));
-    expect(gridResult.A8).toEqual(parseDate("8/21/1969"));
+    expect(gridResult.A7).toEqual(parseDateTime("8/21/1969"));
+    expect(gridResult.A8).toEqual(parseDateTime("8/21/1969"));
   });
 
   //----------------------------------------------------------------------------
@@ -192,12 +192,12 @@ describe("date", () => {
       A6: '=EOMONTH("7/25/2020", 1.9)',
     };
     const gridResult = evaluateGrid(grid);
-    expect(gridResult.A1).toEqual(parseDate("7/31/2020"));
-    expect(gridResult.A2).toEqual(parseDate("8/31/2020"));
-    expect(gridResult.A3).toEqual(parseDate("5/31/2020"));
-    expect(gridResult.A4).toEqual(parseDate("2/29/2020"));
-    expect(gridResult.A5).toEqual(parseDate("5/31/2123"));
-    expect(gridResult.A6).toEqual(parseDate("8/31/2020"));
+    expect(gridResult.A1).toEqual(parseDateTime("7/31/2020"));
+    expect(gridResult.A2).toEqual(parseDateTime("8/31/2020"));
+    expect(gridResult.A3).toEqual(parseDateTime("5/31/2020"));
+    expect(gridResult.A4).toEqual(parseDateTime("2/29/2020"));
+    expect(gridResult.A5).toEqual(parseDateTime("5/31/2123"));
+    expect(gridResult.A6).toEqual(parseDateTime("8/31/2020"));
   });
 
   test("EOMONTH: casting tests on cell arguments", () => {
@@ -206,8 +206,8 @@ describe("date", () => {
       A8: '=EOMONTH("7/21/2020", True)',
     };
     const gridResult = evaluateGrid(grid);
-    expect(gridResult.A7).toEqual(parseDate("8/31/1920"));
-    expect(gridResult.A8).toEqual(parseDate("8/31/2020"));
+    expect(gridResult.A7).toEqual(parseDateTime("8/31/1920"));
+    expect(gridResult.A8).toEqual(parseDateTime("8/31/2020"));
   });
 
   //----------------------------------------------------------------------------
@@ -628,15 +628,15 @@ describe("date", () => {
     };
     const gridResult = evaluateGrid(grid);
 
-    expect(gridResult.C11).toEqual(parseDate("1/4/2013"));
-    expect(gridResult.C12).toEqual(parseDate("1/4/2013"));
-    expect(gridResult.C13).toEqual(parseDate("1/7/2013"));
-    expect(gridResult.C14).toEqual(parseDate("8/16/2013"));
-    expect(gridResult.C15).toEqual(parseDate("8/19/2013"));
-    expect(gridResult.C16).toEqual(parseDate("3/5/2013"));
-    expect(gridResult.C17).toEqual(parseDate("12/27/2012"));
-    expect(gridResult.C18).toEqual(parseDate("12/27/2012"));
-    expect(gridResult.C19).toEqual(parseDate("12/26/2012"));
+    expect(gridResult.C11).toEqual(parseDateTime("1/4/2013"));
+    expect(gridResult.C12).toEqual(parseDateTime("1/4/2013"));
+    expect(gridResult.C13).toEqual(parseDateTime("1/7/2013"));
+    expect(gridResult.C14).toEqual(parseDateTime("8/16/2013"));
+    expect(gridResult.C15).toEqual(parseDateTime("8/19/2013"));
+    expect(gridResult.C16).toEqual(parseDateTime("3/5/2013"));
+    expect(gridResult.C17).toEqual(parseDateTime("12/27/2012"));
+    expect(gridResult.C18).toEqual(parseDateTime("12/27/2012"));
+    expect(gridResult.C19).toEqual(parseDateTime("12/26/2012"));
   });
 
   //----------------------------------------------------------------------------
@@ -671,29 +671,29 @@ describe("date", () => {
     };
 
     const gridResult = evaluateGrid(grid);
-    expect(gridResult.D2).toEqual(parseDate("5/8/2020")); // @compatibility on Google Sheets, return  #VALUE!
+    expect(gridResult.D2).toEqual(parseDateTime("5/8/2020")); // @compatibility on Google Sheets, return  #VALUE!
     expect(gridResult.D3).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
     expect(gridResult.D4).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
     expect(gridResult.D5).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
-    expect(gridResult.D6).toEqual(parseDate("5/8/2020"));
-    expect(gridResult.D7).toEqual(parseDate("5/8/2020"));
-    expect(gridResult.D8).toEqual(parseDate("5/11/2020"));
-    expect(gridResult.D9).toEqual(parseDate("5/12/2020"));
-    expect(gridResult.D10).toEqual(parseDate("5/28/2020"));
+    expect(gridResult.D6).toEqual(parseDateTime("5/8/2020"));
+    expect(gridResult.D7).toEqual(parseDateTime("5/8/2020"));
+    expect(gridResult.D8).toEqual(parseDateTime("5/11/2020"));
+    expect(gridResult.D9).toEqual(parseDateTime("5/12/2020"));
+    expect(gridResult.D10).toEqual(parseDateTime("5/28/2020"));
     expect(gridResult.D11).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
     expect(gridResult.D12).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
-    expect(gridResult.D13).toEqual(parseDate("1/3/1900"));
-    expect(gridResult.D14).toEqual(parseDate("5/4/2020"));
+    expect(gridResult.D13).toEqual(parseDateTime("1/3/1900"));
+    expect(gridResult.D14).toEqual(parseDateTime("5/4/2020"));
 
-    expect(gridResult.D75).toEqual(parseDate("5/11/2020"));
-    expect(gridResult.D76).toEqual(parseDate("4/29/2020"));
-    expect(gridResult.D77).toEqual(parseDate("5/11/2020"));
-    expect(gridResult.D78).toEqual(parseDate("4/27/2020"));
-    expect(gridResult.D79).toEqual(parseDate("5/18/2020"));
-    expect(gridResult.D80).toEqual(parseDate("4/23/2020"));
-    expect(gridResult.D81).toEqual(parseDate("5/12/2020"));
-    expect(gridResult.D82).toEqual(parseDate("4/9/2020"));
-    expect(gridResult.D83).toEqual(parseDate("6/4/2020"));
+    expect(gridResult.D75).toEqual(parseDateTime("5/11/2020"));
+    expect(gridResult.D76).toEqual(parseDateTime("4/29/2020"));
+    expect(gridResult.D77).toEqual(parseDateTime("5/11/2020"));
+    expect(gridResult.D78).toEqual(parseDateTime("4/27/2020"));
+    expect(gridResult.D79).toEqual(parseDateTime("5/18/2020"));
+    expect(gridResult.D80).toEqual(parseDateTime("4/23/2020"));
+    expect(gridResult.D81).toEqual(parseDateTime("5/12/2020"));
+    expect(gridResult.D82).toEqual(parseDateTime("4/9/2020"));
+    expect(gridResult.D83).toEqual(parseDateTime("6/4/2020"));
   });
 
   test("WORKDAY.INTL: functional tests on cell arguments, number method", () => {
@@ -735,37 +735,37 @@ describe("date", () => {
     };
     const gridResult = evaluateGrid(grid);
     expect(gridResult.D18).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
-    expect(gridResult.D19).toEqual(parseDate("5/11/2020"));
-    expect(gridResult.D20).toEqual(parseDate("5/11/2020"));
-    expect(gridResult.D21).toEqual(parseDate("5/12/2020"));
-    expect(gridResult.D22).toEqual(parseDate("5/12/2020"));
-    expect(gridResult.D23).toEqual(parseDate("5/13/2020"));
-    expect(gridResult.D24).toEqual(parseDate("5/13/2020"));
-    expect(gridResult.D25).toEqual(parseDate("5/14/2020"));
-    expect(gridResult.D26).toEqual(parseDate("5/14/2020"));
-    expect(gridResult.D27).toEqual(parseDate("5/15/2020"));
-    expect(gridResult.D28).toEqual(parseDate("5/15/2020"));
-    expect(gridResult.D29).toEqual(parseDate("5/16/2020"));
-    expect(gridResult.D30).toEqual(parseDate("5/16/2020"));
-    expect(gridResult.D31).toEqual(parseDate("5/17/2020"));
-    expect(gridResult.D32).toEqual(parseDate("5/17/2020"));
+    expect(gridResult.D19).toEqual(parseDateTime("5/11/2020"));
+    expect(gridResult.D20).toEqual(parseDateTime("5/11/2020"));
+    expect(gridResult.D21).toEqual(parseDateTime("5/12/2020"));
+    expect(gridResult.D22).toEqual(parseDateTime("5/12/2020"));
+    expect(gridResult.D23).toEqual(parseDateTime("5/13/2020"));
+    expect(gridResult.D24).toEqual(parseDateTime("5/13/2020"));
+    expect(gridResult.D25).toEqual(parseDateTime("5/14/2020"));
+    expect(gridResult.D26).toEqual(parseDateTime("5/14/2020"));
+    expect(gridResult.D27).toEqual(parseDateTime("5/15/2020"));
+    expect(gridResult.D28).toEqual(parseDateTime("5/15/2020"));
+    expect(gridResult.D29).toEqual(parseDateTime("5/16/2020"));
+    expect(gridResult.D30).toEqual(parseDateTime("5/16/2020"));
+    expect(gridResult.D31).toEqual(parseDateTime("5/17/2020"));
+    expect(gridResult.D32).toEqual(parseDateTime("5/17/2020"));
     expect(gridResult.D33).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
 
     expect(gridResult.D39).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
-    expect(gridResult.D40).toEqual(parseDate("5/11/2020"));
-    expect(gridResult.D41).toEqual(parseDate("5/11/2020"));
-    expect(gridResult.D42).toEqual(parseDate("5/12/2020"));
-    expect(gridResult.D43).toEqual(parseDate("5/12/2020"));
-    expect(gridResult.D44).toEqual(parseDate("5/13/2020"));
-    expect(gridResult.D45).toEqual(parseDate("5/13/2020"));
-    expect(gridResult.D46).toEqual(parseDate("5/14/2020"));
-    expect(gridResult.D47).toEqual(parseDate("5/14/2020"));
-    expect(gridResult.D48).toEqual(parseDate("5/15/2020"));
-    expect(gridResult.D49).toEqual(parseDate("5/15/2020"));
-    expect(gridResult.D50).toEqual(parseDate("5/16/2020"));
-    expect(gridResult.D51).toEqual(parseDate("5/16/2020"));
-    expect(gridResult.D52).toEqual(parseDate("5/17/2020"));
-    expect(gridResult.D53).toEqual(parseDate("5/17/2020"));
+    expect(gridResult.D40).toEqual(parseDateTime("5/11/2020"));
+    expect(gridResult.D41).toEqual(parseDateTime("5/11/2020"));
+    expect(gridResult.D42).toEqual(parseDateTime("5/12/2020"));
+    expect(gridResult.D43).toEqual(parseDateTime("5/12/2020"));
+    expect(gridResult.D44).toEqual(parseDateTime("5/13/2020"));
+    expect(gridResult.D45).toEqual(parseDateTime("5/13/2020"));
+    expect(gridResult.D46).toEqual(parseDateTime("5/14/2020"));
+    expect(gridResult.D47).toEqual(parseDateTime("5/14/2020"));
+    expect(gridResult.D48).toEqual(parseDateTime("5/15/2020"));
+    expect(gridResult.D49).toEqual(parseDateTime("5/15/2020"));
+    expect(gridResult.D50).toEqual(parseDateTime("5/16/2020"));
+    expect(gridResult.D51).toEqual(parseDateTime("5/16/2020"));
+    expect(gridResult.D52).toEqual(parseDateTime("5/17/2020"));
+    expect(gridResult.D53).toEqual(parseDateTime("5/17/2020"));
     expect(gridResult.D54).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
   });
 
@@ -783,7 +783,7 @@ describe("date", () => {
     expect(gridResult.D69).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
     expect(gridResult.D70).toBe("#ERROR"); // @compatibility on Google Sheets, return  #NUM!
     expect(gridResult.D71).toBe("#ERROR"); // @compatibility on Google Sheets, return  #VALUE!
-    expect(gridResult.D72).toEqual(parseDate("5/12/2020"));
+    expect(gridResult.D72).toEqual(parseDateTime("5/12/2020"));
   });
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
Allows time management and accepts time formats such as:

- 'hh:mm' (ex: '13:27')
- 'hh:mm:ss' (ex: '17:42:06')
- 'hh:mm a' (ex: '03:23 AM')
- 'hh:mm:ss a' (ex: '06:02:18 PM')
- 'hhhh:mm:ss' (ex: '142:24:12')