### PR TITLE
[IMP] Add JQuery-lite

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,6 +4,7 @@
   <script src="Chart.bundle.js"></script>
   <script src="../dist/o_spreadsheet.js"></script>
   <script src="main.js" type="module"></script>
+  <script src="../node_modules/jquery-lite/dist/jquery.min.js"></script>
   <link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.min.css">
   <script src="../node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
   <title>o_spreadsheet</title>

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   },
   "dependencies": {
     "@odoo/owl": "^1.2.1",
-    "bootstrap": "^4.6.0"
+    "bootstrap": "^4.6.0",
+    "jquery-lite": "^2.2.3"
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
As JQuery is needed to use Bootstrap, this commit
adds Jquery lite.