### PR TITLE
[FIX] core: correct cross-sheet reference on range

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -1045,6 +1045,8 @@ export class CorePlugin extends BasePlugin {
     if (left === "#REF" || right === "#REF") {
       return "#REF";
     }
+    //As updateReference put the sheet in the ref, we need to remove it from the right part
+    right = right.split("!").pop()!;
     return `${left}:${right}`;
   }
 

--- a/tests/plugins/clipboard_test.ts
+++ b/tests/plugins/clipboard_test.ts
@@ -1107,6 +1107,16 @@ describe("clipboard", () => {
     model.dispatch("PASTE", { target: target("A2") });
     expect(model.getters.getCell(0, 1)!.content).toBe("=#REF");
   });
+
+  test("can copy and paste a cell which contains a cross-sheet reference to a range", () => {
+    const model = new Model();
+    model.dispatch("CREATE_SHEET", { id: "42", name: "Sheet2" });
+    model.dispatch("SET_VALUE", { xc: "A1", text: "=SUM(Sheet2!A2:A5)" });
+
+    model.dispatch("COPY", { target: target("A1") });
+    model.dispatch("PASTE", { target: target("B1") });
+    expect(model.getters.getCell(1, 0)!.content).toBe("=SUM(Sheet2!B2:B5)");
+  });
 });
 
 describe("clipboard: pasting outside of sheet", () => {


### PR DESCRIPTION
Before this commit, change a cross-sheet reference on a range during a
copy past or during an autofil duplicated the name of the sheet in the
range.

Before:
(1) A1: =SUM(Sheet2!A2:A4)
(2) Copy past A1 in B1
(3) B1: =SUM(Sheet2!B2:Sheet2!B4)

Now:
(1) A1: =SUM(Sheet2!A2:A4)
(2) Copy past A1 in B1
(3) B1: =SUM(Sheet2!B2:B4)