### PR TITLE
[FIX] grid: Display error tooltip for whole merge

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -6,7 +6,7 @@ import {
   SCROLLBAR_WIDTH,
   HEADER_HEIGHT,
 } from "../constants";
-import { isEqual, isInside } from "../helpers/index";
+import { isEqual, isInside, toXC, toCartesian } from "../helpers/index";
 import { Model } from "../model";
 import { SpreadsheetEnv, Viewport } from "../types/index";
 import { Composer } from "./composer/composer";
@@ -87,7 +87,8 @@ function useErrorTooltip(env: SpreadsheetEnv, getViewPort: () => Viewport): Erro
       if (400 < delta && delta < 600) {
         // mouse did not move for a short while
         const [col, row] = getPosition();
-        const cell = env.getters.getCell(col, row);
+        const mainXc = getters.getMainCell(toXC(col, row));
+        const cell = getters.getCell(...toCartesian(mainXc));
         if (cell && cell.error) {
           tooltip.isOpen = true;
           tooltip.text = cell.error;

--- a/tests/components/grid_test.ts
+++ b/tests/components/grid_test.ts
@@ -365,6 +365,7 @@ describe("error tooltip", () => {
   let currentTime = 0;
 
   beforeEach(async () => {
+    currentTime = 0;
     model = new Model();
     parent = new GridParent(model);
 
@@ -404,5 +405,18 @@ describe("error tooltip", () => {
     intervalCb();
     await nextTick();
     expect(document.querySelector(".o-error-tooltip")).toBeNull();
+  });
+
+  test("can display error when move on merge", async () => {
+    const sheet = model.getters.getActiveSheet();
+    model.dispatch("ADD_MERGE", { sheet, zone: toZone("C1:C8") });
+    model.dispatch("SET_VALUE", { xc: "C1", text: "=1/0" });
+    await nextTick();
+    triggerMouseEvent("canvas", "mousemove", 300, 200); // C8
+
+    currentTime = 500;
+    intervalCb();
+    await nextTick();
+    expect(document.querySelector(".o-error-tooltip")).not.toBeNull();
   });
 });


### PR DESCRIPTION
Merge A1:A2 and set an invalid formula (e.g. `=1/0`).
Hover (what used to be) A2 with the mouse.
The error tooltip should appear.

fixes #314