### PR TITLE
[IMP] spreadsheet: disable interface in readonly mode

### DIFF
--- a/doc/add_plugin.md
+++ b/doc/add_plugin.md
@@ -85,7 +85,7 @@ class MyPlugin extends spreadsheet.CorePlugin {
 }
 
 // makes the new plugin to be instantiated for every spreadsheet mode
-MyPlugin.modes = ["normal", "headless", "readonly"];
+MyPlugin.modes = ["normal", "headless"];
 
 // makes the function getSomething accessible from anywhere that has a reference to model.getters
 MyPlugin.getters = ["getSomething"];

--- a/src/components/bottom_bar.ts
+++ b/src/components/bottom_bar.ts
@@ -14,7 +14,7 @@ const { useState } = owl.hooks;
 
 const TEMPLATE = xml/* xml */ `
   <div class="o-spreadsheet-bottom-bar">
-    <div class="o-sheet-item o-add-sheet" t-on-click="addSheet">${PLUS}</div>
+    <div class="o-sheet-item o-add-sheet" t-att-class="{'disabled': getters.isReadonly()}" t-on-click="addSheet">${PLUS}</div>
     <div class="o-sheet-item o-list-sheets" t-on-click="listSheets">${LIST}</div>
     <div class="o-all-sheets">
       <t t-foreach="getters.getSheets()" t-as="sheet" t-key="sheet.id">
@@ -49,6 +49,10 @@ const CSS = css/* scss */ `
     .o-add-sheet,
     .o-list-sheets {
       margin-right: 5px;
+    }
+
+    .o-add-sheet.disabled {
+      cursor: not-allowed;
     }
 
     .o-sheet-item {

--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -32,7 +32,7 @@ interface ComposerFocusedEventData {
 
 export type HtmlContent = {
   value: string;
-  color: string;
+  color?: string;
   class?: string;
 };
 
@@ -51,11 +51,12 @@ export const tokenColor = {
 
 const TEMPLATE = xml/* xml */ `
 <div class="o-composer-container">
-  <div class="o-composer"
+  <div
+    t-att-class="{ 'o-composer': true, 'text-muted': getters.isReadonly(), 'unfocusable': getters.isReadonly() }"
     t-att-style="props.inputStyle"
     t-ref="o_composer"
     tabindex="1"
-    contenteditable="true"
+    t-att-contenteditable="getters.isReadonly() ? 'false' : 'true'"
     spellcheck="false"
 
     t-on-keydown="onKeydown"
@@ -101,6 +102,9 @@ const CSS = css/* scss */ `
       word-break: break-all;
       &:focus {
         outline: none;
+      }
+      &.unfocusable {
+        pointer-events: none;
       }
       span {
         white-space: pre;
@@ -393,6 +397,9 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
   }
 
   onClick() {
+    if (this.getters.isReadonly()) {
+      return;
+    }
     const newSelection = this.contentHelper.getCurrentSelection();
 
     this.dispatch("STOP_COMPOSER_RANGE_SELECTION");
@@ -442,7 +449,7 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     } else if (value.startsWith("=") && this.getters.getEditionMode() !== "inactive") {
       content = this.getColoredTokens();
     } else {
-      content = [{ value, color: "#000" }];
+      content = [{ value }];
     }
     return content;
   }

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -1,6 +1,7 @@
 import { Component, hooks, tags, useState } from "@odoo/owl";
 import {
   HEADER_HEIGHT,
+  MENU_ITEM_DISABLED_COLOR,
   MENU_ITEM_HEIGHT,
   MENU_SEPARATOR_BORDER_WIDTH,
   MENU_SEPARATOR_HEIGHT,
@@ -81,21 +82,9 @@ const CSS = css/* scss */ `
       text-overflow: ellipsis;
       cursor: pointer;
 
-      &:hover {
-        background-color: #ebebeb;
-      }
-
-      &.disabled {
-        color: grey;
-        cursor: not-allowed;
-      }
-
       &.o-menu-root {
         display: flex;
         justify-content: space-between;
-      }
-      .o-menu-item-shortcut {
-        color: grey;
       }
       .o-menu-item-icon {
         margin-top: auto;
@@ -103,6 +92,19 @@ const CSS = css/* scss */ `
       }
       .o-icon {
         width: 10px;
+      }
+
+      &:not(.disabled) {
+        &:hover {
+          background-color: #ebebeb;
+        }
+        .o-menu-item-shortcut {
+          color: grey;
+        }
+      }
+      &.disabled {
+        color: ${MENU_ITEM_DISABLED_COLOR};
+        cursor: not-allowed;
       }
     }
 

--- a/src/components/side_panel/chart_panel.ts
+++ b/src/components/side_panel/chart_panel.ts
@@ -1,4 +1,5 @@
 import * as owl from "@odoo/owl";
+import { BACKGROUND_HEADER_COLOR } from "../../constants";
 import {
 ChartUIDefinition,
 ChartUIDefinitionUpdate,
@@ -127,7 +128,7 @@ const STYLE = css/* scss */ `
         cursor: pointer;
         border-right: 1px solid darkgray;
         &.inactive {
-          background-color: #f8f9fa;
+          background-color: ${BACKGROUND_HEADER_COLOR};
           border-bottom: 1px solid darkgray;
         }
         .fa {

--- a/src/components/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel.ts
@@ -1,4 +1,5 @@
 import * as owl from "@odoo/owl";
+import { BACKGROUND_HEADER_COLOR } from "../../constants";
 import { SidePanelContent, sidePanelRegistry } from "../../registries/side_panel_registry";
 import { SpreadsheetEnv } from "../../types";
 
@@ -30,7 +31,7 @@ const CSS = css/* scss */ `
     .o-sidePanelHeader {
       padding: 6px;
       height: 30px;
-      background-color: #f8f9fa;
+      background-color: ${BACKGROUND_HEADER_COLOR};
       display: flex;
       align-items: center;
       justify-content: space-between;

--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -305,18 +305,27 @@ export class Spreadsheet extends Component<Props> {
   }
 
   onTopBarComposerFocused(ev: ComposerFocusedEvent) {
+    if (this.model.getters.isReadonly()) {
+      return;
+    }
     this.composer.topBarFocus = "contentFocus";
     this.composer.gridFocusMode = "inactive";
     this.setComposerContent(ev.detail || {});
   }
 
   onGridComposerContentFocused(ev: ComposerFocusedEvent) {
+    if (this.model.getters.isReadonly()) {
+      return;
+    }
     this.composer.topBarFocus = "inactive";
     this.composer.gridFocusMode = "contentFocus";
     this.setComposerContent(ev.detail || {});
   }
 
   onGridComposerCellFocused(ev: ComposerFocusedEvent) {
+    if (this.model.getters.isReadonly()) {
+      return;
+    }
     this.composer.topBarFocus = "inactive";
     this.composer.gridFocusMode = "cellFocus";
     this.setComposerContent(ev.detail || {});

--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -1,5 +1,5 @@
 import * as owl from "@odoo/owl";
-import { DEFAULT_FONT_SIZE } from "../constants";
+import { BACKGROUND_HEADER_COLOR, DEFAULT_FONT_SIZE } from "../constants";
 import { fontSizes } from "../fonts";
 import { isEqual } from "../helpers/index";
 import { setFormatter, setStyle, topbarComponentRegistry } from "../registries/index";
@@ -73,7 +73,12 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
       <!-- Toolbar and Cell Content -->
       <div class="o-topbar-toolbar">
         <!-- Toolbar -->
-        <div class="o-toolbar-tools">
+        <div t-if="getters.isReadonly()" class="o-readonly-toolbar text-muted">
+          <span>
+            <i class="fa fa-eye" /> <t t-esc="env._t('Readonly Access')" />
+          </span>
+        </div>
+        <div t-else="" class="o-toolbar-tools">
           <div class="o-tool" title="Undo" t-att-class="{'o-disabled': !undoTool}" t-on-click="undo" >${icons.UNDO_ICON}</div>
           <div class="o-tool" t-att-class="{'o-disabled': !redoTool}" title="Redo"  t-on-click="redo">${icons.REDO_ICON}</div>
           <div class="o-tool" title="Paint Format" t-att-class="{active:paintFormatTool}" t-on-click="paintFormat">${icons.PAINT_FORMAT_ICON}</div>
@@ -193,8 +198,12 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
         border-bottom: 1px solid #e0e2e4;
         display: flex;
 
-        .o-composer-container {
-          height: 34px;
+        .o-readonly-toolbar {
+          display: flex;
+          align-items: center;
+          background-color: ${BACKGROUND_HEADER_COLOR};
+          padding-left: 18px;
+          padding-right: 18px;
         }
 
         /* Toolbar */
@@ -352,6 +361,7 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
   menuRef = useRef("menuRef");
   composerStyle = `
     line-height: 34px;
+    height: 34px;
     border-bottom: 1px solid #e0e2e4;
     border-left: 1px solid #e0e2e4;
     background-color: white;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ export const SELECTION_BORDER_COLOR = "#3266ca";
 export const HEADER_BORDER_COLOR = "#C0C0C0";
 export const CELL_BORDER_COLOR = "#E2E3E3";
 export const BACKGROUND_CHART_COLOR = "#FFFFFF";
+export const MENU_ITEM_DISABLED_COLOR = "#CACACA";
 
 // Dimensions
 export const MIN_ROW_HEIGHT = 10;

--- a/src/model.ts
+++ b/src/model.ts
@@ -60,7 +60,7 @@ import { getXLSX } from "./xlsx/xlsx_writer";
  * programmatically a spreadsheet.
  */
 
-export type Mode = "normal" | "headless" | "readonly";
+export type Mode = "normal" | "headless";
 export interface ModelConfig {
   mode: Mode;
   openSidePanel: (panel: string, panelProps?: any) => void;
@@ -301,7 +301,7 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
       client,
       moveClient: () => {},
       isHeadless: config.mode === "headless" || false,
-      isReadonly: config.mode === "readonly" || false,
+      isReadonly: config.isReadonly || false,
       snapshotRequested: false,
       dataSources: this.dataSources,
     };

--- a/src/plugins/base_plugin.ts
+++ b/src/plugins/base_plugin.ts
@@ -22,7 +22,7 @@ import {
 
 export class BasePlugin<State = any, C = any> implements CommandHandler<C> {
   static getters: string[] = [];
-  static modes: Mode[] = ["headless", "normal", "readonly"];
+  static modes: Mode[] = ["headless", "normal"];
 
   protected history: WorkbookHistory<State>;
   protected dispatch: CommandDispatcher["dispatch"];

--- a/src/plugins/ui/autofill.ts
+++ b/src/plugins/ui/autofill.ts
@@ -83,7 +83,7 @@ class AutofillGenerator {
 export class AutofillPlugin extends UIPlugin {
   static layers = [LAYERS.Autofill];
   static getters = ["getAutofillTooltip"];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
 
   private autofillZone: Zone | undefined;
   private lastCellSelected: { col?: number; row?: number } = {};

--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -44,7 +44,7 @@ interface ClipboardState {
 export class ClipboardPlugin extends UIPlugin {
   static layers = [LAYERS.Clipboard];
   static getters = ["getClipboardContent", "isPaintingFormat"];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
 
   private status: "visible" | "invisible" = "invisible";
   private state?: ClipboardState;

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -51,7 +51,7 @@ export class EditionPlugin extends UIPlugin {
     "getCurrentTokens",
     "getTokenAtCursor",
   ];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
 
   private col: number = 0;
   private row: number = 0;

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -35,7 +35,7 @@ type FormulaParameters = [ReferenceDenormalizer, EnsureRange, EvalContext];
 
 export class EvaluationPlugin extends UIPlugin {
   static getters = ["evaluateFormula", "getRangeFormattedValues", "getRangeValues"];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
 
   private isUpToDate: Set<UID> = new Set(); // Set<sheetIds>
   private readonly evalContext: EvalContext;

--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -19,7 +19,7 @@ import { UIPlugin } from "../ui_plugin";
 
 export class EvaluationChartPlugin extends UIPlugin {
   static getters = ["getChartRuntime"];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
   // contains the configuration of the chart with it's values like they should be displayed,
   // as well as all the options needed for the chart library to work correctly
   readonly chartRuntime: { [figureId: string]: ChartConfiguration } = {};

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -26,7 +26,7 @@ import { UIPlugin } from "../ui_plugin";
 
 export class EvaluationConditionalFormatPlugin extends UIPlugin {
   static getters = ["getConditionalStyle", "getConditionalIcon"];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
   private isStale: boolean = true;
   // stores the computed styles in the format of computedStyles.sheetName[col][row] = Style
   private computedStyles: { [sheet: string]: { [col: number]: (Style | undefined)[] } } = {};

--- a/src/plugins/ui/highlight.ts
+++ b/src/plugins/ui/highlight.ts
@@ -7,7 +7,7 @@ import { UIPlugin } from "../ui_plugin";
  * HighlightPlugin
  */
 export class HighlightPlugin extends UIPlugin {
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
   static layers = [LAYERS.Highlights];
   static getters = ["getHighlights"];
   private highlights: Highlight[] = [];

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -75,7 +75,7 @@ export class RendererPlugin extends UIPlugin {
     "getEdgeScrollCol",
     "getEdgeScrollRow",
   ];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
 
   private boxes: Box[] = [];
 

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -67,7 +67,7 @@ interface SelectionPluginState {
  */
 export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
   static layers = [LAYERS.Selection];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
   static getters = [
     "getActiveSheet",
     "getActiveSheetId",

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -18,7 +18,7 @@ export interface RangeInputValue {
  * This plugin handles this internal state.
  */
 export class SelectionInputPlugin extends UIPlugin {
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
   static layers = [LAYERS.Highlights];
   static getters = ["getSelectionInput", "getSelectionInputValue", "isRangeValid"];
 

--- a/src/plugins/ui/selection_multiuser.ts
+++ b/src/plugins/ui/selection_multiuser.ts
@@ -30,7 +30,7 @@ interface ClientToDisplay extends Required<Client> {
 export class SelectionMultiUserPlugin extends UIPlugin {
   static getters = ["getClientsToDisplay"];
   static layers = [LAYERS.Selection];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
   private availableColors = new Set(colors);
   private colors: Record<UID, string> = {};
 

--- a/src/plugins/ui/ui_options.ts
+++ b/src/plugins/ui/ui_options.ts
@@ -3,7 +3,7 @@ import { Command } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
 export class UIOptionsPlugin extends UIPlugin {
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
   static getters = ["shouldShowFormulas"];
   private showFormulas: boolean = false;
 

--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -32,7 +32,7 @@ export class ViewportPlugin extends UIPlugin {
     "getViewportDimension",
     "getGridDimension",
   ];
-  static modes: Mode[] = ["normal", "readonly"];
+  static modes: Mode[] = ["normal"];
 
   readonly viewports: ViewportPluginState["viewports"] = {};
   readonly snappedViewports: ViewportPluginState["viewports"] = {};

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -658,7 +658,7 @@ describe("Multi users synchronisation", () => {
   });
 
   test("Spreadsheet in readonly still receive commands", () => {
-    const david = new Model(alice.exportData(), { transportService: network, mode: "readonly" });
+    const david = new Model(alice.exportData(), { transportService: network, isReadonly: true });
     setCellContent(alice, "A1", "hello");
     expect([alice, bob, charlie, david]).toHaveSynchronizedValue(
       (user) => getCellContent(user, "A1"),

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -333,6 +333,7 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
           spellcheck="false"
           style="
     line-height: 34px;
+    height: 34px;
     border-bottom: 1px solid #e0e2e4;
     border-left: 1px solid #e0e2e4;
     background-color: white;

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -370,6 +370,7 @@ exports[`TopBar component can set cell format 1`] = `
         spellcheck="false"
         style="
     line-height: 34px;
+    height: 34px;
     border-bottom: 1px solid #e0e2e4;
     border-left: 1px solid #e0e2e4;
     background-color: white;
@@ -711,6 +712,7 @@ exports[`TopBar component simple rendering 1`] = `
         spellcheck="false"
         style="
     line-height: 34px;
+    height: 34px;
     border-bottom: 1px solid #e0e2e4;
     border-left: 1px solid #e0e2e4;
     background-color: white;

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -62,12 +62,6 @@ describe("Model", () => {
     expect(model["handlers"]).toHaveLength(nbr + 2); //+1 for Range +1 for History
   });
 
-  test("All plugin compatible with readonly mode are loaded on readonly mode", () => {
-    const model = new Model({}, { mode: "readonly" });
-    const nbr = getNbrPlugin("readonly");
-    expect(model["handlers"]).toHaveLength(nbr + 2); //+1 for Range +1 for History
-  });
-
   test("Model in headless mode should not evaluate cells", () => {
     const model = new Model({ sheets: [{ id: "sheet1" }] }, { mode: "headless" });
     setCellContent(model, "A1", "=1", "sheet1");
@@ -81,19 +75,12 @@ describe("Model", () => {
     class HeadlessPlugin extends UIPlugin {
       static modes: Mode[] = ["headless"];
     }
-    class ReadOnlyPlugin extends UIPlugin {
-      static modes: Mode[] = ["readonly"];
-    }
     uiPluginRegistry.add("normalPlugin", NormalPlugin);
     uiPluginRegistry.add("headlessPlugin", HeadlessPlugin);
-    uiPluginRegistry.add("readonlyPlugin", ReadOnlyPlugin);
     const modelNormal = new Model();
     expect(modelNormal["handlers"].find((handler) => handler instanceof NormalPlugin)).toBeTruthy();
     expect(
       modelNormal["handlers"].find((handler) => handler instanceof HeadlessPlugin)
-    ).toBeFalsy();
-    expect(
-      modelNormal["handlers"].find((handler) => handler instanceof ReadOnlyPlugin)
     ).toBeFalsy();
     const modelHeadless = new Model({}, { mode: "headless" });
     expect(
@@ -101,19 +88,6 @@ describe("Model", () => {
     ).toBeFalsy();
     expect(
       modelHeadless["handlers"].find((handler) => handler instanceof HeadlessPlugin)
-    ).toBeTruthy();
-    expect(
-      modelHeadless["handlers"].find((handler) => handler instanceof ReadOnlyPlugin)
-    ).toBeFalsy();
-    const modelReadonly = new Model({}, { mode: "readonly" });
-    expect(
-      modelReadonly["handlers"].find((handler) => handler instanceof NormalPlugin)
-    ).toBeFalsy();
-    expect(
-      modelReadonly["handlers"].find((handler) => handler instanceof HeadlessPlugin)
-    ).toBeFalsy();
-    expect(
-      modelReadonly["handlers"].find((handler) => handler instanceof ReadOnlyPlugin)
     ).toBeTruthy();
   });
 
@@ -203,17 +177,17 @@ describe("Model", () => {
   });
 
   test("Can open a model in readonly mode", () => {
-    const model = new Model({}, { mode: "readonly" });
+    const model = new Model({}, { isReadonly: true });
     expect(model.getters.isReadonly()).toBe(true);
   });
 
   test("Some commands are not dispatched in readonly mode", () => {
-    const model = new Model({}, { mode: "readonly" });
+    const model = new Model({}, { isReadonly: true });
     expect(setCellContent(model, "A1", "hello")).toBeCancelledBecause(CommandResult.Readonly);
   });
 
   test("Moving the selection is allowed in readonly mode", () => {
-    const model = new Model({}, { mode: "readonly" });
+    const model = new Model({}, { isReadonly: true });
     expect(selectCell(model, "A15")).toBeSuccessfullyDispatched();
   });
 });


### PR DESCRIPTION
## Description:


Currently, a user can still interact with the topbar elements (buttons
and composer) in readonly mode even though any change to the spreadsheet
structure will actually be rejected.

This commit introduces 2 changes in readonly mode:
- the topbar tools are replaced by a "readonly" panel
- The composer is no longer editable or clickable to avoid giving the
impression that the user can edit a cell's content.

task 2572290



Odoo task ID : [2572290](https://www.odoo.com/web#id=2572290&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
