### PR TITLE
[IMP] config: Compile Typescript to ES2019

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "serve": "live-server --open=demo",
     "dev": "npm-run-all  build --parallel serve \"build:* -- --watch\"",
-    "build:js": "tsc --target esnext --module es6 --outDir dist/js --incremental",
+    "build:js": "tsc --module es6 --outDir dist/js --incremental",
     "build:bundle": "rollup -c -m",
     "build": "npm run build:js && npm run build:bundle",
     "test": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,22 @@
 {
-    "compilerOptions": {
-      "module": "commonjs",
-      "preserveConstEnums": true,
-      "noImplicitThis": true,
-      "moduleResolution": "node",
-      "removeComments": false,
-      "target": "esnext",
-      "outDir": "dist",
-      "alwaysStrict": true,
-      "noUnusedLocals": true,
-      "noUnusedParameters": false,
-      "noImplicitReturns": true,
-      "noFallthroughCasesInSwitch": true,
-      "strictPropertyInitialization": true,
-      "strictNullChecks": true,
-      "esModuleInterop": true,
-      "allowJs": true,
-      "sourceMap": true
-
-    },
-    "include": ["src", "tests"]
-  }
+  "compilerOptions": {
+    "module": "commonjs",
+    "preserveConstEnums": true,
+    "noImplicitThis": true,
+    "moduleResolution": "node",
+    "removeComments": false,
+    "target": "es2019",
+    "outDir": "dist",
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictPropertyInitialization": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "sourceMap": true
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
The Typescript code is currently compiled to ESNext.
However, some features of ESNext are not yet supported nor by Jest, nor by Odoo

Typescript code will now be compiled to ES2019, which it the last js version
which should be supported by Odoo.