### PR TITLE
[FIX] demo: handle collaborative server connection failures

### DIFF
--- a/demo/transport.js
+++ b/demo/transport.js
@@ -5,16 +5,27 @@ export class WebsocketTransport {
   listeners = [];
   queue = [];
   isConnected = false;
-  socket = new WebSocket(`ws://localhost:9000`);
+  socket = null;
 
-  constructor() {
-    this.socket.addEventListener("open", () => {
-      this.isConnected = true;
-      this.processQueue();
-    });
-    this.socket.addEventListener("message", (ev) => {
-      const message = JSON.parse(ev.data);
-      this.notifyListeners(message);
+  /**
+   * Open a connection to the collaborative server.
+   *
+   * @returns {Promise<void>}
+   */
+  connect() {
+    return new Promise((resolve, reject) => {
+      const socket = new WebSocket(`ws://localhost:9000`);
+      socket.addEventListener("open", () => {
+        this.socket = socket;
+        this.isConnected = true;
+        this.processQueue();
+        resolve();
+      });
+      socket.addEventListener("message", (ev) => {
+        const message = JSON.parse(ev.data);
+        this.notifyListeners(message);
+      });
+      socket.addEventListener("error", reject);
     });
   }
 


### PR DESCRIPTION
Currently, if the collaborative server cannot be reached, the demo spreadsheet
won't open.
This commit adds connection failure handling. The spreadsheet will start in
non-collaborative mode if any connection error occurs.