### PR TITLE
[REF] *: remove Celltype Date

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,3 +37,6 @@ export const DEFAULT_STYLE: Style = {
   textColor: "black",
   fontSize: DEFAULT_FONT_SIZE,
 };
+
+// DateTimeRegex
+export const DATETIME_FORMAT = /[ymd:]/;

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,3 +93,5 @@ export const helpers = {
   formatDecimal,
   computeTextWidth,
 };
+
+export { DATETIME_FORMAT } from "./constants";

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -32,6 +32,7 @@ import {
   Zone,
 } from "../../types/index";
 import { FORMULA_REF_IDENTIFIER } from "../../formulas/tokenizer";
+import { DATETIME_FORMAT } from "../../constants";
 
 const nbspRegexp = new RegExp(String.fromCharCode(160), "g");
 
@@ -163,7 +164,8 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
           if (
             cell &&
             (cell.type === CellType.number ||
-              (cell.type === CellType.formula && typeof cell.value === "number"))
+              (cell.type === CellType.formula && typeof cell.value === "number")) &&
+            !cell.format?.match(DATETIME_FORMAT) // reject dates
           ) {
             return cell.format || this.setDefaultNumberFormat(cell.value as any);
           }
@@ -383,7 +385,6 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
                 cell.dependencies?.map((d) => this.getters.getRangeString(d, _sheet.id)) || [],
             };
             break;
-          case CellType.date:
           case CellType.number:
           case CellType.text:
           case CellType.invalidFormula:
@@ -676,8 +677,8 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
         if (internaldate !== null) {
           cell = {
             id: cellId,
-            type: CellType.date,
-            content: formatDateTime(internaldate),
+            type: CellType.number,
+            content: internaldate.value.toString(),
             value: internaldate.value,
           };
           if (!format) {

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -1,8 +1,10 @@
 import { tokenize, composerTokenize, rangeReference, EnrichedToken } from "../../formulas/index";
+import { formatDateTime } from "../../functions/dates";
 import { colors, getComposerSheetName } from "../../helpers/index";
 import { Command, LAYERS, CancelledReason, CommandResult, CellType, Cell } from "../../types/index";
 import { Mode } from "../../model";
 import { UIPlugin } from "../ui_plugin";
+import { DATETIME_FORMAT } from "../../constants";
 
 export type EditionMode = "editing" | "selecting" | "inactive" | "resettingPosition";
 
@@ -201,8 +203,10 @@ export class EditionPlugin extends UIPlugin {
         return this.getters.getFormulaCellContent(this.getters.getActiveSheetId(), cell);
       case CellType.empty:
         return "";
-      case CellType.date:
       case CellType.number:
+        return cell.format?.match(DATETIME_FORMAT)
+          ? formatDateTime({ value: (cell.value || 0) as number, format: cell.format! })
+          : cell.content;
       case CellType.text:
       case CellType.invalidFormula:
         return cell.content;

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -238,7 +238,6 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
         if (cell) {
           switch (cell.type) {
             case CellType.formula:
-            case CellType.date:
             case CellType.number:
             case CellType.text:
               value = cell.value;
@@ -322,7 +321,6 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       if (cell) {
         switch (cell.type) {
           case CellType.formula:
-          case CellType.date:
           case CellType.number:
           case CellType.text:
             value = cell.value;

--- a/src/registries/autofill_rules.ts
+++ b/src/registries/autofill_rules.ts
@@ -1,5 +1,6 @@
 import { Cell, AutofillModifier, FormulaCell, OtherCell, CellType } from "../types/index";
 import { Registry } from "../registry";
+import { DATETIME_FORMAT } from "../constants";
 
 /**
  * An AutofillRule is used to generate what to do when we need to autofill
@@ -27,7 +28,7 @@ function getGroup(cell: Cell, cells: (Cell | undefined)[]): number[] {
     if (x === cell) {
       found = true;
     }
-    if (x && [CellType.number, CellType.date].includes(x.type)) {
+    if (x && x.type === CellType.number) {
       if (typeof x!.value === "number") {
         group.push(x!.value);
       }
@@ -58,7 +59,11 @@ function getAverageIncrement(group: number[]) {
 autofillRulesRegistry
   .add("simple_value_copy", {
     condition: (cell: Cell, cells: (Cell | undefined)[]) => {
-      return cells.length === 1 && [CellType.text, CellType.number].includes(cell.type);
+      return (
+        cells.length === 1 &&
+        [CellType.text, CellType.number].includes(cell.type) &&
+        !cell.format?.match(DATETIME_FORMAT)
+      );
     },
     generateRule: () => {
       return { type: "COPY_MODIFIER" };
@@ -80,7 +85,7 @@ autofillRulesRegistry
     sequence: 30,
   })
   .add("increment_number", {
-    condition: (cell: Cell) => [CellType.number, CellType.date].includes(cell.type),
+    condition: (cell: Cell) => cell.type === CellType.number,
     generateRule: (cell: Cell, cells: (OtherCell | undefined)[]) => {
       const group = getGroup(cell, cells);
       let increment: number = 1;

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -87,7 +87,6 @@ export enum CellType {
   number = "number",
   formula = "formula",
   empty = "empty",
-  date = "date",
   invalidFormula = "invalidFormula",
 }
 
@@ -101,7 +100,7 @@ export interface CellBase {
 }
 
 export interface OtherCell extends CellBase {
-  type: CellType.date | CellType.number | CellType.text | CellType.invalidFormula;
+  type: CellType.number | CellType.text | CellType.invalidFormula;
   content: string;
 }
 

--- a/tests/plugins/formatting_test.ts
+++ b/tests/plugins/formatting_test.ts
@@ -375,7 +375,7 @@ describe("formatting values (when change decimal)", () => {
     expect(getCell(model, "C3")!.format).toBe("0.0000");
   });
 
-  test("Change decimal format on a range does nothing if there is't 'number' type", () => {
+  test("Change decimal format on a range does nothing if there isn't 'number' type", () => {
     const model = new Model();
 
     // give values ​​with different formats


### PR DESCRIPTION
As dates are simply numbers with a specific format, we decided to treat
them as such and remove the date type altogether. There are still some
exceptions where we filter dates :
- when trying to format cells to  a decimal format : we only apply the
format when we find at least a number that is not a date in the
concerned zone;
- On edition mode, the composer should be able to edit the corresponding
date string and not the number value which doesn't have any meaning for
the end user.

Solves #730 