### PR TITLE
[FIX] numbers: correctly format exponential numbers

### DIFF
--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -51,7 +51,7 @@ export function formatDecimal(n: number, decimals: number, sep: string = ""): st
   if (n < 0) {
     return "-" + formatDecimal(-n, decimals);
   }
-  const exponentString = `${n}e${decimals}`;
+  const exponentString = `${n.toLocaleString("fullwide", { useGrouping: false })}e${decimals}`;
   const value = Math.round(Number(exponentString));
   let result = Number(`${value}e-${decimals}`).toFixed(decimals);
   if (sep) {

--- a/tests/helpers/numbers_test.ts
+++ b/tests/helpers/numbers_test.ts
@@ -144,6 +144,16 @@ describe("formatNumber function", () => {
     expect(formatNumber(100000, "#,##0.00")).toBe("100,000.00");
     expect(formatNumber(1000000, "#,##0.00")).toBe("1,000,000.00");
     expect(formatNumber(-1000000, "#,##0.00")).toBe("-1,000,000.00");
+    expect(formatNumber(0.1, "#,##0.00")).toBe("0.10");
+    expect(formatNumber(0.01, "#,##0.00")).toBe("0.01");
+    expect(formatNumber(0.001, "#,##0.00")).toBe("0.00");
+    expect(formatNumber(0.0001, "#,##0.00")).toBe("0.00");
+    expect(formatNumber(0.00001, "#,##0.00")).toBe("0.00");
+    expect(formatNumber(0.000001, "#,##0.00")).toBe("0.00");
+    expect(formatNumber(0.0000001, "#,##0.00")).toBe("0.00");
+    expect(formatNumber(0.00000001, "#,##0.00")).toBe("0.00");
+    expect(formatNumber(0.000000001, "#,##0.00")).toBe("0.00");
+    expect(formatNumber(0.0000000001, "#,##0.00")).toBe("0.00");
   });
 
   test("formatPercent", () => {


### PR DESCRIPTION
When we have small number, JS automatically converts them to exponential
notation, which is an issue with our formatDecimals function.

This commit fixes the issue by disabling the conversion to exponential
notation.