### PR TITLE
[FIX] ui_sheet: Allow to delete first sheet when it's active

### DIFF
--- a/src/plugins/ui/ui_sheet.ts
+++ b/src/plugins/ui/ui_sheet.ts
@@ -43,9 +43,16 @@ export class SheetUIPlugin extends UIPlugin<UIState> {
           const currentIndex = this.getters
             .getVisibleSheets()
             .findIndex((sheetId) => sheetId === this.getActiveSheetId());
+          let sheetIdTo: UID;
+          const currentSheets = this.getters.getVisibleSheets();
+          if (currentIndex === 0) {
+            sheetIdTo = currentSheets[1];
+          } else {
+            sheetIdTo = currentSheets[Math.max(0, currentIndex - 1)];
+          }
           this.dispatch("ACTIVATE_SHEET", {
             sheetIdFrom: this.getActiveSheetId(),
-            sheetIdTo: this.getters.getVisibleSheets()[Math.max(0, currentIndex - 1)],
+            sheetIdTo,
           });
         }
         break;

--- a/tests/plugins/sheets_test.ts
+++ b/tests/plugins/sheets_test.ts
@@ -684,6 +684,17 @@ describe("sheets", () => {
     expect(model.getters.getActiveSheetId()).toEqual(sheet1);
   });
 
+  test("Can delete the first sheet (active)", () => {
+    const model = new Model();
+    const sheet1 = model.getters.getActiveSheetId();
+    const sheet2 = "Sheet2";
+    model.dispatch("CREATE_SHEET", { sheetId: sheet2, position: 1 });
+    setCellContent(model, "A1", "Hello in Sheet2", sheet2);
+    model.dispatch("DELETE_SHEET", { sheetId: sheet1 });
+    expect(model.getters.getActiveSheetId()).toBe(sheet2);
+    expect(getCellContent(model, "A1")).toBe("Hello in Sheet2");
+  });
+
   test("Can delete a non-active sheet", () => {
     const model = new Model();
     const sheet1 = model.getters.getActiveSheetId();


### PR DESCRIPTION
Deleting the first sheet when it is active crashes.

Co-authored-by: pro-odoo <pro@odoo.com>