### PR TITLE
[FIX] composer: move cursor inside parentheses

### DIFF
--- a/tests/components/__mocks__/content_editable_helper.ts
+++ b/tests/components/__mocks__/content_editable_helper.ts
@@ -38,8 +38,14 @@ export class ContentEditableHelper {
     } else {
       this.el!.append(value);
     }
-    this.currentState.cursorEnd = this.currentState.cursorStart + value.length;
-    this.manualRange = false;
+    if (this.currentState.cursorStart === this.currentState.cursorEnd) {
+      const position = this.currentState.cursorStart + value.length;
+      this.currentState.cursorEnd = position;
+      this.currentState.cursorStart = position;
+    } else {
+      this.currentState.cursorEnd = this.currentState.cursorStart + value.length;
+      this.manualRange = false;
+    }
     this.colors[value] = color;
 
     this.el!.dispatchEvent(new Event("input"));


### PR DESCRIPTION
This commit corrects the number of parentheses after re-editing a
function.

This commit moves the cursor inside the parentheses after re-editing a
function.

Closes #632