### PR TITLE
[FIX] core: correctly detect sheet for second part of ranges

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -1,6 +1,6 @@
 import * as owl from "@odoo/owl";
 import { fontSizeMap } from "../../fonts";
-import { ComposerToken, composerTokenize, rangeReference } from "../../formulas/index";
+import { EnrichedToken, composerTokenize, rangeReference } from "../../formulas/index";
 import { Rect, SpreadsheetEnv, Zone } from "../../types/index";
 import { TextValueProvider } from "./autocomplete_dropdown";
 import { ContentEditableHelper } from "./content_editable_helper";
@@ -97,7 +97,7 @@ export class Composer extends Component<any, SpreadsheetEnv> {
     provider: "functions",
     search: "",
   });
-  tokenAtCursor: ComposerToken | void = undefined;
+  tokenAtCursor: EnrichedToken | void = undefined;
 
   // we can't allow input events to be triggered while we remove and add back the content of the composer in processContent
   shouldProcessInputEvents: boolean = false;
@@ -105,7 +105,7 @@ export class Composer extends Component<any, SpreadsheetEnv> {
   // modify the model anymore.
   isDone: boolean = false;
   refSelectionStart: number = 0;
-  tokens: ComposerToken[] = [];
+  tokens: EnrichedToken[] = [];
 
   keyMapping: { [key: string]: Function } = {
     Enter: this.processEnterKey,

--- a/src/formulas/composer_tokenizer.ts
+++ b/src/formulas/composer_tokenizer.ts
@@ -1,38 +1,14 @@
-import { Token, tokenize, TokenType } from "./tokenizer";
-
-/**
- * Composer_tokenizer is used by the composer to add information on the tokens that are only
- * needed during the edition of a formula.
- *
- * The information added are:
- * - parenthesis matching
- * - range detection (replaces the tokens that composes the range with 1 token)
- * - length, start and end of each token
- */
-
-export interface ComposerToken extends Token {
-  start: number;
-  end: number;
-  length: number;
-  parenIndex?: number;
-}
+import { tokenize } from "./tokenizer";
+import { mergeSymbolsIntoRanges, EnrichedToken, enrichTokens } from "./range_tokenizer";
 
 /**
  * add on each token the length, start and end
  * also matches the opening to its closing parenthesis (using the same number)
  */
-function mapLengthAndParents(tokens: Token[]): ComposerToken[] {
-  let current = 0;
+function mapParenthesis(tokens: EnrichedToken[]): EnrichedToken[] {
   let maxParen = 1;
   const stack: number[] = [];
-  return tokens.map((x) => {
-    const len = x.value.toString().length;
-    const token: ComposerToken = Object.assign({}, x, {
-      start: current,
-      end: current + len,
-      length: len,
-    });
-    current = token.end;
+  return tokens.map((token) => {
     if (token.type === "LEFT_PAREN") {
       stack.push(maxParen);
       token.parenIndex = maxParen;
@@ -45,101 +21,12 @@ function mapLengthAndParents(tokens: Token[]): ComposerToken[] {
 }
 
 /**
- * finds a sequence of token that represent a range and replace them with a single token
- * The range can be
- *  ?spaces symbol ?spaces operator: ?spaces symbol ?spaces
- */
-function mergeSymbolsIntoRanges(result: ComposerToken[]): ComposerToken[] {
-  let operator: number | void = undefined;
-  let refStart: number | void = undefined;
-  let refEnd: number | void = undefined;
-  let startIncludingSpaces: number | void = undefined;
-
-  const reset = () => {
-    startIncludingSpaces = undefined;
-    refStart = undefined;
-    operator = undefined;
-    refEnd = undefined;
-  };
-
-  for (let i = 0; i < result.length; i++) {
-    const token = result[i];
-
-    if (startIncludingSpaces) {
-      if (refStart) {
-        if (token.type === "SPACE") {
-          continue;
-        } else if (token.type === "OPERATOR" && token.value === ":") {
-          operator = i;
-        } else if (operator && token.type === "SYMBOL") {
-          refEnd = i;
-        } else {
-          if (startIncludingSpaces && refStart && operator && refEnd) {
-            const newToken = {
-              type: <TokenType>"SYMBOL",
-              start: result[startIncludingSpaces].start,
-              end: result[i - 1].end,
-              length: result[i - 1].end - result[startIncludingSpaces].start,
-              value: result
-                .slice(startIncludingSpaces, i)
-                .map((x) => x.value)
-                .join(""),
-            };
-            result.splice(startIncludingSpaces, i - startIncludingSpaces, newToken);
-            i = startIncludingSpaces + 1;
-            reset();
-          } else {
-            if (token.type === "SYMBOL") {
-              startIncludingSpaces = i;
-              refStart = i;
-              operator = undefined;
-            } else {
-              reset();
-            }
-          }
-        }
-      } else {
-        if (token.type === "SYMBOL") {
-          refStart = i;
-          operator = refEnd = undefined;
-        } else {
-          reset();
-        }
-      }
-    } else {
-      if (["SPACE", "SYMBOL"].includes(token.type)) {
-        startIncludingSpaces = i;
-        refStart = token.type === "SYMBOL" ? i : undefined;
-        operator = refEnd = undefined;
-      } else {
-        reset();
-      }
-    }
-  }
-  const i = result.length - 1;
-  if (startIncludingSpaces && refStart && operator && refEnd) {
-    const newToken = {
-      type: <TokenType>"SYMBOL",
-      start: result[startIncludingSpaces].start,
-      end: result[i].end,
-      length: result[i].end - result[startIncludingSpaces].start,
-      value: result
-        .slice(startIncludingSpaces, i + 1)
-        .map((x) => x.value)
-        .join(""),
-    };
-    result.splice(startIncludingSpaces, i - startIncludingSpaces + 1, newToken);
-  }
-  return result;
-}
-
-/**
  * Take the result of the tokenizer and transform it to be usable in the composer.
  *
  * @param formula
  */
-export function composerTokenize(formula: string): ComposerToken[] {
+export function composerTokenize(formula: string): EnrichedToken[] {
   const tokens = tokenize(formula);
 
-  return mergeSymbolsIntoRanges(mapLengthAndParents(tokens));
+  return mergeSymbolsIntoRanges(mapParenthesis(enrichTokens(tokens)));
 }

--- a/src/formulas/index.ts
+++ b/src/formulas/index.ts
@@ -8,6 +8,7 @@
  */
 
 export { tokenize, Token } from "./tokenizer";
-export { composerTokenize, ComposerToken } from "./composer_tokenizer";
+export { composerTokenize } from "./composer_tokenizer";
+export { rangeTokenize, EnrichedToken } from "./range_tokenizer";
 export { parse, rangeReference } from "./parser";
 export { compile, AsyncFunction } from "./compiler";

--- a/src/formulas/range_tokenizer.ts
+++ b/src/formulas/range_tokenizer.ts
@@ -1,0 +1,155 @@
+import { Token, tokenize, TokenType } from "./tokenizer";
+
+/**
+ * Enriched Token is used by the composer to add information on the tokens that
+ * are only needed during the edition of a formula.
+ *
+ * The information added are:
+ * - parenthesis matching
+ * - range detection (replaces the tokens that composes the range with 1 token)
+ * - length, start and end of each token
+ */
+
+export interface EnrichedToken extends Token {
+  start: number;
+  end: number;
+  length: number;
+  parenIndex?: number;
+}
+
+/**
+ * Add the following informations on tokens:
+ * - length
+ * - start
+ * - end
+ */
+export function enrichTokens(tokens: Token[]): EnrichedToken[] {
+  let current = 0;
+  return tokens.map((x) => {
+    const len = x.value.toString().length;
+    const token: EnrichedToken = Object.assign({}, x, {
+      start: current,
+      end: current + len,
+      length: len,
+    });
+    current = token.end;
+    return token;
+  });
+}
+
+/**
+ * Remove informations added on EnrichedToken to make a Token
+ */
+function toSimpleTokens(composerTokens: EnrichedToken[]): Token[] {
+  return composerTokens.map((x) => {
+    return {
+      type: x.type,
+      value: x.value,
+    };
+  });
+}
+
+/**
+ * finds a sequence of token that represent a range and replace them with a single token
+ * The range can be
+ *  ?spaces symbol ?spaces operator: ?spaces symbol ?spaces
+ */
+export function mergeSymbolsIntoRanges(
+  result: EnrichedToken[],
+  removeSpace = false
+): EnrichedToken[] {
+  let operator: number | void = undefined;
+  let refStart: number | void = undefined;
+  let refEnd: number | void = undefined;
+  let startIncludingSpaces: number | void = undefined;
+
+  const reset = () => {
+    startIncludingSpaces = undefined;
+    refStart = undefined;
+    operator = undefined;
+    refEnd = undefined;
+  };
+
+  for (let i = 0; i < result.length; i++) {
+    const token = result[i];
+
+    if (startIncludingSpaces) {
+      if (refStart) {
+        if (token.type === "SPACE") {
+          continue;
+        } else if (token.type === "OPERATOR" && token.value === ":") {
+          operator = i;
+        } else if (operator && token.type === "SYMBOL") {
+          refEnd = i;
+        } else {
+          if (startIncludingSpaces && refStart && operator && refEnd) {
+            const newToken = {
+              type: <TokenType>"SYMBOL",
+              start: result[startIncludingSpaces].start,
+              end: result[i - 1].end,
+              length: result[i - 1].end - result[startIncludingSpaces].start,
+              value: result
+                .slice(startIncludingSpaces, i)
+                .filter((x) => !removeSpace || x.type !== "SPACE")
+                .map((x) => x.value)
+                .join(""),
+            };
+            result.splice(startIncludingSpaces, i - startIncludingSpaces, newToken);
+            i = startIncludingSpaces + 1;
+            reset();
+          } else {
+            if (token.type === "SYMBOL") {
+              startIncludingSpaces = i;
+              refStart = i;
+              operator = undefined;
+            } else {
+              reset();
+            }
+          }
+        }
+      } else {
+        if (token.type === "SYMBOL") {
+          refStart = i;
+          operator = refEnd = undefined;
+        } else {
+          reset();
+        }
+      }
+    } else {
+      if (["SPACE", "SYMBOL"].includes(token.type)) {
+        startIncludingSpaces = i;
+        refStart = token.type === "SYMBOL" ? i : undefined;
+        operator = refEnd = undefined;
+      } else {
+        reset();
+      }
+    }
+  }
+  const i = result.length - 1;
+  if (startIncludingSpaces && refStart && operator && refEnd) {
+    const newToken = {
+      type: <TokenType>"SYMBOL",
+      start: result[startIncludingSpaces].start,
+      end: result[i].end,
+      length: result[i].end - result[startIncludingSpaces].start,
+      value: result
+        .slice(startIncludingSpaces, i + 1)
+        .filter((x) => !removeSpace || x.type !== "SPACE")
+        .map((x) => x.value)
+        .join(""),
+    };
+    result.splice(startIncludingSpaces, i - startIncludingSpaces + 1, newToken);
+  }
+  return result;
+}
+
+/**
+ * Take the result of the tokenizer and transform it to be usable in the
+ * manipulations of range
+ *
+ * @param formula
+ */
+export function rangeTokenize(formula: string): Token[] {
+  const tokens = tokenize(formula);
+  return toSimpleTokens(mergeSymbolsIntoRanges(enrichTokens(tokens), true));
+}

--- a/tests/formulas/range_tokenizer_test.ts
+++ b/tests/formulas/range_tokenizer_test.ts
@@ -1,0 +1,55 @@
+import { rangeTokenize } from "../../src/formulas/range_tokenizer";
+
+describe("rangeTokenizer", () => {
+  test("only range", () => {
+    expect(rangeTokenize("=A1:A2")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "A1:A2" },
+    ]);
+  });
+  test("operation and no range", () => {
+    expect(rangeTokenize("=A3+A1")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "A3" },
+      { type: "OPERATOR", value: "+" },
+      { type: "SYMBOL", value: "A1" },
+    ]);
+  });
+  test("operation and range", () => {
+    expect(rangeTokenize("=A3+A1:A2")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "A3" },
+      { type: "OPERATOR", value: "+" },
+      { type: "SYMBOL", value: "A1:A2" },
+    ]);
+  });
+  test("operation and range with spaces", () => {
+    expect(rangeTokenize("=A3+  A1 : A2   ")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "A3" },
+      { type: "OPERATOR", value: "+" },
+      { type: "SYMBOL", value: "A1:A2" },
+    ]);
+  });
+
+  test("range with spaces then operation", () => {
+    expect(rangeTokenize("=  A1 : A2   +a3")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "A1:A2" },
+      { type: "OPERATOR", value: "+" },
+      { type: "SYMBOL", value: "a3" },
+    ]);
+  });
+
+  test("= SUM ( C4 : C5 )", () => {
+    expect(rangeTokenize("= SUM ( C4 : C5 )")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SPACE", value: " " },
+      { type: "FUNCTION", value: "SUM" },
+      { type: "SPACE", value: " " },
+      { type: "LEFT_PAREN", value: "(" },
+      { type: "SYMBOL", value: "C4:C5" },
+      { type: "RIGHT_PAREN", value: ")" },
+    ]);
+  });
+});

--- a/tests/plugins/clipboard_test.ts
+++ b/tests/plugins/clipboard_test.ts
@@ -921,6 +921,16 @@ describe("clipboard", () => {
     model.dispatch("PASTE", { target: target("B3") });
     expect(model.getters.getCell(1, 2)!.content).toBe("=Sheet2!B3");
   });
+
+  test("can copy and paste a cell which contains a cross-sheet reference in a smaller sheet", () => {
+    const model = new Model();
+    model.dispatch("CREATE_SHEET", { id: "42", name: "Sheet2", rows: 2, cols: 2 });
+    model.dispatch("SET_VALUE", { xc: "A1", text: "=Sheet2!A1:A2" });
+
+    model.dispatch("COPY", { target: target("A1") });
+    model.dispatch("PASTE", { target: target("A2") });
+    expect(model.getters.getCell(0, 1)!.content).toBe("=#REF");
+  });
 });
 
 describe("clipboard: pasting outside of sheet", () => {

--- a/tests/plugins/grid_manipulation_test.ts
+++ b/tests/plugins/grid_manipulation_test.ts
@@ -391,6 +391,40 @@ describe("Columns", () => {
         A3: { content: "=Sheet2!B1" },
       });
     });
+    test("On first col deletion", () => {
+      model = new Model({
+        sheets: [
+          {
+            colNumber: 3,
+            rowNumber: 3,
+            cells: {
+              B2: { content: "=SUM(A1:C1)" },
+            },
+          },
+        ],
+      });
+      removeColumns([0]);
+      expect(getSheet(model, 0).cells).toMatchObject({
+        A2: { content: "=SUM(A1:B1)" },
+      });
+    });
+    test("On last col deletion", () => {
+      model = new Model({
+        sheets: [
+          {
+            colNumber: 3,
+            rowNumber: 3,
+            cells: {
+              A2: { content: "=SUM(A1:C1)" },
+            },
+          },
+        ],
+      });
+      removeColumns([2]);
+      expect(getSheet(model, 0).cells).toMatchObject({
+        A2: { content: "=SUM(A1:B1)" },
+      });
+    });
     test("On addition", () => {
       addColumns(1, "before", 1);
       addColumns(0, "after", 1);
@@ -759,6 +793,40 @@ describe("Rows", () => {
         A1: { content: "=A2" },
         B1: { content: "=#REF" },
         C1: { content: "=Sheet2!A2" },
+      });
+    });
+    test("On first row deletion", () => {
+      model = new Model({
+        sheets: [
+          {
+            colNumber: 3,
+            rowNumber: 3,
+            cells: {
+              B2: { content: "=SUM(A1:A3)" },
+            },
+          },
+        ],
+      });
+      removeRows([0]);
+      expect(getSheet(model, 0).cells).toMatchObject({
+        B1: { content: "=SUM(A1:A2)" },
+      });
+    });
+    test("On last row deletion", () => {
+      model = new Model({
+        sheets: [
+          {
+            colNumber: 3,
+            rowNumber: 3,
+            cells: {
+              B1: { content: "=SUM(A1:A3)" },
+            },
+          },
+        ],
+      });
+      removeRows([2]);
+      expect(getSheet(model, 0).cells).toMatchObject({
+        B1: { content: "=SUM(A1:A2)" },
       });
     });
     test("On addition", () => {


### PR DESCRIPTION
Before this commit, ranges likes 'Sheet1!A1:B1' were treated as 'Sheet1!A1'
and 'B1' in the operations of cols/rows deletion and copy/paste. So the 'B1'
lost the sheet reference.

To fix that, we introduce a new tokenizer, named rangeTokenizer which
merges in one token each range.