### PR TITLE
[FIX] grid: fix scrollbars size and position

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -237,15 +237,17 @@ const CSS = css/* scss */ `
       z-index: 2;
       &.vertical {
         right: 0;
-        top: ${SCROLLBAR_WIDTH + 1}px;
-        bottom: 15px;
-        width: 15px;
+        top: ${HEADER_HEIGHT}px;
+        bottom: ${SCROLLBAR_WIDTH}px;
+        width: ${SCROLLBAR_WIDTH}px;
+        overflow-x: hidden;
       }
       &.horizontal {
         bottom: 0;
-        height: 15px;
+        height: ${SCROLLBAR_WIDTH}px;
         right: ${SCROLLBAR_WIDTH + 1}px;
         left: ${HEADER_WIDTH}px;
+        overflow-y: hidden;
       }
     }
   }


### PR DESCRIPTION
## Description:

The vertical scrollbar was misplaced in the grid (higher than the
overlay headers) which was inscreasing its clientHeight, ultimately
reducing its maximum scrolling value*. Namely in Firefox,  it was
impossible to scroll to the actual bottom of the grid.

The problem was not discovered in Chrome because is was counterbalanced
by a CSS issue: both scrollbars were overflowing which artificially
decreased their clientHeight/Width.

This commit addresses both issues - was tested both on Firefox, Edge and
Chrome

=>  We should definitely start testing UI related features in multiple
browsers.

 \* The maximum scroll value  of a scroll bar is the difference between the size of the
element inside the scrollbar (here, the gridSize) and the scrollbar's
size itself (clientHeight or clientWidth).

![scrollbars](https://user-images.githubusercontent.com/10333790/121771970-e1352980-cb72-11eb-89c3-9daed5f06a1c.png)

Odoo task ID : [2569772](https://www.odoo.com/web#id=2569772&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

~~- [ ] undo-able commands (uses this.history.update)~~
~~- [ ] multiuser-able commands (has inverse commands and transformations where needed)~~
- [x] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
~~- [ ] exportable in excel~~
~~- [ ] importable from excel~~
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
