### PR TITLE
[FIX] core: Reference update on header deletion

### DIFF
--- a/tests/plugins/grid_manipulation_test.ts
+++ b/tests/plugins/grid_manipulation_test.ts
@@ -379,7 +379,7 @@ describe("Columns", () => {
         sheets: [
           {
             colNumber: 7,
-            rowNumber: 4,
+            rowNumber: 7,
             cells: {
               A1: { content: "=B1" },
               A2: { content: "=Sheet1!B1" },
@@ -388,6 +388,9 @@ describe("Columns", () => {
               D2: { content: "=B1" },
               D3: { content: "=$E1" },
               D4: { content: "=D3" },
+              A5: { content: "=SUM(A1:D1)" },
+              A6: { content: "=SUM(C1:D1)" },
+              A7: { content: "=SUM(B1:B2)" },
             },
           },
           {
@@ -512,13 +515,17 @@ describe("Columns", () => {
         sheets: [
           {
             colNumber: 9,
-            rowNumber: 3,
+            rowNumber: 5,
             cells: {
-              A1: { content: "=SUM(A2:E5)" },
+              A1: { content: "=SUM(B2:E5)" },
+              A2: { content: "=SUM(F1:F2)" }, // single column range
             },
           },
         ],
       });
+
+      removeColumns([5]);
+      expect(getSheet(model, 0).cells.A2.content).toBe("=SUM(#REF)");
       removeColumns([1, 2, 3, 4]);
       expect(getSheet(model, 0).cells.A1.content).toBe("=SUM(#REF)");
     });
@@ -586,6 +593,9 @@ describe("Columns", () => {
         F2: { content: "=D1" },
         F3: { content: "=$G1" },
         F4: { content: "=F3" },
+        A5: { content: "=SUM(A1:F1)" },
+        A6: { content: "=SUM(E1:F1)" },
+        A7: { content: "=SUM(D1:D2)" },
       });
       expect(getSheet(model, 1).cells).toMatchObject({
         A1: { content: "=B1" },
@@ -759,14 +769,17 @@ describe("Rows", () => {
       model = new Model({
         sheets: [
           {
-            colNumber: 3,
+            colNumber: 5,
             rowNumber: 9,
             cells: {
               A1: { content: "=SUM(A2:A5)" },
+              B1: { content: "=SUM(B6:C6)" }, // single line range
             },
           },
         ],
       });
+      removeRows([5]);
+      expect(getSheet(model, 0).cells.B1.content).toBe("=SUM(#REF)");
       removeRows([1, 2, 3, 4]);
       expect(getSheet(model, 0).cells.A1.content).toBe("=SUM(#REF)");
     });
@@ -982,7 +995,7 @@ describe("Rows", () => {
       model = new Model({
         sheets: [
           {
-            colNumber: 4,
+            colNumber: 7,
             rowNumber: 7,
             cells: {
               A1: { content: "=A2" },
@@ -992,6 +1005,9 @@ describe("Rows", () => {
               C1: { content: "=Sheet2!A2" },
               C4: { content: "=A$5" },
               D4: { content: "=C4" },
+              E1: { content: "=SUM(A1:A4)" },
+              F1: { content: "=SUM(A3:A4)" },
+              G1: { content: "=SUM(B2:C2)" },
             },
           },
           {
@@ -1219,6 +1235,9 @@ describe("Rows", () => {
         C1: { content: "=Sheet2!A2" },
         C6: { content: "=A$7" },
         D6: { content: "=C6" },
+        E1: { content: "=SUM(A1:A6)" },
+        F1: { content: "=SUM(A5:A6)" },
+        G1: { content: "=SUM(B4:C4)" },
       });
       expect(getSheet(model, 1).cells).toMatchObject({
         A1: { content: "=A2" },


### PR DESCRIPTION
Currently, when deleting a column (resp. row), references are updated
based on the assumption that they span over several columns (resp.
rows).
When the reference spans over a single column (resp. row) (e.g. A1:A2),
and that that specific header is being deleted, the "right" part of the
reference is shifted to the left of the "left" part of the reference,
making it invalid. When this happens on column A (resp row 1), the code
crashes because we try to process an invalid zone (where right= -1).

e.g.

in C1,
input "=sum(A1:A2)"
delete column A
=> a traceback occurs

Task 2619342

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2619342](https://www.odoo.com/web#id=2619342&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)


