### PR TITLE
[IMP] sidepanel: Toggle sidepanel

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -90,6 +90,8 @@ export class Spreadsheet extends Component<Props> {
     super(...arguments);
     useSubEnv({
       openSidePanel: (panel: string, panelProps: any = {}) => this.openSidePanel(panel, panelProps),
+      toggleSidePanel: (panel: string, panelProps: any = {}) =>
+        this.toggleSidePanel(panel, panelProps),
       dispatch: this.model.dispatch,
       getters: this.model.getters,
       _t: Spreadsheet._t,
@@ -115,6 +117,14 @@ export class Spreadsheet extends Component<Props> {
     this.sidePanel.component = panel;
     this.sidePanel.panelProps = panelProps;
     this.sidePanel.isOpen = true;
+  }
+
+  toggleSidePanel(panel: string, panelProps: any) {
+    if (this.sidePanel.isOpen && panel === this.sidePanel.component) {
+      this.sidePanel.isOpen = false;
+    } else {
+      this.openSidePanel(panel, panelProps);
+    }
   }
   focusGrid() {
     (<any>this.grid.comp).focus();

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -4,6 +4,7 @@ import { Env } from "@odoo/owl/dist/types/component/component";
 
 export interface SpreadsheetEnv extends Env {
   openSidePanel: (panel: string, panelProps?: any) => void;
+  toggleSidePanel: (panel: string, panelProps?: any) => void;
   dispatch: CommandDispatcher["dispatch"];
   getters: Getters;
   clipboard: Clipboard;


### PR DESCRIPTION
This commit introduces a new function in the spreasheet sub environnement
allowing to toggle a given sidepanel.

This will be usefull in Odoo where we introduce an icon in the topbar which
opens a sidepanel. Clicking a second time on the icon while the sidepanel is
open should close it.

Sidenote: we changed the parent component of all tests in `side_panel_tests.ts` because it was more testing the helper test component `GridParent` than the spreadsheet itself (the entire content of `openSidePanel` could be commented without any test failing).

Task 2168366
Co-authored-by: fleodoo <fle@odoo.com>