### PR TITLE
[FIX] numbers: fix formatting in another language

### DIFF
--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -54,7 +54,7 @@ export function formatDecimal(n: number, decimals: number, sep: string = ""): st
     return "-" + formatDecimal(-n, decimals);
   }
   const maxDecimals = decimals >= maximumDecimalPlaces ? maximumDecimalPlaces : decimals;
-  let result = n.toLocaleString("fullwide", {
+  let result = n.toLocaleString("en-US", {
     minimumFractionDigits: maxDecimals,
     maximumFractionDigits: maxDecimals,
     useGrouping: false,

--- a/src/plugins/formatting.ts
+++ b/src/plugins/formatting.ts
@@ -455,7 +455,7 @@ export class FormattingPlugin extends BasePlugin {
    * - "0.00" (step = -1) --> "0.0"
    * - "0%" (step = -1) --> "0%"
    * - "#,##0.0" (step = -1) --> "#,##0"
-   * - "#,##0;0.0%;0.000" (step = -1) --> "#,##0.0;0.00%;0.0000"
+   * - "#,##0;0.0%;0.000" (step = 1) --> "#,##0.0;0.00%;0.0000"
    */
   private changeDecimalFormat(format: string, step: number): string {
     const sign = Math.sign(step);


### PR DESCRIPTION
Before this fix, when using browser in another language such as french,
decimal numbers were displayed with a comma and not a dot.