### PR TITLE
[FIX] clipboard: cut and paste a formula

### DIFF
--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -98,6 +98,8 @@ export class ClipboardPlugin extends UIPlugin {
           cmd.originSheet,
           cmd.origin,
           cmd.originBorder,
+          cmd.originCol,
+          cmd.originRow,
           cmd.col,
           cmd.row,
           cmd.onlyValue,
@@ -423,6 +425,8 @@ export class ClipboardPlugin extends UIPlugin {
     originSheet: UID,
     origin: Cell | null,
     originBorder: Border | null,
+    originCol: number,
+    originRow: number,
     col: number,
     row: number,
     onlyValue: boolean,
@@ -447,9 +451,8 @@ export class ClipboardPlugin extends UIPlugin {
           content = this.valueToContent(origin.value);
         }
       } else if (!onlyFormat && origin.type === CellType.formula) {
-        const position = this.getters.getCellPosition(origin.id);
-        const offsetX = col - position.col;
-        const offsetY = row - position.row;
+        const offsetX = col - originCol;
+        const offsetY = row - originRow;
         // TODO: replace with range specific stuff
         content = this.getters.applyOffset(sheetId, content, offsetX, offsetY);
       }

--- a/tests/plugins/clipboard_test.ts
+++ b/tests/plugins/clipboard_test.ts
@@ -1241,6 +1241,24 @@ describe("clipboard: pasting outside of sheet", () => {
     expect(getCellContent(model, "B2")).toBe("txt");
   });
 
+  test("Can cut & paste a formula", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=1");
+    model.dispatch("CUT", { target: target("A1") });
+    model.dispatch("PASTE", { target: target("B1") });
+    expect(getCellContent(model, "A1")).toBe("");
+    expect(getCellText(model, "B1")).toBe("=1");
+  });
+
+  test("Cut & paste a formula correctly update offsets", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=B2");
+    model.dispatch("CUT", { target: target("A1") });
+    model.dispatch("PASTE", { target: target("C2") });
+    expect(getCellContent(model, "A1")).toBe("");
+    expect(getCellText(model, "C2")).toBe("=D3");
+  });
+
   test("can paste multiple cells from os to outside of sheet", () => {
     const model = new Model();
 


### PR DESCRIPTION
Before this commit, it was not possible to cut & paste a formula.

Fixes #700