### PR TITLE
[IMP] renderer: display first digits of cropped numbers

### DIFF
--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -483,7 +483,7 @@ export class RendererPlugin extends UIPlugin {
             if (conditionalStyle) {
               style = Object.assign({}, style, conditionalStyle);
             }
-            const align = text
+            let align = text
               ? (style && style.align) || computeAlign(cell, showFormula)
               : undefined;
             let clipRect: Rect | null = null;
@@ -496,6 +496,10 @@ export class RendererPlugin extends UIPlugin {
 
             const isOverflowing =
               contentWidth > cols[colNumber].size || fontSizeMap[fontsize] > row.size;
+
+            if (isOverflowing && typeof cell.value === "number") {
+              align = align !== "center" ? "left" : align;
+            }
 
             if (iconStyle) {
               const colWidth = col.end - col.start;
@@ -656,6 +660,13 @@ export class RendererPlugin extends UIPlugin {
         const fontsize = style.fontSize || DEFAULT_FONT_SIZE;
         const iconWidth = fontSizeMap[fontsize];
         const iconBoxWidth = iconStyle ? 2 * MIN_CF_ICON_MARGIN + iconWidth : 0;
+
+        /** alignment of a number cell should be put to left once the text overflows from the cell */
+        const contentWidth = iconBoxWidth + textWidth;
+        align =
+          text && typeof refCell!.value === "number" && contentWidth > width && align !== "center"
+            ? "left"
+            : align;
 
         const clipRect: Rect = iconStyle
           ? [x + iconBoxWidth, y, Math.max(0, width - iconBoxWidth), height]


### PR DESCRIPTION
When a numerical value is cropped, its first digits are the most
relevant to display.
This commit ensures that we align the text to the left when it's length
overflows from the cell width.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2528759](https://www.odoo.com/web#id=2528759&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
