### PR TITLE
[FIX] Range: Altering sheet structure should not impact ranges of other

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -52,6 +52,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
 
         const groups = groupConsecutive(cmd.elements);
         this.executeOnAllRanges((range: Range) => {
+          if (range.sheetId !== cmd.sheetId) {
+            return { changeType: "NONE" };
+          }
           let newRange = range;
           let changeType: ChangeType = "NONE";
           for (let group of groups) {
@@ -80,6 +83,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
         let dimension: "columns" | "rows" = cmd.dimension === "COL" ? "columns" : "rows";
 
         this.executeOnAllRanges((range: Range) => {
+          if (range.sheetId !== cmd.sheetId) {
+            return { changeType: "NONE" };
+          }
           if (cmd.position === "after") {
             if (range.zone[start] <= cmd.base && cmd.base < range.zone[end]) {
               return {

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -521,6 +521,24 @@ describe("datasource tests", function () {
     expect(chartDefinitionBefore).toEqual(chartDefinitionAfter);
   });
 
+  test("deleting a col on another sheet does not affect a chart", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    createChart(
+      model,
+      {
+        dataSets: ["Sheet1!A8:D8"],
+        labelRange: "Sheet1!A2:A4",
+        type: "line",
+      },
+      "1"
+    );
+    const chartDefinitionBefore = model.getters.getChartDefinitionUI(sheetId, "1");
+    createSheet(model, { sheetId: "42" });
+    deleteColumns(model, ["A"], "42");
+    const chartDefinitionAfter = model.getters.getChartDefinitionUI(sheetId, "1");
+    expect(chartDefinitionBefore).toEqual(chartDefinitionAfter);
+  });
+
   test("delete a data source column", () => {
     createChart(
       model,
@@ -609,6 +627,24 @@ describe("datasource tests", function () {
     expect(chart.data!.datasets![0].data).toEqual([10, undefined, 11, 12, 13]);
     expect(chart.data!.datasets![1].data).toEqual([20, undefined, 19, 18, 17]);
     expect(chart.data!.labels).toEqual(["P1", "", "P2", "P3", "P4"]);
+  });
+
+  test("Add a row on another sheet does not affect a chart", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    createChart(
+      model,
+      {
+        dataSets: ["Sheet1!A8:D8"],
+        labelRange: "Sheet1!A2:A4",
+        type: "line",
+      },
+      "1"
+    );
+    const chartDefinitionBefore = model.getters.getChartDefinitionUI(sheetId, "1");
+    createSheet(model, { sheetId: "42" });
+    addRows(model, "before", 0, 1, "42");
+    const chartDefinitionAfter = model.getters.getChartDefinitionUI(sheetId, "1");
+    expect(chartDefinitionBefore).toEqual(chartDefinitionAfter);
   });
 
   test("delete all the dataset except for the title", () => {

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -5,6 +5,7 @@ import { ApplyRangeChange, BaseCommand, Command, Range, UID } from "../../src/ty
 import {
   addColumns,
   addRows,
+  createSheet,
   deleteColumns,
   deleteRows,
   deleteSheet,
@@ -117,6 +118,12 @@ describe("range plugin", () => {
         deleteColumns(m, ["F"]);
         expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
       });
+
+      test("in another sheet", () => {
+        createSheet(m, { sheetId: "42" });
+        deleteColumns(m, ["A"], "42");
+        expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
+      });
     });
 
     describe("create a range and remove a row", () => {
@@ -142,6 +149,12 @@ describe("range plugin", () => {
 
       test("after the end", () => {
         deleteRows(m, [5]);
+        expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
+      });
+
+      test("in another sheet", () => {
+        createSheet(m, { sheetId: "42" });
+        deleteRows(m, [0], "42");
         expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
       });
     });
@@ -196,6 +209,12 @@ describe("range plugin", () => {
         addColumns(m, "before", "E", 1);
         expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
       });
+
+      test("in another sheet", () => {
+        createSheet(m, { sheetId: "42" });
+        addColumns(m, "before", "A", 1, "42");
+        expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
+      });
     });
 
     describe("create a range and add a row", () => {
@@ -246,6 +265,12 @@ describe("range plugin", () => {
 
       test("before, before the end", () => {
         addRows(m, "before", 5, 1);
+        expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
+      });
+
+      test("in another sheet", () => {
+        createSheet(m, { sheetId: "42" });
+        addRows(m, "before", 1, 1, "42");
         expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
       });
     });


### PR DESCRIPTION
sheets

In the demo sheet, go to sheet2, delete second column then force a
reload of the charts (focus Sheet1 >Sheet2) the Chart ranges have been
adapted even though they point towards Sheet1.

The commit 7580482c846261afbe9a0217a1560556295e425c already adressed the issue
for deleted sheets. This commit covers the missing cases. I.e. addition
and deletion of columns/rows

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
