### PR TITLE
[IMP] selection: allow to move selected columns and rows 

### DIFF
--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -54,6 +54,8 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     "getBottomLeftCell",
     "expandZone",
     "doesIntersectMerge",
+    "doesColumnsHaveCommonMerges",
+    "doesRowsHaveCommonMerges",
     "getMerges",
     "getMerge",
     "isSingleCellOrMerge",
@@ -184,6 +186,32 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
         if (this.getMerge(sheetId, col, row)) {
           return true;
         }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns true if two columns have at least one merge in common
+   */
+  doesColumnsHaveCommonMerges(sheetId: string, colA: number, colB: number) {
+    const sheet = this.getters.getSheet(sheetId);
+    for (let row = 0; row < sheet.rows.length; row++) {
+      if (this.isInSameMerge(sheet.id, colA, row, colB, row)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns true if two rows have at least one merge in common
+   */
+  doesRowsHaveCommonMerges(sheetId: string, rowA: number, rowB: number) {
+    const sheet = this.getters.getSheet(sheetId);
+    for (let col = 0; col <= sheet.cols.length; col++) {
+      if (this.isInSameMerge(sheet.id, col, rowA, col, rowB)) {
+        return true;
       }
     }
     return false;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -213,6 +213,15 @@ export interface RemoveColumnsRowsCommand
   elements: number[];
 }
 
+export interface MoveColumnsRowsCommand
+  extends BaseCommand,
+    SheetDependentCommand,
+    GridDependentCommand {
+  type: "MOVE_COLUMNS_ROWS";
+  base: number;
+  elements: number[];
+}
+
 export interface ResizeColumnsRowsCommand
   extends BaseCommand,
     SheetDependentCommand,
@@ -954,6 +963,7 @@ export type LocalCommand =
   | PasteCFCommand
   | AutoresizeColumnsCommand
   | AutoresizeRowsCommand
+  | MoveColumnsRowsCommand
   | MovePositionCommand
   | DeleteSheetConfirmationCommand
   | ActivateSheetCommand

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -72,6 +72,8 @@ export interface CoreGetters {
   getMainCell: MergePlugin["getMainCell"];
   getBottomLeftCell: MergePlugin["getBottomLeftCell"];
   doesIntersectMerge: MergePlugin["doesIntersectMerge"];
+  doesColumnsHaveCommonMerges: MergePlugin["doesColumnsHaveCommonMerges"];
+  doesRowsHaveCommonMerges: MergePlugin["doesRowsHaveCommonMerges"];
   isInSameMerge: MergePlugin["isInSameMerge"];
   getMerges: MergePlugin["getMerges"];
   getMerge: MergePlugin["getMerge"];

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -551,3 +551,52 @@ describe("Alter selection starting from hidden cells", () => {
     }
   );
 });
+
+describe("move elements(s)", () => {
+  const model = new Model({
+    sheets: [
+      {
+        id: "1",
+        colNumber: 10,
+        rowNumber: 10,
+        merges: ["C3:D4", "G7:H8"],
+      },
+    ],
+  });
+  test("can't move columns whose merges overflow from the selection", () => {
+    const result = model.dispatch("MOVE_COLUMNS_ROWS", {
+      sheetId: "1",
+      dimension: "COL",
+      base: 5,
+      elements: [1, 2],
+    });
+    expect(result).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
+  });
+  test("can't move columns between columns containing common merged ", () => {
+    const result = model.dispatch("MOVE_COLUMNS_ROWS", {
+      sheetId: "1",
+      dimension: "COL",
+      base: 7,
+      elements: [1, 2],
+    });
+    expect(result).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
+  });
+  test("can't move rows whose merges overflow from the selection", () => {
+    const result = model.dispatch("MOVE_COLUMNS_ROWS", {
+      sheetId: "1",
+      dimension: "ROW",
+      base: 5,
+      elements: [1, 2],
+    });
+    expect(result).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
+  });
+  test("can't move rows between rows containing common merged ", () => {
+    const result = model.dispatch("MOVE_COLUMNS_ROWS", {
+      sheetId: "1",
+      dimension: "ROW",
+      base: 7,
+      elements: [1, 2],
+    });
+    expect(result).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
+  });
+});


### PR DESCRIPTION
## Description:

Allow the user to grab and move selected columns or rows

Odoo task ID : 2534595
(https://www.odoo.com/web#id=2534595&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
