### PR TITLE
[REF] sheet: always return sheet name or throw

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -327,10 +327,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       if (range.invalidSheetName) {
         sheetName = range.invalidSheetName;
       } else {
-        const s = this.getters.getSheetName(range.sheetId);
-        if (s) {
-          sheetName = getComposerSheetName(s);
-        }
+        sheetName = getComposerSheetName(this.getters.getSheetName(range.sheetId));
       }
     }
 

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -274,8 +274,11 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     return sheet;
   }
 
-  getSheetName(sheetId: UID): string | undefined {
-    return this.sheets[sheetId]?.name;
+  /**
+   * Return the sheet name. Throw if the sheet is not found.
+   */
+  getSheetName(sheetId: UID): string {
+    return this.getSheet(sheetId).name;
   }
 
   getSheetIdByName(name: string | undefined): UID | undefined {

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -484,7 +484,7 @@ export class EditionPlugin extends UIPlugin {
     let selectedXc = this.getters.zoneToXC(sheetId, zone);
     if (this.getters.getEditionSheet() !== this.getters.getActiveSheetId()) {
       const sheetName = getComposerSheetName(
-        this.getters.getSheetName(this.getters.getActiveSheetId())!
+        this.getters.getSheetName(this.getters.getActiveSheetId())
       );
       selectedXc = `${sheetName}!${selectedXc}`;
     }

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -329,10 +329,7 @@ export class SelectionInputPlugin extends UIPlugin {
       Object.freeze({
         xc:
           h.sheet !== activeSheetId
-            ? `${getComposerSheetName(this.getters.getSheetName(h.sheet)!)}!${toXC(
-                sheetId,
-                h.zone
-              )}`
+            ? `${getComposerSheetName(this.getters.getSheetName(h.sheet))}!${toXC(sheetId, h.zone)}`
             : toXC(sheetId, h.zone),
         id: uuidv4(),
         color: h.color,

--- a/src/plugins/ui/ui_sheet.ts
+++ b/src/plugins/ui/ui_sheet.ts
@@ -120,7 +120,7 @@ export class SheetUIPlugin extends UIPlugin {
   }
 
   private interactiveRenameSheet(sheetId: UID, title: string) {
-    const placeholder = this.getters.getSheetName(sheetId)!;
+    const placeholder = this.getters.getSheetName(sheetId);
     this.ui.editText(title, placeholder, (name: string | null) => {
       if (!name) {
         return;


### PR DESCRIPTION
Currently, the getter `getSheetName` returns the sheet name or `undefined` if
the sheet is not found. However, in practice, the sheet always exists for
every use of the getter. This leads to unnecesarry `if` conditions, fallbacks
or "non-null/undefined" operator (`!`) in order to compile the code.

Now, the getter throws an error if the sheet is not found (it currently never
happens).

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [ ] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
