### PR TITLE
[FIX] core: Correctly update range when all rows are removed

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -935,6 +935,11 @@ export class CorePlugin extends BasePlugin {
     if (left === "#REF" || right === "#REF") {
       return "#REF";
     }
+    const columnLeft = toCartesian(left)[0];
+    const columnRight = toCartesian(right)[0];
+    if (columnLeft > columnRight) {
+      return "#REF";
+    }
     if (left === right) {
       return left;
     }
@@ -1007,6 +1012,11 @@ export class CorePlugin extends BasePlugin {
     left = this.updateRowsRangePart(left, sheet, base, step, 1);
     right = this.updateRowsRangePart(right, sheet, base, step, -1);
     if (left === "#REF" || right === "#REF") {
+      return "#REF";
+    }
+    const rowLeft = toCartesian(left)[1];
+    const rowRight = toCartesian(right)[1];
+    if (rowLeft > rowRight) {
       return "#REF";
     }
     if (left === right) {

--- a/tests/plugins/grid_manipulation_test.ts
+++ b/tests/plugins/grid_manipulation_test.ts
@@ -507,6 +507,21 @@ describe("Columns", () => {
         A2: { content: "=SUM(A1:B1)" },
       });
     });
+    test("delete all columns of a range", () => {
+      model = new Model({
+        sheets: [
+          {
+            colNumber: 9,
+            rowNumber: 3,
+            cells: {
+              A1: { content: "=SUM(A2:E5)" },
+            },
+          },
+        ],
+      });
+      removeColumns([1, 2, 3, 4]);
+      expect(getSheet(model, 0).cells.A1.content).toBe("=SUM(#REF)");
+    });
     test("On multiple col deletion including the last one", () => {
       model = new Model({
         sheets: [
@@ -703,6 +718,21 @@ describe("Rows", () => {
       expect(getSheet(model, 0).cells).toMatchObject({
         A1: { content: "A2" },
       });
+    });
+    test("delete all rows of a range", () => {
+      model = new Model({
+        sheets: [
+          {
+            colNumber: 3,
+            rowNumber: 9,
+            cells: {
+              A1: { content: "=SUM(A2:A5)" },
+            },
+          },
+        ],
+      });
+      removeRows([1, 2, 3, 4]);
+      expect(getSheet(model, 0).cells.A1.content).toBe("=SUM(#REF)");
     });
     test("On addition before", () => {
       addRows(1, "before", 2);


### PR DESCRIPTION
With a cell containing `=SUM(A2:A4)`, remove rows 2, 3 and 4.
The cell is incorrecly updated to `=SUM(A2:A1)`.
It should be `=SUM(#REF)` since the range is now empty and therefore cannot
be referenced anymore.