### PR TITLE
[FIX] conditional_formatting: args validation

### DIFF
--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -275,13 +275,13 @@ export class ConditionalFormatPlugin
     expectedNumber: number,
     operators: ConditionalFormattingOperatorValues[]
   ) {
-    const isEmpty = (value) => value === "" || value === undefined;
     return (rule: CellIsRule) => {
-      if (
-        operators.includes(rule.operator) &&
-        (rule.values.length !== expectedNumber || rule.values.some(isEmpty))
-      ) {
-        return CommandResult.InvalidNumberOfArgs;
+      if (operators.includes(rule.operator)) {
+        for (let i = 0; i < expectedNumber; i++) {
+          if (rule.values[i] === undefined || rule.values[i] === "") {
+            return CommandResult.InvalidNumberOfArgs;
+          }
+        }
       }
       return CommandResult.Success;
     };

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -854,8 +854,48 @@ describe("conditional formats types", () => {
     });
 
     test.each([
+      ["GreaterThan", ["1", ""]],
+      ["GreaterThan", ["1"]],
+      ["GreaterThanOrEqual", ["1", ""]],
+      ["GreaterThanOrEqual", ["1"]],
+      ["LessThan", ["1"]],
+      ["LessThan", ["1", ""]],
+      ["LessThanOrEqual", ["1"]],
+      ["LessThanOrEqual", ["1", ""]],
+      ["BeginsWith", ["1"]],
+      ["BeginsWith", ["1", ""]],
+      ["ContainsText", ["1"]],
+      ["ContainsText", ["1", ""]],
+      ["EndsWith", ["1"]],
+      ["EndsWith", ["1", ""]],
+      ["NotContains", ["1"]],
+      ["NotContains", ["1", ""]],
+      ["Between", ["1", "1"]],
+      ["NotBetween", ["1", "1"]],
+    ])(
+      "%s operator with valid number of arguments: %s",
+      (operator: ConditionalFormattingOperatorValues, values: []) => {
+        let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
+          cf: {
+            rule: {
+              type: "CellIsRule",
+              operator: operator,
+              values: values,
+              style: { fillColor: "#ff0f0f" },
+            },
+            id: "11",
+          },
+          target: [toZone("A1")],
+          sheetId: model.getters.getActiveSheetId(),
+        });
+        expect(result).toBe(CommandResult.Success);
+      }
+    );
+
+    test.each([
       ["GreaterThan", []],
       ["GreaterThan", [""]],
+      ["GreaterThan", ["", "1"]],
       ["GreaterThanOrEqual", []],
       ["GreaterThanOrEqual", [""]],
       ["LessThan", []],
@@ -875,7 +915,7 @@ describe("conditional formats types", () => {
       ["NotBetween", ["1"]],
       ["NotBetween", ["1", ""]],
     ])(
-      "operators with invalid number of arguments",
+      "%s operator with invalid number of arguments %s",
       (operator: ConditionalFormattingOperatorValues, values: []) => {
         let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
           cf: {


### PR DESCRIPTION
Before this commit, the validation of the number of args was broken
because it did not take empty values into account.

This commit fixes it.

Part of Odoo-task-id 2518487

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : 2518487(https://www.odoo.com/web#id=2518487&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
