### PR TITLE
[REF] selection: change the way to determine the curent selected zone

### DIFF
--- a/doc/tsdoc/README.md
+++ b/doc/tsdoc/README.md
@@ -132,10 +132,10 @@ Name | Type |
 `createFullMenuItem` | (`key`: *string*, `value`: MenuItem) => FullMenuItem |
 `formatDecimal` | (`n`: *number*, `decimals`: *number*, `sep`: *string*) => *string* |
 `numberToLetters` | (`n`: *number*) => *string* |
-`toBoolean` | (`value`: *unknown*) => *boolean* |
+`toBoolean` | (`value`: ArgValue) => *boolean* |
 `toCartesian` | (`xc`: *string*) => [*number*, *number*] |
-`toNumber` | (`value`: *unknown*) => *number* |
-`toString` | (`value`: *any*) => *string* |
+`toNumber` | (`value`: ArgValue) => *number* |
+`toString` | (`value`: ArgValue) => *string* |
 `toXC` | (`col`: *number*, `row`: *number*) => *string* |
 `toZone` | (`xc`: *string*) => Zone |
 `uuidv4` | () => *string* |

--- a/doc/tsdoc/enums/commandresult.md
+++ b/doc/tsdoc/enums/commandresult.md
@@ -11,11 +11,11 @@
 - [DuplicatedSheetName](commandresult.md#duplicatedsheetname)
 - [EmptyClipboard](commandresult.md#emptyclipboard)
 - [EmptyDataSet](commandresult.md#emptydataset)
-- [EmptyLabelRange](commandresult.md#emptylabelrange)
 - [EmptyRedoStack](commandresult.md#emptyredostack)
 - [EmptyUndoStack](commandresult.md#emptyundostack)
 - [ForbiddenCharactersInSheetName](commandresult.md#forbiddencharactersinsheetname)
 - [InputAlreadyFocused](commandresult.md#inputalreadyfocused)
+- [InvalidAnchorZone](commandresult.md#invalidanchorzone)
 - [InvalidAutofillSelection](commandresult.md#invalidautofillselection)
 - [InvalidChartDefinition](commandresult.md#invalidchartdefinition)
 - [InvalidDataSet](commandresult.md#invaliddataset)
@@ -83,19 +83,13 @@ ___
 
 ### EmptyClipboard
 
-• **EmptyClipboard**: = 17
+• **EmptyClipboard**: = 18
 
 ___
 
 ### EmptyDataSet
 
-• **EmptyDataSet**: = 23
-
-___
-
-### EmptyLabelRange
-
-• **EmptyLabelRange**: = 24
+• **EmptyDataSet**: = 24
 
 ___
 
@@ -119,7 +113,13 @@ ___
 
 ### InputAlreadyFocused
 
-• **InputAlreadyFocused**: = 20
+• **InputAlreadyFocused**: = 21
+
+___
+
+### InvalidAnchorZone
+
+• **InvalidAnchorZone**: = 14
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 ### InvalidChartDefinition
 
-• **InvalidChartDefinition**: = 22
+• **InvalidChartDefinition**: = 23
 
 ___
 
@@ -155,13 +155,13 @@ ___
 
 ### InvalidRange
 
-• **InvalidRange**: = 18
+• **InvalidRange**: = 19
 
 ___
 
 ### InvalidSheetId
 
-• **InvalidSheetId**: = 19
+• **InvalidSheetId**: = 20
 
 ___
 
@@ -197,7 +197,7 @@ ___
 
 ### MaximumRangesReached
 
-• **MaximumRangesReached**: = 21
+• **MaximumRangesReached**: = 22
 
 ___
 
@@ -293,7 +293,7 @@ ___
 
 ### SelectionOutOfBound
 
-• **SelectionOutOfBound**: = 14
+• **SelectionOutOfBound**: = 15
 
 ___
 
@@ -305,7 +305,7 @@ ___
 
 ### TargetOutOfSheet
 
-• **TargetOutOfSheet**: = 15
+• **TargetOutOfSheet**: = 16
 
 ___
 
@@ -371,7 +371,7 @@ ___
 
 ### WrongPasteSelection
 
-• **WrongPasteSelection**: = 16
+• **WrongPasteSelection**: = 17
 
 ___
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "prettier": "prettier {src/*.ts,src/**/*.ts,tests/*.ts,tests/**/*.ts,doc/*.md} --write",
     "check-formatting": "prettier {src/*.ts,src/**/*.ts,tests/*.ts,tests/**/*.ts,doc/*.md} --check",
-    "dist":"npm run build:all && npm run build:bundle"
+    "dist": "npm run build:all && npm run build:bundle"
   },
   "browserslist": [
     "last 1 Chrome versions"

--- a/src/plugins/ui/autofill.ts
+++ b/src/plugins/ui/autofill.ts
@@ -234,6 +234,7 @@ export class AutofillPlugin extends UIPlugin {
       this.dispatch("SET_SELECTION", {
         zones: [zone],
         anchor: [zone.left, zone.top],
+        anchorZone: zone,
       });
     }
   }

--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -347,16 +347,16 @@ export class ClipboardPlugin extends UIPlugin {
         });
       }
     }
+    const zone = {
+      left: activeCol,
+      top: activeRow,
+      right: activeCol + width - 1,
+      bottom: activeRow + height - 1,
+    };
     this.dispatch("SET_SELECTION", {
       anchor: [activeCol, activeRow],
-      zones: [
-        {
-          left: activeCol,
-          top: activeRow,
-          right: activeCol + width - 1,
-          bottom: activeRow + height - 1,
-        },
-      ],
+      zones: [zone],
+      anchorZone: zone,
     });
   }
 
@@ -444,6 +444,7 @@ export class ClipboardPlugin extends UIPlugin {
       this.dispatch("SET_SELECTION", {
         anchor: [newCol, newRow],
         zones: [newSelection],
+        anchorZone: newSelection,
       });
     }
   }

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -34,6 +34,7 @@ import { UIPlugin } from "../ui_plugin";
 export interface Selection {
   anchor: [number, number];
   zones: Zone[];
+  anchorZone: Zone;
 }
 
 interface SheetInfo {
@@ -82,6 +83,7 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
   private selection: Selection = {
     zones: [{ top: 0, left: 0, bottom: 0, right: 0 }],
     anchor: [0, 0],
+    anchorZone: { top: 0, left: 0, bottom: 0, right: 0 },
   };
   private selectedFigureId: string | null = null;
   private activeCol: number = 0;
@@ -111,6 +113,12 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
 
   allowDispatch(cmd: Command): CommandResult {
     switch (cmd.type) {
+      case "SET_SELECTION": {
+        if (cmd.zones.findIndex((z: Zone) => isEqual(z, cmd.anchorZone)) === -1) {
+          return CommandResult.InvalidAnchorZone;
+        }
+        break;
+      }
       case "MOVE_POSITION": {
         const { cols, rows, id: sheetId } = this.getters.getActiveSheet();
         let targetCol = this.activeCol;
@@ -214,7 +222,7 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
         }
         break;
       case "SET_SELECTION":
-        this.setSelection(cmd.anchor, cmd.zones, cmd.strict);
+        this.setSelection(cmd.anchor, cmd.zones, cmd.anchorZone, cmd.strict);
         break;
       case "START_SELECTION":
         this.mode = SelectionMode.selecting;
@@ -333,7 +341,7 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
   }
 
   getSelectedZone(): Zone {
-    return this.selection.zones[this.selection.zones.length - 1];
+    return this.selection.anchorZone;
   }
 
   getSelection(): Selection {
@@ -442,45 +450,45 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
 
   private selectColumn(index: number, createRange: boolean, updateRange: boolean) {
     const bottom = this.getters.getActiveSheet().rows.length - 1;
-    const zone = { left: index, right: index, top: 0, bottom };
+    let zone = { left: index, right: index, top: 0, bottom };
     const current = this.selection.zones;
-    let zones: Zone[], anchor: [number, number];
+    let newZones: Zone[], anchor: [number, number];
     const top = this.getters.getActiveSheet().rows.findIndex((row) => !row.isHidden);
     if (updateRange) {
       const [col, row] = this.selection.anchor;
-      const updatedZone = union(zone, { left: col, right: col, top, bottom });
-      zones = current.slice(0, -1).concat(updatedZone);
+      zone = union(zone, { left: col, right: col, top, bottom });
+      newZones = this.updateSelectionZones(zone);
       anchor = [col, row];
     } else {
-      zones = createRange ? current.concat(zone) : [zone];
+      newZones = createRange ? current.concat(zone) : [zone];
       anchor = [index, top];
     }
-    this.dispatch("SET_SELECTION", { zones, anchor, strict: true });
+    this.dispatch("SET_SELECTION", { zones: newZones, anchor, strict: true, anchorZone: zone });
   }
 
   private selectRow(index: number, createRange: boolean, updateRange: boolean) {
     const right = this.getters.getActiveSheet().cols.length - 1;
-    const zone = { top: index, bottom: index, left: 0, right };
+    let zone = { top: index, bottom: index, left: 0, right };
     const current = this.selection.zones;
     let zones: Zone[], anchor: [number, number];
     const left = this.getters.getActiveSheet().cols.findIndex((col) => !col.isHidden);
     if (updateRange) {
       const [col, row] = this.selection.anchor;
-      const updatedZone = union(zone, { left, right, top: row, bottom: row });
-      zones = current.slice(0, -1).concat(updatedZone);
+      zone = union(zone, { left, right, top: row, bottom: row });
+      zones = this.updateSelectionZones(zone);
       anchor = [col, row];
     } else {
       zones = createRange ? current.concat(zone) : [zone];
       anchor = [left, index];
     }
-    this.dispatch("SET_SELECTION", { zones, anchor, strict: true });
+    this.dispatch("SET_SELECTION", { zones, anchor, strict: true, anchorZone: zone });
   }
 
   private selectAll() {
     const bottom = this.getters.getActiveSheet().rows.length - 1;
     const right = this.getters.getActiveSheet().cols.length - 1;
     const zone = { left: 0, top: 0, bottom, right };
-    this.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0] });
+    this.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0], anchorZone: zone });
   }
 
   /**
@@ -495,14 +503,12 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
     this.moveClient({ sheetId: sheet.id, col, row });
     let zone = this.getters.expandZone(sheet.id, { left: col, right: col, top: row, bottom: row });
     if (this.mode === SelectionMode.expanding) {
-      // It is important to add the zone at the end of the array.
-      // It is a way to easily find the last selection made by the user.
       this.selection.zones.push(zone);
     } else {
       this.selection.zones = [zone];
     }
     this.selection.zones = uniqueZones(this.selection.zones);
-
+    this.selection.anchorZone = zone;
     this.selection.anchor = [col, row];
     this.activeCol = col;
     this.activeRow = row;
@@ -555,13 +561,15 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
     }
   }
 
-  setSelection(anchor: [number, number], zones: Zone[], strict: boolean = false) {
+  setSelection(anchor: [number, number], zones: Zone[], anchorZone: Zone, strict: boolean = false) {
     this.selectCell(...anchor);
     if (strict) {
       this.selection.zones = zones;
+      this.selection.anchorZone = anchorZone;
     } else {
       const sheetId = this.getters.getActiveSheetId();
       this.selection.zones = zones.map((zone: Zone) => this.getters.expandZone(sheetId, zone));
+      this.selection.anchorZone = this.getters.expandZone(sheetId, anchorZone);
     }
     this.selection.zones = uniqueZones(this.selection.zones);
     this.selection.anchor = anchor;
@@ -569,11 +577,10 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
 
   private moveSelection(deltaX: number, deltaY: number) {
     const selection = this.selection;
-    const zones = selection.zones.slice();
-    const lastZone = zones[selection.zones.length - 1];
+    let newZones: Zone[] = [];
     const [anchorCol, anchorRow] = selection.anchor;
-    const { left, right, top, bottom } = lastZone;
-    let result: Zone | null = lastZone;
+    const { left, right, top, bottom } = selection.anchorZone;
+    let result: Zone | null = selection.anchorZone;
     const activeSheet = this.getters.getActiveSheet();
     const expand = (z: Zone) => {
       const { left, right, top, bottom } = this.getters.expandZone(activeSheet.id, z);
@@ -601,9 +608,13 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
       if (deltaY > 0) {
         result = top + n <= anchorRow ? expand({ top: top + n, left, bottom, right }) : null;
       }
-      if (result && !isEqual(result, lastZone)) {
-        zones[zones.length - 1] = result;
-        this.dispatch("SET_SELECTION", { zones, anchor: [anchorCol, anchorRow] });
+      if (result && !isEqual(result, selection.anchorZone)) {
+        newZones = this.updateSelectionZones(result);
+        this.dispatch("SET_SELECTION", {
+          zones: newZones,
+          anchor: [anchorCol, anchorRow],
+          anchorZone: result,
+        });
         return;
       }
     }
@@ -615,9 +626,13 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
       right: right + deltaX,
     };
     result = expand(union(currentZone, zoneWithDelta));
-    if (!isEqual(result, lastZone)) {
-      zones[zones.length - 1] = result;
-      this.dispatch("SET_SELECTION", { zones, anchor: [anchorCol, anchorRow] });
+    if (!isEqual(result, selection.anchorZone)) {
+      newZones = this.updateSelectionZones(result);
+      this.dispatch("SET_SELECTION", {
+        zones: newZones,
+        anchor: [anchorCol, anchorRow],
+        anchorZone: result,
+      });
     }
   }
 
@@ -630,8 +645,12 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
       right: Math.max(anchorCol, col),
       bottom: Math.max(anchorRow, row),
     };
-    const zones = selection.zones.slice(0, -1).concat(zone);
-    this.dispatch("SET_SELECTION", { zones, anchor: [anchorCol, anchorRow] });
+    const newZones = this.updateSelectionZones(zone);
+    this.dispatch("SET_SELECTION", {
+      zones: newZones,
+      anchor: [anchorCol, anchorRow],
+      anchorZone: zone,
+    });
   }
 
   /**
@@ -639,8 +658,11 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
    * They are clipped to fit inside the sheet if needed.
    */
   private ensureSelectionValidity() {
-    const { anchor, zones } = this.clipSelection(this.getActiveSheetId(), this.selection);
-    this.setSelection(anchor, zones);
+    const { anchor, zones, anchorZone } = this.clipSelection(
+      this.getActiveSheetId(),
+      this.selection
+    );
+    this.setSelection(anchor, zones, anchorZone);
     const deletedSheetIds = Object.keys(this.sheetsData).filter(
       (sheetId) => !this.getters.tryGetSheet(sheetId)
     );
@@ -648,9 +670,12 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
       delete this.sheetsData[sheetId];
     }
     for (const sheetId in this.sheetsData) {
-      const { anchor, zones } = this.clipSelection(sheetId, this.sheetsData[sheetId].selection);
+      const { anchor, zones, anchorZone } = this.clipSelection(
+        sheetId,
+        this.sheetsData[sheetId].selection
+      );
       this.sheetsData[sheetId] = {
-        selection: { anchor, zones },
+        selection: { anchor, zones, anchorZone },
         activeCol: anchor[0],
         activeRow: anchor[1],
       };
@@ -670,23 +695,30 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
       top: clip(z.top, 0, rows),
       bottom: clip(z.bottom, 0, rows),
     }));
-    const anchorCol = zones[zones.length - 1].left;
-    const anchorRow = zones[zones.length - 1].top;
+    const anchorCol = clip(selection.anchor[0], 0, cols);
+    const anchorRow = clip(selection.anchor[1], 0, rows);
+    const anchorZone = {
+      left: clip(selection.anchorZone.left, 0, cols),
+      right: clip(selection.anchorZone.right, 0, cols),
+      top: clip(selection.anchorZone.top, 0, rows),
+      bottom: clip(selection.anchorZone.bottom, 0, rows),
+    };
     return {
       anchor: [anchorCol, anchorRow],
       zones,
+      anchorZone,
     };
   }
 
   private onColumnsRemoved(cmd: RemoveColumnsRowsCommand) {
     const zone = updateSelectionOnDeletion(this.getSelectedZone(), "left", cmd.elements);
-    this.setSelection([zone.left, zone.top], [zone], true);
+    this.setSelection([zone.left, zone.top], [zone], zone, true);
     this.ensureSelectionValidity();
   }
 
   private onRowsRemoved(cmd: RemoveColumnsRowsCommand) {
     const zone = updateSelectionOnDeletion(this.getSelectedZone(), "top", cmd.elements);
-    this.setSelection([zone.left, zone.top], [zone], true);
+    this.setSelection([zone.left, zone.top], [zone], zone, true);
     this.ensureSelectionValidity();
   }
 
@@ -699,9 +731,22 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
       cmd.position,
       cmd.quantity
     );
-    this.setSelection([zone.left, zone.top], [zone], true);
+    this.setSelection([zone.left, zone.top], [zone], zone, true);
   }
 
+  /**
+   * this function searches for anchorZone in selection.zones
+   * and modifies it by newZone
+   */
+  private updateSelectionZones(newZone: Zone): Zone[] {
+    let zones = [...this.selection.zones];
+    const current = this.selection.anchorZone;
+    const index = zones.findIndex((z: Zone) => isEqual(z, current));
+    if (index >= 0) {
+      zones[index] = newZone;
+    }
+    return zones;
+  }
   // ---------------------------------------------------------------------------
   // Grid rendering
   // ---------------------------------------------------------------------------

--- a/src/plugins/ui/sort.ts
+++ b/src/plugins/ui/sort.ts
@@ -157,6 +157,7 @@ export class SortPlugin extends UIPlugin {
           this.dispatch("SET_SELECTION", {
             anchor: anchor,
             zones: [zone],
+            anchorZone: zone,
           });
           this.ui.notifyUser(
             _lt("Cannot sort. To sort, select only cells or only merges that have the same size.")

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -464,6 +464,7 @@ export interface SetSelectionCommand extends BaseCommand {
   type: "SET_SELECTION";
   anchor: [number, number];
   zones: Zone[];
+  anchorZone: Zone;
   strict?: boolean;
 }
 
@@ -979,6 +980,7 @@ export const enum CommandResult {
   ForbiddenCharactersInSheetName,
   WrongSheetMove,
   WrongSheetPosition,
+  InvalidAnchorZone,
   SelectionOutOfBound,
   TargetOutOfSheet,
   WrongPasteSelection,

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -583,6 +583,7 @@ describe("UI of conditional formats", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [1, 1],
       zones: [zone1, zone2],
+      anchorZone: zone2,
     });
     parent.env.openSidePanel("ConditionalFormatting");
     await nextTick();
@@ -600,6 +601,7 @@ describe("UI of conditional formats", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [1, 1],
       zones: [zone1, zone2],
+      anchorZone: zone2,
     });
     triggerMouseEvent(selectors.buttonAdd, "click");
     await nextTick();

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -727,7 +727,7 @@ describe("Context Menu - CF", () => {
       target: cfRule.ranges.map(toZone),
     });
     const zone = { left: 0, top: 0, bottom: 10, right: 10 };
-    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0] });
+    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0], anchorZone: zone });
     simulateContextMenu(240, 110); //click on C5
     await nextTick();
     await simulateClick(".o-menu div[data-name='conditional_formatting']");
@@ -775,7 +775,7 @@ describe("Context Menu - CF", () => {
       target: cfRule2.ranges.map(toZone),
     });
     const zone = { left: 0, top: 0, bottom: 10, right: 10 };
-    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0] });
+    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0], anchorZone: zone });
     simulateContextMenu(240, 110); //click on C5
     await nextTick();
     await simulateClick(".o-menu div[data-name='conditional_formatting']");
@@ -807,7 +807,7 @@ describe("Context Menu - CF", () => {
       target: cfRule1.ranges.map(toZone),
     });
     let zone = { left: 0, top: 0, bottom: 10, right: 0 };
-    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0] });
+    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0], anchorZone: zone });
     simulateContextMenu(80, 90);
     await nextTick();
     await simulateClick(".o-menu div[data-name='conditional_formatting']");
@@ -819,7 +819,7 @@ describe("Context Menu - CF", () => {
     ).toBeTruthy();
 
     zone = { left: 5, top: 5, bottom: 5, right: 5 };
-    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [5, 5] });
+    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [5, 5], anchorZone: zone });
     simulateContextMenu(530, 125);
     await nextTick();
     await simulateClick(".o-menu div[data-name='conditional_formatting']");

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -385,6 +385,7 @@ describe("Grid component", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 0],
         zones: [toZone("A1:B2"), toZone("C4:C6")],
+        anchorZone: toZone("C4:C6"),
       });
       document.activeElement!.dispatchEvent(
         new KeyboardEvent("keydown", { key: "=", altKey: true, bubbles: true })
@@ -426,6 +427,7 @@ describe("Grid component", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 1],
         zones: [toZone("A2:B2")],
+        anchorZone: toZone("A2:B2"),
       });
       document.activeElement!.dispatchEvent(
         new KeyboardEvent("keydown", { key: "=", altKey: true, bubbles: true })
@@ -441,6 +443,7 @@ describe("Grid component", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 0],
         zones: [toZone("A1:A2")],
+        anchorZone: toZone("A1:A2"),
       });
       document.activeElement!.dispatchEvent(
         new KeyboardEvent("keydown", { key: "=", altKey: true, bubbles: true })

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -367,7 +367,7 @@ describe("TopBar - CF", () => {
       target: cfRule.ranges.map(toZone),
     });
     const zone = { left: 0, top: 0, bottom: 10, right: 10 };
-    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0] });
+    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0], anchorZone: zone });
 
     triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
     await nextTick();
@@ -417,7 +417,7 @@ describe("TopBar - CF", () => {
       target: cfRule2.ranges.map(toZone),
     });
     const zone = { left: 0, top: 0, bottom: 10, right: 10 };
-    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0] });
+    model.dispatch("SET_SELECTION", { zones: [zone], anchor: [0, 0], anchorZone: zone });
 
     triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
     await nextTick();

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -612,7 +612,11 @@ describe("Menu Item actions", () => {
     const pathSort = ["edit", "sort_range"];
 
     test("A selected zone", () => {
-      model.dispatch("SET_SELECTION", { anchor: [0, 0], zones: [toZone("A1:A2")] });
+      model.dispatch("SET_SELECTION", {
+        anchor: [0, 0],
+        zones: [toZone("A1:A2")],
+        anchorZone: toZone("A1:A2"),
+      });
       expect(getName(pathSort, env)).toBe("Sort range");
       expect(getNode(pathSort).isVisible(env)).toBeTruthy();
     });
@@ -621,6 +625,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 0],
         zones: [toZone("A1:A2"), toZone("B1:B2")],
+        anchorZone: toZone("B1:B2"),
       });
       expect(getNode(pathSort).isVisible(env)).toBeFalsy();
     });
@@ -643,6 +648,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [1, 0],
         zones: [toZone("B1:B100"), toZone("C5")],
+        anchorZone: toZone("C5"),
       });
       expect(getName(hidePath, env, colMenuRegistry)).toBe("Hide columns B - C");
       expect(getNode(hidePath, colMenuRegistry).isVisible(env)).toBeTruthy();
@@ -657,6 +663,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [1, 0],
         zones: [toZone("B1")],
+        anchorZone: toZone("B1"),
       });
       expect(getName(hidePath, env, colMenuRegistry)).toBe("Hide columns");
       expect(getNode(hidePath, colMenuRegistry).isVisible(env)).toBeTruthy();
@@ -672,6 +679,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 0],
         zones: [toZone("A1:A100"), toZone("A4:Z4")],
+        anchorZone: toZone("A4:Z4"),
       });
       expect(getNode(hidePath, colMenuRegistry).isVisible(env)).toBeFalsy();
     });
@@ -681,6 +689,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 0],
         zones: [toZone("B1:E100")],
+        anchorZone: toZone("B1:E100"),
       });
       expect(getNode(unhidePath, colMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(unhidePath, env, colMenuRegistry);
@@ -694,6 +703,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 0],
         zones: [toZone("B1:E100")],
+        anchorZone: toZone("B1:E100"),
       });
       expect(getNode(unhidePath, colMenuRegistry).isVisible(env)).toBeFalsy();
     });
@@ -729,6 +739,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 1],
         zones: [toZone("A2:Z2"), toZone("C3")],
+        anchorZone: toZone("C3"),
       });
       expect(getName(hidePath, env, rowMenuRegistry)).toBe("Hide rows 2 - 3");
       expect(getNode(hidePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
@@ -743,6 +754,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [1, 0],
         zones: [toZone("B1")],
+        anchorZone: toZone("B1"),
       });
       expect(getName(hidePath, env, rowMenuRegistry)).toBe("Hide rows");
       expect(getNode(hidePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
@@ -758,6 +770,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 0],
         zones: [toZone("A1:A100"), toZone("A4:Z4")],
+        anchorZone: toZone("A4:Z4"),
       });
       expect(getNode(hidePath, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });
@@ -767,6 +780,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 0],
         zones: [toZone("A1:Z4")],
+        anchorZone: toZone("A1:Z4"),
       });
       expect(getNode(unhidePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(unhidePath, env, rowMenuRegistry);
@@ -780,6 +794,7 @@ describe("Menu Item actions", () => {
       model.dispatch("SET_SELECTION", {
         anchor: [0, 0],
         zones: [toZone("A1:Z4")],
+        anchorZone: toZone("A1:Z4"),
       });
       expect(getNode(unhidePath, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -19,6 +19,7 @@ function selectZone(range: string) {
   model.dispatch("SET_SELECTION", {
     anchor: [zone.left, zone.top],
     zones: [zone],
+    anchorZone: zone,
   });
 }
 

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -313,6 +313,7 @@ describe("edition", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [0, 0],
       zones: [toZone("A1:A3")],
+      anchorZone: toZone("A1:A3"),
     });
     expect(model.getters.getCurrentContent()).toBe("=A1:A3");
 

--- a/tests/plugins/grid_manipulation.test.ts
+++ b/tests/plugins/grid_manipulation.test.ts
@@ -964,6 +964,7 @@ describe("Columns", () => {
       const zone = { left: 1, right: 3, top: 0, bottom: 2 };
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -976,6 +977,7 @@ describe("Columns", () => {
       const zone = { left: 1, right: 3, top: 0, bottom: 2 };
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -988,6 +990,7 @@ describe("Columns", () => {
       const zone = toZone("B1:D3");
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -1000,6 +1003,7 @@ describe("Columns", () => {
       const zone = toZone("B1:D3");
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -1012,6 +1016,7 @@ describe("Columns", () => {
       const zone = toZone("C1:C4");
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -1024,6 +1029,7 @@ describe("Columns", () => {
       const zone2 = toZone("C1:C4");
       model.dispatch("SET_SELECTION", {
         zones: [zone1, zone2],
+        anchorZone: zone2,
         anchor: [zone1.left, zone1.top],
         strict: true,
       });
@@ -1771,6 +1777,7 @@ describe("Rows", () => {
       const zone = { left: 2, right: 3, top: 0, bottom: 1 };
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -1783,6 +1790,7 @@ describe("Rows", () => {
       const zone = { left: 2, right: 3, top: 0, bottom: 1 };
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -1795,6 +1803,7 @@ describe("Rows", () => {
       const zone = toZone("C1:D2");
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -1807,6 +1816,7 @@ describe("Rows", () => {
       const zone = toZone("C1:D2");
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -1819,6 +1829,7 @@ describe("Rows", () => {
       const zone = toZone("A3:D3");
       model.dispatch("SET_SELECTION", {
         zones: [zone],
+        anchorZone: zone,
         anchor: [zone.left, zone.top],
         strict: true,
       });
@@ -1831,6 +1842,7 @@ describe("Rows", () => {
       const zone2 = toZone("A3:D3");
       model.dispatch("SET_SELECTION", {
         zones: [zone1, zone2],
+        anchorZone: zone2,
         anchor: [zone1.left, zone1.top],
         strict: true,
       });

--- a/tests/plugins/highlight.test.ts
+++ b/tests/plugins/highlight.test.ts
@@ -163,6 +163,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [1, 1],
       zones: [zone1],
+      anchorZone: zone1,
     });
     model.dispatch("STOP_SELECTION");
     const firstColor = getColor(model);
@@ -177,6 +178,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [6, 6],
       zones: [zone2],
+      anchorZone: zone2,
     });
     model.dispatch("STOP_SELECTION");
     expect(getColor(model)).toBe(firstColor);
@@ -197,6 +199,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [1, 1],
       zones: [zone1],
+      anchorZone: zone1,
     });
     model.dispatch("STOP_SELECTION");
     const firstColor = getColor(model);
@@ -212,6 +215,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [6, 6],
       zones: [zone2],
+      anchorZone: zone2,
     });
     model.dispatch("STOP_SELECTION");
     expect(getColor(model)).not.toBe(firstColor);
@@ -230,6 +234,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [1, 1],
       zones: [zone1],
+      anchorZone: zone1,
     });
     model.dispatch("HIGHLIGHT_SELECTION", { enabled: true });
     model.dispatch("START_SELECTION_EXPANSION");
@@ -253,6 +258,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [1, 1],
       zones: [zone1],
+      anchorZone: zone1,
     });
     model.dispatch("STOP_SELECTION");
     const firstColor = getColor(model);
@@ -262,6 +268,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [6, 6],
       zones: [zone2],
+      anchorZone: zone2,
     });
     model.dispatch("STOP_SELECTION");
     expect(getColor(model)).not.toBe(firstColor);
@@ -275,13 +282,13 @@ describe("highlight", () => {
     const zones = [zone];
     model.dispatch("START_SELECTION");
     const color = getColor(model);
-    model.dispatch("SET_SELECTION", { anchor, zones });
+    model.dispatch("SET_SELECTION", { anchor, zones, anchorZone: zone });
     model.dispatch("STOP_SELECTION");
     expect(model.getters.getHighlights()).toStrictEqual([
       { color, zone, sheet: model.getters.getActiveSheetId() },
     ]);
     model.dispatch("START_SELECTION");
-    model.dispatch("SET_SELECTION", { anchor, zones });
+    model.dispatch("SET_SELECTION", { anchor, zones, anchorZone: zone });
     expect(model.getters.getHighlights()).toStrictEqual([
       { color, zone, sheet: model.getters.getActiveSheetId() },
     ]);
@@ -295,6 +302,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [1, 1],
       zones: [zone1],
+      anchorZone: zone1,
     });
     const firstColor = getColor(model);
     model.dispatch("STOP_SELECTION");
@@ -303,6 +311,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [6, 6],
       zones: [zone2],
+      anchorZone: zone2,
     });
     model.dispatch("STOP_SELECTION");
     expect(model.getters.getHighlights()).toStrictEqual([
@@ -367,6 +376,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [0, 4],
       zones: [toZone("A3:A5")],
+      anchorZone: toZone("A3:A5"),
     });
     const mergeColor = getColor(model);
     expect(model.getters.getHighlights()).toStrictEqual([
@@ -385,6 +395,7 @@ describe("highlight", () => {
     model.dispatch("SET_SELECTION", {
       anchor: [0, 4],
       zones: [toZone("A3:A5")],
+      anchorZone: toZone("A3:A5"),
     });
     const mergeColor = getColor(model);
     model.dispatch("ALTER_SELECTION", { cell: [0, 1] }); // TopLeft

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -294,6 +294,16 @@ describe("selection", () => {
     expect(model.getters.getPosition()).toEqual([1, 0]);
     expect(model.getters.getSheetPosition("42")).toEqual([1, 0]);
   });
+  test("cannot set a selection with an anchor zone not present in the zones provided", () => {
+    const model = new Model();
+    const zone = { top: 0, bottom: 0, left: 0, right: 0 };
+    const anchorZone = { top: 1, bottom: 2, left: 1, right: 2 };
+    const zones = [zone];
+    const anchor: [number, number] = [1, 1];
+    expect(model.dispatch("SET_SELECTION", { zones, anchor, anchorZone })).toBe(
+      CommandResult.InvalidAnchorZone
+    );
+  });
 });
 
 describe("multiple selections", () => {

--- a/tests/plugins/sort.test.ts
+++ b/tests/plugins/sort.test.ts
@@ -754,6 +754,7 @@ describe("Sort Merges", () => {
     expect(notifyUser).toHaveBeenCalled();
     expect(model.getters.getSelection()).toEqual({
       anchor: anchor,
+      anchorZone: contiguousZone,
       zones: [contiguousZone],
     });
     undo(model);
@@ -791,6 +792,7 @@ describe("Sort Merges", () => {
     expect(notifyUser).toHaveBeenCalled();
     expect(model.getters.getSelection()).toEqual({
       anchor: anchor,
+      anchorZone: contiguousZone,
       zones: [contiguousZone],
     });
     undo(model);

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -123,6 +123,7 @@ export function automaticSumMulti(
   model.dispatch("SET_SELECTION", {
     anchor: anchorPosition,
     zones: xcs.map(toZone),
+    anchorZone: mainSelectedZone,
   });
   return model.dispatch("SUM_SELECTION");
 }


### PR DESCRIPTION
## Description:

Some commands like ALTER_SELECTION consider the current selection as the last selection made by the user.
This will no longer be the case with the following task: 2560657
This commit makes the necessary changes and allows you to redefine the current selection via the SET_SELECTION command.

Odoo task ID : 2577963
(https://www.odoo.com/web#id=2577963&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
