### PR TITLE
[IMP] highlights: allow to have same highlights several times

### DIFF
--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -535,8 +535,10 @@ export class EditionPlugin extends UIPlugin {
           (sheet ? `${sheet}!` : `${this.getters.getSheetName(this.getters.getEditionSheet())}!`) +
           xc.replace(/\$/g, "");
         if (!ranges[refSanitized]) {
-          ranges[refSanitized] = colors[lastUsedColorIndex];
+          ranges[refSanitized] = { color: colors[lastUsedColorIndex], quantity: 1 };
           lastUsedColorIndex = ++lastUsedColorIndex % colors.length;
+        } else {
+          ranges[refSanitized].quantity++;
         }
       }
     }

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -1,7 +1,7 @@
 import { rangeReference } from "../../formulas/index";
 import { getComposerSheetName, getNextColor, uuidv4 } from "../../helpers/index";
 import { Mode } from "../../model";
-import { Command, CommandResult, Highlight, LAYERS, UID } from "../../types/index";
+import { Command, CommandResult, Highlight, LAYERS, UID, ZoneReference } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 import { SelectionMode } from "./selection";
 
@@ -349,17 +349,17 @@ export class SelectionInputPlugin extends UIPlugin {
   private inputToHighlights(
     id: UID,
     { xc, color }: Pick<RangeInputValue, "xc" | "color">
-  ): { [range: string]: string } {
+  ): { [range: string]: ZoneReference } {
     const ranges = this.cleanInputs([xc])
       .filter((range) => this.isRangeValid(range))
       .filter((reference) => this.shouldBeHighlighted(this.activeSheets[id], reference));
     if (ranges.length === 0) return {};
     const [fromInput, ...otherRanges] = ranges;
-    const highlights: { [range: string]: string } = {
-      [fromInput]: color || getNextColor(),
+    const highlights: { [range: string]: ZoneReference } = {
+      [fromInput]: { quantity: 1, color: color || getNextColor() },
     };
     for (const range of otherRanges) {
-      highlights[range] = getNextColor();
+      highlights[range] = { quantity: 1, color: getNextColor() };
     }
     return highlights;
   }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -2,7 +2,15 @@ import { ComposerSelection } from "../plugins/ui/edition";
 import { ReplaceOptions, SearchOptions } from "../plugins/ui/find_and_replace";
 import { ChartUIDefinitionUpdate } from "./chart";
 import { BorderCommand, ChartUIDefinition, ConditionalFormat, Figure, Style, Zone } from "./index";
-import { Border, Cell, CellPosition, ClipboardOptions, Dimension, UID } from "./misc";
+import {
+  Border,
+  Cell,
+  CellPosition,
+  ClipboardOptions,
+  Dimension,
+  UID,
+  ZoneReference,
+} from "./misc";
 
 // -----------------------------------------------------------------------------
 // Grid commands
@@ -519,7 +527,7 @@ export interface HighlightSelectionCommand extends BaseCommand {
  */
 export interface AddPendingHighlightCommand extends BaseCommand {
   type: "ADD_PENDING_HIGHLIGHTS";
-  ranges: { [range: string]: string };
+  ranges: { [range: string]: ZoneReference };
 }
 
 /**
@@ -570,7 +578,7 @@ export interface EvaluateCellsCommand extends BaseCommand {
 
 export interface AddHighlightsCommand extends BaseCommand {
   type: "ADD_HIGHLIGHTS";
-  ranges: { [range: string]: string };
+  ranges: { [range: string]: ZoneReference };
 }
 
 /**
@@ -583,7 +591,7 @@ export interface RemoveHighlightsCommand extends BaseCommand {
    * are the associated colors.
    * e.g. { B4: "#e2e2e2" }
    */
-  ranges: { [range: string]: string };
+  ranges: { [range: string]: ZoneReference };
 }
 export interface RemoveAllHighlightsCommand extends BaseCommand {
   type: "REMOVE_ALL_HIGHLIGHTS";

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -19,6 +19,11 @@ export interface ZoneDimension {
   width: number;
 }
 
+export interface ZoneReference {
+  quantity: number;
+  color: string;
+}
+
 export type Align = "left" | "right" | "center" | undefined;
 export interface Style {
   bold?: boolean;

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -938,11 +938,12 @@ describe("composer highlights color", () => {
     expect(getHighlights(model)[1].color).toBe(colors[1]);
   });
 
-  test("highlight do not duplicate", async () => {
+  test("duplicate highlights when there are several same ranges", async () => {
     setCellContent(model, "A1", "=a1+a1");
     await startComposition();
-    expect(getHighlights(model).length).toBe(1);
+    expect(getHighlights(model).length).toBe(2);
     expect(getHighlights(model)[0].color).toBe(colors[0]);
+    expect(getHighlights(model)[1].color).toBe(colors[0]);
   });
 
   test("highlight range", async () => {

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -138,7 +138,7 @@ describe("Selection Input", () => {
     const { model } = await createSelectionInput();
     model.dispatch("ADD_HIGHLIGHTS", {
       ranges: {
-        B4: "#454545",
+        B4: { quantity: 1, color: "#454545" },
       },
     });
     await nextTick();
@@ -147,7 +147,7 @@ describe("Selection Input", () => {
     simulateClick(".o-add-selection");
     model.dispatch("ADD_HIGHLIGHTS", {
       ranges: {
-        B5: "#787878",
+        B5: { quantity: 1, color: "#787878" },
       },
     });
     await nextTick();
@@ -239,7 +239,7 @@ describe("Selection Input", () => {
     const { model } = await createSelectionInput({ onChanged });
     model.dispatch("ADD_HIGHLIGHTS", {
       ranges: {
-        B4: "#454545",
+        B4: { quantity: 1, color: "#454545" },
       },
     });
     await nextTick();
@@ -267,7 +267,7 @@ describe("Selection Input", () => {
     activateSheet(model, "42");
     model.dispatch("ADD_HIGHLIGHTS", {
       ranges: {
-        B4: "#454545",
+        B4: { quantity: 1, color: "#454545" },
       },
     });
     await nextTick();
@@ -284,7 +284,7 @@ describe("Selection Input", () => {
     activateSheet(model, "42");
     model.dispatch("ADD_HIGHLIGHTS", {
       ranges: {
-        B4: "#454545",
+        B4: { quantity: 1, color: "#454545" },
       },
     });
     await nextTick();

--- a/tests/plugins/highlight.test.ts
+++ b/tests/plugins/highlight.test.ts
@@ -22,7 +22,7 @@ beforeEach(async () => {
 describe("highlight", () => {
   test("add highlight", () => {
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B2: "#888" },
+      ranges: { B2: { quantity: 1, color: "#888" } },
     });
     expect(model.getters.getHighlights()).toStrictEqual([
       {
@@ -35,7 +35,7 @@ describe("highlight", () => {
 
   test("remove all highlight", () => {
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B2: "#888", B6: "#999" },
+      ranges: { B2: { quantity: 1, color: "#888" }, B6: { quantity: 1, color: "#999" } },
     });
     expect(model.getters.getHighlights().length).toBe(2);
     model.dispatch("REMOVE_ALL_HIGHLIGHTS");
@@ -44,10 +44,10 @@ describe("highlight", () => {
 
   test("remove a single highlight", () => {
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B2: "#888", B6: "#999" },
+      ranges: { B2: { quantity: 1, color: "#888" }, B6: { quantity: 1, color: "#999" } },
     });
     model.dispatch("REMOVE_HIGHLIGHTS", {
-      ranges: { B6: "#999" },
+      ranges: { B6: { quantity: 1, color: "#999" } },
     });
     expect(model.getters.getHighlights()).toStrictEqual([
       {
@@ -67,10 +67,10 @@ describe("highlight", () => {
 
   test("remove highlight with another color", () => {
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B2: "#888" },
+      ranges: { B2: { quantity: 1, color: "#888" } },
     });
     model.dispatch("REMOVE_HIGHLIGHTS", {
-      ranges: { B2: "#999" },
+      ranges: { B2: { quantity: 1, color: "#999" } },
     });
     expect(model.getters.getHighlights()).toStrictEqual([
       {
@@ -83,13 +83,13 @@ describe("highlight", () => {
 
   test("remove highlight with same range", () => {
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B2: "#888" },
+      ranges: { B2: { quantity: 1, color: "#888" } },
     });
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B2: "#999" },
+      ranges: { B2: { quantity: 1, color: "#999" } },
     });
     model.dispatch("REMOVE_HIGHLIGHTS", {
-      ranges: { B2: "#999" },
+      ranges: { B2: { quantity: 1, color: "#999" } },
     });
     expect(model.getters.getHighlights()).toStrictEqual([
       {
@@ -102,10 +102,10 @@ describe("highlight", () => {
 
   test("remove highlight with sheet reference", () => {
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B2: "#888" },
+      ranges: { B2: { quantity: 1, color: "#888" } },
     });
     model.dispatch("REMOVE_HIGHLIGHTS", {
-      ranges: { "Sheet1!B2": "#888" },
+      ranges: { "Sheet1!B2": { quantity: 1, color: "#888" } },
     });
     expect(model.getters.getHighlights()).toHaveLength(0);
   });
@@ -113,11 +113,11 @@ describe("highlight", () => {
   test("remove highlight from another sheet", () => {
     const sheet1 = model.getters.getActiveSheetId();
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B2: "#888" },
+      ranges: { B2: { quantity: 1, color: "#888" } },
     });
     createSheet(model, { sheetId: "42", activate: true });
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B2: "#888" },
+      ranges: { B2: { quantity: 1, color: "#888" } },
     });
     expect(model.getters.getHighlights()).toStrictEqual([
       {
@@ -132,7 +132,7 @@ describe("highlight", () => {
       },
     ]);
     model.dispatch("REMOVE_HIGHLIGHTS", {
-      ranges: { B2: "#888" },
+      ranges: { B2: { quantity: 1, color: "#888" } },
     });
     expect(model.getters.getHighlights()).toStrictEqual([
       {
@@ -330,10 +330,10 @@ describe("highlight", () => {
 
   test("selection with manually set pending highlight", () => {
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { B10: "#999" },
+      ranges: { B10: { quantity: 1, color: "#999" } },
     });
     model.dispatch("ADD_PENDING_HIGHLIGHTS", {
-      ranges: { B10: "#999" },
+      ranges: { B10: { quantity: 1, color: "#999" } },
     });
     model.dispatch("HIGHLIGHT_SELECTION", { enabled: true });
     model.dispatch("START_SELECTION");
@@ -413,7 +413,7 @@ describe("highlight", () => {
   test("disabling selection highlighting resets pending highlights", () => {
     model.dispatch("HIGHLIGHT_SELECTION", { enabled: true });
     model.dispatch("ADD_PENDING_HIGHLIGHTS", {
-      ranges: { B10: "#999" },
+      ranges: { B10: { quantity: 1, color: "#999" } },
     });
     expect(getPendingHighlights(model).length).toBe(1);
     model.dispatch("HIGHLIGHT_SELECTION", { enabled: false });

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -106,9 +106,9 @@ describe("selection input plugin", () => {
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, maximumRanges: 2 });
     model.dispatch("ADD_HIGHLIGHTS", {
       ranges: {
-        A1: "#000",
-        B1: "#000",
-        C1: "#000",
+        A1: { quantity: 1, color: "#000" },
+        B1: { quantity: 1, color: "#000" },
+        C1: { quantity: 1, color: "#000" },
       },
     });
     expect(model.getters.getSelectionInput(id)).toHaveLength(2);
@@ -426,7 +426,7 @@ describe("selection input plugin", () => {
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
     createSheet(model, { sheetId: "42", activate: true });
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { A1: "#000" },
+      ranges: { A1: { quantity: 1, color: "#000" } },
     });
     expect(model.getters.getSelectionInput(id)[0].xc).toBe("Sheet2!A1");
   });
@@ -437,7 +437,7 @@ describe("selection input plugin", () => {
       model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
       createSheetWithName(model, { sheetId: "42", activate: true }, sheetName);
       model.dispatch("ADD_HIGHLIGHTS", {
-        ranges: { A1: "#000" },
+        ranges: { A1: { quantity: 1, color: "#000" } },
       });
       expect(model.getters.getSelectionInput(id)[0].xc).toBe(`'${sheetName}'!A1`);
     }
@@ -446,7 +446,7 @@ describe("selection input plugin", () => {
   test("focus while in other sheet", () => {
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
     model.dispatch("ADD_HIGHLIGHTS", {
-      ranges: { A1: "#000" },
+      ranges: { A1: { quantity: 1, color: "#000" } },
     });
     createSheet(model, { sheetId: "42", activate: true });
     model.dispatch("FOCUS_RANGE", { id, rangeId: null });


### PR DESCRIPTION
## Description:

The task (Odoo-task-id) #2560657 asks us to have interaction with each highlights
present on the grid. And the resizing of an highlight must not bring to the deletion
of this one when it coincides with another highlight having the same zone.

Indeed, this would remove the element of the dom on which the resize action takes place,
thus creating a bug.

We therefore need to have for each reference found in duplicate a specific highlight.

Odoo task ID : [2593602](https://www.odoo.com/web#id=2593602&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
