### PR TITLE
[FIX] viewport: prevent invalid offset on snapped viewport

### DIFF
--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1024,6 +1024,8 @@ export const enum CommandResult {
   MergeOverlap,
   TooManyHiddenElements,
   Readonly,
+  InvalidOffset,
+  InvalidViewportSize,
 }
 
 export interface CommandHandler<T> {

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -346,10 +346,10 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
     class="o-grid o-two-columns"
   >
     <canvas
-      height="150"
-      style="width:-15px;height:-15px;"
+      height="985"
+      style="width:985px;height:985px;"
       tabindex="-1"
-      width="300"
+      width="985"
     />
     <div
       class="o-autofill"

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -1,4 +1,4 @@
-import { MESSAGE_VERSION } from "../../src/constants";
+import { HEADER_WIDTH, MESSAGE_VERSION } from "../../src/constants";
 import { scrollDelay, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { merge, selectCell, setCellContent, setSelection } from "../test_helpers/commands_helpers";
@@ -727,6 +727,31 @@ describe("Events on Grid update viewport correctly", () => {
       left: 1,
       right: 10,
     });
+  });
+
+  test("Scroll viewport then alter selection with keyboard from before last cell to last cell does not shift viewport", async () => {
+    await simulateClick("canvas"); // gain focus on grid element
+    const { width } = model.getters.getGridDimension(model.getters.getActiveSheet());
+    const { width: viewportWidth } = model.getters.getViewportDimension();
+    document.activeElement!.dispatchEvent(
+      // scroll completely to the right
+      new WheelEvent("wheel", {
+        deltaY: width - viewportWidth + HEADER_WIDTH,
+        deltaX: 0,
+        shiftKey: true,
+        deltaMode: 0,
+        bubbles: true,
+      })
+    );
+    const viewport = model.getters.getActiveSnappedViewport();
+    selectCell(model, "Y1");
+    await nextTick();
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    document.activeElement!.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", shiftKey: true, bubbles: true })
+    );
+    await nextTick();
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
   });
 
   describe("Edge-Scrolling on mouseMove in selection", () => {

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -27,6 +27,9 @@ Object.defineProperty(navigator, "clipboard", {
   configurable: true,
 });
 
+jest.spyOn(HTMLDivElement.prototype, "clientWidth", "get").mockImplementation(() => 1000);
+jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 1000);
+
 class Parent extends Component<any> {
   static template = xml/* xml */ `<Spreadsheet t-ref="spreadsheet" data="data" client="client"/>`;
   static components = { Spreadsheet };


### PR DESCRIPTION
## Description:

We were never evaluating the validity of the offset when updating the
snapped viewport, especially when dispatching a `SET_VIEWPORT_OFFSET`command,

There are 2 implementations for this solution. One of them relies on the properties of the scrollbars to define a more accurate limit to scroll the viewport. Unfortunately, it requires the scrolbars to be actually rendered in the dom to access their properties (`clientHeight`, `scrollHeight`, ...) which cannot be mocked with jest (to my knowledge).

Furthermore, we could experiment scrolling loops in some specific cases (Chrome-core browser + non-default devicePixelRatio) which are detailed in commit "[FIX] viewport,grid: prevent scrolling loop".

To reproduce the isue in the current saas-14.4 branch:  Set your devicePixelRatio to 1.375 or 1.5625  ( set your desktop scale to 125% then zoom in the browser to 110 or 125%) then try to edgeScroll from top to bottom. you should be locked  between 2 viewport positions soon enough.  Note that this also happens when scrolling fro m botom to top


## Suggested tests
! you'll need to apply the changes of https://github.com/odoo/o-spreadsheet/pull/928
From 50% zoom to 200% &  cross-browser - with varying desktop scales (add enough cols and rows to have the opportunity to scroll )

### unit_test
- mousewheel from top to bottom, inverse
- mousewheel from left to right and reverse
- edgescroll top > bottom, reverse
- edgescroll bottom > top
- move position (keyboard nav) up/down/left/right . This test is important because before this commit, the problem was noticable. When crossing the viewport offset that was problematic, the viewport would "jump" 2 cells at once.

reduce cell sizes > **unit_test**
increase cell sizes > **unit_test**

Use this script on a fresh sheet : 
```
var model = o_spreadsheet.__DEBUG__.model

id = (Math.floor(Math.random()*1000000)).toString()
model.dispatch("CREATE_SHEET", {
  sheetId: id,
  position: model.getters.getSheets().length,
  row:100,
  col:26,
  name:"tabouret",
})

start_height = model.getters.getSheet(id).rows[0].size;

var x = start_height;
for(let i=1;i<100;i++){
  x+=5;
  model.dispatch("RESIZE_ROWS", {
    sheetId: id,
    rows:[i],
    size: x,
  })
}
```

**RAR** : tested on Firefox, Edge and Chrome on WIndows. (scales 100% & 125%)  An issue is present -trying to scroll several times too fast will fail since we stop the process of scrolls during the rendering.


Odoo task ID : [2563141](https://www.odoo.com/web#id=2563141&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
