### PR TITLE
[FIX] translation: correctly translate dynamic content

### DIFF
--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -103,7 +103,7 @@ function bindingPower(token: Token): number {
     case "OPERATOR":
       return OP_PRIORITY[token.value] || 15;
   }
-  throw new Error(_lt("?"));
+  throw new Error("?");
 }
 
 export const cellReference = new RegExp(/\$?[A-Z]+\$?[0-9]+/, "i");

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -6,7 +6,8 @@ import { _lt } from "../translation";
 
 const expectNumberValueError = (value: string) =>
   _lt(
-    `The function [[FUNCTION_NAME]] expects a number value, but '${value}' is a string, and cannot be coerced to a number.`
+    "The function [[FUNCTION_NAME]] expects a number value, but '%s' is a string, and cannot be coerced to a number.",
+    value
   );
 
 export function toNumber(value: any): number {
@@ -157,7 +158,8 @@ export function toString(value: any): string {
 
 const expectBooleanValueError = (value: string) =>
   _lt(
-    `The function [[FUNCTION_NAME]] expects a boolean value, but '${value}' is a text, and cannot be coerced to a number.`
+    "The function [[FUNCTION_NAME]] expects a boolean value, but '%s' is a text, and cannot be coerced to a number.",
+    value
   );
 
 export function toBoolean(value: any): boolean {

--- a/src/functions/module_database.ts
+++ b/src/functions/module_database.ts
@@ -34,7 +34,9 @@ function getMatchingCells(database: any, field: any, criteria: any): any[] {
     if (index < 0 || index > dimRowDB - 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 2 value is ${field}. Valid values are between 1 and ${dimRowDB} inclusive.`
+          "Function [[FUNCTION_NAME]] parameter 2 value is %s. Valid values are between 1 and %s inclusive.",
+          field,
+          dimRowDB
         )
       );
     }
@@ -44,11 +46,9 @@ function getMatchingCells(database: any, field: any, criteria: any): any[] {
     if (index === undefined) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 2 value is ${field}. It should be one of: ${[
-            ...indexColNameDB.keys(),
-          ]
-            .map((v) => "'" + v + "'")
-            .join(", ")}.`
+          "Function [[FUNCTION_NAME]] parameter 2 value is %s. It should be one of: %s.",
+          field,
+          [...indexColNameDB.keys()].map((v) => "'" + v + "'").join(", ")
         )
       );
     }

--- a/src/functions/module_date.ts
+++ b/src/functions/module_date.ts
@@ -64,7 +64,7 @@ export const DATEVALUE: AddFunctionDescription = {
     const internalDate = parseDateTime(_dateString);
     if (internalDate === null) {
       throw new Error(
-        _lt(`[[FUNCTION_NAME]] parameter '${_dateString}' cannot be parsed to date/time.`)
+        _lt("[[FUNCTION_NAME]] parameter '%s' cannot be parsed to date/time.", _dateString)
       );
     }
     return Math.trunc(internalDate.value);
@@ -348,7 +348,8 @@ function weekendToDayNumber(weekend: any): number[] {
           default:
             throw new Error(
               _lt(
-                `Function [[FUNCTION_NAME]] parameter 3 requires a string composed of 0 or 1. Actual string is '${weekend}'.`
+                "Function [[FUNCTION_NAME]] parameter 3 requires a string composed of 0 or 1. Actual string is '%s'.",
+                weekend
               )
             );
         }
@@ -357,7 +358,8 @@ function weekendToDayNumber(weekend: any): number[] {
     }
     throw new Error(
       _lt(
-        `Function [[FUNCTION_NAME]] parameter 3 requires a string with 7 characters. Actual string is '${weekend}'.`
+        "Function [[FUNCTION_NAME]] parameter 3 requires a string with 7 characters. Actual string is '%s'.",
+        weekend
       )
     );
   }
@@ -379,7 +381,8 @@ function weekendToDayNumber(weekend: any): number[] {
     }
     throw new Error(
       _lt(
-        `Function [[FUNCTION_NAME]] parameter 3 requires a string or a number in the range 1-7 or 11-17. Actual number is ${weekend}.`
+        "Function [[FUNCTION_NAME]] parameter 3 requires a string or a number in the range 1-7 or 11-17. Actual number is %s.",
+        weekend.toString()
       )
     );
   }
@@ -521,7 +524,7 @@ export const TIMEVALUE: AddFunctionDescription = {
     const internalDate = parseDateTime(_timeString);
     if (internalDate === null) {
       throw new Error(
-        _lt(`[[FUNCTION_NAME]] parameter '${_timeString}' cannot be parsed to date/time.`)
+        _lt("[[FUNCTION_NAME]] parameter '%s' cannot be parsed to date/time.", _timeString)
       );
     }
     const result = internalDate.value - Math.trunc(internalDate.value);
@@ -572,7 +575,9 @@ export const WEEKDAY: AddFunctionDescription = {
       case 3:
         return m === 0 ? 6 : m - 1;
     }
-    throw new Error(_lt(`Function [[FUNCTION_NAME]] parameter 2 value ${_type} is out of range.`));
+    throw new Error(
+      _lt("Function [[FUNCTION_NAME]] parameter 2 value %s is out of range.", _type.toString())
+    );
   },
 };
 
@@ -604,7 +609,7 @@ export const WEEKNUM: AddFunctionDescription = {
       return ISOWEEKNUM.compute(date);
     } else {
       throw new Error(
-        _lt(`Function [[FUNCTION_NAME]] parameter 2 value ${_type} is out of range.`)
+        _lt("Function [[FUNCTION_NAME]] parameter 2 value %s is out of range.", _type.toString())
       );
     }
 

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -154,7 +154,10 @@ export const LOOKUP: AddFunctionDescription = {
     if (nbCol > 1) {
       if (nbCol - 1 < index) {
         throw new Error(
-          _lt(`[[FUNCTION_NAME]] evaluates to an out of range row value ${index + 1}.`)
+          _lt(
+            "[[FUNCTION_NAME]] evaluates to an out of range row value %s.",
+            (index + 1).toString()
+          )
         );
       }
       return resultRange[index][0];
@@ -162,7 +165,10 @@ export const LOOKUP: AddFunctionDescription = {
 
     if (nbRow - 1 < index) {
       throw new Error(
-        _lt(`[[FUNCTION_NAME]] evaluates to an out of range column value ${index + 1}.`)
+        _lt(
+          "[[FUNCTION_NAME]] evaluates to an out of range column value %s.",
+          (index + 1).toString()
+        )
       );
     }
     return resultRange[0][index];
@@ -207,7 +213,7 @@ export const MATCH: AddFunctionDescription = {
     if (index > -1) {
       return index + 1;
     } else {
-      throw new Error(_lt(`Did not find value '${searchKey}' in [[FUNCTION_NAME]] evaluation.`));
+      throw new Error(_lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", searchKey));
     }
   },
 };
@@ -292,7 +298,7 @@ export const VLOOKUP: AddFunctionDescription = {
     if (rowIndex > -1) {
       return range[_index - 1][rowIndex];
     } else {
-      throw new Error(_lt(`Did not find value '${searchKey}' in [[FUNCTION_NAME]] evaluation.`));
+      throw new Error(_lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", searchKey));
     }
   },
 };

--- a/src/functions/module_math.ts
+++ b/src/functions/module_math.ts
@@ -26,7 +26,8 @@ export const ACOS: AddFunctionDescription = {
     if (Math.abs(_value) > 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. Valid values are between -1 and 1 inclusive.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. Valid values are between -1 and 1 inclusive.",
+          _value.toString()
         )
       );
     }
@@ -50,7 +51,8 @@ export const ACOSH: AddFunctionDescription = {
     if (_value < 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. It should be greater than or equal to 1.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. It should be greater than or equal to 1.",
+          _value.toString()
         )
       );
     }
@@ -93,7 +95,8 @@ export const ACOTH: AddFunctionDescription = {
     if (Math.abs(_value) <= 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. Valid values cannot be between -1 and 1 inclusive.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. Valid values cannot be between -1 and 1 inclusive.",
+          _value.toString()
         )
       );
     }
@@ -117,7 +120,8 @@ export const ASIN: AddFunctionDescription = {
     if (Math.abs(_value) > 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. Valid values are between -1 and 1 inclusive.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %S. Valid values are between -1 and 1 inclusive.",
+          _value.toString()
         )
       );
     }
@@ -193,7 +197,8 @@ export const ATANH: AddFunctionDescription = {
     if (Math.abs(_value) >= 1) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. Valid values are between -1 and 1 exclusive.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. Valid values are between -1 and 1 exclusive.",
+          _value.toString()
         )
       );
     }
@@ -219,7 +224,11 @@ export const CEILING: AddFunctionDescription = {
     if (_value > 0 && _factor < 0) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] expects the parameter '${CEILING.args[1].name}' to be positive when parameter '${CEILING.args[0].name}' is positive. Change '${CEILING.args[1].name}' from [${_factor}] to a positive value.`
+          "Function [[FUNCTION_NAME]] expects the parameter '%s' to be positive when parameter '%s' is positive. Change '%s' from [%s] to a positive value.",
+          CEILING.args[1].name,
+          CEILING.args[0].name,
+          CEILING.args[1].name,
+          _factor.toString()
         )
       );
     }
@@ -513,7 +522,12 @@ export const CSCH: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 const decimalErrorParameter2 = (parameterName, base, value) =>
   _lt(
-    `Function DECIMAL expects the parameter '${parameterName}' to be a valid base ${base} representation. Change '${parameterName}' from [${value}] to a valid base ${base} representation.`
+    "Function DECIMAL expects the parameter '%s' to be a valid base %s representation. Change '%s' from [%s] to a valid base %s representation.",
+    parameterName,
+    base,
+    parameterName,
+    value,
+    base
   );
 
 export const DECIMAL: AddFunctionDescription = {
@@ -529,7 +543,10 @@ export const DECIMAL: AddFunctionDescription = {
     if (_base < 2 || _base > 36) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] expects the parameter '${DECIMAL.args[1].name}' to be between 2 and 36 inclusive. Change '${DECIMAL.args[1].name}' from [${_base}] to a value between 2 and 36.`
+          "Function [[FUNCTION_NAME]] expects the parameter '%s' to be between 2 and 36 inclusive. Change '%s' from [%s] to a value between 2 and 36.",
+          DECIMAL.args[1].name,
+          DECIMAL.args[1].name,
+          _base.toString()
         )
       );
     }
@@ -602,7 +619,11 @@ export const FLOOR: AddFunctionDescription = {
     if (_value > 0 && _factor < 0) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] expects the parameter '${FLOOR.args[1].name}' to be positive when parameter '${FLOOR.args[0].name}' is positive. Change '${FLOOR.args[1].name}' from [${_factor}] to a positive value.`
+          "Function [[FUNCTION_NAME]] expects the parameter '%s' to be positive when parameter '%s' is positive. Change '%s' from [%s] to a positive value.",
+          FLOOR.args[1].name,
+          FLOOR.args[0].name,
+          FLOOR.args[1].name,
+          _factor.toString()
         )
       );
     }
@@ -732,7 +753,8 @@ export const LN: AddFunctionDescription = {
     if (_value <= 0) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter 1 value is ${_value}. It should be greater than 0.`
+          "Function [[FUNCTION_NAME]] parameter 1 value is %s. It should be greater than 0.",
+          _value.toString()
         )
       );
     }
@@ -757,7 +779,9 @@ export const MOD: AddFunctionDescription = {
     if (_divisor === 0) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] expects the parameter '${MOD.args[1].name}' to be different from 0. Change '${MOD.args[1].name}' to a value other than 0.`
+          "Function [[FUNCTION_NAME]] expects the parameter '%s' to be different from 0. Change '%s' to a value other than 0.",
+          MOD.args[1].name,
+          MOD.args[1].name
         )
       );
     }
@@ -823,7 +847,11 @@ export const POWER: AddFunctionDescription = {
     if (!Number.isInteger(_exponent)) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] expects the parameter '${POWER.args[1].name}' to be an integer when parameter '${POWER.args[0].name}' is negative. Change '${POWER.args[1].name}' from [${_exponent}] to an integer value.`
+          "Function [[FUNCTION_NAME]] expects the parameter '%s' to be an integer when parameter '%s' is negative. Change '%s' from [%s] to an integer value.",
+          POWER.args[1].name,
+          POWER.args[0].name,
+          POWER.args[1].name,
+          _exponent.toString()
         )
       );
     }
@@ -908,7 +936,10 @@ export const RANDBETWEEN: AddFunctionDescription = {
     if (_high < _low) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter '${RANDBETWEEN.args[1].name}' value is ${_high}. It should be greater than or equal to [${_low}].`
+          "Function [[FUNCTION_NAME]] parameter '%s' value is %s. It should be greater than or equal to [%s].",
+          RANDBETWEEN.args[1].name,
+          _high.toString(),
+          _low.toString()
         )
       );
     }
@@ -1075,7 +1106,10 @@ export const SQRT: AddFunctionDescription = {
     if (_value < 0) {
       throw new Error(
         _lt(
-          `Function [[FUNCTION_NAME]] parameter '${SQRT.args[0].name}' value is negative. It should be positive or zero. Change '${SQRT.args[0].name}' from [${_value}] to a positive value.`
+          "Function [[FUNCTION_NAME]] parameter '%s' value is negative. It should be positive or zero. Change '%s' from [%s] to a positive value.",
+          SQRT.args[0].name,
+          SQRT.args[0].name,
+          _value.toString()
         )
       );
     }

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -31,7 +31,13 @@ function covariance(dataY: any[], dataX: any[], isSample: boolean): number {
   });
 
   if (lenY !== lenX) {
-    throw new Error(_lt(`[[FUNCTION_NAME]] has mismatched argument count ${lenY} vs ${lenX}.`));
+    throw new Error(
+      _lt(
+        "[[FUNCTION_NAME]] has mismatched argument count %s vs %s.",
+        lenY.toString(),
+        lenX.toString()
+      )
+    );
   }
 
   let count = 0;
@@ -502,7 +508,9 @@ export const LARGE: AddFunctionDescription = {
       throw new Error(_lt(`[[FUNCTION_NAME]] has no valid input data.`));
     }
     if (count < n) {
-      throw new Error(_lt(`Function [[FUNCTION_NAME]] parameter 2 value ${n} is out of range.`));
+      throw new Error(
+        _lt("Function [[FUNCTION_NAME]] parameter 2 value %s is out of range.", n.toString())
+      );
     }
     return result;
   },
@@ -848,7 +856,9 @@ export const SMALL: AddFunctionDescription = {
       throw new Error(_lt(`[[FUNCTION_NAME]] has no valid input data.`));
     }
     if (count < n) {
-      throw new Error(_lt(`Function [[FUNCTION_NAME]] parameter 2 value ${n} is out of range.`));
+      throw new Error(
+        _lt("Function [[FUNCTION_NAME]] parameter 2 value %s is out of range.", n.toString())
+      );
     }
     return result;
   },

--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -18,7 +18,10 @@ export const CHAR: AddFunctionDescription = {
     const _tableNumber = Math.trunc(toNumber(tableNumber));
     if (_tableNumber < 1) {
       throw new Error(
-        _lt(`Function [[FUNCTION_NAME]] parameter 1 value ${_tableNumber} is out of range.`)
+        _lt(
+          "Function [[FUNCTION_NAME]] parameter 1 value %s is out of range.",
+          _tableNumber.toString()
+        )
       );
     }
     return String.fromCharCode(_tableNumber);
@@ -88,7 +91,9 @@ export const FIND: AddFunctionDescription = {
     if (result < 0) {
       throw new Error(
         _lt(
-          `In [[FUNCTION_NAME]] evaluation, cannot find '${_searchFor}' within '${_textToSearch}'.`
+          "In [[FUNCTION_NAME]] evaluation, cannot find '%s' within '%s'.",
+          _searchFor.toString(),
+          _textToSearch
         )
       );
     }
@@ -259,7 +264,9 @@ export const SEARCH: AddFunctionDescription = {
     if (result < 0) {
       throw new Error(
         _lt(
-          `In [[FUNCTION_NAME]] evaluation, cannot find '${_searchFor}' within '${_textToSearch}'.`
+          "In [[FUNCTION_NAME]] evaluation, cannot find '%s' within '%s'.",
+          _searchFor,
+          _textToSearch
         )
       );
     }

--- a/src/helpers/coordinates.ts
+++ b/src/helpers/coordinates.ts
@@ -2,8 +2,6 @@
 // Coordinate
 //------------------------------------------------------------------------------
 
-import { _lt } from "../translation";
-
 /**
  * Convert a (col) number to the corresponding letter.
  *
@@ -52,7 +50,7 @@ export function toCartesian(xc: string): [number, number] {
   xc = xc.toUpperCase();
   const [m, letters, numbers] = xc.match(/\$?([A-Z]*)\$?([0-9]*)/)!;
   if (m !== xc) {
-    throw new Error(_lt(`Invalid cell description: ${xc}`));
+    throw new Error(`Invalid cell description: ${xc}`);
   }
   const col = lettersToNumber(letters);
   const row = parseInt(numbers, 10) - 1;

--- a/src/model.ts
+++ b/src/model.ts
@@ -167,7 +167,7 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
       plugin.import(data);
       for (let name of Plugin.getters) {
         if (!(name in plugin)) {
-          throw new Error(_lt(`Invalid getter name: ${name} for plugin ${plugin.constructor}`));
+          throw new Error(`Invalid getter name: ${name} for plugin ${plugin.constructor}`);
         }
         this.getters[name] = plugin[name].bind(plugin);
       }

--- a/src/plugins/ui/sort.ts
+++ b/src/plugins/ui/sort.ts
@@ -10,7 +10,7 @@ import {
   Sheet,
   SortDirection,
   UID,
-  Zone
+  Zone,
 } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -113,9 +113,9 @@ export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetEnv) => {
     last = zone.bottom;
   }
   if (first === last) {
-    return _lt(`Clear row ${first + 1}`);
+    return _lt("Clear row %s", (first + 1).toString());
   }
-  return _lt(`Clear rows ${first + 1} - ${last + 1}`);
+  return _lt("Clear rows %s - %s", (first + 1).toString(), (last + 1).toString());
 };
 
 export const DELETE_CONTENT_ROWS_ACTION = (env: SpreadsheetEnv) => {
@@ -142,9 +142,9 @@ export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetEnv) => {
     last = zone.right;
   }
   if (first === last) {
-    return _lt(`Clear column ${numberToLetters(first)}`);
+    return _lt("Clear column %s", numberToLetters(first));
   }
-  return _lt(`Clear columns ${numberToLetters(first)} - ${numberToLetters(last)}`);
+  return _lt("Clear columns %s - %s", numberToLetters(first), numberToLetters(last));
 };
 
 export const DELETE_CONTENT_COLUMNS_ACTION = (env: SpreadsheetEnv) => {
@@ -171,9 +171,9 @@ export const REMOVE_ROWS_NAME = (env: SpreadsheetEnv) => {
     last = zone.bottom;
   }
   if (first === last) {
-    return _lt(`Delete row ${first + 1}`);
+    return _lt("Delete row %s", (first + 1).toString());
   }
-  return _lt(`Delete rows ${first + 1} - ${last + 1}`);
+  return _lt("Delete rows %s - %s", (first + 1).toString(), (last + 1).toString());
 };
 
 export const REMOVE_ROWS_ACTION = (env: SpreadsheetEnv) => {
@@ -203,9 +203,9 @@ export const REMOVE_COLUMNS_NAME = (env: SpreadsheetEnv) => {
     last = zone.right;
   }
   if (first === last) {
-    return _lt(`Delete column ${numberToLetters(first)}`);
+    return _lt("Delete column %s", numberToLetters(first));
   }
-  return _lt(`Delete columns ${numberToLetters(first)} - ${numberToLetters(last)}`);
+  return _lt("Delete columns %s - %s", numberToLetters(first), numberToLetters(last));
 };
 
 export const REMOVE_COLUMNS_ACTION = (env: SpreadsheetEnv) => {
@@ -227,12 +227,12 @@ export const MENU_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Row above");
   }
-  return _lt(`${number} Rows above`);
+  return _lt("%s Rows above", number.toString());
 };
 
 export const ROW_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   const number = getRowsNumber(env);
-  return number === 1 ? _lt("Insert row above") : _lt(`Insert ${number} rows above`);
+  return number === 1 ? _lt("Insert row above") : _lt("Insert %s rows above", number.toString());
 };
 
 export const CELL_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetEnv) => {
@@ -240,7 +240,7 @@ export const CELL_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Insert row");
   }
-  return _lt(`Insert ${number} rows`);
+  return _lt("Insert %s rows", number.toString());
 };
 
 export const INSERT_ROWS_BEFORE_ACTION = (env: SpreadsheetEnv) => {
@@ -268,12 +268,12 @@ export const MENU_INSERT_ROWS_AFTER_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Row below");
   }
-  return _lt(`${number} Rows below`);
+  return _lt("%s Rows below", number.toString());
 };
 
 export const ROW_INSERT_ROWS_AFTER_NAME = (env: SpreadsheetEnv) => {
   const number = getRowsNumber(env);
-  return number === 1 ? _lt("Insert row below") : _lt(`Insert ${number} rows below`);
+  return number === 1 ? _lt("Insert row below") : _lt("Insert %s rows below", number.toString());
 };
 
 export const INSERT_ROWS_AFTER_ACTION = (env: SpreadsheetEnv) => {
@@ -301,12 +301,14 @@ export const MENU_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Column left");
   }
-  return _lt(`${number} Columns left`);
+  return _lt("%s Columns left", number.toString());
 };
 
 export const COLUMN_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   const number = getColumnsNumber(env);
-  return number === 1 ? _lt("Insert column left") : _lt(`Insert ${number} columns left`);
+  return number === 1
+    ? _lt("Insert column left")
+    : _lt("Insert %s columns left", number.toString());
 };
 
 export const CELL_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetEnv) => {
@@ -314,7 +316,7 @@ export const CELL_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Insert column");
   }
-  return _lt(`Insert ${number} columns`);
+  return _lt("Insert %s columns", number.toString());
 };
 
 export const INSERT_COLUMNS_BEFORE_ACTION = (env: SpreadsheetEnv) => {
@@ -342,12 +344,14 @@ export const MENU_INSERT_COLUMNS_AFTER_NAME = (env: SpreadsheetEnv) => {
   if (number === 1) {
     return _lt("Column right");
   }
-  return _lt(`${number} Columns right`);
+  return _lt("%s Columns right", number.toString());
 };
 
 export const COLUMN_INSERT_COLUMNS_AFTER_NAME = (env: SpreadsheetEnv) => {
   const number = getColumnsNumber(env);
-  return number === 1 ? _lt("Insert column right") : _lt(`Insert ${number} columns right`);
+  return number === 1
+    ? _lt("Insert column right")
+    : _lt("Insert %s columns right", number.toString());
 };
 
 export const INSERT_COLUMNS_AFTER_ACTION = (env: SpreadsheetEnv) => {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -10,7 +10,6 @@
  * 2. it throws an error when the get operation fails
  * 3. it provides a chained API to add items to the registry.
  */
-import { _lt } from "./translation";
 
 export class Registry<T> {
   content: { [key: string]: T } = {};
@@ -31,7 +30,7 @@ export class Registry<T> {
    */
   get(key: string): T {
     if (!(key in this.content)) {
-      throw new Error(_lt(`Cannot find ${key} in this registry!`));
+      throw new Error(`Cannot find ${key} in this registry!`);
     }
     return this.content[key];
   }

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -4,10 +4,23 @@
  *  sub-env of Spreadsheet components as _t
  * */
 
-export type TranslationFunction = (string) => string;
+export type TranslationFunction = (
+  string: string,
+  ...values: string[] | [{ [key: string]: string }]
+) => string;
 
 // define a mock translation function, when o-spreadsheet runs in standalone it doesn't translate any string
 let _t: TranslationFunction = (s) => s;
+
+function sprintf(s: string, ...values: string[] | [{ [key: string]: string }]): string {
+  if (values.length === 1 && typeof values[0] === "object") {
+    const valuesDict = values[0] as { [key: string]: string };
+    s = s.replace(/\%\(?([^\)]+)\)s/g, (match, value) => valuesDict[value]);
+  } else if (values.length > 0) {
+    s = s.replace(/\%s/g, () => values.shift() as string);
+  }
+  return s;
+}
 
 /***
  * Allow to inject a translation function from outside o-spreadsheet.
@@ -17,10 +30,13 @@ export function setTranslationMethod(tfn: TranslationFunction) {
   _t = tfn;
 }
 
-export const _lt: TranslationFunction = function (s) {
+export const _lt: TranslationFunction = function (
+  s,
+  ...values: string[] | [{ [key: string]: string }]
+) {
   return ({
     toString: function () {
-      return _t(s);
+      return sprintf(_t(s), ...values);
     },
     // casts the object to unknown then to string to trick typescript into thinking that the object it receives is actually a string
     // this way it will be typed correctly (behaves like a string) but tests like typeof _lt("whatever") will be object and not string !

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -1,4 +1,4 @@
-import { UID, Range } from ".";
+import { Range, UID } from ".";
 
 export interface DataSet {
   labelCell?: Range; // range of the label


### PR DESCRIPTION
Using backtick to translate will not work with the translation system.
```js
const x = 2;
_lt(`Hello ${x}`);
```
`Hello ${x}` is evaluated *before* the lookup in the table of
translation, so we are looking for "Hello 2" in the table, which is
not correct.

This commit introduces the way to translate such strings in the following
way:
```js
const x = 2;
_lt("Hello %s", x.toString());
```

Forward port of eef1c5e34658e58d3a38f1ef5489d9fe16c3c535