### PR TITLE
[FIX] edition: cancel edition on figure selection

### DIFF
--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -139,6 +139,10 @@ export class EditionPlugin extends UIPlugin {
           this.setActiveContent();
         }
         break;
+      case "SELECT_FIGURE":
+        this.cancelEdition();
+        this.resetContent();
+        break;
       case "SELECT_CELL":
       case "SET_SELECTION":
       case "MOVE_POSITION":

--- a/tests/plugins/figures.test.ts
+++ b/tests/plugins/figures.test.ts
@@ -285,4 +285,25 @@ describe("figure plugin", () => {
     activateSheet(model, "2");
     expect(model.getters.getSelectedFigureId()).toBeNull();
   });
+
+  test("Selecting a cell cancel the edition of a cell", () => {
+    const model = new Model();
+    model.dispatch("CREATE_FIGURE", {
+      sheetId: model.getters.getActiveSheetId(),
+      figure: {
+        id: "someuuid",
+        x: 10,
+        y: 10,
+        tag: "hey",
+        width: 10,
+        height: 10,
+      },
+    });
+    model.dispatch("START_EDITION");
+    model.dispatch("SET_CURRENT_CONTENT", { content: "hello" });
+    expect(model.getters.getEditionMode()).toBe("editing");
+    model.dispatch("SELECT_FIGURE", { id: "someuuid" });
+    expect(model.getters.getEditionMode()).toBe("inactive");
+    expect(model.getters.getActiveCell()?.value).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Before this commit, selecting a figure did not cancel the edition.

Odoo-task-id 2561161

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [X] undo-able commands (uses this.history.update)
- [X] multiuser-able commands (has inverse commands and transformations where needed)
- [X] translations (\_lt("qmsdf %s", abc))
- [X] unit tested
- [X] clean commented code
- [X] feature is organized in plugin, or UI components
- [X] exportable in excel
- [ ] importable from excel
- [X] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [X] in model/UI: ranges are strings (to show the user)
- [X] new/updated/removed commands are documented
- [X] track breaking changes
- [X] public API change (index.ts) must rebuild doc (npm run doc)
- [X] code is prettified with prettier (in each commit, no separate commit)
- [X] status is correct in Odoo
