### PR TITLE
[FIX] clipboard: copy part of the content of a cell

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -141,6 +141,10 @@ export class Spreadsheet extends Component<Props> {
     if (!this.grid.el!.contains(document.activeElement)) {
       return;
     }
+    /* If we are currently editing a cell, let the default behavior */
+    if (this.model.getters.getEditionMode() !== "inactive") {
+      return;
+    }
     const type = cut ? "CUT" : "COPY";
     const target = this.model.getters.getSelectedZones();
     this.model.dispatch(type, { target });


### PR DESCRIPTION
It was not possible to copy the selected content in the composer of a
cell. The copied content was the entire cell instead of the selected text.

This commit fixes this behavior

Note that Jest does not support ClipboardEvent, which make this fix
not testable.

Odoo-task-id #2530991

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2530991](https://www.odoo.com/web#id=2530991&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

