### PR TITLE
[REF] sheet: Rename RESIZE_COLUMNS argument

### DIFF
--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -267,7 +267,7 @@ export class ColResizer extends AbstractResizer {
     const cols = this.getters.getActiveCols();
     this.dispatch("RESIZE_COLUMNS", {
       sheetId: this.getters.getActiveSheetId(),
-      cols: cols.has(index) ? [...cols] : [index],
+      columns: cols.has(index) ? [...cols] : [index],
       size,
     });
   }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -149,7 +149,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
         this.sheetIds[sheet.name] = sheet.id;
         break;
       case "RESIZE_COLUMNS":
-        for (let col of cmd.cols) {
+        for (let col of cmd.columns) {
           this.setColSize(this.sheets[cmd.sheetId]!, col, cmd.size);
         }
         break;

--- a/src/plugins/ui/ui_sheet.ts
+++ b/src/plugins/ui/ui_sheet.ts
@@ -98,7 +98,7 @@ export class SheetUIPlugin extends UIPlugin<UIState> {
           const size = this.getColMaxWidth(cmd.sheetId, col);
           if (size !== 0) {
             this.dispatch("RESIZE_COLUMNS", {
-              cols: [col],
+              columns: [col],
               size: size + 2 * PADDING_AUTORESIZE,
               sheetId: cmd.sheetId,
             });

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -59,7 +59,7 @@ export interface UpdateCellPositionCommand extends BaseCommand {
 export interface ResizeColumnsCommand extends BaseCommand {
   type: "RESIZE_COLUMNS";
   sheetId: UID;
-  cols: number[];
+  columns: number[];
   size: number;
 }
 

--- a/tests/plugins/core_test.ts
+++ b/tests/plugins/core_test.ts
@@ -219,7 +219,7 @@ describe("core", () => {
     model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1 });
     const [, sheet2] = model.getters.getSheets();
     model.dispatch("RESIZE_ROWS", { sheetId: sheet2.id, rows: [0], size: 24 });
-    model.dispatch("RESIZE_COLUMNS", { sheetId: sheet2.id, cols: [0], size: 42 });
+    model.dispatch("RESIZE_COLUMNS", { sheetId: sheet2.id, columns: [0], size: 42 });
     expect(sheet2.id).not.toBe(model.getters.getActiveSheetId());
     expect(model.getters.getRow(sheet2.id, 0)).toEqual({
       cells: {},

--- a/tests/plugins/import_export_test.ts
+++ b/tests/plugins/import_export_test.ts
@@ -109,7 +109,7 @@ describe("Export", () => {
     });
     model.dispatch("RESIZE_COLUMNS", {
       sheetId: model.getters.getActiveSheetId(),
-      cols: [1],
+      columns: [1],
       size: 150,
     });
     const exp = model.exportData();

--- a/tests/plugins/resizing_test.ts
+++ b/tests/plugins/resizing_test.ts
@@ -13,7 +13,7 @@ describe("Model resizer", () => {
 
     model.dispatch("RESIZE_COLUMNS", {
       sheetId: sheetId,
-      cols: [1],
+      columns: [1],
       size: model.getters.getCol(sheetId, 1)!.size + 100,
     });
     expect(model.getters.getCol(sheetId, 1)!.size).toBe(196);
@@ -36,7 +36,7 @@ describe("Model resizer", () => {
     expect(
       model.dispatch("RESIZE_COLUMNS", {
         sheetId: "invalid",
-        cols: [1],
+        columns: [1],
         size: 100,
       })
     ).toEqual({
@@ -124,7 +124,7 @@ describe("Model resizer", () => {
     const model = new Model();
     model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1 });
     const [, sheet2] = model.getters.getSheets();
-    model.dispatch("RESIZE_COLUMNS", { sheetId: sheet2.id, size: 42, cols: [0] });
+    model.dispatch("RESIZE_COLUMNS", { sheetId: sheet2.id, size: 42, columns: [0] });
     expect(model.getters.getActiveSheetId()).not.toBe(sheet2.id);
     expect(model.getters.getCol(sheet2.id, 0)).toEqual({ end: 42, size: 42, name: "A", start: 0 });
   });
@@ -139,7 +139,7 @@ describe("Model resizer", () => {
 
     model.dispatch("RESIZE_COLUMNS", {
       sheetId: sheet2,
-      cols: [1],
+      columns: [1],
       size: model.getters.getCol(sheet2, 1)!.size + 100,
     });
 
@@ -156,7 +156,7 @@ describe("Model resizer", () => {
 
     model.dispatch("RESIZE_COLUMNS", {
       sheetId: model.getters.getActiveSheetId(),
-      cols: [1, 3, 4],
+      columns: [1, 3, 4],
       size: 100,
     });
     expect(model.getters.getCol(sheet, 1)!.size).toBe(100);
@@ -191,7 +191,7 @@ describe("Model resizer", () => {
     const [initialWidth, initialHeight] = model.getters.getGridSize(sheet);
     model.dispatch("RESIZE_COLUMNS", {
       sheetId: model.getters.getActiveSheetId(),
-      cols: [1],
+      columns: [1],
       size: model.getters.getCol(sheetId, 1)!.size + 100,
     });
     expect(model.getters.getGridSize(sheet)[0]).toBe(initialWidth + 100);

--- a/tests/plugins/sheets_test.ts
+++ b/tests/plugins/sheets_test.ts
@@ -639,7 +639,7 @@ describe("sheets", () => {
     const sheet = model.getters.getActiveSheetId();
     model.dispatch("DUPLICATE_SHEET", { sheetIdFrom: sheet, sheetIdTo: uuidv4(), name: "dup" });
     expect(model.getters.getSheets()).toHaveLength(2);
-    model.dispatch("RESIZE_COLUMNS", { cols: [0], size: 1, sheetId: sheet });
+    model.dispatch("RESIZE_COLUMNS", { columns: [0], size: 1, sheetId: sheet });
     model.dispatch("RESIZE_ROWS", { rows: [0], size: 1, sheetId: sheet });
     const newSheet = model.getters.getSheets()[1].id;
     model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: sheet, sheetIdTo: newSheet });


### PR DESCRIPTION
The RESIZE_COLUMNS command takes an argument named `cols`.
The other core command REMOVE_COLUMNS takes the similar argument
but named `columns`.

This commit renames the first argument to `columns` because:
1. consistency
2. the (future) operational transformation is the same for both commands with regard
   to column addition, with the exception of this argument name.
   The same function can be used if they are unified.