### PR TITLE
[FIX] edition: correctly update references when moving the highlight

### DIFF
--- a/src/helpers/coordinates.ts
+++ b/src/helpers/coordinates.ts
@@ -2,6 +2,7 @@
 // Coordinate
 //------------------------------------------------------------------------------
 
+import { RangePart } from "../types";
 import { cellReference } from "./references";
 
 /**
@@ -63,11 +64,20 @@ export function toCartesian(xc: string): [number, number] {
  * Convert from cartesian coordinate to the "XC" coordinate system.
  *
  * Examples:
- *   [0,0] => A1
- *   [1,2] => B3
- *
- * Note: it does not support fixed references
+ *   - 0,0 => A1
+ *   - 1,2 => B3
+ *   - 0,0, {colFixed: false, rowFixed: true} => A$1
+ *   - 1,2, {colFixed: true, rowFixed: false} => $B3
  */
-export function toXC(col: number, row: number): string {
-  return numberToLetters(col) + String(row + 1);
+export function toXC(
+  col: number,
+  row: number,
+  rangePart: RangePart = { colFixed: false, rowFixed: false }
+): string {
+  return (
+    (rangePart.colFixed ? "$" : "") +
+    numberToLetters(col) +
+    (rangePart.rowFixed ? "$" : "") +
+    String(row + 1)
+  );
 }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -22,6 +22,7 @@ import {
   CoreCommand,
   ExcelWorkbookData,
   Range,
+  RangePart,
   Sheet,
   Style,
   UID,
@@ -493,10 +494,18 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
    * if A1:B2 and A4:B5 are merges:
    * {top:1,left:0,right:1,bottom:3} ==> A1:A5
    */
-  zoneToXC(sheetId: UID, zone: Zone): string {
+  zoneToXC(
+    sheetId: UID,
+    zone: Zone,
+    fixedParts: RangePart[] = [{ colFixed: false, rowFixed: false }]
+  ): string {
     zone = this.getters.expandZone(sheetId, zone);
-    const topLeft = toXC(zone.left, zone.top);
-    const botRight = toXC(zone.right, zone.bottom);
+    const topLeft = toXC(zone.left, zone.top, fixedParts[0]);
+    const botRight = toXC(
+      zone.right,
+      zone.bottom,
+      fixedParts.length > 1 ? fixedParts[1] : fixedParts[0]
+    );
     const cellTopLeft = this.getters.getMainCell(sheetId, zone.left, zone.top);
     const cellBotRight = this.getters.getMainCell(sheetId, zone.right, zone.bottom);
     const sameCell = cellTopLeft[0] == cellBotRight[0] && cellTopLeft[1] == cellBotRight[1];

--- a/tests/plugins/highlight.test.ts
+++ b/tests/plugins/highlight.test.ts
@@ -1,7 +1,13 @@
 import { Model } from "../../src";
 import { toZone } from "../../src/helpers";
 import { HighlightPlugin } from "../../src/plugins/ui/highlight";
-import { createSheet, merge, selectCell, setSelection } from "../test_helpers/commands_helpers";
+import {
+  createSheet,
+  createSheetWithName,
+  merge,
+  selectCell,
+  setSelection,
+} from "../test_helpers/commands_helpers";
 
 let model: Model;
 
@@ -64,11 +70,26 @@ describe("highlight", () => {
     ]);
   });
 
-  test("add no hightlight", () => {
+  test("add no highlight", () => {
     model.dispatch("ADD_HIGHLIGHTS", {
       ranges: [],
     });
     expect(model.getters.getHighlights()).toStrictEqual([]);
+  });
+
+  test("can add highlight when valid sheet name", () => {
+    createSheetWithName(model, { sheetId: "42" }, "kikou");
+    model.dispatch("ADD_HIGHLIGHTS", {
+      ranges: [["kikou!B2", "#888"]],
+    });
+    expect(model.getters.getHighlights()).toHaveLength(1);
+  });
+
+  test("can't add highlight with invalid sheet name", () => {
+    model.dispatch("ADD_HIGHLIGHTS", {
+      ranges: [["kikou!B2", "#888"]],
+    });
+    expect(model.getters.getHighlights()).toHaveLength(0);
   });
 
   test("remove highlight with another color", () => {


### PR DESCRIPTION
References were not correctly updated when this one had sheetname or ref fixed.


- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [ ] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [x] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
