### PR TITLE
[FIX] clipboard: Don't paste if nothing was copied

### DIFF
--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -417,6 +417,7 @@ export const enum CancelledReason {
   WrongSheetName,
   SelectionOutOfBound,
   WrongPasteSelection,
+  EmptyClipboard,
 }
 
 export type CommandResult = CommandSuccess | CommandCancelled;

--- a/tests/plugins/clipboard_test.ts
+++ b/tests/plugins/clipboard_test.ts
@@ -65,6 +65,22 @@ describe("clipboard", () => {
     expect(getCell(model, "D3")).toBeNull();
   });
 
+  test("paste without copied value", () => {
+    const model = new Model();
+    const result = model.dispatch("PASTE", { target: target("D2") });
+    expect(result).toEqual({
+      status: "CANCELLED",
+      reason: CancelledReason.EmptyClipboard,
+    });
+  });
+
+  test("paste zones without copied value", () => {
+    const model = new Model();
+    const zones = target("A1,B2");
+    const pasteZone = model.getters.getPasteZones(zones);
+    expect(pasteZone).toEqual(zones);
+  });
+
   test("can cut and paste a cell in differents sheets", () => {
     const model = new Model();
     model.dispatch("SET_VALUE", { xc: "A1", text: "a1" });


### PR DESCRIPTION
If the clipboard is empty, PASTE commands should be cancelled.
They currently crash.

If no cells are in the clipboard, the `getPasteZones` getter should return the target
unmodified.