### PR TITLE
[IMP] edition: use ctrl to add multiple cell reference during selection

### DIFF
--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -423,17 +423,24 @@ export function createAdaptedZone(
   return newZone;
 }
 
-// returns an Zone array with unique occurrence of each zone
+/**
+ * Returns a Zone array with unique occurrence of each zone.
+ * For each multiple occurrence, the occurrence with the largest index is kept.
+ * This allows to always have the last selection made in the last position.
+ * */
 export function uniqueZones(zones: Zone[]): Zone[] {
-  return zones.filter(
-    (zone, index, self) =>
-      index ===
-      self.findIndex(
-        (z) =>
-          z.top === zone.top &&
-          z.bottom === zone.bottom &&
-          z.left === zone.left &&
-          z.right === zone.right
-      )
-  );
+  return zones
+    .reverse()
+    .filter(
+      (zone, index, self) =>
+        index ===
+        self.findIndex(
+          (z) =>
+            z.top === zone.top &&
+            z.bottom === zone.bottom &&
+            z.left === zone.left &&
+            z.right === zone.right
+        )
+    )
+    .reverse();
 }

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -19,6 +19,7 @@ import {
   RemoveColumnsRowsCommand,
 } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
+import { SelectionMode } from "./selection";
 
 export type EditionMode =
   | "editing"
@@ -58,6 +59,7 @@ export class EditionPlugin extends UIPlugin {
   private selectionStart: number = 0;
   private selectionEnd: number = 0;
   private selectionInitialStart: number = 0;
+  private multiSelectionInitialStart: number = 0;
   private initialContent: string | undefined = "";
 
   // ---------------------------------------------------------------------------
@@ -147,13 +149,39 @@ export class EditionPlugin extends UIPlugin {
       case "SELECT_CELL":
       case "SET_SELECTION":
       case "MOVE_POSITION":
-        if (this.mode === "editing") {
-          this.dispatch("STOP_EDITION");
-        } else if (this.mode === "waitingForRangeSelection" || this.mode === "rangeSelected") {
-          this.insertSelectedRange();
-        }
-        if (this.mode === "inactive") {
-          this.setActiveContent();
+        switch (this.mode) {
+          case "editing":
+            this.dispatch("STOP_EDITION");
+            break;
+          case "inactive":
+            this.setActiveContent();
+            break;
+          case "waitingForRangeSelection":
+            this.insertSelectedRange();
+            break;
+          case "rangeSelected":
+            switch (cmd.type) {
+              case "MOVE_POSITION":
+                this.replaceAllSelectedRanges();
+                break;
+              case "SELECT_CELL":
+                if (this.getters.getSelectionMode() === SelectionMode.expanding) {
+                  this.insertSelectedRange();
+                } else {
+                  this.replaceAllSelectedRanges();
+                }
+                break;
+              case "SET_SELECTION":
+                if (!cmd.strict) {
+                  this.replaceSelectedRange();
+                } else if (this.getters.getSelectionMode() === SelectionMode.expanding) {
+                  this.insertSelectedRange();
+                } else {
+                  this.replaceAllSelectedRanges();
+                }
+                break;
+            }
+            break;
         }
         break;
       case "ADD_COLUMNS_ROWS":
@@ -293,10 +321,11 @@ export class EditionPlugin extends UIPlugin {
       row: this.row,
     });
     this.mode = "waitingForRangeSelection";
-    // We set this variable to store the start of the selection, to allow
-    // to replace selections (ex: select twice a cell should only be added
-    // once)
-    this.selectionInitialStart = this.selectionStart;
+    // We set this variable to store the start of the multiple range
+    // selection. This is useful for example when we select multiple
+    // cells with ctrl, release the ctrl and select a new cell.
+    // This should result in deletions of previously selected cells.
+    this.multiSelectionInitialStart = this.selectionStart;
   }
 
   private getCellContent(cell: Cell) {
@@ -407,29 +436,61 @@ export class EditionPlugin extends UIPlugin {
   }
 
   /**
-   * Insert the currently selected zone XC in the composer content.
-   * The XC replaces the following section:
-   *  - start:  where the cursor was when the edition mode was
-   *            changed to `selecting`.
-   *  - end:    the current end of the selection.
+   * Insert reference of the currently selected zone in the composer content.
+   * Separates references with commas when more than one is selected.
    */
   private insertSelectedRange() {
-    this.mode = "rangeSelected";
-    const [zone] = this.getters.getSelectedZones();
-    const sheetId = this.getters.getActiveSheetId();
-    let selectedXc = this.getters.zoneToXC(sheetId, zone);
+    const start = Math.min(this.selectionStart, this.selectionEnd);
+    if (this.mode === "waitingForRangeSelection") {
+      this.insertText(this.getZoneReference(), start);
+      this.selectionInitialStart = start;
+      this.mode = "rangeSelected";
+      return;
+    }
+    // range already present (mean this.mode === "rangeSelected")
+    this.insertText("," + this.getZoneReference(), start);
+    this.selectionInitialStart = start + 1;
+  }
+
+  /**
+   * Replace the last reference by the new one.
+   * This function is particularly useful when multiple cells selection is
+   * enabled and we need to change the last reference (eg: change the cell
+   * reference to a range reference)
+   */
+  private replaceSelectedRange() {
     const { end } = this.getters.getComposerSelection();
     this.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", {
       start: this.selectionInitialStart,
       end,
     });
+    this.replaceSelection(this.getZoneReference());
+  }
+
+  /**
+   * Replace all references selected by the new one.
+   * */
+  private replaceAllSelectedRanges() {
+    const { end } = this.getters.getComposerSelection();
+    this.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", {
+      start: this.multiSelectionInitialStart,
+      end,
+    });
+    this.replaceSelection(this.getZoneReference());
+    this.selectionInitialStart = this.multiSelectionInitialStart;
+  }
+
+  private getZoneReference(): string {
+    const zone = this.getters.getSelectedZone();
+    const sheetId = this.getters.getActiveSheetId();
+    let selectedXc = this.getters.zoneToXC(sheetId, zone);
     if (this.getters.getEditionSheet() !== this.getters.getActiveSheetId()) {
       const sheetName = getComposerSheetName(
         this.getters.getSheetName(this.getters.getActiveSheetId())!
       );
       selectedXc = `${sheetName}!${selectedXc}`;
     }
-    this.replaceSelection(selectedXc);
+    return selectedXc;
   }
 
   /**

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -494,8 +494,9 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
     const sheet = this.getters.getActiveSheet();
     this.moveClient({ sheetId: sheet.id, col, row });
     let zone = this.getters.expandZone(sheet.id, { left: col, right: col, top: row, bottom: row });
-
     if (this.mode === SelectionMode.expanding) {
+      // It is important to add the zone at the end of the array.
+      // It is a way to easily find the last selection made by the user.
       this.selection.zones.push(zone);
     } else {
       this.selection.zones = [zone];


### PR DESCRIPTION
Odoo task ID : 2534899 (https://www.odoo.com/web#id=2534899&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
