### PR TITLE
[IMP] compiler: cache compiled functions (according to structure)

### DIFF
--- a/src/formulas/index.ts
+++ b/src/formulas/index.ts
@@ -11,4 +11,4 @@ export { tokenize, Token } from "./tokenizer";
 export { composerTokenize } from "./composer_tokenizer";
 export { rangeTokenize, EnrichedToken } from "./range_tokenizer";
 export { parse, rangeReference } from "./parser";
-export { compile, AsyncFunction } from "./compiler";
+export { compile } from "./compiler";

--- a/src/plugins/conditional_format.ts
+++ b/src/plugins/conditional_format.ts
@@ -78,7 +78,7 @@ export class ConditionalFormatPlugin extends BasePlugin {
         const cfOrigin = this.getRulesByCell(toXC(cmd.originCol, cmd.originRow));
         for (const cf of cfOrigin) {
           this.adaptRules(sheet, cf, [toXC(cmd.col, cmd.row)], []);
-        };
+        }
         break;
       case "ADD_ROWS":
         const row = cmd.position === "before" ? cmd.row : cmd.row + 1;

--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -1,8 +1,8 @@
 import { BasePlugin } from "../base_plugin";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../constants";
-import { formatDateTime, InternalDate, parseDateTime } from "../functions/dates";
-import { AsyncFunction, compile, rangeTokenize } from "../formulas/index";
+import { compile, rangeTokenize } from "../formulas/index";
 import { cellReference } from "../formulas/parser";
+import { formatDateTime, InternalDate, parseDateTime } from "../functions/dates";
 import {
   formatNumber,
   formatStandardNumber,
@@ -13,21 +13,21 @@ import {
   toCartesian,
   toXC,
 } from "../helpers/index";
+import { _lt } from "../translation";
 import {
+  CancelledReason,
   Cell,
   CellData,
   Col,
   Command,
+  CommandResult,
   HeaderData,
   Row,
   Sheet,
   SheetData,
   WorkbookData,
   Zone,
-  CommandResult,
-  CancelledReason,
 } from "../types/index";
-import { _lt } from "../translation";
 
 const nbspRegexp = new RegExp(String.fromCharCode(160), "g");
 const MIN_PADDING = 3;
@@ -802,10 +802,7 @@ export class CorePlugin extends BasePlugin {
         cell.error = undefined;
         try {
           cell.formula = compile(content, sheet, this.sheetIds);
-
-          if (cell.formula instanceof AsyncFunction) {
-            cell.async = true;
-          }
+          cell.async = cell.formula.async;
         } catch (e) {
           cell.value = "#BAD_EXPR";
           cell.error = _lt("Invalid Expression");

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -51,11 +51,15 @@ export interface NewCell {
   format?: string;
 }
 
-export type CompiledFormula = (
+type _CompiledFormula = (
   readCell: (xc: string, sheet: string) => any,
   range: (v1: string, v2: string, sheetName: string) => any[],
   ctx: {}
 ) => any;
+
+export interface CompiledFormula extends _CompiledFormula {
+  async: boolean;
+}
 
 export interface Cell extends NewCell {
   col: number;

--- a/tests/formulas/__snapshots__/compiler_test.ts.snap
+++ b/tests/formulas/__snapshots__/compiler_test.ts.snap
@@ -14,7 +14,7 @@ exports[`expression compiler cells are converted to ranges if function require a
 "function anonymous(cell,range,ctx
 ) {
 // =sum(A1)
-let _2 = cell('A1', \`Sheet1\`)
+let _2 = cell(0)
 ctx.__lastFnCalled = 'SUM'
 let _1 = ctx['SUM']([[_2]])
 return _1;
@@ -25,11 +25,11 @@ exports[`expression compiler expression with $ref 1`] = `
 "function anonymous(cell,range,ctx
 ) {
 // =$A1+$A$2+A$3
-let _3 = cell('A1', \`Sheet1\`)
-let _4 = cell('A2', \`Sheet1\`)
+let _3 = cell(0)
+let _4 = cell(1)
 ctx.__lastFnCalled = 'ADD'
 let _2 = ctx['ADD'](_3, _4)
-let _5 = cell('A3', \`Sheet1\`)
+let _5 = cell(2)
 ctx.__lastFnCalled = 'ADD'
 let _1 = ctx['ADD'](_2, _5)
 return _1;
@@ -40,7 +40,7 @@ exports[`expression compiler expression with references with a sheet 1`] = `
 "function anonymous(cell,range,ctx
 ) {
 // =Sheet34!B3
-let _1 = cell('B3', \`322\`)
+let _1 = cell(0)
 return _1;
 }"
 `;
@@ -50,7 +50,7 @@ exports[`expression compiler expressions with a debugger 1`] = `
 ) {
 // =? A1 / 2
 debugger;
-let _2 = cell('A1', \`Sheet1\`)
+let _2 = cell(0)
 ctx.__lastFnCalled = 'DIVIDE'
 let _1 = ctx['DIVIDE'](_2, 2)
 return _1;
@@ -91,8 +91,8 @@ exports[`expression compiler read some values and functions 1`] = `
 "function anonymous(cell,range,ctx
 ) {
 // =A1 + sum(A2:C3)
-let _2 = cell('A1', \`Sheet1\`)
-let _4 = range('A2', 'C3', \`Sheet1\`);
+let _2 = cell(0)
+let _4 = range(0);
 ctx.__lastFnCalled = 'SUM'
 let _3 = ctx['SUM'](_4)
 ctx.__lastFnCalled = 'ADD'

--- a/tests/formulas/compiler_test.ts
+++ b/tests/formulas/compiler_test.ts
@@ -1,69 +1,73 @@
 import { compile } from "../../src/formulas";
+import { functionCache } from "../../src/formulas/compiler";
+
+function compiledBaseFunction(formula: string): string {
+  for (let f in functionCache) {
+    delete functionCache[f];
+  }
+  compile(formula, "Sheet1", { Sheet1: "1" });
+  return Object.values(functionCache)[0].toString();
+}
 
 describe("expression compiler", () => {
   test("simple values", () => {
-    expect(compile("=1", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(compile("=true", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(compile(`="abc"`, "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(() => compile(`='abc'`, "Sheet1", { Sheet1: "1" }).toString()).toThrowError();
+    expect(compiledBaseFunction("=1")).toMatchSnapshot();
+    expect(compiledBaseFunction("=true")).toMatchSnapshot();
+    expect(compiledBaseFunction(`="abc"`)).toMatchSnapshot();
+
+    expect(() => compiledBaseFunction(`='abc'`)).toThrowError();
   });
 
   test("some arithmetic expressions", () => {
-    expect(compile("=1 + 3", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(compile("=2 * 3", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(compile("=2 - 3", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(compile("=2 / 3", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(compile("=-3", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(compile("=(3 + 1) * (-1 + 4)", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
+    expect(compiledBaseFunction("=1 + 3")).toMatchSnapshot();
+    expect(compiledBaseFunction("=2 * 3")).toMatchSnapshot();
+    expect(compiledBaseFunction("=2 - 3")).toMatchSnapshot();
+    expect(compiledBaseFunction("=2 / 3")).toMatchSnapshot();
+    expect(compiledBaseFunction("=-3")).toMatchSnapshot();
+    expect(compiledBaseFunction("=(3 + 1) * (-1 + 4)")).toMatchSnapshot();
   });
 
   test("function call", () => {
-    expect(compile("=sum(1,2)", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(compile('=sum(true, "")', "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
-    expect(compile("=sum(1,,2)", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
+    expect(compiledBaseFunction("=sum(1,2)")).toMatchSnapshot();
+    expect(compiledBaseFunction('=sum(true, "")')).toMatchSnapshot();
+    expect(compiledBaseFunction("=sum(1,,2)")).toMatchSnapshot();
   });
 
   test("read some values and functions", () => {
-    expect(compile("=A1 + sum(A2:C3)", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
+    expect(compiledBaseFunction("=A1 + sum(A2:C3)")).toMatchSnapshot();
   });
 
   test("expression with $ref", () => {
-    expect(compile("=$A1+$A$2+A$3", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
+    expect(compiledBaseFunction("=$A1+$A$2+A$3")).toMatchSnapshot();
   });
 
   test("expression with references with a sheet", () => {
-    expect(
-      compile("=Sheet34!B3", "Sheet1", { Sheet1: "1", Sheet34: "322" }).toString()
-    ).toMatchSnapshot();
+    expect(compiledBaseFunction("=Sheet34!B3")).toMatchSnapshot();
   });
 
   test("expressions with a debugger", () => {
-    expect(compile("=? A1 / 2", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
+    expect(compiledBaseFunction("=? A1 / 2")).toMatchSnapshot();
   });
 
   test("async functions", () => {
-    expect(compile("=WAIT(5)", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
+    expect(compiledBaseFunction("=WAIT(5)")).toMatchSnapshot();
   });
 
   test("cells are converted to ranges if function require a range", () => {
-    expect(compile("=sum(A1)", "Sheet1", { Sheet1: "1" }).toString()).toMatchSnapshot();
+    expect(compiledBaseFunction("=sum(A1)")).toMatchSnapshot();
   });
 
   test("cannot compile some invalid formulas", () => {
-    expect(() => compile("=A1:A2", "Sheet1", { Sheet1: "1" })).toThrow();
-    expect(() => compile("=qsdf", "Sheet1", { Sheet1: "1" })).toThrow();
+    expect(() => compiledBaseFunction("=A1:A2")).toThrow();
+    expect(() => compiledBaseFunction("=qsdf")).toThrow();
   });
 
   test("check at compile time for number of arguments", () => {
-    expect(() => compile("=pi()", "Sheet1", { Sheet1: "1" })).not.toThrow();
-    expect(() => compile("=pi(3)", "Sheet1", { Sheet1: "1" })).toThrowError(
-      "Invalid number of arguments"
-    );
-    expect(() => compile("=sum()", "Sheet1", { Sheet1: "1" })).toThrowError(
-      "Invalid number of arguments"
-    );
-    expect(() => compile("=sum(1)", "Sheet1", { Sheet1: "1" })).not.toThrowError();
-    expect(() => compile("=sum(1,2)", "Sheet1", { Sheet1: "1" })).not.toThrowError();
-    expect(() => compile("=sum(1,2,3)", "Sheet1", { Sheet1: "1" })).not.toThrowError();
+    expect(() => compiledBaseFunction("=pi()")).not.toThrow();
+    expect(() => compiledBaseFunction("=pi(3)")).toThrowError("Invalid number of arguments");
+    expect(() => compiledBaseFunction("=sum()")).toThrowError("Invalid number of arguments");
+    expect(() => compiledBaseFunction("=sum(1)")).not.toThrowError();
+    expect(() => compiledBaseFunction("=sum(1,2)")).not.toThrowError();
+    expect(() => compiledBaseFunction("=sum(1,2,3)")).not.toThrowError();
   });
 });

--- a/tests/plugins/autofill_test.ts
+++ b/tests/plugins/autofill_test.ts
@@ -130,7 +130,7 @@ describe("Autofill", () => {
       col: 0,
       row: 0,
       sheet: model.getters.getActiveSheet(),
-      content: "1"
+      content: "1",
     });
     autofill("A1", "A4");
     const cf: ConditionalFormat = {
@@ -159,7 +159,6 @@ describe("Autofill", () => {
     expect(model.getters.getConditionalStyle("A7")).toBeFalsy();
     expect(model.getters.getConditionalStyle("A8")).toBeFalsy();
   });
-
 
   describe("Autofill multiple values", () => {
     test("Autofill numbers", () => {

--- a/tests/plugins/evaluation_async_test.ts
+++ b/tests/plugins/evaluation_async_test.ts
@@ -9,7 +9,7 @@ describe("evaluateCells, async formulas", () => {
     model.dispatch("SET_VALUE", { xc: "A2", text: "=WAIT(3)" });
     model.dispatch("SET_VALUE", { xc: "A3", text: "= WAIT(1) + 1" });
 
-    expect(model["workbook"].activeSheet.cells["A1"].async).toBeUndefined();
+    expect(model["workbook"].activeSheet.cells["A1"].async).toBe(false);
     expect(model["workbook"].activeSheet.cells["A2"].async).toBe(true);
     expect(model["workbook"].activeSheet.cells["A3"].async).toBe(true);
     expect(model["workbook"].activeSheet.cells["A2"].value).toEqual(LOADING);
@@ -73,7 +73,7 @@ describe("evaluateCells, async formulas", () => {
     const model = new Model();
     model.dispatch("SET_VALUE", { xc: "A1", text: "=WAIT(3)" });
     model.dispatch("SET_VALUE", { xc: "A2", text: "=1 + A1" });
-    expect(model["workbook"].activeSheet.cells["A2"].async).toBeUndefined();
+    expect(model["workbook"].activeSheet.cells["A2"].async).toBe(false);
     expect(model["workbook"].activeSheet.cells["A1"].value).toEqual(LOADING);
     expect(model["workbook"].activeSheet.cells["A2"].value).toEqual(LOADING);
     expect(patch.calls.length).toBe(1);
@@ -90,7 +90,7 @@ describe("evaluateCells, async formulas", () => {
     model.dispatch("SET_VALUE", { xc: "A2", text: "=WAIT(1)" });
     model.dispatch("SET_VALUE", { xc: "A3", text: "=A1 + A2" });
 
-    expect(model["workbook"].activeSheet.cells["A3"].async).toBeUndefined();
+    expect(model["workbook"].activeSheet.cells["A3"].async).toBe(false);
     expect(model["workbook"].activeSheet.cells["A1"].value).toEqual(LOADING);
     expect(model["workbook"].activeSheet.cells["A2"].value).toEqual(LOADING);
     expect(model["workbook"].activeSheet.cells["A3"].value).toEqual(LOADING);
@@ -164,7 +164,7 @@ describe("evaluateCells, async formulas", () => {
     model.dispatch("SET_VALUE", { xc: "A1", text: "=WAIT(3)" });
     model.dispatch("SET_VALUE", { xc: "A2", text: "=A1 + 1/0" });
 
-    expect(model["workbook"].activeSheet.cells["A2"].async).toBe(undefined);
+    expect(model["workbook"].activeSheet.cells["A2"].async).toBe(false);
     expect(model["workbook"].activeSheet.cells["A2"].value).toEqual(LOADING);
 
     await waitForRecompute();


### PR DESCRIPTION
This commit introduces a cache for compiled functions.  The reason is
that creating a dynamic function with an arbitrary code is actually very
costly.

Also, this cache works pretty well because we can share the compiled
function code among any formulas that have the same structure, which is
extremely common in spreadsheets:  "=sum(A1:A100)" and "=sum(B1:B100)"
have the same structure.

In a scenario where we load a spreadsheet with 500k formulas, some quick
benchmarks show that this commit improves the loading time from about
30s to 10s.