### PR TITLE
[FIX] config: re-enable live reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A spreadsheet component",
   "main": "index.js",
   "scripts": {
-    "serve": "live-server --open=demo --ignore=logs,./",
+    "serve": "live-server --open=demo --watch=dist,demo",
     "dev": "npm-run-all build --parallel server serve \"build:* -- --watch\"",
     "server": "node tools/server/main.js",
     "build:js": "tsc --module es6 --outDir dist/js --incremental",


### PR DESCRIPTION
Since 7c0e933, the app is no longer reloaded when source files change.
Notice the `--ignore=./` ;)

The live server does not actually need to watch source files, but rather
the built files, which are the ones served to the browser.

Rollup watches source files and takes care of rebuilding the served files.