### PR TITLE
[FIX] evaluation: evaluate empty styled cells as empty

### DIFF
--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -307,14 +307,14 @@ export class EvaluationPlugin extends UIPlugin {
     const sheets = this.getters.getEvaluationSheets();
     const PENDING = this.PENDING;
     function readCell(range: Range): any {
-      let cell;
+      let cell: Cell | undefined;
       const s = sheets[range.sheetId];
       if (s) {
         cell = s.rows[range.zone.top]?.cells[range.zone.left];
       } else {
         throw new Error(_lt("Invalid sheet name"));
       }
-      if (!cell || cell.content === "") {
+      if (!cell || cell.type === CellType.empty) {
         return null;
       }
       return getCellValue(cell, range.sheetId);

--- a/tests/plugins/evaluation_test.ts
+++ b/tests/plugins/evaluation_test.ts
@@ -1,7 +1,14 @@
 import { args, functionRegistry } from "../../src/functions";
 import { Model } from "../../src/model";
 import "../canvas.mock";
-import { evaluateCell, evaluateGrid, getCell, setCellContent } from "../helpers";
+import {
+  evaluateCell,
+  evaluateGrid,
+  getCell,
+  getCellContent,
+  setCellContent,
+  target,
+} from "../helpers";
 import resetAllMocks = jest.resetAllMocks;
 
 describe("evaluateCells", () => {
@@ -877,6 +884,23 @@ describe("evaluateCells", () => {
     expect(getCell(model, "D10")!.value).toBe(1);
     expect(getCell(model, "D11")!.value).toBe(1);
     expect(getCell(model, "D12")!.value).toBe(1);
+  });
+
+  test("evaluate empty colored cell", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A2", "=A1");
+    expect(getCell(model, "A2")!.value).toBe(null);
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: target("A1"),
+      style: {
+        fillColor: "#a7d08c",
+      },
+    });
+    setCellContent(model, "A12", "this re-evaluates cells");
+    expect(getCellContent(model, "A2")).toBe("0");
+    expect(getCell(model, "A2")!.value).toBe(null);
   });
 
   test("evaluation follows dependencies", () => {


### PR DESCRIPTION
Currently, if A1 only has a style but no content, it is
not correctly recognized as an empty cell. Referencing
is (i.e. with the formula `=A1`) should give 0 but it
gives an empty string

Since the introduction of cell types in 67ca3a7, an empty cell
can no longer be recognized by an empty `content`. The key "content"
is not even a valid key in the `Cell` type.

Co-authored-by: rrahir <rar@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
