### PR TITLE
[FIX] viewport: dispatch valid offset on scroll event

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -552,9 +552,12 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
   onScroll() {
     const { offsetX, offsetY } = this.getters.getActiveViewport();
     if (offsetX !== this.hScrollbar.scroll || offsetY !== this.vScrollbar.scroll) {
+      const { maxOffsetX, maxOffsetY } = this.getters.getMaximumViewportOffset(
+        this.getters.getActiveSheet()
+      );
       this.dispatch("SET_VIEWPORT_OFFSET", {
-        offsetX: this.hScrollbar.scroll,
-        offsetY: this.vScrollbar.scroll,
+        offsetX: Math.min(this.hScrollbar.scroll, maxOffsetX),
+        offsetY: Math.min(this.vScrollbar.scroll, maxOffsetY),
       });
     }
   }

--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -31,6 +31,7 @@ export class ViewportPlugin extends UIPlugin {
     "getActiveSnappedViewport",
     "getViewportDimension",
     "getGridDimension",
+    "getMaximumViewportOffset",
   ];
   static modes: Mode[] = ["normal"];
 
@@ -153,18 +154,22 @@ export class ViewportPlugin extends UIPlugin {
     return { width, height };
   }
 
+  getMaximumViewportOffset(sheet: Sheet): { maxOffsetX: number; maxOffsetY: number } {
+    const { width, height } = this.getters.getGridDimension(sheet);
+    return {
+      maxOffsetX: Math.max(0, width - this.clientWidth + HEADER_WIDTH + 1),
+      maxOffsetY: Math.max(0, height - this.clientHeight + HEADER_HEIGHT + 1),
+    };
+  }
+
   // ---------------------------------------------------------------------------
   // Private
   // ---------------------------------------------------------------------------
 
   private checkOffsetValidity(offsetX: number, offsetY: number): CommandResult {
-    const { width, height } = this.getters.getGridDimension(this.getters.getActiveSheet());
-    if (
-      offsetX < 0 ||
-      offsetY < 0 ||
-      this.clientHeight - HEADER_HEIGHT + offsetY > height ||
-      this.clientWidth - HEADER_WIDTH + offsetX > width
-    ) {
+    const sheet = this.getters.getActiveSheet();
+    const { maxOffsetX, maxOffsetY } = this.getMaximumViewportOffset(sheet);
+    if (offsetX < 0 || offsetY < 0 || offsetY > maxOffsetY || offsetX > maxOffsetX) {
       return CommandResult.InvalidOffset;
     }
     return CommandResult.Success;

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -173,6 +173,7 @@ export type Getters = CoreGetters & {
   getActiveViewport: ViewportPlugin["getActiveViewport"];
   getActiveSnappedViewport: ViewportPlugin["getActiveSnappedViewport"];
   getGridDimension: ViewportPlugin["getGridDimension"];
+  getMaximumViewportOffset: ViewportPlugin["getMaximumViewportOffset"];
 
   getAutomaticSums: AutomaticSumPlugin["getAutomaticSums"];
 };

--- a/tests/plugins/viewport.test.ts
+++ b/tests/plugins/viewport.test.ts
@@ -194,6 +194,24 @@ describe("Viewport of Simple sheet", () => {
     });
   });
 
+  test("can horizontal scroll on sheet smaller than viewport", () => {
+    model = new Model({
+      sheets: [{ rowNumber: 2 }],
+    });
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: DEFAULT_CELL_WIDTH * 2,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 0,
+      bottom: 1,
+      left: 2,
+      right: 11,
+      offsetX: DEFAULT_CELL_WIDTH * 2,
+      offsetY: 0,
+    });
+  });
+
   test("Vertical scroll correctly affects offset", () => {
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
@@ -247,6 +265,24 @@ describe("Viewport of Simple sheet", () => {
     });
   });
 
+  test("can vertical scroll on sheet smaller than viewport", () => {
+    model = new Model({
+      sheets: [{ colNumber: 2 }],
+    });
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 2,
+    });
+    expect(model.getters.getActiveViewport()).toMatchObject({
+      top: 2,
+      bottom: 44,
+      left: 0,
+      right: 1,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 2,
+    });
+  });
+
   test("cannot set offset outside of the grid", () => {
     // negative
     const negativeOffsetResult = model.dispatch("SET_VIEWPORT_OFFSET", {
@@ -257,11 +293,11 @@ describe("Viewport of Simple sheet", () => {
 
     // too large
     model.dispatch("RESIZE_VIEWPORT", { height: 1000, width: 1000 });
-    const { height } = model.getters.getGridDimension(model.getters.getActiveSheet());
+    const { maxOffsetY } = model.getters.getMaximumViewportOffset(model.getters.getActiveSheet());
 
     const tooLargeOffsetResult = model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
-      offsetY: height + HEADER_HEIGHT - 1000 + 1,
+      offsetY: maxOffsetY + 1,
     });
     expect(tooLargeOffsetResult).toBeCancelledBecause(CommandResult.InvalidOffset);
   });


### PR DESCRIPTION
Since commit de1ce75524859b0f88ee598f7ba0c8475055aee4, the scrollbar
can no longer be scrolled to its maximum value because of rounding
issues (see explanation in (here)[https://www.odoo.com/web#id=2620080&action=333&model=project.task])

This commit ensures that we allow the maximum value to be 1px higher
than before (takes care of the rounding) and that we dispatch a valid
offset when handling a scrolling event.

task 2631983

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2631983](https://www.odoo.com/web#id=2631983&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
