### PR TITLE
[FIX] Helpers: generalize reference regexes

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -1,7 +1,7 @@
 import * as owl from "@odoo/owl";
-import { EnrichedToken, rangeReference } from "../../formulas/index";
+import { EnrichedToken } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { DEBUG, zoneToXc } from "../../helpers/index";
+import { DEBUG, rangeReference, zoneToXc } from "../../helpers/index";
 import { ComposerSelection, SelectionIndicator } from "../../plugins/ui/edition";
 import { FunctionDescription, Rect, SpreadsheetEnv } from "../../types/index";
 import { TextValueProvider } from "./autocomplete_dropdown";

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -1,6 +1,5 @@
 import * as owl from "@odoo/owl";
-import { rangeReference } from "../../../formulas";
-import { colorNumberString, toZone } from "../../../helpers/index";
+import { colorNumberString, rangeReference, toZone } from "../../../helpers/index";
 import {
   ColorScaleRule,
   CommandResult,

--- a/src/formulas/index.ts
+++ b/src/formulas/index.ts
@@ -10,6 +10,6 @@
 export { compile } from "./compiler";
 export { composerTokenize } from "./composer_tokenizer";
 export { normalize } from "./normalize";
-export { cellReference, parse, rangeReference } from "./parser";
+export { parse } from "./parser";
 export { EnrichedToken, FunctionContext, rangeTokenize } from "./range_tokenizer";
 export { Token, tokenize } from "./tokenizer";

--- a/src/formulas/normalize.ts
+++ b/src/formulas/normalize.ts
@@ -1,5 +1,5 @@
+import { cellReference } from "../helpers";
 import { NormalizedFormula } from "../types";
-import { cellReference } from "./parser";
 import { rangeTokenize } from "./range_tokenizer";
 import { FORMULA_REF_IDENTIFIER } from "./tokenizer";
 

--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -109,12 +109,6 @@ function bindingPower(token: Token): number {
   throw new Error(_lt("Unknown token: %s", token.value));
 }
 
-export const cellReference = new RegExp(/\$?[A-Z]+\$?[0-9]+/, "i");
-export const rangeReference = new RegExp(
-  /^\s*(.*!)?\$?[A-Z]+\$?[0-9]+\s*(\s*:\s*\$?[A-Z]+\$?[0-9]+\s*)?$/,
-  "i"
-);
-
 function parsePrefix(current: Token, tokens: Token[]): AST {
   switch (current.type) {
     case "DEBUGGER":

--- a/src/helpers/coordinates.ts
+++ b/src/helpers/coordinates.ts
@@ -2,6 +2,8 @@
 // Coordinate
 //------------------------------------------------------------------------------
 
+import { cellReference } from "./references";
+
 /**
  * Convert a (col) number to the corresponding letter.
  *
@@ -48,7 +50,7 @@ export function lettersToNumber(letters: string): number {
  */
 export function toCartesian(xc: string): [number, number] {
   xc = xc.toUpperCase().trim();
-  const [m, letters, numbers] = xc.match(/\$?([A-Z]{1,3})\$?([0-9]{1,7})/)!;
+  const [m, letters, numbers] = xc.match(cellReference)!;
   if (m !== xc) {
     throw new Error(`Invalid cell description: ${xc}`);
   }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -4,6 +4,7 @@ export * from "./edge_scrolling";
 export * from "./grid_manipulation";
 export * from "./misc";
 export * from "./numbers";
+export * from "./references";
 export * from "./sheet";
 export * from "./uuid";
 export * from "./visibility";

--- a/src/helpers/references.ts
+++ b/src/helpers/references.ts
@@ -1,0 +1,8 @@
+/**
+ * Regex that detect cell reference and a range reference (without the sheetName)
+ */
+export const cellReference = new RegExp(/\$?([A-Z]{1,3})\$?([0-9]{1,7})/, "i");
+export const rangeReference = new RegExp(
+  /^\s*(.*!)?\$?[A-Z]{1,3}\$?[0-9]{1,7}\s*(\s*:\s*\$?[A-Z]{1,3}\$?[0-9]{1,7}\s*)?$/,
+  "i"
+);

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -1,5 +1,4 @@
-import { rangeReference } from "../../formulas/parser";
-import { zoneToDimension, zoneToXc } from "../../helpers/index";
+import { rangeReference, zoneToDimension, zoneToXc } from "../../helpers/index";
 import {
   ApplyRangeChange,
   ChartDefinition,

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -1,10 +1,10 @@
 import { INCORRECT_RANGE_STRING } from "../../constants";
-import { rangeReference } from "../../formulas";
 import {
   createAdaptedZone,
   getComposerSheetName,
   groupConsecutive,
   numberToLetters,
+  rangeReference,
   toZoneWithoutBoundaryChanges,
 } from "../../helpers/index";
 import {

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -1,9 +1,10 @@
 import { DATETIME_FORMAT } from "../../constants";
-import { composerTokenize, EnrichedToken, rangeReference } from "../../formulas/index";
+import { composerTokenize, EnrichedToken } from "../../formulas/index";
 import { formatDateTime } from "../../functions/dates";
 import {
   colors,
   getComposerSheetName,
+  rangeReference,
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
 } from "../../helpers/index";

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -1,5 +1,4 @@
-import { rangeReference } from "../../formulas/index";
-import { getComposerSheetName, getNextColor } from "../../helpers/index";
+import { getComposerSheetName, getNextColor, rangeReference } from "../../helpers/index";
 import { Mode } from "../../model";
 import { Command, CommandResult, Highlight, LAYERS, UID } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -551,4 +551,12 @@ describe("edition", () => {
     setCellContent(model, "B1", "");
     expect(model.getters.getCurrentContent()).toBe("");
   });
+
+  test("Setting a partial reference as content should not throw an error", () => {
+    const model = new Model();
+    model.dispatch("START_EDITION");
+    model.dispatch("SET_CURRENT_CONTENT", { content: "=Sheet1" });
+    model.dispatch("STOP_EDITION");
+    expect(model.getters.getCurrentContent()).toBe("=Sheet1");
+  });
 });


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Since commit 8b6003bac6e5d4c3a85c85751d3d3b54f3dec99e, toCartesian
throws an error on invalid provided XC. When setting a partial reference
in a cell (e.g. "=Sheet1"), the reference is detected as invalid an
toCartesian (because of the new arbitrary limit) will throw, which
is silent in o-spreadsheet but not in Odoo.

The issue is that the partial reference should be caught earlier when
testing the reference against the rangeReference (or cellReference) regex.

This commit generalizes the new arbitrary limit to cellReference and
rangeReference.

Both regexes were also moved in the helpers to avoid circular
dependencies.

Task 2618171


Odoo task ID : [2618171](https://www.odoo.com/web#id=2618171&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
