### PR TITLE
[IMP] viewport:  make viewport responsive on range selection

### DIFF
--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -7,7 +7,7 @@ import {
   MIN_ROW_HEIGHT,
   UNHIDE_ICON_EDGE_LENGTH,
 } from "../constants";
-import { Col, Row, SpreadsheetEnv } from "../types/index";
+import { Col, EdgeScrollInfo, Row, SpreadsheetEnv } from "../types/index";
 import { ContextMenuType } from "./grid";
 import { startDnd } from "./helpers/drag_and_drop";
 import * as icons from "./icons";
@@ -47,6 +47,10 @@ abstract class AbstractResizer extends Component<any, SpreadsheetEnv> {
 
   abstract _getElementIndex(index: number): number;
 
+  abstract _getEdgeScroll(position: number): EdgeScrollInfo;
+
+  abstract _getBoundaries(): { first: number; last: number };
+
   abstract _getElement(index: number): Col | Row;
 
   abstract _getHeaderSize(): number;
@@ -58,6 +62,8 @@ abstract class AbstractResizer extends Component<any, SpreadsheetEnv> {
   abstract _selectElement(index: number, ctrlKey: boolean): void;
 
   abstract _increaseSelection(index: number): void;
+
+  abstract _adjustViewport(index: number): void;
 
   abstract _fitElementSize(index: number): void;
 
@@ -160,15 +166,37 @@ abstract class AbstractResizer extends Component<any, SpreadsheetEnv> {
     }
     const initialIndex = this._getClientPosition(ev);
     const initialOffset = this._getEvOffset(ev);
+    let timeOutId: any = null;
+    let currentEv: MouseEvent;
+
     const onMouseMoveSelect = (ev: MouseEvent) => {
-      const offset = this._getClientPosition(ev) - initialIndex + initialOffset;
-      const index = this._getElementIndex(offset);
+      currentEv = ev;
+      if (timeOutId) {
+        return;
+      }
+      const offset = this._getClientPosition(currentEv) - initialIndex + initialOffset;
+      const EdgeScrollInfo = this._getEdgeScroll(offset);
+      const { first, last } = this._getBoundaries();
+      let index;
+      if (EdgeScrollInfo.canEdgeScroll) {
+        index = EdgeScrollInfo.direction > 0 ? last : first - 1;
+      } else {
+        index = this._getElementIndex(offset);
+      }
       if (index !== this.lastElement && index !== -1) {
         this._increaseSelection(index);
         this.lastElement = index;
       }
+      if (EdgeScrollInfo.canEdgeScroll) {
+        this._adjustViewport(EdgeScrollInfo.direction);
+        timeOutId = setTimeout(() => {
+          timeOutId = null;
+          onMouseMoveSelect(currentEv);
+        }, Math.round(EdgeScrollInfo.delay));
+      }
     };
     const onMouseUpSelect = () => {
+      clearTimeout(timeOutId);
       this.lastElement = null;
       this.dispatch(ev.ctrlKey ? "PREPARE_SELECTION_EXPANSION" : "STOP_SELECTION");
     };
@@ -282,6 +310,15 @@ export class ColResizer extends AbstractResizer {
     return this.getters.getColIndex(index, this.getters.getActiveSnappedViewport().left);
   }
 
+  _getEdgeScroll(position: number): EdgeScrollInfo {
+    return this.getters.getEdgeScrollCol(position);
+  }
+
+  _getBoundaries(): { first: number; last: number } {
+    const { left, right } = this.getters.getActiveSnappedViewport();
+    return { first: left, last: right };
+  }
+
   _getElement(index: number): Col {
     return this.getters.getCol(this.getters.getActiveSheetId(), index)!;
   }
@@ -316,6 +353,13 @@ export class ColResizer extends AbstractResizer {
 
   _increaseSelection(index: number): void {
     this.dispatch("SELECT_COLUMN", { index, updateRange: true });
+  }
+
+  _adjustViewport(direction: number): void {
+    const { left, offsetY } = this.getters.getActiveSnappedViewport();
+    const { cols } = this.getters.getActiveSheet();
+    const offsetX = cols[left + direction].start;
+    this.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
   }
 
   _fitElementSize(index: number): void {
@@ -456,6 +500,15 @@ export class RowResizer extends AbstractResizer {
     return this.getters.getRowIndex(index, this.getters.getActiveSnappedViewport().top);
   }
 
+  _getEdgeScroll(position: number): EdgeScrollInfo {
+    return this.getters.getEdgeScrollRow(position);
+  }
+
+  _getBoundaries(): { first: number; last: number } {
+    const { top, bottom } = this.getters.getActiveSnappedViewport();
+    return { first: top, last: bottom };
+  }
+
   _getElement(index: number): Row {
     return this.getters.getRow(this.getters.getActiveSheetId(), index)!;
   }
@@ -486,6 +539,13 @@ export class RowResizer extends AbstractResizer {
 
   _increaseSelection(index: number): void {
     this.dispatch("SELECT_ROW", { index, updateRange: true });
+  }
+
+  _adjustViewport(direction: number): void {
+    const { top, offsetX } = this.getters.getActiveSnappedViewport();
+    const { rows } = this.getters.getActiveSheet();
+    const offsetY = rows[top + direction].start;
+    this.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
   }
 
   _fitElementSize(index: number): void {

--- a/src/helpers/edge_scrolling.ts
+++ b/src/helpers/edge_scrolling.ts
@@ -1,0 +1,14 @@
+export const MAX_DELAY = 140;
+const MIN_DELAY = 20;
+const ACCELERATION = 0.035;
+
+/**
+ * Decreasing exponential function used to determine the "speed" of edge-scrolling
+ * as the timeout delay.
+ *
+ * Returns a timeout delay in milliseconds.
+ */
+export function scrollDelay(value: number): number {
+  // decreasing exponential from MAX_DELAY to MIN_DELAY
+  return MIN_DELAY + (MAX_DELAY - MIN_DELAY) * Math.exp(-ACCELERATION * (value - 1));
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,5 +1,6 @@
 export * from "./color";
 export * from "./coordinates";
+export * from "./edge_scrolling";
 export * from "./grid_manipulation";
 export * from "./misc";
 export * from "./numbers";

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -1,4 +1,4 @@
-import { Cell, Sheet, Zone, ZoneDimension } from "../types";
+import { Cell, Sheet, Viewport, Zone, ZoneDimension } from "../types";
 import { toCartesian, toXC } from "./coordinates";
 import { range } from "./misc";
 
@@ -436,4 +436,33 @@ export function uniqueZones(zones: Zone[]): Zone[] {
           z.right === zone.right
       )
   );
+}
+
+/**
+ * This function will compare the modifications of selection to determine
+ * a cell that is part of the new zone and not the previous one.
+ */
+export function findCellInNewZone(
+  oldZone: Zone,
+  currentZone: Zone,
+  viewport: Viewport
+): [number, number] {
+  let col: number, row: number;
+  const { left: oldLeft, right: oldRight, top: oldTop, bottom: oldBottom } = oldZone!;
+  const { left, right, top, bottom } = currentZone;
+  if (left != oldLeft) {
+    col = left;
+  } else if (right != oldRight) {
+    col = right;
+  } else {
+    col = viewport.left;
+  }
+  if (top != oldTop) {
+    row = top;
+  } else if (bottom != oldBottom) {
+    row = bottom;
+  } else {
+    row = viewport.top;
+  }
+  return [col, row];
 }

--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -91,6 +91,13 @@ export class ViewportPlugin extends UIPlugin {
     }
   }
 
+  finalize() {
+    if (this.updateSnap) {
+      this.snapViewportToCell(this.getters.getActiveSheetId());
+      this.updateSnap = false;
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Getters
   // ---------------------------------------------------------------------------
@@ -272,13 +279,14 @@ export class ViewportPlugin extends UIPlugin {
    * In order to keep the coherence of both viewports, it is also necessary to update the standard viewport
    * if the zones of both viewports don't match.
    */
-  private adjustViewportsPosition(sheetId: UID) {
+  private adjustViewportsPosition(sheetId: UID, position?: [number, number]) {
     const sheet = this.getters.getSheet(sheetId);
     const { cols, rows } = sheet;
     const adjustedViewport = this.getSnappedViewport(sheetId);
+    position = position || this.getters.getSheetPosition(sheetId);
     const [col, row] = this.getters.getMainCell(
       sheetId,
-      ...getNextVisibleCellCoords(sheet, ...this.getters.getSheetPosition(sheetId))
+      ...getNextVisibleCellCoords(sheet, position[0], position[1])
     );
     while (
       cols[col].end > adjustedViewport.offsetX + this.clientWidth - HEADER_WIDTH &&
@@ -325,12 +333,5 @@ export class ViewportPlugin extends UIPlugin {
     adjustedViewport.offsetY = rows[viewport.top].start;
     this.adjustViewportZone(sheetId, adjustedViewport);
     this.snappedViewports[sheetId] = adjustedViewport;
-  }
-
-  finalize() {
-    if (this.updateSnap) {
-      this.snapViewportToCell(this.getters.getActiveSheetId());
-      this.updateSnap = false;
-    }
   }
 }

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -137,6 +137,8 @@ export type Getters = CoreGetters & {
   getColIndex: RendererPlugin["getColIndex"];
   getRowIndex: RendererPlugin["getRowIndex"];
   getRect: RendererPlugin["getRect"];
+  getEdgeScrollCol: RendererPlugin["getEdgeScrollCol"];
+  getEdgeScrollRow: RendererPlugin["getEdgeScrollRow"];
 
   getEditionMode: EditionPlugin["getEditionMode"];
   isSelectingForComposer: EditionPlugin["isSelectingForComposer"];

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -43,3 +43,11 @@ export const enum LAYERS {
   Autofill,
   Headers, // Probably keep this at the end
 }
+
+export interface EdgeScrollInfo {
+  canEdgeScroll: boolean;
+  direction: number;
+  delay: number;
+}
+
+export type ScrollDirection = 1 | 0 | -1;


### PR DESCRIPTION
The viewport should be able to move according to the user inputs when
selecting ranges.

Two cases should be covered :
- keyboard navigation : When selecting cells with Shift+ArrowKey,
viewport needs to dispay the latest cells added to the selection.
- Mouse navigation : the viewport should move towards the direction of
the cursor when le latter moves outside the boundaries of the grid.

Note that mouse navigation also affects the rows and columns headers.

In order to reach our goal, we introduce a notion of "edge-scrolling" to
know whether the viewport needs to move, as welle as the direction and
speed at which it should move.


TASK : [2518729](https://www.odoo.com/web#id=2518729&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)



## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] ~~exportable in excel~~
- [ ] ~~importable from excel~~
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo