### PR TITLE
[FIX] context menu: does not close when clicking on menu/tool bar

### DIFF
--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -1,0 +1,7 @@
+/**
+ * Return true if the event was triggered from
+ * a child element.
+ */
+export function isChildEvent(parent: HTMLElement, ev: Event): boolean {
+  return !!ev.target && parent!.contains(ev.target as Node);
+}

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -4,6 +4,7 @@ import { SpreadsheetEnv } from "../types";
 import { BOTTOMBAR_HEIGHT } from "../constants";
 import { FullMenuItem } from "../registries";
 import { cellMenuRegistry } from "../registries/menus/cell_menu_registry";
+import { isChildEvent } from "./helpers/dom_helpers";
 
 const { xml, css } = tags;
 const { useExternalListener, useRef } = hooks;
@@ -187,17 +188,9 @@ export class Menu extends Component<Props, SpreadsheetEnv> {
     return this.props.menuItems.slice(0, index).length * MENU_ITEM_HEIGHT;
   }
 
-  /**
-   * Return true if the event was triggered from
-   * a child element.
-   */
-  private isChildEvent(ev: Event) {
-    return ev.target && this.el!.contains(ev.target as Node);
-  }
-
   private onClick(ev: MouseEvent) {
     // Don't close a root menu when clicked to open the submenus.
-    if (this.isChildEvent(ev)) {
+    if (this.el && isChildEvent(this.el, ev)) {
       return;
     }
     this.close();
@@ -205,7 +198,7 @@ export class Menu extends Component<Props, SpreadsheetEnv> {
 
   private onContextMenu(ev: MouseEvent) {
     // Don't close a root menu when clicked to open the submenus.
-    if (this.isChildEvent(ev)) {
+    if (this.el && isChildEvent(this.el, ev)) {
       return;
     }
     this.subMenu.isOpen = false;

--- a/tests/components/context_menu_test.ts
+++ b/tests/components/context_menu_test.ts
@@ -264,6 +264,42 @@ describe("Context Menu", () => {
     expect(fixture.querySelector(".o-menu")).toBeTruthy();
   });
 
+  test("close contextmenu when clicking on menubar", async () => {
+    const model = new Model();
+    const parent = new GridParent(model);
+    await parent.mount(fixture);
+    simulateContextMenu(100, 100);
+    await nextTick();
+    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
+    triggerMouseEvent(".o-topbar-menus", "click");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeFalsy();
+  });
+
+  test("close contextmenu when clicking on menubar item", async () => {
+    const model = new Model();
+    const parent = new GridParent(model);
+    await parent.mount(fixture);
+    simulateContextMenu(100, 100);
+    await nextTick();
+    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
+    triggerMouseEvent(".o-topbar-menu[data-id='file']", "click");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeFalsy();
+  });
+  test("close contextmenu when clicking on tools bar", async () => {
+    const model = new Model();
+    const parent = new GridParent(model);
+    await parent.mount(fixture);
+    simulateContextMenu(100, 100);
+    await nextTick();
+    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
+    const fontSizeTool = fixture.querySelector('.o-tool[title="Font Size"]')!;
+    triggerMouseEvent(fontSizeTool, "click");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeFalsy();
+  });
+
   test("menu can be hidden/displayed based on the env", async () => {
     const menuDefinitions = Object.assign({}, cellMenuRegistry.content);
     cellMenuRegistry


### PR DESCRIPTION
the context menu wasn't closing when clicking on the menu/toolbar.
this because the menu/toolbar did t-on-click.stop and therefore the click
was never noticed by the listener in the context menu

closes #359