### PR TITLE
[FIX] tests: Correctly mock clientWidth and clientHeight

### DIFF
--- a/tests/components/autofill_test.ts
+++ b/tests/components/autofill_test.ts
@@ -8,18 +8,8 @@ import { HEADER_HEIGHT, HEADER_WIDTH } from "../../src/constants";
 const { Component } = owl;
 const { xml } = owl.tags;
 
-Object.defineProperty(HTMLDivElement.prototype, "clientWidth", {
-  get() {
-    return 1000;
-  },
-  configurable: true,
-});
-Object.defineProperty(HTMLDivElement.prototype, "clientHeight", {
-  get() {
-    return 1000;
-  },
-  configurable: true,
-});
+jest.spyOn(HTMLDivElement.prototype, "clientWidth", "get").mockImplementation(() => 1000);
+jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 1000);
 
 let fixture: HTMLElement;
 let model: Model;

--- a/tests/components/context_menu_test.ts
+++ b/tests/components/context_menu_test.ts
@@ -21,18 +21,8 @@ afterEach(() => {
   fixture.remove();
 });
 
-Object.defineProperty(HTMLDivElement.prototype, "clientWidth", {
-  get() {
-    return 1000;
-  },
-  configurable: true,
-});
-Object.defineProperty(HTMLDivElement.prototype, "clientHeight", {
-  get() {
-    return 1000;
-  },
-  configurable: true,
-});
+jest.spyOn(HTMLDivElement.prototype, "clientWidth", "get").mockImplementation(() => 1000);
+jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 1000);
 
 function getActiveXc(model: Model): string {
   return toXC(...model.getters.getPosition());

--- a/tests/components/grid_test.ts
+++ b/tests/components/grid_test.ts
@@ -14,18 +14,8 @@ function getHorizontalScroll(): number {
   return (parent.grid as any).comp.hScrollbar.scroll;
 }
 
-Object.defineProperty(HTMLDivElement.prototype, "clientWidth", {
-  get() {
-    return 1000;
-  },
-  configurable: true,
-});
-Object.defineProperty(HTMLDivElement.prototype, "clientHeight", {
-  get() {
-    return 1000;
-  },
-  configurable: true,
-});
+jest.spyOn(HTMLDivElement.prototype, "clientWidth", "get").mockImplementation(() => 1000);
+jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 1000);
 
 let fixture: HTMLElement;
 let model: Model;


### PR DESCRIPTION
`clientHeight` and `clientWidth` are mocked in some tests.
However they were not correctly un-mocked.
This could make some other tests fail non-deterministically depending
on execution order.

This commit replaces the current naive mocks with jest spy mocks.