### PR TITLE
[FIX] range: handle invalid range strings

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -1,3 +1,4 @@
+import { rangeReference } from "../../formulas";
 import {
   getComposerSheetName,
   getUnquotedSheetName,
@@ -197,6 +198,9 @@ export class RangePlugin extends CorePlugin<RangeState> {
     let sheetId: UID | undefined;
     let invalidSheetName: string | undefined;
     let prefixSheet: boolean = false;
+    if (!rangeReference.test(sheetXC)) {
+      return this.buildInvalidRange(sheetXC);
+    }
     if (sheetXC.includes("!")) {
       [xc, sheetName] = sheetXC.split("!").reverse();
       if (sheetName) {
@@ -265,7 +269,9 @@ export class RangePlugin extends CorePlugin<RangeState> {
     if (!range) {
       return INCORRECT_RANGE_STRING;
     }
-
+    if (range.invalidXc) {
+      return range.invalidXc;
+    }
     if (range.zone.bottom - range.zone.top < 0 || range.zone.right - range.zone.left < 0) {
       return INCORRECT_RANGE_STRING;
     }
@@ -324,5 +330,16 @@ export class RangePlugin extends CorePlugin<RangeState> {
       }
     }
     set.clear();
+  }
+
+  private buildInvalidRange(invalidXc: string): Range {
+    return {
+      id: uuidv4(),
+      parts: [],
+      prefixSheet: false,
+      zone: { left: -1, top: -1, right: -1, bottom: -1 },
+      sheetId: "",
+      invalidXc,
+    };
   }
 }

--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -226,6 +226,9 @@ export class EvaluationChartPlugin extends UIPlugin {
     if (ds.dataRange) {
       const labelCellZone = ds.labelCell ? [zoneToXc(ds.labelCell.zone)] : [];
       const dataXC = recomputeZones([zoneToXc(ds.dataRange.zone)], labelCellZone)[0];
+      if (!dataXC) {
+        return [];
+      }
       const dataRange = this.getters.getRangeFromSheetXC(sheetId, dataXC, undefined, false);
       const dataRangeXc = this.getters.getRangeString(dataRange, sheetId);
       return this.getters.getRangeValues(dataRangeXc, ds.dataRange.sheetId).flat(1);

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -62,6 +62,7 @@ export type Range = {
   sheetId: UID; // the sheet on which the range is defined
   onChange?: onRangeChange; // the callbacks that needs to be called if a range is modified
   invalidSheetName?: string; // the name of any sheet that is invalid
+  invalidXc?: string;
   parts: RangePart[];
   prefixSheet: boolean; // true if the user provided the range with the sheet name, so it has to be recomputed with the sheet name too
 };

--- a/tests/model/plugins/chart_test.ts
+++ b/tests/model/plugins/chart_test.ts
@@ -2,7 +2,13 @@ import { Model } from "../../../src";
 import { toZone } from "../../../src/helpers/zones";
 import { CancelledReason, Viewport } from "../../../src/types";
 import "../../canvas.mock";
-import { mockUuidV4To, setCellContent, testUndoRedo, waitForRecompute } from "../../helpers";
+import {
+  getCellContent,
+  mockUuidV4To,
+  setCellContent,
+  testUndoRedo,
+  waitForRecompute,
+} from "../../helpers";
 jest.mock("../../../src/helpers/uuid", () => require("../../__mocks__/uuid"));
 
 let model: Model;
@@ -502,6 +508,30 @@ describe("datasource tests", function () {
     expect(chart.data!.datasets![0].data).toEqual([30, 31, 32]);
     expect(chart.data!.datasets![1].data).toEqual([40, 41, 42]);
     expect(chart.type).toEqual("bar");
+  });
+
+  test("delete data rows", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("CREATE_CHART", {
+      id: "1",
+      sheetId,
+      definition: {
+        title: "test 1",
+        dataSets: ["Sheet1!B1:B4"],
+        dataSetsHaveTitle: true,
+        labelRange: "Sheet1!A2:A4",
+        type: "line",
+      },
+    });
+    model.dispatch("REMOVE_ROWS", {
+      rows: [1, 2, 3],
+      sheetId,
+    });
+    expect(model.getters.getChartRuntime("1")!.data!.datasets).toHaveLength(1);
+    expect(model.getters.getChartRuntime("1")!.data!.datasets![0].data).toHaveLength(0);
+    expect(model.getters.getChartRuntime("1")!.data!.datasets![0].label).toBe(
+      getCellContent(model, "B1")
+    );
   });
 
   test.skip("delete a data source column", () => {

--- a/tests/plugins/range_test.ts
+++ b/tests/plugins/range_test.ts
@@ -394,6 +394,8 @@ describe("range plugin", () => {
       ["s1!$A1:$B1"],
       ["s1!A$1:B$1"],
       ["s1!$A$1:$B$1"],
+      ["#REF"],
+      ["invalid xc"],
     ])("test withing a fixed row", (range) => {
       let r = m.getters.getRangeFromSheetXC("s1", range);
       expect(m.getters.getRangeString(r, "s1")).toBe(range);
@@ -424,6 +426,8 @@ describe("range plugin", () => {
       ["s1!$A1:$B1", "s1!$A1:$B1"],
       ["s1!A$1:B$1", "s1!A$1:B$1"],
       ["s1!$A$1:$B$1", "s1!$A$1:$B$1"],
+      ["#REF", "#REF"],
+      ["invalid xc", "invalid xc"],
     ])("test withing a fixed row, displayed for another sheet", (range, expectedString) => {
       let r = m.getters.getRangeFromSheetXC("s1", range);
       expect(m.getters.getRangeString(r, "s2")).toBe(expectedString);


### PR DESCRIPTION
Task 2448448

Note: in master, I would like to try better typing `Range`. Maybe something like
```ts
type Range = ValidRange | InvalidRange;
type ValidRange = { ... };
type InvalidRange = { ... };
```
But I don't think it is easy, nor even possible.
In this commit, it would have caught the fix in `evaluation_chart` at *compile* time. Maybe there are more similar bugs lurking...