### PR TITLE
[FIX] core: handle undefined as value in getCellText

### DIFF
--- a/tests/plugins/cell_test.ts
+++ b/tests/plugins/cell_test.ts
@@ -1,0 +1,26 @@
+import { Model } from "../../src";
+import { CellType } from "../../src/types";
+import "../canvas.mock";
+
+describe("getCellText", () => {
+  test.each([
+    [undefined, ""],
+    [{ hello: 1 }, "0"],
+    [{ hello: 1, toString: () => "hello" }, "0"],
+    [null, "0"],
+  ])("getCellText of cell with %j value", (a, expected) => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    expect(
+      model.getters.getCellText(
+        {
+          id: "42",
+          value: a,
+          type: CellType.text,
+          content: "text",
+        },
+        sheetId
+      )
+    ).toBe(expected);
+  });
+});


### PR DESCRIPTION
OPW-2376306

Co-authored-by: LucasLefevre <lul@odoo.com>