### PR TITLE
[FIX] helpers numbers: fix standard representation

### DIFF
--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -40,39 +40,80 @@ export function parseNumber(str: string): number {
   return n;
 }
 
+const defaultMaximumDecimalPlaces = 10;
+/**
+ * Function used to give the default format of a cell with a number for value.
+ * It is considered that the default format of a number is "0" followed by as
+ * many "0" as there are decimal places. Three rules define the number of decimal
+ * places:
+ *
+ * - number of decimal places limited to 10 for values ​​below 1 and composed only
+ * of decimals.
+ *
+ * - if the length of the integer part is equal to 1 there will be 9 maximum
+ * places for the decimals, if equal to 2 => 8 places maximum, if equal 3 ...
+ * if equal 9 => 1 place.
+ *
+ * - for all integer parts whose length is greater than or equal to 10, the
+ * number of decimal places is 0
+ *
+ * Exemple:
+ * - 1 --> '0'
+ * - 123 --> '0'
+ * - 12345 --> '0'
+ * - 42.1 --> '0.0'
+ * - 456.0001 --> '0.0000'
+ * - 12345.678912345 --> '0.00000'
+ * - 1234567.00012345 --> '0'
+ */
+export function getDefaultNumberFormat(cellValue: number): string {
+  const strValue = cellValue.toString();
+  const parts = strValue.split(".");
+  if (parts.length === 1) {
+    return "0";
+  }
+  const integers = parts[0].length;
+  const decimals = parts[1].length;
+  const remainingDecimalPlaces =
+    parts[0] === "0"
+      ? defaultMaximumDecimalPlaces
+      : Math.max(defaultMaximumDecimalPlaces - integers, 0);
+  const decimalPlaces = Math.min(remainingDecimalPlaces, decimals);
+
+  // Suppose the cell value 12345.678901, at this point decimalPlaces = 5 and
+  // the format returned by the function will be "0.00000". With this format,
+  // the value returned by formatDecimal will be "12345.67890" except that we
+  // don't want to display 0 as the last position. We must therefore remove "0"
+  // from the format when there are useless 0 in the value.
+
+  const zeros = /0+$/.exec(parts[1].substring(0, decimalPlaces));
+  const uselessZeros = zeros ? zeros[0].length : 0;
+  const netZeros = decimalPlaces - uselessZeros;
+  return "0" + (netZeros === 0 ? "" : ".") + Array(netZeros + 1).join("0");
+}
+
 const decimalStandardRepresentation = new Intl.NumberFormat("en-US", {
   useGrouping: false,
   maximumFractionDigits: 10,
 });
-
 export function formatStandardNumber(n: number): string {
-  if (Number.isInteger(n)) {
-    return n.toString();
+  if (n < 0) {
+    return "-" + formatStandardNumber(-n);
   }
-  return decimalStandardRepresentation.format(n);
+  const str = n.toString();
+  if (str.includes("e")) {
+    return decimalStandardRepresentation.format(n);
+  }
+  return _formatValue(n, getDefaultNumberFormat(n));
 }
 
-// this is a cache than can contains decimal representation formats
-// from 0 (minimum) to 20 (maximum) digits after the decimal point
-let decimalRepresentations: Intl.NumberFormat[] = [];
-
 export const maximumDecimalPlaces = 20;
-
 export function formatDecimal(n: number, decimals: number, sep: string = ""): string {
   if (n < 0) {
     return "-" + formatDecimal(-n, decimals);
   }
-  const maxDecimals = decimals >= maximumDecimalPlaces ? maximumDecimalPlaces : decimals;
-
-  let formatter = decimalRepresentations[maxDecimals];
-  if (!formatter) {
-    formatter = new Intl.NumberFormat("en-US", {
-      minimumFractionDigits: maxDecimals,
-      maximumFractionDigits: maxDecimals,
-      useGrouping: false,
-    });
-    decimalRepresentations[maxDecimals] = formatter;
-  }
+  const decimalPlaces = decimals >= maximumDecimalPlaces ? maximumDecimalPlaces : decimals;
+  const formatter = getFormatter(decimalPlaces);
   let result = formatter.format(n);
   if (sep) {
     let p: number = result.indexOf(".")!;
@@ -81,6 +122,23 @@ export function formatDecimal(n: number, decimals: number, sep: string = ""): st
     );
   }
   return result;
+}
+
+// this is a cache than can contains decimal representation formats
+// from 0 (minimum) to 20 (maximum) digits after the decimal point
+let decimalRepresentations: Intl.NumberFormat[] = [];
+
+function getFormatter(decimalPlaces: number): Intl.NumberFormat {
+  let formatter = decimalRepresentations[decimalPlaces];
+  if (!formatter) {
+    formatter = new Intl.NumberFormat("en-US", {
+      minimumFractionDigits: decimalPlaces,
+      maximumFractionDigits: decimalPlaces,
+      useGrouping: false,
+    });
+    decimalRepresentations[decimalPlaces] = formatter;
+  }
+  return formatter;
 }
 
 export function formatPercent(n: number): string {

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -5,6 +5,7 @@ import { formatDateTime, parseDateTime } from "../../functions/dates";
 import {
   formatNumber,
   formatStandardNumber,
+  getDefaultNumberFormat,
   isNumber,
   maximumDecimalPlaces,
   parseNumber,
@@ -185,33 +186,12 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
               (cell.type === CellType.formula && typeof cell.value === "number")) &&
             !cell.format?.match(DATETIME_FORMAT) // reject dates
           ) {
-            return cell.format || this.setDefaultNumberFormat(cell.value as any);
+            return cell.format || getDefaultNumberFormat(cell.value as any);
           }
         }
       }
     }
     return undefined;
-  }
-
-  /**
-   * Function used to give the default format of a cell with a number for value.
-   * It is considered that the default format of a number is 0 followed by as many
-   * 0 as there are decimal places.
-   *
-   * Example:
-   * - 1 --> '0'
-   * - 123 --> '0'
-   * - 12345 --> '0'
-   * - 42.1 --> '0.0'
-   * - 456.0001 --> '0.0000'
-   */
-  private setDefaultNumberFormat(cellValue: number): string {
-    const strValue = cellValue.toString();
-    const parts = strValue.split(".");
-    if (parts.length === 1) {
-      return "0";
-    }
-    return "0." + Array(parts[1].length + 1).join("0");
   }
 
   /**

--- a/tests/helpers/numbers.test.ts
+++ b/tests/helpers/numbers.test.ts
@@ -51,7 +51,7 @@ describe("parseNumber", () => {
 });
 
 describe("formatNumber", () => {
-  test("formatNumber", () => {
+  test("formatStandardNumber", () => {
     expect(formatStandardNumber(1)).toBe("1");
     expect(formatStandardNumber(0)).toBe("0");
     expect(formatStandardNumber(-1)).toBe("-1");
@@ -68,13 +68,16 @@ describe("formatNumber", () => {
     expect(formatStandardNumber(0.00000000001)).toBe("0");
     expect(formatStandardNumber(0.000000000001)).toBe("0");
 
-    // @compatibility note: in Google Sheets, the next three tests result in 1234512345
-    expect(formatStandardNumber(1234512345.1)).toBe("1234512345.1");
-    expect(formatStandardNumber(1234512345.12)).toBe("1234512345.12");
-    expect(formatStandardNumber(1234512345.123)).toBe("1234512345.123");
-
-    expect(formatStandardNumber(123.10000000001)).toBe("123.1");
-    expect(formatStandardNumber(123.10000000000000001)).toBe("123.1");
+    expect(formatStandardNumber(1234567891.123456789)).toBe("1234567891");
+    expect(formatStandardNumber(-1234567891.123456789)).toBe("-1234567891");
+    expect(formatStandardNumber(123456789.123456789)).toBe("123456789.1");
+    expect(formatStandardNumber(-123456789.123456789)).toBe("-123456789.1");
+    expect(formatStandardNumber(12345678.123456789)).toBe("12345678.12");
+    expect(formatStandardNumber(-12345678.123456789)).toBe("-12345678.12");
+    expect(formatStandardNumber(1.12345678912)).toBe("1.123456789");
+    expect(formatStandardNumber(-1.12345678912)).toBe("-1.123456789");
+    expect(formatStandardNumber(0.12345678912)).toBe("0.1234567891");
+    expect(formatStandardNumber(12345.1230045)).toBe("12345.123");
   });
 
   test("formatDecimal", () => {


### PR DESCRIPTION
Before this commit, standard representations of decimal numbers were
displayed with a maximum of 10 decimal places. Now, in addition to that,
decimal parts are displayed if the size of the integer part is below 10.

Before:
123.123456789123456 => 123.1234567891
12345.123456789123456 => 12345.1234567891
1234567.123456789123456 => 1234567.1234567891
1234567891.123456789123456 => 1234567891.1234567891

Now:
123.123456789123456 => 123.1234567
12345.123456789123456 => 12345.12345
1234567.123456789123456 => 1234567.123
1234567891.123456789123456 => 1234567891