### PR TITLE
[FIX] addRow height issues

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -546,8 +546,12 @@ export class CorePlugin extends BasePlugin {
       });
       start += size;
     }
-    this.history.updateLocalState(["height"], start);
+    const sheetID = this.workbook.sheets.findIndex(
+      (s) => s.name === this.workbook.activeSheet.name
+    )!;
+    this.history.updateLocalState(["height"], start + DEFAULT_CELL_HEIGHT + 5);
     this.history.updateState(["rows"], rows);
+    this.history.updateState(["sheets", sheetID, "rows"], rows);
   }
 
   private addEmptyRow() {

--- a/tests/plugins/grid_manipulation_test.ts
+++ b/tests/plugins/grid_manipulation_test.ts
@@ -480,7 +480,7 @@ describe("Rows", () => {
         { start: size + 50, end: 2 * size + 50, size, name: "6", cells: {} },
       ]);
       const dimensions = model.getters.getGridSize();
-      expect(dimensions).toEqual([192, 96]);
+      expect(dimensions).toEqual([192, 124]);
     });
     test("On addition after", () => {
       addRows(2, "after", 2);
@@ -494,7 +494,17 @@ describe("Rows", () => {
         { start: size + 70, end: 2 * size + 70, size, name: "6", cells: {} },
       ]);
       const dimensions = model.getters.getGridSize();
-      expect(dimensions).toEqual([192, 116]);
+      expect(dimensions).toEqual([192, 144]);
+    });
+
+    test("activate Sheet: same size", () => {
+      addRows(2, "after", 1);
+      let dimensions = model.getters.getGridSize();
+      expect(dimensions).toEqual([192, 124]);
+      model.dispatch("CREATE_SHEET", { activate: true });
+      model.dispatch("ACTIVATE_SHEET", { from: "Sheet2", to: "Sheet1" });
+      dimensions = model.getters.getGridSize();
+      expect(dimensions).toEqual([192, 124]);
     });
   });
 


### PR DESCRIPTION
when adding a row the size of the new row was correctly updated
in model -> rows but was not updated in model -> sheet -> rows.
this caused issues when activating a sheet where rows had been added.
The "padding" after the last row was also lost when adding a row.