### PR TITLE
[FIX] composer: include border in size computation

### DIFF
--- a/src/components/composer/grid_composer.ts
+++ b/src/components/composer/grid_composer.ts
@@ -121,7 +121,7 @@ export class GridComposer extends Component<Props, SpreadsheetEnv> {
 
   get composerStyle(): string {
     return `
-      line-height:${DEFAULT_CELL_HEIGHT}px;
+      line-height:${DEFAULT_CELL_HEIGHT - 2 * COMPOSER_BORDER_WIDTH}px;
       max-height: inherit;
       overflow: hidden;
     `;

--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -193,7 +193,7 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
         display: flex;
 
         .o-composer-container {
-          height: 34px;
+          height: 31px;
         }
 
         /* Toolbar */
@@ -340,7 +340,7 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
   menus: FullMenuItem[] = [];
   menuRef = useRef("menuRef");
   composerStyle = `
-    line-height: 34px;
+    line-height: 31px;
     border-bottom: 1px solid #e0e2e4;
     border-left: 1px solid #e0e2e4;
     background-color: white;

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -332,7 +332,7 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
           contenteditable="true"
           spellcheck="false"
           style="
-    line-height: 34px;
+    line-height: 31px;
     border-bottom: 1px solid #e0e2e4;
     border-left: 1px solid #e0e2e4;
     background-color: white;

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -369,7 +369,7 @@ exports[`TopBar component can set cell format 1`] = `
         contenteditable="true"
         spellcheck="false"
         style="
-    line-height: 34px;
+    line-height: 31px;
     border-bottom: 1px solid #e0e2e4;
     border-left: 1px solid #e0e2e4;
     background-color: white;
@@ -710,7 +710,7 @@ exports[`TopBar component simple rendering 1`] = `
         contenteditable="true"
         spellcheck="false"
         style="
-    line-height: 34px;
+    line-height: 31px;
     border-bottom: 1px solid #e0e2e4;
     border-left: 1px solid #e0e2e4;
     background-color: white;


### PR DESCRIPTION
Before this commit, the line height of the composers did not include
the border size, which caused an issue in the rendering.

Task-id 2531049

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2531049](https://www.odoo.com/web#id=2531049&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [X] undo-able commands (uses this.history.update)
- [X] multiuser-able commands (has inverse commands and transformations where needed)
- [X] translations (\_lt("qmsdf %s", abc))
- [X] unit tested
- [X] clean commented code
- [X] feature is organized in plugin, or UI components
- [X] exportable in excel
- [X] importable from excel
- [X] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [X] in model/UI: ranges are strings (to show the user)
- [X] new/updated/removed commands are documented
- [X] track breaking changes
- [X] public API change (index.ts) must rebuild doc (npm run doc)
- [X] code is prettified with prettier (in each commit, no separate commit)
- [X] status is correct in Odoo
