### PR TITLE
[FIX] composer: Throttle content processing

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -7,6 +7,7 @@ import { ContentEditableHelper } from "./content_editable_helper";
 import { zoneToXc, DEBUG } from "../../helpers/index";
 import { ComposerSelection } from "../../plugins/ui/edition";
 import { functionRegistry } from "../../functions/index";
+import { useThrottled } from "../../helpers/hooks";
 
 const { Component } = owl;
 const { useRef, useState } = owl.hooks;
@@ -151,6 +152,10 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     ArrowLeft: this.processArrowKeys,
     ArrowRight: this.processArrowKeys,
   };
+  private readonly throttledProcessContent = useThrottled(
+    (isFocused: boolean) => this.processContent(isFocused),
+    100
+  );
 
   constructor() {
     super(...arguments);
@@ -172,7 +177,7 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
   }
 
   async willUpdateProps(nextProps: Props) {
-    this.processContent(nextProps.focus);
+    this.throttledProcessContent(nextProps.focus);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/helpers/hooks.ts
+++ b/src/helpers/hooks.ts
@@ -1,0 +1,32 @@
+import * as owl from "@odoo/owl";
+
+const { onWillUnmount } = owl.hooks;
+
+/**
+ * Return a throttled version of a function.
+ * The function will be executed only once in the given time interval, even
+ * if it was called multiple times.
+ * The first and last calls are always executed.
+ */
+export function useThrottled<T extends (...args: unknown[]) => void>(
+  func: T,
+  delay
+): (...args: Parameters<T>) => void {
+  let timerId;
+  let nextArgs: Parameters<T> | undefined;
+  function throttledFunction(...args: Parameters<T>) {
+    if (timerId) {
+      nextArgs = args;
+      return;
+    }
+    timerId = setTimeout(() => {
+      timerId = undefined;
+      if (nextArgs) {
+        func(...nextArgs);
+      }
+    }, delay);
+    func(...args);
+  }
+  onWillUnmount(() => clearTimeout(timerId));
+  return throttledFunction;
+}


### PR DESCRIPTION
Let consider a formula with many tokens.
e.g. `=A1+A2+A3+A4+A5+A6+A7+A8+...`

As the formula becomes longer and longer, the composer
feels less and less reactive.
That's because at each input, the content is re-processed
and each token is re-inserted with a given color.
Those re-insertions trigger a style recomputation and layout
rendering by the browser. This is pretty slow (check
Chrome performance devtools, it warns this is a potential
bottleneck).

With this commit, the content is process at most once every
100ms. This means some processing might be skipped but the content
will always eventually be processed correctly.