### PR TITLE
[IMP] composer: arrows behavior within cell composer

### DIFF
--- a/src/components/composer/grid_composer.ts
+++ b/src/components/composer/grid_composer.ts
@@ -42,7 +42,7 @@ interface ComposerState {
 }
 
 interface Props {
-  focus: boolean;
+  focus: "inactive" | "cellFocus" | "contentFocus";
   content: string;
 }
 

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -12,7 +12,7 @@ import { Model } from "../model";
 import { cellMenuRegistry } from "../registries/menus/cell_menu_registry";
 import { colMenuRegistry } from "../registries/menus/col_menu_registry";
 import { rowMenuRegistry } from "../registries/menus/row_menu_registry";
-import { Client, SpreadsheetEnv, Viewport } from "../types/index";
+import { CellType, Client, SpreadsheetEnv, Viewport } from "../types/index";
 import { Autofill } from "./autofill";
 import { ClientTag } from "./collaborative_client_tag";
 import { GridComposer } from "./composer/grid_composer";
@@ -306,13 +306,24 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
     return { isOpen: false };
   }
 
+  get isEmptyCell(): boolean {
+    const cell = this.getters.getActiveCell();
+    return !cell || cell.type === CellType.empty;
+  }
+
   // this map will handle most of the actions that should happen on key down. The arrow keys are managed in the key
   // down itself
   private keyDownMapping: { [key: string]: Function } = {
-    ENTER: () => this.trigger("composer-focused"),
+    ENTER: () =>
+      this.isEmptyCell
+        ? this.trigger("composer-cell-focused")
+        : this.trigger("composer-content-focused"),
     TAB: () => this.dispatch("MOVE_POSITION", { deltaX: 1, deltaY: 0 }),
     "SHIFT+TAB": () => this.dispatch("MOVE_POSITION", { deltaX: -1, deltaY: 0 }),
-    F2: () => this.trigger("composer-focused"),
+    F2: () =>
+      this.isEmptyCell
+        ? this.trigger("composer-cell-focused")
+        : this.trigger("composer-content-focused"),
     DELETE: () => {
       this.dispatch("DELETE_CONTENT", {
         sheetId: this.getters.getActiveSheetId(),
@@ -353,7 +364,7 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
         const zone = sums[0]?.zone;
         const zoneXc = zone ? this.getters.zoneToXC(sheetId, sums[0].zone) : "";
         const formula = `=SUM(${zoneXc})`;
-        this.trigger("composer-focused", {
+        this.trigger("composer-cell-focused", {
           content: formula,
           selection: { start: 5, end: 5 + zoneXc.length },
         });
@@ -604,7 +615,9 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
   onDoubleClick(ev) {
     const [col, row] = this.getCartesianCoordinates(ev);
     if (this.clickedCol === col && this.clickedRow === row) {
-      this.trigger("composer-focused");
+      this.isEmptyCell
+        ? this.trigger("composer-cell-focused")
+        : this.trigger("composer-content-focused");
     }
   }
 
@@ -680,7 +693,7 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
         // character
         ev.preventDefault();
         ev.stopPropagation();
-        this.trigger("composer-focused", { content: ev.key });
+        this.trigger("composer-cell-focused", { content: ev.key });
       }
     }
   }

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -221,13 +221,17 @@ describe("formula assistant", () => {
       await typeInComposer("=FUNC1(1");
       expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
       expect(model.getters.getEditionMode()).toBe("editing");
+    });
+
+    test("leaving 'editing' mode with arrows should hide formula assistant", async () => {
+      await typeInComposer("=FUNC1(1");
       composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
       await nextTick();
       composerEl.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowLeft", bubbles: true }));
       await nextTick();
-      expect(model.getters.getCurrentContent()).toBe("=FUNC1(1");
-      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
-      expect(model.getters.getEditionMode()).toBe("editing");
+      expect(model.getters.getEditionMode()).toBe("inactive");
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
+      expect(model.getters.getCurrentContent()).toBe("=FUNC1(1)");
     });
 
     describe("function definition", () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -83,12 +83,13 @@ export class GridParent extends Component<any, SpreadsheetEnv> {
         model="model"
         t-on-ask-confirmation="askConfirmation"
         focusComposer="focusTopBarComposer"
-        t-on-composer-focused="onTopBarComposerFocused"/>
+        t-on-composer-content-focused="onTopBarComposerFocused"/>
       <Grid
         model="model"
         sidePanelIsOpen="sidePanel.isOpen"
         t-ref="grid"
-        t-on-composer-focused="onGridComposerFocused"
+        t-on-composer-cell-focused="onGridComposerCellFocused"
+        t-on-composer-content-focused="onGridComposerContentFocused"
         focusComposer="focusGridComposer"/>
       <SidePanel t-if="sidePanel.isOpen"
              t-on-close-side-panel="sidePanel.isOpen = false"
@@ -108,9 +109,9 @@ export class GridParent extends Component<any, SpreadsheetEnv> {
   });
 
   composer = useState({
-    topBar: false,
-    grid: false,
-  });
+    topBarFocus: "inactive",
+    gridFocusMode: "inactive",
+  } as { topBarFocus: "inactive" | "contentFocus"; gridFocusMode: "inactive" | "contentFocus" | "cellFocus" });
 
   constructor(model: Model) {
     super();
@@ -132,12 +133,16 @@ export class GridParent extends Component<any, SpreadsheetEnv> {
     this.model = model;
   }
 
-  get focusTopBarComposer(): boolean {
-    return this.model.getters.getEditionMode() !== "inactive" && this.composer.topBar;
+  get focusTopBarComposer(): "inactive" | "contentFocus" {
+    return this.model.getters.getEditionMode() === "inactive"
+      ? "inactive"
+      : this.composer.topBarFocus;
   }
 
-  get focusGridComposer(): boolean {
-    return this.model.getters.getEditionMode() !== "inactive" && this.composer.grid;
+  get focusGridComposer(): "inactive" | "cellFocus" | "contentFocus" {
+    return this.model.getters.getEditionMode() === "inactive"
+      ? "inactive"
+      : this.composer.gridFocusMode;
   }
 
   mounted() {
@@ -166,14 +171,19 @@ export class GridParent extends Component<any, SpreadsheetEnv> {
   }
 
   onTopBarComposerFocused(ev: CustomEvent) {
-    this.composer.grid = false;
-    this.composer.topBar = true;
+    this.composer.topBarFocus = "contentFocus";
+    this.composer.gridFocusMode = "inactive";
+    this.setComposerContent(ev.detail || {});
+  }
+  onGridComposerContentFocused(ev: CustomEvent) {
+    this.composer.topBarFocus = "inactive";
+    this.composer.gridFocusMode = "contentFocus";
     this.setComposerContent(ev.detail || {});
   }
 
-  onGridComposerFocused(ev: CustomEvent) {
-    this.composer.topBar = false;
-    this.composer.grid = true;
+  onGridComposerCellFocused(ev: CustomEvent) {
+    this.composer.topBarFocus = "inactive";
+    this.composer.gridFocusMode = "cellFocus";
     this.setComposerContent(ev.detail || {});
   }
 


### PR DESCRIPTION
currently when editing a cell, the arrowkeys will always move the caret
through the cell content.

this commit changes this behaviour:
The directional arrows will move the caret through the cell content, only if the user:
-opened the cell composer by double-clicking on it
-opened the cell composer by pressing F2
-is editing the content from the topbar composer


## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2523586](https://www.odoo.com/web#id=2523586&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
