### PR TITLE
[IMP] history: allow to clear local history when snapshotting

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -74,6 +74,7 @@ interface Props {
   stateUpdateMessages?: StateUpdateMessage[];
   transportService?: TransportService;
   isReadonly?: boolean;
+  snapshotRequested?: boolean;
 }
 
 const t = (s: string): string => s;
@@ -97,6 +98,7 @@ export class Spreadsheet extends Component<Props> {
       transportService: this.props.transportService,
       client: this.props.client,
       isReadonly: this.props.isReadonly,
+      snapshotRequested: this.props.snapshotRequested,
     },
     this.props.stateUpdateMessages
   );

--- a/src/history/local_history.ts
+++ b/src/history/local_history.ts
@@ -32,6 +32,11 @@ export class LocalHistory extends owl.core.EventBus {
     this.session.on("new-local-state-update", this, this.onNewLocalStateUpdate);
     this.session.on("revision-undone", this, this.selectiveUndo);
     this.session.on("revision-redone", this, this.selectiveRedo);
+    this.session.on("snapshot", this, () => {
+      this.undoStack = [];
+      this.redoStack = [];
+      this.isWaitingForUndoRedo = false;
+    });
   }
 
   allowDispatch(cmd: Command): CommandResult {

--- a/src/model.ts
+++ b/src/model.ts
@@ -67,6 +67,7 @@ export interface ModelConfig {
   client: Client;
   isHeadless: boolean;
   isReadonly: boolean;
+  snapshotRequested: boolean;
 }
 
 const enum Status {
@@ -172,6 +173,10 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
 
     // Load the initial revisions
     this.session.join(stateUpdateMessages);
+
+    if (config.snapshotRequested) {
+      this.session.snapshot(this.exportData());
+    }
   }
 
   get handlers(): CommandHandler<Command>[] {
@@ -272,6 +277,7 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
       moveClient: () => {},
       isHeadless: config.isHeadless || false,
       isReadonly: config.isReadonly || false,
+      snapshotRequested: false,
     };
   }
 

--- a/src/types/collaborative/session.ts
+++ b/src/types/collaborative/session.ts
@@ -49,6 +49,10 @@ export interface NewLocalStateUpdateEvent {
   id: UID;
 }
 
+export interface SnapshotEvent {
+  type: "snapshot";
+}
+
 export type CollaborativeEvent =
   | NewLocalStateUpdateEvent
   | UnexpectedRevisionIdEvent
@@ -56,6 +60,7 @@ export type CollaborativeEvent =
   | RevisionAcknowledgedEvent
   | RevisionUndone
   | RevisionRedone
+  | SnapshotEvent
   | CollaborativeEventReceived;
 
 export type CollaborativeEventTypes = CollaborativeEvent["type"];

--- a/src/types/collaborative/transport_service.ts
+++ b/src/types/collaborative/transport_service.ts
@@ -1,5 +1,6 @@
 import { CoreCommand } from "../commands";
 import { UID } from "../misc";
+import { WorkbookData } from "../workbook_data";
 import { Client, ClientId } from "./session";
 
 export interface AbstractMessage {
@@ -43,10 +44,32 @@ export interface ClientMovedMessage extends AbstractMessage {
   client: Required<Client>;
 }
 
+/**
+ * Send a snapshot of the spreadsheet to the collaborative server
+ */
+export interface SnapshotMessage extends AbstractMessage {
+  type: "SNAPSHOT";
+  data: WorkbookData;
+  serverRevisionId: UID;
+  nextRevisionId: UID;
+}
+
+/**
+ * Notify all clients that the server has a new snapshot of the
+ * spreadsheet and that the previous history may be lost.
+ */
+export interface SnapshotCreatedMessage extends AbstractMessage {
+  type: "SNAPSHOT_CREATED";
+  serverRevisionId: UID;
+  nextRevisionId: UID;
+}
+
 export type CollaborationMessage =
   | RevisionUndoneMessage
   | RevisionRedoneMessage
   | RemoteRevisionMessage
+  | SnapshotMessage
+  | SnapshotCreatedMessage
   | ClientMovedMessage
   | ClientJoinedMessage
   | ClientLeftMessage;

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -311,3 +311,7 @@ export function unMerge(
     target: target(range),
   });
 }
+
+export function snapshot(model: Model) {
+  model["session"].snapshot(model.exportData());
+}


### PR DESCRIPTION
Snapshotting the spreadsheet state regularly is an important optimisation to
ensure low loading times. The next time the spreadsheet will be
opened, the user will load the snapshot instead of the entire history since
the begining of time.

However, it also brings some problems. Let's consider the following scenario:
1. user A loads the spreadsheet, performs some operations and keeps the
   spreadsheet opened.
2. at a later point, the spreadsheet is snapshotted (by another user)
3. user B opens the spreadsheet (loaded from the snapshot)
4. user A undo his last operation
=> we're in trouble: user B won't be able to undo the operation since he does
not have it in its history.

We can mitigate the problem by preventing user A to undo any of its operation
preceding the snapshot. This commit allow the collaboration server to notify
all clients that the history has been snapshotted and they should clear their
own local history.

This should be used with care since clearing the local histroy is a bad user
experience.