### PR TITLE
[FIX] conditional format: fix typo in icon sets point names

### DIFF
--- a/src/components/side_panel/translations_terms.ts
+++ b/src/components/side_panel/translations_terms.ts
@@ -24,13 +24,13 @@ export const conditionalFormattingTerms = {
     [CommandResult.MinBiggerThanMid]: _lt("Minimum must be smaller then Midpoint"),
     [CommandResult.MidBiggerThanMax]: _lt("Midpoint must be smaller then Maximum"),
     [CommandResult.LowerBiggerThanUpper]: _lt(
-      "Lower inflation point must be smaller then upper inflation point"
+      "Lower inflection point must be smaller then upper inflection point"
     ),
     [CommandResult.MinInvalidFormula]: _lt("Invalid Minpoint formula"),
     [CommandResult.MaxInvalidFormula]: _lt("Invalid Maxpoint formula"),
     [CommandResult.MidInvalidFormula]: _lt("Invalid Midpoint formula"),
-    [CommandResult.ValueUpperInvalidFormula]: _lt("Invalid upper inflation point formula"),
-    [CommandResult.ValueLowerInvalidFormula]: _lt("Invalid lower inflation point formula"),
+    [CommandResult.ValueUpperInvalidFormula]: _lt("Invalid upper inflection point formula"),
+    [CommandResult.ValueLowerInvalidFormula]: _lt("Invalid lower inflection point formula"),
     [CommandResult.MinAsyncFormulaNotSupported]: _lt(
       "Some formulas are not supported for the Minpoint"
     ),

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -281,9 +281,9 @@ export class ConditionalFormatPlugin
       case "IconSetRule": {
         return this.checkValidations(
           rule,
-          this.checkInflationPoints(this.checkNaN),
-          this.checkInflationPoints(this.checkFormulaCompilation),
-          this.checkInflationPoints(this.checkAsyncFormula),
+          this.checkInflectionPoints(this.checkNaN),
+          this.checkInflectionPoints(this.checkFormulaCompilation),
+          this.checkInflectionPoints(this.checkAsyncFormula),
           this.checkLowerBiggerThanUpper
         );
       }
@@ -399,7 +399,7 @@ export class ConditionalFormatPlugin
     );
   }
 
-  private checkInflationPoints(check: InflectionPointValidation): Validation<IconSetRule> {
+  private checkInflectionPoints(check: InflectionPointValidation): Validation<IconSetRule> {
     return this.combineValidations(
       (rule) => check(rule.lowerInflectionPoint, "lowerInflectionPoint"),
       (rule) => check(rule.upperInflectionPoint, "upperInflectionPoint")

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -1161,11 +1161,11 @@ describe("UI of conditional formats", () => {
       CommandResult.ValueLowerAsyncFormulaNotSupported,
       "Some formulas are not supported for the lower inflection point",
     ],
-    [CommandResult.ValueUpperInvalidFormula, "Invalid upper inflation point formula"],
-    [CommandResult.ValueLowerInvalidFormula, "Invalid lower inflation point formula"],
+    [CommandResult.ValueUpperInvalidFormula, "Invalid upper inflection point formula"],
+    [CommandResult.ValueLowerInvalidFormula, "Invalid lower inflection point formula"],
     [
       CommandResult.LowerBiggerThanUpper,
-      "Lower inflation point must be smaller then upper inflation point",
+      "Lower inflection point must be smaller then upper inflection point",
     ],
   ])(
     "Show right error message (Command result: %s , Message: %s)",

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -1017,7 +1017,7 @@ describe("conditional formats types", () => {
     describe.each(["", "aaaa", "=SUM(1, 2)"])(
       "dispatch is not allowed if value is not a number",
       (value) => {
-        test("lower inflationpoint is NaN", () => {
+        test("lower inflection point is NaN", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
             target: [toZone("A1")],
@@ -1037,7 +1037,7 @@ describe("conditional formats types", () => {
           });
           expect(result).toBe(CommandResult.ValueUpperInflectionNaN);
         });
-        test("upper inflationpoint is NaN", () => {
+        test("upper inflection point is NaN", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
             target: [toZone("A1")],
@@ -1179,7 +1179,7 @@ describe("conditional formats types", () => {
       expect(model.getters.getConditionalIcon(...toCartesian("A5"))).toEqual("arrowGood");
     });
 
-    test("same upper and lower inflationpoint", () => {
+    test("same upper and lower inflection point", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "3");
       setCellContent(model, "A3", "5");


### PR DESCRIPTION

## Description:

Currently, both "inflation" and "inflection" are used to name the threshold
values.
Now, messages and variable names are unified and only use "inflection"

Odoo task ID : 

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
