### PR TITLE
[IMP] sidepanel: Tweak header and buttons design

### DIFF
--- a/src/components/side_panel/cell_is_rule_editor.ts
+++ b/src/components/side_panel/cell_is_rule_editor.ts
@@ -59,9 +59,9 @@ const TEMPLATE = xml/* xml */ `
                     <ColorPicker t-if="state.fillColorTool" t-on-color-picked="setColor('fillColor')" t-key="fillColor"/>
         </div>
     </div>
-    <div class="o-cf-buttons">
-      <button t-on-click="onCancel" class="o-cf-button o-cf-cancel" t-esc="env._t('${terms.CANCEL}')"></button>
-      <button t-on-click="onSave" class="o-cf-button o-cf-save" t-esc="env._t('${terms.SAVE}')"></button>
+    <div class="o-sidePanelButtons">
+      <button t-on-click="onCancel" class="o-sidePanelButton o-cf-cancel" t-esc="env._t('${terms.CANCEL}')"></button>
+      <button t-on-click="onSave" class="o-sidePanelButton o-cf-save" t-esc="env._t('${terms.SAVE}')"></button>
     </div>
 </div>
 `;
@@ -96,26 +96,6 @@ const CSS = css/* scss */ `
   .o-cf-preview-line {
     border: 1px solid darkgrey;
     padding: 10px;
-  }
-  .o-cf-buttons {
-    padding: 12px;
-    text-align: right;
-    border-bottom: 1px solid #ccc;
-    .o-cf-button {
-      border: 1px solid lightgrey;
-      padding: 0px 20px 0px 20px;
-      border-radius: 4px;
-      font-weight: 500;
-      font-size: 14px;
-      height: 36px;
-      line-height: 16px;
-      background: white;
-      cursor: pointer;
-      margin-left: 8px;
-      &:hover {
-        background-color: rgba(0, 0, 0, 0.08);
-      }
-    }
   }
 `;
 

--- a/src/components/side_panel/color_scale_rule_editor.ts
+++ b/src/components/side_panel/color_scale_rule_editor.ts
@@ -51,9 +51,9 @@ const TEMPLATE = xml/* xml */ `
           <t t-set="threshold" t-value="state.maximum" ></t>
           <t t-set="thresholdType" t-value="'maximum'" ></t>
       </t>
-      <div class="o-cf-buttons">
-        <button t-on-click="onCancel" class="o-cf-button o-cf-cancel">Cancel</button>
-        <button t-on-click="onSave" class="o-cf-button o-cf-save">Save</button>
+      <div class="o-sidePanelButtons">
+        <button t-on-click="onCancel" class="o-sidePanelButton o-cf-cancel">Cancel</button>
+        <button t-on-click="onSave" class="o-sidePanelButton o-cf-save">Save</button>
       </div>
   </div>`;
 
@@ -80,26 +80,6 @@ const CSS = css/* scss */ `
   .o-cf-preview-gradient {
     border: 1px solid darkgrey;
     padding: 10px;
-  }
-  .o-cf-buttons {
-    padding: 5px;
-    text-align: right;
-    border-bottom: 1px solid #ccc;
-    .o-cf-button {
-      border: 1px solid lightgrey;
-      padding: 0px 20px 0px 20px;
-      border-radius: 4px;
-      font-weight: 500;
-      font-size: 14px;
-      height: 36px;
-      line-height: 16px;
-      background: white;
-      cursor: pointer;
-      margin-right: 16px;
-      &:hover {
-        background-color: rgba(0, 0, 0, 0.08);
-      }
-    }
   }
 `;
 

--- a/src/components/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel.ts
@@ -29,18 +29,19 @@ const CSS = css/* scss */ `
     border: 1px solid darkgray;
     .o-sidePanelHeader {
       padding: 6px;
-      height: 41px;
+      height: 30px;
+      background-color: #f8f9fa;
       display: flex;
       justify-content: space-between;
       border-bottom: 1px solid darkgray;
       font-weight: bold;
       .o-sidePanelTitle {
         font-weight: bold;
-        padding: 10px;
+        padding: 5px 10px;
         font-size: 1.2rem;
       }
       .o-sidePanelClose {
-        padding: 11px 15px;
+        padding: 5px 10px;
         cursor: pointer;
         &:hover {
           background-color: WhiteSmoke;
@@ -55,6 +56,30 @@ const CSS = css/* scss */ `
     }
     .o-sidePanelFooter {
       padding: 6px;
+    }
+
+    .o-sidePanelButtons {
+      padding: 5px;
+      text-align: right;
+      border-bottom: 1px solid #ccc;
+      .o-sidePanelButton {
+        border: 1px solid lightgrey;
+        padding: 0px 20px 0px 20px;
+        border-radius: 4px;
+        font-weight: 500;
+        font-size: 14px;
+        height: 30px;
+        line-height: 16px;
+        background: white;
+        cursor: pointer;
+        margin-right: 8px;
+        &:hover {
+          background-color: rgba(0, 0, 0, 0.08);
+        }
+      }
+      .o-sidePanelButton:last-child {
+        margin-right: 0px;
+      }
     }
   }
 `;

--- a/tests/plugins/conditional_formatting_test.ts
+++ b/tests/plugins/conditional_formatting_test.ts
@@ -897,7 +897,7 @@ describe("UI of conditional formats", () => {
       colorPickerYellow: ".o-color-picker div[data-color='#ffc001']",
     },
     cfTabSelector: ".o-cf-type-selector .o-cf-type-tab",
-    buttonSave: ".o-cf-buttons .o-cf-save",
+    buttonSave: ".o-sidePanelButtons .o-cf-save",
     buttonDelete: ".o-cf-delete-button",
     buttonAdd: ".o-cf-add",
   };


### PR DESCRIPTION
- Tweak sidepanel header design.

- Change and move `o-cf-buttons` to `o-sidePanelButtons` to allow
reusing the design in other sidepanels than conditional
formatting.

Task 2168366

Co-authored-by: fleodoo <fle@odoo.com>