### PR TITLE
[REF] sheet: Improve sheet validation

### DIFF
--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -66,27 +66,11 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   // ---------------------------------------------------------------------------
 
   allowDispatch(cmd: Command): CommandResult {
-    switch (cmd.type) {
-      case "REMOVE_COLUMNS":
-      case "REMOVE_ROWS":
-      case "ADD_ROWS":
-      case "ADD_COLUMNS":
-      case "RESIZE_COLUMNS":
-      case "RESIZE_ROWS":
-      case "AUTORESIZE_COLUMNS":
-      case "AUTORESIZE_ROWS":
-      case "UPDATE_CELL":
-      case "CLEAR_CELL":
-      case "RENAME_SHEET":
-      case "DELETE_SHEET":
-      case "DELETE_CONTENT":
-      case "DELETE_SHEET_CONFIRMATION":
-        if (this.sheets[cmd.sheetId] === undefined) {
-          return {
-            status: "CANCELLED",
-            reason: CancelledReason.InvalidSheetId,
-          };
-        }
+    if (cmd.type !== "CREATE_SHEET" && "sheetId" in cmd && this.sheets[cmd.sheetId] === undefined) {
+      return {
+        status: "CANCELLED",
+        reason: CancelledReason.InvalidSheetId,
+      };
     }
     switch (cmd.type) {
       case "CREATE_SHEET": {


### PR DESCRIPTION
Currently, every command with a `sheetId` argument should be explicitely added
to the `allowDispatch` validation. If the developper forgets,
the sheet is not validated. This is not very robust.

With this commit, every command (even future commands) with `sheetId` is
validated. With the exception of the "CREATE_SHEET" command, for an obvious
reason.