### PR TITLE
[REF] xlsx: automatically escape values

### DIFF
--- a/src/types/xlsx.ts
+++ b/src/types/xlsx.ts
@@ -34,7 +34,20 @@ export type XMLAttributeValue = string | number | boolean;
 type XMLAttribute = [string, XMLAttributeValue];
 export type XMLAttributes = XMLAttribute[];
 
-export type XMLString = string;
+/**
+ * Represent a raw XML string
+ */
+export class XMLString {
+  /**
+   * @param xmlString should be a well formed, properly escaped XML string
+   */
+  constructor(private xmlString: string) {}
+
+  toString(): string {
+    return this.xmlString;
+  }
+}
+
 export interface XLSXDxf {
   font?: Partial<XLSXFont>;
   fill?: XLSXFill;

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -14,7 +14,7 @@ import { NormalizedFormula } from "../../types";
 import { XMLAttributes, XMLString } from "../../types/xlsx";
 import { FORCE_DEFAULT_ARGS_FUNCTIONS, NON_RETROCOMPATIBLE_FUNCTIONS } from "../constants";
 import { getCellType, pushElement } from "../helpers/content_helpers";
-import { xmlEscape } from "../helpers/xml_helpers";
+import { escapeXml } from "../helpers/xml_helpers";
 
 export function addFormula(
   formula: NormalizedFormula
@@ -26,24 +26,24 @@ export function addFormula(
   const tokens = tokenize(formula.text);
 
   const attrs: XMLAttributes = [];
-  let node: string = "";
+  let node = escapeXml``;
 
   const isExported = tokens
     .filter((tk) => tk.type === "FUNCTION")
     .every((tk) => functions[tk.value.toUpperCase()].isExported);
 
   if (isExported) {
-    let cycle = "";
+    let cycle = escapeXml``;
     const XlsxFormula = adaptFormulaToExcel(formula);
     // hack for cycles : if we don't set a value (be it 0 or #VALUE!), it will appear as invisible on excel,
     // Making it very hard for the client to find where the recursion is.
     if (formula.value === "#CYCLE") {
       attrs.push(["t", "str"]);
-      cycle = /*xml*/ `<v>${xmlEscape(formula.value)}</v>`;
+      cycle = escapeXml/*xml*/ `<v>${formula.value}</v>`;
     }
-    node = /*xml*/ `
+    node = escapeXml/*xml*/ `
       <f>
-        ${xmlEscape(XlsxFormula)}
+        ${XlsxFormula}
       </f>
       ${cycle}
     `;
@@ -55,7 +55,7 @@ export function addFormula(
     if (value) {
       const type = getCellType(value);
       attrs.push(["t", type]);
-      node = /*xml*/ `<v>${xmlEscape(value)}</v>`;
+      node = escapeXml/*xml*/ `<v>${value}</v>`;
     }
     return { attrs, node };
   }
@@ -79,8 +79,7 @@ export function addContent(
     value = id.toString();
     attrs.push(["t", "s"]);
   }
-
-  return { attrs, node: /*xml*/ `<v>${xmlEscape(value)}</v>` };
+  return { attrs, node: escapeXml/*xml*/ `<v>${value}</v>` };
 }
 
 export function adaptFormulaToExcel(formula: NormalizedFormula): string {

--- a/src/xlsx/functions/drawings.ts
+++ b/src/xlsx/functions/drawings.ts
@@ -3,7 +3,7 @@ import { ExcelChartDefinition, FigureData, HeaderData, SheetData } from "../../t
 import { XMLAttributes, XMLString } from "../../types/xlsx";
 import { DRAWING_NS_A, DRAWING_NS_C, NAMESPACE, RELATIONSHIP_NSR } from "../constants";
 import { convertChartId, convertDotValueToEMU } from "../helpers/content_helpers";
-import { formatAttributes, parseXML } from "../helpers/xml_helpers";
+import { escapeXml, formatAttributes, joinXmlNodes, parseXML } from "../helpers/xml_helpers";
 
 type FigurePosition = {
   to: {
@@ -41,7 +41,7 @@ export function createDrawing(
       ["name", `Chart ${chartId}`],
       ["title", "Chart"],
     ];
-    figuresNodes.push(/*xml*/ `
+    figuresNodes.push(escapeXml/*xml*/ `
       <xdr:twoCellAnchor>
         <xdr:from>
           <xdr:col>${from.col}</xdr:col>
@@ -75,9 +75,9 @@ export function createDrawing(
     `);
   }
 
-  const xml = /*xml*/ `
+  const xml = escapeXml/*xml*/ `
     <xdr:wsDr ${formatAttributes(namespaces)}>
-      ${figuresNodes.join("\n")}
+      ${joinXmlNodes(figuresNodes)}
     </xdr:wsDr>
   `;
   return parseXML(xml);

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -8,12 +8,12 @@ import {
   extractStyle,
   normalizeStyle,
 } from "../helpers/content_helpers";
-import { formatAttributes } from "../helpers/xml_helpers";
+import { escapeXml, formatAttributes, joinXmlNodes } from "../helpers/xml_helpers";
 import { addContent, addFormula } from "./cells";
 
 export function addColumns(cols: { [key: number]: HeaderData }): XMLString {
   if (!Object.values(cols).length) {
-    return /*xml*/ "";
+    return escapeXml``;
   }
   const colNodes: XMLString[] = [];
   for (let [id, col] of Object.entries(cols)) {
@@ -25,13 +25,13 @@ export function addColumns(cols: { [key: number]: HeaderData }): XMLString {
       ["customWidth", 1],
       ["hidden", col.isHidden ? 1 : 0],
     ];
-    colNodes.push(/*xml*/ `
+    colNodes.push(escapeXml/*xml*/ `
       <col ${formatAttributes(attributes)}/>
     `);
   }
-  return /*xml*/ `
+  return escapeXml/*xml*/ `
     <cols>
-      ${colNodes.join("\n")}
+      ${joinXmlNodes(colNodes)}
     </cols>
   `;
 }
@@ -59,7 +59,7 @@ export function addRows(construct, data: ExcelWorkbookData, sheet: ExcelSheetDat
         attributes.push(["s", id]);
 
         let additionalAttrs: XMLAttributes = [];
-        let cellNode: XMLString = "";
+        let cellNode = escapeXml``;
         // Either formula or static value inside the cell
         if (cell.formula) {
           ({ attrs: additionalAttrs, node: cellNode } = addFormula(cell.formula));
@@ -70,7 +70,7 @@ export function addRows(construct, data: ExcelWorkbookData, sheet: ExcelSheetDat
           ));
         }
         attributes.push(...additionalAttrs);
-        cellNodes.push(/*xml*/ `
+        cellNodes.push(escapeXml/*xml*/ `
           <c ${formatAttributes(attributes)}>
             ${cellNode}
           </c>
@@ -78,27 +78,27 @@ export function addRows(construct, data: ExcelWorkbookData, sheet: ExcelSheetDat
       }
     }
     if (cellNodes.length) {
-      rowNodes.push(/*xml*/ `
+      rowNodes.push(escapeXml/*xml*/ `
         <row ${formatAttributes(rowAttrs)}>
-          ${cellNodes.join("\n")}
+          ${joinXmlNodes(cellNodes)}
         </row>
       `);
     }
   }
-  return /*xml*/ `
+  return escapeXml/*xml*/ `
     <sheetData>
-      ${rowNodes.join("\n")}
+      ${joinXmlNodes(rowNodes)}
     </sheetData>
   `;
 }
 
 export function addMerges(merges: string[]): XMLString {
   if (merges.length) {
-    const mergeNodes = merges.map((merge) => /*xml*/ `<mergeCell ref="${merge}" />`);
-    return /*xml*/ `
+    const mergeNodes = merges.map((merge) => escapeXml/*xml*/ `<mergeCell ref="${merge}" />`);
+    return escapeXml/*xml*/ `
       <mergeCells count="${merges.length}">
-        ${mergeNodes.join("\n")}
+        ${joinXmlNodes(mergeNodes)}
       </mergeCells>
     `;
-  } else return "";
+  } else return escapeXml``;
 }

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -7416,6 +7416,16 @@ Object {
                 </f>
             </c>
         </row>
+        <row r=\\"39\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A39\\" s=\\"3\\" t=\\"str\\">
+                <f>
+                    A39
+                </f>
+                <v>
+                    #CYCLE
+                </v>
+            </c>
+        </row>
     </sheetData>
 </worksheet>",
       "contentType": "sheet",

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -1,7 +1,7 @@
 import { Model } from "../src/model";
 import { ChartTypes, NormalizedFormula } from "../src/types";
 import { adaptFormulaToExcel } from "../src/xlsx/functions/cells";
-import { parseXML } from "../src/xlsx/helpers/xml_helpers";
+import { escapeXml, parseXML } from "../src/xlsx/helpers/xml_helpers";
 import { createChart, createSheet } from "./test_helpers/commands_helpers";
 import { exportPrettifiedXlsx } from "./test_helpers/helpers";
 
@@ -39,6 +39,7 @@ const simpleData = {
         A36: { content: "test 'single quot'" },
         A37: { content: `="this is a quote: \\""` },
         A38: { content: `='<Sheet2>'!B2` },
+        A39: { content: `=A39` },
         K3: { border: 5 },
         K4: { border: 4 },
         K5: { border: 4 },
@@ -730,18 +731,18 @@ describe("Test XLSX export", () => {
 
 describe("XML parser", () => {
   test("simple xml", () => {
-    const document = parseXML("<hello>Raoul</hello>");
+    const document = parseXML(escapeXml`<hello>Raoul</hello>`);
     expect(document.firstElementChild?.outerHTML).toBe("<hello>Raoul</hello>");
   });
 
   test("error on the first line", () => {
-    expect(() => parseXML("<hello>Raoul/hello>")).toThrowError(
+    expect(() => parseXML(escapeXml`<hello>Raoul/hello>`)).toThrowError(
       `XML string could not be parsed: null:1:19: unclosed tag: hello\n<hello>Raoul/hello>`
     );
   });
 
   test("error in the middle", () => {
-    const xmlString = /*xml*/ `
+    const xmlString = escapeXml/*xml*/ `
       <root>
         <hello>1</hello>
         <hello>2</hello>
@@ -761,7 +762,7 @@ describe("XML parser", () => {
   });
 
   test("error at the end", () => {
-    const xmlString = /*xml*/ `
+    const xmlString = escapeXml/*xml*/ `
       <root>
         <hello>1</hello>
         <hello>2</hello>


### PR DESCRIPTION
## Description:

The current way XML files are built has one major weakness: values coming
from user inputs needs to be escaped manually. If one is forgotten, the XLSX
might be corrupted and unusable. It's easy to forget because there's nothing
to tell you or remind you what needs to be escaped.

This commit introduces a new template string tag `escapeXml` which
automatically escapes interpolated values. It is almost impossible to fail now.

In most cases, Typescript compiler will yell at you if you try to use a string
which might no be properly escaped. In places where Typescript won't catch the
error (where you want to interpolate already-escaped XML as a native string), it will generate
completely wrong XML, it is impossible to miss (all tags will be escaped).

Co-authored-by: fleodoo <fle@odoo.com>


Odoo task ID : 2558943

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
