### PR TITLE
[FIX] assistants: completely hide composer assitants when empty

### DIFF
--- a/src/components/composer/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown.ts
@@ -33,7 +33,9 @@ providerRegistry.add("functions", async function () {
 // -----------------------------------------------------------------------------
 
 const TEMPLATE = xml/* xml */ `
-  <div t-att-class="{'o-autocomplete-dropdown':state.values.length}" >
+  <div t-att-class="{'o-autocomplete-dropdown':state.values.length}"
+       t-att-style="state.values.length > 0 ? props.borderStyle : null"
+    >
     <t t-foreach="state.values" t-as="v" t-key="v.text">
         <div t-att-class="{'o-autocomplete-value-focus': state.selectedIndex === v_index}" t-on-click.stop.prevent="fillValue(v_index)">
              <div class="o-autocomplete-value" t-esc="v.text"/>
@@ -72,6 +74,7 @@ interface Props {
   provider: string;
   filter?: (searchTerm: string, vals: AutocompleteValue[]) => AutocompleteValue[];
   search: string;
+  borderStyle: string;
 }
 
 export abstract class TextValueProvider extends Component<Props> {

--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -67,6 +67,7 @@ const TEMPLATE = xml/* xml */ `
           search="autoCompleteState.search"
           provider="autoCompleteState.provider"
           t-on-completed="onCompleted"
+          borderStyle="borderStyle"
       />
       <FunctionDescriptionProvider
           t-if="functionDescriptionState.showDescription"
@@ -74,6 +75,7 @@ const TEMPLATE = xml/* xml */ `
           functionName = "functionDescriptionState.functionName"
           functionDescription = "functionDescriptionState.functionDescription"
           argToFocus = "functionDescriptionState.argToFocus"
+          borderStyle="borderStyle"
       />
     </div>
 </div>
@@ -98,7 +100,6 @@ const CSS = css/* scss */ `
     .o-composer-assistant {
       position: absolute;
       margin: 4px;
-      box-shadow: 0 1px 4px 3px rgba(60, 64, 67, 0.15);
       pointer-events: none;
     }
   }
@@ -174,6 +175,8 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     }
     return "";
   }
+
+  borderStyle = `box-shadow: 0 1px 4px 3px rgba(60, 64, 67, 0.15);`;
 
   // we can't allow input events to be triggered while we remove and add back the content of the composer in processContent
   shouldProcessInputEvents: boolean = false;

--- a/src/components/composer/formula_assistant.ts
+++ b/src/components/composer/formula_assistant.ts
@@ -12,6 +12,7 @@ const { useState } = owl.hooks;
 
 const TEMPLATE = xml/* xml */ `
   <div class="o-formula-assistant-container"
+       t-att-style="props.borderStyle"
        t-att-class="{
          'o-formula-assistant-event-none': assistantState.allowCellSelectionBehind,
          'o-formula-assistant-event-auto': !assistantState.allowCellSelectionBehind
@@ -116,6 +117,7 @@ interface Props {
   functionName: string;
   functionDescription: FunctionDescription;
   argToFocus: number;
+  borderStyle: string;
 }
 
 interface AssistantState {

--- a/tests/components/__snapshots__/autocomplete_dropdown_test.ts.snap
+++ b/tests/components/__snapshots__/autocomplete_dropdown_test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
 <div
   class="o-autocomplete-dropdown"
+  style="box-shadow: 0 1px 4px 3px rgba(60, 64, 67, 0.15);"
 >
   <div
     class="o-autocomplete-value-focus"

--- a/tests/components/__snapshots__/formula_assistant_test.ts.snap
+++ b/tests/components/__snapshots__/formula_assistant_test.ts.snap
@@ -2,74 +2,79 @@
 
 exports[`formula assistant appearance simple snapshot with =FUNC1( 1`] = `
 <div
-  class="o-formula-assistant"
+  class="o-formula-assistant-container o-formula-assistant-event-auto"
+  style="box-shadow: 0 1px 4px 3px rgba(60, 64, 67, 0.15);"
 >
   <div
-    class="o-formula-assistant-head"
+    class="o-formula-assistant"
   >
-    <span>
-      FUNC1
-    </span>
-     ( 
-    <span
-      class="o-formula-assistant-focus"
+    <div
+      class="o-formula-assistant-head"
     >
       <span>
+        FUNC1
+      </span>
+       ( 
+      <span
+        class="o-formula-assistant-focus"
+      >
+        <span>
+          <span>
+            f1Arg1
+          </span>
+        </span>
+      </span>
+      <span>
+        , 
+      </span>
+      <span>
+        <span>
+          <span>
+            f1Arg2
+          </span>
+        </span>
+      </span>
+       ) 
+    </div>
+    <div
+      class="o-formula-assistant-core"
+    >
+      <div
+        class="o-formula-assistant-gray"
+      >
+        ABOUT
+      </div>
+      <div>
+        func1 def
+      </div>
+    </div>
+    <div
+      class="o-formula-assistant-arg o-formula-assistant-gray o-formula-assistant-focus"
+    >
+      <div>
         <span>
           f1Arg1
         </span>
-      </span>
-    </span>
-    <span>
-      , 
-    </span>
-    <span>
-      <span>
+      </div>
+      <div
+        class="o-formula-assistant-arg-description"
+      >
+        f1 Arg1 def
+      </div>
+    </div>
+    <div
+      class="o-formula-assistant-arg o-formula-assistant-gray"
+    >
+      <div>
         <span>
           f1Arg2
         </span>
-      </span>
-    </span>
-     ) 
-  </div>
-  <div
-    class="o-formula-assistant-core"
-  >
-    <div
-      class="o-formula-assistant-gray"
-    >
-      ABOUT
-    </div>
-    <div>
-      func1 def
-    </div>
-  </div>
-  <div
-    class="o-formula-assistant-arg o-formula-assistant-gray o-formula-assistant-focus"
-  >
-    <div>
-      <span>
-        f1Arg1
-      </span>
-    </div>
-    <div
-      class="o-formula-assistant-arg-description"
-    >
-      f1 Arg1 def
-    </div>
-  </div>
-  <div
-    class="o-formula-assistant-arg o-formula-assistant-gray"
-  >
-    <div>
-      <span>
-        f1Arg2
-      </span>
-    </div>
-    <div
-      class="o-formula-assistant-arg-description"
-    >
-      f1 Arg2 def
+      </div>
+      <div
+        class="o-formula-assistant-arg-description"
+      >
+        f1 Arg2 def
+      </div>
     </div>
   </div>
 </div>

--- a/tests/components/formula_assistant_test.ts
+++ b/tests/components/formula_assistant_test.ts
@@ -200,7 +200,7 @@ describe("formula assistant", () => {
 
     test("simple snapshot with =FUNC1(", async () => {
       await typeInComposer("=FUNC1(");
-      expect(fixture.querySelector(".o-formula-assistant")).toMatchSnapshot();
+      expect(fixture.querySelector(".o-formula-assistant-container")).toMatchSnapshot();
     });
 
     test("use arowKey during 'selecting' mode in a function should not display formula assistant", async () => {


### PR DESCRIPTION
There wes a visual bug when one would start writing a formula that did
not match any corresponding formula in the registry.
In this event, the autocomplete component will still be loaded but will
be empty and since the composer still adds a box-shadow style around the
component, we have an empty div with a box shadow appearing on the
screen.

After this commit, the said style is provided to the assistants
components in the props and the component decide if they have to apply
it or not.

Co-authored-by: Alexis Lacroix <laa@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2524901](https://www.odoo.com/web#id=2524901&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
