### PR TITLE
[FIX] Charts: Re-create chart on type change

### DIFF
--- a/tests/components/charts_test.ts
+++ b/tests/components/charts_test.ts
@@ -1,19 +1,21 @@
+import { ChartConfiguration } from "chart.js";
 import { Model } from "../../src";
 import { CommandResult } from "../../src/types";
 import { setInputValueAndTrigger, simulateClick, triggerMouseEvent } from "../dom_helper";
 import { GridParent, makeTestFixture, nextTick } from "../helpers";
 
 const mockChart = () => {
-  const mockChartData = {
+  const mockChartData: ChartConfiguration = {
     data: undefined,
-    config: {
-      options: {
-        title: undefined,
-      },
-      type: undefined,
+    options: {
+      title: undefined,
     },
+    type: undefined,
   };
   class ChartMock {
+    constructor(ctx: unknown, chartData: ChartConfiguration) {
+      Object.assign(mockChartData, chartData);
+    }
     set data(value) {
       mockChartData.data = value;
     }
@@ -22,8 +24,8 @@ const mockChart = () => {
     }
     destroy = () => {};
     update = () => {};
-    options = mockChartData.config.options;
-    config = mockChartData.config;
+    options = mockChartData.options;
+    config = mockChartData;
   }
   //@ts-ignore
   window.Chart = ChartMock;
@@ -250,8 +252,8 @@ describe("figures", () => {
     await nextTick();
     expect((mockChartData.data! as any).labels).toEqual(["P1", "P2", "P3", "P4"]);
     expect((mockChartData.data! as any).datasets[0].data).toEqual([10, 11, 12, 13]);
-    expect(mockChartData.config.type).toBe("pie");
-    expect((mockChartData.config.options.title as any).text).toBe("piechart");
+    expect(mockChartData.type).toBe("pie");
+    expect((mockChartData.options!.title as any).text).toBe("piechart");
   });
 
   test("chart is focused after creation", async () => {


### PR DESCRIPTION
Updating a chart type requires to update its options accordingly, if feasible at all.
Since we trust Chart.js to generate most of its options, it is safer to just start from scratch.
See https://www.chartjs.org/docs/latest/developers/updates.html
and https://stackoverflow.com/questions/36949343/chart-js-dynamic-changing-of-chart-type-line-to-bar-as-example

Co-authored-by: Lucas Lefèvre <lul@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2537879](https://www.odoo.com/web#id=2537879&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] ~~undo-able commands (uses this.history.update)~~
- [ ] ~~multiuser-able commands (has inverse commands and transformations where needed)~~
- [x] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] ~~exportable in excel~~
- [ ] ~~importable from excel~~
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
