### PR TITLE
[FIX] composer: selection flag & cursor selection

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -18,7 +18,7 @@ export const OperatorColor = "#3da4ab";
 export const StringColor = "#f6cd61";
 export const NumberColor = "#02c39a";
 export const MatchingParenColor = "pink";
-export const SelectionIndicatorColor = "#e8e8e8";
+export const SelectionIndicatorColor = "lightgrey";
 
 interface ComposerFocusedEventData {
   content?: string;
@@ -49,6 +49,7 @@ const TEMPLATE = xml/* xml */ `
 
       t-on-keydown="onKeydown"
       t-on-beforeinput="onBeforeinput"
+      t-on-mousedown="onMousedown"
       t-on-input="onInput"
       t-on-keyup="onKeyup"
 
@@ -299,6 +300,14 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
 
     this.dispatch("CHANGE_COMPOSER_SELECTION", this.contentHelper.getCurrentSelection());
     this.processTokenAtCursor();
+  }
+
+  onMousedown(ev: MouseEvent) {
+    if (ev.button > 0) {
+      // not main button, probably a context menu
+      return;
+    }
+    this.contentHelper.removeSelection();
   }
 
   onClick() {

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -13,7 +13,7 @@ export interface ComposerSelection {
   end: number;
 }
 
-export const SelectionIndicator = "ⵌ";
+export const SelectionIndicator = "␣";
 
 export class EditionPlugin extends UIPlugin {
   static layers = [LAYERS.Highlights];

--- a/tests/components/autocomplete_dropdown_test.ts
+++ b/tests/components/autocomplete_dropdown_test.ts
@@ -84,18 +84,18 @@ describe("Functions autocomplete", () => {
       expect(fixture.querySelectorAll(".o-autocomplete-value")[1].textContent).toBe("SZZ");
     });
 
-    test("=S+TAB complete the function --> =sum(ⵌ", async () => {
+    test("=S+TAB complete the function --> =sum(␣", async () => {
       await typeInComposer("=S");
       composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
       await nextTick();
-      expect(model.getters.getCurrentContent()).toBe("=SUM(ⵌ");
+      expect(model.getters.getCurrentContent()).toBe("=SUM(␣");
     });
 
-    test("=S+ENTER complete the function --> =sum(ⵌ", async () => {
+    test("=S+ENTER complete the function --> =sum(␣", async () => {
       await typeInComposer("=S");
       composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
       await nextTick();
-      expect(model.getters.getCurrentContent()).toBe("=SUM(ⵌ");
+      expect(model.getters.getCurrentContent()).toBe("=SUM(␣");
     });
 
     test("=SX not show autocomplete (nothing matches SX)", async () => {
@@ -176,7 +176,7 @@ describe("Functions autocomplete", () => {
         .querySelector(".o-autocomplete-dropdown")!
         .children[1].dispatchEvent(new MouseEvent("click"));
       await nextTick();
-      expect(composerEl.textContent).toBe("=SZZ(ⵌ");
+      expect(composerEl.textContent).toBe("=SZZ(␣");
       expect(document.activeElement).toBe(composerEl);
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
     });
@@ -210,7 +210,7 @@ describe("Functions autocomplete", () => {
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(3);
       composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
       await nextTick();
-      expect(model.getters.getCurrentContent()).toBe("=IF(ⵌ");
+      expect(model.getters.getCurrentContent()).toBe("=IF(␣");
     });
     test("= and CTRL+Space & DOWN move to next autocomplete", async () => {
       await typeInComposer("=");
@@ -292,7 +292,7 @@ describe("Autocomplete parenthesis", () => {
     // select the SUM function
     fixture.querySelector(".o-autocomplete-value-focus")!.dispatchEvent(new MouseEvent("click"));
     await nextTick();
-    expect(model.getters.getCurrentContent()).toBe("=SUM(ⵌ");
+    expect(model.getters.getCurrentContent()).toBe("=SUM(␣");
     expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });
   });
 

--- a/tests/components/composer_test.ts
+++ b/tests/components/composer_test.ts
@@ -107,7 +107,7 @@ describe("ranges and highlights", () => {
     await keydown("ArrowDown");
     expect(model.getters.getCurrentContent()).toBe("=A2");
     await typeInComposer("+", false);
-    expect(model.getters.getCurrentContent()).toBe("=A2+ⵌ");
+    expect(model.getters.getCurrentContent()).toBe("=A2+␣");
     expect(model.getters.getEditionMode()).toBe("selecting");
     await keydown("ArrowDown");
     expect(model.getters.getCurrentContent()).toBe("=A2+A2");
@@ -212,7 +212,7 @@ describe("composer", () => {
 
   test("starting the edition with a key stroke =, the composer should have the focus after the key input", async () => {
     composerEl = await startComposition("=");
-    expect(composerEl.textContent).toBe("=ⵌ");
+    expect(composerEl.textContent).toBe("=␣");
   });
 
   test("starting the edition with a key stroke B, the composer should have the focus after the key input", async () => {
@@ -237,7 +237,7 @@ describe("composer", () => {
 
   test("type '=' in the sheet and select a cell", async () => {
     composerEl = await startComposition("=");
-    expect(composerEl.textContent).toBe("=ⵌ");
+    expect(composerEl.textContent).toBe("=␣");
     expect(model.getters.getEditionMode()).toBe("selecting");
     triggerMouseEvent("canvas", "mousedown", 300, 200);
     window.dispatchEvent(new MouseEvent("mouseup", { clientX: 300, clientY: 200 }));
@@ -334,7 +334,7 @@ describe("composer", () => {
           await startComposition();
           await typeInComposer(content);
           expect(model.getters.getEditionMode()).toBe("selecting");
-          expect(model.getters.getCurrentContent()).toBe(content + "ⵌ");
+          expect(model.getters.getCurrentContent()).toBe(content + "␣");
         }
       );
 
@@ -356,7 +356,7 @@ describe("composer", () => {
           await startComposition();
           await typeInComposer(content + "   ");
           expect(model.getters.getEditionMode()).toBe("selecting");
-          expect(model.getters.getCurrentContent()).toBe(content + "   ⵌ");
+          expect(model.getters.getCurrentContent()).toBe(content + "   ␣");
         }
       );
 
@@ -390,7 +390,7 @@ describe("composer", () => {
           await moveToStart();
           await typeInComposer(formula + ",");
           expect(model.getters.getEditionMode()).toBe("selecting");
-          expect(model.getters.getCurrentContent()).toBe(formula + ",ⵌ" + matchingValue);
+          expect(model.getters.getCurrentContent()).toBe(formula + ",␣" + matchingValue);
         }
       );
 
@@ -421,7 +421,7 @@ describe("composer", () => {
           await moveToStart();
           await typeInComposer(formula + ",  ");
           expect(model.getters.getEditionMode()).toBe("selecting");
-          expect(model.getters.getCurrentContent()).toBe(formula + ",  ⵌ" + matchingValue);
+          expect(model.getters.getCurrentContent()).toBe(formula + ",  ␣" + matchingValue);
         }
       );
 
@@ -445,7 +445,7 @@ describe("composer", () => {
           await moveToStart();
           await typeInComposer(formula + ",");
           expect(model.getters.getEditionMode()).toBe("selecting");
-          expect(model.getters.getCurrentContent()).toBe(formula + ",ⵌ   " + matchingValue);
+          expect(model.getters.getCurrentContent()).toBe(formula + ",␣   " + matchingValue);
         }
       );
 
@@ -476,14 +476,14 @@ describe("composer", () => {
       await startComposition();
       await typeInComposer("=");
       expect(model.getters.getEditionMode()).toBe("selecting");
-      expect(model.getters.getCurrentContent()).toBe("=ⵌ");
+      expect(model.getters.getCurrentContent()).toBe("=␣");
     });
 
     test("typing '=' & spaces --> activate 'selecting' mode", async () => {
       await startComposition();
       await typeInComposer("=   ");
       expect(model.getters.getEditionMode()).toBe("selecting");
-      expect(model.getters.getCurrentContent()).toBe("=   ⵌ");
+      expect(model.getters.getCurrentContent()).toBe("=   ␣");
     });
   });
 
@@ -507,7 +507,7 @@ describe("composer", () => {
     setCellContent(model, "C8", "1", "42");
     await typeInComposer("=");
     expect(model.getters.getEditionMode()).toBe("selecting");
-    model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: sheetId, sheetIdTo: "42"});
+    model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: sheetId, sheetIdTo: "42" });
     triggerMouseEvent("canvas", "mousedown", 300, 200);
     window.dispatchEvent(new MouseEvent("mouseup", { clientX: 300, clientY: 200 }));
     await nextTick();


### PR DESCRIPTION
This commit:
- replace the composer selection flag "ⵌ" by "␣"
- remove the persistence of the highlighted selections by the cursor