### PR TITLE
[IMP] misc: Expose debug elements

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -4,7 +4,7 @@ import { EnrichedToken, composerTokenize, rangeReference } from "../../formulas/
 import { Rect, SpreadsheetEnv, Zone } from "../../types/index";
 import { TextValueProvider } from "./autocomplete_dropdown";
 import { ContentEditableHelper } from "./content_editable_helper";
-import { colors } from "../../helpers/index";
+import { colors, DEBUG } from "../../helpers/index";
 
 const { Component } = owl;
 const { useRef, useState } = owl.hooks;
@@ -129,8 +129,7 @@ export class Composer extends Component<any, SpreadsheetEnv> {
   }
 
   mounted() {
-    // @ts-ignore
-    window.composer = this;
+    DEBUG.composer = this;
 
     const el = this.composerRef.el!;
 

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -24,3 +24,5 @@ export function sanitizeSheet(sheet: string): string {
 export function clip(val: number, min: number, max: number): number {
   return val < min ? min : val > max ? max : val;
 }
+
+export const DEBUG: { [key: string]: any } = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export { Spreadsheet } from "./components/index";
 export { Model } from "./model";
 export { parse, astToFormula } from "./formulas/parser";
 export { setTranslationMethod } from "./translation";
+export { DEBUG as __DEBUG__ } from "./helpers/index";
 
 export const registries = {
   autofillModifiersRegistry,

--- a/src/model.ts
+++ b/src/model.ts
@@ -16,6 +16,7 @@ import {
   EvalContext,
 } from "./types/index";
 import { _lt } from "./translation";
+import { DEBUG } from "./helpers/index";
 
 /**
  * Model
@@ -99,7 +100,7 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
 
   constructor(data: any = {}, config: Partial<ModelConfig> = {}) {
     super();
-    (window as any).model = this; // to debug. remove this someday
+    DEBUG.model = this;
 
     const workbookData = load(data);
     this.workbook = createEmptyWorkbook();

--- a/src/plugins/evaluation.ts
+++ b/src/plugins/evaluation.ts
@@ -1,7 +1,7 @@
 import { BasePlugin } from "../base_plugin";
 import { compile } from "../formulas/index";
 import { functionRegistry } from "../functions/index";
-import { toCartesian } from "../helpers/index";
+import { toCartesian, DEBUG } from "../helpers/index";
 import { WHistory } from "../history";
 import { Mode, ModelConfig } from "../model";
 import { Cell, Command, CommandDispatcher, EvalContext, Getters, Workbook } from "../types";
@@ -74,6 +74,9 @@ export class EvaluationPlugin extends BasePlugin {
   ) {
     super(workbook, getters, history, dispatch, config);
     this.evalContext = config.evalContext;
+    DEBUG.evaluation = {
+      isIdle: () => this.loadingCells === 0,
+    };
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Expose some spreadsheet element for debug purposes in a centralized location:
`window.o_spreadsheet.__DEBUG__`

`model` and `composer` were already available on `window`. They are moved to
the new location.

An additional element is added for debug: the number of loading cells.
This is usefull to know if the evaluation is finished or not and will be
used in tours in Odoo.