### PR TITLE
[IMP] top_bar: Add a composer to edit cell content

### DIFF
--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -6,7 +6,6 @@ export class ContentEditableHelper {
 
   updateEl(el: HTMLElement) {
     this.el = el;
-    this.el.focus();
   }
 
   /**
@@ -79,8 +78,16 @@ export class ContentEditableHelper {
    * the selection is replaced by the text to be inserted
    * */
   insertText(value: string, color: string = "#000") {
-    document.execCommand("foreColor", false, color);
-    document.execCommand("insertText", false, value);
+    if (!value) return;
+    if (document.activeElement === this.el) {
+      document.execCommand("foreColor", false, color);
+      document.execCommand("insertText", false, value);
+    } else {
+      const span = document.createElement("span");
+      span.innerText = value;
+      span.style.color = color;
+      this.el.appendChild(span);
+    }
   }
 
   /**

--- a/src/components/composer/grid_composer.ts
+++ b/src/components/composer/grid_composer.ts
@@ -10,22 +10,27 @@ const { xml, css } = owl.tags;
 const TEMPLATE = xml/* xml */ `
   <div class="o-grid-composer" t-att-style="containerStyle">
     <Composer
+      focus="props.focus"
       inputStyle="composerStyle"
-      t-on-input="onInput"/>
+      t-on-keydown="onKeydown"
+      t-on-content-width-changed="onWidthChanged"
+    />
   </div>
 `;
-
-const COMPOSER_BORDER_WIDTH = 1.6;
+const COMPOSER_BORDER_WIDTH = 3 * 0.4 * window.devicePixelRatio || 1;
 const CSS = css/* scss */ `
   .o-grid-composer {
     box-sizing: border-box;
     position: absolute;
     border: ${COMPOSER_BORDER_WIDTH}px solid #3266ca;
+    white-space: nowrap;
   }
 `;
 
 interface Props {
   viewport: Viewport;
+  focus: boolean;
+  content: string;
 }
 /**
  * This component is a composer which positions itself on the grid at the anchor cell.
@@ -76,11 +81,22 @@ export class GridComposer extends Component<Props, SpreadsheetEnv> {
     el.style.height = (this.rect[3] + 1 + "px") as string;
   }
 
-  onInput(ev: KeyboardEvent) {
-    const el = this.el! as HTMLInputElement;
-    const composerInput = ev.target! as HTMLInputElement;
-    if (composerInput.clientWidth !== composerInput.scrollWidth) {
-      el.style.width = (composerInput.scrollWidth + 50) as any;
+  onWidthChanged(ev: CustomEvent) {
+    const padding = this.props.focus ? 40 : 0;
+    this.resize(ev.detail.newWidth + padding);
+  }
+
+  onKeydown(ev: KeyboardEvent) {
+    // In selecting mode, arrows should not move the cursor but it should
+    // select adjacent cells on the grid.
+    if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(ev.key)) {
+      ev.preventDefault();
     }
+  }
+
+  private resize(width: number) {
+    const el = this.el! as HTMLInputElement;
+    el.style.width = (Math.max(width + 10, this.rect[2] + 0.5) + "px") as string;
+    el.style.height = (this.rect[3] + 0.5 + "px") as string;
   }
 }

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -184,7 +184,10 @@ function useTouchMove(handler: (deltaX: number, deltaY: number) => void, canMove
 const TEMPLATE = xml/* xml */ `
   <div class="o-grid" t-on-click="focus" t-on-keydown="onKeydown" t-on-wheel="onMouseWheel">
     <t t-if="getters.getEditionMode() !== 'inactive'">
-      <GridComposer t-on-composer-unmounted="focus" viewport="snappedViewport"/>
+      <GridComposer
+        t-on-composer-unmounted="focus"
+        focus="props.focusComposer"
+        viewport="snappedViewport"/>
     </t>
     <canvas t-ref="canvas"
       t-on-mousedown="onMouseDown"
@@ -305,10 +308,10 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
   // this map will handle most of the actions that should happen on key down. The arrow keys are managed in the key
   // down itself
   private keyDownMapping: { [key: string]: Function } = {
-    ENTER: () => this.dispatch("START_EDITION"),
+    ENTER: () => this.trigger("composer-focused"),
     TAB: () => this.dispatch("MOVE_POSITION", { deltaX: 1, deltaY: 0 }),
     "SHIFT+TAB": () => this.dispatch("MOVE_POSITION", { deltaX: -1, deltaY: 0 }),
-    F2: () => this.dispatch("START_EDITION"),
+    F2: () => this.trigger("composer-focused"),
     DELETE: () => {
       this.dispatch("DELETE_CONTENT", {
         sheetId: this.getters.getActiveSheetId(),
@@ -511,7 +514,7 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
   onDoubleClick(ev) {
     const [col, row] = this.getCartesianCoordinates(ev);
     if (this.clickedCol === col && this.clickedRow === row) {
-      this.dispatch("START_EDITION");
+      this.trigger("composer-focused");
     }
   }
 
@@ -574,7 +577,7 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
         // character
         ev.preventDefault();
         ev.stopPropagation();
-        this.dispatch("START_EDITION", { text: ev.key });
+        this.trigger("composer-focused", { content: ev.key });
       }
     }
   }

--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -9,6 +9,8 @@ import { FullMenuItem } from "../registries/menu_items_registry";
 import { topbarMenuRegistry } from "../registries/menus/topbar_menu_registry";
 import { DEFAULT_FONT_SIZE } from "../constants";
 import { MenuState, Menu } from "./menu";
+import { Composer } from "./composer/composer";
+
 import { setStyle, setFormatter, topbarComponentRegistry } from "../registries/index";
 import { isChildEvent } from "./helpers/dom_helpers";
 const { Component, useState, hooks } = owl;
@@ -149,12 +151,7 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
           <!-- <div class="o-tool" title="Vertical align"><span>${icons.ALIGN_MIDDLE_ICON}</span> ${icons.TRIANGLE_DOWN_ICON}</div> -->
           <!-- <div class="o-tool" title="Text Wrapping">${icons.TEXT_WRAPPING_ICON}</div> -->
         </div>
-
-        <!-- Cell content -->
-        <div class="o-toolbar-cell-content">
-          <t t-set="cell" t-value="getters.getActiveCell()"/>
-          <t t-esc="cell and cell.content"/>
-        </div>
+        <Composer inputStyle="composerStyle" focus="props.focusComposer"/>
 
       </div>
     </div>`;
@@ -196,14 +193,17 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
         border-bottom: 1px solid #e0e2e4;
         display: flex;
 
+        .o-composer-container {
+          height: 34px;
+        }
+
         /* Toolbar */
         .o-toolbar-tools {
           display: flex;
-
+          flex-shrink: 0;
           margin-left: 20px;
           color: #333;
           cursor: default;
-          display: flex;
 
           .o-tool {
             display: flex;
@@ -212,6 +212,7 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
             padding: 0 3px;
             border-radius: 2px;
             cursor: pointer;
+            min-width: fit-content;
           }
 
           .o-tool.active,
@@ -316,19 +317,10 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
             }
           }
         }
-
-        /* Cell Content */
-        .o-toolbar-cell-content {
-          font-size: 12px;
-          font-weight: 500;
-          padding: 0 12px;
-          margin: 0;
-          line-height: 34px;
-        }
       }
     }
   `;
-  static components = { ColorPicker, Menu };
+  static components = { ColorPicker, Menu, Composer };
   formats = FORMATS;
   currentFormat = "auto";
   fontSizes = fontSizes;
@@ -351,6 +343,11 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
   textColor: string = "black";
   menus: FullMenuItem[] = [];
   menuRef = useRef("menuRef");
+  composerStyle = `
+    line-height: 34px;
+    border-bottom: 1px solid #e0e2e4;
+    border-left: 1px solid #e0e2e4;
+  `;
 
   constructor() {
     super(...arguments);

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -422,6 +422,7 @@ export interface StopComposerSelectionCommand extends BaseCommand {
 export interface StartEditionCommand extends BaseCommand {
   type: "START_EDITION";
   text?: string;
+  selection?: ComposerSelection;
 }
 
 export interface StopEditionCommand extends BaseCommand {

--- a/tests/components/__mocks__/content_editable_helper.ts
+++ b/tests/components/__mocks__/content_editable_helper.ts
@@ -7,30 +7,22 @@ export class ContentEditableHelper {
   el: HTMLElement | null = null;
   manualRange: boolean = false;
 
-  constructor() {
-    // @ts-ignore
-    window.mockContentHelper = this;
-  }
-
   updateEl(el: HTMLElement) {
     this.el = el;
-    this.el.focus();
     this.currentState = {
       cursorStart: 0,
       cursorEnd: 0,
     };
-
+    this.attachEventHandlers();
     this.colors = {};
   }
   selectRange(start, end) {
+    this.el!.focus();
+    // @ts-ignore
+    window.mockContentHelper = this;
     this.manualRange = true;
     this.currentState.cursorStart = start;
     this.currentState.cursorEnd = end;
-  }
-  selectLast() {
-    const text = this.el!.textContent!;
-    this.currentState.cursorStart = text.length - 1;
-    this.currentState.cursorEnd = text.length - 1;
   }
   insertText(value, color: string = "#000") {
     const text = this.el!.textContent!;
@@ -72,5 +64,27 @@ export class ContentEditableHelper {
       start: v.length,
       end: v.length,
     };
+  }
+
+  private attachEventHandlers() {
+    if (this.el === null) return;
+    this.el.addEventListener("keydown", (ev: KeyboardEvent) => this.onKeyDown(this.el!, ev));
+  }
+
+  /**
+   * Mock default keydown events
+   */
+  private onKeyDown(el: HTMLElement, ev: KeyboardEvent) {
+    switch (ev.key) {
+      case "Home":
+        this.currentState.cursorStart = 0;
+        this.currentState.cursorEnd = 0;
+        break;
+      case "End":
+        const end = el.textContent ? el.textContent.length : 0;
+        this.currentState.cursorStart = end;
+        this.currentState.cursorEnd = end;
+        break;
+    }
   }
 }

--- a/tests/components/__snapshots__/spreadsheet_test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet_test.ts.snap
@@ -324,10 +324,23 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
         <!-- &lt;div class="o-tool" title="Vertical align"&gt;&lt;span&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M9.5,3 L7,3 L7,0 L5,0 L5,3 L2.5,3 L6,6.5 L9.5,3 L9.5,3 Z M0,8 L0,10 L12,10 L12,8 L0,8 L0,8 Z M2.5,15 L5,15 L5,18 L7,18 L7,15 L9.5,15 L6,11.5 L2.5,15 L2.5,15 Z" transform="translate(3)"/&gt;&lt;/svg&gt;&lt;/span&gt; &lt;svg class="o-icon"&gt;&lt;polygon fill="#000000" points="0 0 4 4 8 0" transform="translate(5 7)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
         <!-- &lt;div class="o-tool" title="Text Wrapping"&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M14,0 L0,0 L0,2 L14,2 L14,0 Z M0,12 L4,12 L4,10 L0,10 L0,12 Z M11.5,5 L0,5 L0,7 L11.75,7 C12.58,7 13.25,7.67 13.25,8.5 C13.25,9.33 12.58,10 11.75,10 L9,10 L9,8 L6,11 L9,14 L9,12 L11.5,12 C13.43,12 15,10.43 15,8.5 C15,6.57 13.43,5 11.5,5 Z" transform="translate(2 3)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
       </div>
-      <!-- Cell content -->
       <div
-        class="o-toolbar-cell-content"
-      />
+        class="o-composer-container"
+      >
+        <div
+          class="o-composer"
+          contenteditable="true"
+          spellcheck="false"
+          style="
+    line-height: 34px;
+    border-bottom: 1px solid #e0e2e4;
+    border-left: 1px solid #e0e2e4;
+  "
+          tabindex="1"
+        >
+          
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/tests/components/__snapshots__/top_bar_test.ts.snap
+++ b/tests/components/__snapshots__/top_bar_test.ts.snap
@@ -361,10 +361,21 @@ exports[`TopBar component can set cell format 1`] = `
       <!-- &lt;div class="o-tool" title="Vertical align"&gt;&lt;span&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M9.5,3 L7,3 L7,0 L5,0 L5,3 L2.5,3 L6,6.5 L9.5,3 L9.5,3 Z M0,8 L0,10 L12,10 L12,8 L0,8 L0,8 Z M2.5,15 L5,15 L5,18 L7,18 L7,15 L9.5,15 L6,11.5 L2.5,15 L2.5,15 Z" transform="translate(3)"/&gt;&lt;/svg&gt;&lt;/span&gt; &lt;svg class="o-icon"&gt;&lt;polygon fill="#000000" points="0 0 4 4 8 0" transform="translate(5 7)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
       <!-- &lt;div class="o-tool" title="Text Wrapping"&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M14,0 L0,0 L0,2 L14,2 L14,0 Z M0,12 L4,12 L4,10 L0,10 L0,12 Z M11.5,5 L0,5 L0,7 L11.75,7 C12.58,7 13.25,7.67 13.25,8.5 C13.25,9.33 12.58,10 11.75,10 L9,10 L9,8 L6,11 L9,14 L9,12 L11.5,12 C13.43,12 15,10.43 15,8.5 C15,6.57 13.43,5 11.5,5 Z" transform="translate(2 3)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
     </div>
-    <!-- Cell content -->
     <div
-      class="o-toolbar-cell-content"
-    />
+      class="o-composer-container"
+    >
+      <div
+        class="o-composer"
+        contenteditable="true"
+        spellcheck="false"
+        style="
+    line-height: 34px;
+    border-bottom: 1px solid #e0e2e4;
+    border-left: 1px solid #e0e2e4;
+  "
+        tabindex="1"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -690,10 +701,21 @@ exports[`TopBar component simple rendering 1`] = `
       <!-- &lt;div class="o-tool" title="Vertical align"&gt;&lt;span&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M9.5,3 L7,3 L7,0 L5,0 L5,3 L2.5,3 L6,6.5 L9.5,3 L9.5,3 Z M0,8 L0,10 L12,10 L12,8 L0,8 L0,8 Z M2.5,15 L5,15 L5,18 L7,18 L7,15 L9.5,15 L6,11.5 L2.5,15 L2.5,15 Z" transform="translate(3)"/&gt;&lt;/svg&gt;&lt;/span&gt; &lt;svg class="o-icon"&gt;&lt;polygon fill="#000000" points="0 0 4 4 8 0" transform="translate(5 7)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
       <!-- &lt;div class="o-tool" title="Text Wrapping"&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M14,0 L0,0 L0,2 L14,2 L14,0 Z M0,12 L4,12 L4,10 L0,10 L0,12 Z M11.5,5 L0,5 L0,7 L11.75,7 C12.58,7 13.25,7.67 13.25,8.5 C13.25,9.33 12.58,10 11.75,10 L9,10 L9,8 L6,11 L9,14 L9,12 L11.5,12 C13.43,12 15,10.43 15,8.5 C15,6.57 13.43,5 11.5,5 Z" transform="translate(2 3)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
     </div>
-    <!-- Cell content -->
     <div
-      class="o-toolbar-cell-content"
-    />
+      class="o-composer-container"
+    >
+      <div
+        class="o-composer"
+        contenteditable="true"
+        spellcheck="false"
+        style="
+    line-height: 34px;
+    border-bottom: 1px solid #e0e2e4;
+    border-left: 1px solid #e0e2e4;
+  "
+        tabindex="1"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/tests/components/autocomplete_dropdown_test.ts
+++ b/tests/components/autocomplete_dropdown_test.ts
@@ -30,7 +30,7 @@ beforeEach(async () => {
   // start composition
   parent.grid.el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
   await nextTick();
-  composerEl = fixture.querySelector("div.o-composer")!;
+  composerEl = fixture.querySelector(".o-grid div.o-composer")!;
 });
 
 afterEach(() => {
@@ -63,7 +63,8 @@ describe("Functions autocomplete", () => {
   describe("autocomplete", () => {
     test("= do not show autocomplete", async () => {
       await typeInComposer("=");
-      expect(document.activeElement).toBe(composerEl);
+      const activeElement = document.activeElement;
+      expect(activeElement).toBe(composerEl);
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
     });
 
@@ -246,8 +247,9 @@ describe("Autocomplete parenthesis", () => {
     await nextTick();
     model.dispatch("SELECT_CELL", { col: 0, row: 0 });
     //edit A1
-    model.dispatch("START_EDITION");
+    parent.grid.el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
     await nextTick();
+    composerEl = fixture.querySelector(".o-grid div.o-composer")!;
     // @ts-ignore
     const cehMock = window.mockContentHelper as ContentEditableHelper;
     // select SUM

--- a/tests/components/grid_test.ts
+++ b/tests/components/grid_test.ts
@@ -11,7 +11,9 @@ import {
 import { toZone } from "../../src/helpers/index";
 import { triggerMouseEvent, simulateClick } from "../dom_helper";
 import { Grid } from "../../src/components/grid";
-jest.mock("../../src/components/composer/content_editable_helper");
+jest.mock("../../src/components/composer/content_editable_helper", () =>
+  require("./__mocks__/content_editable_helper")
+);
 jest.mock("../../src/components/scrollbar", () => require("./__mocks__/scrollbar"));
 
 function getVerticalScroll(): number {
@@ -41,7 +43,12 @@ describe("Grid component", () => {
   beforeEach(async () => {
     model = new Model();
     parent = new GridParent(model);
+    fixture = makeTestFixture();
     await parent.mount(fixture);
+  });
+
+  afterEach(() => {
+    fixture.remove();
   });
 
   test("simple rendering snapshot", async () => {
@@ -417,6 +424,15 @@ describe("error tooltip", () => {
     intervalCb();
     await nextTick();
     expect(document.querySelector(".o-error-tooltip")).not.toBeNull();
+  });
+
+  test("composer content is set when clicking on merged cell (not top left)", async () => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("ADD_MERGE", { sheetId, zone: toZone("C1:C8") });
+    setCellContent(model, "C1", "Hello");
+    await nextTick();
+    await simulateClick("canvas", 300, 200); // C8
+    expect(model.getters.getCurrentContent()).toBe("Hello");
   });
 });
 


### PR DESCRIPTION
The selected cell content is currently displayed in the top bar.
But it's not possible to edit it.

This commit introduces a `Composer` component in the top bar to allow that.
We make sure all composers are synchronized if multiple composers are mounted
at the same time and the focus between composers is correctly handled.


Requires #505 then #512 (commits from those PRs are currently included in this one)