### PR TITLE
[FIX] composer: Don't process keyup events after edition is done

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -267,6 +267,7 @@ export class Composer extends Component<any, SpreadsheetEnv> {
 
   onKeyup(ev: KeyboardEvent) {
     if (
+      this.isDone ||
       [
         "Control",
         "Shift",

--- a/src/plugins/edition.ts
+++ b/src/plugins/edition.ts
@@ -41,7 +41,9 @@ export class EditionPlugin extends BasePlugin {
         });
         break;
       case "STOP_COMPOSER_SELECTION":
-        this.mode = "editing";
+        if (this.mode === "selecting") {
+          this.mode = "editing";
+        }
         break;
       case "START_EDITION":
         this.startEdition(cmd.text);

--- a/tests/components/composer_test.ts
+++ b/tests/components/composer_test.ts
@@ -248,6 +248,27 @@ describe("composer", () => {
     await nextTick();
     expect(model.getters.getCurrentContent()).toBe("");
   });
+  test("keyup event triggered after edition end", async () => {
+    canvasEl.dispatchEvent(
+      new KeyboardEvent("keydown", Object.assign({ key: "d", bubbles: true }))
+    );
+    await nextTick();
+    const composerEl = fixture.querySelector("div.o-composer")!;
+    expect(model.getters.getEditionMode()).toBe("editing");
+    // Enter is pressed really fast while another character is pressed such that
+    // the character keyup event happens after the Enter
+    composerEl.dispatchEvent(
+      new KeyboardEvent("keydown", Object.assign({ key: "Enter", bubbles: true }))
+    );
+    composerEl.dispatchEvent(
+      new KeyboardEvent("keyup", Object.assign({ key: "Enter", bubbles: true }))
+    );
+    composerEl.dispatchEvent(
+      new KeyboardEvent("keyup", Object.assign({ key: "d", bubbles: true }))
+    );
+    await nextTick();
+    expect(model.getters.getEditionMode()).toBe("inactive");
+  });
 
   test("typing a formula with a space should put the composer in 'selecting' mode", async () => {
     await startComposition();

--- a/tests/plugins/edition_test.ts
+++ b/tests/plugins/edition_test.ts
@@ -70,4 +70,11 @@ describe("edition", () => {
     model.dispatch("ACTIVATE_SHEET", { from: model.getters.getActiveSheet(), to: sheet1 });
     expect(getCell(model, "A1")!.content).toBe("=");
   });
+
+  test("ignore stopping composer selection if not selecting", () => {
+    const model = new Model();
+    expect(model.getters.getEditionMode()).toBe("inactive");
+    model.dispatch("STOP_COMPOSER_SELECTION");
+    expect(model.getters.getEditionMode()).toBe("inactive");
+  });
 });


### PR DESCRIPTION
If you press a character key, then Enter with the right timing, the
edition state can be left in a wrong state.

Here is a sequence of events which shows the issue:

1) keydown "d": edition starts
2) keydown "Enter": edition stops
3) in the same frame, keyup "d": the composer is still on the grid,
   it will be removed at the next frame. In the mean time is processes
   input event although it should not.

One consequence is the dispatch of a "STOP_COMPOSER_SELECTION" command
which sets the mode to "editing" even if the edition is actually stopped.