### PR TITLE
[FIX] data: do not mutate imported data

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -20,7 +20,7 @@ export function load(data?: any): WorkbookData {
   if (!data) {
     return createEmptyWorkbookData();
   }
-  data = Object.assign({}, data);
+  data = JSON.parse(JSON.stringify(data));
 
   // apply migrations, if needed
   if ("version" in data) {

--- a/tests/plugins/conditional_formatting_test.ts
+++ b/tests/plugins/conditional_formatting_test.ts
@@ -246,7 +246,7 @@ describe("conditional format", () => {
     const workbookData = model.exportData();
     const newModel = new Model(workbookData);
     const sheetId = model.getters.getActiveSheetId();
-    expect(newModel.getters.getConditionalFormats(sheetId)).toBe(
+    expect(newModel.getters.getConditionalFormats(sheetId)).toEqual(
       model.getters.getConditionalFormats(sheetId)
     );
   });


### PR DESCRIPTION
Before this commit, the imported data could be mutated by plugins.
Now, a deep copy of the imported data is done before givin it to plugins.

Fixes #753