### PR TITLE
[FIX] selection_multiuser: do not render clients with invalid position

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -11,7 +11,7 @@ import { Model } from "../model";
 import { cellMenuRegistry } from "../registries/menus/cell_menu_registry";
 import { colMenuRegistry } from "../registries/menus/col_menu_registry";
 import { rowMenuRegistry } from "../registries/menus/row_menu_registry";
-import { Client, SpreadsheetEnv, UID, Viewport } from "../types/index";
+import { Client, SpreadsheetEnv, Viewport } from "../types/index";
 import { Autofill } from "./autofill";
 import { ClientTag } from "./collaborative_client_tag";
 import { GridComposer } from "./composer/grid_composer";
@@ -169,9 +169,9 @@ const TEMPLATE = xml/* xml */ `
       tabindex="-1"
       t-on-contextmenu="onCanvasContextMenu"
        />
-    <t t-foreach="connectedClients" t-as="client" t-key="getClientPositionKey(client)">
+    <t t-foreach="getters.getClientsToDisplay()" t-as="client" t-key="getClientPositionKey(client)">
       <ClientTag name="client.name"
-                 color="getClientColor(client.id)"
+                 color="client.color"
                  col="client.position.col"
                  row="client.position.row"
                  active="isCellHovered(client.position.col, client.position.row)"
@@ -356,14 +356,6 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
     useTouchMove(this.moveCanvas.bind(this), () => this.vScrollbar.scroll > 0);
   }
 
-  get connectedClients(): Client[] {
-    const activeSheetId = this.getters.getActiveSheetId();
-    return [...this.getters.getConnectedClients()]
-      .filter((client) => client.id !== this.getters.getClient().id)
-      .filter((client) => client.position)
-      .filter((client) => client.position?.sheetId === activeSheetId);
-  }
-
   mounted() {
     this.vScrollbar.el = this.vScrollbarRef.el!;
     this.hScrollbar.el = this.hScrollbarRef.el!;
@@ -476,10 +468,6 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
 
   getClientPositionKey(client: Client) {
     return `${client.id}-${client.position?.sheetId}-${client.position?.col}-${client.position?.row}`;
-  }
-
-  getClientColor(id: UID) {
-    return this.props.model.getters.getClientColor(id);
   }
 
   onMouseWheel(ev: WheelEvent) {

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -144,5 +144,5 @@ export type Getters = CoreGetters & {
 
   getContiguousZone: SortPlugin["getContiguousZone"];
 
-  getClientColor: SelectionMultiUserPlugin["getClientColor"];
+  getClientsToDisplay: SelectionMultiUserPlugin["getClientsToDisplay"];
 };

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -423,6 +423,47 @@ describe("Multi User selection", () => {
       client: { id: "david", name: "David", position: { sheetId: "invalid", col: 1, row: 1 } },
     });
     await nextTick();
+    expect(parent.el?.querySelectorAll(".o-client-tag")).toHaveLength(0);
+    parent.destroy();
+  });
+
+  test("Do not render multi user selection with invalid col", async () => {
+    const transportService = new MockTransportService();
+    const model = new Model({}, { transportService });
+    const parent = new GridParent(model);
+    await parent.mount(fixture);
+    const sheet = model.getters.getActiveSheet();
+    transportService.sendMessage({
+      type: "CLIENT_JOINED",
+      version: MESSAGE_VERSION,
+      client: {
+        id: "david",
+        name: "David",
+        position: { sheetId: sheet.id, col: sheet.cols.length, row: 1 },
+      },
+    });
+    await nextTick();
+    expect(parent.el?.querySelectorAll(".o-client-tag")).toHaveLength(0);
+    parent.destroy();
+  });
+
+  test("Do not render multi user selection with invalid row", async () => {
+    const transportService = new MockTransportService();
+    const model = new Model({}, { transportService });
+    const parent = new GridParent(model);
+    await parent.mount(fixture);
+    const sheet = model.getters.getActiveSheet();
+    transportService.sendMessage({
+      type: "CLIENT_JOINED",
+      version: MESSAGE_VERSION,
+      client: {
+        id: "david",
+        name: "David",
+        position: { sheetId: sheet.id, col: 1, row: sheet.rows.length },
+      },
+    });
+    await nextTick();
+    expect(parent.el?.querySelectorAll(".o-client-tag")).toHaveLength(0);
     parent.destroy();
   });
 });


### PR DESCRIPTION
Before this commit, the position of the clients was not validated when
rendering the clientTags.
This commit fixes this behavior by adding a new getter which provides the
list of the others connected clients that are present in the same sheet
as the current user with a valid position