### PR TITLE
[FIX] core: Correctly update cross sheet references

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -909,7 +909,8 @@ export class CorePlugin extends BasePlugin {
     if (x === base && step === -1) {
       x += direction;
     }
-    return this.updateColumnsRef(toXC(x, y), sheet, base, step);
+    const [xcRef] = this.updateColumnsRef(toXC(x, y), sheet, base, step).split("!").reverse();
+    return xcRef;
   };
 
   /**
@@ -940,7 +941,8 @@ export class CorePlugin extends BasePlugin {
     if (left === right) {
       return left;
     }
-    return `${left}:${right}`;
+    const range = `${left}:${right}`;
+    return sheet ? `${sheet}!${range}` : range;
   };
 
   /**
@@ -988,7 +990,8 @@ export class CorePlugin extends BasePlugin {
       }
       step = 0;
     }
-    return this.updateRowsRef(toXC(x, y), sheet, base, step);
+    const [xcRef] = this.updateRowsRef(toXC(x, y), sheet, base, step).split("!").reverse();
+    return xcRef;
   };
 
   /**
@@ -1019,7 +1022,8 @@ export class CorePlugin extends BasePlugin {
     if (left === right) {
       return left;
     }
-    return `${left}:${right}`;
+    const range = `${left}:${right}`;
+    return sheet ? `${sheet}!${range}` : range;
   };
 
   // ---------------------------------------------------------------------------

--- a/tests/plugins/grid_manipulation_test.ts
+++ b/tests/plugins/grid_manipulation_test.ts
@@ -522,6 +522,42 @@ describe("Columns", () => {
       removeColumns([1, 2, 3, 4]);
       expect(getSheet(model, 0).cells.A1.content).toBe("=SUM(#REF)");
     });
+    test("update cross sheet range on column deletion", () => {
+      model = new Model({
+        sheets: [
+          { name: "Sheet1", colNumber: 5, rowNumber: 5 },
+          {
+            name: "Sheet2",
+            colNumber: 3,
+            rowNumber: 9,
+            cells: {
+              A1: { content: "=SUM(Sheet1!B1:D3)" },
+            },
+          },
+        ],
+      });
+      removeColumns([0]);
+      expect(model.getters.getCell(0, 0, "Sheet2")!.content).toBe("=SUM(Sheet1!A1:C3)");
+    });
+    test("update cross sheet range on column deletion in inactive sheet", () => {
+      model = new Model({
+        sheets: [
+          { name: "Sheet0", colNumber: 1, rowNumber: 1 }, // <-- less column than Sheet1
+          { name: "Sheet1", colNumber: 5, rowNumber: 5 },
+          {
+            name: "Sheet2",
+            colNumber: 5,
+            rowNumber: 9,
+            cells: {
+              A1: { content: "=SUM(Sheet1!B1:D3)" },
+            },
+          },
+        ],
+      });
+      const sheet1Id = model.getters.getSheetIdByName("Sheet1");
+      model.dispatch("REMOVE_COLUMNS", { sheet: sheet1Id!, columns: [0] });
+      expect(model.getters.getCell(0, 0, "Sheet2")!.content).toBe("=SUM(Sheet1!A1:C3)");
+    });
     test("On multiple col deletion including the last one", () => {
       model = new Model({
         sheets: [
@@ -733,6 +769,42 @@ describe("Rows", () => {
       });
       removeRows([1, 2, 3, 4]);
       expect(getSheet(model, 0).cells.A1.content).toBe("=SUM(#REF)");
+    });
+    test("update cross sheet range on row deletion", () => {
+      model = new Model({
+        sheets: [
+          { name: "Sheet1", colNumber: 5, rowNumber: 5 },
+          {
+            name: "Sheet2",
+            colNumber: 3,
+            rowNumber: 9,
+            cells: {
+              A1: { content: "=SUM(Sheet1!A2:A3)" },
+            },
+          },
+        ],
+      });
+      removeRows([0]);
+      expect(model.getters.getCell(0, 0, "Sheet2")!.content).toBe("=SUM(Sheet1!A1:A2)");
+    });
+    test("update cross sheet range on row deletion in inactive sheet", () => {
+      model = new Model({
+        sheets: [
+          { name: "Sheet0", colNumber: 1, rowNumber: 1 }, // <-- less rows than Sheet1
+          { name: "Sheet1", colNumber: 5, rowNumber: 5 },
+          {
+            name: "Sheet2",
+            colNumber: 5,
+            rowNumber: 9,
+            cells: {
+              A1: { content: "=SUM(Sheet1!A2:A3)" },
+            },
+          },
+        ],
+      });
+      const sheet1Id = model.getters.getSheetIdByName("Sheet1");
+      model.dispatch("REMOVE_ROWS", { sheet: sheet1Id!, rows: [0] });
+      expect(model.getters.getCell(0, 0, "Sheet2")!.content).toBe("=SUM(Sheet1!A1:A2)");
     });
     test("On addition before", () => {
       addRows(1, "before", 2);


### PR DESCRIPTION
Range `Sheet1!A2:A5` cannot be updated when row 1 is removed.
It crashed: `Invalid cell description: SHEET1!A2`