### PR TITLE
[FIX] cell: do not override format when specified

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -644,7 +644,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
             dependencies: ranges,
           } as FormulaCell;
 
-          if (!after.formula) {
+          if (!format && !after.formula) {
             format = this.computeFormulaFormat(cell);
           }
         } catch (_) {
@@ -669,7 +669,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
           content: afterContent,
           value: parseNumber(afterContent),
         };
-        if (afterContent.includes("%")) {
+        if (!format && afterContent.includes("%")) {
           format = afterContent.includes(".") ? "0.00%" : "0%";
         }
       } else {

--- a/tests/plugins/cell_test.ts
+++ b/tests/plugins/cell_test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src";
 import { CellType } from "../../src/types";
 import "../canvas.mock";
+import { getCell } from "../helpers";
 
 describe("getCellText", () => {
   test.each([
@@ -22,5 +23,34 @@ describe("getCellText", () => {
         sheetId
       )
     ).toBe(expected);
+  });
+
+  test("Update cell with a format is correctly set", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("UPDATE_CELL", {
+      sheetId,
+      col: 0,
+      row: 0,
+      content: "5%",
+      format: "bla",
+    });
+    model.dispatch("UPDATE_CELL", {
+      sheetId,
+      col: 1,
+      row: 1,
+      content: "12/30/1899",
+      format: "bla",
+    });
+    model.dispatch("UPDATE_CELL", {
+      sheetId,
+      col: 2,
+      row: 2,
+      content: "=DATE(2021,1,1)",
+      format: "bla",
+    });
+    expect(getCell(model, "A1")?.format).toBe("bla");
+    expect(getCell(model, "B2")?.format).toBe("bla");
+    expect(getCell(model, "C3")?.format).toBe("bla");
   });
 });


### PR DESCRIPTION
Before this commit, a update cell with a content tried to compute the
format, even if the format was given in the command