### PR TITLE
[FIX] clipboard: remove zone outline when grid is changed

### DIFF
--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -16,6 +16,7 @@ import {
   Sheet,
   UID,
   Zone,
+  isCoreCommand,
 } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
@@ -121,6 +122,10 @@ export class ClipboardPlugin extends UIPlugin {
         this._isPaintingFormat = true;
         this.status = "visible";
         break;
+      default:
+        if (isCoreCommand(cmd)) {
+          this.status = "invisible";
+        }
     }
   }
 

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -4,7 +4,7 @@ import { Grid } from "../../src/components/grid";
 import { SidePanel } from "../../src/components/side_panel/side_panel";
 import { TopBar } from "../../src/components/top_bar";
 import { functionRegistry } from "../../src/functions/index";
-import { toCartesian, toXC } from "../../src/helpers/index";
+import { toCartesian, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { MergePlugin } from "../../src/plugins/core/merge";
 import { ComposerSelection } from "../../src/plugins/ui/edition";
@@ -392,13 +392,7 @@ export function toPosition(xc: string): Position {
 }
 
 export function zone(str: string): Zone {
-  let [tl, br] = str.split(":");
-  if (!br) {
-    br = tl;
-  }
-  const [left, top] = toCartesian(tl);
-  const [right, bottom] = toCartesian(br);
-  return { left, top, right, bottom };
+  return toZone(str);
 }
 
 export function target(str: string): Zone[] {

--- a/tests/test_helpers/renderer_helpers.ts
+++ b/tests/test_helpers/renderer_helpers.ts
@@ -1,0 +1,93 @@
+import { Model } from "../../src";
+import { GridRenderingContext, Viewport, Zone } from "../../src/types";
+import { MockCanvasRenderingContext2D } from "../setup/canvas.mock";
+
+MockCanvasRenderingContext2D.prototype.measureText = function () {
+  return { width: 100 };
+};
+
+interface ContextObserver {
+  onSet?(key, val): void;
+  onGet?(key): void;
+  onFunctionCall?(fn: string, args: any[]): void;
+}
+
+export class MockGridRenderingContext implements GridRenderingContext {
+  _context = document.createElement("canvas").getContext("2d");
+  ctx: CanvasRenderingContext2D;
+  viewport: Viewport;
+  dpr = 1;
+  thinLineWidth = 0.4;
+
+  constructor(model: Model, width: number, height: number, observer: ContextObserver) {
+    model.dispatch("RESIZE_VIEWPORT", { width, height });
+    this.viewport = model.getters.getActiveViewport();
+
+    const handler = {
+      get: (target, val) => {
+        if (val in (this._context as any).__proto__) {
+          return (...args) => {
+            if (observer.onFunctionCall) {
+              observer.onFunctionCall(val, args);
+            }
+          };
+        } else {
+          if (observer.onGet) {
+            observer.onGet(val);
+          }
+        }
+        return target[val];
+      },
+      set: (target, key, val) => {
+        if (observer.onSet) {
+          observer.onSet(key, val);
+        }
+        target[key] = val;
+        return true;
+      },
+    };
+    this.ctx = new Proxy({}, handler);
+  }
+}
+
+/**
+ * Create a rendering context watching the blue dotted
+ * outline around copied zones
+ */
+export function watchClipboardOutline(model: Model) {
+  const viewportSize = 1000;
+  const viewport: Viewport = {
+    bottom: viewportSize,
+    left: 0,
+    offsetX: 0,
+    offsetY: 0,
+    right: viewportSize,
+    top: 0,
+  };
+  let lineDash = false;
+  let outlinedRects: any[][] = [];
+  const ctx = new MockGridRenderingContext(model, viewportSize, viewportSize, {
+    onFunctionCall: (val, args) => {
+      if (val === "setLineDash") {
+        lineDash = true;
+      } else if (lineDash && val === "strokeRect") {
+        outlinedRects.push(args);
+      } else {
+        lineDash = false;
+      }
+    },
+  });
+  const isDotOutlined = (zones: Zone[]): boolean => {
+    return zones.every((zone) => {
+      const [x, y, width, height] = model.getters.getRect(zone, viewport);
+      return outlinedRects.some(
+        (rect) => rect[0] === x && rect[1] === y && rect[2] === width && rect[3] === height
+      );
+    });
+  };
+  const reset = () => {
+    outlinedRects = [];
+    lineDash = false;
+  };
+  return { ctx, isDotOutlined, reset };
+}


### PR DESCRIPTION
## Description:

When copying a range, a blue dotted outline is displayed.
It should be discarded at the 'next action', like typing in another cell,
but isn't.

This is especially awkward when the range is pasted outside of the spreadsheet
(e.g. in a notepad, excel, etc.) and the spreadsheet doesn't 'see' the pasting.

Odoo task ID : [2518477](https://www.odoo.com/web#id=2518477&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
