### PR TITLE
[FIX] grid, model: correctly update viewport on scroll

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -400,7 +400,7 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
       this.hScrollbar.scroll = this.viewport.offsetX;
       this.vScrollbar.scroll = this.viewport.offsetY;
     }
-    this.snappedViewport = this.getters.snapViewportToCell(this.snappedViewport);
+    this.snappedViewport = this.getters.snapViewportToCell(this.viewport);
 
     // drawing grid on canvas
     const canvas = this.canvas.el as HTMLCanvasElement;

--- a/src/model.ts
+++ b/src/model.ts
@@ -218,7 +218,7 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
   drawGrid(context: GridRenderingContext) {
     // we make sure here that the viewport is properly positioned: the offsets
     // correspond exactly to a cell
-    this.getters.snapViewportToCell(context.viewport);
+    context.viewport = this.getters.snapViewportToCell(context.viewport);
     for (let [renderer, layer] of this.renderers) {
       renderer.drawGrid(context, layer);
     }


### PR DESCRIPTION
Since b530e2640d9261969a46c04db04a936852879703, the snappedViewport and
the contextViewport are not correctly updated. This commit reset the
correct behavior.

Closes: #463