### PR TITLE
[IMP] chart: correct error message with empty dataset

### DIFF
--- a/src/components/side_panel/translations_terms.ts
+++ b/src/components/side_panel/translations_terms.ts
@@ -79,7 +79,7 @@ export const chartTerms = {
   CreateChart: _lt("Create chart"),
   TitlePlaceholder: _lt("New Chart"),
   Errors: {
-    [CommandResult.EmptyDataSet]: _lt("Invalid or no Dataset given"),
+    [CommandResult.EmptyDataSet]: _lt("No Dataset given"),
     [CommandResult.EmptyLabelRange]: _lt("No Labels given"),
     [CommandResult.InvalidDataSet]: _lt("Invalid dataSet"),
     [CommandResult.InvalidLabelRange]: _lt("Invalid Labels"),

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -347,9 +347,9 @@ export class SelectionInputPlugin extends UIPlugin {
     id: UID,
     { xc, color }: Pick<RangeInputValue, "xc" | "color">
   ): { [range: string]: string } {
-    const ranges = this.cleanInputs([xc]).filter((reference) =>
-      this.shouldBeHighlighted(this.activeSheets[id], reference)
-    );
+    const ranges = this.cleanInputs([xc])
+      .filter((range) => this.isRangeValid(range))
+      .filter((reference) => this.shouldBeHighlighted(this.activeSheets[id], reference));
     if (ranges.length === 0) return {};
     const [fromInput, ...otherRanges] = ranges;
     const highlights: { [range: string]: string } = {
@@ -366,8 +366,7 @@ export class SelectionInputPlugin extends UIPlugin {
       .map((xc) => xc.split(","))
       .flat()
       .map((xc) => xc.trim())
-      .filter((xc) => xc !== "")
-      .filter((range) => this.isRangeValid(range));
+      .filter((xc) => xc !== "");
   }
 
   /**
@@ -381,7 +380,7 @@ export class SelectionInputPlugin extends UIPlugin {
     const sheetName = reference.split("!").reverse()[1];
     const sheetId = this.getters.getSheetIdByName(sheetName);
     const activeSheetId = this.getters.getActiveSheet().id;
-    const valid = this.cleanInputs([reference]).length === 1;
+    const valid = this.isRangeValid(reference);
     return (
       valid &&
       (sheetId === activeSheetId || (sheetId === undefined && activeSheetId === inputSheetId))

--- a/tests/components/chart_side_panel.test.ts
+++ b/tests/components/chart_side_panel.test.ts
@@ -35,6 +35,14 @@ async function createChartPanel(
   return { model, parent };
 }
 
+function errorMessages(): string[] {
+  const errors = document.querySelectorAll(".o-sidepanel-error");
+  if (!errors) return [];
+  return [...errors]
+    .map((error) => error.textContent)
+    .filter((error): error is string => error !== null);
+}
+
 describe("Chart sidepanel component", () => {
   test("create a chart", async () => {
     const { parent, model } = await createChartPanel();
@@ -108,5 +116,15 @@ describe("Chart sidepanel component", () => {
       id: "1",
     });
     parent.unmount();
+  });
+
+  test("create chart with invalid dataset and empty labels", async () => {
+    const { parent } = await createChartPanel();
+    await simulateClick(".o-data-series input");
+    setInputValueAndTrigger(".o-data-series input", "This is not valid", "change");
+    await simulateClick(".o-sidePanelButton");
+    await nextTick();
+    expect(errorMessages()).toEqual(["Invalid dataSet"]);
+    parent.destroy();
   });
 });

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -284,6 +284,7 @@ describe("selection input plugin", () => {
       rangeId: idOfRange(model, id, 0),
       value: "This is invalid",
     });
+    expect(model.getters.getSelectionInputValue(id)).toEqual(["This is invalid"]);
     expect(highlightedZones(model)).toStrictEqual([]);
   });
 
@@ -303,6 +304,7 @@ describe("selection input plugin", () => {
     expect(model.getters.getSelectionInput(id)[0].xc).toBe("A1");
     expect(model.getters.getSelectionInput(id)[1].xc).toBe("This is invalid");
     expect(model.getters.getSelectionInput(id)[2].xc).toBe("E3");
+    expect(model.getters.getSelectionInputValue(id)).toEqual(["A1", "This is invalid", "E3"]);
   });
 
   test("writing an empty range removes the highlight", () => {


### PR DESCRIPTION

## Description:

Currently, whether your dataset is empty or does not look like a valid XC
string, the error message is the same: "Invalid or no Dataset given".

With both dataset, the CommandResult is EmptyDataSet. Hence, the component can't
differenciate between an empty dataset and an invalid one.

The root cause is the SelectionInput component filtering invalid XC strings.
It is not really it's responsability to decide what to do with
non-xc values.

Odoo task ID : no task

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
