### PR TITLE
[FIX] translation: fix incorrect use of translation functions on template strings

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -50,7 +50,7 @@ export const LOOKUP: FunctionDescription = {
 
     const index = dichotomicPredecessorSearch(searchRange, search_key);
     if (index === -1) {
-      throw new Error(_lt(`Did not find value '${search_key}' in LOOKUP evaluation.`));
+      throw new Error(_lt("Did not find value '%s' in LOOKUP evaluation.", search_key));
     }
     if (result_range === undefined) {
       return verticalSearch ? search_array.pop()[index] : search_array[index].pop();

--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -191,7 +191,8 @@ export const REPLACE: FunctionDescription = {
     if (_position < 1) {
       throw new Error(
         _lt(
-          `Function REPLACE parameter 2 value is ${_position}. It should be greater than or equal to 1.`
+          "Function REPLACE parameter 2 value is %s. It should be greater than or equal to 1.",
+          toString(_position)
         )
       );
     }

--- a/src/plugins/conditional_format.ts
+++ b/src/plugins/conditional_format.ts
@@ -303,7 +303,9 @@ export class ConditionalFormatPlugin extends BasePlugin {
         default:
           console.warn(
             _lt(
-              `Not implemented operator ${rule.operator} for kind of conditional formatting:  ${rule.type}`
+              "Not implemented operator %s for kind of conditional formatting:  %s",
+              rule.operator,
+              rule.type
             )
           );
       }

--- a/src/registries/menus/sheet_menu_registry.ts
+++ b/src/registries/menus/sheet_menu_registry.ts
@@ -8,8 +8,8 @@ export const sheetMenuRegistry = new MenuItemRegistry();
 function getDuplicateSheetName(env: SpreadsheetEnv, sheet: string) {
   let i = 1;
   const names = env.getters.getSheets().map((s) => s.name);
-  const baseName = env._t(`Copy of ${sheet}`);
-  let name = baseName;
+  const baseName = _lt("Copy of %s", sheet);
+  let name = baseName.toString();
   while (names.includes(name)) {
     name = `${baseName} (${i})`;
     i++;


### PR DESCRIPTION
See #746 for why the version before the commit can't get translated.