### PR TITLE
[REF] merge: Remove unused `isMergeDestructive` getter

### DIFF
--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -36,7 +36,6 @@ interface MergeState {
 
 export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
   static getters = [
-    "isMergeDestructive",
     "isInMerge",
     "isInSameMerge",
     "getMainCell",
@@ -158,28 +157,6 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
   }
 
   /**
-   * Return true if the current selection requires losing state if it is merged.
-   * This happens when there is some textual content in other cells than the
-   * top left.
-   */
-  isMergeDestructive(sheet: Sheet, zone: Zone): boolean {
-    let { left, right, top, bottom } = zone;
-    right = clip(right, 0, sheet.cols.length - 1);
-    bottom = clip(bottom, 0, sheet.rows.length - 1);
-    for (let row = top; row <= bottom; row++) {
-      const actualRow = this.getters.getRow(sheet.id, row)!;
-      for (let col = left; col <= right; col++) {
-        if (col !== left || row !== top) {
-          const cell = actualRow.cells[col];
-          if (cell && cell.type !== CellType.empty) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
-  }
-  /**
    * Return true if the zone intersects an existing merge:
    * if they have at least a common cell
    */
@@ -244,6 +221,29 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
   // ---------------------------------------------------------------------------
   // Merges
   // ---------------------------------------------------------------------------
+
+  /**
+   * Return true if the current selection requires losing state if it is merged.
+   * This happens when there is some textual content in other cells than the
+   * top left.
+   */
+  private isMergeDestructive(sheet: Sheet, zone: Zone): boolean {
+    let { left, right, top, bottom } = zone;
+    right = clip(right, 0, sheet.cols.length - 1);
+    bottom = clip(bottom, 0, sheet.rows.length - 1);
+    for (let row = top; row <= bottom; row++) {
+      const actualRow = this.getters.getRow(sheet.id, row)!;
+      for (let col = left; col <= right; col++) {
+        if (col !== left || row !== top) {
+          const cell = actualRow.cells[col];
+          if (cell && cell.type !== CellType.empty) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
 
   private getMergeById(sheetId: UID, mergeId: number): Merge | undefined {
     const merges = this.merges[sheetId];

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -58,7 +58,6 @@ export interface CoreGetters {
   getPasteZones: ClipboardPlugin["getPasteZones"];
 
   expandZone: MergePlugin["expandZone"];
-  isMergeDestructive: MergePlugin["isMergeDestructive"];
   isInMerge: MergePlugin["isInMerge"];
   getMainCell: MergePlugin["getMainCell"];
   doesIntersectMerge: MergePlugin["doesIntersectMerge"];

--- a/tests/plugins/merges_test.ts
+++ b/tests/plugins/merges_test.ts
@@ -206,9 +206,11 @@ describe("merges", () => {
   });
 
   test("properly compute if a merge is destructive or not", () => {
+    const sheetId = "42";
     const model = new Model({
       sheets: [
         {
+          id: sheetId,
           colNumber: 10,
           rowNumber: 10,
           cells: { B2: { content: "b2" } },
@@ -216,20 +218,23 @@ describe("merges", () => {
       ],
     });
     // B2 is not top left, so it is destructive
-    expect(
-      model.getters.isMergeDestructive(model.getters.getActiveSheet(), toZone("A1:C4"))
-    ).toBeTruthy();
+    expect(model.dispatch("ADD_MERGE", { sheetId, zone: toZone("A1:C4") })).toEqual({
+      status: "CANCELLED",
+      reason: CancelledReason.MergeIsDestructive,
+    });
 
     // B2 is top left, so it is not destructive
-    expect(
-      model.getters.isMergeDestructive(model.getters.getActiveSheet(), toZone("B2:C4"))
-    ).toBeFalsy();
+    expect(model.dispatch("ADD_MERGE", { sheetId, zone: toZone("B2:C4") })).toEqual({
+      status: "SUCCESS",
+    });
   });
 
   test("a merge with only style should not be considered destructive", () => {
+    const sheetId = "42";
     const model = new Model({
       sheets: [
         {
+          id: sheetId,
           colNumber: 10,
           rowNumber: 10,
           cells: { B2: { style: 1 } },
@@ -237,10 +242,9 @@ describe("merges", () => {
       ],
       styles: { 1: {} },
     });
-
-    expect(
-      model.getters.isMergeDestructive(model.getters.getActiveSheet(), toZone("A1:C4"))
-    ).toBeFalsy();
+    expect(model.dispatch("ADD_MERGE", { sheetId, zone: toZone("A1:C4") })).toEqual({
+      status: "SUCCESS",
+    });
   });
 
   test("merging destructively a selection ask for confirmation", async () => {


### PR DESCRIPTION
The getter `isMergeDestructive` is never used outside tests.
With this commit, the method is no longer exposed as a getter.
This reduces the public API to maintain.

Tests that used the getters are adapted.