### PR TITLE
[FIX] Selection: handle hidden cells when reducing selection

### DIFF
--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -493,3 +493,12 @@ export function findCellInNewZone(
   }
   return [col, row];
 }
+
+export function organizeZone(zone: Zone): Zone {
+  return {
+    top: Math.min(zone.top, zone.bottom),
+    bottom: Math.max(zone.top, zone.bottom),
+    left: Math.min(zone.left, zone.right),
+    right: Math.max(zone.left, zone.right),
+  };
+}

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -156,11 +156,53 @@ describe("selection", () => {
 
     // select right cell C3
     model.dispatch("ALTER_SELECTION", { cell: [2, 2] });
-
-    expect(model.getters.getSelectedZones()[0]).toEqual({ top: 1, right: 3, left: 1, bottom: 2 });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("B2:D3"));
   });
 
-  test("extend selection through hidden columns", () => {
+  test("expand selection when starting from a merge", () => {
+    const model = new Model({
+      sheets: [
+        {
+          colNumber: 10,
+          rowNumber: 10,
+          merges: ["B2:B3", "E2:G2"],
+        },
+      ],
+    });
+    selectCell(model, "B2");
+    model.dispatch("ALTER_SELECTION", { delta: [0, 1] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("B2:B4"));
+
+    selectCell(model, "B2");
+    model.dispatch("ALTER_SELECTION", { delta: [0, -1] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("B1:B3"));
+
+    selectCell(model, "B3");
+    model.dispatch("ALTER_SELECTION", { delta: [0, 1] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("B2:B4"));
+
+    selectCell(model, "B3");
+    model.dispatch("ALTER_SELECTION", { delta: [0, -1] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("B1:B3"));
+
+    selectCell(model, "E2");
+    model.dispatch("ALTER_SELECTION", { delta: [1, 0] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("E2:H2"));
+
+    selectCell(model, "E2");
+    model.dispatch("ALTER_SELECTION", { delta: [-1, 0] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("D2:G2"));
+
+    selectCell(model, "G2");
+    model.dispatch("ALTER_SELECTION", { delta: [1, 0] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("E2:H2"));
+
+    selectCell(model, "G2");
+    model.dispatch("ALTER_SELECTION", { delta: [-1, 0] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("D2:G2"));
+  });
+
+  test("extend and reduce selection through hidden columns", () => {
     const model = new Model({
       sheets: [
         {
@@ -173,9 +215,11 @@ describe("selection", () => {
     selectCell(model, "B1");
     model.dispatch("ALTER_SELECTION", { delta: [1, 0] });
     expect(model.getters.getSelectedZone()).toEqual(toZone("B1:E1"));
+    model.dispatch("ALTER_SELECTION", { delta: [-1, 0] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("B1"));
   });
 
-  test("extend selection through hidden rows", () => {
+  test("extend and reduce selection through hidden rows", () => {
     const model = new Model({
       sheets: [
         {
@@ -188,6 +232,8 @@ describe("selection", () => {
     selectCell(model, "A5");
     model.dispatch("ALTER_SELECTION", { delta: [0, -1] });
     expect(model.getters.getSelectedZone()).toEqual(toZone("A2:A5"));
+    model.dispatch("ALTER_SELECTION", { delta: [0, 1] });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A5"));
   });
 
   test("can select a whole column", () => {


### PR DESCRIPTION
Since commit 9fde073563dbe489c9db24592167afb20bca51b3, hidden cells will
be "jumped" over when moving a selection or extending it but not when
reducing it.

E.g.
- Hide B, C
- select A1
- Shift+ArrowRight => B & C are jumped: ok, D1 is selected
- Shift+ArrowLeft => B & C are not jumped

task 2615378

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2615378](https://www.odoo.com/web#id=2615378&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
