### PR TITLE
[FIX] test: snapshot test nondeterminism

### DIFF
--- a/tests/components/spreadsheet_test.ts
+++ b/tests/components/spreadsheet_test.ts
@@ -47,6 +47,7 @@ afterEach(() => {
 
 describe("Spreadsheet", () => {
   test("simple rendering snapshot", async () => {
+    await nextTick();
     expect(fixture.querySelector(".o-spreadsheet")).toMatchSnapshot();
   });
 


### PR DESCRIPTION
Sometimes the test "simple rendering snapshot" failed because the
viewport didn't have the correct size.
With this fix I hope to ensure it always has time to take its correct
size before verifying the snapshot.