### PR TITLE
[FIX] import: correctly import styles on merges

### DIFF
--- a/src/plugins/formatting.ts
+++ b/src/plugins/formatting.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_FONT, DEFAULT_FONT_SIZE, DEFAULT_FONT_WEIGHT } from "../constants";
 import { fontSizeMap } from "../fonts";
-import { stringify, toCartesian, toXC, maximumDecimalPlaces } from "../helpers/index";
+import { stringify, toCartesian, toXC, maximumDecimalPlaces, toZone } from "../helpers/index";
 import {
   Border,
   BorderCommand,
@@ -81,6 +81,11 @@ export class FormattingPlugin extends BasePlugin {
 
   handle(cmd: Command) {
     switch (cmd.type) {
+      case "ADD_MERGE":
+        if (!cmd.interactive) {
+          this.addMerge(cmd.sheetId, cmd.zone);
+        }
+        break;
       case "SET_FORMATTING":
         if (cmd.style) {
           this.setStyle(cmd.sheetId, cmd.target, cmd.style);
@@ -605,6 +610,32 @@ export class FormattingPlugin extends BasePlugin {
     return format;
   }
 
+  addMerge(sheetId: UID, zone: Zone) {
+    const { left, right, top, bottom } = zone;
+    const topLeft = this.getters.getCell(sheetId, left, top);
+    const bottomRight = this.getters.getCell(sheetId, right, bottom) || topLeft;
+    const bordersTopLeft = topLeft ? this.getCellBorder(topLeft) : null;
+    const bordersBottomRight =
+      (bottomRight ? this.getCellBorder(bottomRight) : null) || bordersTopLeft;
+    this.setBorder(sheetId, [{ left, right, top, bottom }], "clear");
+    if (bordersBottomRight && bordersBottomRight.right) {
+      const zone = [{ left: right, right, top, bottom }];
+      this.setBorder(sheetId, zone, "right");
+    }
+    if (bordersTopLeft && bordersTopLeft.left) {
+      const zone = [{ left, right: left, top, bottom }];
+      this.setBorder(sheetId, zone, "left");
+    }
+    if (bordersTopLeft && bordersTopLeft.top) {
+      const zone = [{ left, right, top, bottom: top }];
+      this.setBorder(sheetId, zone, "top");
+    }
+    if (bordersBottomRight && bordersBottomRight.bottom) {
+      const zone = [{ left, right, top: bottom, bottom }];
+      this.setBorder(sheetId, zone, "bottom");
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Import/Export
   // ---------------------------------------------------------------------------
@@ -625,6 +656,14 @@ export class FormattingPlugin extends BasePlugin {
       nextId = Math.max(k as any, nextId);
     }
     this.nextId = nextId + 1;
+    const sheets = data.sheets || [];
+    for (let sheetData of sheets) {
+      if (sheetData.merges) {
+        for (let merge of sheetData.merges) {
+          this.addMerge(sheetData.id, toZone(merge));
+        }
+      }
+    }
   }
 
   export(data: WorkbookData) {

--- a/tests/plugins/import_export_test.ts
+++ b/tests/plugins/import_export_test.ts
@@ -174,7 +174,7 @@ test("complete import, then export", () => {
         id: "someuuid",
         colNumber: 10,
         rowNumber: 10,
-        merges: ["A1:A2", "B1:C1"],
+        merges: ["A1:A2"],
         cols: {
           0: { size: 42 },
         },

--- a/tests/plugins/merges_test.ts
+++ b/tests/plugins/merges_test.ts
@@ -487,6 +487,35 @@ describe("merges", () => {
     model.dispatch("UNDO");
     expect(model.getters.getSelection().zones).toEqual([{ bottom: 2, left: 1, right: 1, top: 1 }]);
   });
+
+  test("import merge with style", () => {
+    const model = new Model({
+      sheets: [
+        {
+          id: "sheet1",
+          colNumber: 4,
+          rowNumber: 5,
+          cells: {
+            B4: { style: 1, border: 1 },
+          },
+          merges: ["B4:C5"],
+        },
+      ],
+      styles: { 1: { textColor: "#fe0000" } },
+      borders: { 1: { top: ["thin", "#000"] } },
+    });
+    const sheetId = model.getters.getActiveSheetId();
+    expect(model.getters.getMerge(sheetId, "B4")).toBeTruthy();
+    expect(model.getters.getMerge(sheetId, "C4")).toBeTruthy();
+    expect(getCell(model, "B4")!.style).toBe(1);
+    expect(getCell(model, "B4")!.border).toBe(1);
+    model.dispatch("REMOVE_MERGE", { sheetId, zone: toZone("B4:C5") });
+    expect(getCell(model, "B4")!.style).toBe(1);
+    expect(getCell(model, "C4")!.style).toBe(1);
+    expect(getCell(model, "B4")!.border).toBe(1);
+    expect(getCell(model, "C4")!.border).toBe(1);
+    expect(getCell(model, "C5")!.border).toBeUndefined();
+  });
 });
 
 function getStyle(model: Model, xc: string): Style {


### PR DESCRIPTION
In addition, this commit remove incorrect dependence of the merge plugin
on the formatting plugin. Now, the formatting plugin correctly depends on
the merge.

Fixes #636