### PR TITLE
[FIX] grid: Set focus when sheet changed

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -333,7 +333,6 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
   async willUpdateProps() {
     const sheet = this.getters.getActiveSheet();
     if (this.currentSheet !== sheet) {
-      this.currentSheet = sheet;
       // We need to reset the viewport as the sheet is changed
       this.viewport.offsetX = 0;
       this.viewport.offsetY = 0;


### PR DESCRIPTION
Commit df25aa8 broke a test: the focus should be given
to the canvas when the active sheet is changed.