### PR TITLE
[FIX] sidepanel: Remove padding and fix delete button

### DIFF
--- a/src/components/side_panel/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting.ts
@@ -137,7 +137,7 @@ const CSS = css/* scss */ `
       }
       .o-cf-delete{
         height: 56px;
-        left: 250px;
+        left: 90%;
         line-height: 56px;
         position: absolute;
       }

--- a/src/components/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel.ts
@@ -52,10 +52,6 @@ const CSS = css/* scss */ `
       overflow: auto;
       width: 100%;
       height: 100%;
-      padding: 6px;
-    }
-    .o-sidePanelFooter {
-      padding: 6px;
     }
 
     .o-sidePanelButtons {


### PR DESCRIPTION
1) padding around panel body is removed to  allow more flexibility.
(see conditional formatting side panel: there is a white border when
hovered

2) Delete button of conditional formatting is wrongly placed.

Co-authored-by: fleodoo <fle@odoo.com>