### PR TITLE
[FIX] composer: move cursor inside parentheses

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -443,26 +443,33 @@ export class Composer extends Component<any, SpreadsheetEnv> {
   autoComplete(value: string) {
     this.saveSelection();
     if (value) {
-      if (this.tokenAtCursor && ["SYMBOL", "FUNCTION"].includes(this.tokenAtCursor.type)) {
-        this.selectionStart = this.tokenAtCursor.start;
-        this.selectionEnd = this.tokenAtCursor.end;
-      }
+      if (this.tokenAtCursor) {
+        let start = this.tokenAtCursor.end;
+        let end = this.tokenAtCursor.end;
 
-      if (this.autoCompleteState.provider === "functions") {
-        if (this.tokens.length && this.tokenAtCursor) {
-          const currentTokenIndex = this.tokens.indexOf(this.tokenAtCursor);
+        if (["SYMBOL", "FUNCTION"].includes(this.tokenAtCursor.type)) {
+          start = this.tokenAtCursor.start;
+        }
+
+        if (this.autoCompleteState.provider && this.tokens.length) {
+          value += "(";
+
+          const currentTokenIndex = this.tokens
+            .map((token) => token.start)
+            .indexOf(this.tokenAtCursor.start);
           if (currentTokenIndex + 1 < this.tokens.length) {
             const nextToken = this.tokens[currentTokenIndex + 1];
-            if (nextToken.type !== "LEFT_PAREN") {
-              value += "(";
+            if (nextToken.type === "LEFT_PAREN") {
+              end++;
             }
-          } else {
-            value += "(";
           }
         }
+        this.selectionStart = start;
+        this.selectionEnd = end;
       }
       this.addText(value);
     }
+
     this.autoCompleteState.search = "";
     this.autoCompleteState.showProvider = false;
     this.processContent();

--- a/tests/components/__mocks__/content_editable_helper.ts
+++ b/tests/components/__mocks__/content_editable_helper.ts
@@ -43,8 +43,14 @@ export class ContentEditableHelper {
     } else {
       this.el!.append(value);
     }
-    this.currentState.cursorEnd = this.currentState.cursorStart + value.length;
-    this.manualRange = false;
+    if (this.currentState.cursorStart === this.currentState.cursorEnd) {
+      const position = this.currentState.cursorStart + value.length;
+      this.currentState.cursorEnd = position;
+      this.currentState.cursorStart = position;
+    } else {
+      this.currentState.cursorEnd = this.currentState.cursorStart + value.length;
+      this.manualRange = false;
+    }
     this.colors[value] = color;
 
     this.el!.dispatchEvent(new Event("input"));

--- a/tests/components/autocomplete_dropdown_test.ts
+++ b/tests/components/autocomplete_dropdown_test.ts
@@ -10,8 +10,10 @@ let model: Model;
 let composerEl: Element;
 let fixture: HTMLElement;
 let parent: any;
+
 async function typeInComposer(text: string) {
-  composerEl.append(text);
+  const cehMock = parent.grid.comp.composer.comp.contentHelper as ContentEditableHelper;
+  cehMock.insertText(text, "#000");
   composerEl.dispatchEvent(new Event("input"));
   composerEl.dispatchEvent(new Event("keyup"));
   await nextTick();
@@ -254,6 +256,22 @@ describe("Autocomplete parenthesis", () => {
     composerEl.dispatchEvent(new KeyboardEvent("keyup"));
     await nextTick();
     expect(model.getters.getCurrentContent()).toBe("=if(1,2)");
+  });
+
+  test("=S( + edit S with autocomplete does not add left parenthesis", async () => {
+    await typeInComposer("=S(");
+    // go behind the letter "S"
+    const cehMock = parent.grid.comp.composer.comp.contentHelper as ContentEditableHelper;
+    cehMock.selectRange(2, 2);
+    // type U to display the autocomplete-dropdown with the SUM function
+    await typeInComposer("U");
+    expect(model.getters.getCurrentContent()).toBe("=SU(");
+    expect(document.activeElement).toBe(composerEl);
+    expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(1);
+    // select the SUM function
+    fixture.querySelector(".o-autocomplete-value-focus")!.dispatchEvent(new MouseEvent("click"));
+    await nextTick();
+    expect(model.getters.getCurrentContent()).toBe("=SUM(");
   });
 
   test("=sum(sum(1,2 + enter add 2 closing parenthesis", async () => {


### PR DESCRIPTION
This commit corrects the number of parentheses after re-editing a
function.

This commit moves the cursor inside the parentheses after re-editing a
function.

Closes #632

Co-authored-by: LucasLefevre <lul@odoo.com>