### PR TITLE
[FIX] composer: assign width with pixels

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -260,7 +260,7 @@ export class Composer extends Component<any, SpreadsheetEnv> {
     }
     const el = this.composerRef.el! as HTMLInputElement;
     if (el.clientWidth !== el.scrollWidth) {
-      el.style.width = (el.scrollWidth + 20) as any;
+      el.style.width = `${el.scrollWidth + 20}px`;
     }
     const content = el.childNodes.length ? el.textContent! : "";
     this.dispatch("SET_CURRENT_CONTENT", { content });

--- a/tests/components/composer_test.ts
+++ b/tests/components/composer_test.ts
@@ -387,4 +387,14 @@ describe("composer highlights color", () => {
     expect(highlights[1].sheet).toBe("42");
     expect(highlights[1].zone).toEqual({ left: 0, right: 0, top: 0, bottom: 0 });
   });
+
+  test("composer is resized when input content is larger than composer", async () => {
+    await typeInComposer("Hello");
+    const composerEl = fixture.querySelector("div.o-composer")! as HTMLElement;
+    const styleSpy = jest.spyOn(composerEl.style, "width", "set");
+    jest.spyOn(composerEl, "clientWidth", "get").mockImplementation(() => 100);
+    jest.spyOn(composerEl, "scrollWidth", "get").mockImplementation(() => 120);
+    await typeInComposer("world", false);
+    expect(styleSpy).toHaveBeenCalledWith("140px"); // scrollWidth + padding 20px
+  });
 });


### PR DESCRIPTION
The composer width is assigned as a unitless number
instead of a string explicitely giving the unit: "25px"

For a reason I do not explain, it worked with standalone
spreadsheet but it does not work when the library is
used in Odoo.

The cast `... as any` hinted that it was wrong.