### PR TITLE
[FIX] tests: Node needs a timezone

### DIFF
--- a/tests/functions/module_date_test.ts
+++ b/tests/functions/module_date_test.ts
@@ -6,7 +6,7 @@ describe("date", () => {
   // DATE
   //----------------------------------------------------------------------------
 
-  test("DATE: functional tests on cell arguments", () => {
+  test("DATE: functional tests on cell arguments CHECK TIMEZONE IF FAILS", () => {
     // prettier-ignore
     const grid = {
       // YEAR / MONTH / DAY


### PR DESCRIPTION
Some date tests (namely date > DATE: functional tests on cell arguments)
might fail when Node uses a wrong timezone. In this case, you need to
make sure it has a timezone.

e.g. on Linux, the environment variable TZ needs to be defined.
To do so, run tzselect, choose a timezone then you can add it to your
.profile.
```bash
tzselect && echo $TZ >> ~/.profile
```

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2605530](https://www.odoo.com/web#id=2605530&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
