### PR TITLE
[FIX] sheet: correctly duplicate cells

### DIFF
--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -492,14 +492,33 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
 
   private duplicateSheet(fromId: UID, toId: UID, toName: string) {
     const sheet = this.sheets[fromId];
-    const newSheet = JSON.parse(JSON.stringify(sheet));
+    const newSheet: Sheet = JSON.parse(JSON.stringify(sheet));
     newSheet.id = toId;
     newSheet.name = toName;
+    for (let col = 0; col <= newSheet.cols.length; col++) {
+      for (let row = 0; row <= newSheet.rows.length; row++) {
+        if (newSheet.rows[row]) {
+          newSheet.rows[row].cells[col] = undefined;
+        }
+      }
+    }
     const visibleSheets = this.visibleSheets.slice();
     const currentIndex = visibleSheets.findIndex((id) => id === fromId);
     visibleSheets.splice(currentIndex + 1, 0, newSheet.id);
     this.history.update("visibleSheets", visibleSheets);
     this.history.update("sheets", Object.assign({}, this.sheets, { [newSheet.id]: newSheet }));
+
+    for (const cell of Object.values(this.getters.getCells(fromId))) {
+      const { col, row } = this.getCellPosition(cell.id);
+      this.dispatch("UPDATE_CELL", {
+        sheetId: newSheet.id,
+        col,
+        row,
+        content: this.getters.getCellText(cell, fromId, true),
+        format: cell.format,
+        style: cell.style,
+      });
+    }
 
     const sheetIds = Object.assign({}, this.sheetIds);
     sheetIds[newSheet.name] = newSheet.id;

--- a/tests/plugins/import_export_test.ts
+++ b/tests/plugins/import_export_test.ts
@@ -3,7 +3,7 @@ import { CURRENT_VERSION } from "../../src/data";
 import { Model } from "../../src/model";
 import { BorderDescr } from "../../src/types/index";
 import "../helpers"; // to have getcontext mocks
-import { getMerges, mockUuidV4To, toPosition } from "../helpers";
+import { getCellContent, getMerges, mockUuidV4To, setCellContent, toPosition } from "../helpers";
 
 describe("data", () => {
   test("give default col size if not specified", () => {
@@ -338,6 +338,18 @@ test("complete import, then export", () => {
   // We test here a that two import with the same data give the same result.
   const model2 = new Model(modelData);
   expect(model2.exportData()).toEqual(modelData);
+});
+
+test("Data of a duplicate sheet are correctly duplicated", () => {
+  const model = new Model();
+  setCellContent(model, "A1", "hello");
+  const sheetId = model.getters.getActiveSheetId();
+  model.dispatch("DUPLICATE_SHEET", { sheetIdFrom: sheetId, sheetIdTo: "42", name: "second" });
+  expect(getCellContent(model, "A1", sheetId)).toBe("hello");
+  expect(getCellContent(model, "A1", "42")).toBe("hello");
+  const data = model.exportData();
+  expect(Object.keys(data.sheets[0].cells)).toHaveLength(1);
+  expect(Object.keys(data.sheets[1].cells)).toHaveLength(1);
 });
 
 test("import then export (figures)", () => {


### PR DESCRIPTION
This commit fix the cell duplication during sheet duplication

Fixes #811

IMHO, it's not clean. We have to force cells on sheet.rows.cell to undefined because the updateCell should think that it's a new cell. 