### PR TITLE
[IMP] functions: Add env to the evaluation context

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -5,6 +5,7 @@ import { BottomBar } from "./bottom_bar";
 import { Grid } from "./grid";
 import { SidePanel } from "./side_panel/side_panel";
 import { TopBar } from "./top_bar";
+import { EvalContext } from "../types";
 
 const { Component, useState } = owl;
 const { useRef, useExternalListener } = owl.hooks;
@@ -61,12 +62,13 @@ export class Spreadsheet extends Component<Props> {
   static template = TEMPLATE;
   static style = CSS;
   static components = { TopBar, Grid, BottomBar, SidePanel };
-
+  private evalContext: EvalContext = {};
   model = new Model(this.props.data, {
     notifyUser: (content: string) => this.trigger("notify-user", { content }),
     askConfirmation: (content: string, confirm: () => any, cancel?: () => any) =>
       this.trigger("ask-confirmation", { content, confirm, cancel }),
     openSidePanel: (panel: string, panelProps: any = {}) => this.openSidePanel(panel, panelProps),
+    evalContext: this.evalContext,
   });
   grid = useRef("grid");
 
@@ -88,6 +90,7 @@ export class Spreadsheet extends Component<Props> {
       dispatch: this.model.dispatch,
       getters: this.model.getters,
     });
+    this.evalContext.env = this.env;
     useExternalListener(window as any, "resize", this.render);
     useExternalListener(document.body, "cut", this.copy.bind(this, true));
     useExternalListener(document.body, "copy", this.copy.bind(this, false));

--- a/src/model.ts
+++ b/src/model.ts
@@ -13,6 +13,7 @@ import {
   GridRenderingContext,
   LAYERS,
   CommandSuccess,
+  EvalContext,
 } from "./types/index";
 
 /**
@@ -47,6 +48,7 @@ export interface ModelConfig {
   openSidePanel: (panel: string, panelProps?: any) => void;
   notifyUser: (content: string) => any;
   askConfirmation: (content: string, confirm: () => any, cancel?: () => any) => any;
+  evalContext: EvalContext;
 }
 
 const enum Status {
@@ -113,6 +115,7 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
       openSidePanel: config.openSidePanel || (() => {}),
       notifyUser: config.notifyUser || (() => {}),
       askConfirmation: config.askConfirmation || (() => {}),
+      evalContext: config.evalContext || {},
     };
 
     // registering plugins

--- a/tests/functions/functions_test.ts
+++ b/tests/functions/functions_test.ts
@@ -1,5 +1,5 @@
 import { functionRegistry, args } from "../../src/functions/index";
-import { evaluateCell } from "../helpers";
+import { evaluateCell, getCell } from "../helpers";
 import { Model } from "../../src";
 
 describe("addFunction", () => {
@@ -15,16 +15,24 @@ describe("addFunction", () => {
     expect(evaluateCell("A1", { A1: "=DOUBLEDOUBLE(3)" })).toBe(6);
   });
 
-  test("Can use a getter in a function", () => {
-    const model = new Model();
-    functionRegistry.add("GETACTIVESHEET", {
-      description: "Get the name of the current sheet",
+  test("Can use a custom evaluation context in a function", () => {
+    const model = new Model(
+      {},
+      {
+        evalContext: {
+          coucou: "Raoul",
+        },
+      }
+    );
+    functionRegistry.add("GETCOUCOU", {
+      description: "Get coucou's name",
       compute: function () {
-        return (this as any).getters.getActiveSheet();
+        return (this as any).coucou;
       },
       args: args``,
       returns: ["STRING"],
     });
-    expect(evaluateCell("A1", { A1: "=GETACTIVESHEET()" })).toBe(model.getters.getActiveSheet());
+    model.dispatch("SET_VALUE", { xc: "A1", text: "=GETCOUCOU()" });
+    expect(getCell(model, "A1")!.value).toBe("Raoul");
   });
 });


### PR DESCRIPTION
Evaluating a function might require a particular service (e.g. an
rpc service). Since services are usually accessible from the
environnement in an Owl application, we make it avalaible in
the evaluation context of any function evaluation

```js
functionRegistry.add("GET_REMOTE_DATA", {
 description: "Call a remote procedure to get data",
 compute: async function () {
   return this.env.rpc(...);
  },
  args: args``,
  returns: ["STRING"],
});

```

In particular, this will be usefull to evaluate the `PIVOT` function
in the Odoo integration.

Note: this is a breaking change since `getters` are no longer
accessible in the function evaluation with `this.getters` but
with `this.env.getters`.