### PR TITLE
[IMP] components: add formula assistant

### DIFF
--- a/src/components/composer/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown.ts
@@ -44,7 +44,7 @@ const TEMPLATE = xml/* xml */ `
 
 const CSS = css/* scss */ `
   .o-autocomplete-dropdown {
-    width: 260px;
+    width: 300px;
     margin: 4px;
     background-color: #fff;
     box-shadow: 0 1px 4px 3px rgba(60, 64, 67, 0.15);

--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -1,14 +1,22 @@
 import * as owl from "@odoo/owl";
-import { EnrichedToken, composerTokenize, rangeReference } from "../../formulas/index";
-import { SpreadsheetEnv } from "../../types/index";
+import {
+  EnrichedToken,
+  composerTokenize,
+  rangeReference,
+  argumentToFocus,
+} from "../../formulas/index";
+import { SpreadsheetEnv, FunctionDescription } from "../../types/index";
 import { TextValueProvider } from "./autocomplete_dropdown";
+import { FunctionDescriptionProvider } from "./formula_assistant";
 import { ContentEditableHelper } from "./content_editable_helper";
 import { zoneToXc, DEBUG } from "../../helpers/index";
 import { ComposerSelection } from "../../plugins/ui/edition";
+import { functionRegistry } from "../../functions/index";
 
 const { Component } = owl;
 const { useRef, useState } = owl.hooks;
 const { xml, css } = owl.tags;
+const functions = functionRegistry.content;
 
 export const FunctionColor = "#4a4e4d";
 export const OperatorColor = "#3da4ab";
@@ -56,6 +64,13 @@ const TEMPLATE = xml/* xml */ `
         provider="autoCompleteState.provider"
         t-on-completed="onCompleted"
     />
+    <FunctionDescriptionProvider
+        t-if="functionDescriptionState.showDescription and props.focus"
+        t-ref="o_function_description_provider"
+        functionName = "functionDescriptionState.functionName"
+        functionDescription = "functionDescriptionState.functionDescription"
+        argToFocus = "functionDescriptionState.argToFocus"
+    />
 </div>
   `;
 const CSS = css/* scss */ `
@@ -83,10 +98,23 @@ interface Props {
   focus: boolean;
 }
 
+interface AutoCompleteState {
+  showProvider: boolean;
+  provider: string;
+  search: string;
+}
+
+interface FunctionDescriptionState {
+  showDescription: boolean;
+  functionName: string;
+  functionDescription: FunctionDescription;
+  argToFocus: number;
+}
+
 export class Composer extends Component<Props, SpreadsheetEnv> {
   static template = TEMPLATE;
   static style = CSS;
-  static components = { TextValueProvider };
+  static components = { TextValueProvider, FunctionDescriptionProvider };
   static defaultProps = {
     inputStyle: "",
     focus: false,
@@ -100,10 +128,17 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
 
   contentHelper: ContentEditableHelper;
 
-  autoCompleteState = useState({
+  autoCompleteState: AutoCompleteState = useState({
     showProvider: false,
     provider: "functions",
     search: "",
+  });
+
+  functionDescriptionState: FunctionDescriptionState = useState({
+    showDescription: false,
+    functionName: "",
+    functionDescription: {} as FunctionDescription,
+    argToFocus: 0,
   });
 
   // we can't allow input events to be triggered while we remove and add back the content of the composer in processContent
@@ -151,6 +186,7 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
 
   private processArrowKeys(ev: KeyboardEvent) {
     if (this.getters.isSelectingForComposer()) {
+      this.functionDescriptionState.showDescription = false;
       return;
     }
     ev.stopPropagation();
@@ -227,46 +263,46 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     if (!this.props.focus || !this.shouldProcessInputEvents) {
       return;
     }
+    this.dispatch("STOP_COMPOSER_SELECTION");
     const el = this.composerRef.el! as HTMLInputElement;
     const content = el.childNodes.length ? el.textContent! : "";
     this.dispatch("SET_CURRENT_CONTENT", {
       content,
       selection: this.contentHelper.getCurrentSelection(),
     });
+    if (this.canStartComposerSelection()) {
+      this.dispatch("START_COMPOSER_SELECTION");
+    }
   }
 
   onKeyup(ev: KeyboardEvent) {
-    if (
-      !this.props.focus ||
-      ["Control", "Shift", "ArrowUp", "ArrowDown", "Tab", "Enter"].includes(ev.key)
-    ) {
-      // already processed in keydown
+    if (!this.props.focus || ["Control", "Shift", "Tab", "Enter"].includes(ev.key)) {
       return;
     }
+
+    if (this.autoCompleteState.showProvider && ["ArrowUp", "ArrowDown"].includes(ev.key)) {
+      return; // already processed in keydown
+    }
+
+    if (
+      this.getters.isSelectingForComposer() &&
+      ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(ev.key)
+    ) {
+      return; // already processed in keydown
+    }
+
     ev.preventDefault();
     ev.stopPropagation();
 
-    // reset the state of the ref selector and autocomplete for safety.
-    // They will be set correctly if needed in `processTokenAtCursor`
     this.autoCompleteState.showProvider = false;
-    this.autoCompleteState.search = "";
     if (ev.ctrlKey && ev.key === " ") {
+      this.autoCompleteState.search = "";
       this.autoCompleteState.showProvider = true;
-    } else if (
-      ev.key === "ArrowLeft" ||
-      ev.key === "ArrowRight" ||
-      ev.key === "End" ||
-      ev.key === "Home"
-    ) {
-      const { start, end } = this.contentHelper.getCurrentSelection();
-      this.dispatch("CHANGE_COMPOSER_SELECTION", {
-        start,
-        end,
-      });
-    } else {
-      this.dispatch("STOP_COMPOSER_SELECTION");
-      this.processTokenAtCursor();
+      return;
     }
+
+    this.dispatch("CHANGE_COMPOSER_SELECTION", this.contentHelper.getCurrentSelection());
+    this.processTokenAtCursor();
   }
 
   onClick() {
@@ -275,6 +311,7 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
         selection: this.contentHelper.getCurrentSelection(),
       });
     }
+    this.dispatch("STOP_COMPOSER_SELECTION");
     this.dispatch("CHANGE_COMPOSER_SELECTION", this.contentHelper.getCurrentSelection());
     this.processTokenAtCursor();
   }
@@ -374,26 +411,56 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     return this.getters.getEditionMode() !== "inactive" ? MatchingParenColor : undefined;
   }
 
+  private canStartComposerSelection(): boolean {
+    // todo: check the precise context of the surrounding tokens in which the selection can start
+    const tokenAtCursor = this.getters.getTokenAtCursor();
+    if (
+      tokenAtCursor &&
+      ["COMMA", "LEFT_PAREN", "OPERATOR", "SPACE"].includes(tokenAtCursor.type)
+    ) {
+      return true;
+    }
+    return false;
+  }
+
   /**
    * Compute the state of the composer from the tokenAtCursor.
-   * If the token is a bool, function or symbol we have to initialize the autocomplete engine.
-   * If it's a comma, left_paren or operator we have to initialize the range selection.
+   * If the token is a function or symbol (that isn't a cell/range reference) we have to initialize
+   * the autocomplete engine otherwise we initialize the formula assistant.
    */
-  private processTokenAtCursor() {
-    const tokenAtCursor = this.getters.getTokenAtCursor();
-    const content = this.getters.getCurrentContent();
-    if (!tokenAtCursor || !content.startsWith("=")) {
-      return;
-    }
-    if (["BOOLEAN", "FUNCTION", "SYMBOL"].includes(tokenAtCursor.type)) {
-      if (tokenAtCursor.value.length > 0) {
-        this.autoCompleteState.search = tokenAtCursor.value;
-        this.autoCompleteState.showProvider = true;
+  private processTokenAtCursor(): void {
+    let value = this.getters.getCurrentContent();
+    this.tokens = composerTokenize(value);
+
+    this.autoCompleteState.showProvider = false;
+    this.functionDescriptionState.showDescription = false;
+
+    if (value.startsWith("=")) {
+      const tokenAtCursor = this.getters.getTokenAtCursor();
+      if (tokenAtCursor) {
+        const [xc] = tokenAtCursor.value.split("!").reverse();
+        if (
+          tokenAtCursor.type === "FUNCTION" ||
+          (tokenAtCursor.type === "SYMBOL" && !rangeReference.test(xc))
+        ) {
+          // initialize Autocomplete Dropdown
+          this.autoCompleteState.search = tokenAtCursor.value;
+          this.autoCompleteState.showProvider = true;
+        } else if (tokenAtCursor.functionContext) {
+          // initialize Formula Assistant
+          const tokenContext = tokenAtCursor.functionContext;
+          const parentFunction = tokenContext.parent.toUpperCase();
+          const description = functions[parentFunction];
+          const argPosition = tokenContext.argPosition;
+
+          this.functionDescriptionState = {
+            functionName: parentFunction,
+            functionDescription: description,
+            argToFocus: argumentToFocus(description.args, argPosition),
+            showDescription: true,
+          };
+        }
       }
-    } else if (["COMMA", "LEFT_PAREN", "OPERATOR", "SPACE"].includes(tokenAtCursor.type)) {
-      // we need to reset the anchor of the selection to the active cell, so the next Arrow key down
-      // is relative the to the cell we edit
-      this.dispatch("START_COMPOSER_SELECTION");
     }
   }
 
@@ -426,8 +493,9 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
         text: value,
       });
     }
-    this.autoCompleteState.search = "";
-    this.autoCompleteState.showProvider = false;
     this.processTokenAtCursor();
+    if (this.canStartComposerSelection()) {
+      this.dispatch("START_COMPOSER_SELECTION");
+    }
   }
 }

--- a/src/components/composer/formula_assistant.ts
+++ b/src/components/composer/formula_assistant.ts
@@ -1,0 +1,113 @@
+import * as owl from "@odoo/owl";
+import { FunctionDescription } from "../../types";
+import { formulaAssistantTerms } from "./translation_terms";
+
+const { Component } = owl;
+const { xml, css } = owl.tags;
+
+// -----------------------------------------------------------------------------
+// Formula Assistant component
+// -----------------------------------------------------------------------------
+
+const TEMPLATE = xml/* xml */ `
+  <div>
+    <t t-set="context" t-value="getContext()"/>
+    <div class="o-formula-assistant" t-if="context.functionName" >
+
+      <div class="o-formula-assistant-head">
+        <span t-esc="context.functionName"/> (
+        <t t-foreach="context.functionDescription.args" t-as="arg" t-key="arg.name" >
+          <span t-if="arg_index > '0'" >, </span>
+          <span t-att-class="{ 'o-formula-assistant-focus': context.argToFocus === arg_index }" >
+            <span>
+              <span t-if="arg.optional">[</span>
+              <span t-esc="arg.name" />
+              <span t-if="arg.repeating">, ...</span>
+              <span t-if="arg.optional">]</span>
+            </span>
+          </span>
+        </t> )
+      </div>
+
+      <div class="o-formula-assistant-core">
+        <div class="o-formula-assistant-gray" t-esc="env._t('${formulaAssistantTerms.ABOUT}')"/>
+        <div t-esc="context.functionDescription.description"/>
+      </div>
+
+      <t t-foreach="context.functionDescription.args" t-as="arg" t-key="arg.name">
+        <div class="o-formula-assistant-arg"
+            t-att-class="{
+              'o-formula-assistant-gray': context.argToFocus >= '0',
+              'o-formula-assistant-focus': context.argToFocus === arg_index,
+            }" >
+          <div>
+            <span t-esc="arg.name" />
+            <span t-if="arg.optional"> - [<t t-esc="env._t('${formulaAssistantTerms.OPTIONAL}')"/>] </span>
+            <span t-if="arg.default !== undefined">
+              <t t-esc="arg.default" />
+              <t t-esc="env._t(' ${formulaAssistantTerms.BY_DEFAULT}')"/>
+            </span>
+            <span t-if="arg.repeating" t-esc="env._t('${formulaAssistantTerms.REPEATABLE}')"/>
+          </div>
+          <div class="o-formula-assistant-arg-description" t-esc="arg.description"/>
+        </div>
+      </t>
+
+    </div>
+  </div>
+`;
+
+const CSS = css/* scss */ `
+  .o-formula-assistant {
+    width: 300px;
+    background-color: #fff;
+    box-shadow: 0 1px 4px 3px rgba(60, 64, 67, 0.15);
+    margin: 4px;
+    white-space: normal;
+    .o-formula-assistant-head {
+      background-color: #f2f2f2;
+      padding: 10px;
+    }
+    .o-formula-assistant-core {
+      padding: 0px 0px 10px 0px;
+      margin: 10px;
+      border-bottom: 1px solid gray;
+    }
+    .o-formula-assistant-arg {
+      padding: 0px 10px 10px 10px;
+      display: flex;
+      flex-direction: column;
+    }
+    .o-formula-assistant-arg-description {
+      font-size: 85%;
+    }
+    .o-formula-assistant-focus {
+      div:first-child,
+      span {
+        color: purple;
+        text-shadow: 0px 0px 1px purple;
+      }
+      div:last-child {
+        color: black;
+      }
+    }
+    .o-formula-assistant-gray {
+      color: gray;
+    }
+  }
+`;
+
+interface Props {
+  functionName: string;
+  functionDescription: FunctionDescription;
+  argToFocus: number;
+}
+
+export class FunctionDescriptionProvider extends Component<Props> {
+  static template = TEMPLATE;
+  static style = CSS;
+
+  getContext(): Props {
+    return this.props;
+  }
+}

--- a/src/components/composer/translation_terms.ts
+++ b/src/components/composer/translation_terms.ts
@@ -1,0 +1,8 @@
+import { _lt } from "../../translation";
+
+export const formulaAssistantTerms = {
+  ABOUT: _lt("ABOUT"),
+  OPTIONAL: _lt("optional"),
+  BY_DEFAULT: _lt("by default"),
+  REPEATABLE: _lt("repeatable"),
+};

--- a/src/formulas/composer_tokenizer.ts
+++ b/src/formulas/composer_tokenizer.ts
@@ -1,5 +1,22 @@
 import { tokenize } from "./tokenizer";
-import { mergeSymbolsIntoRanges, EnrichedToken, enrichTokens } from "./range_tokenizer";
+import { Arg } from "../types/index";
+import {
+  mergeSymbolsIntoRanges,
+  EnrichedToken,
+  enrichTokens,
+  FunctionContext,
+} from "./range_tokenizer";
+
+/**
+ * Take the result of the tokenizer and transform it to be usable in the composer.
+ *
+ * @param formula
+ */
+export function composerTokenize(formula: string): EnrichedToken[] {
+  const tokens = tokenize(formula);
+
+  return mapParentFunction(mergeSymbolsIntoRanges(mapParenthesis(enrichTokens(tokens))));
+}
 
 /**
  * add on each token the length, start and end
@@ -21,12 +38,87 @@ function mapParenthesis(tokens: EnrichedToken[]): EnrichedToken[] {
 }
 
 /**
- * Take the result of the tokenizer and transform it to be usable in the composer.
- *
- * @param formula
+ * add on each token its parent function and the index corresponding to
+ * its position as an argument of the function.
+ * In this example "=MIN(42,SUM(MAX(1,2),3))":
+ * - the parent function of the token correspond to number 42 is the MIN function
+ * - the argument position of the token correspond to number 42 is 0
+ * - the parent function of the token correspond to number 3 is the SUM function
+ * - the argument position of the token correspond to number 3 is 1
  */
-export function composerTokenize(formula: string): EnrichedToken[] {
-  const tokens = tokenize(formula);
+function mapParentFunction(tokens: EnrichedToken[]): EnrichedToken[] {
+  let stack: FunctionContext[] = [];
+  let functionStarted = "";
+  const res = tokens.map((token, i) => {
+    if (!["SPACE", "LEFT_PAREN"].includes(token.type)) {
+      functionStarted = "";
+    }
 
-  return mergeSymbolsIntoRanges(mapParenthesis(enrichTokens(tokens)));
+    switch (token.type) {
+      case "FUNCTION":
+        functionStarted = token.value;
+        break;
+      case "LEFT_PAREN":
+        stack.push({ parent: functionStarted, argPosition: 0 });
+        functionStarted = "";
+        break;
+      case "RIGHT_PAREN":
+        stack.pop();
+        break;
+      case "COMMA":
+        if (stack.length) {
+          // increment position on current function
+          stack[stack.length - 1].argPosition++;
+        }
+        break;
+    }
+
+    if (stack.length) {
+      const functionContext = stack[stack.length - 1];
+      if (functionContext.parent) {
+        token.functionContext = Object.assign({}, functionContext);
+      }
+    }
+    return token;
+  });
+  return res;
+}
+
+/**
+ * Function returning the index of the function argument need to be focus in the formula assistant.
+ * This is particularly useful for functions with repeatable arguments.
+ *
+ * Indeed the function makes it possible to center the index on repeatable arguments when the
+ * number of arguments supplied is greater than the number of arguments defined by the function.
+ *
+ * Ex:
+ *
+ * in the formula "=ADD(11, 55, 66)" which is defined like this "ADD(value1, value2)"
+ * - 11 corresponds to the value1 argument => index will be 1
+ * - 55 corresponds to the value2 argument => index will be 2
+ * - 66 does not correspond any argument => index will be -1
+ *
+ * in the formula "=AVERAGE.WEIGHTED(1, 2, 3, 4, 5, 6)" which is defined like this
+ * "AVERAGE.WEIGHTED(values, weights, [additional_values, ...], [additional_weights, ...])"
+ * - 1 corresponds to the values argument => index will be 1
+ * - 2 corresponds to the weights argument => index will be 2
+ * - 3 corresponds to the [additional_values, ...] argument => index will be 3
+ * - 4 corresponds to the [additional_weights, ...] argument => index will be 4
+ * - 5 corresponds to the [additional_values, ...] argument => index will be 3
+ * - 6 corresponds to the [additional_weights, ...] argument => index will be 4
+ */
+export function argumentToFocus(args: Arg[], argPosition: number): number {
+  const nbrArgs = args.length;
+  if (argPosition + 1 > nbrArgs) {
+    const nbrRepeatable = args.filter((a) => a.repeating).length;
+    if (nbrRepeatable) {
+      if (nbrRepeatable === 1) {
+        return nbrArgs - 1;
+      }
+      const repeatableArg = (argPosition + 1 - nbrArgs) % nbrRepeatable;
+      return nbrArgs - nbrRepeatable + repeatableArg - 1;
+    }
+    return -1;
+  }
+  return argPosition;
 }

--- a/src/formulas/index.ts
+++ b/src/formulas/index.ts
@@ -8,8 +8,8 @@
  */
 
 export { tokenize, Token } from "./tokenizer";
-export { composerTokenize } from "./composer_tokenizer";
-export { rangeTokenize, EnrichedToken } from "./range_tokenizer";
+export { composerTokenize, argumentToFocus } from "./composer_tokenizer";
+export { rangeTokenize, EnrichedToken, FunctionContext } from "./range_tokenizer";
 export { parse, rangeReference, cellReference } from "./parser";
 export { compile } from "./compiler";
 export { normalize } from "./normalize";

--- a/src/formulas/range_tokenizer.ts
+++ b/src/formulas/range_tokenizer.ts
@@ -5,9 +5,11 @@ import { Token, tokenize, TokenType } from "./tokenizer";
  * are only needed during the edition of a formula.
  *
  * The information added are:
- * - parenthesis matching
+ * - start, end and length of each token
  * - range detection (replaces the tokens that composes the range with 1 token)
- * - length, start and end of each token
+ * - parenthesis matching (only for parenthesis tokens)
+ * - parent function (only for tokens surrounded by a function)
+ * - arg position (only for tokens surrounded by a function)
  */
 
 export interface EnrichedToken extends Token {
@@ -15,6 +17,12 @@ export interface EnrichedToken extends Token {
   end: number;
   length: number;
   parenIndex?: number;
+  functionContext?: FunctionContext;
+}
+
+export interface FunctionContext {
+  parent: string;
+  argPosition: number;
 }
 
 /**

--- a/src/functions/arguments.ts
+++ b/src/functions/arguments.ts
@@ -60,8 +60,7 @@ function makeArg(str: string): Arg {
     } else if (key === "LAZY") {
       isLazy = true;
     } else if (key.startsWith("DEFAULT=")) {
-      const value = param.trim().slice(8);
-      defaultVal = value[0] === '"' ? value.slice(1, -1) : parseFloat(value);
+      defaultVal = param.trim().slice(8);
     }
   }
   let description = parts[3].trim();

--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -83,9 +83,9 @@ export const IFERROR: FunctionDescription = {
   description: _lt("Value if it is not an error, otherwise 2nd argument."),
   args: args(`
     value (any, lazy) ${_lt("The value to return if value itself is not an error.")}
-    value_if_error (any, lazy, optional, default="") ${_lt(
-      "The value the function returns if value is an error."
-    )}
+    value_if_error (any, lazy, optional, default=${_lt("An empty value")}) ${_lt(
+    "The value the function returns if value is an error."
+  )}
   `),
   returns: ["ANY"],
   compute: function (value: () => any, valueIfError: () => any = () => ""): any {

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -36,9 +36,9 @@ function linearSearch(range: any[], target: any): number {
 export const COLUMN: FunctionDescription = {
   description: _lt("Column number of a specified cell."),
   args: args(
-    `cell_reference (meta, optional, default='The cell in which the formula is entered by default') ${_lt(
-      "The cell whose column number will be returned. Column A corresponds to 1."
-    )}
+    `cell_reference (meta, optional, default=${_lt(
+      "The cell in which the formula is entered"
+    )}) ${_lt("The cell whose column number will be returned. Column A corresponds to 1.")}
     `
   ),
   returns: ["NUMBER"],
@@ -89,7 +89,7 @@ export const HLOOKUP: FunctionDescription = {
       index (number) ${_lt(
         "The row index of the value to be returned, where the first row in range is numbered 1."
       )}
-      is_sorted (boolean, optional, default = TRUE) ${_lt(
+      is_sorted (boolean, optional, default=TRUE) ${_lt(
         "Indicates whether the row to be searched (the first row of the specified range) is sorted, in which case the closest match for search_key will be returned."
       )}
   `),
@@ -219,9 +219,9 @@ export const MATCH: FunctionDescription = {
 export const ROW: FunctionDescription = {
   description: _lt("Row number of a specified cell."),
   args: args(
-    `cell_reference (meta, optional, default='The cell in which the formula is entered by default')) ${_lt(
-      "The cell whose row number will be returned."
-    )}`
+    `cell_reference (meta, optional, default=${_lt(
+      "The cell in which the formula is entered"
+    )})) ${_lt("The cell whose row number will be returned.")}`
   ),
   returns: ["NUMBER"],
   compute: function (cellReference?: string): number {
@@ -269,7 +269,7 @@ export const VLOOKUP: FunctionDescription = {
       index (number) ${_lt(
         "The column index of the value to be returned, where the first column in range is numbered 1."
       )}
-      is_sorted (boolean, optional, default = TRUE) ${_lt(
+      is_sorted (boolean, optional, default=TRUE) ${_lt(
         "Indicates whether the column to be searched (the first column of the specified range) is sorted, in which case the closest match for search_key will be returned."
       )}
   `),

--- a/src/functions/module_math.ts
+++ b/src/functions/module_math.ts
@@ -1111,9 +1111,9 @@ export const SUMIF: FunctionDescription = {
   args: args(`
       criteria_range (any, range) ${_lt("The range which is tested against criterion.")}
       criterion (string) ${_lt("The pattern or test to apply to range.")}
-      sum_range (any, range, optional, default=criteria_range) ${_lt(
-        "The range to be summed, if different from range."
-      )}
+      sum_range (any, range, optional, default=${_lt("criteria_range")}) ${_lt(
+    "The range to be summed, if different from range."
+  )}
     `),
   returns: ["NUMBER"],
   compute: function (criteriaRange: any, criterion: any, sumRange: any = undefined): number {

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -278,9 +278,9 @@ export const AVERAGEIF: FunctionDescription = {
   args: args(`
       criteria_range (any, range) ${_lt("The range to check against criterion.")}
       criterion (string) ${_lt("The pattern or test to apply to criteria_range.")}
-      average_range (any, range, optional, default=criteria_range) ${_lt(
-        "The range to average. If not included, criteria_range is used for the average instead."
-      )}
+      average_range (any, range, optional, default=${_lt("criteria_range")}) ${_lt(
+    "The range to average. If not included, criteria_range is used for the average instead."
+  )}
     `),
   returns: ["NUMBER"],
   compute: function (criteriaRange: any, criterion: any, averageRange: any = undefined): number {

--- a/tests/components/__snapshots__/formula_assistant_test.ts.snap
+++ b/tests/components/__snapshots__/formula_assistant_test.ts.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`formula assistant appearance simple snapshot with =FUNC1( 1`] = `
+<div
+  class="o-formula-assistant"
+>
+  <div
+    class="o-formula-assistant-head"
+  >
+    <span>
+      FUNC1
+    </span>
+     ( 
+    <span
+      class="o-formula-assistant-focus"
+    >
+      <span>
+        <span>
+          f1Arg1
+        </span>
+      </span>
+    </span>
+    <span>
+      , 
+    </span>
+    <span>
+      <span>
+        <span>
+          f1Arg2
+        </span>
+      </span>
+    </span>
+     ) 
+  </div>
+  <div
+    class="o-formula-assistant-core"
+  >
+    <div
+      class="o-formula-assistant-gray"
+    >
+      ABOUT
+    </div>
+    <div>
+      func1 def
+    </div>
+  </div>
+  <div
+    class="o-formula-assistant-arg o-formula-assistant-gray o-formula-assistant-focus"
+  >
+    <div>
+      <span>
+        f1Arg1
+      </span>
+    </div>
+    <div
+      class="o-formula-assistant-arg-description"
+    >
+      f1 Arg1 def
+    </div>
+  </div>
+  <div
+    class="o-formula-assistant-arg o-formula-assistant-gray"
+  >
+    <div>
+      <span>
+        f1Arg2
+      </span>
+    </div>
+    <div
+      class="o-formula-assistant-arg-description"
+    >
+      f1 Arg2 def
+    </div>
+  </div>
+</div>
+`;

--- a/tests/components/composer_test.ts
+++ b/tests/components/composer_test.ts
@@ -216,6 +216,7 @@ describe("composer", () => {
     // @ts-ignore
     const cehMock = window.mockContentHelper as ContentEditableHelper;
     cehMock.removeAll();
+    composerEl.dispatchEvent(new Event("input"));
     composerEl.dispatchEvent(new Event("keyup"));
     triggerMouseEvent("canvas", "mousedown", 300, 200);
     await nextTick();
@@ -379,6 +380,14 @@ describe("composer", () => {
     jest.spyOn(composerEl, "scrollWidth", "get").mockImplementation(() => 120);
     await typeInComposer("world", false);
     expect(styleSpy).toHaveBeenCalledWith("170px"); // scrollWidth + 50
+  });
+
+  test("clicking on the composer while in 'selecting' mode should put the composer in 'edition' mode", async () => {
+    await typeInComposer("=");
+    expect(model.getters.getEditionMode()).toBe("selecting");
+    composerEl.dispatchEvent(new MouseEvent("click"));
+    await nextTick();
+    expect(model.getters.getEditionMode()).toBe("editing");
   });
 });
 

--- a/tests/components/formula_assistant_test.ts
+++ b/tests/components/formula_assistant_test.ts
@@ -1,0 +1,378 @@
+import { Model } from "../../src/model";
+import {
+  GridParent,
+  makeTestFixture,
+  nextTick,
+  resetFunctions,
+  typeInComposer as typeInComposerHelper,
+} from "../helpers";
+import { args, functionRegistry } from "../../src/functions/index";
+jest.mock("../../src/components/composer/content_editable_helper", () =>
+  require("./__mocks__/content_editable_helper")
+);
+
+let model: Model;
+let composerEl: Element;
+let fixture: HTMLElement;
+let parent: any;
+async function typeInComposer(text: string) {
+  await typeInComposerHelper(composerEl, text);
+}
+
+beforeEach(async () => {
+  fixture = makeTestFixture();
+  model = new Model();
+  parent = new GridParent(model);
+  await parent.mount(fixture);
+
+  // start composition
+  parent.grid.el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+  await nextTick();
+  composerEl = fixture.querySelector(".o-grid div.o-composer")!;
+});
+
+afterEach(() => {
+  fixture.remove();
+});
+
+describe("formula assistant", () => {
+  beforeEach(() => {
+    resetFunctions();
+    functionRegistry.add("FUNC0", {
+      description: "func without args",
+      args: args(``),
+      compute: () => 1,
+      returns: ["ANY"],
+    });
+    functionRegistry.add("FUNC1", {
+      description: "func1 def",
+      args: args(`
+              f1Arg1 (any) f1 Arg1 def
+              f1Arg2 (any) f1 Arg2 def
+          `),
+      compute: () => 1,
+      returns: ["ANY"],
+    });
+    functionRegistry.add("FUNC2", {
+      description: "func2 def",
+      args: args(`
+              f2Arg1 (any) f2 Arg1 def
+              f2Arg2 (any, optional, default=TRUE) f2 Arg2 def
+          `),
+      compute: () => 1,
+      returns: ["ANY"],
+    });
+    functionRegistry.add("FUNC3", {
+      description: "func3 def",
+      args: args(`
+                f3Arg1 (any) f3 Arg1 def
+                f3Arg2 (any, optional, repeating) f3 Arg2 def
+            `),
+      compute: () => 1,
+      returns: ["ANY"],
+    });
+    // functionRegistry.add("UPTOWNFUNC", {
+    //   description: "a Bruno Mars song ?",
+    //   args: args(`
+    //           f4Arg1 (any) f4 Arg1 def
+    //           f4Arg2 (any, optional, repeating) f4 Arg2 def
+    //           f4Arg3 (any, optional, repeating) f4 Arg3 def
+    //       `),
+    //   compute: () => 1,
+    //   returns: ["ANY"],
+    // });
+  });
+
+  describe("appearance", () => {
+    test("empty not show autocomplete", async () => {
+      await typeInComposer("");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("= do not show formula assistant", async () => {
+      await typeInComposer("=");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUNC1( show formula assistant", async () => {
+      await typeInComposer("=FUNC1(");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+    });
+
+    test("=func1( show formula assistant", async () => {
+      await typeInComposer("=func1(");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+    });
+
+    test("FUNC1( do not show formula assistant", async () => {
+      await typeInComposer("FUNC1");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUNC1 do not show formula assistant", async () => {
+      await typeInComposer("=FUNC1");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUN( do not show formula assistant (nothing matches FUN)", async () => {
+      await typeInComposer("=FUN(");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUNC1) do not show formula assistant", async () => {
+      await typeInComposer("=FUNC1)");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUNC1() do not show formula assistant", async () => {
+      await typeInComposer("=FUNC1()");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUNC1(( do not show formula assistant", async () => {
+      await typeInComposer("=FUNC1((");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUNC1)( do not show formula assistant", async () => {
+      await typeInComposer("=FUNC1)(");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUNC1(() show formula assistant", async () => {
+      await typeInComposer("=FUNC1(()");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+    });
+
+    test("=FUNC1()( do not show formula assistant", async () => {
+      await typeInComposer("=FUNC1()(");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUNC1(FUNC2( show formula assistant for 2nd function", async () => {
+      await typeInComposer("=FUNC1(FUNC2(");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+      expect(fixture.querySelectorAll(".o-formula-assistant-head span")[0].textContent).toBe(
+        "FUNC2"
+      );
+    });
+
+    test("=FUNC1(FUNC2() show formula assistant for 1st function", async () => {
+      await typeInComposer("=FUNC1(FUNC2()");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+      expect(fixture.querySelectorAll(".o-formula-assistant-head span")[0].textContent).toBe(
+        "FUNC1"
+      );
+    });
+
+    test("=FUNC1(FUNC2 do not show formula assistant", async () => {
+      await typeInComposer("=FUNC1(FUNC2");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+    });
+
+    test("=FUNC1(A2 show formula assistant (A2 is a ref)", async () => {
+      await typeInComposer("=FUNC1(A2");
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+    });
+
+    test("simple snapshot with =FUNC1(", async () => {
+      await typeInComposer("=FUNC1(");
+      expect(fixture.querySelector(".o-formula-assistant")).toMatchSnapshot();
+    });
+
+    test("use arowKey during 'selecting' mode in a function should not display formula assistant", async () => {
+      await typeInComposer("=FUNC1(1,");
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+      expect(model.getters.getEditionMode()).toBe("selecting");
+      composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+      await nextTick();
+      composerEl.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowRight", bubbles: true }));
+      await nextTick();
+      expect(model.getters.getCurrentContent()).toBe("=FUNC1(1,B1");
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+      expect(model.getters.getEditionMode()).toBe("selecting");
+    });
+
+    test("use arowKey during 'editing' mode in a function should display formula assistant", async () => {
+      await typeInComposer("=FUNC1(1");
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+      expect(model.getters.getEditionMode()).toBe("editing");
+      composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+      await nextTick();
+      composerEl.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowLeft", bubbles: true }));
+      await nextTick();
+      expect(model.getters.getCurrentContent()).toBe("=FUNC1(1");
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+      expect(model.getters.getEditionMode()).toBe("editing");
+    });
+
+    describe("function definition", () => {
+      test("function without argument", async () => {
+        await typeInComposer("=FUNC0(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "FUNC0 (  ) "
+        );
+      });
+
+      test("normal function", async () => {
+        await typeInComposer("=FUNC1(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "FUNC1 ( f1Arg1, f1Arg2 ) "
+        );
+      });
+
+      test("function with default argument", async () => {
+        await typeInComposer("=FUNC2(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "FUNC2 ( f2Arg1, [f2Arg2] ) "
+        );
+      });
+
+      test("function with repeatable argument", async () => {
+        await typeInComposer("=FUNC3(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "FUNC3 ( f3Arg1, [f3Arg2, ...] ) "
+        );
+      });
+    });
+
+    describe("arguments description", () => {
+      test("function without argument", async () => {
+        await typeInComposer("=FUNC0(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg")).toHaveLength(0);
+      });
+
+      test("normal argument", async () => {
+        await typeInComposer("=FUNC1(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg")).toHaveLength(2);
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg div")[2].textContent).toBe(
+          "f1Arg2"
+        );
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg div")[3].textContent).toBe(
+          "f1 Arg2 def"
+        );
+      });
+
+      test("function with default argument", async () => {
+        await typeInComposer("=FUNC2(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg")).toHaveLength(2);
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg div")[2].textContent).toBe(
+          "f2Arg2 - [optional] TRUE by default"
+        );
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg div")[3].textContent).toBe(
+          "f2 Arg2 def"
+        );
+      });
+
+      test("function with repeatable argument", async () => {
+        await typeInComposer("=FUNC3(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg")).toHaveLength(2);
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg div")[2].textContent).toBe(
+          "f3Arg2 - [optional] repeatable"
+        );
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg div")[3].textContent).toBe(
+          "f3 Arg2 def"
+        );
+      });
+    });
+  });
+
+  describe("focus argument", () => {
+    test("=FUNC1( focus index on 1st arg", async () => {
+      await typeInComposer("=FUNC1(");
+      expect(
+        fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0]
+          .textContent
+      ).toBe("f1Arg1");
+    });
+
+    test("=FUNC1(42 focus index on 1st arg", async () => {
+      await typeInComposer("=FUNC1(42");
+      expect(
+        fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0]
+          .textContent
+      ).toBe("f1Arg1");
+    });
+
+    test("=FUNC1(42, focus index on 2nd arg", async () => {
+      await typeInComposer("=FUNC1(42,");
+      expect(
+        fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0]
+          .textContent
+      ).toBe("f1Arg2");
+    });
+
+    test("functions with more arguments than allowed do not have focus", async () => {
+      await typeInComposer("=FUNC1(42, 24, 22");
+      expect(
+        fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")
+      ).toHaveLength(0);
+    });
+
+    describe("functions with repeatable argument always have a focus", () => {
+      test("=FUNC3(84, focus on 2nd argument", async () => {
+        await typeInComposer("=FUNC3(84,");
+        expect(
+          fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0]
+            .textContent
+        ).toBe("f3Arg2");
+      });
+
+      test("=FUNC3(84, 42, focus on 2nd argument", async () => {
+        await typeInComposer("=FUNC3(84, 42,");
+        expect(
+          fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0]
+            .textContent
+        ).toBe("f3Arg2");
+      });
+    });
+
+    // describe("functions with more than one repeatable argument have an alternate focus", () => {
+    //   test("=UPTOWNFUNC(1, 2, focus on 3th argument", async () => {
+    //     await typeInComposer("=UPTOWNFUNC(1, 2,");
+    //     expect(fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0].textContent).toBe(
+    //       "f4Arg3"
+    //     );
+    //   });
+
+    //   test("=UPTOWNFUNC(1, 2, 3, focus on 4th argument", async () => {
+    //     await typeInComposer("=UPTOWNFUNC(1, 2, 3,");
+    //     expect(fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")).toHaveLength(2);
+    //     expect(fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0].textContent).toBe(
+    //       "f4Arg4"
+    //     );
+    //   });
+
+    //   test("=UPTOWNFUNC(1, 2, 3, 4,  focus on 3th argument", async () => {
+    //     await typeInComposer("=UPTOWNFUNC(1, 2, 3, 4,");
+    //     expect(fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0].textContent).toBe(
+    //       "f4Arg3"
+    //     );
+    //   });
+
+    //   test("=UPTOWNFUNC(1, 2, 3, 4, 5, focus on 4th argument", async () => {
+    //     await typeInComposer("=UPTOWNFUNC(1, 2, 3, 4, 5,");
+    //     expect(fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0].textContent).toBe(
+    //       "f4Arg4"
+    //     );
+    //   });
+    // });
+  });
+});

--- a/tests/formulas/__snapshots__/composer_tokenizer_test.ts.snap
+++ b/tests/formulas/__snapshots__/composer_tokenizer_test.ts.snap
@@ -1,0 +1,373 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`composerTokenizer = SUM ( C4 : C5 ) 1`] = `
+Array [
+  Object {
+    "end": 1,
+    "length": 1,
+    "start": 0,
+    "type": "OPERATOR",
+    "value": "=",
+  },
+  Object {
+    "end": 2,
+    "length": 1,
+    "start": 1,
+    "type": "SPACE",
+    "value": " ",
+  },
+  Object {
+    "end": 5,
+    "length": 3,
+    "start": 2,
+    "type": "FUNCTION",
+    "value": "SUM",
+  },
+  Object {
+    "end": 6,
+    "length": 1,
+    "start": 5,
+    "type": "SPACE",
+    "value": " ",
+  },
+  Object {
+    "end": 7,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "parenIndex": 1,
+    "start": 6,
+    "type": "LEFT_PAREN",
+    "value": "(",
+  },
+  Object {
+    "end": 16,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "SUM",
+    },
+    "length": 9,
+    "start": 7,
+    "type": "SYMBOL",
+    "value": " C4 : C5 ",
+  },
+  Object {
+    "end": 17,
+    "length": 1,
+    "parenIndex": 1,
+    "start": 16,
+    "type": "RIGHT_PAREN",
+    "value": ")",
+  },
+]
+`;
+
+exports[`composerTokenizer base tests Boolean 1`] = `
+Array [
+  Object {
+    "end": 1,
+    "length": 1,
+    "start": 0,
+    "type": "OPERATOR",
+    "value": "=",
+  },
+  Object {
+    "end": 4,
+    "length": 3,
+    "start": 1,
+    "type": "FUNCTION",
+    "value": "AND",
+  },
+  Object {
+    "end": 5,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "AND",
+    },
+    "length": 1,
+    "parenIndex": 1,
+    "start": 4,
+    "type": "LEFT_PAREN",
+    "value": "(",
+  },
+  Object {
+    "end": 9,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "AND",
+    },
+    "length": 4,
+    "start": 5,
+    "type": "SYMBOL",
+    "value": "true",
+  },
+  Object {
+    "end": 10,
+    "functionContext": Object {
+      "argPosition": 1,
+      "parent": "AND",
+    },
+    "length": 1,
+    "start": 9,
+    "type": "COMMA",
+    "value": ",",
+  },
+  Object {
+    "end": 15,
+    "functionContext": Object {
+      "argPosition": 1,
+      "parent": "AND",
+    },
+    "length": 5,
+    "start": 10,
+    "type": "SYMBOL",
+    "value": "false",
+  },
+  Object {
+    "end": 16,
+    "length": 1,
+    "parenIndex": 1,
+    "start": 15,
+    "type": "RIGHT_PAREN",
+    "value": ")",
+  },
+]
+`;
+
+exports[`composerTokenizer base tests formula token 1`] = `
+Array [
+  Object {
+    "end": 1,
+    "length": 1,
+    "start": 0,
+    "type": "OPERATOR",
+    "value": "=",
+  },
+  Object {
+    "end": 4,
+    "length": 3,
+    "start": 1,
+    "type": "FUNCTION",
+    "value": "SUM",
+  },
+  Object {
+    "end": 5,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "parenIndex": 1,
+    "start": 4,
+    "type": "LEFT_PAREN",
+    "value": "(",
+  },
+  Object {
+    "end": 6,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "start": 5,
+    "type": "NUMBER",
+    "value": "1",
+  },
+  Object {
+    "end": 7,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "start": 6,
+    "type": "SPACE",
+    "value": " ",
+  },
+  Object {
+    "end": 8,
+    "functionContext": Object {
+      "argPosition": 1,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "start": 7,
+    "type": "COMMA",
+    "value": ",",
+  },
+  Object {
+    "end": 9,
+    "length": 1,
+    "parenIndex": 2,
+    "start": 8,
+    "type": "LEFT_PAREN",
+    "value": "(",
+  },
+  Object {
+    "end": 10,
+    "length": 1,
+    "start": 9,
+    "type": "NUMBER",
+    "value": "1",
+  },
+  Object {
+    "end": 11,
+    "length": 1,
+    "start": 10,
+    "type": "OPERATOR",
+    "value": "+",
+  },
+  Object {
+    "end": 12,
+    "length": 1,
+    "start": 11,
+    "type": "NUMBER",
+    "value": "2",
+  },
+  Object {
+    "end": 13,
+    "functionContext": Object {
+      "argPosition": 1,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "parenIndex": 2,
+    "start": 12,
+    "type": "RIGHT_PAREN",
+    "value": ")",
+  },
+  Object {
+    "end": 14,
+    "functionContext": Object {
+      "argPosition": 2,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "start": 13,
+    "type": "COMMA",
+    "value": ",",
+  },
+  Object {
+    "end": 17,
+    "functionContext": Object {
+      "argPosition": 2,
+      "parent": "SUM",
+    },
+    "length": 3,
+    "start": 14,
+    "type": "FUNCTION",
+    "value": "ADD",
+  },
+  Object {
+    "end": 18,
+    "functionContext": Object {
+      "argPosition": 2,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "start": 17,
+    "type": "SPACE",
+    "value": " ",
+  },
+  Object {
+    "end": 19,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "ADD",
+    },
+    "length": 1,
+    "parenIndex": 3,
+    "start": 18,
+    "type": "LEFT_PAREN",
+    "value": "(",
+  },
+  Object {
+    "end": 20,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "ADD",
+    },
+    "length": 1,
+    "start": 19,
+    "type": "NUMBER",
+    "value": "2",
+  },
+  Object {
+    "end": 21,
+    "functionContext": Object {
+      "argPosition": 1,
+      "parent": "ADD",
+    },
+    "length": 1,
+    "start": 20,
+    "type": "COMMA",
+    "value": ",",
+  },
+  Object {
+    "end": 22,
+    "functionContext": Object {
+      "argPosition": 1,
+      "parent": "ADD",
+    },
+    "length": 1,
+    "start": 21,
+    "type": "SPACE",
+    "value": " ",
+  },
+  Object {
+    "end": 23,
+    "functionContext": Object {
+      "argPosition": 1,
+      "parent": "ADD",
+    },
+    "length": 1,
+    "start": 22,
+    "type": "NUMBER",
+    "value": "3",
+  },
+  Object {
+    "end": 24,
+    "functionContext": Object {
+      "argPosition": 2,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "parenIndex": 3,
+    "start": 23,
+    "type": "RIGHT_PAREN",
+    "value": ")",
+  },
+  Object {
+    "end": 25,
+    "functionContext": Object {
+      "argPosition": 3,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "start": 24,
+    "type": "COMMA",
+    "value": ",",
+  },
+  Object {
+    "end": 26,
+    "functionContext": Object {
+      "argPosition": 3,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "start": 25,
+    "type": "NUMBER",
+    "value": "4",
+  },
+  Object {
+    "end": 27,
+    "length": 1,
+    "parenIndex": 1,
+    "start": 26,
+    "type": "RIGHT_PAREN",
+    "value": ")",
+  },
+]
+`;

--- a/tests/formulas/composer_tokenizer_test.ts
+++ b/tests/formulas/composer_tokenizer_test.ts
@@ -1,4 +1,5 @@
-import { composerTokenize } from "../../src/formulas/composer_tokenizer";
+import { composerTokenize, argumentToFocus } from "../../src/formulas/composer_tokenizer";
+import { args } from "../../src/functions/arguments";
 
 describe("composerTokenizer", () => {
   test("only range", () => {
@@ -42,15 +43,7 @@ describe("composerTokenizer", () => {
   }); //"= SUM ( C4 : C5 )"
 
   test("= SUM ( C4 : C5 )", () => {
-    expect(composerTokenize("= SUM ( C4 : C5 )")).toEqual([
-      { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
-      { start: 1, end: 2, length: 1, type: "SPACE", value: " " },
-      { start: 2, end: 5, length: 3, type: "FUNCTION", value: "SUM" },
-      { start: 5, end: 6, length: 1, type: "SPACE", value: " " },
-      { start: 6, end: 7, length: 1, type: "LEFT_PAREN", value: "(", parenIndex: 1 },
-      { start: 7, end: 16, length: 9, type: "SYMBOL", value: " C4 : C5 " },
-      { start: 16, end: 17, length: 1, type: "RIGHT_PAREN", value: ")", parenIndex: 1 },
-    ]);
+    expect(composerTokenize("= SUM ( C4 : C5 )")).toMatchSnapshot();
   });
 });
 
@@ -65,6 +58,7 @@ describe("composerTokenizer base tests", () => {
       { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
       { start: 1, end: 2, length: 1, type: "NUMBER", value: "1" },
     ]);
+    expect(composerTokenize("=SUM(1 ,(1+2),ADD (2, 3),4)")).toMatchSnapshot();
   });
   test("longer operators >=", () => {
     expect(composerTokenize("= >= <= <")).toEqual([
@@ -120,18 +114,49 @@ describe("composerTokenizer base tests", () => {
     expect(composerTokenize("false")).toEqual([
       { start: 0, end: 5, length: 5, type: "SYMBOL", value: "false" },
     ]);
-    expect(composerTokenize("=AND(true,false)")).toEqual([
-      { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
-      { start: 1, end: 4, length: 3, type: "FUNCTION", value: "AND" },
-      { start: 4, end: 5, length: 1, type: "LEFT_PAREN", value: "(", parenIndex: 1 },
-      { start: 5, end: 9, length: 4, type: "SYMBOL", value: "true" },
-      { start: 9, end: 10, length: 1, type: "COMMA", value: "," },
-      { start: 10, end: 15, length: 5, type: "SYMBOL", value: "false" },
-      { start: 15, end: 16, length: 1, type: "RIGHT_PAREN", parenIndex: 1, value: ")" },
-    ]);
+    expect(composerTokenize("=AND(true,false)")).toMatchSnapshot();
     expect(composerTokenize("=trueee")).toEqual([
       { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
       { start: 1, end: 7, length: 6, type: "SYMBOL", value: "trueee" },
     ]);
+  });
+});
+
+describe("function argumentToFocus", () => {
+  test("focus simple arguments", () => {
+    const simpleArgs = args(`
+      arg1 (any)
+      arg2 (any)
+      arg3 (any)
+    `);
+    expect(argumentToFocus(simpleArgs, 0)).toBe(0);
+    expect(argumentToFocus(simpleArgs, 1)).toBe(1);
+    expect(argumentToFocus(simpleArgs, 2)).toBe(2);
+    expect(argumentToFocus(simpleArgs, 3)).toBe(-1);
+  });
+
+  test("focus arguments with one repeatable", () => {
+    const oneOptionalArg = args(`
+      arg1 (any)
+      arg2 (any, optional, repeating)
+    `);
+    expect(argumentToFocus(oneOptionalArg, 0)).toBe(0);
+    expect(argumentToFocus(oneOptionalArg, 1)).toBe(1);
+    expect(argumentToFocus(oneOptionalArg, 2)).toBe(1);
+    expect(argumentToFocus(oneOptionalArg, 42)).toBe(1);
+  });
+
+  test("focus arguments with more than one repeatable", () => {
+    const threeOptionalArg = args(`
+      arg1 (any)
+      arg2 (any, optional, repeating)
+      arg3 (any, optional, repeating)
+      arg3 (any, optional, repeating)
+    `);
+    expect(argumentToFocus(threeOptionalArg, 0)).toBe(0);
+    expect(argumentToFocus(threeOptionalArg, 1)).toBe(1);
+    expect(argumentToFocus(threeOptionalArg, 3)).toBe(3);
+    expect(argumentToFocus(threeOptionalArg, 5)).toBe(2);
+    expect(argumentToFocus(threeOptionalArg, 19)).toBe(1);
   });
 });

--- a/tests/functions/arguments_test.ts
+++ b/tests/functions/arguments_test.ts
@@ -46,7 +46,7 @@ describe("args", () => {
         type: ["NUMBER"],
         name: "test",
         description: "descr",
-        default: 10,
+        default: "10",
       },
     ]);
   });
@@ -57,7 +57,7 @@ describe("args", () => {
         type: ["NUMBER"],
         name: "test",
         description: "descr",
-        default: "asdf",
+        default: '"asdf"',
       },
     ]);
   });


### PR DESCRIPTION
This commit adds a formula assistant that gives information about
function arguments when entering a function in the composer.

this commit changes the composer selection activation. Now this can be
activated if and only if text has been typed in the composer.