### PR TITLE
[FIX] composer: allow to select a cell after a space

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -175,7 +175,7 @@ export class Composer extends Component<any, SpreadsheetEnv> {
   // Handlers
   // ---------------------------------------------------------------------------
 
-  processArrowKeys(ev: KeyboardEvent, delta: Array<number>) {
+  processArrowKeys(ev: KeyboardEvent) {
     if (this.getters.getEditionMode() === "selecting") {
       ev.preventDefault();
       return;
@@ -396,7 +396,7 @@ export class Composer extends Component<any, SpreadsheetEnv> {
         this.autoCompleteState.search = this.tokenAtCursor.value;
         this.autoCompleteState.showProvider = true;
       }
-    } else if (["COMMA", "LEFT_PAREN", "OPERATOR"].includes(this.tokenAtCursor.type)) {
+    } else if (["COMMA", "LEFT_PAREN", "OPERATOR", "SPACE"].includes(this.tokenAtCursor.type)) {
       // we need to reset the anchor of the selection to the active cell, so the next Arrow key down
       // is relative the to the cell we edit
       this.dispatch("START_COMPOSER_SELECTION");

--- a/tests/components/composer_test.ts
+++ b/tests/components/composer_test.ts
@@ -248,6 +248,12 @@ describe("composer", () => {
     await nextTick();
     expect(model.getters.getCurrentContent()).toBe("");
   });
+
+  test("typing a formula with a space should put the composer in 'selecting' mode", async () => {
+    await startComposition();
+    await typeInComposer("= ");
+    expect(model.getters.getEditionMode()).toBe("selecting");
+  });
 });
 
 describe("composer highlights color", () => {


### PR DESCRIPTION
Scenario:  after typing a space in the composer, if the user used the arrow keys
Before this fix, he would change the active cell.
After this fix, he will be able to select a cell to use as reference.

closes #212