### PR TITLE
[FIX] xlsx: export stacked bar charts

### DIFF
--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -45,4 +45,5 @@ export interface ExcelChartDefinition {
   backgroundColor: string;
   verticalAxisPosition: "left" | "right";
   legendPosition: "top" | "bottom" | "left" | "right";
+  stackedBar: boolean;
 }

--- a/src/xlsx/functions/charts.ts
+++ b/src/xlsx/functions/charts.ts
@@ -217,11 +217,13 @@ function addBarChart(chart: ExcelChartDefinition): XMLString {
   // Excel does not support this feature
   const axisPos = chart.verticalAxisPosition === "left" ? "l" : "r";
 
+  const grouping = chart.stackedBar ? "stacked" : "clustered";
+  const overlap = chart.stackedBar ? 100 : -20;
   return /*xml*/ `
     <c:barChart>
       <c:barDir val="col"/>
-      <c:grouping val="clustered"/>
-      <c:overlap val="-20"/>
+      <c:grouping val="${grouping}"/>
+      <c:overlap val="${overlap}"/>
       <c:gapWidth val="70"/>
       <!-- each data marker in the series does not have a different color -->
       <c:varyColors val="0"/>

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -32,6 +32,11 @@ import {
   xmlEscape,
 } from "./helpers/xml_helpers";
 
+/**
+ * Return the spreadsheet data in the Office Open XML file format.
+ * See ECMA-376 standard.
+ * https://www.ecma-international.org/publications-and-standards/standards/ecma-376/
+ */
 export function getXLSX(data: ExcelWorkbookData): XLSXExport {
   const files: XLSXExportFile[] = [];
   const construct = getDefaultXLSXStructure();

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -6070,6 +6070,601 @@ Object {
 }
 `;
 
+exports[`Test XLSX export Charts stacked bar chart 1`] = `
+Object {
+  "files": Array [
+    Object {
+      "content": "<workbook xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <sheets>
+        <sheet name=\\"Sheet1\\" sheetId=\\"1\\" r:id=\\"rId1\\"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    Object {
+      "content": "<c:chartSpace xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
+    <c:roundedCorners val=\\"0\\"/>
+    <!-- <manualLayout/> to manually position the chart in the figure container -->
+    <c:spPr>
+        <a:solidFill>
+            <a:srgbClr val=\\"FFFFFF\\"/>
+        </a:solidFill>
+        <a:ln cmpd=\\"sng\\">
+            <a:solidFill>
+                <a:srgbClr val=\\"000000\\"/>
+            </a:solidFill>
+        </a:ln>
+    </c:spPr>
+    <c:chart>
+        <c:title>
+            <c:tx>
+                <c:rich>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl=\\"0\\">
+                            <a:defRPr b=\\"0\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"000000\\"/>
+                                </a:solidFill>
+                                <a:latin typeface=\\"+mn-lt\\"/>
+                            </a:defRPr>
+                        </a:pPr>
+                        <a:r>
+                            <!-- Runs -->
+                            <a:rPr sz=\\"2200\\"/>
+                            <a:t>
+                                test
+                            </a:t>
+                        </a:r>
+                    </a:p>
+                </c:rich>
+            </c:tx>
+            <c:overlay val=\\"0\\"/>
+        </c:title>
+        <c:autoTitleDeleted val=\\"0\\"/>
+        <c:plotArea>
+            <!-- how the chart element is placed on the chart -->
+            <c:layout/>
+            <c:barChart>
+                <c:barDir val=\\"col\\"/>
+                <c:grouping val=\\"stacked\\"/>
+                <c:overlap val=\\"100\\"/>
+                <c:gapWidth val=\\"70\\"/>
+                <!-- each data marker in the series does not have a different color -->
+                <c:varyColors val=\\"0\\"/>
+                <c:ser>
+                    <c:idx val=\\"0\\"/>
+                    <c:order val=\\"0\\"/>
+                    <c:tx>
+                        <c:strRef>
+                            <c:f>
+                                Sheet1!B1
+                            </c:f>
+                        </c:strRef>
+                    </c:tx>
+                    <c:spPr>
+                        <a:solidFill>
+                            <a:srgbClr val=\\"1F77B4\\"/>
+                        </a:solidFill>
+                        <a:ln cmpd=\\"sng\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"1F77B4\\"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                    <c:cat>
+                        <c:strRef>
+                            <c:f>
+                                Sheet1!A2:A4
+                            </c:f>
+                        </c:strRef>
+                    </c:cat>
+                    <!-- x-coordinate values -->
+                    <c:val>
+                        <!-- x-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!B2:B4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:val>
+                </c:ser>
+                <c:ser>
+                    <c:idx val=\\"1\\"/>
+                    <c:order val=\\"1\\"/>
+                    <c:tx>
+                        <c:strRef>
+                            <c:f>
+                                Sheet1!C1
+                            </c:f>
+                        </c:strRef>
+                    </c:tx>
+                    <c:spPr>
+                        <a:solidFill>
+                            <a:srgbClr val=\\"FF7F0E\\"/>
+                        </a:solidFill>
+                        <a:ln cmpd=\\"sng\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"FF7F0E\\"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                    <c:cat>
+                        <c:strRef>
+                            <c:f>
+                                Sheet1!A2:A4
+                            </c:f>
+                        </c:strRef>
+                    </c:cat>
+                    <!-- x-coordinate values -->
+                    <c:val>
+                        <!-- x-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!C2:C4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:val>
+                </c:ser>
+                <c:axId val=\\"17781237\\"/>
+                <c:axId val=\\"88853993\\"/>
+            </c:barChart>
+            <c:catAx>
+                <c:axId val=\\"17781237\\"/>
+                <c:crossAx val=\\"88853993\\"/>
+                <!-- reference to the other axe of the chart -->
+                <c:delete val=\\"0\\"/>
+                <!-- by default, axis are not displayed -->
+                <c:scaling>
+                    <c:orientation val=\\"minMax\\"/>
+                </c:scaling>
+                <c:axPos val=\\"b\\"/>
+                <c:majorGridlines>
+                    <c:spPr>
+                        <a:ln cmpd=\\"sng\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"B7B7B7\\"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                </c:majorGridlines>
+                <c:majorTickMark val=\\"out\\"/>
+                <c:minorTickMark val=\\"none\\"/>
+                <c:numFmt formatCode=\\"General\\" sourceLinked=\\"1\\"/>
+                <c:title>
+                    <c:tx>
+                        <c:rich>
+                            <a:bodyPr/>
+                            <a:lstStyle/>
+                            <a:p>
+                                <a:pPr lvl=\\"0\\">
+                                    <a:defRPr b=\\"0\\">
+                                        <a:solidFill>
+                                            <a:srgbClr val=\\"000000\\"/>
+                                        </a:solidFill>
+                                        <a:latin typeface=\\"+mn-lt\\"/>
+                                    </a:defRPr>
+                                </a:pPr>
+                                <a:r>
+                                    <!-- Runs -->
+                                    <a:rPr sz=\\"2200\\"/>
+                                    <a:t/>
+                                </a:r>
+                            </a:p>
+                        </c:rich>
+                    </c:tx>
+                </c:title>
+                <c:txPr>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl=\\"0\\">
+                            <a:defRPr b=\\"0\\" i=\\"0\\" sz=\\"1000\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"000000\\"/>
+                                </a:solidFill>
+                                <a:latin typeface=\\"+mn-lt\\"/>
+                            </a:defRPr>
+                        </a:pPr>
+                    </a:p>
+                </c:txPr>
+            </c:catAx>
+            <!-- <tickLblPos/> omitted -->
+            <c:valAx>
+                <c:axId val=\\"88853993\\"/>
+                <c:crossAx val=\\"17781237\\"/>
+                <!-- reference to the other axe of the chart -->
+                <c:delete val=\\"0\\"/>
+                <!-- by default, axis are not displayed -->
+                <c:scaling>
+                    <c:orientation val=\\"minMax\\"/>
+                </c:scaling>
+                <c:axPos val=\\"l\\"/>
+                <c:majorGridlines>
+                    <c:spPr>
+                        <a:ln cmpd=\\"sng\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"B7B7B7\\"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                </c:majorGridlines>
+                <c:majorTickMark val=\\"out\\"/>
+                <c:minorTickMark val=\\"none\\"/>
+                <c:numFmt formatCode=\\"General\\" sourceLinked=\\"1\\"/>
+                <c:title>
+                    <c:tx>
+                        <c:rich>
+                            <a:bodyPr/>
+                            <a:lstStyle/>
+                            <a:p>
+                                <a:pPr lvl=\\"0\\">
+                                    <a:defRPr b=\\"0\\">
+                                        <a:solidFill>
+                                            <a:srgbClr val=\\"000000\\"/>
+                                        </a:solidFill>
+                                        <a:latin typeface=\\"+mn-lt\\"/>
+                                    </a:defRPr>
+                                </a:pPr>
+                                <a:r>
+                                    <!-- Runs -->
+                                    <a:rPr sz=\\"2200\\"/>
+                                    <a:t/>
+                                </a:r>
+                            </a:p>
+                        </c:rich>
+                    </c:tx>
+                </c:title>
+                <c:txPr>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl=\\"0\\">
+                            <a:defRPr b=\\"0\\" i=\\"0\\" sz=\\"1000\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"000000\\"/>
+                                </a:solidFill>
+                                <a:latin typeface=\\"+mn-lt\\"/>
+                            </a:defRPr>
+                        </a:pPr>
+                    </a:p>
+                </c:txPr>
+            </c:valAx>
+            <!-- <tickLblPos/> omitted -->
+            <c:spPr>
+                <a:solidFill>
+                    <a:srgbClr val=\\"FFFFFF\\"/>
+                </a:solidFill>
+            </c:spPr>
+        </c:plotArea>
+        <c:legend>
+            <c:legendPos val=\\"t\\"/>
+            <c:overlay val=\\"0\\"/>
+            <c:txPr>
+                <a:bodyPr/>
+                <a:lstStyle/>
+                <a:p>
+                    <a:pPr lvl=\\"0\\">
+                        <a:defRPr b=\\"0\\" i=\\"0\\" sz=\\"1000\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"000000\\"/>
+                            </a:solidFill>
+                            <a:latin typeface=\\"+mn-lt\\"/>
+                        </a:defRPr>
+                    </a:pPr>
+                </a:p>
+            </c:txPr>
+        </c:legend>
+    </c:chart>
+</c:chartSpace>",
+      "contentType": "chart",
+      "path": "xl/charts/chart1.xml",
+    },
+    Object {
+      "content": "<xdr:wsDr xmlns:xdr=\\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
+    <xdr:twoCellAnchor>
+        <xdr:from>
+            <xdr:col>
+                0
+            </xdr:col>
+            <xdr:colOff>
+                9525
+            </xdr:colOff>
+            <xdr:row>
+                0
+            </xdr:row>
+            <xdr:rowOff>
+                9525
+            </xdr:rowOff>
+        </xdr:from>
+        <xdr:to>
+            <xdr:col>
+                5
+            </xdr:col>
+            <xdr:colOff>
+                542925
+            </xdr:colOff>
+            <xdr:row>
+                14
+            </xdr:row>
+            <xdr:rowOff>
+                133350
+            </xdr:rowOff>
+        </xdr:to>
+        <xdr:graphicFrame>
+            <xdr:nvGraphicFramePr>
+                <xdr:cNvPr id=\\"1\\" name=\\"Chart 1\\" title=\\"Chart\\"/>
+                <xdr:cNvGraphicFramePr/>
+            </xdr:nvGraphicFramePr>
+            <xdr:xfrm>
+                <a:off x=\\"0\\" y=\\"0\\"/>
+                <a:ext cx=\\"0\\" cy=\\"0\\"/>
+            </xdr:xfrm>
+            <a:graphic>
+                <a:graphicData uri=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
+                    <c:chart r:id=\\"rId1\\"/>
+                </a:graphicData>
+            </a:graphic>
+        </xdr:graphicFrame>
+        <xdr:clientData fLocksWithSheet=\\"0\\"/>
+    </xdr:twoCellAnchor>
+</xdr:wsDr>",
+      "contentType": "drawing",
+      "path": "xl/drawings/drawing0.xml",
+    },
+    Object {
+      "content": "<worksheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <sheetFormatPr defaultRowHeight=\\"17.25\\" defaultColWidth=\\"13.68\\"/>
+    <cols>
+        <col min=\\"1\\" max=\\"1\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"2\\" max=\\"2\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"3\\" max=\\"3\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"4\\" max=\\"4\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"5\\" max=\\"5\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"6\\" max=\\"6\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"7\\" max=\\"7\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"8\\" max=\\"8\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"9\\" max=\\"9\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"10\\" max=\\"10\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"11\\" max=\\"11\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"12\\" max=\\"12\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"13\\" max=\\"13\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"14\\" max=\\"14\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"15\\" max=\\"15\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"16\\" max=\\"16\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"17\\" max=\\"17\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"18\\" max=\\"18\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"19\\" max=\\"19\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"20\\" max=\\"20\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"21\\" max=\\"21\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"22\\" max=\\"22\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"23\\" max=\\"23\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"24\\" max=\\"24\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"25\\" max=\\"25\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+    </cols>
+    <sheetData>
+        <row r=\\"1\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"B1\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    0
+                </v>
+            </c>
+            <c r=\\"C1\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    1
+                </v>
+            </c>
+        </row>
+        <row r=\\"2\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A2\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    2
+                </v>
+            </c>
+            <c r=\\"B2\\" s=\\"1\\">
+                <v>
+                    10
+                </v>
+            </c>
+            <c r=\\"C2\\" s=\\"1\\">
+                <v>
+                    20
+                </v>
+            </c>
+        </row>
+        <row r=\\"3\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A3\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    3
+                </v>
+            </c>
+            <c r=\\"B3\\" s=\\"1\\">
+                <v>
+                    11
+                </v>
+            </c>
+            <c r=\\"C3\\" s=\\"1\\">
+                <v>
+                    19
+                </v>
+            </c>
+        </row>
+        <row r=\\"4\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A4\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    4
+                </v>
+            </c>
+            <c r=\\"B4\\" s=\\"1\\">
+                <v>
+                    12
+                </v>
+            </c>
+            <c r=\\"C4\\" s=\\"1\\">
+                <v>
+                    18
+                </v>
+            </c>
+        </row>
+        <row r=\\"5\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A5\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    5
+                </v>
+            </c>
+            <c r=\\"B5\\" s=\\"1\\">
+                <v>
+                    13
+                </v>
+            </c>
+            <c r=\\"C5\\" s=\\"1\\">
+                <v>
+                    17
+                </v>
+            </c>
+        </row>
+    </sheetData>
+    <drawing r:id=\\"rId1\\"/>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    Object {
+      "content": "<styleSheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <numFmts count=\\"0\\">
+    </numFmts>
+    <fonts count=\\"2\\">
+        <font>
+            <sz val=\\"10\\"/>
+            <color rgb=\\"000000\\"/>
+            <name val=\\"Calibri\\"/>
+        </font>
+        <font>
+            <sz val=\\"10\\"/>
+            <color rgb=\\"000000\\"/>
+            <name val=\\"Arial\\"/>
+        </font>
+    </fonts>
+    <fills count=\\"2\\">
+        <fill>
+            <patternFill patternType=\\"none\\"/>
+        </fill>
+        <fill>
+            <patternFill patternType=\\"gray125\\"/>
+        </fill>
+    </fills>
+    <borders count=\\"1\\">
+        <border>
+            <left/>
+            <right/>
+            <top/>
+            <bottom/>
+            <diagonal/>
+        </border>
+    </borders>
+    <cellXfs count=\\"2\\">
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"0\\" borderId=\\"0\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"1\\" borderId=\\"0\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+    </cellXfs>
+    <dxfs count=\\"0\\">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    Object {
+      "content": "<sst xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" count=\\"6\\" uniqueCount=\\"6\\">
+    <si>
+        <t>
+            first column dataset
+        </t>
+    </si>
+    <si>
+        <t>
+            second column dataset
+        </t>
+    </si>
+    <si>
+        <t>
+            P1
+        </t>
+    </si>
+    <si>
+        <t>
+            P2
+        </t>
+    </si>
+    <si>
+        <t>
+            P3
+        </t>
+    </si>
+    <si>
+        <t>
+            P4
+        </t>
+    </si>
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Target=\\"worksheets/sheet0.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\\"/>
+    <Relationship Id=\\"rId2\\" Target=\\"sharedStrings.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\\"/>
+    <Relationship Id=\\"rId3\\" Target=\\"styles.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Target=\\"../charts/chart1.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/drawings/_rels/drawing0.xml.rels",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Target=\\"../drawings/drawing0.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/worksheets/_rels/sheet0.xml.rels",
+    },
+    Object {
+      "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
+    <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\\" PartName=\\"/xl/charts/chart1.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawing+xml\\" PartName=\\"/xl/drawings/drawing0.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\\" PartName=\\"/xl/worksheets/sheet0.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\\" PartName=\\"/xl/styles.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\\" PartName=\\"/xl/sharedStrings.xml\\"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\\" Target=\\"xl/workbook.xml\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
 exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional formatting 1`] = `
 Object {
   "files": Array [

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -650,6 +650,21 @@ describe("Test XLSX export", () => {
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
 
+    test("stacked bar chart", async () => {
+      const model = new Model(chartData);
+      createChart(
+        model,
+        {
+          dataSets: ["Sheet1!B1:B4", "Sheet1!C1:C4"],
+          labelRange: "Sheet1!A2:A4",
+          stackedBar: true,
+          type: "bar",
+        },
+        "1"
+      );
+      expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
+    });
+
     test("charts in different sheets", async () => {
       const model = new Model(chartData);
       createSheet(model, { sheetId: "42" });


### PR DESCRIPTION
## Description:

Stacked bar charts are not exported as stacked.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
