### PR TITLE
[FIX] style: Unify style with Odoo

### DIFF
--- a/src/components/composer/grid_composer.ts
+++ b/src/components/composer/grid_composer.ts
@@ -121,7 +121,7 @@ export class GridComposer extends Component<Props, SpreadsheetEnv> {
 
   get composerStyle(): string {
     return `
-      line-height:${DEFAULT_CELL_HEIGHT}px;
+      line-height:${DEFAULT_CELL_HEIGHT - 2 * COMPOSER_BORDER_WIDTH}px;
       max-height: inherit;
       overflow: hidden;
     `;

--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -1,5 +1,10 @@
 import * as owl from "@odoo/owl";
-import { BOTTOMBAR_HEIGHT, ICON_EDGE_LENGTH, TOPBAR_HEIGHT } from "../constants";
+import {
+  BOTTOMBAR_HEIGHT,
+  CF_ICON_EDGE_LENGTH,
+  ICON_EDGE_LENGTH,
+  TOPBAR_HEIGHT,
+} from "../constants";
 import { Model } from "../model";
 import { ComposerSelection } from "../plugins/ui/edition";
 import { SelectionMode } from "../plugins/ui/selection";
@@ -65,11 +70,12 @@ const CSS = css/* scss */ `
     width: ${ICON_EDGE_LENGTH}px;
     height: ${ICON_EDGE_LENGTH}px;
     opacity: 0.6;
+    vertical-align: middle;
   }
 
   .o-cf-icon {
-    width: 15px;
-    height: 15px;
+    width: ${CF_ICON_EDGE_LENGTH}px;
+    height: ${CF_ICON_EDGE_LENGTH}px;
     vertical-align: sub;
   }
 `;

--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -160,6 +160,7 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
       display: flex;
       flex-direction: column;
       font-size: 13px;
+      line-height: 1.2;
 
       .o-topbar-top {
         border-bottom: 1px solid #e0e2e4;
@@ -200,7 +201,7 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
         .o-toolbar-tools {
           display: flex;
           flex-shrink: 0;
-          margin-left: 20px;
+          margin-left: 16px;
           color: #333;
           cursor: default;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,7 @@ export const ICON_EDGE_LENGTH = 18;
 export const UNHIDE_ICON_EDGE_LENGTH = 14;
 export const MIN_CF_ICON_MARGIN = 4;
 export const MIN_CELL_TEXT_MARGIN = 4;
+export const CF_ICON_EDGE_LENGTH = 15;
 
 export const FIGURE_BORDER_SIZE = 1;
 


### PR DESCRIPTION
Up until the indroduction of bootstrap in this repository, we have
had to make specific style rules inside Odoo for both versions of
spreadsheet to look the same. Concretely, we had to override
o-spreadsheet rules inside documents_spreadsheet because the former did
not have default css rules introduced by bootstrap (e.g.
`vertical-align: mmiddle` on icons).

Now that bootstrap is part of o_spreadsheet, the old o-spreadsheet rules
have become obsolete and as we removed them, we did not correctly adapt
documents_spreadsheet. With bootstrap, we can however define rules
directly in the components definition as those will applied in both
o-spreadsheet and documents_spreadsheet.

Co-authored-by: Pierre Rousseau <pro@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2531049](https://www.odoo.com/web#id=2531049&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
