### PR TITLE
[FIX] composer: Autocomplete does not resize composer

### DIFF
--- a/src/components/composer/grid_composer.ts
+++ b/src/components/composer/grid_composer.ts
@@ -73,10 +73,11 @@ export class GridComposer extends Component<Props, SpreadsheetEnv> {
     el.style.height = (this.rect[3] + 0.5 + "px") as string;
   }
 
-  onInput() {
+  onInput(ev: KeyboardEvent) {
     const el = this.el! as HTMLInputElement;
-    if (el.clientWidth !== el.scrollWidth) {
-      el.style.width = (el.scrollWidth + 50) as any;
+    const composerInput = ev.target! as HTMLInputElement;
+    if (composerInput.clientWidth !== composerInput.scrollWidth) {
+      el.style.width = (composerInput.scrollWidth + 50) as any;
     }
   }
 }

--- a/tests/components/composer_test.ts
+++ b/tests/components/composer_test.ts
@@ -26,6 +26,7 @@ async function typeInComposer(text: string, fromScratch: boolean = true) {
   // @ts-ignore
   const cehMock = window.mockContentHelper as ContentEditableHelper;
   cehMock.insertText(text);
+  composerEl.dispatchEvent(new Event("input", { bubbles: true }));
   composerEl.dispatchEvent(new Event("keyup", { bubbles: true }));
   await nextTick();
 }
@@ -334,6 +335,16 @@ describe("composer", () => {
     window.dispatchEvent(new MouseEvent("mouseup", { clientX: 300, clientY: 200 }));
     await nextTick();
     expect(composerEl.textContent).toBe("=C8");
+  });
+
+  test("composer is resized when input content is larger than composer", async () => {
+    await typeInComposer("Hello");
+    const gridComposer = fixture.querySelector(".o-grid-composer")! as HTMLElement;
+    const styleSpy = jest.spyOn(gridComposer.style, "width", "set");
+    jest.spyOn(gridComposer, "clientWidth", "get").mockImplementation(() => 100);
+    jest.spyOn(composerEl, "scrollWidth", "get").mockImplementation(() => 120);
+    await typeInComposer("world", false);
+    expect(styleSpy).toHaveBeenCalledWith(170); // scrollWidth + 50
   });
 });
 


### PR DESCRIPTION
Type "=SU" in the composer, the autocomplete helper appears but the composer
is also resized with the width of the autocomplete.