### PR TITLE
[FIX] range: handle sheetname with space

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -6,6 +6,7 @@ import {
   toZone,
   uuidv4,
   groupConsecutive,
+  getUnquotedSheetName,
 } from "../../helpers/index";
 import { CorePlugin } from "../core_plugin";
 
@@ -196,7 +197,7 @@ export class RangePlugin extends CorePlugin<RangeState> {
     if (sheetXC.includes("!")) {
       [xc, sheetName] = sheetXC.split("!").reverse();
       if (sheetName) {
-        sheetId = this.getters.getSheetIdByName(sheetName);
+        sheetId = this.getters.getSheetIdByName(getUnquotedSheetName(sheetName));
         prefixSheet = true;
         if (!sheetId) {
           invalidSheetName = sheetName;

--- a/tests/components/composer_test.ts
+++ b/tests/components/composer_test.ts
@@ -501,6 +501,21 @@ describe("composer", () => {
     expect(composerEl.textContent).toBe("=Sheet2!C8");
   });
 
+  test("type '=', select a cell in another sheet which contains spaces", async () => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("CREATE_SHEET", { sheetId: "42", name: "Sheet 2", position: 1 });
+    setCellContent(model, "C8", "1", "42");
+    await typeInComposer("=");
+    expect(model.getters.getEditionMode()).toBe("selecting");
+    model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: sheetId, sheetIdTo: "42"});
+    triggerMouseEvent("canvas", "mousedown", 300, 200);
+    window.dispatchEvent(new MouseEvent("mouseup", { clientX: 300, clientY: 200 }));
+    await nextTick();
+    expect(composerEl.textContent).toBe("='Sheet 2'!C8");
+    model.dispatch("STOP_EDITION");
+    expect(getCellContent(model, "A1", sheetId)).toBe("1");
+  });
+
   test("Home key sets cursor at the begining", async () => {
     await typeInComposer("Hello");
     expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });


### PR DESCRIPTION
Steps to reproduce:
- Create a sheet with a space in the name
- In Sheet1, type '='
- Activate the newly created sheet
- Select a cell
 => In the composer, the sheet name is correctly surrounded by quotes
- Press enter
 => The cell is in error, with a 'invalid sheet name'

This commit fixes this behaviour.

Odoo-task-id: 2439703

Co-authored-by: LucasLefevre <lul@odoo.com>