### PR TITLE
[FIX] chart: remove labels from side panel

### DIFF
--- a/src/components/side_panel/chart_panel.ts
+++ b/src/components/side_panel/chart_panel.ts
@@ -1,5 +1,11 @@
 import * as owl from "@odoo/owl";
-import { ChartUIDefinition, CommandResult, Figure, SpreadsheetEnv } from "../../types/index";
+import {
+  ChartUIDefinition,
+  ChartUIDefinitionUpdate,
+  CommandResult,
+  Figure,
+  SpreadsheetEnv,
+} from "../../types/index";
 import { ColorPicker } from "../color_picker";
 import * as icons from "../icons";
 import { SelectionInput } from "../selection_input";
@@ -184,10 +190,10 @@ export class ChartPanel extends Component<Props, SpreadsheetEnv> {
   }
 
   updateLabelRange() {
-    this.updateChart({ labelRange: this.state.labelRange });
+    this.updateChart({ labelRange: this.state.labelRange || null });
   }
 
-  private updateChart(definition: Partial<ChartUIDefinition>) {
+  private updateChart(definition: ChartUIDefinitionUpdate) {
     const result = this.env.dispatch("UPDATE_CHART", {
       id: this.props.figure.id,
       sheetId: this.getters.getActiveSheetId(),

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -4,6 +4,7 @@ import {
   ApplyRangeChange,
   ChartDefinition,
   ChartUIDefinition,
+  ChartUIDefinitionUpdate,
   Command,
   CommandResult,
   CoreCommand,
@@ -332,7 +333,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
    * Update the chart definition linked to the given id with the attributes
    * given in the partial UI definition
    */
-  private updateChartDefinition(id: UID, definition: Partial<ChartUIDefinition>) {
+  private updateChartDefinition(id: UID, definition: ChartUIDefinitionUpdate) {
     const chart = this.chartFigures[id];
     if (!chart) {
       throw new Error(`There is no chart with the given id: ${id}`);
@@ -348,7 +349,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
       const dataSets = this.createDataSets(definition.dataSets, chart.sheetId, dataSetsHaveTitle);
       this.history.update("chartFigures", id, "dataSets", dataSets);
     }
-    if (definition.labelRange) {
+    if (definition.labelRange !== undefined) {
       const labelRange = definition.labelRange
         ? this.getters.getRangeFromSheetXC(chart.sheetId, definition.labelRange)
         : undefined;

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -30,6 +30,13 @@ export interface ChartUIDefinition
   labelRange?: string;
 }
 
+/**
+ * Data to be updated on a chart definition.
+ */
+export interface ChartUIDefinitionUpdate extends Omit<Partial<ChartUIDefinition>, "labelRange"> {
+  labelRange?: string | null;
+}
+
 export interface ExcelChartDefinition {
   title: string;
   type: ChartTypes;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,5 +1,6 @@
 import { ComposerSelection } from "../plugins/ui/edition";
 import { ReplaceOptions, SearchOptions } from "../plugins/ui/find_and_replace";
+import { ChartUIDefinitionUpdate } from "./chart";
 import { BorderCommand, ChartUIDefinition, ConditionalFormat, Figure, Style, Zone } from "./index";
 import { Border, Cell, CellPosition, ClipboardOptions, Dimension, UID } from "./misc";
 
@@ -335,7 +336,7 @@ export interface CreateChartCommand extends BaseCommand, SheetDependentCommand {
 export interface UpdateChartCommand extends BaseCommand, SheetDependentCommand {
   type: "UPDATE_CHART";
   id: UID;
-  definition: Partial<ChartUIDefinition>;
+  definition: ChartUIDefinitionUpdate;
 }
 
 export interface RefreshChartCommand extends BaseCommand {

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -252,6 +252,19 @@ describe("figures", () => {
     });
   });
 
+  test("remove labels", async () => {
+    const model = parent.model;
+    const sheetId = model.getters.getActiveSheetId();
+    const figure = model.getters.getFigure(sheetId, chartId);
+    expect(parent.model.getters.getChartDefinition(chartId)?.labelRange).not.toBeUndefined();
+    parent.env.openSidePanel("ChartPanel", { figure });
+    await nextTick();
+    await simulateClick(".o-data-labels input");
+    setInputValueAndTrigger(".o-data-labels input", "", "change");
+    await simulateClick(".o-data-labels .o-selection-ok");
+    expect(parent.model.getters.getChartDefinition(chartId)?.labelRange).toBeUndefined();
+  });
+
   test("drawing of chart will receive new data after update", async () => {
     await simulateClick(".o-figure");
     await simulateClick(".o-chart-menu");

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -541,6 +541,20 @@ describe("datasource tests", function () {
     expect(chart.type).toEqual("bar");
   });
 
+  test("remove labels from existing chart", () => {
+    createChart(
+      model,
+      {
+        dataSets: ["Sheet1!A8:D8"],
+        labelRange: "Sheet1!A2:A4",
+        type: "line",
+      },
+      "1"
+    );
+    updateChart(model, "1", { labelRange: null });
+    expect(model.getters.getChartDefinition("1")?.labelRange).toBeUndefined();
+  });
+
   test("deleting a random sheet does not affect a chart", () => {
     const sheetId = model.getters.getActiveSheetId();
     createChart(

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -570,9 +570,15 @@ describe("history", () => {
       });
       expect(getRangeValues(model, "A1:A3", sheet1Id)).toEqual([["1000", undefined, "2000"]]);
       expect(getRangeValues(model, "$A$1:$A$3", sheet1Id)).toEqual([["1000", undefined, "2000"]]);
-      expect(getRangeValues(model, "Sheet1!A1:A3", sheet1Id)).toEqual([["1000", undefined, "2000"]]);
-      expect(getRangeValues(model, "Sheet2!A1:A3", sheet2Id)).toEqual([["21000", undefined, "44196"]]);
-      expect(getRangeValues(model, "Sheet2!A1:A3", sheet1Id)).toEqual([["21000", undefined, "44196"]]);
+      expect(getRangeValues(model, "Sheet1!A1:A3", sheet1Id)).toEqual([
+        ["1000", undefined, "2000"],
+      ]);
+      expect(getRangeValues(model, "Sheet2!A1:A3", sheet2Id)).toEqual([
+        ["21000", undefined, "44196"],
+      ]);
+      expect(getRangeValues(model, "Sheet2!A1:A3", sheet1Id)).toEqual([
+        ["21000", undefined, "44196"],
+      ]);
       expect(getRangeValues(model, "B2", sheet1Id)).toEqual([["TRUE"]]);
       expect(getRangeValues(model, "Sheet1!B2", sheet1Id)).toEqual([["TRUE"]]);
       expect(getRangeValues(model, "Sheet2!B2", sheet2Id)).toEqual([["TRUE"]]);

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -4,6 +4,7 @@ import { Model } from "../../src/model";
 import {
   BorderCommand,
   ChartUIDefinition,
+  ChartUIDefinitionUpdate,
   CommandResult,
   CreateSheetCommand,
   UID,
@@ -107,7 +108,7 @@ export function createChart(
 export function updateChart(
   model: Model,
   chartId: UID,
-  definition: Partial<ChartUIDefinition>,
+  definition: ChartUIDefinitionUpdate,
   sheetId: UID = model.getters.getActiveSheetId()
 ): CommandResult {
   return model.dispatch("UPDATE_CHART", {


### PR DESCRIPTION

## Description:
Since commit ef5cefa, chart labels are no longer required.
However, if you have an existing chart with labels, removing the label range in
the side panel won't remove labels in the chart figure.


Odoo task ID : 

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
