### PR TITLE
[FIX] components: Selection input style with multiple ranges

### DIFF
--- a/src/components/selection_input.ts
+++ b/src/components/selection_input.ts
@@ -54,10 +54,10 @@ const CSS = css/* scss */ `
       padding: 3px 5px;
     }
     button.o-remove-selection {
+      margin-left: -30px;
       background: transparent;
       border: none;
       color: #333;
-      font-size: 17px;
       cursor: pointer;
     }
     button.o-btn {


### PR DESCRIPTION
Add several ranges to a selection input component => the cross buttons "✖"
to remove ranges are not inlined with their range.

Since 2310f11