### PR TITLE
[IMP] compiler: allow lazy parameters

### DIFF
--- a/src/functions/arguments.ts
+++ b/src/functions/arguments.ts
@@ -42,6 +42,7 @@ function makeArg(str: string): Arg {
   let types: ArgType[] = [];
   let isOptional = false;
   let isRepeating = false;
+  let isLazy = false;
   let defaultVal;
 
   for (let param of parts[2].split(",")) {
@@ -55,6 +56,8 @@ function makeArg(str: string): Arg {
       isOptional = true;
     } else if (key === "REPEATING") {
       isRepeating = true;
+    } else if (key === "LAZY") {
+      isLazy = true;
     } else if (key.startsWith("DEFAULT=")) {
       const value = param.trim().slice(8);
       defaultVal = value[0] === '"' ? value.slice(1, -1) : parseFloat(value);
@@ -71,6 +74,9 @@ function makeArg(str: string): Arg {
   }
   if (isRepeating) {
     result.repeating = true;
+  }
+  if (isLazy) {
+    result.lazy = true;
   }
   if (defaultVal !== undefined) {
     result.default = defaultVal;

--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -58,18 +58,20 @@ export const IF: FunctionDescription = {
       logical_expression (boolean) ${_lt(
         "An expression or reference to a cell containing an expression that represents some logical value, i.e. TRUE or FALSE."
       )}
-      value_if_true (any) ${_lt("The value the function returns if logical_expression is TRUE.")}
-      value_if_false (any, optional, default=FALSE) ${_lt(
+      value_if_true (any, lazy) ${_lt(
+        "The value the function returns if logical_expression is TRUE."
+      )}
+      value_if_false (any, lazy, optional, default=FALSE) ${_lt(
         "The value the function returns if logical_expression is FALSE."
       )}
     `),
   returns: ["ANY"],
   compute: function (
     logical_expression: any,
-    value_if_true: any,
-    value_if_false: any = false
+    value_if_true: () => any,
+    value_if_false: () => any = () => false
   ): any {
-    const result = toBoolean(logical_expression) ? value_if_true : value_if_false;
+    const result = toBoolean(logical_expression) ? value_if_true() : value_if_false();
     return result === null ? "" : result;
   },
 };
@@ -80,11 +82,11 @@ export const IF: FunctionDescription = {
 export const IFS: FunctionDescription = {
   description: _lt("Returns a value depending on multiple logical expressions."),
   args: args(`
-      condition1 (boolean) ${_lt(
+      condition1 (boolean, lazy) ${_lt(
         "The first condition to be evaluated. This can be a boolean, a number, an array, or a reference to any of those."
       )}
-      value1 (any) ${_lt("The returned value if condition1 is TRUE.")}
-      additional_values (any, optional, repeating) ${_lt(
+      value1 (any, lazy) ${_lt("The returned value if condition1 is TRUE.")}
+      additional_values (any, lazy, optional, repeating) ${_lt(
         "Additional conditions and values to be evaluated if the previous ones are FALSE."
       )}
     `),
@@ -99,8 +101,8 @@ export const IFS: FunctionDescription = {
       throw new Error(_lt(`Wrong number of arguments. Expected an even number of arguments.`));
     }
     for (let n = 0; n < arguments.length - 1; n += 2) {
-      if (toBoolean(arguments[n])) {
-        return arguments[n + 1];
+      if (toBoolean(arguments[n]())) {
+        return arguments[n + 1]();
       }
     }
     throw new Error(_lt(`No match.`));

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -12,6 +12,7 @@ export type ArgType =
 export interface Arg {
   repeating?: boolean;
   optional?: boolean;
+  lazy?: boolean;
   description: string;
   name: string;
   type: ArgType[];

--- a/tests/formulas/__snapshots__/compiler_test.ts.snap
+++ b/tests/formulas/__snapshots__/compiler_test.ts.snap
@@ -57,6 +57,50 @@ return _1;
 }"
 `;
 
+exports[`expression compiler function call (with lazy parameters) 1`] = `
+"function anonymous(cell,range,ctx
+) {
+// =IF(TRUE, 42, 24)
+let _2 = ()=> 42
+let _3 = ()=> 24
+ctx.__lastFnCalled = 'IF'
+let _1 = ctx['IF'](true,_2,_3)
+return _1;
+}"
+`;
+
+exports[`expression compiler function call (with lazy parameters) 2`] = `
+"function anonymous(cell,range,ctx
+) {
+// =IF(TRUE, A2, 1/0)
+let _2 = ()=> cell(0)
+ctx.__lastFnCalled = 'DIVIDE'
+let _3 = ()=> ctx['DIVIDE'](1, 0)
+ctx.__lastFnCalled = 'IF'
+let _1 = ctx['IF'](true,_2,_3)
+return _1;
+}"
+`;
+
+exports[`expression compiler function call (with lazy parameters) 3`] = `
+"function anonymous(cell,range,ctx
+) {
+// =IF(TRUE, IF(TRUE, A2, SQRT(-1)), 1/0)
+let _3 = ()=> cell(0)
+ctx.__lastFnCalled = 'UMINUS'
+let _5 = ctx['UMINUS']( 1)
+ctx.__lastFnCalled = 'SQRT'
+let _4 = ()=> ctx['SQRT'](_5)
+ctx.__lastFnCalled = 'IF'
+let _2 = ()=> ctx['IF'](true,_3,_4)
+ctx.__lastFnCalled = 'DIVIDE'
+let _6 = ()=> ctx['DIVIDE'](1, 0)
+ctx.__lastFnCalled = 'IF'
+let _1 = ctx['IF'](true,_2,_6)
+return _1;
+}"
+`;
+
 exports[`expression compiler function call 1`] = `
 "function anonymous(cell,range,ctx
 ) {

--- a/tests/formulas/compiler_test.ts
+++ b/tests/formulas/compiler_test.ts
@@ -33,6 +33,12 @@ describe("expression compiler", () => {
     expect(compiledBaseFunction("=sum(1,,2)")).toMatchSnapshot();
   });
 
+  test("function call (with lazy parameters)", () => {
+    expect(compiledBaseFunction("=IF(TRUE, 42, 24)")).toMatchSnapshot();
+    expect(compiledBaseFunction("=IF(TRUE, A2, 1/0)")).toMatchSnapshot();
+    expect(compiledBaseFunction("=IF(TRUE, IF(TRUE, A2, SQRT(-1)), 1/0)")).toMatchSnapshot();
+  });
+
   test("read some values and functions", () => {
     expect(compiledBaseFunction("=A1 + sum(A2:C3)")).toMatchSnapshot();
   });

--- a/tests/functions/module_logical_test.ts
+++ b/tests/functions/module_logical_test.ts
@@ -57,6 +57,11 @@ describe("bool", () => {
     expect(evaluateCell("A1", { A1: "=IF(TRUE , FALSE, 2)" })).toBe(false);
   });
 
+  test("IF: functional tests on simple arguments with errors", () => {
+    expect(evaluateCell("A1", { A1: "=IF(TRUE,42,1/0)" })).toBe(42);
+    expect(evaluateCell("A1", { A1: "=IF(TRUE,1/0,42)" })).toBe("#ERROR"); // @compatibility: on google sheets, return #DIV/0!
+  });
+
   test("IF: casting tests on simple arguments", () => {
     expect(evaluateCell("A1", { A1: "=IF(42, 1, 2)" })).toBe(1);
     expect(evaluateCell("A1", { A1: "=IF(0, 1, 2)" })).toBe(2);
@@ -64,9 +69,20 @@ describe("bool", () => {
   });
 
   test("IF: functional tests on cell arguments", () => {
+    expect(evaluateCell("A1", { A1: "=IF(A2, A3, A4)" })).toBe("");
+    expect(evaluateCell("A1", { A1: "=IF(A2, A3, A4)" })).toBe("");
     expect(evaluateCell("A1", { A1: "=IF(A2, A3, A4)", A2: "TRUE", A3: "1", A4: "2" })).toBe(1);
     expect(evaluateCell("A1", { A1: "=IF(A2, A3, A4)", A2: "FALSE", A3: "1", A4: "2" })).toBe(2);
     expect(evaluateCell("A1", { A1: "=IF(A2, A3, A4)", A2: " ", A3: "1", A4: "2" })).toBe("#ERROR"); // @compatibility: on google sheets, return #VALUE!
+  });
+
+  test("IF: functional tests on cell arguments with errors", () => {
+    expect(evaluateCell("A1", { A1: "=IF(A2, A3, A4)", A2: "TRUE", A3: "42", A4: "=1/0" })).toBe(
+      42
+    );
+    expect(evaluateCell("A1", { A1: "=IF(A2, A3, A4)", A2: "TRUE", A3: "=1/0", A4: "42" })).toBe(
+      "#ERROR"
+    ); // @compatibility: on google sheets, return #DIV/0!
   });
 
   test("IF: casting tests on cell arguments", () => {
@@ -85,6 +101,12 @@ describe("bool", () => {
     expect(evaluateCell("A1", { A1: "=IFS(TRUE, 1)" })).toBe(1);
     expect(evaluateCell("A1", { A1: '=IFS(TRUE, "1")' })).toBe("1");
     expect(evaluateCell("A1", { A1: "=IFS(TRUE, FALSE)" })).toBe(false);
+  });
+
+  test("IFS: functional tests on simple arguments with errors", () => {
+    expect(evaluateCell("A1", { A1: '=IFS(TRUE, "ok1", 1/0, 1/0)' })).toBe("ok1");
+    expect(evaluateCell("A1", { A1: '=IFS(1/0, "ok1", TRUE, 42)' })).toBe("#ERROR"); // @compatibility: on google sheets, return #DIV/0!
+    expect(evaluateCell("A1", { A1: "=IFS(TRUE, 1/0, TRUE, 42)" })).toBe("#ERROR"); // @compatibility: on google sheets, return #DIV/0!
   });
 
   test("IFS: casting tests on simple arguments", () => {
@@ -116,6 +138,36 @@ describe("bool", () => {
         A5: "ok2",
       })
     ).toBe("ok1");
+  });
+
+  test("IFS: functional tests on cell arguments with errors", () => {
+    expect(
+      evaluateCell("A1", {
+        A1: "=IFS(A2, A3, A4, A5)",
+        A2: "TRUE",
+        A3: "ok1",
+        A4: "=1/0",
+        A5: "=1/0",
+      })
+    ).toBe("ok1");
+    expect(
+      evaluateCell("A1", {
+        A1: "=IFS(A2, A3, A4, A5)",
+        A2: "=1/0",
+        A3: "ok1",
+        A4: "TRUE",
+        A5: "42",
+      })
+    ).toBe("#ERROR"); // @compatibility: on google sheets, return #DIV/0!
+    expect(
+      evaluateCell("A1", {
+        A1: "=IFS(A2, A3, A4, A5)",
+        A2: "TRUE",
+        A3: "=1/0",
+        A4: "TRUE",
+        A5: "42",
+      })
+    ).toBe("#ERROR"); // @compatibility: on google sheets, return #DIV/0!
   });
 
   test("IFS: casting tests on cell arguments", () => {


### PR DESCRIPTION
The purpose of this commit is to allow a certain function like the
"IF()" function to return a value without worrying about others,
especially when these are errors.

Before:
A1: =IF(true, A2, A3), A2: "Aquecoucou Bob", A3: =1/0
A1 => ERROR

Now:
A1: =IF(true, A2, A3), A2: "Aquecoucou Bob", A3: =1/0
A1 => Aquecoucou Bob

closes #496