### PR TITLE
[FIX] uuid: conflicts with fastId

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -124,6 +124,8 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
       this.setupUiPlugin(Plugin);
     }
 
+    setIsFastStrategy(false);
+
     // starting plugins
     this.dispatch("START");
   }


### PR DESCRIPTION
issue #757

Using fastId can ultimately lead to a conflict when used on sheets since
they are persistent. It can "only" work when the
ids are regenerated at load, therefore, we can deactivated the
`fastStrategy` once the import is done.
