### PR TITLE
[IMP] SelectionInput: red border if invalid range

### DIFF
--- a/src/components/selection_input.ts
+++ b/src/components/selection_input.ts
@@ -16,7 +16,7 @@ const TEMPLATE = xml/* xml */ `
         t-on-change="onInputChanged(range.id)"
         t-on-focus="focus(range.id)"
         t-att-value="range.xc"
-        t-attf-style="color: {{range.color || '#000'}}"
+        t-att-style="getStyle(range)"
         t-att-class="range.isFocused ? 'o-focused' : ''"
       />
       <button
@@ -96,7 +96,7 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
   private dispatch = this.env.dispatch;
   private originSheet = this.env.getters.getActiveSheetId();
 
-  get ranges(): (RangeInputValue & { isFocused: boolean })[] {
+  get ranges(): (RangeInputValue & { isFocused: boolean; isValidRange?: boolean })[] {
     const ranges = this.getters.getSelectionInput(this.id);
     return ranges.length
       ? ranges
@@ -134,6 +134,15 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
     if (this.previousRanges.join() !== value.join()) {
       this.triggerChange();
     }
+  }
+
+  getStyle(range: RangeInputValue & { isFocused: boolean; isValidRange?: boolean }) {
+    const color = range.color || "#000";
+    let style = "color: " + color;
+    if (range.isValidRange !== undefined && !range.isValidRange) {
+      style = style + "; border-color: red";
+    }
+    return style;
   }
 
   private triggerChange() {

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -9,6 +9,7 @@ export interface RangeInputValue {
   id: UID;
   xc: string;
   color?: string | null;
+  validRange?: boolean;
 }
 
 /**
@@ -281,6 +282,7 @@ export class SelectionInputPlugin extends UIPlugin {
       valuesNotHighlighted.map((value) => ({
         id: uuidv4(),
         xc: value,
+        isValidRange: this.isRangeValid(value),
       }))
     );
   }

--- a/tests/components/selection_input_test.ts
+++ b/tests/components/selection_input_test.ts
@@ -21,6 +21,7 @@ async function writeInput(index: number, text: string) {
   input.value = text;
   input.dispatchEvent(new Event("input"));
   input.dispatchEvent(new Event("change"));
+  await nextTick();
 }
 
 interface SelectionInputTestConfig {
@@ -290,5 +291,19 @@ describe("Selection Input", () => {
     expect(model.getters.getActiveSheetId()).toBe(sheet1Id);
     model.dispatch("UNDO");
     expect(model.getters.getActiveSheetId()).toBe(sheet1Id);
+  });
+  test("show red border if and only if invalid range", async () => {
+    await createSelectionInput();
+    await writeInput(0, "A1");
+    expect(fixture.querySelectorAll("input")[0].value).toBe("A1");
+    expect(fixture.querySelectorAll("input")[0].getAttribute("style")).toBe("color: #0074d9");
+    await writeInput(0, "aaaaa");
+    expect(fixture.querySelectorAll("input")[0].value).toBe("aaaaa");
+    expect(fixture.querySelectorAll("input")[0].getAttribute("style")).toBe(
+      "color: #000; border-color: red"
+    );
+    await writeInput(0, "B1");
+    expect(fixture.querySelectorAll("input")[0].value).toBe("B1");
+    expect(fixture.querySelectorAll("input")[0].getAttribute("style")).toBe("color: #ffdc00");
   });
 });


### PR DESCRIPTION
In order to notify the user that an entered range has the wrong format,
a red border is now display in the component if the range is invalid.

closes: #725