### PR TITLE
[FIX] cell, borders: correctly handle duplicate sheet

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -69,6 +69,12 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
           this.handleAddRows(cmd);
         }
         break;
+      case "DUPLICATE_SHEET":
+        const borders = this.borders[cmd.sheetId];
+        if (borders) {
+          this.history.update("borders", cmd.sheetIdTo, JSON.parse(JSON.stringify(borders)));
+        }
+        break;
     }
   }
 

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -115,6 +115,13 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
         this.updateCell(this.getters.getSheet(cmd.sheetId), cmd.col, cmd.row, cmd);
         break;
 
+      case "DUPLICATE_SHEET":
+        const cells = this.cells[cmd.sheetId];
+        if (cells) {
+          this.history.update("cells", cmd.sheetIdTo, JSON.parse(JSON.stringify(cells)));
+        }
+        break;
+
       case "CLEAR_CELL":
         this.dispatch("UPDATE_CELL", {
           sheetId: cmd.sheetId,

--- a/tests/plugins/borders.test.ts
+++ b/tests/plugins/borders.test.ts
@@ -309,6 +309,15 @@ describe("borders", () => {
     expect(getBorder(model, "C4")).toEqual({ top: s, bottom: s, right: s, left: s });
     expect(getBorder(model, "B2")).toBeNull();
   });
+
+  test("Borders are correctly duplicated on sheet duplication", () => {
+    const model = new Model();
+    setBorder(model, "external", "B2");
+    const s = DEFAULT_BORDER_DESC;
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "42", name: "hello" });
+    expect(getBorder(model, "B2", "42")).toEqual({ top: s, bottom: s, right: s, left: s });
+  });
 });
 
 describe("Grid manipulation", () => {

--- a/tests/plugins/import_export.test.ts
+++ b/tests/plugins/import_export.test.ts
@@ -4,8 +4,14 @@ import { CURRENT_VERSION } from "../../src/data";
 import { Model } from "../../src/model";
 import { corePluginRegistry } from "../../src/plugins";
 import { BorderDescr, WorkbookData } from "../../src/types/index";
-import { activateSheet, merge, resizeColumns, resizeRows } from "../test_helpers/commands_helpers";
-import { getMerges } from "../test_helpers/getters_helpers";
+import {
+  activateSheet,
+  merge,
+  resizeColumns,
+  resizeRows,
+  setCellContent,
+} from "../test_helpers/commands_helpers";
+import { getCellContent, getMerges } from "../test_helpers/getters_helpers";
 import "../test_helpers/helpers";
 import { mockUuidV4To, toPosition } from "../test_helpers/helpers";
 
@@ -332,6 +338,18 @@ test("complete import, then export", () => {
   // We test here a that two import with the same data give the same result.
   const model2 = new Model(modelData);
   expect(model2.exportData()).toEqual(modelData);
+});
+
+test("Data of a duplicate sheet are correctly duplicated", () => {
+  const model = new Model();
+  setCellContent(model, "A1", "hello");
+  const sheetId = model.getters.getActiveSheetId();
+  model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "42", name: "second" });
+  expect(getCellContent(model, "A1", sheetId)).toBe("hello");
+  expect(getCellContent(model, "A1", "42")).toBe("hello");
+  const data = model.exportData();
+  expect(Object.keys(data.sheets[0].cells)).toHaveLength(1);
+  expect(Object.keys(data.sheets[1].cells)).toHaveLength(1);
 });
 
 test("import then export (figures)", () => {


### PR DESCRIPTION
Before this commit, duplicate a sheet was not correctly handled in cell
and borders:
- borders: the borders of the first sheet were not copied to the new one
- cell: The cells of the sheet were not copied to the new one.

Note that, in rendering, it worked for the cells because the cells on
sheet.rows were correctly copied. But during export, it's the cells on
the cell plugin which are exported.