### PR TITLE
[FIX] figures: display the figure at the stored position

### DIFF
--- a/src/components/figures/container.ts
+++ b/src/components/figures/container.ts
@@ -63,8 +63,6 @@ const CSS = css/*SCSS*/ `
     border: 1px solid black;
     box-sizing: border-box;
     position: absolute;
-    bottom: 3px;
-    right: 3px;
     &:focus {
       outline: none;
     }


### PR DESCRIPTION
Before this commit, a figure at (0,0) was positioned at (3,3), which
was incorrect.

Odoo-task-id 2543173

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2543173](https://www.odoo.com/web#id=2543173&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [X] undo-able commands (uses this.history.update)
- [X] multiuser-able commands (has inverse commands and transformations where needed)
- [X] translations (\_lt("qmsdf %s", abc))
- [X] unit tested
- [X] clean commented code
- [X] feature is organized in plugin, or UI components
- [X] exportable in excel
- [X] importable from excel
- [X] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [X] in model/UI: ranges are strings (to show the user)
- [X] new/updated/removed commands are documented
- [X] track breaking changes
- [X] public API change (index.ts) must rebuild doc (npm run doc)
- [X] code is prettified with prettier (in each commit, no separate commit)
- [X] status is correct in Odoo
