### PR TITLE
[FIX] context_menu: hide children of children context_menu

### DIFF
--- a/src/components/context_menu/context_menu.ts
+++ b/src/components/context_menu/context_menu.ts
@@ -8,7 +8,7 @@ import {
 } from "./context_menu_registry";
 
 const { xml, css } = tags;
-const { useExternalListener } = hooks;
+const { useExternalListener, useRef } = hooks;
 
 const MENU_WIDTH = 200;
 const MENU_ITEM_HEIGHT = 32;
@@ -49,6 +49,7 @@ const TEMPLATE = xml/* xml */ `
         position="subMenu.position"
         menuItems="subMenu.menuItems"
         depth="props.depth + 1"
+        t-ref="subContextMenu"
         t-on-close="subMenu.isOpen=false"/>
     </div>`;
 
@@ -115,6 +116,7 @@ export class ContextMenu extends Component<Props, SpreadsheetEnv> {
     depth: 1,
   };
   private subMenu: MenuState;
+  subContextMenu = useRef("subContextMenu");
 
   constructor() {
     super(...arguments);
@@ -224,11 +226,19 @@ export class ContextMenu extends Component<Props, SpreadsheetEnv> {
     this.subMenu.isOpen = false;
   }
 
+  closeSubMenus() {
+    if (this.subContextMenu.comp) {
+      (<ContextMenu>this.subContextMenu.comp).closeSubMenus();
+    }
+    this.subMenu.isOpen = false;
+  }
+
   /**
    * If the given menu is not disabled, open it's submenu at the
    * correct position according to available surrounding space.
    */
-  openSubMenu(menu: RootContextMenuItem, position: number, delay: number) {
+  openSubMenu(menu: RootContextMenuItem, position: number) {
+    this.closeSubMenus();
     if (!menu.isEnabled || menu.isEnabled(this.env.getters.getActiveCell())) {
       this.subMenu.isOpen = true;
       this.subMenu.menuItems = menu.subMenus(this.env);

--- a/tests/components/context_menu_test.ts
+++ b/tests/components/context_menu_test.ts
@@ -414,6 +414,61 @@ describe("Context Menu", () => {
     await nextTick();
     expect(fixture.querySelector(".o-context-menu div[data-name='subMenu']")).toBeTruthy();
   });
+
+  test("Submenus are correctly hidden", async () => {
+    const menuItems: ContextMenuItem[] = [
+      {
+        type: "root",
+        name: "root_1",
+        description: "root_1",
+        subMenus: () => [
+          {
+            type: "root",
+            name: "root_1_1",
+            description: "root_1_1",
+            subMenus: () => [
+              {
+                type: "action",
+                name: "subMenu_1",
+                description: "subMenu_1",
+                action() {},
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "root",
+        name: "root_2",
+        description: "root_2",
+        subMenus: () => [
+          {
+            type: "root",
+            name: "root_2_1",
+            description: "root_2_1",
+            subMenus: () => [
+              {
+                type: "action",
+                name: "subMenu_2",
+                description: "subMenu_2",
+                action() {},
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    await renderContextMenu(300, 300, { menuItems });
+
+    triggerMouseEvent(".o-context-menu div[data-name='root_1']", "mouseover");
+    await nextTick();
+    triggerMouseEvent(".o-context-menu div[data-name='root_1_1']", "mouseover");
+    await nextTick();
+    expect(fixture.querySelector(".o-context-menu div[data-name='subMenu_1']")).toBeTruthy();
+    triggerMouseEvent(".o-context-menu div[data-name='root_2']", "mouseover");
+    await nextTick();
+    expect(fixture.querySelector(".o-context-menu div[data-name='subMenu_1']")).toBeFalsy();
+  });
 });
 
 describe("Context Menu position", () => {


### PR DESCRIPTION
Steps to reproduce, with the following structure:

    [menu1] (root)
        [menu2] (root)
            [menu3] (action)
    [menuA] (root)
        [menuB] (action)

1) hover menu1 and menu2:
    [menu1][menu2][menu3]
    [menuA]

2) hover menuA:
    [menu1]       [menu3]
    [menuA][menuB]

This commit fixes this behavior.