### PR TITLE
[FIX] grid: remove resize event handler

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -35,7 +35,7 @@ import { ScrollBar } from "./scrollbar";
 
 const { Component, useState } = owl;
 const { xml, css } = owl.tags;
-const { useRef, onMounted, onWillUnmount } = owl.hooks;
+const { useRef, onMounted, onWillUnmount, useExternalListener } = owl.hooks;
 export type ContextMenuType = "ROW" | "COL" | "CELL";
 
 const registries = {
@@ -342,19 +342,15 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
     this.vScrollbar = new ScrollBar(this.vScrollbarRef.el, "vertical");
     this.hScrollbar = new ScrollBar(this.hScrollbarRef.el, "horizontal");
     useTouchMove(this.moveCanvas.bind(this), () => this.vScrollbar.scroll > 0);
+    useExternalListener(window, "resize", this.resizeGrid.bind(this));
   }
 
   mounted() {
     this.vScrollbar.el = this.vScrollbarRef.el!;
     this.hScrollbar.el = this.hScrollbarRef.el!;
-    window.addEventListener("resize", this.resizeGrid.bind(this));
     this.focus();
     this.resizeGrid();
     this.drawGrid();
-  }
-
-  onWillUnmount() {
-    () => window.removeEventListener("resize", this.resizeGrid);
   }
 
   patched() {

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -598,4 +598,9 @@ describe("Events on Grid update viewport correctly", () => {
       right: 10,
     });
   });
+
+  test("resize event handler is removed", () => {
+    parent.destroy();
+    window.dispatchEvent(new Event("resize"));
+  });
 });


### PR DESCRIPTION
The resize event handler was not correctly removed when the component is unmounted.
This can lead to crashes (e.g. in Odoo) since the `el` does not exist anymore.