### PR TITLE
[FIX] functions: Make env available at plugin start 

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -5,7 +5,6 @@ import { BottomBar } from "./bottom_bar";
 import { Grid } from "./grid";
 import { SidePanel } from "./side_panel/side_panel";
 import { TopBar } from "./top_bar";
-import { EvalContext } from "../types";
 
 const { Component, useState } = owl;
 const { useRef, useExternalListener } = owl.hooks;
@@ -62,13 +61,12 @@ export class Spreadsheet extends Component<Props> {
   static template = TEMPLATE;
   static style = CSS;
   static components = { TopBar, Grid, BottomBar, SidePanel };
-  private evalContext: EvalContext = {};
   model = new Model(this.props.data, {
     notifyUser: (content: string) => this.trigger("notify-user", { content }),
     askConfirmation: (content: string, confirm: () => any, cancel?: () => any) =>
       this.trigger("ask-confirmation", { content, confirm, cancel }),
     openSidePanel: (panel: string, panelProps: any = {}) => this.openSidePanel(panel, panelProps),
-    evalContext: this.evalContext,
+    evalContext: { env: this.env },
   });
   grid = useRef("grid");
 
@@ -90,7 +88,6 @@ export class Spreadsheet extends Component<Props> {
       dispatch: this.model.dispatch,
       getters: this.model.getters,
     });
-    this.evalContext.env = this.env;
     useExternalListener(window as any, "resize", this.render);
     useExternalListener(document.body, "cut", this.copy.bind(this, true));
     useExternalListener(document.body, "copy", this.copy.bind(this, false));

--- a/src/plugins/evaluation.ts
+++ b/src/plugins/evaluation.ts
@@ -244,7 +244,9 @@ export class EvaluationPlugin extends BasePlugin {
       sheets[sheet.name] = sheet;
     }
 
-    const evalContext = Object.assign(Object.create(functionMap), this.evalContext);
+    const evalContext = Object.assign(Object.create(functionMap), this.evalContext, {
+      getters: this.getters,
+    });
 
     function readCell(xc: string, sheet: string): any {
       let cell;

--- a/tests/functions/functions_test.ts
+++ b/tests/functions/functions_test.ts
@@ -35,4 +35,17 @@ describe("addFunction", () => {
     model.dispatch("SET_VALUE", { xc: "A1", text: "=GETCOUCOU()" });
     expect(getCell(model, "A1")!.value).toBe("Raoul");
   });
+
+  test("Can use a getter in a function", () => {
+    const model = new Model();
+    functionRegistry.add("GETACTIVESHEET", {
+      description: "Get the name of the current sheet",
+      compute: function () {
+        return (this as any).getters.getActiveSheet();
+      },
+      args: args``,
+      returns: ["STRING"],
+    });
+    expect(evaluateCell("A1", { A1: "=GETACTIVESHEET()" })).toBe(model.getters.getActiveSheet());
+  });
 });


### PR DESCRIPTION
Commit 92dc378 added the env to the function evaluation context.
However it is not available when plugins start (at Model instanciation)
because the env is only added after the Spreadsheet subenv is created.
At this point, the model and all its plugins have already been started and
all function which requires the env failed.
The rational behind adding the env aftert was to use the same env as in the
entire spreadsheet application (= the Spreadsheet subenv). But it seems we
cannot achieve this since the subenv needs the model (getters and dispatch)
and the model needs the env.