### PR TITLE
[FIX] helpers: toCartesian throws on invalid inputs

### DIFF
--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -1,4 +1,5 @@
 import * as owl from "@odoo/owl";
+import { rangeReference } from "../../../formulas";
 import { colorNumberString, toZone, uuidv4 } from "../../../helpers/index";
 import {
   ColorScaleRule,
@@ -427,6 +428,13 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
 
   saveConditionalFormat() {
     if (this.state.currentCF) {
+      const invalidRanges = this.state.currentCF.ranges.some((xc) => !xc.match(rangeReference));
+      if (invalidRanges) {
+        this.state.error = this.env._t(
+          conditionalFormattingTerms.Errors[CommandResult.InvalidRange]
+        );
+        return;
+      }
       const result = this.env.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: {
           rule: this.getEditorRule(),

--- a/src/components/side_panel/translations_terms.ts
+++ b/src/components/side_panel/translations_terms.ts
@@ -14,6 +14,7 @@ export const conditionalFormattingTerms = {
   SAVE: _lt("Save"),
   PREVIEW_TEXT: _lt("Preview text"),
   Errors: {
+    [CommandResult.InvalidRange]: _lt("The range is invalid"),
     [CommandResult.InvalidNumberOfArgs]: _lt("Invalid number of arguments"),
     [CommandResult.MinNaN]: _lt("The minpoint must be a number"),
     [CommandResult.MidNaN]: _lt("The midpoint must be a number"),

--- a/src/helpers/coordinates.ts
+++ b/src/helpers/coordinates.ts
@@ -49,8 +49,8 @@ export function lettersToNumber(letters: string): number {
  * Note: it also accepts lowercase coordinates, but not fixed references
  */
 export function toCartesian(xc: string): [number, number] {
-  xc = xc.toUpperCase();
-  const [m, letters, numbers] = xc.match(/\$?([A-Z]*)\$?([0-9]*)/)!;
+  xc = xc.toUpperCase().trim();
+  const [m, letters, numbers] = xc.match(/\$?([A-Z]{1,3})\$?([0-9]{1,7})/)!;
   if (m !== xc) {
     throw new Error(`Invalid cell description: ${xc}`);
   }

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -56,6 +56,19 @@ export function toZone(xc: string): Zone {
 }
 
 /**
+ * Check that the zone has valid coordinates and in
+ * the correct order.
+ */
+export function isZoneValid(zone: Zone): boolean {
+  // Typescript *should* prevent this kind of errors but
+  // it's better to be on the safe side at runtime as well.
+  if (isNaN(zone.bottom) || isNaN(zone.top) || isNaN(zone.left) || isNaN(zone.right)) {
+    return false;
+  }
+  return zone.bottom >= zone.top && zone.right >= zone.left;
+}
+
+/**
  * Convert from zone to a cartesian reference
  *
  */
@@ -196,6 +209,13 @@ export function overlap(z1: Zone, z2: Zone): boolean {
 export function isInside(col: number, row: number, zone: Zone): boolean {
   const { left, right, top, bottom } = zone;
   return col >= left && col <= right && row >= top && row <= bottom;
+}
+
+/**
+ * Check if a zone is inside another
+ */
+export function isZoneInside(smallZone, biggerZone): boolean {
+  return isEqual(union(biggerZone, smallZone), biggerZone);
 }
 
 /**

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -16,7 +16,9 @@ import { FORCE_DEFAULT_ARGS_FUNCTIONS, NON_RETROCOMPATIBLE_FUNCTIONS } from "../
 import { getCellType, pushElement } from "../helpers/content_helpers";
 import { xmlEscape } from "../helpers/xml_helpers";
 
-export function addFormula(formula: NormalizedFormula): {
+export function addFormula(
+  formula: NormalizedFormula
+): {
   attrs: XMLAttributes;
   node: XMLString;
 } {

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -291,6 +291,23 @@ describe("UI of conditional formats", () => {
         sheetId: model.getters.getActiveSheetId(),
       });
     });
+
+    test("cannot create a new CF with invalid range", async () => {
+      mockUuidV4To("42");
+
+      triggerMouseEvent(selectors.buttonAdd, "click");
+      await nextTick();
+
+      setInputValueAndTrigger(selectors.ruleEditor.range, "hello", "change");
+
+      parent.env.dispatch = jest.fn(() => CommandResult.Success);
+      //  click save
+      triggerMouseEvent(selectors.buttonSave, "click");
+      await nextTick();
+      expect(parent.env.dispatch).not.toHaveBeenCalled();
+      const errorString = document.querySelector(selectors.error);
+      expect(errorString!.textContent).toBe("The range is invalid");
+    });
     test("displayed range is updated if range changes", async () => {
       const previews = document.querySelectorAll(selectors.listPreview);
       expect(previews[0].querySelector(selectors.description.range)!.textContent).toBe("A1:A2");

--- a/tests/functions/module_financial_test.ts
+++ b/tests/functions/module_financial_test.ts
@@ -899,7 +899,7 @@ describe("IRR formula", () => {
       test("boolean/boolean in cell are interpreted as numbers", () => {
         expect(evaluateCell("A1", { A1: "=IRR(A2:A3, TRUE)", ...grid })).toBeCloseTo(-0.4, 5);
         expect(evaluateCell("A1", { A1: "=IRR(A2:A3, FALSE)", ...grid })).toBeCloseTo(-0.4, 5);
-        expect(evaluateCell("A1", { A1: "=IRR(A2:A3, A4)", ...grid, 4: "TRUE" })).toBeCloseTo(
+        expect(evaluateCell("A1", { A1: "=IRR(A2:A3, A4)", ...grid, A4: "TRUE" })).toBeCloseTo(
           -0.4,
           5
         );

--- a/tests/helpers/coordinates.test.ts
+++ b/tests/helpers/coordinates.test.ts
@@ -13,6 +13,23 @@ describe("toCartesian", () => {
     expect(toCartesian("A1")).toEqual([0, 0]);
     expect(toCartesian("B1")).toEqual([1, 0]);
     expect(toCartesian("C5")).toEqual([2, 4]);
+    expect(toCartesian("AA55")).toEqual([26, 54]);
+    expect(toCartesian("c5")).toEqual([2, 4]);
+    expect(toCartesian(" C5 ")).toEqual([2, 4]);
+    expect(toCartesian("AAA1")).toEqual([702, 0]);
+    expect(toCartesian("A999999")).toEqual([0, 999998]);
+  });
+
+  test("invalid ranges", () => {
+    expect(() => toCartesian("C5A")).toThrow();
+    expect(() => toCartesian("C5C5")).toThrow();
+    expect(() => toCartesian("C")).toThrow();
+    expect(() => toCartesian("5")).toThrow();
+    expect(() => toCartesian("C 5")).toThrow();
+    expect(() => toCartesian("")).toThrow();
+    expect(() => toCartesian(" ")).toThrow();
+    expect(() => toCartesian("AAAA1")).toThrow();
+    expect(() => toCartesian("A10000000")).toThrow();
   });
 });
 

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -101,6 +101,19 @@ describe("conditional format", () => {
     ]);
   });
 
+  test("add conditional format outside the sheet", () => {
+    model = new Model();
+    createSheet(model, { sheetId: "42" });
+    const sheetId = model.getters.getActiveSheetId();
+    expect(
+      model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: createEqualCF("4", { fillColor: "#0000FF" }, "2"),
+        target: [toZone("A1:A4000")],
+        sheetId: sheetId,
+      })
+    ).toBe(CommandResult.TargetOutOfSheet);
+  });
+
   test("remove a conditional format rule", () => {
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");

--- a/tests/plugins/import_export.test.ts
+++ b/tests/plugins/import_export.test.ts
@@ -11,7 +11,6 @@ import { corePluginRegistry } from "../../src/plugins";
 import { BorderDescr, ColorScaleRule, IconSetRule, WorkbookData } from "../../src/types/index";
 import {
   activateSheet,
-  merge,
   resizeColumns,
   resizeRows,
   setCellContent,
@@ -330,6 +329,7 @@ describe("Import", () => {
         {
           colNumber: 2,
           rowNumber: 2,
+          merges: ["A2:B2"],
         },
         {
           colNumber: 2,
@@ -339,8 +339,6 @@ describe("Import", () => {
     });
     const sheet1 = model.getters.getVisibleSheets()[0];
     const sheet2 = model.getters.getVisibleSheets()[1];
-    model.dispatch("SELECT_ROW", { index: 1 });
-    merge(model, "A2:F2", sheet1);
     activateSheet(model, sheet2);
     expect(Object.keys(getMerges(model))).toHaveLength(0);
     activateSheet(model, sheet1);

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -80,7 +80,7 @@ describe("merges", () => {
     expect(Object.keys(getMerges(model))).toEqual([]);
   });
 
-  test("merge is clipped to sheet dimension", () => {
+  test("merge outside the sheet is refused", () => {
     const model = new Model({
       sheets: [
         {
@@ -90,8 +90,8 @@ describe("merges", () => {
       ],
     });
     const sheetId = model.getters.getActiveSheetId();
-    merge(model, "A1:C3");
-    expect(model.getters.getMerge(sheetId, ...toCartesian("A1"))).toMatchObject(toZone("A1:B2"));
+    expect(merge(model, "A1:C3")).toBe(CommandResult.TargetOutOfSheet);
+    expect(model.getters.getMerge(sheetId, ...toCartesian("A1"))).toBeUndefined();
   });
 
   test("editing a merge cell actually edits the top left", () => {

--- a/tests/plugins/sort.test.ts
+++ b/tests/plugins/sort.test.ts
@@ -443,7 +443,7 @@ describe("Sort multi adjacent columns", () => {
    */
   test("Sort on second column w/ contiguous", () => {
     model = new Model(modelData);
-    const zone = toZone("B2:DB3");
+    const zone = toZone("B2:B3");
     anchor = [1, 1];
     const sheetId = model.getters.getActiveSheetId();
     const contiguousZone = model.getters.getContiguousZone(sheetId, zone);


### PR DESCRIPTION
## Description:

Creating a conditional formatting with a range being "hello hello" creates
the CF with a corrupted zone such as
`{ bottom: null, top: null, left: 154675, right: 154675 }`

The root cause is the helper `toCartesian` which should throw an error
instead of returning wrong coordinates.

This commit fixes the helper and also adds validation for all commands to check
zones (better safe than sorry). This later change revealed some typos in tests.

Odoo task ID : 2571312

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
