### PR TITLE
[IMP] collaborative_client_tag: display only on hover

### DIFF
--- a/src/components/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag.ts
@@ -18,7 +18,6 @@ const TEMPLATE = xml/* xml */ `
   <div>
     <div
       class="o-client-tag"
-      t-transition="fade"
       t-att-style="tagStyle"
       t-esc="props.name"
     />
@@ -34,13 +33,6 @@ const CSS = css/* scss */ `
     color: white;
     opacity: 0;
     pointer-events: none;
-  }
-  .o-client-tag.fade-enter {
-    opacity: 1;
-  }
-
-  .o-client-tag.fade-enter-to {
-    transition: opacity 0.3s 1s;
   }
 `;
 export class ClientTag extends Component<ClientTagProps, SpreadsheetEnv> {


### PR DESCRIPTION
As the tag display by default is quite bothering, this commit removes
the fade transition. The tag can be displayed by hovering the cell.

Odoo-task-id 2582276

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2582276](https://www.odoo.com/web#id=2582276&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
