### PR TITLE
[FIX] function: VLOOKUP in undefined cells

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -399,27 +399,67 @@ export function visitMatchingRanges(
  * - [3, 6, 10], 9 => 1
  * - [3, 6, 10], 42 => 2
  * - [3, 6, 10], 2 => -1
+ * - [3, undefined, 6, undefined, 10], 9 => 2
+ * - [3, 6, undefined, undefined, undefined, 10], 2 => -1
  */
 export function dichotomicPredecessorSearch(range: any[], target: any): number {
-  const typeofTarget = typeof target;
-  let min = 0;
-  let max = range.length - 1;
-  let avg = Math.ceil((min + max) / 2);
-  let current = range[avg];
-  while (max - min > 0) {
-    if (typeofTarget === typeof current && current <= target) {
-      min = avg;
-    } else {
-      max = avg - 1;
-    }
-    avg = Math.ceil((min + max) / 2);
-    current = range[avg];
-  }
-  if (target < current) {
-    // all values in the range are greater than the target, -1 is returned.
+  const targetType = typeof target;
+
+  let valMin: any;
+  let valMinIndex: number | undefined = undefined;
+
+  let indexLeft = 0;
+  let indexRight = range.length - 1;
+
+  if (typeof range[indexLeft] === targetType && target < range[indexLeft]) {
     return -1;
   }
-  return avg;
+
+  if (typeof range[indexRight] === targetType && range[indexRight] <= target) {
+    return indexRight;
+  }
+
+  let indexMedian: number;
+  let currentIndex: number;
+  let currentVal: any;
+  let currentType: any;
+
+  while (indexRight - indexLeft >= 0) {
+    indexMedian = Math.ceil((indexLeft + indexRight) / 2);
+
+    currentIndex = indexMedian;
+    currentVal = range[currentIndex];
+    currentType = typeof currentVal;
+
+    // 1 - linear search to find value with the same type
+    while (indexLeft <= currentIndex && targetType !== currentType) {
+      currentIndex--;
+      currentVal = range[currentIndex];
+      currentType = typeof currentVal;
+    }
+
+    // 2 - check if value match
+    if (currentType === targetType && currentVal <= target) {
+      if (
+        valMin === undefined ||
+        valMin < currentVal ||
+        (valMin === currentVal && valMinIndex! < currentIndex)
+      ) {
+        valMin = currentVal;
+        valMinIndex = currentIndex;
+      }
+    }
+
+    // 3 - give new indexs for the Binary search
+    if (currentType === targetType && currentVal > target) {
+      indexRight = currentIndex - 1;
+    } else {
+      indexLeft = indexMedian + 1;
+    }
+  }
+
+  // note that valMinIndex could be 0
+  return valMinIndex !== undefined ? valMinIndex : -1;
 }
 
 /**
@@ -434,24 +474,64 @@ export function dichotomicPredecessorSearch(range: any[], target: any): number {
  * - [10, 6, 3], 9 => 0
  * - [10, 6, 3], 42 => -1
  * - [10, 6, 3], 2 => 2
+ * - [10, undefined, 6, undefined, 3], 9 => 0
+ * - [10, 6, undefined, undefined, undefined, 3], 2 => 5
  */
 export function dichotomicSuccessorSearch(range: any[], target: any): number {
-  const typeofTarget = typeof target;
-  let min = 0;
-  let max = range.length - 1;
-  let avg = Math.floor((min + max) / 2);
-  let current = range[avg];
-  while (max - min > 0) {
-    if (typeofTarget === typeof current && target >= current) {
-      max = avg;
-    } else {
-      min = avg + 1;
+  const targetType = typeof target;
+
+  let valMax: any;
+  let valMaxIndex: number | undefined = undefined;
+
+  let indexLeft = 0;
+  let indexRight = range.length - 1;
+
+  if (typeof range[indexLeft] === targetType && target > range[indexLeft]) {
+    return -1;
+  }
+
+  if (typeof range[indexRight] === targetType && range[indexRight] > target) {
+    return indexRight;
+  }
+
+  let indexMedian: number;
+  let currentIndex: number;
+  let currentVal: any;
+  let currentType: any;
+
+  while (indexRight - indexLeft >= 0) {
+    indexMedian = Math.ceil((indexLeft + indexRight) / 2);
+    currentIndex = indexMedian;
+    currentVal = range[currentIndex];
+    currentType = typeof currentVal;
+
+    // 1 - linear search to find value with the same type
+    while (indexLeft <= currentIndex && targetType !== currentType) {
+      currentIndex--;
+      currentVal = range[currentIndex];
+      currentType = typeof currentVal;
     }
-    avg = Math.floor((min + max) / 2);
-    current = range[avg];
+
+    // 2 - check if value match
+    if (currentType === targetType && currentVal >= target) {
+      if (
+        valMax === undefined ||
+        valMax > currentVal ||
+        (valMax === currentVal && valMaxIndex! > currentIndex)
+      ) {
+        valMax = currentVal;
+        valMaxIndex = currentIndex;
+      }
+    }
+
+    // 3 - give new indexs for the Binary search
+    if (currentType === targetType && currentVal <= target) {
+      indexRight = currentIndex - 1;
+    } else {
+      indexLeft = indexMedian + 1;
+    }
   }
-  if (target > current) {
-    return avg - 1;
-  }
-  return avg;
+
+  // note that valMaxIndex could be 0
+  return valMaxIndex !== undefined ? valMaxIndex : -1;
 }

--- a/tests/functions/helper_test.ts
+++ b/tests/functions/helper_test.ts
@@ -1,0 +1,98 @@
+import {
+  dichotomicPredecessorSearch,
+  dichotomicSuccessorSearch,
+} from "../../src/functions/helpers";
+
+describe("Function helpers", () => {
+  describe("dichotomicPredecessorSearch", () => {
+    test("with numbers only", () => {
+      expect(dichotomicPredecessorSearch([0, 1, 2, 3, 4], 0)).toBe(0);
+      expect(dichotomicPredecessorSearch([0, 1, 2, 3, 4], 4)).toBe(4);
+      expect(dichotomicPredecessorSearch([0, 1, 2, 3, 4], 2)).toBe(2);
+      expect(dichotomicPredecessorSearch([0, 1, 2, 3, 4], 22)).toBe(4);
+      expect(dichotomicPredecessorSearch([0, 1, 2, 3, 4], -22)).toBe(-1);
+      expect(dichotomicPredecessorSearch([0, 1, 2, 3, 3], 3)).toBe(4);
+    });
+
+    test("with strings only", () => {
+      expect(dichotomicPredecessorSearch(["0", "1", "2", "3", "4"], "0")).toBe(0);
+      expect(dichotomicPredecessorSearch(["0", "1", "2", "3", "4"], "4")).toBe(4);
+      expect(dichotomicPredecessorSearch(["0", "1", "2", "3", "4"], "2")).toBe(2);
+      expect(dichotomicPredecessorSearch(["0", "1", "2", "3", "4"], "22")).toBe(2);
+      expect(dichotomicPredecessorSearch(["0", "1", "2", "3", "4"], "9")).toBe(4);
+      expect(dichotomicPredecessorSearch(["0", "1", "2", "3", "4"], "-22")).toBe(-1);
+      expect(dichotomicPredecessorSearch(["0", "1", "3", "3", "4"], "3")).toBe(3);
+    });
+
+    test("search number in strings and numbers", () => {
+      expect(dichotomicPredecessorSearch([0, "a", "a", "a", "a"], 0)).toBe(0);
+      expect(dichotomicPredecessorSearch(["a", "a", "a", "a", 0], 0)).toBe(4);
+      expect(dichotomicPredecessorSearch(["a", "a", 0, "a", "a"], 0)).toBe(2);
+      expect(dichotomicPredecessorSearch(["a", "a", "a", "a", "a"], 0)).toBe(-1);
+      expect(dichotomicPredecessorSearch(["0", "0", "a", 0, "0"], 0)).toBe(3);
+    });
+
+    test("search string in strings and numbers", () => {
+      const u = undefined;
+      expect(dichotomicPredecessorSearch(["a", u, u, u, u], "a")).toBe(0);
+      expect(dichotomicPredecessorSearch([u, u, u, u, "a"], "a")).toBe(4);
+      expect(dichotomicPredecessorSearch([u, u, "a", u, u], "a")).toBe(2);
+      expect(dichotomicPredecessorSearch([u, u, u, u, u], "a")).toBe(-1);
+      expect(dichotomicPredecessorSearch([u, "0", u, u, u], "0")).toBe(1);
+    });
+
+    test("search string in strings and numbers", () => {
+      expect(dichotomicPredecessorSearch(["a", 0, 0, 0, 0], "a")).toBe(0);
+      expect(dichotomicPredecessorSearch([0, 0, 0, 0, "a"], "a")).toBe(4);
+      expect(dichotomicPredecessorSearch([0, 0, "a", 0, 0], "a")).toBe(2);
+      expect(dichotomicPredecessorSearch([0, 0, 0, 0, 0], "a")).toBe(-1);
+      expect(dichotomicPredecessorSearch([0, "0", 0, 0, 0], "0")).toBe(1);
+    });
+  });
+
+  describe("dichotomicSuccessorSearch", () => {
+    test("with numbers only", () => {
+      expect(dichotomicSuccessorSearch([4, 3, 2, 1, 0], 4)).toBe(0);
+      expect(dichotomicSuccessorSearch([4, 3, 2, 1, 0], 0)).toBe(4);
+      expect(dichotomicSuccessorSearch([4, 3, 2, 1, 0], 2)).toBe(2);
+      expect(dichotomicSuccessorSearch([4, 3, 2, 1, 0], 22)).toBe(-1);
+      expect(dichotomicSuccessorSearch([4, 3, 2, 1, 0], -22)).toBe(4);
+      expect(dichotomicSuccessorSearch([3, 3, 2, 1, 0], 3)).toBe(0);
+    });
+
+    test("with strings only", () => {
+      expect(dichotomicSuccessorSearch(["4", "3", "2", "1", "0"], "0")).toBe(4);
+      expect(dichotomicSuccessorSearch(["4", "3", "2", "1", "0"], "4")).toBe(0);
+      expect(dichotomicSuccessorSearch(["4", "3", "2", "1", "0"], "2")).toBe(2);
+      expect(dichotomicSuccessorSearch(["4", "3", "2", "1", "0"], "22")).toBe(1);
+      expect(dichotomicSuccessorSearch(["4", "3", "2", "1", "0"], "9")).toBe(-1);
+      expect(dichotomicSuccessorSearch(["4", "3", "2", "1", "0"], "-22")).toBe(4);
+      expect(dichotomicSuccessorSearch(["4", "3", "2", "1", "0"], "3")).toBe(1);
+    });
+
+    test("search number in strings and numbers", () => {
+      expect(dichotomicSuccessorSearch([0, "a", "a", "a", "a"], 0)).toBe(0);
+      expect(dichotomicSuccessorSearch(["a", "a", "a", "a", 0], 0)).toBe(4);
+      expect(dichotomicSuccessorSearch(["a", "a", 0, "a", "a"], 0)).toBe(2);
+      expect(dichotomicSuccessorSearch(["a", "a", "a", "a", "a"], 0)).toBe(-1);
+      expect(dichotomicSuccessorSearch(["0", "0", "a", 0, "0"], 0)).toBe(3);
+    });
+
+    test("search string in strings and numbers", () => {
+      const u = undefined;
+      expect(dichotomicSuccessorSearch(["a", u, u, u, u], "a")).toBe(0);
+      expect(dichotomicSuccessorSearch([u, u, u, u, "a"], "a")).toBe(4);
+      expect(dichotomicSuccessorSearch([u, u, "a", u, u], "a")).toBe(2);
+      expect(dichotomicSuccessorSearch([u, u, u, u, u], "a")).toBe(-1);
+      expect(dichotomicSuccessorSearch([u, "0", u, u, u], "0")).toBe(1);
+    });
+
+    test("search string in strings and numbers", () => {
+      expect(dichotomicSuccessorSearch(["a", 0, 0, 0, 0], "a")).toBe(0);
+      expect(dichotomicSuccessorSearch([0, 0, 0, 0, "a"], "a")).toBe(4);
+      expect(dichotomicSuccessorSearch([0, 0, "a", 0, 0], "a")).toBe(2);
+      expect(dichotomicSuccessorSearch([0, 0, 0, 0, 0], "a")).toBe(-1);
+      expect(dichotomicSuccessorSearch([0, "0", 0, 0, 0], "0")).toBe(1);
+    });
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -132,7 +132,7 @@ export class GridParent extends Component<any, SpreadsheetEnv> {
   }
 }
 
-type GridDescr = { [xc: string]: string };
+type GridDescr = { [xc: string]: string | undefined };
 type FormattedGridDescr = GridDescr;
 type GridResult = { [xc: string]: any };
 
@@ -156,7 +156,9 @@ export function getGrid(model: Model): GridResult {
 export function evaluateGrid(grid: GridDescr): GridResult {
   const model = new Model();
   for (let xc in grid) {
-    model.dispatch("SET_VALUE", { xc, text: grid[xc] });
+    if (grid[xc]) {
+      model.dispatch("SET_VALUE", { xc, text: grid[xc]! });
+    }
   }
   const result = {};
   for (let xc in grid) {
@@ -169,7 +171,9 @@ export function evaluateGrid(grid: GridDescr): GridResult {
 export function evaluateGridText(grid: GridDescr): FormattedGridDescr {
   const model = new Model();
   for (let xc in grid) {
-    model.dispatch("SET_VALUE", { xc, text: grid[xc] });
+    if (grid[xc] !== undefined) {
+      model.dispatch("SET_VALUE", { xc, text: grid[xc]! });
+    }
   }
   const result = {};
   for (let xc in grid) {
@@ -194,7 +198,7 @@ export function evaluateCell(xc: string, grid: GridDescr): any {
 
 export function evaluateCellText(xc: string, grid: GridDescr): string {
   const gridResult = evaluateGridText(grid);
-  return gridResult[xc];
+  return gridResult[xc] || "";
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This commit improve the binary search algorithms used in several
functions like VLOOKUP HLOOKUP and MATCH. Now these functions can be
used on lists composed of missing values ​​or values ​​having a different
type.

fixes #638

Co-authored-by: LucasLefevre <lul@odoo.com>
Co-authored-by: laa-odoo <laa@odoo.com>