### PR TITLE
[IMP] find_and_replace: handle Enter key

### DIFF
--- a/src/components/side_panel/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace.ts
@@ -5,11 +5,12 @@ import { FindAndReplaceTerms } from "./translations_terms";
 const { Component, useState } = owl;
 const { xml, css } = owl.tags;
 
-const TEMPLATE = xml/* xml */ `<div class="o-find-and-replace" tabindex="0" t-on-focusin="onFocusSidePanel">
+const TEMPLATE = xml/* xml */ `
+<div class="o-find-and-replace" tabindex="0" t-on-focusin="onFocusSidePanel">
   <div class="o-section">
     <div t-esc="env._t('${FindAndReplaceTerms.Search}')" class="o-section-title"/>
     <div class="o-input-search-container">
-      <input type="text" class="o-input o-input-with-count" t-on-input="onInput">
+      <input type="text" class="o-input o-input-with-count" t-on-input="onInput" t-on-keydown="onKeydownSearch">
       </input>
       <div class="o-input-count" t-if="hasSearchResult">
         <t t-esc="env.getters.getCurrentSelectedMatchIndex()+1"/>
@@ -41,7 +42,7 @@ const TEMPLATE = xml/* xml */ `<div class="o-find-and-replace" tabindex="0" t-on
 
   <div class="o-section">
     <div t-esc="env._t('${FindAndReplaceTerms.Replace}')" class="o-section-title"/>
-    <input type="text" class="o-input" t-model="state.replaceWith"/>
+    <input type="text" class="o-input" t-model="state.replaceWith" t-on-keydown="onKeydownReplace"/>
     <label class="o-far-checkbox">
       <input t-att-disabled="state.searchOptions.searchFormulas" type="checkbox"
              t-model="state.replaceOptions.modifyFormulas"/>
@@ -114,6 +115,20 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetEnv> {
   onInput(ev) {
     this.state.toSearch = ev.target.value;
     this.debouncedUpdateSearch();
+  }
+
+  onKeydownSearch(ev: KeyboardEvent) {
+    if (ev.key === "Enter") {
+      ev.preventDefault();
+      this.onSelectNextCell();
+    }
+  }
+
+  onKeydownReplace(ev: KeyboardEvent) {
+    if (ev.key === "Enter") {
+      ev.preventDefault();
+      this.replace();
+    }
   }
 
   onFocusSidePanel() {

--- a/tests/components/find_replace_side_panel_test.ts
+++ b/tests/components/find_replace_side_panel_test.ts
@@ -118,6 +118,16 @@ describe("find and replace sidePanel component", () => {
       expect(parent.env.dispatch).toHaveBeenCalledWith("SELECT_SEARCH_NEXT_MATCH");
     });
 
+    test("Going to next with Enter key", async () => {
+      setInputValueAndTrigger(selectors.inputSearch, "1", "input");
+      jest.runAllTimers();
+      document
+        .querySelector(selectors.inputSearch)!
+        .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+      await nextTick();
+      expect(parent.env.dispatch).toHaveBeenCalledWith("SELECT_SEARCH_NEXT_MATCH");
+    });
+
     test("clicking on previous", async () => {
       setInputValueAndTrigger(selectors.inputSearch, "1", "input");
       jest.runAllTimers();
@@ -243,6 +253,21 @@ describe("find and replace sidePanel component", () => {
       triggerMouseEvent(document.querySelector(selectors.replaceAllButton), "click");
       await nextTick();
       expect(parent.env.dispatch).toHaveBeenCalledWith("REPLACE_ALL_SEARCH", {
+        replaceOptions: { modifyFormulas: false },
+        replaceWith: "kikou",
+      });
+    });
+
+    test("Can replace with Enter key", async () => {
+      setInputValueAndTrigger(selectors.inputSearch, "hell", "input");
+      setInputValueAndTrigger(selectors.inputReplace, "kikou", "input");
+      jest.runAllTimers();
+      parent.env.dispatch = jest.fn((command) => ({ status: "SUCCESS" } as CommandResult));
+      document
+        .querySelector(selectors.inputReplace)!
+        .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+      await nextTick();
+      expect(parent.env.dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", {
         replaceOptions: { modifyFormulas: false },
         replaceWith: "kikou",
       });


### PR DESCRIPTION
With this commit, the user is now able to navigate through the search
results with Enter if the focus is in the search input.
If the focus is in the replace input, the first match is replaced.

fixes #646