### PR TITLE
[FIX] local_history: restore active sheet 

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -93,6 +93,7 @@ export class Session extends EventBus<CollaborativeEvent> {
       serverRevisionId: this.serverRevisionId,
       nextRevisionId: uuidv4(),
       undoneRevisionId: revisionId,
+      clientId: this.clientId,
     });
   }
 
@@ -103,6 +104,7 @@ export class Session extends EventBus<CollaborativeEvent> {
       serverRevisionId: this.serverRevisionId,
       nextRevisionId: uuidv4(),
       redoneRevisionId: revisionId,
+      clientId: this.clientId,
     });
   }
 
@@ -198,13 +200,19 @@ export class Session extends EventBus<CollaborativeEvent> {
       case "REVISION_REDONE": {
         this.waitingAck = false;
         this.revisions.redo(message.redoneRevisionId, message.nextRevisionId);
-        this.trigger("revision-redone", { revisionId: message.redoneRevisionId });
+        this.trigger("revision-redone", {
+          revisionId: message.redoneRevisionId,
+          isLocal: message.clientId === this.clientId,
+        });
         break;
       }
       case "REVISION_UNDONE":
         this.waitingAck = false;
         this.revisions.undo(message.undoneRevisionId, message.nextRevisionId);
-        this.trigger("revision-undone", { revisionId: message.undoneRevisionId });
+        this.trigger("revision-undone", {
+          revisionId: message.undoneRevisionId,
+          isLocal: message.clientId === this.clientId,
+        });
         break;
       case "REMOTE_REVISION":
         this.waitingAck = false;

--- a/src/history/local_history.ts
+++ b/src/history/local_history.ts
@@ -1,7 +1,14 @@
 import * as owl from "@odoo/owl";
 import { Session } from "../collaborative/session";
 import { MAX_HISTORY_STEPS } from "../constants";
-import { CancelledReason, Command, CommandDispatcher, CommandResult, UID } from "../types";
+import {
+  CancelledReason,
+  Command,
+  CommandDispatcher,
+  CommandResult,
+  RevisionRedone,
+  UID,
+} from "../types";
 
 /**
  * Local History
@@ -93,13 +100,13 @@ export class LocalHistory extends owl.core.EventBus {
     }
   }
 
-  private selectiveUndo() {
-    this.dispatch("UNDO");
+  private selectiveUndo({ isLocal }: RevisionRedone) {
+    this.dispatch("UNDO", { isLocal });
     this.isWaitingForUndoRedo = false;
   }
 
-  private selectiveRedo() {
-    this.dispatch("REDO");
+  private selectiveRedo({ isLocal }: RevisionRedone) {
+    this.dispatch("REDO", { isLocal });
     this.isWaitingForUndoRedo = false;
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -186,7 +186,7 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
 
   private setupUiPlugin(Plugin: UIPluginConstructor) {
     if (Plugin.modes.includes(this.config.mode)) {
-      const plugin = new Plugin(this.getters, this.state, this.dispatch, this.config);
+      const plugin = new Plugin(this.getters, this.dispatch, this.config);
       for (let name of Plugin.getters) {
         if (!(name in plugin)) {
           throw new Error(`Invalid getter name: ${name} for plugin ${plugin.constructor}`);

--- a/src/plugins/base_plugin.ts
+++ b/src/plugins/base_plugin.ts
@@ -1,6 +1,5 @@
 import { Mode, ModelConfig } from "../model";
-import { StateObserver } from "../state_observer";
-import { CommandDispatcher, CommandHandler, CommandResult, WorkbookHistory } from "../types/index";
+import { CommandDispatcher, CommandHandler, CommandResult } from "../types/index";
 
 /**
  * BasePlugin
@@ -14,23 +13,14 @@ import { CommandDispatcher, CommandHandler, CommandResult, WorkbookHistory } fro
  * and UI plugins handling transient data.
  */
 
-export class BasePlugin<State = any, C = any> implements CommandHandler<C> {
+export class BasePlugin<C = any> implements CommandHandler<C> {
   static getters: string[] = [];
   static modes: Mode[] = ["headless", "normal", "readonly"];
 
-  protected history: WorkbookHistory<State>;
   protected dispatch: CommandDispatcher["dispatch"];
   protected currentMode: Mode;
 
-  constructor(
-    stateObserver: StateObserver,
-    dispatch: CommandDispatcher["dispatch"],
-    config: ModelConfig
-  ) {
-    this.history = Object.assign(Object.create(stateObserver), {
-      update: stateObserver.addChange.bind(stateObserver, this),
-      selectCell: () => {},
-    });
+  constructor(dispatch: CommandDispatcher["dispatch"], config: ModelConfig) {
     this.dispatch = dispatch;
     this.currentMode = config.mode;
   }

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -7,6 +7,7 @@ import {
   RangeProvider,
   UID,
   WorkbookData,
+  WorkbookHistory,
 } from "../types";
 import { CoreGetters } from "../types/getters";
 import { BasePlugin } from "./base_plugin";
@@ -31,10 +32,11 @@ export interface CorePluginConstructor {
  * They should not be concerned about UI parts or transient state.
  */
 export class CorePlugin<State = any, C = CoreCommand>
-  extends BasePlugin<State, C>
+  extends BasePlugin<C>
   implements RangeProvider {
   protected getters: CoreGetters;
   protected range: RangeAdapter;
+  protected history: WorkbookHistory<State>;
 
   constructor(
     getters: CoreGetters,
@@ -43,10 +45,13 @@ export class CorePlugin<State = any, C = CoreCommand>
     protected dispatch: CoreCommandDispatcher["dispatch"],
     config: ModelConfig
   ) {
-    super(stateObserver, dispatch, config);
+    super(dispatch, config);
     this.range = range;
     range.addRangeProvider(this.adaptRanges.bind(this));
     this.getters = getters;
+    this.history = Object.assign(Object.create(stateObserver), {
+      update: stateObserver.addChange.bind(stateObserver, this),
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -17,6 +17,7 @@ import { FindAndReplacePlugin } from "./ui/find_and_replace";
 import { HighlightPlugin } from "./ui/highlight";
 import { RendererPlugin } from "./ui/renderer";
 import { SelectionPlugin } from "./ui/selection";
+import { SelectionHistoryPlugin } from "./ui/selection_history";
 import { SelectionInputPlugin } from "./ui/selection_inputs";
 import { SelectionMultiUserPlugin } from "./ui/selection_multiuser";
 import { SortPlugin } from "./ui/sort";
@@ -36,6 +37,7 @@ export const corePluginRegistry = new Registry<CorePluginConstructor>()
 
 export const uiPluginRegistry = new Registry<UIPluginConstructor>()
   .add("selection", SelectionPlugin)
+  .add("selection_history", SelectionHistoryPlugin)
   .add("ui_sheet", SheetUIPlugin)
   .add("ui_options", UIOptionsPlugin)
   .add("evaluation", EvaluationPlugin)

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -2,7 +2,6 @@ import { compile, normalize } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
 import { mapCellsInZone, toXC, toZone } from "../../helpers/index";
 import { Mode, ModelConfig } from "../../model";
-import { StateObserver } from "../../state_observer";
 import { _lt } from "../../translation";
 import {
   Cell,
@@ -73,13 +72,8 @@ export class EvaluationPlugin extends UIPlugin {
    */
   private COMPUTED: Set<Cell> = new Set();
 
-  constructor(
-    getters: Getters,
-    state: StateObserver,
-    dispatch: CommandDispatcher["dispatch"],
-    config: ModelConfig
-  ) {
-    super(getters, state, dispatch, config);
+  constructor(getters: Getters, dispatch: CommandDispatcher["dispatch"], config: ModelConfig) {
+    super(getters, dispatch, config);
     this.evalContext = config.evalContext;
   }
 

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -8,7 +8,6 @@ import {
   updateSelectionOnInsertion,
 } from "../../helpers/index";
 import { Mode, ModelConfig } from "../../model";
-import { StateObserver } from "../../state_observer";
 import {
   AddColumnsRowsCommand,
   CancelledReason,
@@ -47,14 +46,10 @@ export enum SelectionMode {
   expanding,
 }
 
-interface SelectionPluginState {
-  activeSheet: Sheet;
-}
-
 /**
  * SelectionPlugin
  */
-export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
+export class SelectionPlugin extends UIPlugin {
   static layers = [LAYERS.Selection];
   static modes: Mode[] = ["normal", "readonly"];
   static getters = [
@@ -88,13 +83,8 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
   private moveClient: (position: ClientPosition) => void;
   activeSheet: Sheet = null as any;
 
-  constructor(
-    getters: Getters,
-    state: StateObserver,
-    dispatch: CommandDispatcher["dispatch"],
-    config: ModelConfig
-  ) {
-    super(getters, state, dispatch, config);
+  constructor(getters: Getters, dispatch: CommandDispatcher["dispatch"], config: ModelConfig) {
+    super(getters, dispatch, config);
     this.moveClient = config.moveClient;
   }
 

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -86,11 +86,6 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
   private mode = SelectionMode.idle;
   private sheetsData: { [sheet: string]: SheetInfo } = {};
   private moveClient: (position: ClientPosition) => void;
-
-  // This flag is used to avoid to historize the ACTIVE_SHEET command when it's
-  // the main command.
-
-  private historizeActiveSheet: boolean = true;
   activeSheet: Sheet = null as any;
 
   constructor(
@@ -164,7 +159,6 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
       case "ACTIVATE_SHEET":
         try {
           this.getters.getSheet(cmd.sheetIdTo);
-          this.historizeActiveSheet = false;
           break;
         } catch (error) {
           return { status: "CANCELLED", reason: CancelledReason.InvalidSheetId };
@@ -200,7 +194,6 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
     }
     switch (cmd.type) {
       case "START":
-        this.historizeActiveSheet = false;
         this.dispatch("ACTIVATE_SHEET", {
           sheetIdTo: this.getters.getSheets()[0].id,
           sheetIdFrom: this.getters.getSheets()[0].id,
@@ -291,7 +284,6 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
   }
 
   finalize() {
-    this.historizeActiveSheet = true;
     if (!this.getters.tryGetSheet(this.getActiveSheetId())) {
       const currentSheets = this.getters.getVisibleSheets();
       this.activeSheet = this.getters.getSheet(currentSheets[0]);
@@ -499,11 +491,7 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
 
   private setActiveSheet(id: UID) {
     const sheet = this.getters.getSheet(id);
-    if (this.historizeActiveSheet) {
-      this.history.update("activeSheet", sheet);
-    } else {
-      this.activeSheet = sheet;
-    }
+    this.activeSheet = sheet;
   }
 
   /**

--- a/src/plugins/ui/selection_history.ts
+++ b/src/plugins/ui/selection_history.ts
@@ -1,0 +1,59 @@
+import { Mode } from "../../model";
+import { Command, isCoreCommand, UID } from "../../types/index";
+import { UIPlugin } from "../ui_plugin";
+
+export class SelectionHistoryPlugin extends UIPlugin {
+  static modes: Mode[] = ["normal"];
+  private undoStack: UID[] = [];
+  private redoStack: UID[] = [];
+  private activeSheetId: UID | undefined = undefined;
+  private isStarted = false;
+  private isHandlingLocalCoreCommand = false;
+
+  beforeHandle(cmd: Command) {
+    if (!this.isStarted || this.activeSheetId) return;
+    this.activeSheetId = this.getters.getActiveSheetId();
+  }
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "START":
+        this.isStarted = true;
+        break;
+      case "UNDO": {
+        if (!cmd.isLocal) return;
+        const sheetId = this.undoStack.pop();
+        if (!sheetId) break;
+        this.activate(sheetId);
+        this.redoStack.push(sheetId);
+        break;
+      }
+      case "REDO":
+        if (!cmd.isLocal) return;
+        const sheetId = this.redoStack.pop();
+        if (!sheetId) break;
+        this.activate(sheetId);
+        this.undoStack.push(sheetId);
+        break;
+    }
+    if (cmd.isPrimaryDispatch && isCoreCommand(cmd)) {
+      this.isHandlingLocalCoreCommand = true;
+    }
+  }
+
+  finalize() {
+    if (this.isHandlingLocalCoreCommand && this.activeSheetId) {
+      this.undoStack.push(this.activeSheetId);
+    }
+    this.activeSheetId = undefined;
+    this.isHandlingLocalCoreCommand = false;
+  }
+
+  private activate(sheetId: UID) {
+    if (!this.getters.tryGetSheet(sheetId) || this.getters.getActiveSheetId() === sheetId) return;
+    this.dispatch("ACTIVATE_SHEET", {
+      sheetIdFrom: this.getters.getActiveSheetId(),
+      sheetIdTo: sheetId,
+    });
+  }
+}

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -1,17 +1,11 @@
 import { Mode, ModelConfig } from "../model";
-import { StateObserver } from "../state_observer";
 import { Command, CommandDispatcher, Getters, GridRenderingContext, LAYERS } from "../types/index";
 import { BasePlugin } from "./base_plugin";
 
 type UIActions = Pick<ModelConfig, "askConfirmation" | "notifyUser" | "openSidePanel" | "editText">;
 
 export interface UIPluginConstructor {
-  new (
-    getters: Getters,
-    state: StateObserver,
-    dispatch: CommandDispatcher["dispatch"],
-    config: ModelConfig
-  ): UIPlugin;
+  new (getters: Getters, dispatch: CommandDispatcher["dispatch"], config: ModelConfig): UIPlugin;
   layers: LAYERS[];
   getters: string[];
   modes: Mode[];
@@ -21,19 +15,14 @@ export interface UIPluginConstructor {
  * UI plugins handle any transient data required to display a spreadsheet.
  * They can draw on the grid canvas.
  */
-export class UIPlugin<State = any, C = Command> extends BasePlugin<State, C> {
+export class UIPlugin<C = Command> extends BasePlugin<C> {
   static layers: LAYERS[] = [];
 
   protected getters: Getters;
   protected ui: UIActions;
 
-  constructor(
-    getters: Getters,
-    state: StateObserver,
-    dispatch: CommandDispatcher["dispatch"],
-    config: ModelConfig
-  ) {
-    super(state, dispatch, config);
+  constructor(getters: Getters, dispatch: CommandDispatcher["dispatch"], config: ModelConfig) {
+    super(dispatch, config);
     this.getters = getters;
     this.ui = config;
   }

--- a/src/types/collaborative/session.ts
+++ b/src/types/collaborative/session.ts
@@ -27,11 +27,13 @@ export interface RevisionAcknowledgedEvent {
 
 export interface RevisionUndone {
   type: "revision-undone";
+  isLocal: boolean;
   revisionId: UID;
 }
 
 export interface RevisionRedone {
   type: "revision-redone";
+  isLocal: boolean;
   revisionId: UID;
 }
 

--- a/src/types/collaborative/transport_service.ts
+++ b/src/types/collaborative/transport_service.ts
@@ -16,6 +16,7 @@ export interface RemoteRevisionMessage extends AbstractMessage {
 
 export interface RevisionUndoneMessage extends AbstractMessage {
   type: "REVISION_UNDONE";
+  clientId: ClientId;
   undoneRevisionId: UID;
   nextRevisionId: UID;
   serverRevisionId: UID;
@@ -23,6 +24,7 @@ export interface RevisionUndoneMessage extends AbstractMessage {
 
 export interface RevisionRedoneMessage extends AbstractMessage {
   type: "REVISION_REDONE";
+  clientId: ClientId;
   redoneRevisionId: UID;
   nextRevisionId: UID;
   serverRevisionId: UID;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -38,6 +38,7 @@ import { Border, Cell, Dimension, UID } from "./misc";
 
 export interface BaseCommand {
   interactive?: boolean;
+  isPrimaryDispatch?: boolean;
 }
 
 export interface SheetDependentCommand {
@@ -585,10 +586,12 @@ export interface ClearCellCommand extends BaseCommand {
 
 export interface UndoCommand extends BaseCommand {
   type: "UNDO";
+  isLocal?: boolean;
 }
 
 export interface RedoCommand extends BaseCommand {
   type: "REDO";
+  isLocal?: boolean;
 }
 
 export interface StartCommand extends BaseCommand {
@@ -918,21 +921,21 @@ export interface CommandHandler<T> {
 
 export interface CommandDispatcher {
   dispatch<T extends CommandTypes, C extends Extract<Command, { type: T }>>(
-    type: {} extends Omit<C, "type"> ? T : never
+    type: {} extends Omit<C, "type" | "isPrimaryDispatch"> ? T : never
   ): CommandResult;
   dispatch<T extends CommandTypes, C extends Extract<Command, { type: T }>>(
     type: T,
-    r: Omit<C, "type">
+    r: Omit<C, "type" | "isPrimaryDispatch">
   ): CommandResult;
 }
 
 export interface CoreCommandDispatcher {
   dispatch<T extends CoreCommandTypes, C extends Extract<CoreCommand, { type: T }>>(
-    type: {} extends Omit<C, "type"> ? T : never
+    type: {} extends Omit<C, "type" | "isPrimaryDispatch"> ? T : never
   ): CommandResult;
   dispatch<T extends CoreCommandTypes, C extends Extract<CoreCommand, { type: T }>>(
     type: T,
-    r: Omit<C, "type">
+    r: Omit<C, "type" | "isPrimaryDispatch">
   ): CommandResult;
 }
 

--- a/tests/plugins/history.test.ts
+++ b/tests/plugins/history.test.ts
@@ -271,11 +271,12 @@ describe("Model history", () => {
 
   test("ACTIVATE_SHEET standalone is not saved", () => {
     const model = new Model();
+    const firstSheetId = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42" });
-    setCellContent(model, "A1", "this will be undone");
+    setCellContent(model, "A1", "this will be undone", firstSheetId);
     activateSheet(model, "42");
     undo(model);
-    expect(model.getters.getActiveSheetId()).toBe("42");
+    expect(model.getters.getActiveSheetId()).toBe(firstSheetId);
   });
 
   test("create and activate sheet, then undo", () => {
@@ -290,11 +291,21 @@ describe("Model history", () => {
     expect(model.getters.getActiveSheetId()).toBe(originActiveSheetId);
   });
 
-  test("ACTIVATE_SHEET with another command is saved", () => {
+  test("undo active sheet creation changes the active sheet", () => {
     const model = new Model();
     const sheet = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42", activate: true });
     undo(model);
     expect(model.getters.getActiveSheetId()).toBe(sheet);
+  });
+
+  test("ACTIVATE_SHEET with another command is saved", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    createSheet(model, { sheetId: "42" });
+    setCellContent(model, "A1", "Hello in sheet 1", sheetId);
+    activateSheet(model, "42");
+    undo(model);
+    expect(model.getters.getActiveSheetId()).toBe(sheetId);
   });
 });

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -751,7 +751,7 @@ describe("sheets", () => {
     expect(model.getters.getActiveSheetId()).toEqual(sheet1);
     undo(model);
     expect(model.getters.getSheets()).toHaveLength(2);
-    expect(model.getters.getActiveSheetId()).toEqual(sheet1);
+    expect(model.getters.getActiveSheetId()).toEqual(sheet2);
     redo(model);
     expect(model.getters.getSheets()).toHaveLength(1);
     expect(model.getters.getActiveSheetId()).toEqual(sheet1);


### PR DESCRIPTION
When we undo an operation, we would like the selection to be restored as it was
at the time. The active sheet is actually the most important to restore because
if you undo a change that's in another sheet than your current active sheet,
you won't see the effect of the undo and might think that it didn't work.

We first tried to restore the entire selection (selected zone and active sheet).
This is unfortunately not an easy task disappointed.

Several explored options:

Maintain undo/redo stacks of selections
-----------------
Maintain undo/redo stacks of selections such as in the local history. Problems
arise in a collaborative environnement. The "saved" selections must be transformed
according to action of others. Transformations are only handled by the
SelectiveHistory (and it's not trivial. It is its job and its only job). We don't
want any coupling between plugins and the SelectiveHistory.

Enrich the UNDO & REDO commands
--------
Enrich the UNDO & REDO commands with the undone/redone command(s) and select
the corresponding zone and sheet.
e.g. Redo an "UPDATE_CELL" command would set the selection according to
`command.row`,`command.col` and `command.sheetId`.

However, one operation can dispatch multiple commands and it's not always obvious
which should be used to restore the selection.
e.g.
- SORT_CELLS leads to many UPDATE_CELL, here we want the selection of SORT_CELLS
- SELECT_CELL can lead to an UPDATE_CELL if the composer is active. Here we want
the selection of UPDATE_CELL.

Note that the "selection command" can be a UI command (SORT_CELLS) which should
be saved somehow in the history. It would also need to be transformed... We
probably don't want UI command transformations. Even if c5292a7 would mitigates
the problem.

The core/UI plugins, the selective undo and transformations are still pretty
new. I think we are missing something to implement what we want in a proper
and clean way. The architecture probably needs to be refined/evolve.
But it's unclear how (yet).

We abandoned the idea of restoring the complete selection for now. We only
restore the active sheet (which does not require transformation).

Co-authored-by: fleodoo <fle@odoo.com>