### PR TITLE
[FIX] tests: open composer after toolbar is used

### DIFF
--- a/tests/components/spreadsheet_test.ts
+++ b/tests/components/spreadsheet_test.ts
@@ -4,7 +4,7 @@ import { Spreadsheet } from "../../src/components";
 import { args, functionRegistry } from "../../src/functions";
 import { DEBUG } from "../../src/helpers";
 import { SelectionMode } from "../../src/plugins/selection";
-import { triggerMouseEvent } from "../dom_helper";
+import { simulateClick, triggerMouseEvent } from "../dom_helper";
 import { makeTestFixture, MockClipboard, nextTick } from "../helpers";
 
 const { xml } = tags;
@@ -180,5 +180,15 @@ describe("Spreadsheet", () => {
   test("Debug informations are removed when Spreadsheet is destroyed", async () => {
     parent["spreadsheet"].comp.destroy();
     expect(Object.keys(DEBUG)).toHaveLength(0);
+  });
+
+  test("typing opens composer after toolbar clicked", async () => {
+    await simulateClick(`div[title="Bold"]`);
+    expect(document.activeElement).not.toBeNull();
+    document.activeElement?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "d", bubbles: true })
+    );
+    expect(parent.model.getters.getEditionMode()).toBe("editing");
+    expect(parent.model.getters.getCurrentContent()).toBe("d");
   });
 });

--- a/tests/dom_helper.ts
+++ b/tests/dom_helper.ts
@@ -3,7 +3,10 @@ import { nextTick } from "./helpers";
 export async function simulateClick(selector: string, x: number = 10, y: number = 10) {
   const target = document.querySelector(selector)! as HTMLElement;
   triggerMouseEvent(selector, "mousedown", x, y);
-  target.focus();
+  if (target !== document.activeElement) {
+    (document.activeElement as HTMLElement | null)?.blur();
+    target.focus();
+  }
   triggerMouseEvent(selector, "mouseup", x, y);
   triggerMouseEvent(selector, "click", x, y);
   await nextTick();


### PR DESCRIPTION
This commit adds a test for 332a7e5 which remains untested to this day.
Removing the following line breaks the behaviour without breaking any test.

https://github.com/odoo/o-spreadsheet/blob/4a4bf9c6adf14180aba4e73d42fcdf1e46571f13/src/components/spreadsheet.ts#L184