### PR TITLE
[FIX] chart: Create a chart with data in other sheet

### DIFF
--- a/tests/model/plugins/__snapshots__/chart_test.ts.snap
+++ b/tests/model/plugins/__snapshots__/chart_test.ts.snap
@@ -1,5 +1,174 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`datasource tests create chart in another sheet 1`] = `
+Object {
+  "data": Object {
+    "datasets": Array [
+      Object {
+        "backgroundColor": "rgb(31,119,180)",
+        "borderColor": "rgb(31,119,180)",
+        "data": Array [
+          10,
+          11,
+          12,
+        ],
+        "label": Object {
+          "toString": [Function],
+        },
+        "lineTension": 0,
+      },
+      Object {
+        "backgroundColor": "rgb(255,127,14)",
+        "borderColor": "rgb(255,127,14)",
+        "data": Array [
+          20,
+        ],
+        "label": Object {
+          "toString": [Function],
+        },
+        "lineTension": 0,
+      },
+    ],
+    "labels": Array [
+      "P1",
+      "P2",
+      "P3",
+    ],
+  },
+  "options": Object {
+    "animation": Object {
+      "duration": 0,
+    },
+    "elements": Object {
+      "line": Object {
+        "fill": false,
+      },
+      "point": Object {
+        "hitRadius": 15,
+      },
+    },
+    "hover": Object {
+      "animationDuration": 10,
+    },
+    "layout": Object {
+      "padding": Object {
+        "bottom": 10,
+        "left": 20,
+        "right": 20,
+        "top": 10,
+      },
+    },
+    "maintainAspectRatio": false,
+    "responsive": true,
+    "responsiveAnimationDuration": 0,
+    "scales": Object {
+      "xAxes": Array [
+        Object {
+          "ticks": Object {
+            "labelOffset": 2,
+            "maxRotation": 60,
+            "minRotation": 15,
+            "padding": 5,
+          },
+        },
+      ],
+      "yAxes": Array [
+        Object {
+          "ticks": Object {
+            "beginAtZero": true,
+          },
+        },
+      ],
+    },
+    "title": Object {
+      "display": true,
+      "fontSize": 22,
+      "fontStyle": "normal",
+      "text": "test 1",
+    },
+  },
+  "type": "line",
+}
+`;
+
+exports[`datasource tests create chart in another sheet with labels 1`] = `
+Object {
+  "data": Object {
+    "datasets": Array [
+      Object {
+        "backgroundColor": "rgb(31,119,180)",
+        "borderColor": "rgb(31,119,180)",
+        "data": Array [
+          10,
+          11,
+          12,
+        ],
+        "label": "first column dataset",
+        "lineTension": 0,
+      },
+    ],
+    "labels": Array [
+      "P1",
+      "P2",
+      "P3",
+    ],
+  },
+  "options": Object {
+    "animation": Object {
+      "duration": 0,
+    },
+    "elements": Object {
+      "line": Object {
+        "fill": false,
+      },
+      "point": Object {
+        "hitRadius": 15,
+      },
+    },
+    "hover": Object {
+      "animationDuration": 10,
+    },
+    "layout": Object {
+      "padding": Object {
+        "bottom": 10,
+        "left": 20,
+        "right": 20,
+        "top": 10,
+      },
+    },
+    "maintainAspectRatio": false,
+    "responsive": true,
+    "responsiveAnimationDuration": 0,
+    "scales": Object {
+      "xAxes": Array [
+        Object {
+          "ticks": Object {
+            "labelOffset": 2,
+            "maxRotation": 60,
+            "minRotation": 15,
+            "padding": 5,
+          },
+        },
+      ],
+      "yAxes": Array [
+        Object {
+          "ticks": Object {
+            "beginAtZero": true,
+          },
+        },
+      ],
+    },
+    "title": Object {
+      "display": true,
+      "fontSize": 22,
+      "fontStyle": "normal",
+      "text": "test 1",
+    },
+  },
+  "type": "line",
+}
+`;
+
 exports[`datasource tests create chart with column datasets 1`] = `
 Object {
   "data": Object {

--- a/tests/model/plugins/chart_test.ts
+++ b/tests/model/plugins/chart_test.ts
@@ -79,6 +79,55 @@ describe("datasource tests", function () {
     expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
   });
 
+  test("create chart in another sheet", () => {
+    model.dispatch("CREATE_SHEET", { sheetId: "42", activate: true });
+    model.dispatch("CREATE_CHART", {
+      id: "1",
+      sheetId: "42",
+      definition: {
+        title: "test 1",
+        dataSets: ["Sheet1!B2:B4", "Sheet1!C2"],
+        seriesHasTitle: false,
+        labelRange: "Sheet1!A2:A4",
+        type: "line",
+      },
+    });
+    expect(model.getters.getFigures(viewport)[0].data).toEqual({
+      dataSets: [
+        { dataRange: "Sheet1!B2:B4", labelCell: undefined },
+        { dataRange: "Sheet1!C2", labelCell: undefined },
+      ],
+      labelRange: "Sheet1!A2:A4",
+      sheetId: model.getters.getActiveSheetId(),
+      title: "test 1",
+      type: "line",
+    });
+    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+  });
+
+  test("create chart in another sheet with labels", () => {
+    model.dispatch("CREATE_SHEET", { sheetId: "42", activate: true });
+    model.dispatch("CREATE_CHART", {
+      id: "1",
+      sheetId: "42",
+      definition: {
+        title: "test 1",
+        dataSets: ["Sheet1!B1:B4", "Sheet1!C1"],
+        seriesHasTitle: true,
+        labelRange: "Sheet1!A2:A4",
+        type: "line",
+      },
+    });
+    expect(model.getters.getFigures(viewport)[0].data).toEqual({
+      dataSets: [{ dataRange: "Sheet1!B2:B4", labelCell: "Sheet1!B1" }],
+      labelRange: "Sheet1!A2:A4",
+      sheetId: model.getters.getActiveSheetId(),
+      title: "test 1",
+      type: "line",
+    });
+    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+  });
+
   test("create chart with rectangle dataset", () => {
     model.dispatch("CREATE_CHART", {
       id: "1",


### PR DESCRIPTION
The command `CREATE_CHART` ignores sheet references. Hence the data
always comes from the same sheet at the chart, even if it was specified
otherwise at the chart creation.

e.g. a chart created with the following command would take its data
from B1:B4 in sheet 2 instead of sheet 1.
```ts
dispatch("CREATE_CHART", {
    sheetId: <id of sheet 2>,
    ...
    dataSets: ["Sheet1!B1:B4"],
    ...
})
```