### PR TITLE
[FIX] borders: correctly duplicate borders on sheet duplication

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -54,6 +54,12 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
           this.addBordersToMerge(cmd.sheetId, cmd.zone);
         }
         break;
+      case "DUPLICATE_SHEET":
+        const borders = this.borders[cmd.sheetIdFrom];
+        if (borders) {
+          this.history.update("borders", cmd.sheetIdTo, JSON.parse(JSON.stringify(borders)));
+        }
+        break;
       case "SET_BORDER":
         this.setBorder(cmd.sheetId, cmd.col, cmd.row, cmd.border);
         break;

--- a/tests/plugins/borders_test.ts
+++ b/tests/plugins/borders_test.ts
@@ -391,4 +391,13 @@ describe("Grid manipulation", () => {
     expect(getBorder(model, "C2")).toBeNull();
     expect(getBorder(model, "B4")).toEqual({ top: b });
   });
+
+  test("Borders are correctly duplicated on sheet dup", () => {
+    setBorder(model, "external", "B2");
+    const sheetIdFrom = model.getters.getActiveSheetId();
+    const sheetIdTo = "42";
+    model.dispatch("DUPLICATE_SHEET", { sheetIdFrom, sheetIdTo, name: "42" });
+    model.dispatch("ACTIVATE_SHEET", { sheetIdFrom, sheetIdTo });
+    expect(getBorder(model, "B2")).toEqual({ top: b, left: b, right: b, bottom: b });
+  });
 });


### PR DESCRIPTION
Before this commit, the borders were not copied when a sheet was
duplicated