### PR TITLE
[FIX] evaluation: use the latest cell object to store the value

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -57,6 +57,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     "getCellValue",
     "getCellStyle",
     "buildFormulaContent",
+    "getCellById",
   ];
 
   public readonly cells: { [sheetId: string]: { [id: string]: Cell } } = {};
@@ -368,6 +369,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   export(data: WorkbookData) {
     let styleId = 0;
     const styles: { [styleId: number]: Style } = {};
+
     /**
      * Get the id of the given style. If the style does not exist, it creates
      * one.
@@ -381,6 +383,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       styles[++styleId] = style;
       return styleId;
     }
+
     for (let _sheet of data.sheets) {
       const cells: { [key: string]: CellData } = {};
       for (let [cellId, cell] of Object.entries(this.cells[_sheet.id] || {})) {
@@ -422,6 +425,19 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   // ---------------------------------------------------------------------------
   getCells(sheetId: UID): Record<UID, Cell> {
     return this.cells[sheetId] || {};
+  }
+
+  /**
+   * get a cell by ID. Used in evaluation when evaluating an async cell, we need to be able to find it back after
+   * starting an async evaluation even if it has been moved or re-allocated
+   */
+  getCellById(cellId: UID): Cell | undefined {
+    for (const sheet of Object.values(this.cells)) {
+      if (sheet[cellId]) {
+        return sheet[cellId];
+      }
+    }
+    return undefined;
   }
 
   buildFormulaContent(sheetId: UID, formula: string, dependencies: Range[]): string {

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -63,6 +63,7 @@ export interface CoreGetters {
   getCellText: CellPlugin["getCellText"];
   getCellValue: CellPlugin["getCellValue"];
   getCellStyle: CellPlugin["getCellStyle"];
+  getCellById: CellPlugin["getCellById"];
 
   getClipboardContent: ClipboardPlugin["getClipboardContent"];
   isPaintingFormat: ClipboardPlugin["isPaintingFormat"];

--- a/tests/plugins/evaluation_async.test.ts
+++ b/tests/plugins/evaluation_async.test.ts
@@ -3,8 +3,8 @@ import { Model } from "../../src/model";
 import { LOADING } from "../../src/plugins/ui/evaluation";
 import { FormulaCell } from "../../src/types";
 import { setCellContent } from "../test_helpers/commands_helpers";
-import { getCell } from "../test_helpers/getters_helpers";
-import { initPatcher } from "../test_helpers/helpers";
+import { getCell, getCellContent } from "../test_helpers/getters_helpers";
+import { initPatcher, target } from "../test_helpers/helpers";
 
 let asyncComputations: () => Promise<void>;
 let waitForRecompute: () => Promise<void>;
@@ -257,5 +257,19 @@ describe("evaluateCells, async formulas", () => {
     expect(getCell(model, "A1")!.error).toBe("This is an error");
     expect(getCell(model, "A2")!.error).toBe("");
     expect(getCell(model, "A3")!.error).toBe("4");
+  });
+
+  test("change style while evaluating async formula", async () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=WAIT(300)");
+    model.dispatch("SET_FORMATTING", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: target("A1"),
+      style: {
+        strikethrough: true,
+      },
+    });
+    await waitForRecompute();
+    expect(getCellContent(model, "A1")).toBe("300");
   });
 });

--- a/tests/plugins/evaluation_async_issue.test.ts
+++ b/tests/plugins/evaluation_async_issue.test.ts
@@ -1,0 +1,99 @@
+import { Model } from "../../src";
+import { StateUpdateMessage } from "../../src/types/collaborative/transport_service";
+import { getCellContent } from "../test_helpers/getters_helpers";
+import { nextTick } from "../test_helpers/helpers";
+
+test("loading a save with extra commands moving cells that depends on async failed", async () => {
+  jest.useFakeTimers();
+
+  const data = {
+    version: 7,
+    sheets: [
+      {
+        name: "Sheet1",
+        colNumber: 26,
+        rowNumber: 120,
+        cols: { 1: {}, 3: {} },
+        rows: {},
+        cells: {
+          A1: { content: "=wait(10)" },
+          C12: { content: "=A1+A1" },
+        },
+        conditionalFormats: [
+          {
+            id: "1",
+            ranges: ["C12:C12"],
+            rule: {
+              values: ["10"],
+              operator: "Equal",
+              type: "CellIsRule",
+              style: { fillColor: "#FFA500" },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const stateUpdateMessages: StateUpdateMessage[] = [
+    {
+      type: "REMOTE_REVISION",
+      version: 1,
+      serverRevisionId: "START_REVISION",
+      nextRevisionId: "d8135fad-3f59-47fb-a529-775031e8efc3",
+      clientId: "784b2823-440c-4f54-affb-7c3ea542b70b",
+      commands: [
+        { type: "CLEAR_CELL", col: 2, row: 11, sheetId: "Sheet1" },
+        {
+          type: "CLEAR_FORMATTING",
+          sheetId: "Sheet1",
+          target: [{ left: 2, right: 2, top: 11, bottom: 11 }],
+        },
+        {
+          type: "UPDATE_CELL",
+          col: 10,
+          row: 12,
+          sheetId: "Sheet1",
+          content: "=A1+A1",
+          style: null,
+        },
+        {
+          type: "ADD_CONDITIONAL_FORMAT",
+          cf: {
+            id: "1",
+            rule: {
+              values: ["42"],
+              operator: "Equal",
+              type: "CellIsRule",
+              style: { fillColor: "#FFA500" },
+            },
+          },
+          target: [
+            { top: 0, bottom: 10, left: 2, right: 2 },
+            {
+              top: 12,
+              bottom: 99,
+              left: 2,
+              right: 2,
+            },
+            { top: 12, bottom: 12, left: 10, right: 10 },
+          ],
+          sheetId: "Sheet1",
+        },
+      ],
+    },
+  ];
+
+  const model = new Model(data, {}, stateUpdateMessages);
+
+  jest.advanceTimersByTime(10);
+  await nextTick();
+  expect(getCellContent(model, "A1")).toBe("10");
+
+  // We have "waited" for 10 ms, the =wait(10) is already done and the scheduler that uses setTimeout 5 ms,
+  // then setTimeout 15 ms (MAXIMUM_EVALUATION_CHECK_DELAY_MS) until all the pending cells are computed.
+  // The first wait 5 ms of the scheduler has already been done and some cells are still pending,
+  // so we need to wait 5 ms + 15 ms - 10 ms = 10 ms for the next scheduler run.
+  jest.advanceTimersByTime(10);
+  expect(getCellContent(model, "K13")).toBe("20");
+});


### PR DESCRIPTION
In the evaluation, the evaluated cells are stored as a reference to a
cell object. As updating a cell actually changes the reference, a cell
update **during** a async evaluation causes the evaluation to write the
value on the old reference.

This commit fixes this behavior by retrieving the last cell object.

Odoo-task-id 2575266

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2575266](https://www.odoo.com/web#id=2575266&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
