### PR TITLE
[FIX] grid: correctly update viewport after sheet switching

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -330,6 +330,21 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
     this.drawGrid();
   }
 
+  async willUpdateProps() {
+    const sheet = this.getters.getActiveSheet();
+    if (this.currentSheet !== sheet) {
+      this.currentSheet = sheet;
+      // We need to reset the viewport as the sheet is changed
+      this.viewport.offsetX = 0;
+      this.viewport.offsetY = 0;
+      this.hScrollbar.scroll = 0;
+      this.vScrollbar.scroll = 0;
+      this.viewport = this.getters.adjustViewportZone(this.viewport);
+      this.viewport = this.getters.adjustViewportPosition(this.viewport);
+      this.snappedViewport = this.getters.snapViewportToCell(this.viewport);
+    }
+  }
+
   patched() {
     this.drawGrid();
   }

--- a/tests/components/grid_test.ts
+++ b/tests/components/grid_test.ts
@@ -566,4 +566,26 @@ describe("figures", () => {
     expect(fixture.querySelector(".o-figure")).toBeNull();
     expect(model.getters.getCell(0, 0)!.content).toBe("content");
   });
+
+  test("Add a figure on sheet2, scroll down on sheet 1, switch to sheet 2, the figure should be displayed", async () => {
+    model.dispatch("CREATE_SHEET", { id: "42" });
+    model.dispatch("CREATE_FIGURE", {
+      sheet: "42",
+      figure: {
+        id: "someuuid",
+        tag: "text",
+        width: 100,
+        height: 100,
+        x: 1,
+        y: 1,
+        data: undefined,
+      },
+    });
+    fixture.querySelector(".o-grid")!.dispatchEvent(new WheelEvent("wheel", { deltaX: 1500 }));
+    fixture.querySelector(".o-scrollbar.vertical")!.dispatchEvent(new Event("scroll"));
+    await nextTick();
+    model.dispatch("ACTIVATE_SHEET", { from: model.getters.getActiveSheet(), to: "42" });
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-figure")).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Before this commit, the viewport of the grid was only computed on patched
method, which implies that all sub-components have the old viewport.
It was ok except in one use case: sheet switching as the viewport should
be reset to the top-left.

Closes #554