### PR TITLE
[FIX] numbers: correctly format exponential numbers

### DIFF
--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -51,9 +51,13 @@ export function formatDecimal(n: number, decimals: number, sep: string = ""): st
   if (n < 0) {
     return "-" + formatDecimal(-n, decimals);
   }
-  const exponentString = `${n}e${decimals}`;
-  const value = Math.round(Number(exponentString));
-  let result = Number(`${value}e-${decimals}`).toFixed(decimals);
+  let number = n;
+  if (!n.toString().includes("e")) {
+    const exponentString = `${n}e${decimals}`;
+    const value = Math.round(Number(exponentString));
+    number = Number(`${value}e-${decimals}`);
+  }
+  let result = number.toFixed(decimals);
   if (sep) {
     let p: number = result.indexOf(".")!;
     result = result.replace(/\d(?=(?:\d{3})+(?:\.|$))/g, (m, i) =>

--- a/tests/plugins/formatting_test.ts
+++ b/tests/plugins/formatting_test.ts
@@ -121,4 +121,12 @@ describe("formatting values (with formatters)", () => {
     setFormat(model, "mm/dd/yyyy");
     expect(model.getters.getCellText(model["workbook"].cells.A1)).toBe("Test");
   });
+
+  test("Can set number format to low value", () => {
+    const model = new Model();
+    model.dispatch("SET_VALUE", { xc: "A1", text: "0.0000001" });
+    model.dispatch("SELECT_CELL", { col: 0, row: 0 });
+    setFormat(model, "#,##0.00");
+    expect(model.getters.getCellText(model["workbook"].cells.A1)).toBe("0.00");
+  });
 });


### PR DESCRIPTION
In a cell, type 0.0000001 and format as number. It gives NaN instead of 0.00