### PR TITLE
[FIX] conditional_format: display of conditional_format doesn't display bold or strike

### DIFF
--- a/src/components/side_panel/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting.ts
@@ -281,7 +281,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
       const fontStyle = cellRule.style.italic ? "italic" : "normal";
       const color = cellRule.style.textColor || "none";
       const backgroundColor = cellRule.style.fillColor || "none";
-      return `font-weight:${fontWeight}
+      return `font-weight:${fontWeight};
                text-decoration:${fontDecoration};
                font-style:${fontStyle};
                color:${color};

--- a/tests/plugins/__snapshots__/conditional_formatting_test.ts.snap
+++ b/tests/plugins/__snapshots__/conditional_formatting_test.ts.snap
@@ -33,7 +33,7 @@ exports[`UI of conditional formats simple snapshot 1`] = `
           >
             <div
               class="o-cf-preview-image"
-              style="font-weight:normal
+              style="font-weight:normal;
                text-decoration:none;
                font-style:normal;
                color:none;

--- a/tests/plugins/conditional_formatting_test.ts
+++ b/tests/plugins/conditional_formatting_test.ts
@@ -990,6 +990,21 @@ describe("UI of conditional formats", () => {
     });
   });
 
+  test("the preview should be bold when the rule is bold", async () => {
+    parent.env.dispatch = jest.fn((command) => ({ status: "SUCCESS" } as CommandResult));
+
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF(["C1:C5"], "2", { bold: true, fillColor: "#ff0000" }, "99"),
+      sheetId: model.getters.getActiveSheetId(),
+    });
+
+    await nextTick();
+
+    let previews = document.querySelectorAll(selectors.listPreview);
+    let line = previews[2].querySelector(selectors.previewImage);
+    expect(line!.getAttribute("style")).toMatch("font-weight:bold;");
+  });
+
   test("can edit an existing ColorScaleRule", async () => {
     triggerMouseEvent(document.querySelectorAll(selectors.listPreview)[1], "click");
     await nextTick();


### PR DESCRIPTION
- Create a rule with bold, click on save
- The preview is not in bold