### PR TITLE
[FIX] menus: Copy/paste to/from OS clipboard

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -92,6 +92,7 @@ export class Spreadsheet extends Component<Props> {
       dispatch: this.model.dispatch,
       getters: this.model.getters,
       _t: Spreadsheet._t,
+      clipboard: navigator.clipboard,
     });
     useExternalListener(window as any, "resize", this.render);
     useExternalListener(document.body, "cut", this.copy.bind(this, true));

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -1,6 +1,5 @@
-import { SpreadsheetEnv } from "../../types/env";
-import { Style } from "../../types/misc";
-import { numberToLetters } from "../../helpers/coordinates";
+import { Style, SpreadsheetEnv } from "../../types/index";
+import { numberToLetters } from "../../helpers/index";
 import { _lt } from "../../translation";
 
 //------------------------------------------------------------------------------
@@ -51,14 +50,36 @@ export const UNDO_ACTION = (env: SpreadsheetEnv) => env.dispatch("UNDO");
 
 export const REDO_ACTION = (env: SpreadsheetEnv) => env.dispatch("REDO");
 
-export const COPY_ACTION = (env: SpreadsheetEnv) =>
+export const COPY_ACTION = async (env: SpreadsheetEnv) => {
   env.dispatch("COPY", { target: env.getters.getSelectedZones() });
+  await env.clipboard.writeText(env.getters.getClipboardContent());
+};
 
-export const CUT_ACTION = (env: SpreadsheetEnv) =>
+export const CUT_ACTION = async (env: SpreadsheetEnv) => {
   env.dispatch("CUT", { target: env.getters.getSelectedZones() });
+  await env.clipboard.writeText(env.getters.getClipboardContent());
+};
 
-export const PASTE_ACTION = (env: SpreadsheetEnv) =>
-  env.dispatch("PASTE", { target: env.getters.getSelectedZones(), interactive: true });
+export const PASTE_ACTION = async (env: SpreadsheetEnv) => {
+  const spreadsheetClipboard = env.getters.getClipboardContent();
+  let osClipboard;
+  try {
+    osClipboard = await env.clipboard.readText();
+  } catch (e) {
+    // Permission is required to read the clipboard.
+    console.warn("The OS clipboard could not be read.");
+    console.error(e);
+  }
+  const target = env.getters.getSelectedZones();
+  if (osClipboard && osClipboard !== spreadsheetClipboard) {
+    env.dispatch("PASTE_FROM_OS_CLIPBOARD", {
+      target,
+      text: osClipboard,
+    });
+  } else {
+    env.dispatch("PASTE", { target, interactive: true });
+  }
+};
 
 export const PASTE_FORMAT_ACTION = (env: SpreadsheetEnv) =>
   env.dispatch("PASTE", { target: env.getters.getSelectedZones(), onlyFormat: true });
@@ -74,8 +95,8 @@ export const DELETE_CONTENT_ACTION = (env: SpreadsheetEnv) =>
 //------------------------------------------------------------------------------
 
 export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetEnv) => {
-  let first = 0;
-  let last = 0;
+  let first: number;
+  let last: number;
   const activesRows = env.getters.getActiveRows();
   if (activesRows.size !== 0) {
     first = Math.min(...activesRows);
@@ -102,8 +123,8 @@ export const DELETE_CONTENT_ROWS_ACTION = (env: SpreadsheetEnv) => {
 };
 
 export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetEnv) => {
-  let first = 0;
-  let last = 0;
+  let first: number;
+  let last: number;
   const activeCols = env.getters.getActiveCols();
   if (activeCols.size !== 0) {
     first = Math.min(...activeCols);
@@ -130,8 +151,8 @@ export const DELETE_CONTENT_COLUMNS_ACTION = (env: SpreadsheetEnv) => {
 };
 
 export const REMOVE_ROWS_NAME = (env: SpreadsheetEnv) => {
-  let first = 0;
-  let last = 0;
+  let first: number;
+  let last: number;
   const activesRows = env.getters.getActiveRows();
   if (activesRows.size !== 0) {
     first = Math.min(...activesRows);
@@ -162,8 +183,8 @@ export const REMOVE_ROWS_ACTION = (env: SpreadsheetEnv) => {
 };
 
 export const REMOVE_COLUMNS_NAME = (env: SpreadsheetEnv) => {
-  let first = 0;
-  let last = 0;
+  let first: number;
+  let last: number;
   const activeCols = env.getters.getActiveCols();
   if (activeCols.size !== 0) {
     first = Math.min(...activeCols);
@@ -211,8 +232,8 @@ export const CELL_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetEnv) => {
 
 export const INSERT_ROWS_BEFORE_ACTION = (env: SpreadsheetEnv) => {
   const activeRows = env.getters.getActiveRows();
-  let row = 0;
-  let quantity = 0;
+  let row: number;
+  let quantity: number;
   if (activeRows.size) {
     row = Math.min(...activeRows);
     quantity = activeRows.size;
@@ -239,8 +260,8 @@ export const MENU_INSERT_ROWS_AFTER_NAME = (env: SpreadsheetEnv) => {
 
 export const INSERT_ROWS_AFTER_ACTION = (env: SpreadsheetEnv) => {
   const activeRows = env.getters.getActiveRows();
-  let row = 0;
-  let quantity = 0;
+  let row: number;
+  let quantity: number;
   if (activeRows.size) {
     row = Math.max(...activeRows);
     quantity = activeRows.size;
@@ -275,8 +296,8 @@ export const CELL_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetEnv) => {
 
 export const INSERT_COLUMNS_BEFORE_ACTION = (env: SpreadsheetEnv) => {
   const activeCols = env.getters.getActiveCols();
-  let column = 0;
-  let quantity = 0;
+  let column: number;
+  let quantity: number;
   if (activeCols.size) {
     column = Math.min(...activeCols);
     quantity = activeCols.size;
@@ -303,8 +324,8 @@ export const MENU_INSERT_COLUMNS_AFTER_NAME = (env: SpreadsheetEnv) => {
 
 export const INSERT_COLUMNS_AFTER_ACTION = (env: SpreadsheetEnv) => {
   const activeCols = env.getters.getActiveCols();
-  let column = 0;
-  let quantity = 0;
+  let column: number;
+  let quantity: number;
   if (activeCols.size) {
     column = Math.max(...activeCols);
     quantity = activeCols.size;

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -6,4 +6,5 @@ export interface SpreadsheetEnv extends Env {
   openSidePanel: (panel: string, panelProps?: any) => void;
   dispatch: CommandDispatcher["dispatch"];
   getters: Getters;
+  clipboard: Clipboard;
 }

--- a/tests/components/spreadsheet_test.ts
+++ b/tests/components/spreadsheet_test.ts
@@ -2,13 +2,21 @@ import { Component, hooks, tags } from "@odoo/owl";
 import { Model } from "../../src";
 import { Spreadsheet } from "../../src/components";
 import { args, functionRegistry } from "../../src/functions";
-import { makeTestFixture, nextTick } from "../helpers";
+import { makeTestFixture, nextTick, MockClipboard } from "../helpers";
 
 const { xml } = tags;
 const { useRef } = hooks;
 
 let fixture: HTMLElement;
 let parent: Parent;
+const clipboard = new MockClipboard();
+
+Object.defineProperty(navigator, "clipboard", {
+  get() {
+    return clipboard;
+  },
+  configurable: true,
+});
 
 class Parent extends Component<any> {
   static template = xml`<Spreadsheet t-ref="spreadsheet" data="data"/>`;
@@ -94,5 +102,9 @@ describe("Spreadsheet", () => {
     });
     await parent.mount(fixture);
     expect(env).toBeTruthy();
+  });
+
+  test("Clipboard is in spreadsheet env", () => {
+    expect((parent as any).spreadsheet.comp.env.clipboard).toBe(clipboard);
   });
 });

--- a/tests/components/top_bar_test.ts
+++ b/tests/components/top_bar_test.ts
@@ -275,7 +275,6 @@ describe("TopBar component", () => {
       sequence: 1,
       action: () => {
         number++;
-        return { status: "SUCCESS" };
       },
     });
     const parent = new Parent(new Model());

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -37,6 +37,25 @@ export function makeTestFixture() {
 
 const t = (s: string): string => s;
 
+export class MockClipboard {
+  private content: string = "Some random clipboard content";
+
+  readText(): Promise<string> {
+    return Promise.resolve(this.content);
+  }
+
+  writeText(content: string): Promise<void> {
+    this.content = content;
+    return Promise.resolve();
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() {
+    return false;
+  }
+}
+
 export class GridParent extends Component<any, SpreadsheetEnv> {
   static template = xml`
     <div class="parent">
@@ -66,6 +85,7 @@ export class GridParent extends Component<any, SpreadsheetEnv> {
       dispatch: model.dispatch,
       getters: model.getters,
       _t: GridParent._t,
+      clipboard: new MockClipboard(),
     });
 
     const drawGrid = model.drawGrid;


### PR DESCRIPTION
This commit fixes two issues:

1) copying with the menu did not put the copied content to
the OS clipboard

2) pasting with the menu did not take into account the OS clipboard

Using the OS clipboard in the menu actions required to make actions
asynchronous since reading and writing in the clipboard is asynchronous.

fixes #304