### PR TITLE
[IMP] rollup: allow to import directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",
     "rollup": "^2.29.0",
+    "@rollup/plugin-node-resolve": "^11.0.1",
     "ts-jest": "^25.3.1",
     "typescript": "^3.9.7"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,11 @@
 import { version } from "./package.json";
 import git from "git-rev-sync";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
 
 export default {
   input: "dist/js/src/index.js",
   external: ["@odoo/owl"],
+  plugins: [nodeResolve()],
   output: {
     file: "dist/o_spreadsheet.js",
     format: "iife",


### PR DESCRIPTION
Before this commit, we had to import DIR/index.ts instead of import DIR.
As code editors import DIR by default, it was confusing.

Now, rollup will be able to manage the import of DIR
See https://nodejs.org/api/modules.html#modules_all_together