### PR TITLE
[IMP] evaluation: Don't evaluate out of bounds ranges

### DIFF
--- a/src/plugins/evaluation.ts
+++ b/src/plugins/evaluation.ts
@@ -305,10 +305,13 @@ export class EvaluationPlugin extends BasePlugin {
      * that are actually present in the grid.
      */
     function range(v1: string, v2: string, sheetId: string) {
-      const [left, top] = toCartesian(v1);
-      const [right, bottom] = toCartesian(v2);
+      const sheet = sheets[sheetId];
+      let [left, top] = toCartesian(v1);
+      let [right, bottom] = toCartesian(v2);
+      right = Math.min(right, sheet.colNumber - 1);
+      bottom = Math.min(bottom, sheet.rowNumber - 1);
       const zone = { left, top, right, bottom };
-      return mapCellsInZone(zone, sheets[sheetId], (cell) => getCellValue(cell, sheetId));
+      return mapCellsInZone(zone, sheet, (cell) => getCellValue(cell, sheetId));
     }
 
     return [readCell, range, evalContext];

--- a/tests/functions/module_math_test.ts
+++ b/tests/functions/module_math_test.ts
@@ -2285,6 +2285,7 @@ describe("math", () => {
       A2: "=SUM(B2:E2)",
       A3: "=SUM(B3:E3)",
       A4: "=SUM(B4:E4)",
+      A5: "=SUM(B4:E2000)",
 
       B1: "=SUM(B2:B4)",
       C1: "=SUM(C2:C4)",
@@ -2312,6 +2313,7 @@ describe("math", () => {
     expect(gridResult.A2).toBe(6);
     expect(gridResult.A3).toBe(0);
     expect(gridResult.A4).toBe(0);
+    expect(gridResult.A5).toBe(0);
     expect(gridResult.B1).toBe(3);
     expect(gridResult.C1).toBe(3);
     expect(gridResult.D1).toBe(0);

--- a/tests/plugins/evaluation_test.ts
+++ b/tests/plugins/evaluation_test.ts
@@ -171,6 +171,16 @@ describe("evaluateCells", () => {
     expect(getCell(model, "A3")!.value).toBe(3);
   });
 
+  test("error in range vlookup", () => {
+    const model = new Model();
+    expect(model.getters.getNumberRows(model.getters.getActiveSheet())).toBeLessThan(200);
+    model.dispatch("SET_VALUE", { xc: "A1", text: "=VLOOKUP(D12, A2:A200, 2, false)" });
+
+    expect(getCell(model, "A1")!.error!.toString()).toBe(
+      "VLOOKUP evaluates to an out of bounds range."
+    );
+  });
+
   test("range", () => {
     const model = new Model();
     model.dispatch("SET_VALUE", { xc: "D4", text: "42" });


### PR DESCRIPTION
This commit fixes two issues:

1/ Slow range evaluation
------------------------
Formula `=SUM(A1:ZZZZZZZZ1)` takes a long time to evaluate
since the range is really large (several billion cells).
This formula would make the entire evaluation slow every time!

We can cut off some evaluation time by ignoring parts of the range
which are outside the sheet.

Closes #452

2/ Access to unexisting column
------------------------------
On a sheet with less than 200 rows:

Formula `=VLOOKUP(D12, A1:A200, 2, false)`
=> error message cannot read property cells of undefined.
It should display a user friendly error message

Formula `=SUM(A2:A200)` is in error.

Closes #486