### PR TITLE
[FIX] overlay: reset resizer preview

### DIFF
--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -224,7 +224,6 @@ export class ColResizer extends AbstractResizer {
       left: ${HEADER_WIDTH}px;
       right: 0;
       height: ${HEADER_HEIGHT}px;
-      overflow: hidden;
       .o-handle {
         position: absolute;
         height: ${HEADER_HEIGHT}px;
@@ -393,7 +392,6 @@ export class RowResizer extends AbstractResizer {
       right: 0;
       width: ${HEADER_WIDTH}px;
       height: 100%;
-      overflow: hidden;
       .o-handle {
         position: absolute;
         height: 4px;


### PR DESCRIPTION
Since cee96ee2157cb152c85cec067878888fdb0fe25f, the resizer preview bar
was hidden.

Odoo-task-id 2528722

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2528722](https://www.odoo.com/web#id=2528722&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
