### PR TITLE
[IMP] server: Log usefull info

### DIFF
--- a/tools/server/main.js
+++ b/tools/server/main.js
@@ -46,7 +46,6 @@ function log(message) {
 }
 
 function logMessage(msg) {
-  log(msg.type);
   switch (msg.type) {
     case "REMOTE_REVISION":
       log(`${msg.type}: ${msg.nextRevisionId} : ${JSON.stringify(msg.commands)}`);
@@ -73,6 +72,7 @@ app.get("/", function (req, res) {
 app.get("/clear", function (req, res) {
   messages = [];
   serverRevisionId = "START_REVISION";
+  log("History cleared");
   res.send("Cleared");
 });
 


### PR DESCRIPTION
Currently, the server logs the type of every received message. Including,
"CLIENT_MOVED", "CLIENT_JOINED" and "CLIENT_LEFT" messages. There is no value
to log this.

It might be usefull to log when the server history is cleared.