### PR TITLE
[FIX] Selection after insert before loses selection

### DIFF
--- a/src/plugins/selection.ts
+++ b/src/plugins/selection.ts
@@ -148,12 +148,12 @@ export class SelectionPlugin extends BasePlugin {
         break;
       case "ADD_COLUMNS":
         if (cmd.position === "before") {
-          this.onAddColumns(cmd.column, cmd.quantity);
+          this.onAddColumns(cmd.quantity);
         }
         break;
       case "ADD_ROWS":
         if (cmd.position === "before") {
-          this.onAddRows(cmd.row, cmd.quantity);
+          this.onAddRows(cmd.quantity);
         }
         break;
     }
@@ -422,16 +422,26 @@ export class SelectionPlugin extends BasePlugin {
     this.dispatch("SET_SELECTION", { zones, anchor: [anchorCol, anchorRow] });
   }
 
-  private onAddColumns(column: number, quantity: number) {
-    let start = column + quantity;
-    const zone = this.getters.getColsZone(start, start + quantity - 1);
-    this.dispatch("SET_SELECTION", { zones: [zone], anchor: [start, 0], strict: true });
+  private onAddColumns(quantity: number) {
+    const selection = this.getSelectedZone();
+    const zone = {
+      left: selection.left + quantity,
+      right: selection.right + quantity,
+      top: selection.top,
+      bottom: selection.bottom,
+    };
+    this.dispatch("SET_SELECTION", { zones: [zone], anchor: [zone.left, zone.top], strict: true });
   }
 
-  private onAddRows(row: number, quantity: number) {
-    const start = row + quantity;
-    const zone = this.getters.getRowsZone(start, start + quantity - 1);
-    this.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, start], strict: true });
+  private onAddRows(quantity: number) {
+    const selection = this.getSelectedZone();
+    const zone = {
+      left: selection.left,
+      right: selection.right,
+      top: selection.top + quantity,
+      bottom: selection.bottom + quantity,
+    };
+    this.dispatch("SET_SELECTION", { zones: [zone], anchor: [zone.left, zone.top], strict: true });
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/plugins/grid_manipulation_test.ts
+++ b/tests/plugins/grid_manipulation_test.ts
@@ -435,6 +435,57 @@ describe("Columns", () => {
       expect(model.exportData()).toEqual(beforeAdd);
     });
   });
+
+  describe("Correctly update selection", () => {
+    test("On add left 1", () => {
+      model = new Model(fullData);
+      const zone = { left: 1, right: 3, top: 0, bottom: 2 };
+      model.dispatch("SET_SELECTION", {
+        zones: [zone],
+        anchor: [zone.left, zone.top],
+        strict: true,
+      });
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 1, right: 3, top: 0 });
+      addColumns(1, "before", 1);
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 2, right: 4, top: 0 });
+    });
+    test("On add left 3", () => {
+      model = new Model(fullData);
+      const zone = { left: 1, right: 3, top: 0, bottom: 2 };
+      model.dispatch("SET_SELECTION", {
+        zones: [zone],
+        anchor: [zone.left, zone.top],
+        strict: true,
+      });
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 1, right: 3, top: 0 });
+      addColumns(1, "before", 3);
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 4, right: 6, top: 0 });
+    });
+    test("On add right 1", () => {
+      model = new Model(fullData);
+      const zone = { left: 1, right: 3, top: 0, bottom: 2 };
+      model.dispatch("SET_SELECTION", {
+        zones: [zone],
+        anchor: [zone.left, zone.top],
+        strict: true,
+      });
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 1, right: 3, top: 0 });
+      addColumns(1, "after", 1);
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 1, right: 3, top: 0 });
+    });
+    test("On add right 3", () => {
+      model = new Model(fullData);
+      const zone = { left: 1, right: 3, top: 0, bottom: 2 };
+      model.dispatch("SET_SELECTION", {
+        zones: [zone],
+        anchor: [zone.left, zone.top],
+        strict: true,
+      });
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 1, right: 3, top: 0 });
+      addColumns(1, "after", 1);
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 1, right: 3, top: 0 });
+    });
+  });
 });
 
 //------------------------------------------------------------------------------
@@ -730,6 +781,57 @@ describe("Rows", () => {
       undo();
       undo();
       expect(model.exportData()).toEqual(beforeAdd);
+    });
+  });
+
+  describe("Correctly update selection", () => {
+    test("On add top 1", () => {
+      model = new Model(fullData);
+      const zone = { left: 2, right: 3, top: 0, bottom: 1 };
+      model.dispatch("SET_SELECTION", {
+        zones: [zone],
+        anchor: [zone.left, zone.top],
+        strict: true,
+      });
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 1, left: 2, right: 3, top: 0 });
+      addRows(0, "before", 1);
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 2, right: 3, top: 1 });
+    });
+    test("On add top 3", () => {
+      model = new Model(fullData);
+      const zone = { left: 2, right: 3, top: 0, bottom: 1 };
+      model.dispatch("SET_SELECTION", {
+        zones: [zone],
+        anchor: [zone.left, zone.top],
+        strict: true,
+      });
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 1, left: 2, right: 3, top: 0 });
+      addRows(0, "before", 3);
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 4, left: 2, right: 3, top: 3 });
+    });
+    test("On add bottom 1", () => {
+      model = new Model(fullData);
+      const zone = { left: 2, right: 3, top: 0, bottom: 1 };
+      model.dispatch("SET_SELECTION", {
+        zones: [zone],
+        anchor: [zone.left, zone.top],
+        strict: true,
+      });
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 1, left: 2, right: 3, top: 0 });
+      addRows(0, "after", 1);
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 1, left: 2, right: 3, top: 0 });
+    });
+    test("On add bottom 3", () => {
+      model = new Model(fullData);
+      const zone = { left: 1, right: 3, top: 0, bottom: 2 };
+      model.dispatch("SET_SELECTION", {
+        zones: [zone],
+        anchor: [zone.left, zone.top],
+        strict: true,
+      });
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 1, right: 3, top: 0 });
+      addRows(0, "after", 3);
+      expect(model.getters.getSelectedZone()).toEqual({ bottom: 2, left: 1, right: 3, top: 0 });
     });
   });
 });


### PR DESCRIPTION
Inserting row/col before the currently selected cell selects the full new row, but doing it after keeps the current selection.

with this commit the selection is preserved,  the selected zone to stays selected

closes #399