### PR TITLE
[FIX] evaluation: Don't wait for async cells in error

### DIFF
--- a/src/plugins/evaluation.ts
+++ b/src/plugins/evaluation.ts
@@ -189,7 +189,10 @@ export class EvaluationPlugin extends BasePlugin {
       computeValue(cell, sheetId);
     }
 
-    function handleError(e: Error, cell: Cell) {
+    function handleError(e: Error | any, cell: Cell) {
+      if (!(e instanceof Error)) {
+        e = new Error(e);
+      }
       if (PENDING.has(cell)) {
         PENDING.delete(cell);
         self.loadingCells--;
@@ -265,7 +268,7 @@ export class EvaluationPlugin extends BasePlugin {
       getters: this.getters,
     });
     const sheets = this.workbook.sheets;
-
+    const PENDING = this.PENDING;
     function readCell(xc: string, sheet: string): any {
       let cell;
       const s = sheets[sheet];
@@ -281,6 +284,9 @@ export class EvaluationPlugin extends BasePlugin {
     }
 
     function getCellValue(cell: Cell, sheetId: string): any {
+      if (cell.async && cell.error && !PENDING.has(cell)) {
+        throw new Error(_lt("This formula depends on invalid values"));
+      }
       computeValue(cell, sheetId);
       if (cell.error) {
         throw new Error(_lt("This formula depends on invalid values"));

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -239,6 +239,11 @@ function clearTimers() {
   }
 }
 
+export async function asyncComputations() {
+  clearTimers();
+  await nextTick();
+}
+
 export async function waitForRecompute() {
   patch.resolveAll();
   await nextTick();


### PR DESCRIPTION
A cell depending on an async cell which crashed keeps waiting.
Hence the cell is continually re-evaluated, hoping that the async
cell is now computed (but it won't ever since it crashed).

Async cells which are not pending and in an error state should not
be re-evaluated.