### PR TITLE
[IMP] top_bar: insert rows/cols

### DIFF
--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -383,7 +383,9 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
     const width = this.el!.clientWidth;
     const height = this.el!.parentElement!.clientHeight;
     this.state.menuState.position = { x, y, width, height };
-    this.state.menuState.menuItems = topbarMenuRegistry.getChildren(menu, this.env);
+    this.state.menuState.menuItems = topbarMenuRegistry
+      .getChildren(menu, this.env)
+      .filter((item) => !item.isVisible || item.isVisible(this.env));
     this.isSelectingMenu = true;
     this.openedEl = ev.target as HTMLElement;
   }
@@ -421,7 +423,9 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
     } else {
       this.currentFormat = "auto";
     }
-    this.menus = topbarMenuRegistry.getAll();
+    this.menus = topbarMenuRegistry
+      .getAll()
+      .filter((item) => !item.isVisible || item.isVisible(this.env));
   }
 
   getMenuName(menu: FullMenuItem) {

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -73,22 +73,26 @@ topbarMenuRegistry
     name: ACTIONS.MENU_INSERT_ROWS_BEFORE_NAME,
     sequence: 10,
     action: ACTIONS.INSERT_ROWS_BEFORE_ACTION,
+    isVisible: (env: SpreadsheetEnv) => env.getters.getActiveCols().size === 0,
   })
   .addChild("insert_row_after", ["insert"], {
     name: ACTIONS.MENU_INSERT_ROWS_AFTER_NAME,
     sequence: 20,
     action: ACTIONS.INSERT_ROWS_AFTER_ACTION,
+    isVisible: (env: SpreadsheetEnv) => env.getters.getActiveCols().size === 0,
     separator: true,
   })
   .addChild("insert_column_before", ["insert"], {
     name: ACTIONS.MENU_INSERT_COLUMNS_BEFORE_NAME,
     sequence: 30,
     action: ACTIONS.INSERT_COLUMNS_BEFORE_ACTION,
+    isVisible: (env: SpreadsheetEnv) => env.getters.getActiveRows().size === 0,
   })
   .addChild("insert_column_after", ["insert"], {
     name: ACTIONS.MENU_INSERT_COLUMNS_AFTER_NAME,
     sequence: 40,
     action: ACTIONS.INSERT_COLUMNS_AFTER_ACTION,
+    isVisible: (env: SpreadsheetEnv) => env.getters.getActiveRows().size === 0,
     separator: true,
   })
   .addChild("insert_sheet", ["insert"], {

--- a/tests/menu_items_registry_test.ts
+++ b/tests/menu_items_registry_test.ts
@@ -232,6 +232,7 @@ describe("Menu Item actions", () => {
     test("A selected row", () => {
       model.dispatch("SELECT_ROW", { index: 4, createRange: true });
       expect(getName(path, env)).toBe("Row above");
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected rows", () => {
@@ -245,11 +246,18 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
+      expect(getNode(path).isVisible(env)).toBeTruthy();
+    });
+
+    test("A selected column should hide the item", () => {
+      model.dispatch("SELECT_COLUMN", { index: 4, createRange: true });
+      expect(getNode(path).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       model.dispatch("SELECT_CELL", { col: 3, row: 3 });
       expect(getName(path, env)).toBe("Row above");
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -263,6 +271,7 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -272,6 +281,7 @@ describe("Menu Item actions", () => {
     test("A selected row", () => {
       model.dispatch("SELECT_ROW", { index: 4, createRange: true });
       expect(getName(path, env)).toBe("Row below");
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected rows", () => {
@@ -285,11 +295,18 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
+      expect(getNode(path).isVisible(env)).toBeTruthy();
+    });
+
+    test("A selected column should hide the item", () => {
+      model.dispatch("SELECT_COLUMN", { index: 4, createRange: true });
+      expect(getNode(path).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       model.dispatch("SELECT_CELL", { col: 3, row: 3 });
       expect(getName(path, env)).toBe("Row below");
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -303,6 +320,7 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -312,6 +330,7 @@ describe("Menu Item actions", () => {
     test("A selected column", () => {
       model.dispatch("SELECT_COLUMN", { index: 4, createRange: true });
       expect(getName(path, env)).toBe("Column left");
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected columns", () => {
@@ -325,11 +344,18 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
+      expect(getNode(path).isVisible(env)).toBeTruthy();
+    });
+
+    test("A selected row should hide the item", () => {
+      model.dispatch("SELECT_ROW", { index: 4, createRange: true });
+      expect(getNode(path).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       model.dispatch("SELECT_CELL", { col: 3, row: 3 });
       expect(getName(path, env)).toBe("Column left");
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -343,6 +369,7 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -352,6 +379,7 @@ describe("Menu Item actions", () => {
     test("A selected column", () => {
       model.dispatch("SELECT_COLUMN", { index: 4, createRange: true });
       expect(getName(path, env)).toBe("Column right");
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected columns", () => {
@@ -365,11 +393,18 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
+      expect(getNode(path).isVisible(env)).toBeTruthy();
+    });
+
+    test("A selected row should hide the item", () => {
+      model.dispatch("SELECT_ROW", { index: 4, createRange: true });
+      expect(getNode(path).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       model.dispatch("SELECT_CELL", { col: 3, row: 3 });
       expect(getName(path, env)).toBe("Column right");
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -383,6 +418,7 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
+      expect(getNode(path).isVisible(env)).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
With this commit, the items insert rows/cols are hidden when a full
col/row is selected.

Closes #429