### PR TITLE
[IMP] clipboard: allow copy/paste value only

### DIFF
--- a/src/plugins/conditional_format.ts
+++ b/src/plugins/conditional_format.ts
@@ -79,7 +79,9 @@ export class ConditionalFormatPlugin extends BasePlugin {
         this.isStale = true;
         break;
       case "PASTE_CELL":
-        this.pasteCf(cmd.originCol, cmd.originRow, cmd.col, cmd.row, cmd.sheet, cmd.cut);
+        if (!cmd.onlyValue) {
+          this.pasteCf(cmd.originCol, cmd.originRow, cmd.col, cmd.row, cmd.sheet, cmd.cut);
+        }
         break;
       case "EVALUATE_CELLS":
       case "UPDATE_CELL":

--- a/src/registries/menus/cell_menu_registry.ts
+++ b/src/registries/menus/cell_menu_registry.ts
@@ -31,9 +31,14 @@ cellMenuRegistry
     sequence: 40,
     separator: true,
   })
+  .addChild("paste_value_only", ["paste_special"], {
+    name: _lt("Paste value only"),
+    sequence: 10,
+    action: ACTIONS.PASTE_VALUE_ACTION,
+  })
   .addChild("paste_format_only", ["paste_special"], {
     name: _lt("Paste format only"),
-    sequence: 10,
+    sequence: 20,
     action: ACTIONS.PASTE_FORMAT_ACTION,
   })
   .add("add_row_before", {

--- a/src/registries/menus/col_menu_registry.ts
+++ b/src/registries/menus/col_menu_registry.ts
@@ -26,9 +26,14 @@ colMenuRegistry
     sequence: 40,
     separator: true,
   })
+  .addChild("paste_value_only", ["paste_special"], {
+    name: _lt("Paste value only"),
+    sequence: 10,
+    action: ACTIONS.PASTE_VALUE_ACTION,
+  })
   .addChild("paste_format_only", ["paste_special"], {
     name: _lt("Paste format only"),
-    sequence: 10,
+    sequence: 20,
     action: ACTIONS.PASTE_FORMAT_ACTION,
   })
   .add("conditional_formatting", {

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -81,6 +81,9 @@ export const PASTE_ACTION = async (env: SpreadsheetEnv) => {
   }
 };
 
+export const PASTE_VALUE_ACTION = (env: SpreadsheetEnv) =>
+  env.dispatch("PASTE", { target: env.getters.getSelectedZones(), onlyValue: true });
+
 export const PASTE_FORMAT_ACTION = (env: SpreadsheetEnv) =>
   env.dispatch("PASTE", { target: env.getters.getSelectedZones(), onlyFormat: true });
 

--- a/src/registries/menus/row_menu_registry.ts
+++ b/src/registries/menus/row_menu_registry.ts
@@ -26,9 +26,14 @@ rowMenuRegistry
     sequence: 40,
     separator: true,
   })
+  .addChild("paste_value_only", ["paste_special"], {
+    name: _lt("Paste value only"),
+    sequence: 10,
+    action: ACTIONS.PASTE_VALUE_ACTION,
+  })
   .addChild("paste_format_only", ["paste_special"], {
     name: _lt("Paste format only"),
-    sequence: 10,
+    sequence: 20,
     action: ACTIONS.PASTE_FORMAT_ACTION,
   })
   .add("conditional_formatting", {

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -49,6 +49,11 @@ topbarMenuRegistry
     sequence: 60,
     separator: true,
   })
+  .addChild("paste_special_value", ["edit", "paste_special"], {
+    name: _lt("Paste value only"),
+    sequence: 10,
+    action: ACTIONS.PASTE_VALUE_ACTION,
+  })
   .addChild("paste_special_format", ["edit", "paste_special"], {
     name: _lt("Paste format only"),
     sequence: 20,

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -166,6 +166,7 @@ export interface CutCommand extends BaseCommand {
 export interface PasteCommand extends BaseCommand {
   type: "PASTE";
   target: Zone[];
+  onlyValue?: boolean;
   onlyFormat?: boolean;
   force?: boolean;
 }
@@ -179,6 +180,8 @@ export interface PasteCellCommand extends BaseCommand {
   row: number;
   sheet: string;
   cut?: boolean;
+  onlyValue: boolean;
+  onlyFormat: boolean;
 }
 
 export interface AutoFillCellCommand extends BaseCommand {

--- a/tests/menu_items_registry_test.ts
+++ b/tests/menu_items_registry_test.ts
@@ -128,6 +128,14 @@ describe("Menu Item actions", () => {
     });
   });
 
+  test("Edit -> paste_special -> paste_special_value", () => {
+    doAction(["edit", "paste_special", "paste_special_value"], env);
+    expect(env.dispatch).toHaveBeenCalledWith("PASTE", {
+      target: env.getters.getSelectedZones(),
+      onlyValue: true,
+    });
+  });
+
   test("Edit -> paste_special -> paste_special_format", () => {
     doAction(["edit", "paste_special", "paste_special_format"], env);
     expect(env.dispatch).toHaveBeenCalledWith("PASTE", {


### PR DESCRIPTION
This commit adds the possibility to copy / paste value(s) of a cell(s)
ignoring the format, borders and style.

This commit adds the functionality in the:
- topbar_menu
- cell_menu
- col_menu
- row_menu