### PR TITLE
[IMP] evaluation: add a way to reset evaluation after command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export {
   RevisionUndoneMessage,
   TransportService,
 } from "./types/collaborative/transport_service";
-export { coreTypes, readonlyAllowedCommands } from "./types/commands";
+export { coreTypes, invalidateEvaluationCommands, readonlyAllowedCommands } from "./types/commands";
 export const SPREADSHEET_DIMENSIONS = {
   MIN_ROW_HEIGHT,
   MIN_COL_WIDTH,

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -15,6 +15,7 @@ import {
   EvalContext,
   FormulaCell,
   Getters,
+  invalidateEvaluationCommands,
   NormalizedFormula,
   Range,
   ReferenceDenormalizer,
@@ -57,16 +58,10 @@ export class EvaluationPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
 
   handle(cmd: Command) {
+    if (invalidateEvaluationCommands.has(cmd.type)) {
+      this.isUpToDate.clear();
+    }
     switch (cmd.type) {
-      case "RENAME_SHEET":
-      case "DELETE_SHEET":
-      case "CREATE_SHEET":
-      case "ADD_COLUMNS_ROWS":
-      case "REMOVE_COLUMNS_ROWS":
-      case "DELETE_CELL":
-      case "INSERT_CELL":
-        this.isUpToDate.clear();
-        break;
       case "UPDATE_CELL":
         if ("content" in cmd) {
           this.isUpToDate.clear();
@@ -78,10 +73,6 @@ export class EvaluationPlugin extends UIPlugin {
         break;
       case "EVALUATE_ALL_SHEETS":
         this.evaluateAllSheets();
-        break;
-      case "UNDO":
-      case "REDO":
-        this.isUpToDate.clear();
         break;
     }
   }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -75,6 +75,18 @@ export function isPositionDependent(cmd: CoreCommand): boolean {
   return "col" in cmd && "row" in cmd;
 }
 
+export const invalidateEvaluationCommands = new Set<CommandTypes>([
+  "RENAME_SHEET",
+  "DELETE_SHEET",
+  "CREATE_SHEET",
+  "ADD_COLUMNS_ROWS",
+  "REMOVE_COLUMNS_ROWS",
+  "DELETE_CELL",
+  "INSERT_CELL",
+  "UNDO",
+  "REDO",
+]);
+
 export const readonlyAllowedCommands = new Set<CommandTypes>([
   "START",
   "ACTIVATE_SHEET",


### PR DESCRIPTION
In order to reset the evaluation after a command, its type can now be
added in invalidEvaluationCommands.

It's needed for the global filter feature.

Part of task-id 2632018

