### PR TITLE
[FIX] Charts: charts crashes when removing sheet with chart data

### DIFF
--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -40,6 +40,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "applyOffset",
     "getSheetName",
     "getSheet",
+    "tryGetSheet",
     "getSheetIdByName",
     "getSheets",
     "getVisibleSheets",
@@ -266,6 +267,10 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   // Getters
   // ---------------------------------------------------------------------------
 
+  tryGetSheet(sheetId: UID): Sheet | undefined {
+    return this.sheets[sheetId];
+  }
+
   getSheet(sheetId: UID): Sheet {
     const sheet = this.sheets[sheetId];
     if (!sheet) {
@@ -320,7 +325,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   }
 
   getCell(sheetId: UID, col: number, row: number): Cell | undefined {
-    const sheet = this.getSheet(sheetId);
+    const sheet = this.tryGetSheet(sheetId);
     return (sheet && sheet.rows[row] && sheet.rows[row].cells[col]) || undefined;
   }
 
@@ -912,7 +917,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     const freezeRow = symbol.includes("$", 1);
     x += freezeCol && updateFreeze ? 0 : offsetX;
     y += freezeRow && updateFreeze ? 0 : offsetY;
-    const sheet = this.getters.getSheet(referenceSheetId || sheetId);
+    const sheet = this.getSheet(referenceSheetId || sheetId);
     if (!sheet || x < 0 || x >= sheet.cols.length || y < 0 || y >= sheet.rows.length) {
       return INCORRECT_RANGE_STRING;
     }

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -175,7 +175,7 @@ export class EvaluationPlugin extends UIPlugin {
   getRangeValues(reference: string, defaultSheetId: UID): any[][] {
     const [range, sheetName] = reference.split("!").reverse();
     const sheetId = sheetName ? this.getters.getSheetIdByName(sheetName) : defaultSheetId;
-    const sheet = sheetId ? this.getters.getSheet(sheetId) : undefined;
+    const sheet = sheetId ? this.getters.tryGetSheet(sheetId) : undefined;
     if (sheet === undefined) return [[]];
     return mapCellsInZone(toZone(range), sheet, (cell) => cell.value);
   }

--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -175,14 +175,13 @@ export class EvaluationChartPlugin extends UIPlugin {
   }
 
   private mapDefinitionToRuntime(definition: ChartDefinition): ChartConfiguration {
-    const labels = definition.labelRange
-      ? this.getters
-          .getRangeFormattedValues(
-            this.getters.getRangeString(definition.labelRange, definition.sheetId),
-            definition.sheetId
-          )
-          .flat(1)
-      : [];
+    let labels: string[] = [];
+    if (definition.labelRange) {
+      const rangeString = this.getters.getRangeString(definition.labelRange, definition.sheetId);
+      if (rangeString !== "#REF") {
+        labels = this.getters.getRangeFormattedValues(rangeString, definition.sheetId).flat(1);
+      }
+    }
     const runtime = this.getDefaultConfiguration(definition.type, definition.title, labels);
 
     let graphColorIndex = 0;

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -31,6 +31,7 @@ export interface CoreGetters {
   applyOffset: SheetPlugin["applyOffset"];
   getEvaluationSheets: SheetPlugin["getEvaluationSheets"];
   getSheet: SheetPlugin["getSheet"];
+  tryGetSheet: SheetPlugin["tryGetSheet"];
   getSheetName: SheetPlugin["getSheetName"];
   getSheetIdByName: SheetPlugin["getSheetIdByName"];
   getSheets: SheetPlugin["getSheets"];

--- a/tests/components/charts_test.ts
+++ b/tests/components/charts_test.ts
@@ -338,3 +338,63 @@ describe("figures", () => {
     expect((labels!.querySelector(".o-selection input") as HTMLInputElement).value).toBe("A2:A4");
   });
 });
+describe("charts with multiple sheets", () => {
+  beforeEach(async () => {
+    fixture = makeTestFixture();
+    mockChartData = mockChart();
+    model = new Model({
+      sheets: [
+        {
+          name: "Sheet1",
+          cells: {
+            B1: { content: "first dataset" },
+            B2: { content: "12" },
+            B3: { content: "13" },
+            B4: { content: "14" },
+            C1: { content: "second dataset" },
+            C2: { content: "2" },
+            C3: { content: "3" },
+            C4: { content: "4" },
+            A2: { content: "Emily Anderson (Emmy)" },
+            A3: { content: "Sophie Allen (Saffi)" },
+            A4: { content: "Chloe Adams" },
+          },
+        },
+        {
+          name: "Sheet2",
+          figures: [
+            {
+              id: "1",
+              tag: "chart",
+              width: 400,
+              height: 300,
+              x: 100,
+              y: 100,
+              data: {
+                type: "line",
+                title: "demo chart",
+                labelRange: "Sheet1!A2:A4",
+                dataSets: ["Sheet1!B1:B4", "Sheet1!C1:C4"],
+                dataSetsHaveTitle: true,
+              },
+            },
+          ],
+        },
+      ],
+    });
+    parent = new GridParent(model);
+    await parent.mount(fixture);
+    await nextTick();
+  });
+  afterEach(() => {
+    fixture.remove();
+  });
+  test("delete sheet containing chart data doesnt crash", async () => {
+    expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("Sheet1");
+    model.dispatch("DELETE_SHEET", { sheetId: model.getters.getActiveSheetId() });
+    const runtimeChart = model.getters.getChartRuntime("1");
+    expect(runtimeChart).toBeDefined();
+    await nextTick();
+    expect(fixture.querySelector(".o-chart-container")).toBeDefined();
+  });
+});

--- a/tests/model/plugins/chart_test.ts
+++ b/tests/model/plugins/chart_test.ts
@@ -724,7 +724,7 @@ describe.skip("multiple sheets", function () {
 test.skip("select a graph, it should have the  resize handles", () => {});
 describe.skip("size and position", function () {
   test("resize columns before a graph, it should move", () => {});
-  test("resize columns before within graph, it should resize and rerender at the correct size", () => {});
+  test("resize columns within graph, it should resize and rerender at the correct size", () => {});
   test("delete a column before a graph, it should move", () => {});
   test("delete a columns within graph, it should resize and rerender at the size-sizeOfRemovedColumn", () => {});
   test("delete all columns that a graph is defined on, it should remove the graph", () => {});

--- a/tests/plugins/core_test.ts
+++ b/tests/plugins/core_test.ts
@@ -555,6 +555,7 @@ describe("history", () => {
       expect(model.getters.getRangeValues("Sheet1!B2", sheet1Id)).toEqual([[true]]);
       expect(model.getters.getRangeValues("Sheet2!B2", sheet2Id)).toEqual([[true]]);
       expect(model.getters.getRangeValues("Sheet2!B2", sheet1Id)).toEqual([[true]]);
+      expect(model.getters.getRangeValues("B2", "invalidSheetId")).toEqual([[]]);
     });
   });
 });

--- a/tests/plugins/sheets_test.ts
+++ b/tests/plugins/sheets_test.ts
@@ -148,11 +148,17 @@ describe("sheets", () => {
     expect(getCell(model, "A1")!.value).toBe(3);
   });
 
-  test("throw if invalid sheet name", () => {
+  test("show #ERROR if invalid sheet name in content", () => {
     const model = new Model();
     setCellContent(model, "A1", "=Sheet133!A1");
 
     expect(getCell(model, "A1")!.value).toBe("#ERROR");
+  });
+
+  test("does not throw if invalid sheetId", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "hello");
+    expect(getCell(model, "A1", "invalidSheetId")!).toBe(undefined);
   });
 
   test("cannot activate an invalid sheet", () => {


### PR DESCRIPTION
currenlty the spreadsheet will crash when removing a sheet with chart data,
when trying to render the chart afterwards.

task-id: 2448448