### PR TITLE
[FIX] chart: Correctly import chart figures

### DIFF
--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -6,6 +6,7 @@ import {
   Zone,
   CommandResult,
   CancelledReason,
+  WorkbookData,
 } from "../../types/index";
 import { toXC, toZone, zoneToXc } from "../../helpers/index";
 import { rangeReference } from "../../formulas/parser";
@@ -93,6 +94,20 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   getChartDefinition(figureId: string): ChartDefinition | undefined {
     const figure = this.getters.getFigure<ChartDefinition>(figureId);
     return figure ? figure.data : undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Import/Export
+  // ---------------------------------------------------------------------------
+
+  import(data: WorkbookData) {
+    for (let sheet of data.sheets) {
+      for (let f of sheet.figures) {
+        if (f.tag === "chart") {
+          this.chartFigures.add(f.id);
+        }
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/model/plugins/chart_test.ts
+++ b/tests/model/plugins/chart_test.ts
@@ -247,6 +247,53 @@ describe("datasource tests", function () {
     expect(datasets[0].label!.toString()).toEqual("Series");
   });
 
+  test("can delete an imported chart", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("CREATE_CHART", {
+      id: "1",
+      sheetId,
+      definition: {
+        title: "test 1",
+        dataSets: ["B7:B8"],
+        seriesHasTitle: true,
+        labelRange: "B7",
+        type: "line",
+      },
+    });
+    const newModel = new Model(model.exportData());
+    expect(newModel.getters.getFigures(sheetId, viewport)).toHaveLength(1);
+    expect(newModel.getters.getChartRuntime("1")).toBeTruthy();
+    newModel.dispatch("DELETE_FIGURE", { id: "1" });
+    expect(newModel.getters.getFigures(sheetId, viewport)).toHaveLength(0);
+    expect(newModel.getters.getChartRuntime("1")).toBeUndefined();
+  });
+
+  test("update dataset of imported chart", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("CREATE_CHART", {
+      id: "1",
+      sheetId,
+      definition: {
+        title: "test 1",
+        dataSets: ["Sheet1!B1:B4"],
+        seriesHasTitle: true,
+        labelRange: "Sheet1!A2:A4",
+        type: "line",
+      },
+    });
+    const newModel = new Model(model.exportData());
+    let chart = newModel.getters.getChartRuntime("1")!;
+    expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
+    newModel.dispatch("UPDATE_CELL", {
+      col: 1,
+      row: 1,
+      sheetId,
+      content: "99",
+    });
+    chart = newModel.getters.getChartRuntime("1")!;
+    expect(chart.data!.datasets![0].data).toEqual([99, 11, 12]);
+  });
+
   test.skip("delete a data source column", () => {
     model.dispatch("CREATE_CHART", {
       id: "1",


### PR DESCRIPTION
Imported chart figures are not correctly imported in the chart plugin.
As a result, they cannot be deleted and they are not updated when a cell
in the dataset is changed.