### PR TITLE
[FIX] viewport: Use a visible cell position to adjust viewport

### DIFF
--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -276,9 +276,9 @@ export class ViewportPlugin extends UIPlugin {
     const { cols, rows } = sheet;
     const adjustedViewport = this.getSnappedViewport(sheetId);
     position = position || this.getters.getSheetPosition(sheetId);
-    const [col, row] = this.getters.getMainCell(
-      sheetId,
-      ...getNextVisibleCellCoords(sheet, position[0], position[1])
+    const [col, row] = getNextVisibleCellCoords(
+      sheet,
+      ...this.getters.getMainCell(sheetId, position[0], position[1])
     );
     while (
       cols[col].end > adjustedViewport.offsetX + this.clientWidth - HEADER_WIDTH &&

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -327,6 +327,28 @@ describe("selection", () => {
     expect(model.getters.getPosition()).toEqual([1, 0]);
     expect(model.getters.getSheetPosition("42")).toEqual([1, 0]);
   });
+
+  test("Select a merge when its topLeft column is hidden", () => {
+    const model = new Model({
+      sheets: [{ colNumber: 3, rowNumber: 2, merges: ["A1:B2"], cols: { 0: { isHidden: true } } }],
+    });
+    selectCell(model, "B1");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B2"));
+    selectCell(model, "C2");
+    model.dispatch("MOVE_POSITION", { deltaX: -1, deltaY: 0 });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B2"));
+  });
+
+  test("Select a merge when its topLeft row is hidden", () => {
+    const model = new Model({
+      sheets: [{ colNumber: 2, rowNumber: 3, merges: ["A1:B2"], rows: { 0: { isHidden: true } } }],
+    });
+    selectCell(model, "A2");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B2"));
+    selectCell(model, "A3");
+    model.dispatch("MOVE_POSITION", { deltaX: 0, deltaY: -1 });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B2"));
+  });
 });
 
 describe("multiple selections", () => {


### PR DESCRIPTION
When adjusting a viewport position, typically after modifying the
selection to select a merge, we'd adjust the viewport to make sure the
main cell of the merge is visible. Unfortunately, when the said cell
is hidden and is on a boundary of the grid, we'd fall into an infinite
loop. Adjusting the viewport on a hidden cell is a mistake, we should
adjust it on the next visible cell instead.

task 2616482

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2616482](https://www.odoo.com/web#id=2616482&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
