### PR TITLE
[REF] range: Remove rows and columns in batch

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -65,6 +65,23 @@ export function range(start: number, end: number) {
 }
 
 /**
+ * Groups consecutive numbers.
+ * The input array is assumed to be sorted
+ * @param numbers
+ */
+export function groupConsecutive(numbers: number[]): number[][] {
+  return numbers.reduce((groups, currentRow, index, rows) => {
+    if (Math.abs(currentRow - rows[index - 1]) === 1) {
+      const lastGroup = groups[groups.length - 1];
+      lastGroup.push(currentRow);
+    } else {
+      groups.push([currentRow]);
+    }
+    return groups;
+  }, [] as number[][]);
+}
+
+/**
  * This helper function can be used as a type guard when filtering arrays.
  * const foo: number[] = [1, 2, undefined, 4].filter(isDefined)
  */

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -17,7 +17,13 @@ import {
   Zone,
 } from "../../types/index";
 import { _lt } from "../../translation";
-import { getComposerSheetName, isDefined, numberToLetters, toCartesian } from "../../helpers/index";
+import {
+  getComposerSheetName,
+  groupConsecutive,
+  isDefined,
+  numberToLetters,
+  toCartesian,
+} from "../../helpers/index";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../constants";
 import { cellReference, rangeTokenize } from "../../formulas/index";
 import { INCORRECT_RANGE_STRING } from "./range";
@@ -549,17 +555,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     // begin with the end.
     rows.sort((a, b) => b - a);
 
-    const consecutiveRows = rows.reduce((groups, currentRow, index, rows) => {
-      if (currentRow - rows[index - 1] === -1) {
-        const lastGroup = groups[groups.length - 1];
-        lastGroup.push(currentRow);
-      } else {
-        groups.push([currentRow]);
-      }
-      return groups;
-    }, [] as number[][]);
-
-    for (let group of consecutiveRows) {
+    for (let group of groupConsecutive(rows)) {
       // Move the cells.
       this.moveCellOnRowsDeletion(sheet, group[group.length - 1], group[0]);
 

--- a/tests/helpers/misc_test.ts
+++ b/tests/helpers/misc_test.ts
@@ -1,4 +1,4 @@
-import { range } from "../../src/helpers/misc";
+import { range, groupConsecutive } from "../../src/helpers/misc";
 
 describe("Misc", () => {
   test("range", () => {
@@ -7,5 +7,14 @@ describe("Misc", () => {
     expect(range(10, 1)).toEqual([]);
     expect(range(10, 13)).toEqual([10, 11, 12]);
     expect(range(-2, 2)).toEqual([-2, -1, 0, 1]);
+  });
+
+  test("groupConsecutive", () => {
+    expect(groupConsecutive([])).toEqual([]);
+    expect(groupConsecutive([1, 2])).toEqual([[1, 2]]);
+    expect(groupConsecutive([2, 2])).toEqual([[2], [2]]);
+    expect(groupConsecutive([1, 2, 4])).toEqual([[1, 2], [4]]);
+    expect(groupConsecutive([-1, 0, 4])).toEqual([[-1, 0], [4]]);
+    expect(groupConsecutive([4, 2, 1])).toEqual([[4], [2, 1]]);
   });
 });


### PR DESCRIPTION
Removing many rows and columns is slow. This is a limiting
factor for spreadsheet templates in Odoo.

To speed up the process, we remove consecutive rows/columns
in one go

Co-authored-by: pro-odoo <pro@odoo.com>