### PR TITLE
Master viewports rar

### DIFF
--- a/src/components/autofill.ts
+++ b/src/components/autofill.ts
@@ -1,6 +1,7 @@
 import * as owl from "@odoo/owl";
+import { AUTOFILL_EDGE_LENGTH } from "../constants";
 import { clip } from "../helpers/misc";
-import { SpreadsheetEnv, Viewport } from "../types";
+import { SpreadsheetEnv } from "../types";
 import { startDnd } from "./helpers/drag_and_drop";
 
 const { Component } = owl;
@@ -31,8 +32,8 @@ const CSS = css/* scss */ `
 
     .o-autofill-handler {
       position: absolute;
-      height: 8px;
-      width: 8px;
+      height: ${AUTOFILL_EDGE_LENGTH}px;
+      width: ${AUTOFILL_EDGE_LENGTH}px;
 
       &:hover {
         cursor: crosshair;
@@ -53,7 +54,6 @@ const CSS = css/* scss */ `
 
 interface Props {
   position: Position;
-  viewport: Viewport;
 }
 
 interface Position {
@@ -117,11 +117,9 @@ export class Autofill extends Component<Props, SpreadsheetEnv> {
       };
       const parent = this.el!.parentElement! as HTMLElement;
       const position = parent.getBoundingClientRect();
-      const col = this.env.getters.getColIndex(
-        ev.clientX - position.left,
-        this.props.viewport.left
-      );
-      const row = this.env.getters.getRowIndex(ev.clientY - position.top, this.props.viewport.top);
+      const { top: viewportTop, left: viewportLeft } = this.env.getters.getActiveSnappedViewport();
+      const col = this.env.getters.getColIndex(ev.clientX - position.left, viewportLeft);
+      const row = this.env.getters.getRowIndex(ev.clientY - position.top, viewportTop);
       if (lastCol !== col || lastRow !== row) {
         const activeSheet = this.env.getters.getActiveSheet();
         lastCol = col === -1 ? lastCol : clip(col, 0, activeSheet.cols.length);

--- a/src/components/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag.ts
@@ -49,12 +49,14 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetEnv> {
   static style = CSS;
 
   get tagStyle(): string {
-    const { col, row, viewport, color } = this.props;
+    const { col, row, color } = this.props;
+    const viewport = this.env.getters.getActiveSnappedViewport();
+    const { height } = this.env.getters.getViewportDimension();
     const [x, y, ,] = this.env.getters.getRect(
       { left: col, top: row, right: col, bottom: row },
       viewport
     );
-    return `bottom: ${viewport.height - y + 15}px;left: ${
+    return `bottom: ${height - y + 15}px;left: ${
       x - 1
     }px;border: 1px solid ${color};background-color: ${color};${
       this.props.active ? "opacity:1 !important" : ""

--- a/src/components/composer/grid_composer.ts
+++ b/src/components/composer/grid_composer.ts
@@ -1,6 +1,6 @@
 import * as owl from "@odoo/owl";
 import { fontSizeMap } from "../../fonts";
-import { Rect, SpreadsheetEnv, Viewport, Zone } from "../../types/index";
+import { Rect, SpreadsheetEnv, Zone } from "../../types/index";
 import { Composer } from "./composer";
 
 const { Component } = owl;
@@ -31,7 +31,6 @@ const CSS = css/* scss */ `
 `;
 
 interface Props {
-  viewport: Viewport;
   focus: boolean;
   content: string;
 }
@@ -57,7 +56,7 @@ export class GridComposer extends Component<Props, SpreadsheetEnv> {
       top: row,
       bottom: row,
     });
-    this.rect = this.getters.getRect(this.zone, this.props.viewport);
+    this.rect = this.getters.getRect(this.zone, this.getters.getActiveSnappedViewport());
   }
 
   get containerStyle(): string {

--- a/src/components/figures/container.ts
+++ b/src/components/figures/container.ts
@@ -2,7 +2,7 @@ import * as owl from "@odoo/owl";
 import { Component } from "@odoo/owl";
 import { HEADER_HEIGHT, HEADER_WIDTH, SELECTION_BORDER_COLOR } from "../../constants";
 import { figureRegistry } from "../../registries/index";
-import { Figure, SpreadsheetEnv, Viewport } from "../../types/index";
+import { Figure, SpreadsheetEnv } from "../../types/index";
 import { startDnd } from "../helpers/drag_and_drop";
 import { ChartFigure } from "./chart";
 
@@ -129,10 +129,7 @@ const CSS = css/*SCSS*/ `
   }
 `;
 
-export class FiguresContainer extends Component<
-  { viewport: Viewport; sidePanelIsOpen: Boolean },
-  SpreadsheetEnv
-> {
+export class FiguresContainer extends Component<{ sidePanelIsOpen: Boolean }, SpreadsheetEnv> {
   static template = TEMPLATE;
   static style = CSS;
   static components = {};
@@ -151,13 +148,11 @@ export class FiguresContainer extends Component<
 
   getVisibleFigures(): FigureInfo[] {
     const selectedId = this.getters.getSelectedFigureId();
-    return this.getters
-      .getVisibleFigures(this.getters.getActiveSheetId(), this.props.viewport)
-      .map((f) => ({
-        id: f.id,
-        isSelected: f.id === selectedId,
-        figure: f,
-      }));
+    return this.getters.getVisibleFigures(this.getters.getActiveSheetId()).map((f) => ({
+      id: f.id,
+      isSelected: f.id === selectedId,
+      figure: f,
+    }));
   }
 
   getDims(info: FigureInfo) {
@@ -169,7 +164,7 @@ export class FiguresContainer extends Component<
 
   getStyle(info: FigureInfo) {
     const { figure, isSelected } = info;
-    const { offsetX, offsetY } = this.props.viewport;
+    const { offsetX, offsetY } = this.getters.getActiveSnappedViewport();
     const target = figure.id === (isSelected && this.dnd.figureId) ? this.dnd : figure;
     const { width, height } = target;
     let x = target.x - offsetX + HEADER_WIDTH - 1;

--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -1,6 +1,6 @@
 import * as owl from "@odoo/owl";
 import { HEADER_HEIGHT, HEADER_WIDTH, MIN_COL_WIDTH, MIN_ROW_HEIGHT } from "../constants";
-import { Col, Row, SpreadsheetEnv, Viewport } from "../types/index";
+import { Col, Row, SpreadsheetEnv } from "../types/index";
 import { ContextMenuType } from "./grid";
 import { startDnd } from "./helpers/drag_and_drop";
 
@@ -230,11 +230,11 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getStateOffset(): number {
-    return this.props.viewport.offsetX - HEADER_WIDTH;
+    return this.getters.getActiveSnappedViewport().offsetX - HEADER_WIDTH;
   }
 
   _getViewportOffset(): number {
-    return this.props.viewport.left;
+    return this.getters.getActiveSnappedViewport().left;
   }
 
   _getClientPosition(ev: MouseEvent): number {
@@ -242,7 +242,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getElementIndex(index: number): number {
-    return this.getters.getColIndex(index, this.props.viewport.left);
+    return this.getters.getColIndex(index, this.getters.getActiveSnappedViewport().left);
   }
 
   _getElement(index: number): Col {
@@ -354,11 +354,11 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getStateOffset(): number {
-    return this.props.viewport.offsetY - HEADER_HEIGHT;
+    return this.getters.getActiveSnappedViewport().offsetY - HEADER_HEIGHT;
   }
 
   _getViewportOffset(): number {
-    return this.props.viewport.top;
+    return this.getters.getActiveSnappedViewport().top;
   }
 
   _getClientPosition(ev: MouseEvent): number {
@@ -366,7 +366,7 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getElementIndex(index: number): number {
-    return this.getters.getRowIndex(index, this.props.viewport.top);
+    return this.getters.getRowIndex(index, this.getters.getActiveSnappedViewport().top);
   }
 
   _getElement(index: number): Row {
@@ -424,15 +424,11 @@ export class RowResizer extends AbstractResizer {
   }
 }
 
-interface Props {
-  viewport: Viewport;
-}
-
-export class Overlay extends Component<Props, SpreadsheetEnv> {
+export class Overlay extends Component<any, SpreadsheetEnv> {
   static template = xml/* xml */ `
     <div class="o-overlay">
-      <ColResizer viewport="props.viewport"/>
-      <RowResizer viewport="props.viewport"/>
+      <ColResizer />
+      <RowResizer />
       <div class="all" t-on-mousedown.self="selectAll"/>
     </div>`;
 

--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -1,5 +1,5 @@
 import * as owl from "@odoo/owl";
-import { BOTTOMBAR_HEIGHT, TOPBAR_HEIGHT } from "../constants";
+import { BOTTOMBAR_HEIGHT, ICON_EDGE_LENGTH, TOPBAR_HEIGHT } from "../constants";
 import { Model } from "../model";
 import { ComposerSelection } from "../plugins/ui/edition";
 import { SelectionMode } from "../plugins/ui/selection";
@@ -62,8 +62,8 @@ const CSS = css/* scss */ `
   }
 
   .o-icon {
-    width: 18px;
-    height: 18px;
+    width: ${ICON_EDGE_LENGTH}px;
+    height: ${ICON_EDGE_LENGTH}px;
     opacity: 0.6;
   }
 `;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,8 @@ export const DEFAULT_CELL_WIDTH = 96;
 export const DEFAULT_CELL_HEIGHT = 23;
 export const SCROLLBAR_WIDTH = 15;
 export const PADDING_AUTORESIZE = 3;
+export const AUTOFILL_EDGE_LENGTH = 8;
+export const ICON_EDGE_LENGTH = 18;
 
 // Fonts
 export const DEFAULT_FONT_WEIGHT = "400";

--- a/src/model.ts
+++ b/src/model.ts
@@ -395,7 +395,7 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
   drawGrid(context: GridRenderingContext) {
     // we make sure here that the viewport is properly positioned: the offsets
     // correspond exactly to a cell
-    context.viewport = this.getters.snapViewportToCell(context.viewport);
+    context.viewport = this.getters.getActiveSnappedViewport(); //snaped one
     for (let [renderer, layer] of this.renderers) {
       context.ctx.save();
       renderer.drawGrid(context, layer);

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../constants";
 import {
   createCols,
   createDefaultCols,
@@ -49,7 +48,6 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "getCell",
     "getCellPosition",
     "getColCells",
-    "getGridSize",
     "getColsZone",
     "getRowsZone",
   ];
@@ -291,12 +289,6 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
       left: 0,
       right: this.getSheet(sheetId).cols.length - 1,
     };
-  }
-
-  getGridSize(sheet: Sheet): [number, number] {
-    const height = sheet.rows[sheet.rows.length - 1].end + DEFAULT_CELL_HEIGHT + 5;
-    const width = sheet.cols[sheet.cols.length - 1].end + DEFAULT_CELL_WIDTH;
-    return [width, height];
   }
 
   getCellPosition(cellId: UID): CellPosition {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -22,6 +22,7 @@ import { SelectionMultiUserPlugin } from "./ui/selection_multiuser";
 import { SortPlugin } from "./ui/sort";
 import { UIOptionsPlugin } from "./ui/ui_options";
 import { SheetUIPlugin } from "./ui/ui_sheet";
+import { ViewportPlugin } from "./ui/viewport";
 import { UIPluginConstructor } from "./ui_plugin";
 
 export const corePluginRegistry = new Registry<CorePluginConstructor>()
@@ -44,6 +45,7 @@ export const uiPluginRegistry = new Registry<UIPluginConstructor>()
   .add("edition", EditionPlugin)
   .add("highlight", HighlightPlugin)
   .add("selectionInput", SelectionInputPlugin)
+  .add("viewport", ViewportPlugin)
   .add("grid renderer", RendererPlugin)
   .add("autofill", AutofillPlugin)
   .add("find_and_replace", FindAndReplacePlugin)

--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -1,0 +1,314 @@
+import {
+  DEFAULT_CELL_HEIGHT,
+  DEFAULT_CELL_WIDTH,
+  HEADER_HEIGHT,
+  HEADER_WIDTH,
+} from "../../constants";
+import { Mode } from "../../model";
+import { Command, Sheet, UID, Viewport, ZoneDimension } from "../../types/index";
+import { UIPlugin } from "../ui_plugin";
+
+interface ViewportPluginState {
+  readonly viewports: Record<UID, Viewport>;
+}
+
+/**
+ * Viewport plugin.
+ *
+ * This plugin manages all things related to all viewport states.
+ *
+ * There are two types of viewports :
+ *  1. The viewport related to the scrollbar absolute position
+ *  2. The snappedViewport which represents the previous one but but 'snapped' to
+ *     the col/row structure, so, the offsets are correct for computations necessary
+ *     to align elements to the grid.
+ */
+export class ViewportPlugin extends UIPlugin {
+  static getters = [
+    "getActiveViewport",
+    "getSnappedViewport",
+    "getActiveSnappedViewport",
+    "getViewportDimension",
+    "getGridDimension",
+  ];
+  static modes: Mode[] = ["normal", "readonly"];
+
+  readonly viewports: ViewportPluginState["viewports"] = {};
+  readonly snappedViewports: ViewportPluginState["viewports"] = {};
+  private clientWidth: number = 0;
+  private clientHeight: number = 0;
+  private updateSnap: boolean = false;
+
+  // ---------------------------------------------------------------------------
+  // Command Handling
+  // ---------------------------------------------------------------------------
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "UNDO":
+      case "REDO":
+        this.cleanViewports();
+        this.resetViewports();
+        break;
+      case "RESIZE_VIEWPORT":
+        this.cleanViewports();
+        this.resizeViewport(cmd.height, cmd.width);
+        break;
+      case "SET_VIEWPORT_OFFSET":
+        this.setViewportOffset(cmd.offsetX, cmd.offsetY);
+        break;
+      case "REMOVE_ROWS":
+      case "RESIZE_ROWS":
+        this.adjustViewportOffsetY(cmd.sheetId);
+        break;
+      case "REMOVE_COLUMNS":
+      case "RESIZE_COLUMNS":
+        this.adjustViewportOffsetX(cmd.sheetId);
+        break;
+      case "ADD_COLUMNS":
+        this.adjustViewportZoneX(cmd.sheetId, this.getViewport(cmd.sheetId));
+        break;
+      case "ADD_ROWS":
+        this.adjustViewportZoneY(cmd.sheetId, this.getViewport(cmd.sheetId));
+        break;
+      case "ACTIVATE_SHEET":
+        this.refreshViewport(cmd.sheetIdTo);
+        break;
+      case "SELECT_CELL":
+      case "MOVE_POSITION":
+        this.refreshViewport(this.getters.getActiveSheetId());
+        break;
+      case "SELECT_ROW":
+      case "SELECT_COLUMN":
+        if (!cmd.updateRange) {
+          this.refreshViewport(this.getters.getActiveSheetId());
+        }
+        break;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Getters
+  // ---------------------------------------------------------------------------
+
+  getViewportDimension(): ZoneDimension {
+    return { width: this.clientWidth, height: this.clientHeight };
+  }
+
+  getActiveViewport(): Viewport {
+    const sheetId = this.getters.getActiveSheetId();
+    return this.getViewport(sheetId);
+  }
+
+  getActiveSnappedViewport(): Viewport {
+    const sheetId = this.getters.getActiveSheetId();
+    return this.getSnappedViewport(sheetId);
+  }
+
+  private getSnappedViewport(sheetId: UID) {
+    this.snapViewportToCell(sheetId);
+    return this.snappedViewports[sheetId];
+  }
+
+  getGridDimension(sheet: Sheet): ZoneDimension {
+    const lastCol = sheet.cols[sheet.cols.length - 1]; // to change with hide
+    const effectiveWidth = this.clientWidth - HEADER_WIDTH;
+    const lastRow = sheet.rows[sheet.rows.length - 1]; // to change with hide
+    const effectiveHeight = this.clientHeight - HEADER_HEIGHT;
+
+    const leftCol =
+      sheet.cols.find((col) => col.end > lastCol.end - effectiveWidth) ||
+      sheet.cols[sheet.cols.length - 1];
+    const topRow =
+      sheet.rows.find((row) => row.end > lastRow.end - effectiveHeight) ||
+      sheet.rows[sheet.rows.length - 1];
+
+    const width =
+      lastCol.end +
+      Math.max(DEFAULT_CELL_WIDTH, Math.min(leftCol.size, effectiveWidth - lastCol.size));
+    const height =
+      lastRow.end +
+      Math.max(DEFAULT_CELL_HEIGHT + 5, Math.min(topRow.size, effectiveHeight - lastRow.size));
+
+    return { width, height };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private getViewport(sheetId: UID): Viewport {
+    if (!this.viewports[sheetId]) {
+      return this.generateViewportState(sheetId);
+    }
+    return this.viewports[sheetId];
+  }
+
+  private cleanViewports() {
+    const sheets = this.getters.getVisibleSheets();
+    for (let sheetId of Object.keys(this.viewports)) {
+      if (!sheets.includes(sheetId)) {
+        delete this.viewports[sheetId];
+      }
+    }
+  }
+
+  private resetViewports() {
+    for (let sheetId of Object.keys(this.viewports)) {
+      this.adjustViewportOffsetX(sheetId);
+      this.adjustViewportOffsetY(sheetId);
+      this.adjustViewportsPosition(sheetId);
+    }
+  }
+
+  private adjustViewportOffsetX(sheetId: UID) {
+    const { offsetX } = this.getViewport(sheetId);
+    const { width: sheetWidth } = this.getGridDimension(this.getters.getSheet(sheetId));
+    if (this.clientWidth - HEADER_WIDTH + offsetX > sheetWidth) {
+      const diff = this.clientWidth - HEADER_WIDTH + offsetX - sheetWidth;
+      this.viewports[sheetId].offsetX = Math.max(0, offsetX - diff);
+    }
+    this.adjustViewportZoneX(sheetId, this.viewports[sheetId]);
+  }
+
+  private adjustViewportOffsetY(sheetId: UID) {
+    const { offsetY } = this.getViewport(sheetId);
+    const { height: sheetHeight } = this.getGridDimension(this.getters.getSheet(sheetId));
+    if (this.clientHeight - HEADER_HEIGHT + offsetY > sheetHeight) {
+      const diff = this.clientHeight - HEADER_HEIGHT + offsetY - sheetHeight;
+      this.viewports[sheetId].offsetY = Math.max(0, offsetY - diff);
+    }
+    this.adjustViewportZoneY(sheetId, this.viewports[sheetId]);
+  }
+
+  private resizeViewport(height: number, width: number) {
+    this.clientHeight = height;
+    this.clientWidth = width;
+    this.recomputeViewports();
+  }
+
+  private recomputeViewports() {
+    for (let sheetId of Object.keys(this.viewports)) {
+      this.adjustViewportZone(sheetId, this.viewports[sheetId]);
+    }
+  }
+
+  private setViewportOffset(offsetX: number, offsetY: number) {
+    const sheetId = this.getters.getActiveSheetId();
+    this.getActiveViewport();
+    this.viewports[sheetId].offsetX = offsetX;
+    this.viewports[sheetId].offsetY = offsetY;
+    this.adjustViewportZone(sheetId, this.viewports[sheetId]);
+  }
+
+  private generateViewportState(sheetId: UID): Viewport {
+    this.viewports[sheetId] = {
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      offsetX: 0,
+      offsetY: 0,
+    };
+    return this.viewports[sheetId];
+  }
+
+  private refreshViewport(sheetId: UID) {
+    const viewport = this.getViewport(sheetId);
+    this.adjustViewportZone(sheetId, viewport);
+    this.adjustViewportsPosition(sheetId);
+  }
+
+  private adjustViewportZone(sheetId: UID, viewport: Viewport) {
+    this.adjustViewportZoneX(sheetId, viewport);
+    this.adjustViewportZoneY(sheetId, viewport);
+  }
+
+  private adjustViewportZoneX(sheetId: UID, viewport: Viewport) {
+    const sheet = this.getters.getSheet(sheetId);
+    const cols = sheet.cols;
+    viewport.left = this.getters.getColIndex(viewport.offsetX + HEADER_WIDTH, 0, sheet);
+    const x = this.clientWidth + viewport.offsetX - HEADER_WIDTH;
+    viewport.right = cols.length - 1;
+    for (let i = viewport.left; i < cols.length; i++) {
+      if (x < cols[i].end) {
+        viewport.right = i;
+        break;
+      }
+    }
+    this.updateSnap = true;
+  }
+
+  private adjustViewportZoneY(sheetId: UID, viewport: Viewport) {
+    const sheet = this.getters.getSheet(sheetId);
+    const rows = sheet.rows;
+    viewport.top = this.getters.getRowIndex(viewport.offsetY + HEADER_HEIGHT, 0, sheet);
+    const y = this.clientHeight + viewport.offsetY - HEADER_HEIGHT;
+    viewport.bottom = rows.length - 1;
+    for (let i = viewport.top; i < rows.length; i++) {
+      if (y < rows[i].end) {
+        viewport.bottom = i;
+        break;
+      }
+    }
+    this.updateSnap = true;
+  }
+
+  /**
+   * This function will make sure that the current cell is part of the viewport that is actually
+   * displayed on the client, that is, the snapped one. We therefore adjust the offset of the snapped viewport
+   * until it contains the current cell completely.
+   * In order to keep the coherence of both viewports, it is also necessary to update the standard viewport
+   * if the zones of both viewports don't match.
+   */
+  private adjustViewportsPosition(sheetId: UID) {
+    const sheet = this.getters.getSheet(sheetId);
+    const { cols, rows } = sheet;
+    const adjustedViewport = this.getSnappedViewport(sheetId);
+    const [col, row] = this.getters.getMainCell(sheetId, ...this.getters.getSheetPosition(sheetId));
+    while (
+      cols[col].end > adjustedViewport.offsetX + this.clientWidth - HEADER_WIDTH &&
+      adjustedViewport.offsetX < cols[col].start
+    ) {
+      adjustedViewport.offsetX = cols[adjustedViewport.left].end;
+      this.adjustViewportZoneX(sheetId, adjustedViewport);
+    }
+    while (col < adjustedViewport.left) {
+      adjustedViewport.offsetX = cols[adjustedViewport.left - 1].start;
+      this.adjustViewportZoneX(sheetId, adjustedViewport);
+    }
+    while (
+      rows[row].end > adjustedViewport.offsetY + this.clientHeight - HEADER_HEIGHT &&
+      adjustedViewport.offsetY < rows[row].start
+    ) {
+      adjustedViewport.offsetY = rows[adjustedViewport.top].end;
+      this.adjustViewportZoneY(sheetId, adjustedViewport);
+    }
+    while (row < adjustedViewport.top) {
+      adjustedViewport.offsetY = rows[adjustedViewport.top - 1].start;
+      this.adjustViewportZoneY(sheetId, adjustedViewport);
+    }
+    // cast the new snappedViewport in the standard viewport
+    const { top, left } = this.viewports[sheetId];
+    if (top !== adjustedViewport.top || left !== adjustedViewport.left)
+      this.viewports[sheetId] = adjustedViewport;
+    this.updateSnap = false;
+  }
+
+  private snapViewportToCell(sheetId: UID) {
+    const { cols, rows } = this.getters.getSheet(sheetId);
+    const viewport = this.getViewport(sheetId);
+    const adjustedViewport = Object.assign({}, viewport);
+    adjustedViewport.offsetX = cols[viewport.left].start;
+    adjustedViewport.offsetY = rows[viewport.top].start;
+    this.adjustViewportZone(sheetId, adjustedViewport);
+    this.snappedViewports[sheetId] = adjustedViewport;
+  }
+
+  finalize() {
+    if (this.updateSnap) {
+      this.snapViewportToCell(this.getters.getActiveSheetId());
+      this.updateSnap = false;
+    }
+  }
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -726,6 +726,18 @@ export interface SortCommand extends BaseCommand {
 }
 export type SortDirection = "ascending" | "descending";
 
+export interface ResizeViewportCommand extends BaseCommand {
+  type: "RESIZE_VIEWPORT";
+  width: number;
+  height: number;
+}
+
+export interface SetViewportOffsetCommand extends BaseCommand {
+  type: "SET_VIEWPORT_OFFSET";
+  offsetX: number;
+  offsetY: number;
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -833,7 +845,9 @@ export type LocalCommand =
   | SelectSearchNextCommand
   | ReplaceSearchCommand
   | ReplaceAllSearchCommand
-  | SortCommand;
+  | SortCommand
+  | ResizeViewportCommand
+  | SetViewportOffsetCommand;
 
 export type Command = CoreCommand | LocalCommand;
 export interface CommandSuccess {

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -23,6 +23,7 @@ import { SelectionMultiUserPlugin } from "../plugins/ui/selection_multiuser";
 import { SortPlugin } from "../plugins/ui/sort";
 import { UIOptionsPlugin } from "../plugins/ui/ui_options";
 import { SheetUIPlugin } from "../plugins/ui/ui_sheet";
+import { ViewportPlugin } from "../plugins/ui/viewport";
 // -----------------------------------------------------------------------------
 // Getters
 // -----------------------------------------------------------------------------
@@ -45,7 +46,6 @@ export interface CoreGetters {
   getColCells: SheetPlugin["getColCells"];
   getColsZone: SheetPlugin["getColsZone"];
   getRowsZone: SheetPlugin["getRowsZone"];
-  getGridSize: SheetPlugin["getGridSize"];
 
   zoneToXC: CellPlugin["zoneToXC"];
   getCells: CellPlugin["getCells"];
@@ -97,6 +97,7 @@ export type Getters = CoreGetters & {
   getSelectedFigureId: SelectionPlugin["getSelectedFigureId"];
   getVisibleFigures: SelectionPlugin["getVisibleFigures"];
   getPosition: SelectionPlugin["getPosition"];
+  getSheetPosition: SelectionPlugin["getSheetPosition"];
   getAggregate: SelectionPlugin["getAggregate"];
   getSelectionMode: SelectionPlugin["getSelectionMode"];
   isSelected: SelectionPlugin["isSelected"];
@@ -123,9 +124,6 @@ export type Getters = CoreGetters & {
   getColIndex: RendererPlugin["getColIndex"];
   getRowIndex: RendererPlugin["getRowIndex"];
   getRect: RendererPlugin["getRect"];
-  snapViewportToCell: RendererPlugin["snapViewportToCell"];
-  adjustViewportPosition: RendererPlugin["adjustViewportPosition"];
-  adjustViewportZone: RendererPlugin["adjustViewportZone"];
 
   getEditionMode: EditionPlugin["getEditionMode"];
   isSelectingForComposer: EditionPlugin["isSelectingForComposer"];
@@ -145,4 +143,10 @@ export type Getters = CoreGetters & {
   getContiguousZone: SortPlugin["getContiguousZone"];
 
   getClientsToDisplay: SelectionMultiUserPlugin["getClientsToDisplay"];
+
+  getSnappedViewport: ViewportPlugin["getViewport"];
+  getViewportDimension: ViewportPlugin["getViewportDimension"];
+  getActiveViewport: ViewportPlugin["getActiveViewport"];
+  getActiveSnappedViewport: ViewportPlugin["getActiveSnappedViewport"];
+  getGridDimension: ViewportPlugin["getGridDimension"];
 };

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -16,9 +16,12 @@ export interface Box {
   error?: string;
 }
 
-export interface Viewport extends Zone {
+export interface GridDimension {
   width: number;
   height: number;
+}
+
+export interface Viewport extends Zone {
   offsetX: number;
   offsetY: number;
 }

--- a/tests/collaborative/collaborative_helpers.ts
+++ b/tests/collaborative/collaborative_helpers.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../src/model";
+import { createModelWithViewport } from "../test_helpers/commands_helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
 interface CollaborativeEnv {
   network: MockTransportService;
@@ -19,6 +20,24 @@ export function setupCollaborativeEnv(): CollaborativeEnv {
     client: { id: "bob", name: "Bob" },
   });
   const charlie = new Model(emptySheetData, {
+    transportService: network,
+    client: { id: "charlie", name: "Charlie" },
+  });
+  return { network, alice, bob, charlie };
+}
+
+export function setupCollaborativeEnvWithViewport(): CollaborativeEnv {
+  const network = new MockTransportService();
+  const emptySheetData = new Model().exportData();
+  const alice = createModelWithViewport(emptySheetData, {
+    transportService: network,
+    client: { id: "alice", name: "Alice" },
+  });
+  const bob = createModelWithViewport(emptySheetData, {
+    transportService: network,
+    client: { id: "bob", name: "Bob" },
+  });
+  const charlie = createModelWithViewport(emptySheetData, {
     transportService: network,
     client: { id: "charlie", name: "Charlie" },
   });

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../test_helpers/commands_helpers";
 import { getCell } from "../test_helpers/getters_helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
-import { setupCollaborativeEnv } from "./collaborative_helpers";
+import { setupCollaborativeEnvWithViewport } from "./collaborative_helpers";
 
 describe("Collaborative Sheet manipulation", () => {
   let network: MockTransportService;
@@ -21,7 +21,7 @@ describe("Collaborative Sheet manipulation", () => {
   let charlie: Model;
 
   beforeEach(() => {
-    ({ network, alice, bob, charlie } = setupCollaborativeEnv());
+    ({ network, alice, bob, charlie } = setupCollaborativeEnvWithViewport());
   });
 
   test("create and delete sheet concurrently", () => {

--- a/tests/components/chart_side_panel.test.ts
+++ b/tests/components/chart_side_panel.test.ts
@@ -1,7 +1,8 @@
 import { Component, hooks, tags } from "@odoo/owl";
 import { Model } from "../../src";
 import { ChartPanel } from "../../src/components/side_panel/chart_panel";
-import { Figure, SpreadsheetEnv, Viewport } from "../../src/types";
+import { Figure, SpreadsheetEnv } from "../../src/types";
+import { createModelWithViewport } from "../test_helpers/commands_helpers";
 import { setInputValueAndTrigger, simulateClick } from "../test_helpers/dom_helper";
 import { makeTestFixture, mockUuidV4To, nextTick } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
@@ -23,16 +24,6 @@ class Parent extends Component<any, SpreadsheetEnv> {
   }
 }
 
-const viewport: Viewport = {
-  bottom: 1000,
-  right: 1000,
-  left: 0,
-  top: 0,
-  height: 1000,
-  width: 1000,
-  offsetX: 0,
-  offsetY: 0,
-};
 let fixture: HTMLElement;
 
 async function createChartPanel(
@@ -75,7 +66,7 @@ describe("Chart sidepanel component", () => {
 
   // Skipped because updating of a chart is not yet supported
   test.skip("update chart", async () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     model.dispatch("CREATE_CHART", {
       id: "1",
       sheetId: model.getters.getActiveSheetId(),
@@ -87,10 +78,7 @@ describe("Chart sidepanel component", () => {
         type: "line",
       },
     });
-    const [figure] = model.getters.getVisibleFigures(
-      model.getters.getActiveSheetId(),
-      viewport
-    ) as Figure[];
+    const [figure] = model.getters.getVisibleFigures(model.getters.getActiveSheetId()) as Figure[];
     const { parent } = await createChartPanel({ model, figure });
     parent.env.dispatch = jest.fn(() => ({ status: "SUCCESS" }));
     await simulateClick(".o-sidePanelButton");

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -22,6 +22,9 @@ let model: Model;
 ColResizer.prototype._getMaxSize = () => 1000;
 RowResizer.prototype._getMaxSize = () => 1000;
 
+jest.spyOn(HTMLDivElement.prototype, "clientWidth", "get").mockImplementation(() => 1000);
+jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 1000);
+
 function fillData() {
   for (let i = 0; i < 8; i++) {
     setCellContent(model, toXC(i, i), "i");

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -1,26 +1,21 @@
 import { Model } from "../../src";
 import { toZone } from "../../src/helpers/zones";
-import { CancelledReason, Viewport } from "../../src/types";
-import { deleteColumns, selectCell, setCellContent } from "../test_helpers/commands_helpers";
+import { CancelledReason } from "../../src/types";
+import {
+  createModelWithViewport,
+  deleteColumns,
+  selectCell,
+  setCellContent,
+} from "../test_helpers/commands_helpers";
 import { mockUuidV4To, testUndoRedo, waitForRecompute } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
 let model: Model;
-const viewport: Viewport = {
-  bottom: 1000,
-  right: 1000,
-  left: 0,
-  top: 0,
-  height: 1000,
-  width: 1000,
-  offsetX: 0,
-  offsetY: 0,
-};
 
 beforeEach(() => {
   mockUuidV4To(1);
 
-  model = new Model({
+  model = createModelWithViewport({
     sheets: [
       {
         name: "Sheet1",
@@ -404,11 +399,11 @@ describe("datasource tests", function () {
       },
     });
     const exportedData = model.exportData();
-    const newModel = new Model(exportedData);
-    expect(newModel.getters.getVisibleFigures(sheetId, viewport)).toHaveLength(1);
+    const newModel = createModelWithViewport(exportedData);
+    expect(newModel.getters.getVisibleFigures(sheetId)).toHaveLength(1);
     expect(newModel.getters.getChartRuntime("1")).toBeTruthy();
     newModel.dispatch("DELETE_FIGURE", { sheetId: model.getters.getActiveSheetId(), id: "1" });
-    expect(newModel.getters.getVisibleFigures(sheetId, viewport)).toHaveLength(0);
+    expect(newModel.getters.getVisibleFigures(sheetId)).toHaveLength(0);
     expect(newModel.getters.getChartRuntime("1")).toBeUndefined();
   });
 
@@ -725,7 +720,7 @@ describe("datasource tests", function () {
   test.skip("extend data set labels to new values manually", () => {});
 
   test("duplicate a sheet with and without a chart", () => {
-    const model = new Model({
+    const model = createModelWithViewport({
       sheets: [
         {
           id: "1",
@@ -756,14 +751,14 @@ describe("datasource tests", function () {
       sheetIdFrom: "1",
       sheetIdTo: "SheetNoFigure",
     });
-    expect(model.getters.getVisibleFigures("SheetNoFigure", viewport)).toEqual([]);
+    expect(model.getters.getVisibleFigures("SheetNoFigure")).toEqual([]);
     model.dispatch("DUPLICATE_SHEET", {
       name: "SheetWithFigure",
       sheetIdFrom: "2",
       sheetIdTo: "SheetWithFigure",
     });
-    const { x, y, height, width, tag } = model.getters.getVisibleFigures("2", viewport)[0];
-    expect(model.getters.getVisibleFigures("SheetWithFigure", viewport)).toMatchObject([
+    const { x, y, height, width, tag } = model.getters.getVisibleFigures("2")[0];
+    expect(model.getters.getVisibleFigures("SheetWithFigure")).toMatchObject([
       { x, y, height, width, tag },
     ]);
   });

--- a/tests/plugins/figures.test.ts
+++ b/tests/plugins/figures.test.ts
@@ -1,21 +1,15 @@
 import { Model } from "../../src/model";
-import { Viewport } from "../../src/types";
-import { activateSheet, createSheet, selectCell, undo } from "../test_helpers/commands_helpers";
-
-const viewport: Viewport = {
-  left: 0,
-  right: 10,
-  top: 0,
-  bottom: 10,
-  offsetX: 0,
-  offsetY: 0,
-  width: 1000,
-  height: 1000,
-};
+import {
+  activateSheet,
+  createModelWithViewport,
+  createSheet,
+  selectCell,
+  undo,
+} from "../test_helpers/commands_helpers";
 
 describe("figure plugin", () => {
   test("can create a simple figure", () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     model.dispatch("CREATE_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),
       figure: {
@@ -34,7 +28,7 @@ describe("figure plugin", () => {
       { id: "someuuid", height: 100, tag: "hey", width: 100, x: 100, y: 100 },
     ]);
 
-    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId(), viewport)).toEqual([
+    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId())).toEqual([
       { id: "someuuid", height: 100, tag: "hey", width: 100, x: 100, y: 100 },
     ]);
   });
@@ -46,7 +40,7 @@ describe("figure plugin", () => {
   });
 
   test("can undo figure creation", () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     model.dispatch("CREATE_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),
       figure: {
@@ -58,18 +52,13 @@ describe("figure plugin", () => {
         y: 100,
       },
     });
-
-    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId(), viewport).length).toBe(
-      1
-    );
+    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId()).length).toBe(1);
     undo(model);
-    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId(), viewport).length).toBe(
-      0
-    );
+    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId()).length).toBe(0);
   });
 
   test("can create a figure in a different sheet", () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     const sheetId = "Sheet2";
     createSheet(model, { sheetId }); // The sheet is not activated
 
@@ -91,11 +80,11 @@ describe("figure plugin", () => {
       { id: "someuuid", height: 100, tag: "hey", width: 100, x: 100, y: 100 },
     ]);
 
-    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId(), viewport)).toEqual([]); // empty because active sheet is sheet1
+    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId())).toEqual([]); // empty because active sheet is sheet1
   });
 
   test("getVisibleFigures only returns visible figures", () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     model.dispatch("CREATE_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),
       figure: {
@@ -107,33 +96,17 @@ describe("figure plugin", () => {
         height: 100,
       },
     });
+    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId()).length).toBe(1);
 
-    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId(), viewport).length).toBe(
-      1
-    );
-    const viewport2: Viewport = {
-      left: 3,
-      top: 3,
-      right: 3,
-      bottom: 3,
-      width: 10,
-      height: 10,
-      offsetX: 200,
-      offsetY: 200,
-    };
-    expect(
-      model.getters.getVisibleFigures(model.getters.getActiveSheetId(), viewport2).length
-    ).toBe(0);
+    model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 200, offsetY: 200 });
+    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId()).length).toBe(0);
 
-    viewport2.offsetX = 10;
-    viewport2.offsetY = 10;
-    expect(
-      model.getters.getVisibleFigures(model.getters.getActiveSheetId(), viewport2).length
-    ).toBe(1);
+    model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 10, offsetY: 10 });
+    expect(model.getters.getVisibleFigures(model.getters.getActiveSheetId()).length).toBe(1);
   });
 
   test("selecting a figure, then clicking on a cell unselect figure", () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     model.dispatch("CREATE_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),
       figure: {
@@ -176,7 +149,7 @@ describe("figure plugin", () => {
   });
 
   test("can move a figure", () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     model.dispatch("CREATE_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),
       figure: {
@@ -189,7 +162,7 @@ describe("figure plugin", () => {
       },
     });
 
-    const { x, y } = model.getters.getVisibleFigures(model.getters.getActiveSheetId(), viewport)[0];
+    const { x, y } = model.getters.getVisibleFigures(model.getters.getActiveSheetId())[0];
     expect(x).toBe(10);
     expect(y).toBe(10);
 
@@ -200,15 +173,14 @@ describe("figure plugin", () => {
       y: 200,
     });
     const { x: newx, y: newy } = model.getters.getVisibleFigures(
-      model.getters.getActiveSheetId(),
-      viewport
+      model.getters.getActiveSheetId()
     )[0];
     expect(newx).toBe(100);
     expect(newy).toBe(200);
   });
 
   test("can undo an update operation", () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     model.dispatch("CREATE_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),
       figure: {
@@ -227,24 +199,18 @@ describe("figure plugin", () => {
       x: 100,
       y: 200,
     });
-    const { x: x1, y: y1 } = model.getters.getVisibleFigures(
-      model.getters.getActiveSheetId(),
-      viewport
-    )[0];
+    const { x: x1, y: y1 } = model.getters.getVisibleFigures(model.getters.getActiveSheetId())[0];
     expect(x1).toBe(100);
     expect(y1).toBe(200);
 
     undo(model);
-    const { x: x2, y: y2 } = model.getters.getVisibleFigures(
-      model.getters.getActiveSheetId(),
-      viewport
-    )[0];
+    const { x: x2, y: y2 } = model.getters.getVisibleFigures(model.getters.getActiveSheetId())[0];
     expect(x2).toBe(10);
     expect(y2).toBe(10);
   });
 
   test("prevent moving a figure left or above of the sheet", () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     model.dispatch("CREATE_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),
       figure: {
@@ -264,13 +230,13 @@ describe("figure plugin", () => {
       y: 50,
     });
 
-    const { x, y } = model.getters.getVisibleFigures(model.getters.getActiveSheetId(), viewport)[0];
+    const { x, y } = model.getters.getVisibleFigures(model.getters.getActiveSheetId())[0];
     expect(x).toBe(0);
     expect(y).toBe(50);
   });
 
   test("can delete a figure", () => {
-    const model = new Model();
+    const model = createModelWithViewport();
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("CREATE_FIGURE", {
       sheetId,
@@ -285,13 +251,13 @@ describe("figure plugin", () => {
     });
     model.dispatch("SELECT_FIGURE", { id: "someuuid" });
     expect(model.getters.getSelectedFigureId()).toBe("someuuid");
-    expect(model.getters.getVisibleFigures(sheetId, viewport)).toHaveLength(1);
+    expect(model.getters.getVisibleFigures(sheetId)).toHaveLength(1);
     model.dispatch("DELETE_FIGURE", { sheetId, id: "someuuid" });
     expect(model.getters.getSelectedFigureId()).toBeNull();
-    expect(model.getters.getVisibleFigures(sheetId, viewport)).toHaveLength(0);
+    expect(model.getters.getVisibleFigures(sheetId)).toHaveLength(0);
     undo(model);
     expect(model.getters.getSelectedFigureId()).toBeNull();
-    expect(model.getters.getVisibleFigures(sheetId, viewport)).toHaveLength(1);
+    expect(model.getters.getVisibleFigures(sheetId)).toHaveLength(1);
   });
 
   test("change sheet deselect figure", () => {

--- a/tests/plugins/grid_manipulation.test.ts
+++ b/tests/plugins/grid_manipulation.test.ts
@@ -995,8 +995,8 @@ describe("Rows", () => {
         { start: size + 30, end: size + 50, size: 20, name: "5", cells: {} },
         { start: size + 50, end: 2 * size + 50, size, name: "6", cells: {} },
       ]);
-      const dimensions = model.getters.getGridSize(model.getters.getActiveSheet());
-      expect(dimensions).toEqual([192, 124]);
+      const dimensions = model.getters.getGridDimension(model.getters.getActiveSheet());
+      expect(dimensions).toMatchObject({ width: 192, height: 124 });
       expect(model.getters.getActiveSheet().rows.length).toBe(6);
     });
     test("On addition after", () => {
@@ -1010,8 +1010,8 @@ describe("Rows", () => {
         { start: size + 50, end: size + 70, size: 20, name: "5", cells: {} },
         { start: size + 70, end: 2 * size + 70, size, name: "6", cells: {} },
       ]);
-      const dimensions = model.getters.getGridSize(model.getters.getActiveSheet());
-      expect(dimensions).toEqual([192, 144]);
+      const dimensions = model.getters.getGridDimension(model.getters.getActiveSheet());
+      expect(dimensions).toMatchObject({ width: 192, height: 144 });
       expect(model.getters.getActiveSheet().rows.length).toBe(6);
     });
     test("cannot delete column in invalid sheet", () => {
@@ -1021,13 +1021,13 @@ describe("Rows", () => {
 
     test("activate Sheet: same size", () => {
       addRows(model, "after", 2, 1);
-      let dimensions = model.getters.getGridSize(model.getters.getActiveSheet());
-      expect(dimensions).toEqual([192, 124]);
+      let dimensions = model.getters.getGridDimension(model.getters.getActiveSheet());
+      expect(dimensions).toMatchObject({ width: 192, height: 124 });
       const to = model.getters.getActiveSheetId();
       createSheet(model, { activate: true, sheetId: "42" });
       activateSheet(model, to);
-      dimensions = model.getters.getGridSize(model.getters.getActiveSheet());
-      expect(dimensions).toEqual([192, 124]);
+      dimensions = model.getters.getGridDimension(model.getters.getActiveSheet());
+      expect(dimensions).toMatchObject({ width: 192, height: 124 });
     });
   });
 

--- a/tests/plugins/navigation.test.ts
+++ b/tests/plugins/navigation.test.ts
@@ -11,9 +11,9 @@ function getViewport(
   offsetX: number,
   offsetY: number
 ): Viewport {
-  let viewport = { width, height, offsetX, offsetY, left: 0, right: 0, top: 0, bottom: 0 };
-  viewport = model.getters.adjustViewportZone(viewport);
-  return viewport;
+  model.dispatch("RESIZE_VIEWPORT", { width, height });
+  model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
+  return model.getters.getActiveViewport();
 }
 
 describe("navigation", () => {
@@ -149,12 +149,12 @@ describe("navigation", () => {
     expect(viewport.right).toBe(5);
 
     selectCell(model, "E1");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.left).toBe(0);
     expect(viewport.right).toBe(5);
 
     selectCell(model, "F1");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.left).toBe(1);
     expect(viewport.right).toBe(6);
   });
@@ -166,12 +166,12 @@ describe("navigation", () => {
     expect(viewport.right).toBe(6);
 
     selectCell(model, "B1");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.left).toBe(1);
     expect(viewport.right).toBe(6);
 
     selectCell(model, "A1");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.left).toBe(0);
     expect(viewport.right).toBe(5);
   });
@@ -183,12 +183,12 @@ describe("navigation", () => {
     expect(viewport.bottom).toBe(11);
 
     selectCell(model, "A11");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(0);
     expect(viewport.bottom).toBe(11);
 
     selectCell(model, "A12");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(1);
     expect(viewport.bottom).toBe(12);
   });
@@ -200,12 +200,12 @@ describe("navigation", () => {
     expect(viewport.bottom).toBe(14);
 
     selectCell(model, "A3");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(2);
     expect(viewport.bottom).toBe(14);
 
     selectCell(model, "A2");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(1);
     expect(viewport.bottom).toBe(12);
   });
@@ -222,12 +222,12 @@ describe("navigation", () => {
     });
 
     selectCell(model, "A3");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(2);
     expect(viewport.bottom).toBe(14);
 
     selectCell(model, "A2");
-    viewport = model.getters.adjustViewportPosition(viewport);
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(0);
     expect(viewport.bottom).toBe(11);
   });

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -24,17 +24,8 @@ class MockGridRenderingContext implements GridRenderingContext {
   thinLineWidth = 0.4;
 
   constructor(model: Model, width: number, height: number, observer: ContextObserver) {
-    this.viewport = {
-      width,
-      height,
-      offsetX: 0,
-      offsetY: 0,
-      left: 0,
-      right: 0,
-      top: 0,
-      bottom: 0,
-    };
-    this.viewport = model.getters.adjustViewportZone(this.viewport);
+    model.dispatch("RESIZE_VIEWPORT", { width, height });
+    this.viewport = model.getters.getActiveViewport();
 
     const handler = {
       get: (target, val) => {

--- a/tests/plugins/resizing.test.ts
+++ b/tests/plugins/resizing.test.ts
@@ -9,7 +9,7 @@ describe("Model resizer", () => {
     const sheetId = sheet.id;
     const initialSize = model.getters.getCol(sheetId, 1)!.size;
     const initialTop = model.getters.getCol(sheetId, 2)!.start;
-    const initialWidth = model.getters.getGridSize(sheet)[0];
+    const initialWidth = model.getters.getGridDimension(sheet).width;
 
     model.dispatch("RESIZE_COLUMNS", {
       sheetId: sheetId,
@@ -18,17 +18,17 @@ describe("Model resizer", () => {
     });
     expect(model.getters.getCol(sheetId, 1)!.size).toBe(196);
     expect(model.getters.getCol(sheetId, 2)!.start).toBe(initialTop + 100);
-    expect(model.getters.getGridSize(sheet)[0]).toBe(initialWidth + 100);
+    expect(model.getters.getGridDimension(sheet).width).toBe(initialWidth + 100);
 
     undo(model);
     expect(model.getters.getCol(sheetId, 1)!.size).toBe(initialSize);
     expect(model.getters.getCol(sheetId, 2)!.start).toBe(initialTop);
-    expect(model.getters.getGridSize(sheet)[0]).toBe(initialWidth);
+    expect(model.getters.getGridDimension(sheet).width).toBe(initialWidth);
 
     redo(model);
     expect(model.getters.getCol(sheetId, 1)!.size).toBe(initialSize + 100);
     expect(model.getters.getCol(sheetId, 2)!.start).toBe(initialTop + 100);
-    expect(model.getters.getGridSize(sheet)[0]).toBe(initialWidth + 100);
+    expect(model.getters.getGridDimension(sheet).width).toBe(initialWidth + 100);
   });
 
   test("Cannot resize column in invalid sheet", async () => {
@@ -76,7 +76,7 @@ describe("Model resizer", () => {
     const sheetId = sheet.id;
     const initialSize = model.getters.getRow(sheetId, 1)!.size;
     const initialTop = model.getters.getRow(sheetId, 2)!.start;
-    const initialHeight = model.getters.getGridSize(sheet)[1];
+    const initialHeight = model.getters.getGridDimension(sheet).height;
 
     model.dispatch("RESIZE_ROWS", {
       sheetId: sheetId,
@@ -85,12 +85,12 @@ describe("Model resizer", () => {
     });
     expect(model.getters.getRow(sheetId, 1)!.size).toBe(initialSize + 100);
     expect(model.getters.getRow(sheetId, 2)!.start).toBe(initialTop + 100);
-    expect(model.getters.getGridSize(sheet)[1]).toBe(initialHeight + 100);
+    expect(model.getters.getGridDimension(sheet).height).toBe(initialHeight + 100);
 
     undo(model);
     expect(model.getters.getRow(sheetId, 1)!.size).toBe(initialSize);
     expect(model.getters.getRow(sheetId, 2)!.start).toBe(initialTop);
-    expect(model.getters.getGridSize(sheet)[1]).toBe(initialHeight);
+    expect(model.getters.getGridDimension(sheet).height).toBe(initialHeight);
   });
 
   test("Can resize row of inactive sheet", async () => {
@@ -131,10 +131,12 @@ describe("Model resizer", () => {
       size: model.getters.getCol(sheet2, 1)!.size + 100,
     });
 
-    const initialWidth = model.getters.getGridSize(model.getters.getActiveSheet())[0];
+    const initialWidth = model.getters.getGridDimension(model.getters.getActiveSheet()).width;
 
     activateSheet(model, sheet1);
-    expect(model.getters.getGridSize(model.getters.getActiveSheet())[0]).toBe(initialWidth - 100);
+    expect(model.getters.getGridDimension(model.getters.getActiveSheet()).width).toBe(
+      initialWidth - 100
+    );
   });
 
   test("Can resize multiple columns", async () => {
@@ -176,19 +178,19 @@ describe("Model resizer", () => {
     const model = new Model();
     const sheet = model.getters.getActiveSheet();
     const sheetId = sheet.id;
-    const [initialWidth, initialHeight] = model.getters.getGridSize(sheet);
+    const { width: initialWidth, height: initialHeight } = model.getters.getGridDimension(sheet);
     model.dispatch("RESIZE_COLUMNS", {
       sheetId: model.getters.getActiveSheetId(),
       columns: [1],
       size: model.getters.getCol(sheetId, 1)!.size + 100,
     });
-    expect(model.getters.getGridSize(sheet)[0]).toBe(initialWidth + 100);
+    expect(model.getters.getGridDimension(sheet).width).toBe(initialWidth + 100);
 
     model.dispatch("RESIZE_ROWS", {
       sheetId: model.getters.getActiveSheetId(),
       rows: [1],
       size: model.getters.getRow(sheetId, 1)!.size + 42,
     });
-    expect(model.getters.getGridSize(sheet)[1]).toBe(initialHeight + 42);
+    expect(model.getters.getGridDimension(sheet).height).toBe(initialHeight + 42);
   });
 });

--- a/tests/plugins/viewport.test.ts
+++ b/tests/plugins/viewport.test.ts
@@ -1,0 +1,683 @@
+import {
+  DEFAULT_CELL_HEIGHT,
+  DEFAULT_CELL_WIDTH,
+  HEADER_HEIGHT,
+  HEADER_WIDTH,
+} from "../../src/constants";
+import { toXC } from "../../src/helpers";
+import { Model } from "../../src/model";
+import {
+  activateSheet,
+  addColumns,
+  addRows,
+  createModelWithViewport,
+  redo,
+  selectCell,
+  undo,
+} from "../test_helpers/commands_helpers";
+import { makeTestFixture } from "../test_helpers/helpers";
+
+let fixture: HTMLElement;
+let model: Model;
+
+beforeEach(async () => {
+  fixture = makeTestFixture();
+});
+
+afterEach(() => {
+  fixture.remove();
+});
+
+describe("Viewport of Simple sheet", () => {
+  beforeEach(async () => {
+    model = new Model();
+    model.dispatch("RESIZE_VIEWPORT", { width: 1000, height: 1000 }); // normally called by the grid component on mounted()
+  });
+
+  test("Select cell correctly affects offset", () => {
+    // Since we rely on the adjustViewportPosition function here, the offsets will be linear combinations of the cells width and height
+    selectCell(model, "P1");
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 7,
+      right: 16,
+      offsetX: 7 * DEFAULT_CELL_WIDTH,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    selectCell(model, "A79");
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 37,
+      bottom: 79,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: 37 * DEFAULT_CELL_HEIGHT,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    // back to topleft
+    selectCell(model, "A1");
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    selectCell(model, "U51");
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 9,
+      bottom: 51,
+      left: 12,
+      right: 21,
+      offsetX: 12 * DEFAULT_CELL_WIDTH,
+      offsetY: 9 * DEFAULT_CELL_HEIGHT,
+    });
+  });
+  test("Can Undo/Redo action that alters viewport structure (add/delete rows or cols)", () => {
+    model.getters.getActiveViewport();
+    addRows(model, "before", 0, 70);
+    selectCell(model, "B170");
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      left: 0,
+      right: 9,
+      top: 128,
+      bottom: 169,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 128,
+    });
+    undo(model);
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      left: 0,
+      right: 9,
+      top: 58,
+      bottom: 99,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 58,
+    });
+    redo(model); // should not alter offset
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      left: 0,
+      right: 9,
+      top: 58,
+      bottom: 100,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 58,
+    });
+  });
+
+  test("Add columns doesn't affect offset", () => {
+    selectCell(model, "P1");
+    const currentViewport = model.getters.getActiveViewport();
+    addColumns(model, "after", "P", 30);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
+    undo(model);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
+    addColumns(model, "before", "P", 30);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
+  });
+  test("Add rows doesn't affect offset", () => {
+    selectCell(model, "A51");
+    const currentViewport = model.getters.getActiveViewport();
+    addRows(model, "after", 50, 30);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
+    undo(model);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
+    addRows(model, "before", 50, 30);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
+  });
+
+  test("Horizontal scroll correctly affects offset", () => {
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: DEFAULT_CELL_WIDTH * 2,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 2,
+      right: 11,
+      offsetX: DEFAULT_CELL_WIDTH * 2,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: DEFAULT_CELL_WIDTH * 17,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 17,
+      right: 25,
+      offsetX: DEFAULT_CELL_WIDTH * 17,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: DEFAULT_CELL_WIDTH * 12.5,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 12,
+      right: 22,
+      offsetX: DEFAULT_CELL_WIDTH * 12.5,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 12,
+      right: 21,
+      offsetX: DEFAULT_CELL_WIDTH * 12,
+      offsetY: 0,
+    });
+  });
+
+  test("Vertical scroll correctly affects offset", () => {
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 2,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 2,
+      bottom: 44,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 2,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 57,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 57,
+      bottom: 99,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 57,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 12.5,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 12,
+      bottom: 54,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 12.5,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 12,
+      bottom: 54,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 12,
+    });
+  });
+
+  test("Resize (increase) columns correctly affects viewport without changing the offset", () => {
+    const { cols, id: sheetId } = model.getters.getActiveSheet();
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: DEFAULT_CELL_WIDTH * 2,
+      offsetY: 0,
+    });
+    const { offsetX } = model.getters.getActiveViewport();
+    model.dispatch("RESIZE_COLUMNS", {
+      sheetId: sheetId,
+      size: DEFAULT_CELL_WIDTH * 2,
+      columns: [...Array(cols.length).keys()],
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 1,
+      right: 5,
+      offsetX: offsetX,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+  });
+
+  test("Resize (reduce) columns correctly changes offset", () => {
+    const { cols, id: sheetId } = model.getters.getActiveSheet();
+    //scroll max
+    selectCell(model, "Z1");
+    model.dispatch("SELECT_ALL");
+
+    model.dispatch("RESIZE_COLUMNS", {
+      sheetId: sheetId,
+      size: DEFAULT_CELL_WIDTH / 2,
+      columns: [...Array(cols.length).keys()],
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 8,
+      right: 25,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 8,
+      right: 25,
+      offsetX: (DEFAULT_CELL_WIDTH / 2) * 8,
+      offsetY: 0,
+    });
+  });
+
+  test("Resize rows correctly affects viewport without changing the offset", () => {
+    const { rows, id: sheetId } = model.getters.getActiveSheet();
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 2,
+    });
+    const { offsetY } = model.getters.getActiveViewport();
+    model.dispatch("RESIZE_ROWS", {
+      sheetId: sheetId,
+      size: DEFAULT_CELL_HEIGHT * 2,
+      rows: [...Array(rows.length).keys()],
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 1,
+      bottom: 22,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: offsetY,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+  });
+
+  test("Resize (reduce) rows correctly changes offset", () => {
+    const { rows, id: sheetId } = model.getters.getActiveSheet();
+    //scroll max
+    selectCell(model, "A100");
+    model.dispatch("SELECT_ALL");
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 58,
+      bottom: 99,
+      left: 0,
+      right: 9,
+    });
+    model.dispatch("RESIZE_ROWS", {
+      sheetId: sheetId,
+      size: DEFAULT_CELL_HEIGHT / 2,
+      rows: [...Array(rows.length).keys()],
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 17,
+      bottom: 99,
+      left: 0,
+      right: 9,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 17,
+      bottom: 99,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: (DEFAULT_CELL_HEIGHT / 2) * 17,
+    });
+  });
+
+  test("Horizontally move position to top right then back to top left correctly affects offset", () => {
+    const { cols } = model.getters.getActiveSheet();
+    const { right } = model.getters.getActiveViewport();
+    model.dispatch("MOVE_POSITION", { deltaX: right, deltaY: 0 });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 1,
+      right: 10,
+      offsetX: DEFAULT_CELL_WIDTH,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("MOVE_POSITION", { deltaX: 5, deltaY: 0 });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 6,
+      right: 15,
+      offsetX: DEFAULT_CELL_WIDTH * 6,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("MOVE_POSITION", {
+      deltaX: cols.length - 2 - model.getters.getPosition()[0], // target penultimate cell to trigger a move
+      deltaY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 16,
+      right: 25,
+      offsetX: DEFAULT_CELL_WIDTH * 16,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("MOVE_POSITION", { deltaX: -24, deltaY: 0 });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+  });
+
+  test("Vertically move position to bottom left then back to top left correctly affects offset", () => {
+    const { rows } = model.getters.getActiveSheet();
+    const { bottom } = model.getters.getActiveViewport();
+    model.dispatch("MOVE_POSITION", { deltaX: 0, deltaY: bottom });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 1,
+      bottom: 43,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("MOVE_POSITION", { deltaX: 0, deltaY: 5 });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 6,
+      bottom: 48,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 6,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("MOVE_POSITION", {
+      deltaX: 0,
+      deltaY: rows.length - 2 - model.getters.getPosition()[1], // target penultimate cell to trigger a move
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 57,
+      bottom: 99,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 57,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+    model.dispatch("MOVE_POSITION", { deltaX: 0, deltaY: -98 });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+  });
+
+  test("Move position on cells that are taller than the client's height", () => {
+    const { height } = model.getters.getViewportDimension();
+    model.dispatch("RESIZE_ROWS", {
+      sheetId: model.getters.getActiveSheetId(),
+      size: height + 50,
+      rows: [1],
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 1,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: 0,
+    });
+    model.dispatch("MOVE_POSITION", { deltaX: 0, deltaY: 2 });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 2,
+      bottom: 44,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT + height + 50, // row1 + row2
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+  });
+  test("Move position on cells wider than the client's width", () => {
+    const { width } = model.getters.getViewportDimension();
+    model.dispatch("RESIZE_COLUMNS", {
+      sheetId: model.getters.getActiveSheetId(),
+      size: width + 50,
+      columns: [1],
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 0,
+      right: 1,
+      offsetX: 0,
+      offsetY: 0,
+    });
+    model.dispatch("MOVE_POSITION", { deltaX: 2, deltaY: 0 });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 42,
+      left: 2,
+      right: 11,
+      offsetX: DEFAULT_CELL_WIDTH + width + 50, // colA + colB
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
+  });
+  test("Select Column without updating range updates viewport offset", () => {
+    selectCell(model, "C79");
+    model.dispatch("SELECT_COLUMN", { index: 3 });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      left: 0,
+      right: 9,
+      top: 0,
+      bottom: 42,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+  test("Select Column while updating range does not recomputes viewport", () => {
+    selectCell(model, "C51");
+    model.dispatch("SELECT_COLUMN", { index: 3, updateRange: true });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      left: 0,
+      right: 9,
+      top: 9,
+      bottom: 51,
+      offsetX: 0,
+      offsetY: 9 * DEFAULT_CELL_HEIGHT,
+    });
+  });
+  test("Select Row without updating range updates viewport offset", () => {
+    selectCell(model, "U5");
+    model.dispatch("SELECT_ROW", { index: 3 });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      left: 0,
+      right: 9,
+      top: 0,
+      bottom: 42,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+  test("Select Row while updating range does not recomputes viewport", () => {
+    selectCell(model, "U5");
+    model.dispatch("SELECT_ROW", { index: 3, updateRange: true });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      left: 12,
+      right: 21,
+      top: 0,
+      bottom: 42,
+      offsetX: 12 * DEFAULT_CELL_WIDTH,
+      offsetY: 0,
+    });
+  });
+  test("Resize Viewport is correctly computed and does not adjust position", () => {
+    selectCell(model, "K71");
+    model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 100, offsetY: 112 });
+    const viewport = model.getters.getActiveSnappedViewport();
+    model.dispatch("RESIZE_VIEWPORT", {
+      width: 500,
+      height: 500,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      ...viewport,
+      bottom: viewport.top + Math.ceil((500 - HEADER_HEIGHT) / DEFAULT_CELL_HEIGHT) - 1,
+      right: viewport.left + Math.ceil((500 - HEADER_WIDTH) / DEFAULT_CELL_WIDTH) - 1,
+    });
+  });
+});
+
+describe("multi sheet with different sizes", () => {
+  beforeEach(async () => {
+    model = createModelWithViewport({
+      sheets: [
+        {
+          name: "small",
+          id: "small",
+          colNumber: 2,
+          rowNumber: 2,
+          cells: {},
+        },
+        {
+          name: "big",
+          id: "big",
+          colNumber: 5,
+          rowNumber: 5,
+          cells: {},
+        },
+      ],
+    });
+  });
+
+  test("viewports of multiple sheets of different size are correctly computed", () => {
+    activateSheet(model, "small");
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 1,
+      left: 0,
+      right: 1,
+      offsetX: 0,
+      offsetY: 0,
+    });
+    activateSheet(model, "big");
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 4,
+      left: 0,
+      right: 4,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+
+  test("deleting the column that has the active cell doesn't crash", () => {
+    expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("small");
+    selectCell(model, "B2");
+    model.dispatch("REMOVE_COLUMNS", { columns: [1], sheetId: model.getters.getActiveSheetId() });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 1,
+      left: 0,
+      right: 0,
+    });
+    expect(model.getters.getActiveCell()).toBeUndefined();
+  });
+
+  test("deleting the row that has the active cell doesn't crash", () => {
+    expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("small");
+    selectCell(model, "B2");
+    model.dispatch("REMOVE_ROWS", { rows: [1], sheetId: model.getters.getActiveSheetId() });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 1,
+    });
+    expect(model.getters.getActiveCell()).toBeUndefined();
+  });
+
+  test("Client resize impacts all sheets", () => {
+    model.dispatch("RESIZE_VIEWPORT", {
+      width: 2.5 * DEFAULT_CELL_WIDTH + HEADER_WIDTH, // concretely 2.5 cells visible
+      height: 3.5 * DEFAULT_CELL_HEIGHT + HEADER_HEIGHT, // concretely 3.5 cells visible
+    });
+    activateSheet(model, "small");
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 1,
+      left: 0,
+      right: 1,
+    });
+    activateSheet(model, "big");
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 3,
+      left: 0,
+      right: 2,
+    });
+  });
+  test.skip("can undo/redo actions on other sheets", () => {
+    // Currently broken due to issue with selection
+    activateSheet(model, "small");
+    addColumns(model, "after", "A", 200);
+    selectCell(model, toXC(200, 0));
+    activateSheet(model, "big");
+    undo(model);
+  });
+});

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -1,6 +1,7 @@
 import { lettersToNumber, toCartesian, toZone, uuidv4 } from "../../src/helpers/index";
-import { Model } from "../../src/model";
+import { Model, ModelConfig } from "../../src/model";
 import { BorderCommand, CommandResult, CreateSheetCommand, UID } from "../../src/types";
+import { StateUpdateMessage } from "../../src/types/collaborative/transport_service";
 
 /**
  * Dispatch an UNDO to the model
@@ -153,4 +154,16 @@ export function setCellContent(
 export function selectCell(model: Model, xc: string) {
   const [col, row] = toCartesian(xc);
   model.dispatch("SELECT_CELL", { col, row });
+}
+
+export function createModelWithViewport(
+  data?: any,
+  config?: Partial<ModelConfig>,
+  stateUpdateMessages?: StateUpdateMessage[],
+  width: number = 1000,
+  height: number = 1000
+): Model {
+  const model = new Model(data, config, stateUpdateMessages);
+  model.dispatch("RESIZE_VIEWPORT", { width, height });
+  return model;
 }

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -125,8 +125,6 @@ export class GridParent extends Component<any, SpreadsheetEnv> {
 
     const drawGrid = model.drawGrid;
     model.drawGrid = function (context: GridRenderingContext) {
-      context.viewport.width = 1000;
-      context.viewport.height = 1000;
       drawGrid.call(this, context);
     };
     this.model = model;
@@ -142,6 +140,10 @@ export class GridParent extends Component<any, SpreadsheetEnv> {
 
   mounted() {
     this.model.on("update", this, this.render);
+    this.model.dispatch("RESIZE_VIEWPORT", {
+      width: this.el!.clientWidth,
+      height: this.el!.clientWidth,
+    });
   }
 
   willUnmount() {


### PR DESCRIPTION
- [ ]  ~~change getVisible figure signature to get active snapped viewport && viewportsize~~ Can't as the figurePlugin is in core
- [x] change adjusteViewportZone(X|Y) signature to make it callable directly fron handle (no need to recompute Y when processing an operation on X and vice-versa)
- [x] add test on selectRow/ selectColumn
- [ ] ?~~change signature of getColIndex and getRowIndex to require current row col instead of sheet?~~
- [x] getViewportSize now returns an object 

 => make version 2 where we only act on the activeViewport, the others are stored in a dataset.