### PR TITLE
[IMP] chart: reword chart error messages

### DIFF
--- a/src/components/side_panel/translations_terms.ts
+++ b/src/components/side_panel/translations_terms.ts
@@ -106,11 +106,11 @@ export const chartTerms = {
   CreateChart: _lt("Create chart"),
   TitlePlaceholder: _lt("New Chart"),
   Errors: {
-    [CommandResult.EmptyDataSet]: _lt("No Dataset given"),
-    [CommandResult.EmptyLabelRange]: _lt("No Labels given"),
-    [CommandResult.InvalidDataSet]: _lt("Invalid dataSet"),
-    [CommandResult.InvalidLabelRange]: _lt("Invalid Labels"),
-    unexpected: _lt("The chartdefinition is invalid for an unknown reason"),
+    [CommandResult.EmptyDataSet]: _lt("A dataset needs to be defined"),
+    [CommandResult.EmptyLabelRange]: _lt("Labels need to be defined"),
+    [CommandResult.InvalidDataSet]: _lt("The dataset is invalid"),
+    [CommandResult.InvalidLabelRange]: _lt("Labels are invalid"),
+    unexpected: _lt("The chart definition is invalid for an unknown reason"),
   },
 };
 

--- a/tests/components/chart_side_panel.test.ts
+++ b/tests/components/chart_side_panel.test.ts
@@ -118,13 +118,42 @@ describe("Chart sidepanel component", () => {
     parent.unmount();
   });
 
+  test("create chart with empty dataset and empty labels", async () => {
+    const { parent } = await createChartPanel();
+    await simulateClick(".o-sidePanelButton");
+    await nextTick();
+    expect(errorMessages()).toEqual(["A dataset needs to be defined"]);
+    parent.destroy();
+  });
+
   test("create chart with invalid dataset and empty labels", async () => {
     const { parent } = await createChartPanel();
     await simulateClick(".o-data-series input");
     setInputValueAndTrigger(".o-data-series input", "This is not valid", "change");
     await simulateClick(".o-sidePanelButton");
     await nextTick();
-    expect(errorMessages()).toEqual(["Invalid dataSet"]);
+    expect(errorMessages()).toEqual(["The dataset is invalid"]);
+    parent.destroy();
+  });
+
+  test("create chart with empty labels", async () => {
+    const { parent } = await createChartPanel();
+    await simulateClick(".o-data-series input");
+    setInputValueAndTrigger(".o-data-series input", "A2:A10", "change");
+    await simulateClick(".o-sidePanelButton");
+    await nextTick();
+    expect(errorMessages()).toEqual(["Labels need to be defined"]);
+    parent.destroy();
+  });
+
+  test("create chart with invalid labels", async () => {
+    const { parent } = await createChartPanel();
+    await simulateClick(".o-data-series input");
+    setInputValueAndTrigger(".o-data-series input", "A2:A10", "change");
+    setInputValueAndTrigger(".o-data-labels input", "this is not valid", "change");
+    await simulateClick(".o-sidePanelButton");
+    await nextTick();
+    expect(errorMessages()).toEqual(["Labels are invalid"]);
     parent.destroy();
   });
 });


### PR DESCRIPTION

## Description:

Better error messages.
Follow up of #890 which was merged before functional review because the PR
was not correctly linked to the task

Odoo task ID : [2532424](https://www.odoo.com/web#id=2532424&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
