### PR TITLE
[FIX] top bar: prevent dropdown carets from wrapping

### DIFF
--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -199,11 +199,10 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
         /* Toolbar */
         .o-toolbar-tools {
           display: flex;
-
+          flex-shrink: 0;
           margin-left: 20px;
           color: #333;
           cursor: default;
-          display: flex;
 
           .o-tool {
             display: flex;
@@ -212,6 +211,7 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
             padding: 0 3px;
             border-radius: 2px;
             cursor: pointer;
+            min-width: fit-content;
           }
 
           .o-tool.active,
@@ -324,6 +324,7 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
           padding: 0 12px;
           margin: 0;
           line-height: 34px;
+          white-space: nowrap;
         }
       }
     }


### PR DESCRIPTION
## Description:

This commit removes a visual bug in the top bar that appeared
when the window was minimized.

Task 2325786

Odoo task ID : 2325786 (https://www.odoo.com/web#id=2325786&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
