### PR TITLE
[FIX] Charts: fix Pie charts display

### DIFF
--- a/tests/model/plugins/chart_test.ts
+++ b/tests/model/plugins/chart_test.ts
@@ -126,8 +126,8 @@ describe("datasource tests", function () {
       type: "line",
     });
     const datasets = model.getters.getChartRuntime("1")!.data!.datasets!;
-    expect(datasets[0].label!.toString()).toEqual("Series");
-    expect(datasets[1].label!.toString()).toEqual("Series");
+    expect(datasets[0].label!.toString()).toEqual("Series 1");
+    expect(datasets[1].label!.toString()).toEqual("Series 2");
   });
 
   test("create chart with row datasets", () => {
@@ -225,7 +225,7 @@ describe("datasource tests", function () {
     });
     const datasets = model.getters.getChartRuntime("1")!.data!.datasets!;
     expect(datasets).toHaveLength(1);
-    expect(datasets[0].label!.toString()).toEqual("Series");
+    expect(datasets[0].label!.toString()).toEqual("Series 1");
   });
 
   test("create chart with async as label", () => {
@@ -243,7 +243,41 @@ describe("datasource tests", function () {
     });
     const datasets = model.getters.getChartRuntime("1")!.data!.datasets!;
     expect(datasets).toHaveLength(1);
-    expect(datasets[0].label!.toString()).toEqual("Series");
+    expect(datasets[0].label!.toString()).toEqual("Series 1");
+  });
+
+  test("pie chart tooltip title display the correct dataset", () => {
+    model.dispatch("CREATE_CHART", {
+      id: "1",
+      sheetId: model.getters.getActiveSheet(),
+      definition: {
+        title: "test 1",
+        dataSets: ["B7:B8"],
+        seriesHasTitle: true,
+        labelRange: "B7",
+        type: "pie",
+      },
+    });
+    const title = model.getters.getChartRuntime("1")!.options!.tooltips!.callbacks!.title!;
+    const chartData = { datasets: [{ label: "dataset 1" }, { label: "dataset 2" }] };
+    expect(title([{ datasetIndex: 0 }], chartData)).toBe("dataset 1");
+    expect(title([{ datasetIndex: 1 }], chartData)).toBe("dataset 2");
+  });
+
+  test.each(["bar", "line"] as const)("chart %s tooltip title is not dynamic", (chartType) => {
+    model.dispatch("CREATE_CHART", {
+      id: "1",
+      sheetId: model.getters.getActiveSheet(),
+      definition: {
+        title: "test 1",
+        dataSets: ["B7:B8"],
+        seriesHasTitle: true,
+        labelRange: "B7",
+        type: chartType,
+      },
+    });
+    const title = model.getters.getChartRuntime("1")?.options?.tooltips?.callbacks?.title;
+    expect(title).toBeUndefined();
   });
 
   test("can delete an imported chart", () => {


### PR DESCRIPTION
Currently, Pie charts support several datasets but the colors are not
share between them of a same label.
Furthermore, The tooltip on the graph doesn't allow to distinguish the
different datasets.

This commits addresses both issues by creating a fixed color set for
each dataset and by adding a custom toolip callback to Chart.js options.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2538128](https://www.odoo.com/web#id=2538128&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] ~~undo-able commands (uses this.history.update)~~
- [ ] ~~multiuser-able commands (has inverse commands and transformations where needed)~~
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] ~~exportable in excel~~
- [ ] ~~importable from excel~~
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
