### PR TITLE
[FIX] core: adapt references outside the sheet

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -344,7 +344,7 @@ export class CorePlugin extends BasePlugin {
   }
 
   getSheetIdByName(name: string | undefined): string | undefined {
-    return name && this.sheetIds[name];
+    return name && this.sheetIds[getUnquotedSheetName(name)];
   }
 
   getSheets(): Sheet[] {

--- a/tests/formulas/formulas_test.ts
+++ b/tests/formulas/formulas_test.ts
@@ -65,9 +65,16 @@ describe("applyOffset", () => {
       ],
     });
     expect(model.getters.applyOffset("=Sheet2!B2", 0, 1)).toEqual("=Sheet2!B3");
+    expect(model.getters.applyOffset("='Sheet2'!B2", 0, 1)).toEqual("=Sheet2!B3");
     expect(model.getters.applyOffset("=Sheet2!B2", 0, -2)).toEqual("=#REF");
     expect(model.getters.applyOffset("=Sheet2!B2", -2, 0)).toEqual("=#REF");
     expect(model.getters.applyOffset("=Sheet2!B2", 1, 1)).toEqual("=Sheet2!C3");
     expect(model.getters.applyOffset("=Sheet2!B2", 1, 10)).toEqual("=Sheet2!C12");
+  });
+
+  test("can handle sheet reference with names", () => {
+    const model = new Model();
+    model.dispatch("CREATE_SHEET", { id: "42", name: "Sheet 2" });
+    expect(model.getters.applyOffset("='Sheet 2'!B2", 0, 1)).toEqual("='Sheet 2'!B3");
   });
 });

--- a/tests/plugins/autofill_test.ts
+++ b/tests/plugins/autofill_test.ts
@@ -446,4 +446,12 @@ describe("Autofill", () => {
     expect(getCell(model, "A2")!.content).toBe("=Sheet2!A2");
     expect(getCell(model, "A3")!.content).toBe("=Sheet2!A3");
   });
+
+  test("Autofill cross-sheet references with a space in the name", () => {
+    model.dispatch("CREATE_SHEET", { id: "42", name: "Sheet 2" });
+    setValue("A1", "='Sheet 2'!A1");
+    autofill("A1", "A3");
+    expect(getCell(model, "A2")!.content).toBe("='Sheet 2'!A2");
+    expect(getCell(model, "A3")!.content).toBe("='Sheet 2'!A3");
+  });
 });

--- a/tests/plugins/clipboard_test.ts
+++ b/tests/plugins/clipboard_test.ts
@@ -1098,6 +1098,16 @@ describe("clipboard", () => {
     expect(model.getters.getCell(1, 2)!.content).toBe("=Sheet2!B3");
   });
 
+  test("can copy and paste a cell which contains a cross-sheet reference with a space in the name", () => {
+    const model = new Model();
+    model.dispatch("CREATE_SHEET", { id: "42", name: "Sheet 2" });
+    model.dispatch("SET_VALUE", { xc: "B2", text: "='Sheet 2'!B2" });
+
+    model.dispatch("COPY", { target: target("B2") });
+    model.dispatch("PASTE", { target: target("B3") });
+    expect(model.getters.getCell(1, 2)!.content).toBe("='Sheet 2'!B3");
+  });
+
   test("can copy and paste a cell which contains a cross-sheet reference in a smaller sheet", () => {
     const model = new Model();
     model.dispatch("CREATE_SHEET", { id: "42", name: "Sheet2", rows: 2, cols: 2 });


### PR DESCRIPTION
## Description 1

1) In a cell, set the formula `=SUM(A1:A1000)` such that it references cells
   that are lower than the last row
2) auto-fill or copy-paste this cell somewhere below its current position
=> the reference is not adapted and is now #REF

Note: this is a behavior change. The new behavior is already the behavior of
saas-14.4 (and GSheet)

opw-2559009

Odoo task ID : [2559009](https://www.odoo.com/web#id=2559009&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Description 2

If you reference a cell in a sheet which contains a space in its name
(e.g. `='My Sheet'!A1`), the reference is not correctly adapted when
autofilling or copy-pasting the formula. The sheet name is dropped.

## review checklist

- [x] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
