### PR TITLE
[FIX] range: remove ranges only from deleted sheets

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -114,6 +114,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       }
       case "DELETE_SHEET": {
         this.executeOnAllRanges((range: Range) => {
+          if (range.sheetId !== cmd.sheetId) {
+            return { changeType: "NONE" };
+          }
           range = {
             ...range,
             zone: { ...range.zone },

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -8,6 +8,7 @@ import {
   createSheet,
   deleteColumns,
   deleteRows,
+  deleteSheet,
   redo,
   selectCell,
   setCellContent,
@@ -500,6 +501,24 @@ describe("datasource tests", function () {
     expect(chart.data!.datasets![0].data).toEqual([30, 31, 32]);
     expect(chart.data!.datasets![1].data).toEqual([40, 41, 42]);
     expect(chart.type).toEqual("bar");
+  });
+
+  test("deleting a random sheet does not affect a chart", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    createChart(
+      model,
+      {
+        dataSets: ["Sheet1!A8:D8"],
+        labelRange: "Sheet1!A2:A4",
+        type: "line",
+      },
+      "1"
+    );
+    const chartDefinitionBefore = model.getters.getChartDefinitionUI(sheetId, "1");
+    createSheet(model, { sheetId: "42" });
+    deleteSheet(model, "42");
+    const chartDefinitionAfter = model.getters.getChartDefinitionUI(sheetId, "1");
+    expect(chartDefinitionBefore).toEqual(chartDefinitionAfter);
   });
 
   test("delete a data source column", () => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -47,6 +47,10 @@ export function createSheet(
   return result;
 }
 
+export function deleteSheet(model: Model, sheetId: UID) {
+  return model.dispatch("DELETE_SHEET", { sheetId });
+}
+
 /**
  * Create a new chart by default of type bar with titles
  * in the data sets, on the active sheet.


### PR DESCRIPTION
In the demo spreadsheet, add a third sheet, then delete it:
The chart's data in sheet 2 is gone :(

Currently, when a sheet is deleted, every range is considered to be removed
even if the range belongs to another sheet.

Co-authored-by: rrahir <rar@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2536037](https://www.odoo.com/web#id=2536037&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
