### PR TITLE
[FIX] translation: correctly translate dynamic content

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -1,7 +1,7 @@
 import { functionRegistry } from "../functions/index";
-import { CompiledFormula, Arg } from "../types/index";
-import { AST, ASTAsyncFuncall, ASTFuncall, parse } from "./parser";
 import { _lt } from "../translation";
+import { Arg, CompiledFormula } from "../types/index";
+import { AST, ASTAsyncFuncall, ASTFuncall, parse } from "./parser";
 
 const functions = functionRegistry.content;
 
@@ -101,9 +101,12 @@ export function compile(
     }
     if (result.length < minArg || result.length > maxArg) {
       throw new Error(
-        _lt(`
-          Invalid number of arguments for the ${ast.value.toUpperCase()} function.
-          Expected ${fn.args.length}, but got ${result.length} instead.`)
+        _lt(
+          "Invalid number of arguments for the %s function. Expected %s, but got %s instead.",
+          ast.value.toUpperCase(),
+          fn.args.length.toString(),
+          result.length.toString()
+        )
       );
     }
     return result;

--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -105,7 +105,7 @@ function bindingPower(token: Token): number {
     case "OPERATOR":
       return OP_PRIORITY[token.value] || 15;
   }
-  throw new Error(_lt("?"));
+  throw new Error("?");
 }
 
 export const cellReference = new RegExp(/\$?[A-Z]+\$?[0-9]+/, "i");

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -1,11 +1,12 @@
 // HELPERS
 
-import { parseNumber, isNumber } from "../helpers/index";
+import { isNumber, parseNumber } from "../helpers/index";
 import { _lt } from "../translation";
 
 const expectNumberValueError = (value: string) =>
   _lt(
-    `The function [[FUNCTION_NAME]] expects a number value, but '${value}' is a string, and cannot be coerced to a number.`
+    "The function [[FUNCTION_NAME]] expects a number value, but '%s' is a string, and cannot be coerced to a number.",
+    value
   );
 
 export function toNumber(value: any): number {
@@ -152,7 +153,8 @@ export function toString(value: any): string {
 
 const expectBooleanValueError = (value: string) =>
   _lt(
-    `The function [[FUNCTION_NAME]] expects a boolean value, but '${value}' is a text, and cannot be coerced to a number.`
+    "The function [[FUNCTION_NAME]] expects a boolean value, but '%s' is a text, and cannot be coerced to a number.",
+    value
   );
 
 export function toBoolean(value: any): boolean {

--- a/src/functions/module_database.ts
+++ b/src/functions/module_database.ts
@@ -1,9 +1,9 @@
-import { args } from "./arguments";
-import { FunctionDescription } from "../types";
-import { visitMatchingRanges, toString } from "./helpers";
-import { COUNT, AVERAGE, COUNTA, MAX, MIN, STDEV, STDEVP, VAR, VARP } from "./module_statistical";
-import { PRODUCT, SUM } from "./module_math";
 import { _lt } from "../translation";
+import { FunctionDescription } from "../types";
+import { args } from "./arguments";
+import { toString, visitMatchingRanges } from "./helpers";
+import { PRODUCT, SUM } from "./module_math";
+import { AVERAGE, COUNT, COUNTA, MAX, MIN, STDEV, STDEVP, VAR, VARP } from "./module_statistical";
 
 function getMatchingCells(database: any, field: any, criteria: any): any[] {
   // Exemple :
@@ -34,7 +34,9 @@ function getMatchingCells(database: any, field: any, criteria: any): any[] {
     if (index < 0 || index > dimRowDB - 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 2 value is ${field}. Valid values are between 1 and ${dimRowDB} inclusive.`
+          "Function [[FUNCTION_NAME]] parameter 2 value is %s. Valid values are between 1 and %s inclusive.",
+          field,
+          dimRowDB
         )
       );
     }
@@ -44,11 +46,9 @@ function getMatchingCells(database: any, field: any, criteria: any): any[] {
     if (index === undefined) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 2 value is ${field}. It should be one of: ${[
-            ...indexColNameDB.keys(),
-          ]
-            .map((v) => "'" + v + "'")
-            .join(", ")}.`
+          "Function [[FUNCTION_NAME]] parameter 2 value is %s. It should be one of: %s.",
+          field,
+          [...indexColNameDB.keys()].map((v) => "'" + v + "'").join(", ")
         )
       );
     }

--- a/src/functions/module_date.ts
+++ b/src/functions/module_date.ts
@@ -1,8 +1,8 @@
-import { args } from "./arguments";
-import { FunctionDescription } from "../types";
-import { toNativeDate, InternalDate, parseDateTime } from "../functions/dates";
-import { toNumber, toString, visitAny } from "./helpers";
+import { InternalDate, parseDateTime, toNativeDate } from "../functions/dates";
 import { _lt } from "../translation";
+import { FunctionDescription } from "../types";
+import { args } from "./arguments";
+import { toNumber, toString, visitAny } from "./helpers";
 
 const INITIAL_1900_DAY = new Date(1899, 11, 30);
 
@@ -62,7 +62,7 @@ export const DATEVALUE: FunctionDescription = {
     const _dateString = toString(date_string);
     const datetime = parseDateTime(_dateString);
     if (datetime === null) {
-      throw new Error(_lt(`DATEVALUE parameter '${_dateString}' cannot be parsed to date/time.`));
+      throw new Error(_lt("DATEVALUE parameter '%s' cannot be parsed to date/time.", _dateString));
     }
     return Math.trunc(datetime.value);
   },
@@ -351,7 +351,8 @@ function weekendToDayNumber(weekend: any): number[] {
           default:
             throw new Error(
               _lt(
-                `Function [[FUNCTION_NAME]] parameter 3 requires a string composed of 0 or 1. Actual string is '${weekend}'.`
+                "Function [[FUNCTION_NAME]] parameter 3 requires a string composed of 0 or 1. Actual string is '%s'.",
+                weekend
               )
             );
         }
@@ -360,7 +361,8 @@ function weekendToDayNumber(weekend: any): number[] {
     }
     throw new Error(
       _lt(
-        `Function [[FUNCTION_NAME]] parameter 3 requires a string with 7 characters. Actual string is '${weekend}'.`
+        "Function [[FUNCTION_NAME]] parameter 3 requires a string with 7 characters. Actual string is '%s'.",
+        weekend
       )
     );
   }
@@ -382,7 +384,8 @@ function weekendToDayNumber(weekend: any): number[] {
     }
     throw new Error(
       _lt(
-        `Function [[FUNCTION_NAME]] parameter 3 requires a string or a number in the range 1-7 or 11-17. Actual number is ${weekend}.`
+        "Function [[FUNCTION_NAME]] parameter 3 requires a string or a number in the range 1-7 or 11-17. Actual number is %s.",
+        weekend.toString()
       )
     );
   }
@@ -531,7 +534,7 @@ export const TIMEVALUE: FunctionDescription = {
     const _timeString = toString(time_string);
     const datetime = parseDateTime(_timeString);
     if (datetime === null) {
-      throw new Error(_lt(`TIMEVALUE parameter '${_timeString}' cannot be parsed to date/time.`));
+      throw new Error(_lt("TIMEVALUE parameter '%s' cannot be parsed to date/time.", _timeString));
     }
     const result = datetime.value - Math.trunc(datetime.value);
 
@@ -584,7 +587,9 @@ export const WEEKDAY: FunctionDescription = {
       case 3:
         return m === 0 ? 6 : m - 1;
     }
-    throw new Error(_lt(`Function WEEKDAY parameter 2 value ${_type} is out of range.`));
+    throw new Error(
+      _lt("Function WEEKDAY parameter 2 value %s is out of range.", _type.toString())
+    );
   },
 };
 
@@ -615,7 +620,9 @@ export const WEEKNUM: FunctionDescription = {
     } else if (_type === 21) {
       return ISOWEEKNUM.compute(date);
     } else {
-      throw new Error(_lt(`Function WEEKNUM parameter 2 value ${_type} is out of range.`));
+      throw new Error(
+        _lt("Function WEEKNUM parameter 2 value %s is out of range.", _type.toString())
+      );
     }
 
     const y = _date.getFullYear();

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1,12 +1,12 @@
-import { args } from "./arguments";
+import { _lt } from "../translation";
 import { FunctionDescription } from "../types";
+import { args } from "./arguments";
 import {
-  toNumber,
-  toBoolean,
   dichotomicPredecessorSearch,
   dichotomicSuccessorSearch,
+  toBoolean,
+  toNumber,
 } from "./helpers";
-import { _lt } from "../translation";
 
 /**
  * Perform a linear search and return the index of the perfect match.
@@ -64,13 +64,17 @@ export const LOOKUP: FunctionDescription = {
 
     if (nbCol > 1) {
       if (nbCol - 1 < index) {
-        throw new Error(_lt(`LOOKUP evaluates to an out of range row value ${index + 1}.`));
+        throw new Error(
+          _lt("LOOKUP evaluates to an out of range row value %s.", (index + 1).toString())
+        );
       }
       return result_range[index][0];
     }
 
     if (nbRow - 1 < index) {
-      throw new Error(_lt(`LOOKUP evaluates to an out of range column value ${index + 1}.`));
+      throw new Error(
+        _lt("LOOKUP evaluates to an out of range column value %s.", (index + 1).toString())
+      );
     }
     return result_range[0][index];
   },
@@ -114,7 +118,7 @@ export const MATCH: FunctionDescription = {
     if (index > -1) {
       return index + 1;
     } else {
-      throw new Error(_lt(`Did not find value '${search_key}' in MATCH evaluation.`));
+      throw new Error(_lt("Did not find value '%s' in MATCH evaluation.", search_key));
     }
   },
 };
@@ -156,7 +160,7 @@ export const VLOOKUP: FunctionDescription = {
     if (lineIndex > -1) {
       return range[_index - 1][lineIndex];
     } else {
-      throw new Error(_lt(`Did not find value '${search_key}' in VLOOKUP evaluation.`));
+      throw new Error(_lt("Did not find value '%s' in VLOOKUP evaluation.", search_key));
     }
   },
 };

--- a/src/functions/module_math.ts
+++ b/src/functions/module_math.ts
@@ -1,14 +1,14 @@
-import { args } from "./arguments";
+import { _lt } from "../translation";
 import { FunctionDescription } from "../types";
+import { args } from "./arguments";
 import {
-  toNumber,
-  strictToNumber,
-  toString,
   reduceArgs,
   reduceNumbers,
+  strictToNumber,
+  toNumber,
+  toString,
   visitMatchingRanges,
 } from "./helpers";
-import { _lt } from "../translation";
 
 // -----------------------------------------------------------------------------
 // ACOS
@@ -26,7 +26,8 @@ export const ACOS: FunctionDescription = {
     if (Math.abs(_value) > 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. Valid values are between -1 and 1 inclusive.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. Valid values are between -1 and 1 inclusive.",
+          _value.toString()
         )
       );
     }
@@ -50,7 +51,8 @@ export const ACOSH: FunctionDescription = {
     if (_value < 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. It should be greater than or equal to 1.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. It should be greater than or equal to 1.",
+          _value.toString()
         )
       );
     }
@@ -93,7 +95,8 @@ export const ACOTH: FunctionDescription = {
     if (Math.abs(_value) <= 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. Valid values cannot be between -1 and 1 inclusive.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. Valid values cannot be between -1 and 1 inclusive.",
+          _value.toString()
         )
       );
     }
@@ -117,7 +120,8 @@ export const ASIN: FunctionDescription = {
     if (Math.abs(_value) > 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. Valid values are between -1 and 1 inclusive.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %S. Valid values are between -1 and 1 inclusive.",
+          _value.toString()
         )
       );
     }
@@ -193,7 +197,8 @@ export const ATANH: FunctionDescription = {
     if (Math.abs(_value) >= 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. Valid values are between -1 and 1 exclusive.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. Valid values are between -1 and 1 exclusive.",
+          _value.toString()
         )
       );
     }
@@ -220,7 +225,11 @@ export const CEILING: FunctionDescription = {
     if (_value > 0 && _factor < 0) {
       throw new Error(
         _lt(
-          `Function CEILING expects the parameter '${CEILING.args[1].name}' to be positive when parameter '${CEILING.args[0].name}' is positive. Change '${CEILING.args[1].name}' from [${_factor}] to a positive value.`
+          "Function CEILING expects the parameter '%s' to be positive when parameter '%s' is positive. Change '%s' from [%s] to a positive value.",
+          CEILING.args[1].name,
+          CEILING.args[0].name,
+          CEILING.args[1].name,
+          _factor.toString()
         )
       );
     }
@@ -525,7 +534,12 @@ export const CSCH: FunctionDescription = {
 // -----------------------------------------------------------------------------
 const decimalErrorParameter2 = (parameterName, base, value) =>
   _lt(
-    `Function DECIMAL expects the parameter '${parameterName}' to be a valid base ${base} representation. Change '${parameterName}' from [${value}] to a valid base ${base} representation.`
+    "Function DECIMAL expects the parameter '%s' to be a valid base %s representation. Change '%s' from [%s] to a valid base %s representation.",
+    parameterName,
+    base,
+    parameterName,
+    value,
+    base
   );
 
 export const DECIMAL: FunctionDescription = {
@@ -541,7 +555,10 @@ export const DECIMAL: FunctionDescription = {
     if (_base < 2 || _base > 36) {
       throw new Error(
         _lt(
-          `Function DECIMAL expects the parameter '${DECIMAL.args[1].name}' to be between 2 and 36 inclusive. Change '${DECIMAL.args[1].name}' from [${_base}] to a value between 2 and 36.`
+          "Function DECIMAL expects the parameter '%s' to be between 2 and 36 inclusive. Change '%s' from [%s] to a value between 2 and 36.",
+          DECIMAL.args[1].name,
+          DECIMAL.args[1].name,
+          _base.toString()
         )
       );
     }
@@ -615,7 +632,11 @@ export const FLOOR: FunctionDescription = {
     if (_value > 0 && _factor < 0) {
       throw new Error(
         _lt(
-          `Function FLOOR expects the parameter '${FLOOR.args[1].name}' to be positive when parameter '${FLOOR.args[0].name}' is positive. Change '${FLOOR.args[1].name}' from [${_factor}] to a positive value.`
+          "Function FLOOR expects the parameter '%s' to be positive when parameter '%s' is positive. Change '%s' from [%s] to a positive value.",
+          FLOOR.args[1].name,
+          FLOOR.args[0].name,
+          FLOOR.args[1].name,
+          _factor.toString()
         )
       );
     }
@@ -744,7 +765,8 @@ export const LN: FunctionDescription = {
     if (_value <= 0) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. It should be greater than 0.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. It should be greater than 0.",
+          _value.toString()
         )
       );
     }
@@ -768,7 +790,9 @@ export const MOD: FunctionDescription = {
     if (_divisor === 0) {
       throw new Error(
         _lt(
-          `Function MOD expects the parameter '${MOD.args[1].name}' to be different from 0. Change '${MOD.args[1].name}' to a value other than 0.`
+          "Function MOD expects the parameter '%s' to be different from 0. Change '%s' to a value other than 0.",
+          MOD.args[1].name,
+          MOD.args[1].name
         )
       );
     }
@@ -832,7 +856,11 @@ export const POWER: FunctionDescription = {
     if (!Number.isInteger(_exponent)) {
       throw new Error(
         _lt(
-          `Function POWER expects the parameter '${POWER.args[1].name}' to be an integer when parameter '${POWER.args[0].name}' is negative. Change '${POWER.args[1].name}' from [${_exponent}] to an integer value.`
+          "Function POWER expects the parameter '%s' to be an integer when parameter '%s' is negative. Change '%s' from [%s] to an integer value.",
+          POWER.args[1].name,
+          POWER.args[0].name,
+          POWER.args[1].name,
+          _exponent.toString()
         )
       );
     }
@@ -915,7 +943,10 @@ export const RANDBETWEEN: FunctionDescription = {
     if (_high < _low) {
       throw new Error(
         _lt(
-          `Function RANDBETWEEN parameter '${RANDBETWEEN.args[1].name}' value is ${_high}. It should be greater than or equal to [${_low}].`
+          "Function RANDBETWEEN parameter '%s' value is %s. It should be greater than or equal to [%s].",
+          RANDBETWEEN.args[1].name,
+          _high.toString(),
+          _low.toString()
         )
       );
     }
@@ -1078,7 +1109,10 @@ export const SQRT: FunctionDescription = {
     if (_value < 0) {
       throw new Error(
         _lt(
-          `Function SQRT parameter '${SQRT.args[0].name}' value is negative. It should be positive or zero. Change '${SQRT.args[0].name}' from [${_value}] to a positive value.`
+          "Function SQRT parameter '%s' value is negative. It should be positive or zero. Change '%s' from [%s] to a positive value.",
+          SQRT.args[0].name,
+          SQRT.args[0].name,
+          _value.toString()
         )
       );
     }

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -1,16 +1,16 @@
-import { args } from "./arguments";
-import { FunctionDescription } from "../types";
-import {
-  toNumber,
-  reduceNumbers,
-  visitAny,
-  reduceArgs,
-  dichotomicPredecessorSearch,
-  reduceNumbersTextAs0,
-  visitMatchingRanges,
-} from "./helpers";
 import { isNumber } from "../helpers/index";
 import { _lt } from "../translation";
+import { FunctionDescription } from "../types";
+import { args } from "./arguments";
+import {
+  dichotomicPredecessorSearch,
+  reduceArgs,
+  reduceNumbers,
+  reduceNumbersTextAs0,
+  toNumber,
+  visitAny,
+  visitMatchingRanges,
+} from "./helpers";
 
 // Note: dataY and dataX may not have the same dimension
 function covariance(dataY: any[], dataX: any[], isSample: boolean): number {
@@ -30,7 +30,13 @@ function covariance(dataY: any[], dataX: any[], isSample: boolean): number {
   });
 
   if (lenY !== lenX) {
-    throw new Error(_lt(`[[FUNCTION_NAME]] has mismatched argument count ${lenY} vs ${lenX}.`));
+    throw new Error(
+      _lt(
+        "[[FUNCTION_NAME]] has mismatched argument count %s vs %s.",
+        lenY.toString(),
+        lenX.toString()
+      )
+    );
   }
 
   let count = 0;
@@ -464,7 +470,7 @@ export const LARGE: FunctionDescription = {
       throw new Error(_lt(`LARGE has no valid input data.`));
     }
     if (count < n) {
-      throw new Error(_lt(`Function LARGE parameter 2 value ${n} is out of range.`));
+      throw new Error(_lt("Function LARGE parameter 2 value %s is out of range.", n.toString()));
     }
     return result;
   },
@@ -687,7 +693,7 @@ export const SMALL: FunctionDescription = {
       throw new Error(_lt(`SMALL has no valid input data.`));
     }
     if (count < n) {
-      throw new Error(_lt(`Function SMALL parameter 2 value ${n} is out of range.`));
+      throw new Error(_lt("Function SMALL parameter 2 value %s is out of range.", n.toString()));
     }
     return result;
   },

--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -1,7 +1,7 @@
-import { args } from "./arguments";
-import { FunctionDescription } from "../types";
-import { toNumber, toString, reduceArgs, toBoolean } from "./helpers";
 import { _lt } from "../translation";
+import { FunctionDescription } from "../types";
+import { args } from "./arguments";
+import { reduceArgs, toBoolean, toNumber, toString } from "./helpers";
 
 // -----------------------------------------------------------------------------
 // CHAR
@@ -17,7 +17,9 @@ export const CHAR: FunctionDescription = {
   compute: function (table_number: any): string {
     const _tableNumber = Math.trunc(toNumber(table_number));
     if (_tableNumber < 1) {
-      throw new Error(_lt(`Function CHAR parameter 1 value ${_tableNumber} is out of range.`));
+      throw new Error(
+        _lt("Function CHAR parameter 1 value %s is out of range.", _tableNumber.toString())
+      );
     }
     return String.fromCharCode(_tableNumber);
   },
@@ -85,7 +87,11 @@ export const FIND: FunctionDescription = {
     const result = _textToSearch.indexOf(_searchFor, _startingAt - 1);
     if (result < 0) {
       throw new Error(
-        _lt(`In FIND evaluation, cannot find '${_searchFor}' within '${_textToSearch}'.`)
+        _lt(
+          "In FIND evaluation, cannot find '%s' within '%s'.",
+          _searchFor.toString(),
+          _textToSearch
+        )
       );
     }
     return result + 1;
@@ -252,7 +258,7 @@ export const SEARCH: FunctionDescription = {
     const result = _textToSearch.indexOf(_searchFor, _startingAt - 1);
     if (result < 0) {
       throw new Error(
-        _lt(`In SEARCH evaluation, cannot find '${_searchFor}' within '${_textToSearch}'.`)
+        _lt("In SEARCH evaluation, cannot find '%s' within '%s'.", _searchFor, _textToSearch)
       );
     }
     return result + 1;

--- a/src/helpers/coordinates.ts
+++ b/src/helpers/coordinates.ts
@@ -2,8 +2,6 @@
 // Coordinate
 //------------------------------------------------------------------------------
 
-import { _lt } from "../translation";
-
 /**
  * Convert a (col) number to the corresponding letter.
  *
@@ -52,7 +50,7 @@ export function toCartesian(xc: string): [number, number] {
   xc = xc.toUpperCase();
   const [m, letters, numbers] = xc.match(/\$?([A-Z]*)\$?([0-9]*)/)!;
   if (m !== xc) {
-    throw new Error(_lt(`Invalid cell description: ${xc}`));
+    throw new Error(`Invalid cell description: ${xc}`);
   }
   const col = lettersToNumber(letters);
   const row = parseInt(numbers, 10) - 1;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,22 +1,22 @@
 import * as owl from "@odoo/owl";
 import { BasePlugin } from "./base_plugin";
 import { createEmptyWorkbook, createEmptyWorkbookData, load } from "./data";
+import { DEBUG } from "./helpers/index";
 import { WHistory } from "./history";
 import { pluginRegistry } from "./plugins/index";
+import { _lt } from "./translation";
 import {
+  Command,
   CommandDispatcher,
   CommandHandler,
-  Getters,
-  Command,
-  Workbook,
-  WorkbookData,
-  GridRenderingContext,
-  LAYERS,
   CommandSuccess,
   EvalContext,
+  Getters,
+  GridRenderingContext,
+  LAYERS,
+  Workbook,
+  WorkbookData,
 } from "./types/index";
-import { _lt } from "./translation";
-import { DEBUG } from "./helpers/index";
 
 /**
  * Model
@@ -149,7 +149,7 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
       plugin.import(data);
       for (let name of Plugin.getters) {
         if (!(name in plugin)) {
-          throw new Error(_lt(`Invalid getter name: ${name} for plugin ${plugin.constructor}`));
+          throw new Error(`Invalid getter name: ${name} for plugin ${plugin.constructor}`);
         }
         this.getters[name] = plugin[name].bind(plugin);
       }

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -1,6 +1,6 @@
-import { Style, SpreadsheetEnv } from "../../types/index";
 import { numberToLetters, uuidv4 } from "../../helpers/index";
 import { _lt } from "../../translation";
+import { SpreadsheetEnv, Style } from "../../types/index";
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -113,9 +113,9 @@ export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetEnv) => {
     last = zone.bottom;
   }
   if (first === last) {
-    return _lt(`Clear row ${first + 1}`);
+    return _lt("Clear row %s", (first + 1).toString());
   }
-  return _lt(`Clear rows ${first + 1} - ${last + 1}`);
+  return _lt("Clear rows %s - %s", (first + 1).toString(), (last + 1).toString());
 };
 
 export const DELETE_CONTENT_ROWS_ACTION = (env: SpreadsheetEnv) => {
@@ -141,9 +141,9 @@ export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetEnv) => {
     last = zone.right;
   }
   if (first === last) {
-    return _lt(`Clear column ${numberToLetters(first)}`);
+    return _lt("Clear column %s", numberToLetters(first));
   }
-  return _lt(`Clear columns ${numberToLetters(first)} - ${numberToLetters(last)}`);
+  return _lt("Clear columns %s - %s", numberToLetters(first), numberToLetters(last));
 };
 
 export const DELETE_CONTENT_COLUMNS_ACTION = (env: SpreadsheetEnv) => {
@@ -169,9 +169,9 @@ export const REMOVE_ROWS_NAME = (env: SpreadsheetEnv) => {
     last = zone.bottom;
   }
   if (first === last) {
-    return _lt(`Delete row ${first + 1}`);
+    return _lt("Delete row %s", (first + 1).toString());
   }
-  return _lt(`Delete rows ${first + 1} - ${last + 1}`);
+  return _lt("Delete rows %s - %s", (first + 1).toString(), (last + 1).toString());
 };
 
 export const REMOVE_ROWS_ACTION = (env: SpreadsheetEnv) => {
@@ -201,9 +201,9 @@ export const REMOVE_COLUMNS_NAME = (env: SpreadsheetEnv) => {
     last = zone.right;
   }
   if (first === last) {
-    return _lt(`Delete column ${numberToLetters(first)}`);
+    return _lt("Delete column %s", numberToLetters(first));
   }
-  return _lt(`Delete columns ${numberToLetters(first)} - ${numberToLetters(last)}`);
+  return _lt("Delete columns %s - %s", numberToLetters(first), numberToLetters(last));
 };
 
 export const REMOVE_COLUMNS_ACTION = (env: SpreadsheetEnv) => {
@@ -225,12 +225,12 @@ export const MENU_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Row above");
   }
-  return _lt(`${number} Rows above`);
+  return _lt("%s Rows above", number.toString());
 };
 
 export const ROW_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   const number = getRowsNumber(env);
-  return number === 1 ? _lt("Insert row above") : _lt(`Insert ${number} rows above`);
+  return number === 1 ? _lt("Insert row above") : _lt("Insert %s rows above", number.toString());
 };
 
 export const CELL_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetEnv) => {
@@ -238,7 +238,7 @@ export const CELL_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Insert row");
   }
-  return _lt(`Insert ${number} rows`);
+  return _lt("Insert %s rows", number.toString());
 };
 
 export const INSERT_ROWS_BEFORE_ACTION = (env: SpreadsheetEnv) => {
@@ -266,12 +266,12 @@ export const MENU_INSERT_ROWS_AFTER_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Row below");
   }
-  return _lt(`${number} Rows below`);
+  return _lt("%s Rows below", number.toString());
 };
 
 export const ROW_INSERT_ROWS_AFTER_NAME = (env: SpreadsheetEnv) => {
   const number = getRowsNumber(env);
-  return number === 1 ? _lt("Insert row below") : _lt(`Insert ${number} rows below`);
+  return number === 1 ? _lt("Insert row below") : _lt("Insert %s rows below", number.toString());
 };
 
 export const INSERT_ROWS_AFTER_ACTION = (env: SpreadsheetEnv) => {
@@ -299,12 +299,14 @@ export const MENU_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Column left");
   }
-  return _lt(`${number} Columns left`);
+  return _lt("%s Columns left", number.toString());
 };
 
 export const COLUMN_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   const number = getColumnsNumber(env);
-  return number === 1 ? _lt("Insert column left") : _lt(`Insert ${number} columns left`);
+  return number === 1
+    ? _lt("Insert column left")
+    : _lt("Insert %s columns left", number.toString());
 };
 
 export const CELL_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetEnv) => {
@@ -312,7 +314,7 @@ export const CELL_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Insert column");
   }
-  return _lt(`Insert ${number} columns`);
+  return _lt("Insert %s columns", number.toString());
 };
 
 export const INSERT_COLUMNS_BEFORE_ACTION = (env: SpreadsheetEnv) => {
@@ -340,12 +342,14 @@ export const MENU_INSERT_COLUMNS_AFTER_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Column right");
   }
-  return _lt(`${number} Columns right`);
+  return _lt("%s Columns right", number.toString());
 };
 
 export const COLUMN_INSERT_COLUMNS_AFTER_NAME = (env: SpreadsheetEnv) => {
   const number = getColumnsNumber(env);
-  return number === 1 ? _lt("Insert column right") : _lt(`Insert ${number} columns right`);
+  return number === 1
+    ? _lt("Insert column right")
+    : _lt("Insert %s columns right", number.toString());
 };
 
 export const INSERT_COLUMNS_AFTER_ACTION = (env: SpreadsheetEnv) => {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -31,7 +31,7 @@ export class Registry<T> {
    */
   get(key: string): T {
     if (!(key in this.content)) {
-      throw new Error(_lt(`Cannot find ${key} in this registry!`));
+      throw new Error(`Cannot find ${key} in this registry!`);
     }
     return this.content[key];
   }

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -4,10 +4,23 @@
  *  sub-env of Spreadsheet components as _t
  * */
 
-export type TranslationFunction = (string) => string;
+export type TranslationFunction = (
+  string: string,
+  ...values: string[] | [{ [key: string]: string }]
+) => string;
 
 // define a mock translation function, when o-spreadsheet runs in standalone it doesn't translate any string
 let _t: TranslationFunction = (s) => s;
+
+function sprintf(s: string, ...values: string[] | [{ [key: string]: string }]): string {
+  if (values.length === 1 && typeof values[0] === "object") {
+    const valuesDict = values[0] as { [key: string]: string };
+    s = s.replace(/\%\(?([^\)]+)\)s/g, (match, value) => valuesDict[value]);
+  } else if (values.length > 0) {
+    s = s.replace(/\%s/g, () => values.shift() as string);
+  }
+  return s;
+}
 
 /***
  * Allow to inject a translation function from outside o-spreadsheet.
@@ -17,10 +30,13 @@ export function setTranslationMethod(tfn: TranslationFunction) {
   _t = tfn;
 }
 
-export const _lt: TranslationFunction = function (s) {
+export const _lt: TranslationFunction = function (
+  s,
+  ...values: string[] | [{ [key: string]: string }]
+) {
   return ({
     toString: function () {
-      return _t(s);
+      return sprintf(_t(s), ...values);
     },
     // casts the object to unknown then to string to trick typescript into thinking that the object it receives is actually a string
     // this way it will be typed correctly (behaves like a string) but tests like typeof _lt("whatever") will be object and not string !


### PR DESCRIPTION
Using backtick to translate will not work with the translation system.
```js
const x = 2;
_lt(`Hello ${x}`);
```
`Hello ${x}` is evaluated *before* the lookup in the table of
translation, so we are looking for "Hello 2" in the table, which is
not correct.

This commit introduces the way to translate such strings in the following
way:
```js
const x = 2;
_lt("Hello %s", x.toString());
```