### PR TITLE
[FIX] Support right-to-left selection in composer

### DIFF
--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -18,6 +18,7 @@ export class ContentEditableHelper {
     if (start == end && start === 0) {
       range.setStart(this.el, 0);
       range.setEnd(this.el, 0);
+      selection.addRange(range);
     } else {
       if (start < 0 || end > this.el!.textContent!.length) {
         console.warn(
@@ -31,9 +32,9 @@ export class ContentEditableHelper {
       let startNode = this.findChildAtCharacterIndex(start);
       let endNode = this.findChildAtCharacterIndex(end);
       range.setStart(startNode.node, startNode.offset);
-      range.setEnd(endNode.node, endNode.offset);
+      selection.addRange(range);
+      selection.extend(endNode.node, endNode.offset);
     }
-    selection.addRange(range);
   }
 
   /**
@@ -147,13 +148,11 @@ export class ContentEditableHelper {
   private getStartAndEndSelection() {
     const selection = document.getSelection()!;
 
-    const range = selection.getRangeAt(0);
-
     return {
-      startElement: range.startContainer,
-      startSelectionOffset: range.startOffset,
-      endElement: range.endContainer,
-      endSelectionOffset: range.endOffset,
+      startElement: selection.anchorNode || this.el,
+      startSelectionOffset: selection.anchorOffset,
+      endElement: selection.focusNode || this.el,
+      endSelectionOffset: selection.focusOffset,
     };
   }
 }

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -44,16 +44,21 @@ export class EditionPlugin extends UIPlugin {
   allowDispatch(cmd: Command): CommandResult {
     switch (cmd.type) {
       case "CHANGE_COMPOSER_SELECTION":
-        const length = this.currentContent.length;
-        const { start, end } = cmd;
-        return start >= 0 && start <= length && end >= 0 && end <= length && start <= end
-          ? { status: "SUCCESS" }
-          : { status: "CANCELLED", reason: CancelledReason.WrongComposerSelection };
+        return this.validateSelection(this.currentContent.length, cmd.start, cmd.end);
       case "SET_CURRENT_CONTENT":
+        if (cmd.selection) {
+          return this.validateSelection(cmd.content.length, cmd.selection.start, cmd.selection.end);
+        } else {
+          return { status: "SUCCESS" };
+        }
       case "START_EDITION":
-        return cmd.selection && cmd.selection.start > cmd.selection.end
-          ? { status: "CANCELLED", reason: CancelledReason.WrongComposerSelection }
-          : { status: "SUCCESS" };
+        if (cmd.selection) {
+          const cell = this.getters.getActiveCell();
+          const content = cmd.text || (cell && this.getCellContent(cell)) || "";
+          return this.validateSelection(content.length, cmd.selection.start, cmd.selection.end);
+        } else {
+          return { status: "SUCCESS" };
+        }
       default:
         return { status: "SUCCESS" };
     }
@@ -163,8 +168,8 @@ export class EditionPlugin extends UIPlugin {
    * Return the (enriched) token just before the cursor.
    */
   getTokenAtCursor(): EnrichedToken | undefined {
-    const start = this.selectionStart;
-    const end = this.selectionEnd;
+    const start = Math.min(this.selectionStart, this.selectionEnd);
+    const end = Math.max(this.selectionStart, this.selectionEnd);
     if (start === end && end === 0) {
       return undefined;
     } else {
@@ -176,6 +181,12 @@ export class EditionPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
   // Misc
   // ---------------------------------------------------------------------------
+
+  private validateSelection(length: number, start: number, end: number): CommandResult {
+    return start >= 0 && start <= length && end >= 0 && end <= length
+      ? { status: "SUCCESS" }
+      : { status: "CANCELLED", reason: CancelledReason.WrongComposerSelection };
+  }
 
   /**
    * Enable the selecting mode
@@ -344,12 +355,12 @@ export class EditionPlugin extends UIPlugin {
    * The cursor is then set at the end of the text.
    */
   private replaceSelection(text) {
-    const start = this.selectionStart;
-    const end = this.selectionEnd;
+    const start = Math.min(this.selectionStart, this.selectionEnd);
+    const end = Math.max(this.selectionStart, this.selectionEnd);
     this.currentContent =
       this.currentContent.slice(0, start) +
       this.currentContent.slice(end, this.currentContent.length);
-    this.insertText(text, this.selectionStart);
+    this.insertText(text, start);
   }
 
   /**

--- a/tests/components/__mocks__/content_editable_helper.ts
+++ b/tests/components/__mocks__/content_editable_helper.ts
@@ -91,6 +91,18 @@ export class ContentEditableHelper {
         this.currentState.cursorStart = end;
         this.currentState.cursorEnd = end;
         break;
+      case "ArrowRight":
+        this.currentState.cursorEnd += 1;
+        this.currentState.cursorStart = ev.shiftKey
+          ? this.currentState.cursorStart
+          : this.currentState.cursorEnd;
+        break;
+      case "ArrowLeft":
+        this.currentState.cursorEnd -= 1;
+        this.currentState.cursorStart = ev.shiftKey
+          ? this.currentState.cursorStart
+          : this.currentState.cursorEnd;
+        break;
     }
   }
 }

--- a/tests/components/composer_test.ts
+++ b/tests/components/composer_test.ts
@@ -517,25 +517,57 @@ describe("composer", () => {
     expect(getCellContent(model, "A1", sheetId)).toBe("1");
   });
 
-  test("Home key sets cursor at the begining", async () => {
+  test("Home key sets cursor at the beginning", async () => {
     await typeInComposer("Hello");
     expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });
-    composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Home" }));
-    await nextTick();
-    composerEl.dispatchEvent(new KeyboardEvent("keyup", { key: "Home" }));
-    await nextTick();
+    await keydown("Home");
+    await keyup("Home");
     expect(model.getters.getComposerSelection()).toEqual({ start: 0, end: 0 });
   });
 
-  test("End key sets cursor at the begining", async () => {
+  test("End key sets cursor at the end", async () => {
     await typeInComposer("Hello");
     model.dispatch("CHANGE_COMPOSER_SELECTION", { start: 0, end: 0 });
     await nextTick();
-    composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "End" }));
-    await nextTick();
-    composerEl.dispatchEvent(new KeyboardEvent("keyup", { key: "End" }));
-    await nextTick();
+    await keydown("End");
+    await keyup("End");
     expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });
+  });
+
+  test("Move cursor while in edit mode", async () => {
+    await typeInComposer("Hello");
+    expect(model.getters.getEditionMode()).toBe("editing");
+    expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });
+    for (let _ in [1, 2, 3]) {
+      await keydown("ArrowLeft");
+    }
+    await keyup("ArrowLeft");
+    expect(model.getters.getComposerSelection()).toEqual({ start: 2, end: 2 });
+    for (let _ in [1, 2]) {
+      await keydown("ArrowRight");
+    }
+    await keyup("ArrowRight");
+    expect(model.getters.getComposerSelection()).toEqual({ start: 4, end: 4 });
+  });
+
+  test("Select a right-to-left range with the keyboard", async () => {
+    await typeInComposer("Hello");
+    const { end } = model.getters.getComposerSelection();
+    await keydown("ArrowLeft", { shiftKey: true });
+    await keyup("ArrowLeft", { shiftKey: true });
+    expect(model.getters.getComposerSelection()).toEqual({
+      start: end,
+      end: end - 1,
+    });
+  });
+
+  test("Select a left-to-right range with the keyboard", async () => {
+    await typeInComposer("Hello");
+    model.dispatch("CHANGE_COMPOSER_SELECTION", { start: 0, end: 0 });
+    await nextTick();
+    await keydown("ArrowRight", { shiftKey: true });
+    await keyup("ArrowRight", { shiftKey: true });
+    expect(model.getters.getComposerSelection()).toEqual({ start: 0, end: 1 });
   });
 
   test("type '=', select a cell in another sheet with space in name", async () => {

--- a/tests/plugins/edition_test.ts
+++ b/tests/plugins/edition_test.ts
@@ -132,6 +132,19 @@ describe("edition", () => {
     });
   });
 
+  test("Allow setting content with right-to-left selection", () => {
+    const model = new Model();
+    expect(model.getters.getComposerSelection()).toEqual({
+      start: 0,
+      end: 0,
+    });
+    const result = model.dispatch("SET_CURRENT_CONTENT", {
+      content: "hello",
+      selection: { start: 4, end: 0 },
+    });
+    expect(result).toEqual({ status: "SUCCESS" });
+  });
+
   test("setting content with wrong selection", () => {
     const model = new Model();
     expect(model.getters.getComposerSelection()).toEqual({
@@ -140,7 +153,7 @@ describe("edition", () => {
     });
     const result = model.dispatch("SET_CURRENT_CONTENT", {
       content: "hello",
-      selection: { start: 4, end: 1 },
+      selection: { start: 1, end: 6 },
     });
     expect(result).toEqual({
       status: "CANCELLED",
@@ -167,7 +180,7 @@ describe("edition", () => {
     });
   });
 
-  test("setting selection start after end is invalid", () => {
+  test("Allow setting right-to-left selection", () => {
     const model = new Model();
     model.dispatch("SET_CURRENT_CONTENT", {
       content: "hello",
@@ -177,10 +190,7 @@ describe("edition", () => {
         start: 2,
         end: 1,
       })
-    ).toEqual({
-      status: "CANCELLED",
-      reason: CancelledReason.WrongComposerSelection,
-    });
+    ).toEqual({ status: "SUCCESS" });
   });
 
   test("setting selection out of content is invalid", () => {
@@ -341,6 +351,16 @@ describe("edition", () => {
       selection: { start: 4, end: 5 },
     });
     expect(model.getters.getComposerSelection()).toEqual({ start: 4, end: 5 });
+  });
+
+  test("Allow start edition with a right-to-left selection", () => {
+    const model = new Model();
+    expect(
+      model.dispatch("START_EDITION", {
+        text: "coucou",
+        selection: { start: 5, end: 1 },
+      })
+    ).toEqual({ status: "SUCCESS" });
   });
 
   test("start edition with a wrong selection", () => {


### PR DESCRIPTION
## Description:

The goal is to add support for right-to-left text selection inside the composer. To do so, we had to change the method 
 `getSelection` from `content_editable_helper` as well as some functions inside `editionPlugin`.

Odoo task ID : [2532420](https://www.odoo.com/web#id=2532420&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [ ] ~~multiuser-able commands (has inverse commands and transformations where needed)~~
- [ ] ~~translations (\_lt("qmsdf %s", abc))~~
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] ~~exportable in excel~~
- [ ] ~~importable from excel~~
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
