### PR TITLE
[REV] : Revert "[REM] plugins: remove mode"

### DIFF
--- a/doc/add_plugin.md
+++ b/doc/add_plugin.md
@@ -84,6 +84,9 @@ class MyPlugin extends spreadsheet.CorePlugin {
   }
 }
 
+// makes the new plugin to be instantiated for every spreadsheet mode
+MyPlugin.modes = ["normal", "headless", "readonly"];
+
 // makes the function getSomething accessible from anywhere that has a reference to model.getters
 MyPlugin.getters = ["getSomething"];
 

--- a/src/plugins/base_plugin.ts
+++ b/src/plugins/base_plugin.ts
@@ -1,4 +1,4 @@
-import { ModelConfig } from "../model";
+import { Mode, ModelConfig } from "../model";
 import { StateObserver } from "../state_observer";
 import {
   CommandDispatcher,
@@ -22,9 +22,11 @@ import {
 
 export class BasePlugin<State = any, C = any> implements CommandHandler<C> {
   static getters: string[] = [];
+  static modes: Mode[] = ["headless", "normal", "readonly"];
 
   protected history: WorkbookHistory<State>;
   protected dispatch: CommandDispatcher["dispatch"];
+  protected currentMode: Mode;
 
   constructor(
     stateObserver: StateObserver,
@@ -36,6 +38,7 @@ export class BasePlugin<State = any, C = any> implements CommandHandler<C> {
       selectCell: () => {},
     });
     this.dispatch = dispatch;
+    this.currentMode = config.mode;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -1,4 +1,4 @@
-import { ModelConfig } from "../model";
+import { Mode, ModelConfig } from "../model";
 import { StateObserver } from "../state_observer";
 import {
   ApplyRangeChange,
@@ -21,6 +21,7 @@ export interface CorePluginConstructor {
     config: ModelConfig
   ): CorePlugin;
   getters: string[];
+  modes: Mode[];
 }
 
 /**

--- a/src/plugins/ui/autofill.ts
+++ b/src/plugins/ui/autofill.ts
@@ -1,4 +1,5 @@
 import { clip, isInside, toCartesian, toXC, union } from "../../helpers/index";
+import { Mode } from "../../model";
 import { autofillModifiersRegistry, autofillRulesRegistry } from "../../registries/index";
 import {
   AutofillData,
@@ -81,6 +82,7 @@ class AutofillGenerator {
 export class AutofillPlugin extends UIPlugin {
   static layers = [LAYERS.Autofill];
   static getters = ["getAutofillTooltip"];
+  static modes: Mode[] = ["normal", "readonly"];
 
   private autofillZone: Zone | undefined;
   private lastCellSelected: { col?: number; row?: number } = {};

--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -1,4 +1,5 @@
 import { clip, overlap } from "../../helpers/index";
+import { Mode } from "../../model";
 import { _lt } from "../../translation";
 import {
   Border,
@@ -33,6 +34,7 @@ interface ClipboardCell {
 export class ClipboardPlugin extends UIPlugin {
   static layers = [LAYERS.Clipboard];
   static getters = ["getClipboardContent", "isPaintingFormat", "getPasteZones"];
+  static modes: Mode[] = ["normal", "readonly"];
 
   private status: "empty" | "visible" | "invisible" = "empty";
   private shouldCut?: boolean;

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -7,6 +7,7 @@ import {
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
 } from "../../helpers/index";
+import { Mode } from "../../model";
 import { _lt } from "../../translation";
 import {
   AddColumnsRowsCommand,
@@ -46,6 +47,7 @@ export class EditionPlugin extends UIPlugin {
     "getCurrentTokens",
     "getTokenAtCursor",
   ];
+  static modes: Mode[] = ["normal", "readonly"];
 
   private col: number = 0;
   private row: number = 0;

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -1,7 +1,7 @@
 import { compile, normalize } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
 import { mapCellsInZone, toXC, toZone } from "../../helpers/index";
-import { ModelConfig } from "../../model";
+import { Mode, ModelConfig } from "../../model";
 import { StateObserver } from "../../state_observer";
 import { _lt } from "../../translation";
 import {
@@ -38,6 +38,7 @@ export const LOADING = "Loading...";
 
 export class EvaluationPlugin extends UIPlugin {
   static getters = ["evaluateFormula", "isIdle", "getRangeFormattedValues", "getRangeValues"];
+  static modes: Mode[] = ["normal", "readonly"];
 
   private isUpToDate: Set<UID> = new Set(); // Set<sheetIds>
   private loadingCells: number = 0;

--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -2,6 +2,7 @@ import { ChartConfiguration, ChartType } from "chart.js";
 import { chartTerms } from "../../components/side_panel/translations_terms";
 import { INCORRECT_RANGE_STRING } from "../../constants";
 import { isDefined, isInside, overlap, recomputeZones, zoneToXc } from "../../helpers/index";
+import { Mode } from "../../model";
 import { ChartDefinition, DataSet } from "../../types/chart";
 import { Command } from "../../types/commands";
 import { Cell, UID, Zone } from "../../types/misc";
@@ -33,6 +34,7 @@ const GraphColors = [
 
 export class EvaluationChartPlugin extends UIPlugin {
   static getters = ["getChartRuntime"];
+  static modes: Mode[] = ["normal", "readonly"];
   // contains the configuration of the chart with it's values like they should be displayed,
   // as well as all the options needed for the chart library to work correctly
   readonly chartRuntime: { [figureId: string]: ChartConfiguration } = {};

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -1,5 +1,6 @@
 import { colorNumberString, isInside, recomputeZones, toXC, toZone } from "../../helpers/index";
 import { clip } from "../../helpers/misc";
+import { Mode } from "../../model";
 import { _lt } from "../../translation";
 import {
   Cell,
@@ -22,6 +23,7 @@ import { UIPlugin } from "../ui_plugin";
 
 export class EvaluationConditionalFormatPlugin extends UIPlugin {
   static getters = ["getConditionalStyle"];
+  static modes: Mode[] = ["normal", "readonly"];
   private isStale: boolean = true;
   // stores the computed styles in the format of computedStyles.sheetName[col][row] = Style
   private computedStyles: { [sheet: string]: { [col: number]: (Style | undefined)[] } } = {};

--- a/src/plugins/ui/highlight.ts
+++ b/src/plugins/ui/highlight.ts
@@ -1,4 +1,5 @@
 import { getNextColor, isEqual, toZone } from "../../helpers/index";
+import { Mode } from "../../model";
 import { Command, GridRenderingContext, Highlight, LAYERS, Zone } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
@@ -6,6 +7,7 @@ import { UIPlugin } from "../ui_plugin";
  * HighlightPlugin
  */
 export class HighlightPlugin extends UIPlugin {
+  static modes: Mode[] = ["normal", "readonly"];
   static layers = [LAYERS.Highlights];
   static getters = ["getHighlights"];
   private highlights: Highlight[] = [];

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -14,6 +14,7 @@ import {
 } from "../../constants";
 import { fontSizeMap } from "../../fonts";
 import { overlap } from "../../helpers/index";
+import { Mode } from "../../model";
 import {
   Box,
   Cell,
@@ -71,6 +72,7 @@ function searchIndex(headers: Header[], offset: number): number {
 export class RendererPlugin extends UIPlugin {
   static layers = [LAYERS.Background, LAYERS.Headers];
   static getters = ["getColIndex", "getRowIndex", "getRect"];
+  static modes: Mode[] = ["normal", "readonly"];
 
   private boxes: Box[] = [];
 

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -9,7 +9,7 @@ import {
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
 } from "../../helpers/index";
-import { ModelConfig } from "../../model";
+import { Mode, ModelConfig } from "../../model";
 import { StateObserver } from "../../state_observer";
 import {
   AddColumnsRowsCommand,
@@ -58,6 +58,7 @@ interface SelectionPluginState {
  */
 export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
   static layers = [LAYERS.Selection];
+  static modes: Mode[] = ["normal", "readonly"];
   static getters = [
     "getActiveSheet",
     "getActiveSheetId",

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -1,5 +1,6 @@
 import { rangeReference } from "../../formulas/index";
 import { getNextColor, uuidv4 } from "../../helpers/index";
+import { Mode } from "../../model";
 import { Command, CommandResult, Highlight, LAYERS, UID } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 import { SelectionMode } from "./selection";
@@ -18,6 +19,7 @@ export interface RangeInputValue {
  * This plugin handles this internal state.
  */
 export class SelectionInputPlugin extends UIPlugin {
+  static modes: Mode[] = ["normal", "readonly"];
   static layers = [LAYERS.Highlights];
   static getters = ["getSelectionInput", "getSelectionInputValue", "isRangeValid"];
 

--- a/src/plugins/ui/selection_multiuser.ts
+++ b/src/plugins/ui/selection_multiuser.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FONT, DEFAULT_FONT_SIZE } from "../../constants";
+import { Mode } from "../../model";
 import { Client, ClientPosition, GridRenderingContext, LAYERS, UID } from "../../types";
 import { UIPlugin } from "../ui_plugin";
 
@@ -28,6 +29,7 @@ interface ClientToDisplay extends Required<Client> {
 export class SelectionMultiUserPlugin extends UIPlugin {
   static getters = ["getClientsToDisplay"];
   static layers = [LAYERS.Selection];
+  static modes: Mode[] = ["normal", "readonly"];
   private availableColors = new Set(colors);
   private colors: Record<UID, string> = {};
 

--- a/src/plugins/ui/ui_options.ts
+++ b/src/plugins/ui/ui_options.ts
@@ -1,7 +1,9 @@
+import { Mode } from "../../model";
 import { Command } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
 export class UIOptionsPlugin extends UIPlugin {
+  static modes: Mode[] = ["normal", "readonly"];
   static getters = ["shouldShowFormulas"];
   private showFormulas: boolean = false;
 

--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -5,6 +5,7 @@ import {
   HEADER_WIDTH,
 } from "../../constants";
 import { getNextVisibleCellCoords } from "../../helpers";
+import { Mode } from "../../model";
 import { Command, Sheet, UID, Viewport, ZoneDimension } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
@@ -31,6 +32,7 @@ export class ViewportPlugin extends UIPlugin {
     "getViewportDimension",
     "getGridDimension",
   ];
+  static modes: Mode[] = ["normal", "readonly"];
 
   readonly viewports: ViewportPluginState["viewports"] = {};
   readonly snappedViewports: ViewportPluginState["viewports"] = {};

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -1,4 +1,4 @@
-import { ModelConfig } from "../model";
+import { Mode, ModelConfig } from "../model";
 import { StateObserver } from "../state_observer";
 import { Command, CommandDispatcher, Getters, GridRenderingContext, LAYERS } from "../types/index";
 import { BasePlugin } from "./base_plugin";
@@ -14,6 +14,7 @@ export interface UIPluginConstructor {
   ): UIPlugin;
   layers: LAYERS[];
   getters: string[];
+  modes: Mode[];
 }
 
 /**

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -637,7 +637,7 @@ describe("Multi users synchronisation", () => {
   });
 
   test("Spreadsheet in readonly still receive commands", () => {
-    const david = new Model(alice.exportData(), { transportService: network, isReadonly: true });
+    const david = new Model(alice.exportData(), { transportService: network, mode: "readonly" });
     setCellContent(alice, "A1", "hello");
     expect([alice, bob, charlie, david]).toHaveSynchronizedValue(
       (user) => getCellContent(user, "A1"),

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1,36 +1,112 @@
 import { CommandResult } from "../src";
-import { Model } from "../src/model";
+import { Mode, Model } from "../src/model";
+import { BordersPlugin } from "../src/plugins/core/borders";
+import { CellPlugin } from "../src/plugins/core/cell";
+import { ChartPlugin } from "../src/plugins/core/chart";
+import { ConditionalFormatPlugin } from "../src/plugins/core/conditional_format";
+import { FigurePlugin } from "../src/plugins/core/figures";
+import { MergePlugin } from "../src/plugins/core/merge";
+import { RangeAdapter } from "../src/plugins/core/range";
+import { SheetPlugin } from "../src/plugins/core/sheet";
 import { corePluginRegistry, uiPluginRegistry } from "../src/plugins/index";
+import { FindAndReplacePlugin } from "../src/plugins/ui/find_and_replace";
+import { SortPlugin } from "../src/plugins/ui/sort";
+import { SheetUIPlugin } from "../src/plugins/ui/ui_sheet";
+import { UIPlugin } from "../src/plugins/ui_plugin";
 import { selectCell, setCellContent } from "./test_helpers/commands_helpers";
+import { getCell } from "./test_helpers/getters_helpers";
 
-function getNbrPlugin(): number {
-  return corePluginRegistry.getAll().length + uiPluginRegistry.getAll().length;
+function getNbrPlugin(mode: Mode): number {
+  return (
+    corePluginRegistry
+      .getAll()
+      .reduce((acc, plugin) => (plugin.modes.includes(mode) ? acc + 1 : acc), 0) +
+    uiPluginRegistry
+      .getAll()
+      .reduce((acc, plugin) => (plugin.modes.includes(mode) ? acc + 1 : acc), 0)
+  );
 }
 
 describe("Model", () => {
+  test("can create model in headless mode", () => {
+    const model = new Model({}, { mode: "headless" });
+    expect(model["handlers"]).toHaveLength(11);
+    expect(model["handlers"][0]).toBeInstanceOf(RangeAdapter);
+    expect(model["handlers"][1]).toBeInstanceOf(SheetPlugin);
+    expect(model["handlers"][2]).toBeInstanceOf(CellPlugin);
+    expect(model["handlers"][3]).toBeInstanceOf(MergePlugin);
+    expect(model["handlers"][4]).toBeInstanceOf(BordersPlugin);
+    expect(model["handlers"][5]).toBeInstanceOf(ConditionalFormatPlugin);
+    expect(model["handlers"][6]).toBeInstanceOf(FigurePlugin);
+    expect(model["handlers"][7]).toBeInstanceOf(ChartPlugin);
+    expect(model["handlers"][8]).toBeInstanceOf(SheetUIPlugin);
+    expect(model["handlers"][9]).toBeInstanceOf(FindAndReplacePlugin);
+    expect(model["handlers"][10]).toBeInstanceOf(SortPlugin);
+  });
+
   test("All plugin compatible with normal mode are loaded on normal mode", () => {
     const model = new Model();
-    const nbr = getNbrPlugin();
+    const nbr = getNbrPlugin("normal");
     expect(model["handlers"]).toHaveLength(nbr + 1); //+1 for Range
   });
 
-  test("Can open a model in headless mode", () => {
-    const model = new Model({}, { isHeadless: true });
-    expect(model["handlers"]).toHaveLength(corePluginRegistry.getAll().length + 1); //+1 for Range
+  test("All plugin compatible with headless mode are loaded on headless mode", () => {
+    const model = new Model({}, { mode: "headless" });
+    const nbr = getNbrPlugin("headless");
+    expect(model["handlers"]).toHaveLength(nbr + 1); //+1 for Range
+  });
+
+  test("All plugin compatible with readonly mode are loaded on readonly mode", () => {
+    const model = new Model({}, { mode: "readonly" });
+    const nbr = getNbrPlugin("readonly");
+    expect(model["handlers"]).toHaveLength(nbr + 1); //+1 for Range
+  });
+
+  test("Model in headless mode should not evaluate cells", () => {
+    const model = new Model({ sheets: [{ id: "sheet1" }] }, { mode: "headless" });
+    setCellContent(model, "A1", "=1", "sheet1");
+    expect(getCell(model, "A1", "sheet1")!.value).not.toBe("1");
+  });
+
+  test("can add a Plugin only in headless mode", () => {
+    class NormalPlugin extends UIPlugin {
+      static modes: Mode[] = ["normal"];
+    }
+    class HeadlessPlugin extends UIPlugin {
+      static modes: Mode[] = ["headless"];
+    }
+    class ReadOnlyPlugin extends UIPlugin {
+      static modes: Mode[] = ["readonly"];
+    }
+    uiPluginRegistry.add("normalPlugin", NormalPlugin);
+    uiPluginRegistry.add("headlessPlugin", HeadlessPlugin);
+    uiPluginRegistry.add("readonlyPlugin", ReadOnlyPlugin);
+    const modelNormal = new Model();
+    expect(modelNormal["handlers"][modelNormal["handlers"].length - 1]).toBeInstanceOf(
+      NormalPlugin
+    );
+    const modelHeadless = new Model({}, { mode: "headless" });
+    expect(modelHeadless["handlers"][modelHeadless["handlers"].length - 1]).toBeInstanceOf(
+      HeadlessPlugin
+    );
+    const modelReadonly = new Model({}, { mode: "readonly" });
+    expect(modelReadonly["handlers"][modelReadonly["handlers"].length - 1]).toBeInstanceOf(
+      ReadOnlyPlugin
+    );
   });
 
   test("Can open a model in readonly mode", () => {
-    const model = new Model({}, { isReadonly: true });
+    const model = new Model({}, { mode: "readonly" });
     expect(model.getters.isReadonly()).toBe(true);
   });
 
   test("Some commands are not dispatched in readonly mode", () => {
-    const model = new Model({}, { isReadonly: true });
+    const model = new Model({}, { mode: "readonly" });
     expect(setCellContent(model, "A1", "hello")).toBe(CommandResult.Readonly);
   });
 
   test("Moving the selection is allowed in readonly mode", () => {
-    const model = new Model({}, { isReadonly: true });
+    const model = new Model({}, { mode: "readonly" });
     expect(selectCell(model, "A15")).toBe(CommandResult.Success);
   });
 });


### PR DESCRIPTION
This reverts commit a0763cda46e299eb86166e8102df4d35f3d158d2.
We need to revert this commit because the assumption that only core
plugins need to be loaded in headless mode is wrong:
some ui plugins need to be loaded in order to have their getters
accessible.