### PR TITLE
[FIX] infra: do not use incremental flag when compiling typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "serve": "live-server --open=demo",
     "dev": "npm-run-all  build --parallel serve \"build:* -- --watch\"",
-    "build:js": "tsc --module es6 --outDir dist/js --incremental",
+    "build:js": "tsc --module es6 --outDir dist/js",
     "build:bundle": "rollup -c -m",
     "build": "npm run build:js && npm run build:bundle",
     "test": "jest",


### PR DESCRIPTION
Typescript seems to have issues with tracking usage of enums on unmodified files,
leading to inconsistent enum values.
While this doesn't create bugs in production, it still creates inconsistencies between
what the enum value is (when used in plugins and in components) and how it is declared.
