### PR TITLE
[REF] plugins: split rule validation

### DIFF
--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -2,6 +2,7 @@
 // MISC
 // -----------------------------------------------------------------------------
 
+import { CommandResult } from "./commands";
 import { NormalizedFormula } from "./workbook_data";
 
 export type UID = string;
@@ -196,3 +197,5 @@ export type ConsecutiveIndexes = number[];
 export interface RangeProvider {
   adaptRanges: (applyChange: ApplyRangeChange, sheetId?: UID) => void;
 }
+
+export type Validation<T> = (toValidate: T) => CommandResult;


### PR DESCRIPTION
Small refactoring started this weekend ^^'

Validation logic implemented in `allowDispatch` are not always trivial and easy to read. There are sometimes many (nested) `if` and `for` loops, many early returns, many different validation rules mixed together. This can be hard to follow.

Also, it is often difficult to quickly see *what* is validated, because it is burried inside the implementation of very long methods without very descriptive names (such as `private checkMyThing(...)`, which gives no clue about what it actually validates)

This commit splits some of the hairiest `allowDispatch` in smaller validations steps.
Smaller is better because:
- there is less to read
- smaller scope: focus on one thing only
- smaller scope means it can be better named

The full validation is built from those small validations.
It makes easier to see *what* is validated without the concern of *how*
it is validated.

```js
allowDispatch(...) {
  const combinedValidation = combineValidations(
    validationFunction1,
    validationFunction2,
    validationFunction3,
  )
  return combinedValidation(whatIWantToValidate)
}
```

What do you think ?

Note: as always, naming things is hard, ideas are welcome :)
