### PR TITLE
[IMP] compiler: allow meta parameters

### DIFF
--- a/src/functions/arguments.ts
+++ b/src/functions/arguments.ts
@@ -16,6 +16,7 @@ const ARG_TYPES: ArgType[] = [
   "RANGE<BOOLEAN>",
   "RANGE<NUMBER>",
   "RANGE<STRING>",
+  "META",
 ];
 
 /**
@@ -92,6 +93,14 @@ export function validateArguments(args: Arg[]) {
   let previousArgRepeating: boolean | undefined = false;
   let previousArgOptional: boolean | undefined = false;
   for (let current of args) {
+    if (current.type.includes("META") && current.type.length > 1) {
+      throw new Error(
+        _lt(
+          "Function ${name} has an argument that has been declared with more than one type whose type 'META'. The 'META' type can only be declared alone."
+        )
+      );
+    }
+
     if (previousArgRepeating) {
       throw new Error(
         _lt(

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -7,6 +7,7 @@ import {
   dichotomicSuccessorSearch,
 } from "./helpers";
 import { _lt } from "../translation";
+import { toZone } from "../helpers/index";
 
 /**
  * Perform a linear search and return the index of the perfect match.
@@ -27,6 +28,52 @@ function linearSearch(range: any[], target: any): number {
   // no value is found, -1 is returned
   return -1;
 }
+
+// -----------------------------------------------------------------------------
+// COLUMN
+// -----------------------------------------------------------------------------
+
+export const COLUMN: FunctionDescription = {
+  description: _lt("Column number of a specified cell."),
+  args: args(
+    `cell_reference (meta, optional, default='The cell in which the formula is entered by default') ${_lt(
+      "The cell whose column number will be returned. Column A corresponds to 1."
+    )}
+    `
+  ),
+  returns: ["NUMBER"],
+  compute: function (cellReference?: string): number {
+    let zone;
+    if (cellReference) {
+      zone = toZone(cellReference);
+    } else {
+      if (this.__originCellXC) {
+        zone = toZone(this.__originCellXC);
+      } else {
+        throw new Error(
+          _lt(
+            `In this context, the function [[FUNCTION_NAME]] needs to have a cell or range in parameter.`
+          )
+        );
+      }
+    }
+    return zone.left + 1;
+  },
+};
+
+// -----------------------------------------------------------------------------
+// COLUMNS
+// -----------------------------------------------------------------------------
+
+export const COLUMNS: FunctionDescription = {
+  description: _lt("Number of columns in a specified array or range."),
+  args: args(`range (meta) ${_lt("The range whose column count will be returned.")}`),
+  returns: ["NUMBER"],
+  compute: function (range: string): number {
+    const zone = toZone(range);
+    return zone.right - zone.left + 1;
+  },
+};
 
 // -----------------------------------------------------------------------------
 // LOOKUP
@@ -116,6 +163,49 @@ export const MATCH: FunctionDescription = {
     } else {
       throw new Error(_lt(`Did not find value '${search_key}' in MATCH evaluation.`));
     }
+  },
+};
+
+// -----------------------------------------------------------------------------
+// ROW
+// -----------------------------------------------------------------------------
+
+export const ROW: FunctionDescription = {
+  description: _lt("Row number of a specified cell."),
+  args: args(
+    `cell_reference (meta, optional, default='The cell in which the formula is entered by default')) ${_lt(
+      "The cell whose row number will be returned."
+    )}`
+  ),
+  returns: ["NUMBER"],
+  compute: function (cellReference?: string): number {
+    let zone;
+    if (cellReference) {
+      zone = toZone(cellReference);
+    } else {
+      if (this.__originCellXC) {
+        zone = toZone(this.__originCellXC);
+      } else {
+        throw Error(
+          `In this context, the function [[FUNCTION_NAME]] needs to have a cell or range in parameter.`
+        );
+      }
+    }
+    return zone.top + 1;
+  },
+};
+
+// -----------------------------------------------------------------------------
+// ROWS
+// -----------------------------------------------------------------------------
+
+export const ROWS: FunctionDescription = {
+  description: _lt("Number of rows in a specified array or range."),
+  args: args(`range (meta) ${_lt("The range whose row count will be returned.")}`),
+  returns: ["NUMBER"],
+  compute: function (range: string): number {
+    const zone = toZone(range);
+    return zone.bottom - zone.top + 1;
   },
 };
 

--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -873,7 +873,7 @@ export class CorePlugin extends BasePlugin {
       if (cell.type === "formula") {
         cell.error = undefined;
         try {
-          cell.formula = compile(content, sheetId, this.sheetIds);
+          cell.formula = compile(content, sheetId, this.sheetIds, xc);
           cell.async = cell.formula.async;
         } catch (e) {
           cell.value = "#BAD_EXPR";

--- a/src/plugins/evaluation.ts
+++ b/src/plugins/evaluation.ts
@@ -4,7 +4,7 @@ import { functionRegistry } from "../functions/index";
 import { mapCellsInZone, toCartesian } from "../helpers/index";
 import { WHistory } from "../history";
 import { Mode, ModelConfig } from "../model";
-import { Cell, Command, CommandDispatcher, EvalContext, Getters } from "../types";
+import { Cell, Command, CommandDispatcher, EvalContext, Getters, ReadCell, Range } from "../types";
 import { _lt } from "../translation";
 
 function* makeObjectIterator(obj: Object) {
@@ -21,8 +21,6 @@ function* makeSetIterator(set: Set<any>) {
 
 const functionMap = functionRegistry.mapping;
 
-type ReadCell = (xc: string, sheet: string) => any;
-type Range = (v1: string, v2: string, sheetName: string) => any[];
 type FormulaParameters = [ReadCell, Range, EvalContext];
 
 export const LOADING = "Loading...";

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -7,7 +7,8 @@ export type ArgType =
   | "RANGE"
   | "RANGE<BOOLEAN>"
   | "RANGE<NUMBER>"
-  | "RANGE<STRING>";
+  | "RANGE<STRING>"
+  | "META";
 
 export interface Arg {
   repeating?: boolean;
@@ -30,5 +31,6 @@ export interface FunctionDescription {
 
 export interface EvalContext {
   __lastFnCalled?: string;
+  __originCellXC?: string;
   [key: string]: any;
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -50,11 +50,9 @@ export interface NewCell {
   format?: string;
 }
 
-type _CompiledFormula = (
-  readCell: (xc: string, sheet: string) => any,
-  range: (v1: string, v2: string, sheetName: string) => any[],
-  ctx: {}
-) => any;
+export type ReadCell = (xc: string, sheet: string) => any;
+export type Range = (v1: string, v2: string, sheetName: string) => any[];
+export type _CompiledFormula = (readCell: ReadCell, range: Range, ctx: {}) => any;
 
 export interface CompiledFormula extends _CompiledFormula {
   async: boolean;

--- a/tests/formulas/__snapshots__/compiler_test.ts.snap
+++ b/tests/formulas/__snapshots__/compiler_test.ts.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`compile functions with meta arguments function call requesting meta parameter 1`] = `
+"function anonymous(cell,range,ctx
+) {
+// =USEMETAARG(A1)
+let _2 = \\"A1\\"
+ctx.__lastFnCalled = 'USEMETAARG'
+let _1 = ctx['USEMETAARG'](_2)
+return _1;
+}"
+`;
+
+exports[`compile functions with meta arguments function call requesting meta parameter 2`] = `
+"function anonymous(cell,range,ctx
+) {
+// =USEMETAARG(B2)
+let _2 = \\"B2\\"
+ctx.__lastFnCalled = 'USEMETAARG'
+let _1 = ctx['USEMETAARG'](_2)
+return _1;
+}"
+`;
+
 exports[`expression compiler async functions 1`] = `
 "async function anonymous(cell,range,ctx
 ) {

--- a/tests/functions/arguments_test.ts
+++ b/tests/functions/arguments_test.ts
@@ -1,4 +1,4 @@
-import { args } from "../../src/functions/arguments";
+import { args, validateArguments } from "../../src/functions/arguments";
 
 describe("args", () => {
   test("various", () => {
@@ -137,5 +137,76 @@ describe("args", () => {
         repeating: true,
       },
     ]);
+  });
+});
+
+describe("arguments validation", () => {
+  test("'META' type can only be declared alone", () => {
+    expect(() => validateArguments(args(`metaArg (meta)`))).not.toThrow();
+    expect(() => validateArguments(args(`metaArg (meta, optional)`))).not.toThrow();
+    expect(() => validateArguments(args(`metaArg (meta, repeating)`))).not.toThrow();
+
+    expect(() => validateArguments(args(`metaArg (meta, any)`))).toThrow();
+    expect(() => validateArguments(args(`metaArg (meta, range)`))).toThrow();
+    expect(() => validateArguments(args(`metaArg (meta, number)`))).toThrow();
+    expect(() => validateArguments(args(`metaArg (meta, string)`))).toThrow();
+    expect(() => validateArguments(args(`metaArg (meta, boolean)`))).toThrow();
+  });
+
+  test("The maximum repeating arguments is 1", () => {
+    expect(() =>
+      validateArguments(
+        args(`
+      arg1 (any)
+      arg2 (any, repeating)
+    `)
+      )
+    ).not.toThrow();
+    expect(() =>
+      validateArguments(
+        args(`
+      arg1 (any, repeating)
+      arg2 (any, repeating)
+    `)
+      )
+    ).toThrow();
+    expect(() =>
+      validateArguments(
+        args(`
+      arg1 (any, repeating)
+      arg2 (any)
+    `)
+      )
+    ).toThrow();
+  });
+
+  test("All optional arguments must be after all mandatory arguments", () => {
+    expect(() =>
+      validateArguments(
+        args(`
+      arg1 (any)
+      arg2 (any, optional)
+      arg3 (any, optional)
+    `)
+      )
+    ).not.toThrow();
+    expect(() =>
+      validateArguments(
+        args(`
+    arg1 (any)
+    arg2 (any, optional)
+    arg3 (any, optional, repeating)
+  `)
+      )
+    ).not.toThrow();
+    expect(() =>
+      validateArguments(
+        args(`
+      arg1 (any)
+      arg2 (any, optional)
+      arg3 (any)
+    `)
+      )
+    ).toThrow();
   });
 });

--- a/tests/functions/module_lookup_test.ts
+++ b/tests/functions/module_lookup_test.ts
@@ -1,6 +1,61 @@
-import { evaluateGrid } from "../helpers";
+import { evaluateGrid, evaluateCell } from "../helpers";
+import { Model } from "../../src/model";
 
 describe("lookup", () => {
+  //----------------------------------------------------------------------------
+  // COLUMN
+  //----------------------------------------------------------------------------
+
+  test("COLUMN: functional tests without argument", () => {
+    expect(evaluateCell("A1", { A1: "=COLUMN()" })).toBe(1);
+    expect(evaluateCell("X20", { X20: "=COLUMN()" })).toBe(24);
+    expect(evaluateCell("A1", { A1: "=COLUMN(,)" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
+  });
+
+  test("COLUMN: fuctional test without grid context", () => {
+    const model = new Model();
+    model.dispatch("SET_VALUE", { xc: "A1", text: "kikoulol" });
+    expect(() => model.getters.evaluateFormula("=COLUMN()")).toThrow();
+    expect(() => model.getters.evaluateFormula("=COLUMN(A1)")).not.toThrow();
+  });
+
+  test("COLUMN: functional tests on cell arguments", () => {
+    expect(evaluateCell("A1", { A1: "=COLUMN(G2)" })).toBe(7);
+    expect(evaluateCell("A1", { A1: "=COLUMN(ABC2)" })).toBe(731);
+    expect(evaluateCell("A1", { A1: "=COLUMN($ABC$2)" })).toBe(731);
+    expect(evaluateCell("A1", { A1: "=COLUMN(Sheet42!$ABC$2)" })).toBe(731);
+  });
+
+  test("COLUMN: functional tests on range arguments", () => {
+    expect(evaluateCell("A1", { A1: "=COLUMN(B3:C40)" })).toBe(2);
+    expect(evaluateCell("A1", { A1: "=COLUMN(D3:Z9)" })).toBe(4);
+    expect(evaluateCell("A1", { A1: "=COLUMN($D$3:$Z$9)" })).toBe(4);
+    expect(evaluateCell("A1", { A1: "=COLUMN(Sheet42!$D$3:$Z$9)" })).toBe(4);
+  });
+
+  //----------------------------------------------------------------------------
+  // COLUMNS
+  //----------------------------------------------------------------------------
+
+  test("COLUMNS: functional tests without arguments", () => {
+    expect(evaluateCell("A1", { A1: "=COLUMNS()" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
+    expect(evaluateCell("A1", { A1: "=COLUMNS(,)" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
+  });
+
+  test("COLUMNS: functional tests on cell arguments", () => {
+    expect(evaluateCell("A1", { A1: "=COLUMNS(H2)" })).toBe(1);
+    expect(evaluateCell("A1", { A1: "=COLUMNS(ABC2)" })).toBe(1);
+    expect(evaluateCell("A1", { A1: "=COLUMNS($ABC$2)" })).toBe(1);
+    expect(evaluateCell("A1", { A1: "=COLUMNS(Sheet42!$ABC$2)" })).toBe(1);
+  });
+
+  test("COLUMNS: functional tests on range arguments", () => {
+    expect(evaluateCell("A1", { A1: "=COLUMNS(B3:C40)" })).toBe(2);
+    expect(evaluateCell("A1", { A1: "=COLUMNS(D3:Z9)" })).toBe(23);
+    expect(evaluateCell("A1", { A1: "=COLUMNS($D$3:$Z$9)" })).toBe(23);
+    expect(evaluateCell("A1", { A1: "=COLUMNS(Sheet42!$D$3:$Z$9)" })).toBe(23);
+  });
+
   //----------------------------------------------------------------------------
   // LOOKUP
   //----------------------------------------------------------------------------
@@ -9,24 +64,24 @@ describe("lookup", () => {
     // prettier-ignore
     const grid = {
       A1: "1", B1: "res 01", C1: "res 11", D1: "res 21", E1: "res 31",
-      A2: "2", B2: "res 02", C2: "res 12", D2: "res 22", E2: "res 32", 
-      A3: "6", B3: "res 06", C3: "res 16", D3: "res 26", E3: "res 36", 
+      A2: "2", B2: "res 02", C2: "res 12", D2: "res 22", E2: "res 32",
+      A3: "6", B3: "res 06", C3: "res 16", D3: "res 26", E3: "res 36",
       A4: "9", B4: "res 09", C4: "res 19", D4: "res 29", E4: "res 39",
 
-      A5: "=LOOKUP(6, A1:A4)", 
-      A6: "=LOOKUP(6, A1:B4)", 
+      A5: "=LOOKUP(6, A1:A4)",
+      A6: "=LOOKUP(6, A1:B4)",
       A7: "=LOOKUP(6, A1:C4)",
       A8: "=LOOKUP(6, A1:D4)",
       A9: "=LOOKUP(6, A1:E4)",
 
       A10: "=LOOKUP(6, A1:D4, E1:E4)", B10: "=LOOKUP(6, A1:C4, D1:E4)",
-      A11: "=LOOKUP(6, A1:A2, B3:B4)", B11: "=LOOKUP(6, A1:A2, B2:B4)", 
-      A12: "=LOOKUP(1, A1:A2, B1:C1)", B12: "=LOOKUP(2, A1:A2, B1:C1)", 
+      A11: "=LOOKUP(6, A1:A2, B3:B4)", B11: "=LOOKUP(6, A1:A2, B2:B4)",
+      A12: "=LOOKUP(1, A1:A2, B1:C1)", B12: "=LOOKUP(2, A1:A2, B1:C1)",
 
       A13: "=LOOKUP(6, A1:A3, B2:B3)",
       A14: "=LOOKUP(6, A1:A3, B3:C3)",
 
-      A15: "=LOOKUP(0, A1:B4)", 
+      A15: "=LOOKUP(0, A1:B4)",
       A16: "=LOOKUP(10, A1:B4)"
     };
 
@@ -57,17 +112,17 @@ describe("lookup", () => {
 
   // prettier-ignore
   const rangeAscending = {
-    A1: "1", A2: "2", A3: "2", A4: "3",  A5: "5", A6: "6"
+    A1: "1", A2: "2", A3: "2", A4: "3", A5: "5", A6: "6"
   };
 
   // prettier-ignore
   const rangeUnsorted = {
-    A1: "1", A2: "5", A3: "3", A4: "3",  A5: "2", A6: "7"
+    A1: "1", A2: "5", A3: "3", A4: "3", A5: "2", A6: "7"
   };
 
   // prettier-ignore
   const rangeDescending = {
-    A1: "6", A2: "5", A3: "3", A4: "2",  A5: "2", A6: "1"
+    A1: "6", A2: "5", A3: "3", A4: "2", A5: "2", A6: "1"
   };
 
   // prettier-ignore
@@ -211,7 +266,7 @@ describe("lookup", () => {
   test("MATCH: grid of STRING ascending", () => {
     // prettier-ignore
     const ascendingStringEvAsAscending = {
-      A1: '="1"', A2: '="10"', A3: '="100"', A4: '="2"',  A5: '="2"',
+      A1: '="1"', A2: '="10"', A3: '="100"', A4: '="2"', A5: '="2"',
       B1: '=MATCH( "1",   A1:A5, 1)',
       B2: '=MATCH( "2",   A1:A5, 1)',
       B3: '=MATCH( "5",   A1:A5, 1)',
@@ -230,7 +285,7 @@ describe("lookup", () => {
   test("MATCH: grid of STRING unsorted", () => {
     // prettier-ignore
     const unsortedStringEvAsUnsorted = {
-      A1: '="1"', A2: '="2"', A3: '="2"', A4: '="10"',  A5: '="100"',
+      A1: '="1"', A2: '="2"', A3: '="2"', A4: '="10"', A5: '="100"',
       C1: '=MATCH( "1",   A1:A5, 0)',
       C2: '=MATCH( "2",   A1:A5, 0)',
       C3: '=MATCH( "5",   A1:A5, 0)',
@@ -249,7 +304,7 @@ describe("lookup", () => {
   test("MATCH: grid of STRING descending", () => {
     // prettier-ignore
     const descendingStringEvAsDescending = {
-      A1: '="2"', A2: '="2"', A3: '="100"', A4: '="10"',  A5: '="1"',
+      A1: '="2"', A2: '="2"', A3: '="100"', A4: '="10"', A5: '="1"',
       D1: '=MATCH( "1",   A1:A5, -1)',
       D2: '=MATCH( "2",   A1:A5, -1)',
       D3: '=MATCH( "5",   A1:A5, -1)',
@@ -263,6 +318,60 @@ describe("lookup", () => {
     expect(descendingString.D3).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
     expect(descendingString.D4).toBe(4);
     expect(descendingString.D5).toBe(3);
+  });
+
+  //----------------------------------------------------------------------------
+  // ROW
+  //----------------------------------------------------------------------------
+
+  test("ROW: functional tests on simple arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ROW()" })).toBe(1);
+    expect(evaluateCell("X20", { X20: "=ROW()" })).toBe(20);
+    expect(evaluateCell("A1", { A1: "=ROW(,)" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
+  });
+
+  test("ROW: fuctional test without grid context", () => {
+    const model = new Model();
+    model.dispatch("SET_VALUE", { xc: "A1", text: "kikoulol" });
+    expect(() => model.getters.evaluateFormula("=ROW()")).toThrow();
+    expect(() => model.getters.evaluateFormula("=ROW(A1)")).not.toThrow();
+  });
+
+  test("ROW: functional tests on cell arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ROW(H2)" })).toBe(2);
+    expect(evaluateCell("A1", { A1: "=ROW(A234)" })).toBe(234);
+    expect(evaluateCell("A1", { A1: "=ROW($A$234)" })).toBe(234);
+    expect(evaluateCell("A1", { A1: "=ROW(Sheet42!$A$234)" })).toBe(234);
+  });
+
+  test("ROW: functional tests on range arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ROW(B3:C40)" })).toBe(3);
+    expect(evaluateCell("A1", { A1: "=ROW(D3:Z9)" })).toBe(3);
+    expect(evaluateCell("A1", { A1: "=ROW($D$3:$Z$9)" })).toBe(3);
+    expect(evaluateCell("A1", { A1: "=ROW(Sheet42!$D$3:$Z$9)" })).toBe(3);
+  });
+
+  //----------------------------------------------------------------------------
+  // ROWS
+  //----------------------------------------------------------------------------
+
+  test("ROWS: functional tests without arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ROWS()" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
+    expect(evaluateCell("A1", { A1: "=ROWS(,)" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
+  });
+
+  test("ROWS: functional tests on cell arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ROWS(H2)" })).toBe(1);
+    expect(evaluateCell("A1", { A1: "=ROWS(ABC2)" })).toBe(1);
+    expect(evaluateCell("A1", { A1: "=ROWS($ABC$2)" })).toBe(1);
+    expect(evaluateCell("A1", { A1: "=ROWS(Sheet42!$ABC$2)" })).toBe(1);
+  });
+
+  test("ROWS: functional tests on range arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ROWS(B3:C40)" })).toBe(38);
+    expect(evaluateCell("A1", { A1: "=ROWS(D3:Z9)" })).toBe(7);
+    expect(evaluateCell("A1", { A1: "=ROWS($D$3:$Z$9)" })).toBe(7);
+    expect(evaluateCell("A1", { A1: "=ROWS(Sheet42!$D$3:$Z$9)" })).toBe(7);
   });
 
   //----------------------------------------------------------------------------
@@ -291,145 +400,145 @@ describe("lookup", () => {
 
   // prettier-ignore
   const evAsSorted = {
-   C1: "=VLOOKUP( 0, A1:B6, 1, TRUE )",   D1: "=VLOOKUP( 0, A1:B6, 2, TRUE )",
-   C2: "=VLOOKUP( 1, A1:B6, 1, TRUE )",   D2: "=VLOOKUP( 1, A1:B6, 2, TRUE )",
-   C3: "=VLOOKUP( 2, A1:B6, 1, TRUE )",   D3: "=VLOOKUP( 2, A1:B6, 2, TRUE )",
-   C4: "=VLOOKUP( 3, A1:B6, 1, TRUE )",   D4: "=VLOOKUP( 3, A1:B6, 2, TRUE )",
-   C5: "=VLOOKUP( 4, A1:B6, 1, TRUE )",   D5: "=VLOOKUP( 4, A1:B6, 2, TRUE )",
-   C6: "=VLOOKUP( 5, A1:B6, 1, TRUE )",   D6: "=VLOOKUP( 5, A1:B6, 2, TRUE )",
-   C7: "=VLOOKUP( 6, A1:B6, 1, TRUE )",   D7: "=VLOOKUP( 6, A1:B6, 2, TRUE )",
-   C8: "=VLOOKUP( 7, A1:B6, 1, TRUE )",   D8: "=VLOOKUP( 7, A1:B6, 2, TRUE )",
+    C1: "=VLOOKUP( 0, A1:B6, 1, TRUE )", D1: "=VLOOKUP( 0, A1:B6, 2, TRUE )",
+    C2: "=VLOOKUP( 1, A1:B6, 1, TRUE )", D2: "=VLOOKUP( 1, A1:B6, 2, TRUE )",
+    C3: "=VLOOKUP( 2, A1:B6, 1, TRUE )", D3: "=VLOOKUP( 2, A1:B6, 2, TRUE )",
+    C4: "=VLOOKUP( 3, A1:B6, 1, TRUE )", D4: "=VLOOKUP( 3, A1:B6, 2, TRUE )",
+    C5: "=VLOOKUP( 4, A1:B6, 1, TRUE )", D5: "=VLOOKUP( 4, A1:B6, 2, TRUE )",
+    C6: "=VLOOKUP( 5, A1:B6, 1, TRUE )", D6: "=VLOOKUP( 5, A1:B6, 2, TRUE )",
+    C7: "=VLOOKUP( 6, A1:B6, 1, TRUE )", D7: "=VLOOKUP( 6, A1:B6, 2, TRUE )",
+    C8: "=VLOOKUP( 7, A1:B6, 1, TRUE )", D8: "=VLOOKUP( 7, A1:B6, 2, TRUE )",
 
-   E1: "=VLOOKUP( 0, A1:B6, 0, TRUE )",   F1: "=VLOOKUP( 0, A1:B6, 3, TRUE )",
-   E2: "=VLOOKUP( 1, A1:B6, 0, TRUE )",   F2: "=VLOOKUP( 1, A1:B6, 3, TRUE )",
+    E1: "=VLOOKUP( 0, A1:B6, 0, TRUE )", F1: "=VLOOKUP( 0, A1:B6, 3, TRUE )",
+    E2: "=VLOOKUP( 1, A1:B6, 0, TRUE )", F2: "=VLOOKUP( 1, A1:B6, 3, TRUE )",
 
-   G1: "=VLOOKUP( 1, A1:B6, 2.8, TRUE )",
+    G1: "=VLOOKUP( 1, A1:B6, 2.8, TRUE )",
   };
 
   // prettier-ignore
   const evAsNotSorted = {
-    C1: "=VLOOKUP( 0, A1:B6, 1, FALSE )",   D1: "=VLOOKUP( 0, A1:B6, 2, FALSE )",
-    C2: "=VLOOKUP( 1, A1:B6, 1, FALSE )",   D2: "=VLOOKUP( 1, A1:B6, 2, FALSE )",
-    C3: "=VLOOKUP( 2, A1:B6, 1, FALSE )",   D3: "=VLOOKUP( 2, A1:B6, 2, FALSE )",
-    C4: "=VLOOKUP( 3, A1:B6, 1, FALSE )",   D4: "=VLOOKUP( 3, A1:B6, 2, FALSE )",
-    C5: "=VLOOKUP( 4, A1:B6, 1, FALSE )",   D5: "=VLOOKUP( 4, A1:B6, 2, FALSE )",
-    C6: "=VLOOKUP( 5, A1:B6, 1, FALSE )",   D6: "=VLOOKUP( 5, A1:B6, 2, FALSE )",
-    C7: "=VLOOKUP( 6, A1:B6, 1, FALSE )",   D7: "=VLOOKUP( 6, A1:B6, 2, FALSE )",
-    C8: "=VLOOKUP( 7, A1:B6, 1, FALSE )",   D8: "=VLOOKUP( 7, A1:B6, 2, FALSE )",
+    C1: "=VLOOKUP( 0, A1:B6, 1, FALSE )", D1: "=VLOOKUP( 0, A1:B6, 2, FALSE )",
+    C2: "=VLOOKUP( 1, A1:B6, 1, FALSE )", D2: "=VLOOKUP( 1, A1:B6, 2, FALSE )",
+    C3: "=VLOOKUP( 2, A1:B6, 1, FALSE )", D3: "=VLOOKUP( 2, A1:B6, 2, FALSE )",
+    C4: "=VLOOKUP( 3, A1:B6, 1, FALSE )", D4: "=VLOOKUP( 3, A1:B6, 2, FALSE )",
+    C5: "=VLOOKUP( 4, A1:B6, 1, FALSE )", D5: "=VLOOKUP( 4, A1:B6, 2, FALSE )",
+    C6: "=VLOOKUP( 5, A1:B6, 1, FALSE )", D6: "=VLOOKUP( 5, A1:B6, 2, FALSE )",
+    C7: "=VLOOKUP( 6, A1:B6, 1, FALSE )", D7: "=VLOOKUP( 6, A1:B6, 2, FALSE )",
+    C8: "=VLOOKUP( 7, A1:B6, 1, FALSE )", D8: "=VLOOKUP( 7, A1:B6, 2, FALSE )",
 
-    E1: "=VLOOKUP( 0, A1:B6, 0, FALSE )",   F1: "=VLOOKUP( 0, A1:B6, 3, FALSE )",
-    E2: "=VLOOKUP( 1, A1:B6, 0, FALSE )",   F2: "=VLOOKUP( 1, A1:B6, 3, FALSE )",
- 
-    G1: "=VLOOKUP( 1, A1:B6, 2.8, FALSE )",    
+    E1: "=VLOOKUP( 0, A1:B6, 0, FALSE )", F1: "=VLOOKUP( 0, A1:B6, 3, FALSE )",
+    E2: "=VLOOKUP( 1, A1:B6, 0, FALSE )", F2: "=VLOOKUP( 1, A1:B6, 3, FALSE )",
+
+    G1: "=VLOOKUP( 1, A1:B6, 2.8, FALSE )",
   };
 
   // prettier-ignore
-  test("VLOOKUP: grid (sorted) evaluate as sorted" , () => {
+  test("VLOOKUP: grid (sorted) evaluate as sorted", () => {
 
-    const gridSortedEvAsSorted = {...gridSorted, ...evAsSorted};
+    const gridSortedEvAsSorted = { ...gridSorted, ...evAsSorted };
     const sAsS = evaluateGrid(gridSortedEvAsSorted);
 
     // case is_sorted is true: If all values in the search column are greater 
     // than the search key, #ERROR is returned.
     // @compatibility: on google sheets return #N/A
-    expect(sAsS.C1).toEqual("#ERROR");  expect(sAsS.D1).toEqual("#ERROR");
+    expect(sAsS.C1).toEqual("#ERROR"); expect(sAsS.D1).toEqual("#ERROR");
 
     // normal behavior: 
-    expect(sAsS.C2).toEqual(1);  expect(sAsS.D2).toEqual("res 1");
-    expect(sAsS.C4).toEqual(3);  expect(sAsS.D4).toEqual("res 3");
-    expect(sAsS.C6).toEqual(5);  expect(sAsS.D6).toEqual("res 5");
-    expect(sAsS.C7).toEqual(6);  expect(sAsS.D7).toEqual("res 6");
-    
+    expect(sAsS.C2).toEqual(1); expect(sAsS.D2).toEqual("res 1");
+    expect(sAsS.C4).toEqual(3); expect(sAsS.D4).toEqual("res 3");
+    expect(sAsS.C6).toEqual(5); expect(sAsS.D6).toEqual("res 5");
+    expect(sAsS.C7).toEqual(6); expect(sAsS.D7).toEqual("res 6");
+
     // multiple matching values: contrary to 'is_sorted = FALSE' 
     // return the last founded value and no the first
-    expect(sAsS.C3).toEqual(2);  expect(sAsS.D3).toEqual("res 2.2");
+    expect(sAsS.C3).toEqual(2); expect(sAsS.D3).toEqual("res 2.2");
 
     // no present value: return the nearest match 
     // (less than or equal to the search key)
-    expect(sAsS.C5).toEqual(3);  expect(sAsS.D5).toEqual("res 3");
-    expect(sAsS.C8).toEqual(6);  expect(sAsS.D8).toEqual("res 6");
+    expect(sAsS.C5).toEqual(3); expect(sAsS.D5).toEqual("res 3");
+    expect(sAsS.C8).toEqual(6); expect(sAsS.D8).toEqual("res 6");
 
     // error on index: if index is not between 1 and the number of columns in 
     // range, #ERROR is returned"
     // @compatibility: on googlesheets, return #VALUE!
     expect(sAsS.E1).toEqual("#ERROR"); expect(sAsS.F1).toEqual("#ERROR");
     expect(sAsS.E2).toEqual("#ERROR"); expect(sAsS.F2).toEqual("#ERROR");
-    
+
     // float index 
     expect(sAsS.G1).toEqual("res 1");
   });
 
   // prettier-ignore
-  test("VLOOKUP: grid (not sorted) evaluate as sorted" , () => {
+  test("VLOOKUP: grid (not sorted) evaluate as sorted", () => {
 
-    const gridNotSortedEvAsSorted = {...gridNotSorted, ...evAsSorted};
+    const gridNotSortedEvAsSorted = { ...gridNotSorted, ...evAsSorted };
     const nsAsS = evaluateGrid(gridNotSortedEvAsSorted);
 
     // case is_sorted is true: If all values in the search column are greater 
     // than the search key, #ERROR is returned.
     // @compatibility: on google sheets return #N/A
-    expect(nsAsS.C1).toEqual("#ERROR");  expect(nsAsS.D1).toEqual("#ERROR");
+    expect(nsAsS.C1).toEqual("#ERROR"); expect(nsAsS.D1).toEqual("#ERROR");
 
     // normal behavior: 
-    expect(nsAsS.C2).toEqual(1);  expect(nsAsS.D2).toEqual("res 1");
-    expect(nsAsS.C6).toEqual(5);  expect(nsAsS.D6).toEqual("res 5");
-    expect(nsAsS.C7).toEqual(6);  expect(nsAsS.D7).toEqual("res 6");
-    
+    expect(nsAsS.C2).toEqual(1); expect(nsAsS.D2).toEqual("res 1");
+    expect(nsAsS.C6).toEqual(5); expect(nsAsS.D6).toEqual("res 5");
+    expect(nsAsS.C7).toEqual(6); expect(nsAsS.D7).toEqual("res 6");
+
     // multiple matching values: contrary to 'is_sorted = FALSE' 
     // return the last founded value and no the first
-    expect(nsAsS.C3).toEqual(2);  expect(nsAsS.D3).toEqual("res 2.2");
+    expect(nsAsS.C3).toEqual(2); expect(nsAsS.D3).toEqual("res 2.2");
 
     // if is_sorted is set to TRUE or omitted, and the first column of the range 
     // is not in sorted order, an incorrect value might be returned.
-    expect(nsAsS.C4).toEqual(2);  expect(nsAsS.D4).toEqual("res 2.2");
-    expect(nsAsS.C5).toEqual(2);  expect(nsAsS.D5).toEqual("res 2.2");
+    expect(nsAsS.C4).toEqual(2); expect(nsAsS.D4).toEqual("res 2.2");
+    expect(nsAsS.C5).toEqual(2); expect(nsAsS.D5).toEqual("res 2.2");
 
     // no present value: return the nearest match 
     // (less than or equal to the search key)
-    expect(nsAsS.C8).toEqual(6);  expect(nsAsS.D8).toEqual("res 6");
+    expect(nsAsS.C8).toEqual(6); expect(nsAsS.D8).toEqual("res 6");
 
     // error on index: if index is not between 1 and the number of columns in 
     // range, #ERROR is returned
     // @compatibility: on googlesheets, return #VALUE!
     expect(nsAsS.E1).toEqual("#ERROR"); expect(nsAsS.F1).toEqual("#ERROR");
     expect(nsAsS.E2).toEqual("#ERROR"); expect(nsAsS.F2).toEqual("#ERROR");
-    
+
     // float index 
     expect(nsAsS.G1).toEqual("res 1");
   });
 
   // prettier-ignore
-  test("VLOOKUP: grid (sorted and not sorted) evaluate as not sorted" , () => {
+  test("VLOOKUP: grid (sorted and not sorted) evaluate as not sorted", () => {
 
-    const gridSortedEvAsNotSorted = {...gridSorted, ...evAsNotSorted};
+    const gridSortedEvAsNotSorted = { ...gridSorted, ...evAsNotSorted };
     const sAsNs = evaluateGrid(gridSortedEvAsNotSorted);
-  
-    const gridNotSortedEvAsNotSorted = {...gridNotSorted, ...evAsNotSorted};
+
+    const gridNotSortedEvAsNotSorted = { ...gridNotSorted, ...evAsNotSorted };
     const nsAsNs = evaluateGrid(gridNotSortedEvAsNotSorted);
 
     // case is_sorted is false: #ERROR is returned if no such value is found.
     // @compatibility: on google sheets return #N/A
-    expect(sAsNs.C1).toEqual("#ERROR");  expect(sAsNs.D1).toEqual("#ERROR");
-    expect(sAsNs.C5).toEqual("#ERROR");  expect(sAsNs.D5).toEqual("#ERROR");
-    expect(sAsNs.C8).toEqual("#ERROR");  expect(sAsNs.D8).toEqual("#ERROR");
-    expect(nsAsNs.C1).toEqual("#ERROR");  expect(nsAsNs.D1).toEqual("#ERROR");
-    expect(nsAsNs.C5).toEqual("#ERROR");  expect(nsAsNs.D5).toEqual("#ERROR");
-    expect(nsAsNs.C8).toEqual("#ERROR");  expect(nsAsNs.D8).toEqual("#ERROR");
+    expect(sAsNs.C1).toEqual("#ERROR"); expect(sAsNs.D1).toEqual("#ERROR");
+    expect(sAsNs.C5).toEqual("#ERROR"); expect(sAsNs.D5).toEqual("#ERROR");
+    expect(sAsNs.C8).toEqual("#ERROR"); expect(sAsNs.D8).toEqual("#ERROR");
+    expect(nsAsNs.C1).toEqual("#ERROR"); expect(nsAsNs.D1).toEqual("#ERROR");
+    expect(nsAsNs.C5).toEqual("#ERROR"); expect(nsAsNs.D5).toEqual("#ERROR");
+    expect(nsAsNs.C8).toEqual("#ERROR"); expect(nsAsNs.D8).toEqual("#ERROR");
 
     // normal behavior: 
-    expect(sAsNs.C2).toEqual(1);  expect(sAsNs.D2).toEqual("res 1");
-    expect(sAsNs.C4).toEqual(3);  expect(sAsNs.D4).toEqual("res 3");
-    expect(sAsNs.C6).toEqual(5);  expect(sAsNs.D6).toEqual("res 5");
-    expect(sAsNs.C7).toEqual(6);  expect(sAsNs.D7).toEqual("res 6");
-    expect(nsAsNs.C2).toEqual(1);  expect(nsAsNs.D2).toEqual("res 1");
-    expect(nsAsNs.C4).toEqual(3);  expect(nsAsNs.D4).toEqual("res 3");
-    expect(nsAsNs.C6).toEqual(5);  expect(nsAsNs.D6).toEqual("res 5");
-    expect(nsAsNs.C7).toEqual(6);  expect(nsAsNs.D7).toEqual("res 6");
-    
+    expect(sAsNs.C2).toEqual(1); expect(sAsNs.D2).toEqual("res 1");
+    expect(sAsNs.C4).toEqual(3); expect(sAsNs.D4).toEqual("res 3");
+    expect(sAsNs.C6).toEqual(5); expect(sAsNs.D6).toEqual("res 5");
+    expect(sAsNs.C7).toEqual(6); expect(sAsNs.D7).toEqual("res 6");
+    expect(nsAsNs.C2).toEqual(1); expect(nsAsNs.D2).toEqual("res 1");
+    expect(nsAsNs.C4).toEqual(3); expect(nsAsNs.D4).toEqual("res 3");
+    expect(nsAsNs.C6).toEqual(5); expect(nsAsNs.D6).toEqual("res 5");
+    expect(nsAsNs.C7).toEqual(6); expect(nsAsNs.D7).toEqual("res 6");
+
     // multiple matching values: contrary to 'is_sorted = TRUE' 
     // return the first founded value and no the last
-    expect(sAsNs.C3).toEqual(2);  expect(sAsNs.D3).toEqual("res 2.1");
-    expect(nsAsNs.C3).toEqual(2);  expect(nsAsNs.D3).toEqual("res 2.1");
+    expect(sAsNs.C3).toEqual(2); expect(sAsNs.D3).toEqual("res 2.1");
+    expect(nsAsNs.C3).toEqual(2); expect(nsAsNs.D3).toEqual("res 2.1");
 
     // error on index: if index is not between 1 and the number of columns in 
     // range, #ERROR is returned
@@ -446,77 +555,77 @@ describe("lookup", () => {
 
   // prettier-ignore
   const gridOfStringSorted = {
-    A1: '="1"',   B1: "res 1",
-    A2: '="10"',  B2: "res 10",
+    A1: '="1"', B1: "res 1",
+    A2: '="10"', B2: "res 10",
     A3: '="100"', B3: "res 100",
-    A4: '="2"',   B4: "res 2.1",
-    A5: '="2"',   B5: "res 2.2",
+    A4: '="2"', B4: "res 2.1",
+    A5: '="2"', B5: "res 2.2",
   };
 
   // prettier-ignore
   const gridOfStringNotSorted = {
-    A1: '="1"',   B1: "res 1",
-    A2: '="2"',   B2: "res 2.1",
-    A3: '="2"',   B3: "res 2.2",
-    A4: '="10"',  B4: "res 10",
+    A1: '="1"', B1: "res 1",
+    A2: '="2"', B2: "res 2.1",
+    A3: '="2"', B3: "res 2.2",
+    A4: '="10"', B4: "res 10",
     A5: '="100"', B5: "res 100",
   };
 
   // prettier-ignore
   const evAsSortedString = {
-    C1: '=VLOOKUP( "1",   A1:B5, 1, TRUE )',   D1: '=VLOOKUP( "1",   A1:B5, 2, TRUE )',
-    C2: '=VLOOKUP( "2",   A1:B5, 1, TRUE )',   D2: '=VLOOKUP( "2",   A1:B5, 2, TRUE )',
-    C3: '=VLOOKUP( "5",   A1:B5, 1, TRUE )',   D3: '=VLOOKUP( "5",   A1:B5, 2, TRUE )',
-    C4: '=VLOOKUP( "10",  A1:B5, 1, TRUE )',   D4: '=VLOOKUP( "10",  A1:B5, 2, TRUE )',
-    C5: '=VLOOKUP( "100", A1:B5, 1, TRUE )',   D5: '=VLOOKUP( "100", A1:B5, 2, TRUE )',
-   };
+    C1: '=VLOOKUP( "1",   A1:B5, 1, TRUE )', D1: '=VLOOKUP( "1",   A1:B5, 2, TRUE )',
+    C2: '=VLOOKUP( "2",   A1:B5, 1, TRUE )', D2: '=VLOOKUP( "2",   A1:B5, 2, TRUE )',
+    C3: '=VLOOKUP( "5",   A1:B5, 1, TRUE )', D3: '=VLOOKUP( "5",   A1:B5, 2, TRUE )',
+    C4: '=VLOOKUP( "10",  A1:B5, 1, TRUE )', D4: '=VLOOKUP( "10",  A1:B5, 2, TRUE )',
+    C5: '=VLOOKUP( "100", A1:B5, 1, TRUE )', D5: '=VLOOKUP( "100", A1:B5, 2, TRUE )',
+  };
 
   // prettier-ignore
   const evAsNotSortedString = {
-    C1: '=VLOOKUP( "1",   A1:B5, 1, FALSE )',   D1: '=VLOOKUP( "1",   A1:B5, 2, FALSE )',
-    C2: '=VLOOKUP( "2",   A1:B5, 1, FALSE )',   D2: '=VLOOKUP( "2",   A1:B5, 2, FALSE )',
-    C3: '=VLOOKUP( "5",   A1:B5, 1, FALSE )',   D3: '=VLOOKUP( "5",   A1:B5, 2, FALSE )',
-    C4: '=VLOOKUP( "10",  A1:B5, 1, FALSE )',   D4: '=VLOOKUP( "10",  A1:B5, 2, FALSE )',
-    C5: '=VLOOKUP( "100", A1:B5, 1, FALSE )',   D5: '=VLOOKUP( "100", A1:B5, 2, FALSE )',
-   };
+    C1: '=VLOOKUP( "1",   A1:B5, 1, FALSE )', D1: '=VLOOKUP( "1",   A1:B5, 2, FALSE )',
+    C2: '=VLOOKUP( "2",   A1:B5, 1, FALSE )', D2: '=VLOOKUP( "2",   A1:B5, 2, FALSE )',
+    C3: '=VLOOKUP( "5",   A1:B5, 1, FALSE )', D3: '=VLOOKUP( "5",   A1:B5, 2, FALSE )',
+    C4: '=VLOOKUP( "10",  A1:B5, 1, FALSE )', D4: '=VLOOKUP( "10",  A1:B5, 2, FALSE )',
+    C5: '=VLOOKUP( "100", A1:B5, 1, FALSE )', D5: '=VLOOKUP( "100", A1:B5, 2, FALSE )',
+  };
 
   // prettier-ignore
-  test("VLOOKUP: grid of STRING (sorted) evaluate as sorted" , () => {
+  test("VLOOKUP: grid of STRING (sorted) evaluate as sorted", () => {
 
-    const gridOfStringSortedEvAsSortedString = {...gridOfStringSorted, ...evAsSortedString};
+    const gridOfStringSortedEvAsSortedString = { ...gridOfStringSorted, ...evAsSortedString };
     const ssAsSs = evaluateGrid(gridOfStringSortedEvAsSortedString);
 
-    expect(ssAsSs.C1).toEqual("1");    expect(ssAsSs.D1).toEqual("res 1");
-    expect(ssAsSs.C2).toEqual("2");    expect(ssAsSs.D2).toEqual("res 2.2");
-    expect(ssAsSs.C3).toEqual("2");    expect(ssAsSs.D3).toEqual("res 2.2");
-    expect(ssAsSs.C4).toEqual("10");   expect(ssAsSs.D4).toEqual("res 10");
-    expect(ssAsSs.C5).toEqual("100");  expect(ssAsSs.D5).toEqual("res 100");
+    expect(ssAsSs.C1).toEqual("1"); expect(ssAsSs.D1).toEqual("res 1");
+    expect(ssAsSs.C2).toEqual("2"); expect(ssAsSs.D2).toEqual("res 2.2");
+    expect(ssAsSs.C3).toEqual("2"); expect(ssAsSs.D3).toEqual("res 2.2");
+    expect(ssAsSs.C4).toEqual("10"); expect(ssAsSs.D4).toEqual("res 10");
+    expect(ssAsSs.C5).toEqual("100"); expect(ssAsSs.D5).toEqual("res 100");
   });
 
   // prettier-ignore
-  test("VLOOKUP: grid of STRING (not sorted) evaluate as sorted" , () => {
+  test("VLOOKUP: grid of STRING (not sorted) evaluate as sorted", () => {
 
-    const gridOfStringNotSortedEvAsSortedString = {...gridOfStringNotSorted, ...evAsSortedString};
+    const gridOfStringNotSortedEvAsSortedString = { ...gridOfStringNotSorted, ...evAsSortedString };
     const nssAsSs = evaluateGrid(gridOfStringNotSortedEvAsSortedString);
 
-    expect(nssAsSs.C1).toEqual("1");   expect(nssAsSs.D1).toEqual("res 1");
+    expect(nssAsSs.C1).toEqual("1"); expect(nssAsSs.D1).toEqual("res 1");
     expect(nssAsSs.C2).toEqual("100"); expect(nssAsSs.D2).toEqual("res 100");
     expect(nssAsSs.C3).toEqual("100"); expect(nssAsSs.D3).toEqual("res 100");
-    expect(nssAsSs.C4).toEqual("1");   expect(nssAsSs.D4).toEqual("res 1");
-    expect(nssAsSs.C5).toEqual("1");   expect(nssAsSs.D5).toEqual("res 1");
+    expect(nssAsSs.C4).toEqual("1"); expect(nssAsSs.D4).toEqual("res 1");
+    expect(nssAsSs.C5).toEqual("1"); expect(nssAsSs.D5).toEqual("res 1");
   });
 
   // prettier-ignore
-  test("VLOOKUP: grid of STRING (sorted and not sorted) evaluate as not sorted" , () => {
+  test("VLOOKUP: grid of STRING (sorted and not sorted) evaluate as not sorted", () => {
 
-    const gridOfStringSortedEvAsNotSortedString = {...gridOfStringSorted, ...evAsNotSortedString};
+    const gridOfStringSortedEvAsNotSortedString = { ...gridOfStringSorted, ...evAsNotSortedString };
     const ssAsNss = evaluateGrid(gridOfStringSortedEvAsNotSortedString);
 
-    const gridOfStringNotSortedEvAsNotSortedString = {...gridOfStringNotSorted, ...evAsNotSortedString};
+    const gridOfStringNotSortedEvAsNotSortedString = { ...gridOfStringNotSorted, ...evAsNotSortedString };
     const nssAsNss = evaluateGrid(gridOfStringNotSortedEvAsNotSortedString);
 
-    expect(ssAsNss.C1).toEqual("1");   expect(ssAsNss.D1).toEqual("res 1");
-    expect(nssAsNss.C1).toEqual("1");   expect(nssAsNss.D1).toEqual("res 1");
+    expect(ssAsNss.C1).toEqual("1"); expect(ssAsNss.D1).toEqual("res 1");
+    expect(nssAsNss.C1).toEqual("1"); expect(nssAsNss.D1).toEqual("res 1");
 
     expect(ssAsNss.C2).toEqual("2"); expect(ssAsNss.D2).toEqual("res 2.1");
     expect(nssAsNss.C2).toEqual("2"); expect(nssAsNss.D2).toEqual("res 2.1");
@@ -524,10 +633,10 @@ describe("lookup", () => {
     expect(ssAsNss.C3).toEqual("#ERROR"); expect(ssAsNss.D3).toEqual("#ERROR");
     expect(nssAsNss.C3).toEqual("#ERROR"); expect(nssAsNss.D3).toEqual("#ERROR");
 
-    expect(ssAsNss.C4).toEqual("10");   expect(ssAsNss.D4).toEqual("res 10");
-    expect(nssAsNss.C4).toEqual("10");   expect(nssAsNss.D4).toEqual("res 10");
+    expect(ssAsNss.C4).toEqual("10"); expect(ssAsNss.D4).toEqual("res 10");
+    expect(nssAsNss.C4).toEqual("10"); expect(nssAsNss.D4).toEqual("res 10");
 
-    expect(ssAsNss.C5).toEqual("100");   expect(ssAsNss.D5).toEqual("res 100");
-    expect(nssAsNss.C5).toEqual("100");   expect(nssAsNss.D5).toEqual("res 100");
+    expect(ssAsNss.C5).toEqual("100"); expect(ssAsNss.D5).toEqual("res 100");
+    expect(nssAsNss.C5).toEqual("100"); expect(nssAsNss.D5).toEqual("res 100");
   });
 });


### PR DESCRIPTION
The purpose of this commit is to allow certain functions such as the
"COLUMN" function to know informations about cells other than the value
of the cell.

This is useful for example to know the coordinates of the cell passed in
parameter of a function. This therefore made it possible to add two new
functions:

-COLUM (module_lookup)
-ROW (module_lookup)

Each serving to define the x-axis and the y-axis of a cell.