### PR TITLE
[FIX] conditional_format: correctly handle undo/redo

### DIFF
--- a/src/plugins/conditional_format.ts
+++ b/src/plugins/conditional_format.ts
@@ -372,8 +372,7 @@ export class ConditionalFormatPlugin extends BasePlugin {
       if (updatedRanges.length === 0) {
         continue;
       }
-      cf.ranges = updatedRanges;
-      newCfs.push(cf);
+      newCfs.push({ ...cf, ranges: updatedRanges });
     }
     this.history.updateLocalState(["cfRules", sheet], newCfs);
   }

--- a/tests/plugins/conditional_formatting_test.ts
+++ b/tests/plugins/conditional_formatting_test.ts
@@ -179,6 +179,35 @@ describe("conditional format", () => {
     expect(model.getters.getConditionalStyle("A2")).toEqual({ fillColor: "#FF0000" });
   });
 
+  test("Still correct after ADD_COLUMNS and UNDO/REDO", () => {
+    const sheet = model.getters.getActiveSheet();
+    model.dispatch("SET_VALUE", { xc: "B1", text: "1" });
+    model.dispatch("SET_VALUE", { xc: "B2", text: "1" });
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF(["B1", "B2"], "1", { fillColor: "#FF0000" }, "1"),
+      sheet,
+    });
+    expect(model.getters.getConditionalStyle("B1")).toEqual({ fillColor: "#FF0000" });
+    expect(model.getters.getConditionalStyle("B2")).toEqual({ fillColor: "#FF0000" });
+    model.dispatch("ADD_COLUMNS", { sheet, column: 0, position: "after", quantity: 1 });
+    expect(model.getters.getConditionalStyle("B1")).toBeUndefined();
+    expect(model.getters.getConditionalStyle("B2")).toBeUndefined();
+    expect(model.getters.getConditionalStyle("C1")).toEqual({ fillColor: "#FF0000" });
+    expect(model.getters.getConditionalStyle("C2")).toEqual({ fillColor: "#FF0000" });
+
+    model.dispatch("UNDO");
+    expect(model.getters.getConditionalStyle("B1")).toEqual({ fillColor: "#FF0000" });
+    expect(model.getters.getConditionalStyle("B2")).toEqual({ fillColor: "#FF0000" });
+    expect(model.getters.getConditionalStyle("C1")).toBeUndefined();
+    expect(model.getters.getConditionalStyle("C2")).toBeUndefined();
+
+    model.dispatch("REDO");
+    expect(model.getters.getConditionalStyle("B1")).toBeUndefined();
+    expect(model.getters.getConditionalStyle("B2")).toBeUndefined();
+    expect(model.getters.getConditionalStyle("C1")).toEqual({ fillColor: "#FF0000" });
+    expect(model.getters.getConditionalStyle("C2")).toEqual({ fillColor: "#FF0000" });
+  });
+
   test("is saved/restored", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF(["A1:A4"], "2", { fillColor: "#FF0000" }, "1"),


### PR DESCRIPTION
Before this commit, the reference of the ranges was updated in place
before the history, so the undo did not reset the correct value.