### PR TITLE
[IMP] conditional_formatting: add isEmpty and isNotEmpty operators

### DIFF
--- a/src/components/side_panel/cell_is_rule_editor.ts
+++ b/src/components/side_panel/cell_is_rule_editor.ts
@@ -27,9 +27,17 @@ const TEMPLATE = xml/* xml */ `
             <option t-att-value="op" t-esc="cellIsOperators[op]"/>
         </t>
     </select>
-    <input type="text" placeholder="Value" t-model="state.condition.value1" class="o-input o-cell-is-value"/>
-    <t t-if="state.condition.operator === 'Between' || state.condition.operator === 'NotBetween'">
-        <input type="text" placeholder="and value" t-model="state.condition.value2" class="o-input"/>
+    <t t-if="state.condition.operator !== 'IsEmpty' and state.condition.operator !== 'IsNotEmpty'">
+      <input type="text"
+             placeholder="Value"
+             t-model="state.condition.value1"
+             class="o-input o-cell-is-value"/>
+      <t t-if="state.condition.operator === 'Between' || state.condition.operator === 'NotBetween'">
+          <input type="text"
+                 placeholder="and value"
+                 t-model="state.condition.value2"
+                 class="o-input"/>
+      </t>
     </t>
     <div class="o-cf-title-text" t-esc="env._t('${conditionalFormatingTerms.FORMATTING_STYLE}')"></div>
 
@@ -58,6 +66,9 @@ const TEMPLATE = xml/* xml */ `
                     <ColorPicker t-if="state.fillColorTool" t-on-color-picked="setColor('fillColor')" t-key="fillColor"/>
         </div>
     </div>
+    <div class="o-cf-error" t-if="props.error">
+        <t t-esc="props.error"/>
+      </div>
     <div class="o-sidePanelButtons">
       <button t-on-click="onCancel" class="o-sidePanelButton o-cf-cancel" t-esc="env._t('${conditionalFormatingTerms.CANCEL}')"></button>
       <button t-on-click="onSave" class="o-sidePanelButton o-cf-save" t-esc="env._t('${conditionalFormatingTerms.SAVE}')"></button>
@@ -75,6 +86,10 @@ const CSS = css/* scss */ `
   .o-cf-preview-line {
     border: 1px solid darkgrey;
     padding: 10px;
+  }
+  .o-cf-error {
+    color: red;
+    margin-top: 10px;
   }
 `;
 
@@ -94,7 +109,7 @@ export class CellIsRuleEditor extends Component<Props, SpreadsheetEnv> {
   rule = this.cf.rule as CellIsRule;
   state = useState({
     condition: {
-      operator: this.rule && this.rule.operator ? this.rule.operator : "Equal",
+      operator: this.rule && this.rule.operator ? this.rule.operator : "IsNotEmpty",
       value1: this.rule && this.rule.values.length > 0 ? this.rule.values[0] : "",
       value2: this.cf && this.rule.values.length > 1 ? this.rule.values[1] : "",
     },

--- a/src/components/side_panel/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting.ts
@@ -370,7 +370,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
     return {
       rule: {
         type: "CellIsRule",
-        operator: "Equal",
+        operator: "IsNotEmpty",
         values: [],
         style: { fillColor: "#FF0000" },
       },

--- a/src/components/side_panel/translations_terms.ts
+++ b/src/components/side_panel/translations_terms.ts
@@ -51,18 +51,20 @@ export const colorScale = {
 };
 
 export const cellIsOperators = {
-  BeginsWith: _lt("Begins with"),
-  Between: _lt("Between"),
-  ContainsText: _lt("Contains text"),
+  IsEmpty: _lt("Is empty"),
+  IsNotEmpty: _lt("Is not empty"),
+  ContainsText: _lt("Contains"),
+  NotContains: _lt("Does not contain"),
+  BeginsWith: _lt("Starts with"),
   EndsWith: _lt("Ends with"),
   Equal: _lt("Is equal to"),
-  GreaterThan: _lt("Greater than"),
-  GreaterThanOrEqual: _lt("Greater than or equal"),
-  LessThan: _lt("Less than"),
-  LessThanOrEqual: _lt("Less than or equal"),
-  NotBetween: _lt("Not between"),
-  NotContains: _lt("Not contains"),
-  NotEqual: _lt("Not equal"),
+  NotEqual: _lt("Is not equal to"),
+  GreaterThan: _lt("Is greater than"),
+  GreaterThanOrEqual: _lt("Is greater than or equal to"),
+  LessThan: _lt("Is less than"),
+  LessThanOrEqual: _lt("Is less than or equal to"),
+  Between: _lt("Is between"),
+  NotBetween: _lt("Is not between"),
 };
 
 export const chartTerms = {

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -253,7 +253,8 @@ export class ConditionalFormatPlugin
             "LessThan",
             "LessThanOrEqual",
             "NotContains",
-          ])
+          ]),
+          this.checkOperatorArgsNumber(0, ["IsEmpty", "IsNotEmpty"])
         );
       case "ColorScaleRule": {
         return this.checkValidations(

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -330,6 +330,10 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       }
 
       switch (rule.operator) {
+        case "IsEmpty":
+          return !cell || value.toString().trim() === "";
+        case "IsNotEmpty":
+          return cell && value.toString().trim() !== "";
         case "BeginsWith":
           if (!cell && rule.values[0] === "") {
             return false;
@@ -339,7 +343,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
           if (!cell && rule.values[0] === "") {
             return false;
           }
-          return cell && value.endsWith(rule.values[0]);
+          return cell && value && value.toString().endsWith(rule.values[0]);
         case "Between":
           return cell && value >= rule.values[0] && value <= rule.values[1];
         case "NotBetween":
@@ -347,7 +351,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
         case "ContainsText":
           return cell && value && value.toString().indexOf(rule.values[0]) > -1;
         case "NotContains":
-          return cell && value && value.toString().indexOf(rule.values[0]) == -1;
+          return !cell || !value || value.toString().indexOf(rule.values[0]) == -1;
         case "GreaterThan":
           return cell && value > rule.values[0];
         case "GreaterThanOrEqual":
@@ -360,12 +364,12 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
           if (!cell && rule.values[0] === "") {
             return false;
           }
-          return cell && value != rule.values[0];
+          return cell && value !== rule.values[0];
         case "Equal":
           if (!cell && rule.values[0] === "") {
             return true;
           }
-          return cell && value == rule.values[0];
+          return cell && value.toString() === rule.values[0];
         default:
           console.warn(
             _lt(

--- a/src/types/conditional_formatting.ts
+++ b/src/types/conditional_formatting.ts
@@ -123,10 +123,13 @@ export interface Top10Rule extends SingleColorRule {
   rank: number;
 }
 //https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.conditionalformattingoperatorvalues?view=openxml-2.8.1
+// Note: IsEmpty and IsNotEmpty does not exist on the specification
 export type ConditionalFormattingOperatorValues =
   | "BeginsWith"
   | "Between"
   | "ContainsText"
+  | "IsEmpty"
+  | "IsNotEmpty"
   | "EndsWith"
   | "Equal"
   | "GreaterThan"

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -251,6 +251,7 @@ describe("UI of conditional formats", () => {
       // change every value
       setInputValueAndTrigger(selectors.ruleEditor.range, "A1:A3", "change");
       setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
+      await nextTick();
       setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3", "input");
 
       triggerMouseEvent(selectors.ruleEditor.editor.bold, "click");

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -814,6 +814,9 @@ describe("conditional formats types", () => {
         target: [toZone("A1")],
         sheetId: model.getters.getActiveSheetId(),
       });
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toEqual({
+        fillColor: "#ff0f0f",
+      });
 
       setCellContent(model, "A1", "hellqsdfo");
       expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toBeUndefined();
@@ -853,7 +856,81 @@ describe("conditional formats types", () => {
       expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toBeUndefined();
     });
 
+    test("Operator IsEmpty", () => {
+      model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: {
+          rule: {
+            type: "CellIsRule",
+            operator: "IsEmpty",
+            values: [],
+            style: { fillColor: "#ff0f0f" },
+          },
+          id: "11",
+        },
+        target: [toZone("A1")],
+        sheetId: model.getters.getActiveSheetId(),
+      });
+      setCellContent(model, "A1", "");
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toEqual({
+        fillColor: "#ff0f0f",
+      });
+
+      setCellContent(model, "A1", " ");
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toEqual({
+        fillColor: "#ff0f0f",
+      });
+
+      setCellContent(model, "A2", "");
+      setCellContent(model, "A1", "=A2");
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toBeUndefined();
+
+      setCellContent(model, "A1", '=""');
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toEqual({
+        fillColor: "#ff0f0f",
+      });
+
+      setCellContent(model, "A1", '=" "');
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toEqual({
+        fillColor: "#ff0f0f",
+      });
+
+      setCellContent(model, "A1", "helabclo");
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toBeUndefined();
+    });
+
+    test("Operator IsNotEmpty", () => {
+      model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: {
+          rule: {
+            type: "CellIsRule",
+            operator: "IsNotEmpty",
+            values: [],
+            style: { fillColor: "#ff0f0f" },
+          },
+          id: "11",
+        },
+        target: [toZone("A1")],
+        sheetId: model.getters.getActiveSheetId(),
+      });
+      setCellContent(model, "A1", "");
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toBeUndefined();
+
+      setCellContent(model, "A1", " ");
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toBeUndefined();
+
+      setCellContent(model, "A1", "helabclo");
+      expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toEqual({
+        fillColor: "#ff0f0f",
+      });
+    });
+
     test.each([
+      ["IsEmpty", ["", ""]],
+      ["IsEmpty", []],
+      ["IsEmpty", [""]],
+      ["IsNotEmpty", ["", ""]],
+      ["IsNotEmpty", []],
+      ["IsNotEmpty", [""]],
       ["GreaterThan", ["1", ""]],
       ["GreaterThan", ["1"]],
       ["GreaterThanOrEqual", ["1", ""]],


### PR DESCRIPTION
Before this commit, it was not possible to create a rule that highlight
a cell if this one is empty or not empty.

In the specification (https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.conditionalformattingoperatorvalues?view=openxml-2.8.1),
the operators `IsEmpty` and `IsNotEmpty` do not exist, so we will have
to pay attention to this when we import-export to-from excel.

This commit also re-organize and re-word the operators.

Odoo-task-id: 2518487

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2518487](https://www.odoo.com/web#id=2518487&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
