### PR TITLE
[FIX] sheet,evaluation: Support references to sheet names containing a

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -1,7 +1,6 @@
 import { rangeReference } from "../../formulas";
 import {
   getComposerSheetName,
-  getUnquotedSheetName,
   groupConsecutive,
   isDefined,
   numberToLetters,
@@ -204,7 +203,7 @@ export class RangePlugin extends CorePlugin<RangeState> {
     if (sheetXC.includes("!")) {
       [xc, sheetName] = sheetXC.split("!").reverse();
       if (sheetName) {
-        sheetId = this.getters.getSheetIdByName(getUnquotedSheetName(sheetName));
+        sheetId = this.getters.getSheetIdByName(sheetName);
         prefixSheet = true;
         if (!sheetId) {
           invalidSheetName = sheetName;

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -1,5 +1,5 @@
 import { rangeReference } from "../../formulas/index";
-import { getNextColor, uuidv4 } from "../../helpers/index";
+import { getComposerSheetName, getNextColor, uuidv4 } from "../../helpers/index";
 import { Mode } from "../../model";
 import { CancelledReason, Command, CommandResult, Highlight, LAYERS, UID } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
@@ -314,7 +314,10 @@ export class SelectionInputPlugin extends UIPlugin {
       Object.freeze({
         xc:
           h.sheet !== activeSheetId
-            ? `${this.getters.getSheetName(h.sheet)}!${toXC(sheetId, h.zone)}`
+            ? `${getComposerSheetName(this.getters.getSheetName(h.sheet)!)}!${toXC(
+                sheetId,
+                h.zone
+              )}`
             : toXC(sheetId, h.zone),
         id: uuidv4(),
         color: h.color,

--- a/tests/components/composer_test.ts
+++ b/tests/components/composer_test.ts
@@ -97,6 +97,23 @@ describe("ranges and highlights", () => {
     ).toBe(colors[0]);
   });
 
+  test.each([
+    "A1",
+    "$A1",
+    "A$1",
+    "A1:B2",
+    "Sheet1!A1",
+    "Sheet1!A1:B2",
+    "'Sheet1'!A1",
+    "Sheet1!$A$1",
+  ])("reference %s should be colored", async (ref) => {
+    await typeInComposer(`=SUM(${ref})`);
+    expect(
+      // @ts-ignore
+      (window.mockContentHelper as ContentEditableHelper).colors[ref]
+    ).toBe(colors[0]);
+  });
+
   test("=Key DOWN in A1, should select and highlight A2", async () => {
     await typeInComposer("=");
     await keydown("ArrowDown");

--- a/tests/plugins/core_test.ts
+++ b/tests/plugins/core_test.ts
@@ -528,10 +528,14 @@ describe("history", () => {
       expect(model.getters.getRangeFormattedValues("Sheet2!A1:A3", sheet1Id)).toEqual([
         ["21,000", "", "12/31/2020"],
       ]);
+      expect(model.getters.getRangeFormattedValues("'Sheet2'!A1:A3", sheet1Id)).toEqual([
+        ["21,000", "", "12/31/2020"],
+      ]);
       expect(model.getters.getRangeFormattedValues("B2", sheet1Id)).toEqual([["TRUE"]]);
       expect(model.getters.getRangeFormattedValues("Sheet1!B2", sheet1Id)).toEqual([["TRUE"]]);
       expect(model.getters.getRangeFormattedValues("Sheet2!B2", sheet2Id)).toEqual([["TRUE"]]);
       expect(model.getters.getRangeFormattedValues("Sheet2!B2", sheet1Id)).toEqual([["TRUE"]]);
+      expect(model.getters.getRangeFormattedValues("'Sheet2'!B2", sheet1Id)).toEqual([["TRUE"]]);
     });
 
     test("getRangeValues", () => {

--- a/tests/plugins/selection_input_test.ts
+++ b/tests/plugins/selection_input_test.ts
@@ -434,6 +434,39 @@ describe("selection input plugin", () => {
     expect(model.getters.getSelectionInput(id)[0].xc).toBe("Sheet2!A1");
   });
 
+  test("can select a range in sheet with a space in its name", () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
+    model.dispatch("CREATE_SHEET", {
+      sheetId: "42",
+      activate: true,
+      position: 1,
+      name: "sheet name",
+    });
+    model.dispatch("ADD_HIGHLIGHTS", {
+      ranges: { A1: "#000" },
+    });
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe(`'sheet name'!A1`);
+  });
+
+  test.each(["Sheet+", "Sheet:)"])(
+    "can select a range in sheet with special characters in its name: %s",
+    (sheetName) => {
+      // Note: this test will fail in saas-14.4 since special characters
+      // are quoted. In saas-14.4, it can be combined with the test above :)
+      model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
+      model.dispatch("CREATE_SHEET", {
+        sheetId: "42",
+        activate: true,
+        position: 1,
+        name: sheetName,
+      });
+      model.dispatch("ADD_HIGHLIGHTS", {
+        ranges: { A1: "#000" },
+      });
+      expect(model.getters.getSelectionInput(id)[0].xc).toBe(`${sheetName}!A1`);
+    }
+  );
+
   test("focus while in other sheet", () => {
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
     model.dispatch("ADD_HIGHLIGHTS", {

--- a/tests/plugins/sheets_test.ts
+++ b/tests/plugins/sheets_test.ts
@@ -1,4 +1,4 @@
-import { toCartesian, toZone, uuidv4 } from "../../src/helpers";
+import { getComposerSheetName, toCartesian, toZone, uuidv4 } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CancelledReason } from "../../src/types";
 import "../helpers"; // to have getcontext mocks
@@ -868,5 +868,22 @@ describe("sheets", () => {
       row: 1,
       sheetId: model.getters.getActiveSheetId(),
     });
+  });
+
+  test.each(["Sheet", "My sheet"])("getSheetIdByName", (name) => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("RENAME_SHEET", {
+      sheetId,
+      name,
+    });
+    expect(model.getters.getSheetIdByName(name)).toBe(sheetId);
+    expect(model.getters.getSheetIdByName(`'${name}'`)).toBe(sheetId);
+    expect(model.getters.getSheetIdByName(getComposerSheetName(name))).toBe(sheetId);
+  });
+
+  test("getSheetIdByName with invalid name", () => {
+    const model = new Model();
+    expect(model.getters.getSheetIdByName("this name does not exist")).toBeUndefined();
   });
 });


### PR DESCRIPTION
space



## Description:

The main issue was actually fixed by 0b7eaad
This commit adds some tests and some cleaning.

With this commit, quotes are also displayed around cross-sheet references in
the SelectionInput for sheet names that need it. Note that it is only for
consistency and "cosmetic". It correctly works without quotes (probably by
chance).

Co-authored-by: Lucas Lefèvre <lul@odoo.com>

Odoo task ID : [2556824](https://www.odoo.com/web#id=2556824&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
