### PR TITLE
[POC][FIX] component: Blur input on click

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -51,6 +51,24 @@ const keyDownMappingIgnore: string[] = ["CTRL+C", "CTRL+V"];
 // Error Tooltip Hook
 // -----------------------------------------------------------------------------
 
+const gridClickEventBus = new owl.core.EventBus();
+
+/**
+ * Allows to attach external event listeners when the grid triggers
+ * a mouse event
+ * (only mousedown for this POC)
+ */
+export function useGridClickEvent(owner, handlers: { [event: string]: (ev: MouseEvent) => void }) {
+  for (let [eventType, handler] of Object.entries(handlers)) {
+    gridClickEventBus.on(eventType, owner, handler);
+  }
+  onWillUnmount(() => {
+    for (let eventType of Object.keys(handlers)) {
+      gridClickEventBus.off(eventType, owner);
+    }
+  });
+}
+
 interface ErrorTooltip {
   isOpen: boolean;
   text: string;
@@ -459,6 +477,7 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
   }
 
   onMouseDown(ev: MouseEvent) {
+    gridClickEventBus.trigger(ev.type, ev);
     if (ev.button > 0) {
       // not main button, probably a context menu
       return;

--- a/src/components/selection_input.ts
+++ b/src/components/selection_input.ts
@@ -1,10 +1,12 @@
 import * as owl from "@odoo/owl";
 import { SpreadsheetEnv } from "../types";
 import { uuidv4 } from "../helpers/index";
+import { useGridClickEvent } from "./grid";
 
 const { Component } = owl;
 
 const { xml, css } = owl.tags;
+const { useExternalListener } = owl.hooks;
 
 const TEMPLATE = xml/* xml */ `
   <div class="o-selection">
@@ -94,6 +96,14 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
   private getters = this.env.getters;
   private dispatch = this.env.dispatch;
 
+  constructor() {
+    super(...arguments);
+    useExternalListener(document.body, "mousedown", () => this.focus(null));
+    useGridClickEvent(this, {
+      mousedown: (ev) => this.onGridMouseDown(ev),
+    });
+  }
+
   get ranges() {
     return this.getters.getSelectionInput(this.id);
   }
@@ -156,6 +166,12 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
     });
     target.blur();
     this.triggerChange();
+  }
+
+  onGridMouseDown(ev: MouseEvent) {
+    if (this.hasFocus) {
+      ev.stopPropagation();
+    }
   }
 
   disable() {


### PR DESCRIPTION
SelectionInput component should lose focus if the user
click anywhere outside the inputs except if the user
clicks on the grid to select a range.