### PR TITLE
[FIX] scrollbar disappear on addRowbefore/addRowAfter

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -546,7 +546,7 @@ export class CorePlugin extends BasePlugin {
       });
       start += size;
     }
-    this.history.updateLocalState(["height"], top);
+    this.history.updateLocalState(["height"], start);
     this.history.updateState(["rows"], rows);
   }
 

--- a/tests/plugins/grid_manipulation_test.ts
+++ b/tests/plugins/grid_manipulation_test.ts
@@ -479,6 +479,8 @@ describe("Rows", () => {
         { start: size + 30, end: size + 50, size: 20, name: "5", cells: {} },
         { start: size + 50, end: 2 * size + 50, size, name: "6", cells: {} },
       ]);
+      const dimensions = model.getters.getGridSize();
+      expect(dimensions).toEqual([192, 96]);
     });
     test("On addition after", () => {
       addRows(2, "after", 2);
@@ -491,6 +493,8 @@ describe("Rows", () => {
         { start: size + 50, end: size + 70, size: 20, name: "5", cells: {} },
         { start: size + 70, end: 2 * size + 70, size, name: "6", cells: {} },
       ]);
+      const dimensions = model.getters.getGridSize();
+      expect(dimensions).toEqual([192, 116]);
     });
   });
 


### PR DESCRIPTION
this commit fixes a bug that made the vertical scrollbar disappear
when adding a row to the grid

closes #285