### PR TITLE
[REF] evaluation: use Range to evaluate chart data

### DIFF
--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -1,7 +1,7 @@
 import { MAXIMUM_EVALUATION_CHECK_DELAY_MS } from "../../constants";
 import { compile, normalize } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { mapCellsInZone, toXC, toZone } from "../../helpers/index";
+import { mapCellsInZone, toXC } from "../../helpers/index";
 import { Mode, ModelConfig } from "../../model";
 import { StateObserver } from "../../state_observer";
 import { _lt } from "../../translation";
@@ -157,30 +157,27 @@ export class EvaluationPlugin extends UIPlugin {
     return this.loadingCells === 0 && this.WAITING.size === 0 && this.PENDING.size === 0;
   }
 
-  getRangeFormattedValues(reference: string, defaultSheetId: UID): string[][] {
-    const [range, sheetName] = reference.split("!").reverse();
-    const sheetId = sheetName ? this.getters.getSheetIdByName(sheetName) : defaultSheetId;
-    const sheet = sheetId ? this.getters.getSheet(sheetId) : undefined;
+  /**
+   * Return the value of each cell in the range as they are displayed in the grid.
+   */
+  getRangeFormattedValues(range: Range): string[][] {
+    const sheet = this.getters.tryGetSheet(range.sheetId);
     if (sheet === undefined) return [[]];
     return mapCellsInZone(
-      toZone(range),
+      range.zone,
       sheet,
-      (cell) =>
-        this.getters.getCellText(
-          cell,
-          sheetId || defaultSheetId,
-          this.getters.shouldShowFormulas()
-        ),
+      (cell) => this.getters.getCellText(cell, range.sheetId, this.getters.shouldShowFormulas()),
       ""
     );
   }
 
-  getRangeValues(reference: string, defaultSheetId: UID): any[][] {
-    const [range, sheetName] = reference.split("!").reverse();
-    const sheetId = sheetName ? this.getters.getSheetIdByName(sheetName) : defaultSheetId;
-    const sheet = sheetId ? this.getters.tryGetSheet(sheetId) : undefined;
+  /**
+   * Return the value of each cell in the range.
+   */
+  getRangeValues(range: Range): any[][] {
+    const sheet = this.getters.tryGetSheet(range.sheetId);
     if (sheet === undefined) return [[]];
-    return mapCellsInZone(toZone(range), sheet, (cell) => cell.value);
+    return mapCellsInZone(range.zone, sheet, (cell) => cell.value);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -7,7 +7,6 @@ import {
   ChartType,
 } from "chart.js";
 import { chartTerms } from "../../components/side_panel/translations_terms";
-import { INCORRECT_RANGE_STRING } from "../../constants";
 import { ChartColors } from "../../helpers/chart";
 import { isDefined, isInside, overlap, recomputeZones, zoneToXc } from "../../helpers/index";
 import { Mode } from "../../model";
@@ -263,9 +262,8 @@ export class EvaluationChartPlugin extends UIPlugin {
   private mapDefinitionToRuntime(definition: ChartDefinition): ChartConfiguration {
     let labels: string[] = [];
     if (definition.labelRange) {
-      const rangeString = this.getters.getRangeString(definition.labelRange, definition.sheetId);
-      if (rangeString !== INCORRECT_RANGE_STRING) {
-        labels = this.getters.getRangeFormattedValues(rangeString, definition.sheetId).flat(1);
+      if (!definition.labelRange.invalidXc && !definition.labelRange.invalidSheetName) {
+        labels = this.getters.getRangeFormattedValues(definition.labelRange).flat(1);
       }
     }
     const runtime = this.getDefaultConfiguration(definition.type, definition.title, labels);
@@ -320,8 +318,7 @@ export class EvaluationChartPlugin extends UIPlugin {
         return [];
       }
       const dataRange = this.getters.getRangeFromSheetXC(ds.dataRange.sheetId, dataXC);
-      const dataRangeXc = this.getters.getRangeString(dataRange, sheetId);
-      return this.getters.getRangeValues(dataRangeXc, ds.dataRange.sheetId).flat(1);
+      return this.getters.getRangeValues(dataRange).flat(1);
     }
     return [];
   }

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -16,7 +16,9 @@ import { FORCE_DEFAULT_ARGS_FUNCTIONS, NON_RETROCOMPATIBLE_FUNCTIONS } from "../
 import { getCellType, pushElement } from "../helpers/content_helpers";
 import { xmlEscape } from "../helpers/xml_helpers";
 
-export function addFormula(formula: NormalizedFormula): {
+export function addFormula(
+  formula: NormalizedFormula
+): {
   attrs: XMLAttributes;
   node: XMLString;
 } {

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -12,7 +12,12 @@ import {
   setCellContent,
   undo,
 } from "../test_helpers/commands_helpers";
-import { getCell, getCellContent } from "../test_helpers/getters_helpers";
+import {
+  getCell,
+  getCellContent,
+  getRangeFormattedValues,
+  getRangeValues,
+} from "../test_helpers/getters_helpers";
 import { initPatcher } from "../test_helpers/helpers";
 
 let waitForRecompute: () => Promise<void>;
@@ -517,25 +522,23 @@ describe("history", () => {
         ],
       });
       activateSheet(model, sheet2Id); // evaluate Sheet2
-      expect(model.getters.getRangeFormattedValues("A1:A3", sheet1Id)).toEqual([
+      expect(getRangeFormattedValues(model, "A1:A3", sheet1Id)).toEqual([["1,000", "", "2,000"]]);
+      expect(getRangeFormattedValues(model, "$A$1:$A$3", sheet1Id)).toEqual([
         ["1,000", "", "2,000"],
       ]);
-      expect(model.getters.getRangeFormattedValues("$A$1:$A$3", sheet1Id)).toEqual([
+      expect(getRangeFormattedValues(model, "Sheet1!A1:A3", sheet1Id)).toEqual([
         ["1,000", "", "2,000"],
       ]);
-      expect(model.getters.getRangeFormattedValues("Sheet1!A1:A3", sheet1Id)).toEqual([
-        ["1,000", "", "2,000"],
-      ]);
-      expect(model.getters.getRangeFormattedValues("Sheet2!A1:A3", sheet2Id)).toEqual([
+      expect(getRangeFormattedValues(model, "Sheet2!A1:A3", sheet2Id)).toEqual([
         ["21,000", "", "12/31/2020"],
       ]);
-      expect(model.getters.getRangeFormattedValues("Sheet2!A1:A3", sheet1Id)).toEqual([
+      expect(getRangeFormattedValues(model, "Sheet2!A1:A3", sheet1Id)).toEqual([
         ["21,000", "", "12/31/2020"],
       ]);
-      expect(model.getters.getRangeFormattedValues("B2", sheet1Id)).toEqual([["TRUE"]]);
-      expect(model.getters.getRangeFormattedValues("Sheet1!B2", sheet1Id)).toEqual([["TRUE"]]);
-      expect(model.getters.getRangeFormattedValues("Sheet2!B2", sheet2Id)).toEqual([["TRUE"]]);
-      expect(model.getters.getRangeFormattedValues("Sheet2!B2", sheet1Id)).toEqual([["TRUE"]]);
+      expect(getRangeFormattedValues(model, "B2", sheet1Id)).toEqual([["TRUE"]]);
+      expect(getRangeFormattedValues(model, "Sheet1!B2", sheet1Id)).toEqual([["TRUE"]]);
+      expect(getRangeFormattedValues(model, "Sheet2!B2", sheet2Id)).toEqual([["TRUE"]]);
+      expect(getRangeFormattedValues(model, "Sheet2!B2", sheet1Id)).toEqual([["TRUE"]]);
     });
 
     test("getRangeValues", () => {
@@ -565,24 +568,16 @@ describe("history", () => {
           },
         ],
       });
-      expect(model.getters.getRangeValues("A1:A3", sheet1Id)).toEqual([[1000, undefined, 2000]]);
-      expect(model.getters.getRangeValues("$A$1:$A$3", sheet1Id)).toEqual([
-        [1000, undefined, 2000],
-      ]);
-      expect(model.getters.getRangeValues("Sheet1!A1:A3", sheet1Id)).toEqual([
-        [1000, undefined, 2000],
-      ]);
-      expect(model.getters.getRangeValues("Sheet2!A1:A3", sheet2Id)).toEqual([
-        [21000, undefined, 44196],
-      ]);
-      expect(model.getters.getRangeValues("Sheet2!A1:A3", sheet1Id)).toEqual([
-        [21000, undefined, 44196],
-      ]);
-      expect(model.getters.getRangeValues("B2", sheet1Id)).toEqual([[true]]);
-      expect(model.getters.getRangeValues("Sheet1!B2", sheet1Id)).toEqual([[true]]);
-      expect(model.getters.getRangeValues("Sheet2!B2", sheet2Id)).toEqual([[true]]);
-      expect(model.getters.getRangeValues("Sheet2!B2", sheet1Id)).toEqual([[true]]);
-      expect(model.getters.getRangeValues("B2", "invalidSheetId")).toEqual([[]]);
+      expect(getRangeValues(model, "A1:A3", sheet1Id)).toEqual([[1000, undefined, 2000]]);
+      expect(getRangeValues(model, "$A$1:$A$3", sheet1Id)).toEqual([[1000, undefined, 2000]]);
+      expect(getRangeValues(model, "Sheet1!A1:A3", sheet1Id)).toEqual([[1000, undefined, 2000]]);
+      expect(getRangeValues(model, "Sheet2!A1:A3", sheet2Id)).toEqual([[21000, undefined, 44196]]);
+      expect(getRangeValues(model, "Sheet2!A1:A3", sheet1Id)).toEqual([[21000, undefined, 44196]]);
+      expect(getRangeValues(model, "B2", sheet1Id)).toEqual([[true]]);
+      expect(getRangeValues(model, "Sheet1!B2", sheet1Id)).toEqual([[true]]);
+      expect(getRangeValues(model, "Sheet2!B2", sheet2Id)).toEqual([[true]]);
+      expect(getRangeValues(model, "Sheet2!B2", sheet1Id)).toEqual([[true]]);
+      expect(getRangeValues(model, "B2", "invalidSheetId")).toEqual([[]]);
     });
   });
 });

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -48,6 +48,22 @@ export function getCellText(
   return cell ? model.getters.getCellText(cell, sheetId, true) : "";
 }
 
+export function getRangeFormattedValues(
+  model: Model,
+  xc: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+): string[][] {
+  return model.getters.getRangeFormattedValues(model.getters.getRangeFromSheetXC(sheetId, xc));
+}
+
+export function getRangeValues(
+  model: Model,
+  xc: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+): any[][] {
+  return model.getters.getRangeValues(model.getters.getRangeFromSheetXC(sheetId, xc));
+}
+
 /**
  * Get the sheet at the given index
  */


### PR DESCRIPTION

## Description:

There is an unecessary round trip between
Range => string => Zone

Odoo task ID : 

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
