### PR TITLE
[FIX] CF: correct the condition to accept a create command

### DIFF
--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -179,11 +179,23 @@ export class ConditionalFormatPlugin
     switch (rule.type) {
       case "CellIsRule":
         if (rule.operator === "Between" || rule.operator === "NotBetween") {
-          if (rule.values.length !== 2) {
+          if (rule.values.length !== 2 || rule.values.some((x) => x === "")) {
             return CancelledReason.InvalidNumberOfArgs;
           }
         } else {
-          if (rule.values.length !== 1) {
+          if (
+            [
+              "BeginsWith",
+              "ContainsText",
+              "EndsWith",
+              "GreaterThan",
+              "GreaterThanOrEqual",
+              "LessThan",
+              "LessThanOrEqual",
+              "NotContains",
+            ].includes(rule.operator) &&
+            (rule.values[0] === "" || rule.values[0] === undefined)
+          ) {
             return CancelledReason.InvalidNumberOfArgs;
           }
         }

--- a/tests/plugins/clipboard_test.ts
+++ b/tests/plugins/clipboard_test.ts
@@ -1,9 +1,10 @@
 import { toCartesian } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { ClipboardPlugin } from "../../src/plugins/ui/clipboard";
-import { CancelledReason, ConditionalFormat, Style, Zone } from "../../src/types/index";
+import { CancelledReason, CommandSuccess, Zone } from "../../src/types/index";
 import "../canvas.mock";
 import {
+  createEqualCF,
   getBorder,
   getCell,
   getCellContent,
@@ -17,19 +18,6 @@ import {
 function getClipboardVisibleZones(model: Model): Zone[] {
   const clipboardPlugin = (model as any).handlers.find((h) => h instanceof ClipboardPlugin);
   return clipboardPlugin.status === "visible" ? clipboardPlugin.zones : [];
-}
-
-function createEqualCF(
-  ranges: string[],
-  value: string,
-  style: Style,
-  id: string
-): ConditionalFormat {
-  return {
-    ranges,
-    id,
-    rule: { values: [value], operator: "Equal", type: "CellIsRule", style },
-  };
 }
 
 describe("clipboard", () => {
@@ -823,10 +811,12 @@ describe("clipboard", () => {
     setCellContent(model, "A2", "2");
     setCellContent(model, "C1", "1");
     setCellContent(model, "C2", "2");
-    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+    let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF(["A1", "A2"], "1", { fillColor: "#FF0000" }, "1"),
       sheetId: model.getters.getActiveSheetId(),
     });
+
+    expect(result).toEqual({ status: "SUCCESS" } as CommandSuccess);
     model.dispatch("COPY", { target: target("A1") });
     model.dispatch("PASTE", { target: target("C1"), onlyValue: true });
     model.dispatch("COPY", { target: target("A2") });

--- a/tests/plugins/renderer_test.ts
+++ b/tests/plugins/renderer_test.ts
@@ -475,10 +475,11 @@ describe("renderer", () => {
     model.drawGrid(ctx);
     expect(fillStyle).toEqual([]);
     fillStyle = [];
-    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+    let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF(["A1"], "", { fillColor: "#DC6CDF" }, "1"),
       sheetId: model.getters.getActiveSheetId(),
     });
+    expect(result).toEqual({ status: "SUCCESS" });
     model.drawGrid(ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDF", h: 23, w: 96, x: 48, y: 26 }]);
   });


### PR DESCRIPTION
This fix changes the way we process the Conditional formats (CF) validation to allow Equal and NotEqual to have no parameter, and to ensure that Between and NotBetween have two parameters set. All other operators should have one parameter set.