### PR TITLE
[FIX] sheet: getSheetIdByName should not be case-sensitive

### DIFF
--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -279,7 +279,15 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   }
 
   getSheetIdByName(name: string | undefined): UID | undefined {
-    return name && this.sheetIds[getUnquotedSheetName(name)];
+    if (name) {
+      const unquotedName = getUnquotedSheetName(name);
+      for (const key in this.sheetIds) {
+        if (key.toUpperCase() === unquotedName.toUpperCase()) {
+          return this.sheetIds[key];
+        }
+      }
+    }
+    return undefined;
   }
 
   getSheets(): Sheet[] {

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -974,4 +974,14 @@ describe("sheets", () => {
     const model = new Model();
     expect(model.getters.getSheetIdByName("this name does not exist")).toBeUndefined();
   });
+
+  test("getSheetIdByName works with non-matching case", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("RENAME_SHEET", {
+      sheetId,
+      name: "Sheet1",
+    });
+    expect(model.getters.getSheetIdByName("shEeT1")).toBeDefined();
+  });
 });


### PR DESCRIPTION
Before this commit, it was not possible to create a reference to a sheet
with a non-matching case name.

Task-id 2627066

