### PR TITLE
[FIX] links: don't open sheet link in new tab

### DIFF
--- a/src/components/link/link_display.ts
+++ b/src/components/link/link_display.ts
@@ -12,7 +12,18 @@ const { xml, css } = tags;
 const TEMPLATE = xml/* xml */ `
   <div class="o-link-tool">
     <t t-set="link" t-value="cell.link"/>
-    <a t-att-href="link.url" target="_blank" t-on-click.prevent="openLink" t-att-title="link.url">
+    <a t-if="link.isExternal"
+      class="o-link"
+      t-att-href="link.url"
+      target="_blank"
+      t-on-click.prevent="openLink"
+      t-att-title="link.url">
+      <t t-esc="cell.urlRepresentation"/>
+    </a>
+    <a t-else=""
+      class="o-link"
+      t-on-click.prevent="openLink"
+      t-att-title="cell.urlRepresentation">
       <t t-esc="cell.urlRepresentation"/>
     </a>
     <span class="o-link-icon o-unlink" t-on-click="unlink" title="${LinkEditorTerms.Remove}">${UNLINK}</span>
@@ -29,11 +40,17 @@ const CSS = css/* scss */ `
     border-radius: 4px;
     display: flex;
     justify-content: space-between;
-    a {
+    a.o-link {
+      color: #007bff;
       flex-grow: 2;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+    a.o-link:hover {
+      text-decoration: underline;
+      color: #0056b3;
+      cursor: pointer;
     }
   }
   .o-link-icon {

--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -172,6 +172,7 @@ export class WebLinkCell extends LinkCell {
   constructor(id: UID, content: string, properties: CellDisplayProperties = {}) {
     super(id, content, properties);
     this.link.url = this.withHttp(this.link.url);
+    this.link.isExternal = true;
     this.content = markdownLink(this.link.label, this.link.url);
     this.urlRepresentation = this.link.url;
     this.isUrlEditable = true;

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -11,6 +11,11 @@ export type UID = string;
 export interface Link {
   label: string;
   url: string;
+  /**
+   * Specifies if the resource is external and can
+   * be opened in a new tab.
+   */
+  isExternal?: boolean;
 }
 
 export interface Zone {

--- a/tests/components/link/link_display.test.ts
+++ b/tests/components/link/link_display.test.ts
@@ -26,8 +26,21 @@ describe("link display component", () => {
   test("link shows the url", async () => {
     setCellContent(model, "A1", "[label](url.com)");
     await clickCell(model, "A1");
+    expect(fixture.querySelector("a")?.innerHTML).toBe("https://url.com");
     expect(fixture.querySelector("a")?.getAttribute("href")).toBe("https://url.com");
+    expect(fixture.querySelector("a")?.getAttribute("title")).toBe("https://url.com");
     expect(fixture.querySelector("a")?.getAttribute("target")).toBe("_blank");
+  });
+
+  test("sheet link title shows the sheet name and doesn't have a href", async () => {
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", `[label](${buildSheetLink(sheetId)})`);
+    await clickCell(model, "A1");
+    expect(fixture.querySelector("a")?.innerHTML).toBe("Sheet1");
+    expect(fixture.querySelector("a")?.getAttribute("title")).toBe("Sheet1");
+    // with "href", the browser opens a new tab on CTRL+Click
+    // it won't work since the "url" is custom and only makes sense within the spreadsheet
+    expect(fixture.querySelector("a")?.getAttribute("href")).toBeNull();
   });
 
   test("link is displayed and closed when cell is clicked", async () => {


### PR DESCRIPTION


## Description:

Currently, a link to a sheet behaves like a regular link from the browser
perspective. It means CTRL+Click will open the link in a new tab but the browser
can't handle it.

Also, the "title" is the sheet "url", which is technical. It makes no sense
to show it to the user.

Those changes will also apply to "menu/action" links in Odoo.

Follow up of task 2572184
Odoo task ID : [2572184](https://www.odoo.com/web#id=2572184&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
