### PR TITLE
[FIX] selection_inputs: make the id unique

### DIFF
--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -1,8 +1,15 @@
-import { getComposerSheetName, getNextColor, rangeReference } from "../../helpers/index";
+import {
+  getComposerSheetName,
+  getNextColor,
+  rangeReference,
+  UuidGenerator,
+} from "../../helpers/index";
 import { Mode } from "../../model";
 import { Command, CommandResult, Highlight, LAYERS, UID } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 import { SelectionMode } from "./selection";
+
+const uuidGenerator = new UuidGenerator();
 
 export interface RangeInputValue {
   id: UID;
@@ -329,13 +336,13 @@ export class SelectionInputPlugin extends UIPlugin {
   private highlightsToInput(highlights: Highlight[], activeSheetId: UID): RangeInputValue[] {
     const toXC = this.getters.zoneToXC;
     const sheetId = this.getters.getActiveSheetId();
-    return highlights.map((h, i) =>
+    return highlights.map((h) =>
       Object.freeze({
         xc:
           h.sheet !== activeSheetId
             ? `${getComposerSheetName(this.getters.getSheetName(h.sheet))}!${toXC(sheetId, h.zone)}`
             : toXC(sheetId, h.zone),
-        id: i.toString(),
+        id: uuidGenerator.uuidv4(),
         color: h.color,
       })
     );

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -50,7 +50,7 @@ jest.spyOn(HTMLDivElement.prototype, "clientWidth", "get").mockImplementation(()
 jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 1000);
 
 let fixture: HTMLElement;
-let model;
+let model: Model;
 let mockChartData = mockChart();
 let chartId: string;
 
@@ -392,6 +392,25 @@ describe("figures", () => {
     await nextTick();
     await simulateClick(".o-data-labels .o-selection-ok");
     expect(errorMessages()).toEqual(["Labels are invalid"]);
+  });
+
+  test("Can remove the last data series", async () => {
+    await simulateClick(".o-figure");
+    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-menu div[data-name='edit']");
+    await simulateClick(".o-data-series .o-add-selection");
+    const element = document.querySelectorAll(".o-data-series input")[1];
+    setInputValueAndTrigger(element, "C1:C4", "change");
+    await nextTick();
+    await simulateClick(".o-data-series .o-selection-ok");
+    const sheetId = model.getters.getActiveSheetId();
+    expect(model.getters.getChartDefinitionUI(sheetId, chartId).dataSets).toEqual([
+      "B1:B4",
+      "C1:C4",
+    ]);
+    const remove = document.querySelectorAll(".o-data-series .o-remove-selection")[1];
+    await simulateClick(remove);
+    expect(model.getters.getChartDefinitionUI(sheetId, chartId).dataSets).toEqual(["B1:B4"]);
   });
 });
 describe("charts with multiple sheets", () => {


### PR DESCRIPTION
Since https://github.com/odoo/o-spreadsheet/commit/59c6de8a1fc8507e8ac15352d653af4e987f0abe,
the ids of the selection inputs were not unique anymore. This caused an
issue in the chart panel

Here is the step to reproduce:
- Create a chart with a data-series
- Add another data-series
- Remove the last one
 => The first one was removed, not the selected one

Odoo-task-id 2622796

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
