### PR TITLE
[FIX] edition: add possibility to change highlight of merged cells

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -1,7 +1,7 @@
 import * as owl from "@odoo/owl";
 import { EnrichedToken } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { DEBUG, rangeReference, zoneToXc } from "../../helpers/index";
+import { DEBUG, isEqual, rangeReference, toZone } from "../../helpers/index";
 import { ComposerSelection, SelectionIndicator } from "../../plugins/ui/edition";
 import { FunctionDescription, Rect, SpreadsheetEnv } from "../../types/index";
 import { TextValueProvider } from "./autocomplete_dropdown";
@@ -515,7 +515,8 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
       : this.getters.getEditionSheet();
     const highlight = highlights.find(
       (highlight) =>
-        zoneToXc(highlight.zone) == xc.replace(/\$/g, "") && highlight.sheet === refSheet
+        highlight.sheet === refSheet &&
+        isEqual(this.getters.expandZone(refSheet, toZone(xc)), highlight.zone)
     );
     return highlight && highlight.color ? highlight.color : undefined;
   }

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -184,9 +184,10 @@ export class EditionPlugin extends UIPlugin {
             let value = token.value;
             const [xc, sheet] = value.split("!").reverse();
             const sheetName = sheet || this.getters.getSheetName(this.sheet);
+            const activeSheetId = this.getters.getActiveSheetId();
             return (
-              isEqual(toZone(xc), cmd.zone) &&
-              this.getters.getSheetName(this.getters.getActiveSheetId()) === sheetName
+              isEqual(this.getters.expandZone(activeSheetId, toZone(xc)), cmd.zone) &&
+              this.getters.getSheetName(activeSheetId) === sheetName
             );
           });
         this.previousRef = previousRefToken!.value;

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -318,6 +318,30 @@ describe("ranges and highlights", () => {
       expect(composerEl.textContent).toBe(resultRef);
     });
 
+    test("can change cells merged reference", async () => {
+      merge(model, "B1:B2");
+      await typeInComposer("=B1");
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1") });
+      await nextTick();
+      expect(composerEl.textContent).toBe("=C1");
+
+      await typeInComposer("+B2");
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C2") });
+      await nextTick();
+      expect(composerEl.textContent).toBe("=C1+C2");
+    });
+
+    test("can change cells merged reference with index fixed", async () => {
+      merge(model, "B1:B2");
+      await typeInComposer("=B$2");
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1:C2") });
+      await nextTick();
+      expect(composerEl.textContent).toBe("=C$1:C$2");
+    });
+
     test("can change references of different length with index fixed", async () => {
       await typeInComposer("=SUM($B$1)");
       model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });


### PR DESCRIPTION
## Description

The task [2560657](https://www.odoo.com/web#id=2560657&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720) introduces possibility to move highlight on the grid. 
Unfortunately, references were not correctly updated when this one designates merged cells.
This commit fixes this issue.
    
Task [2638518](https://www.odoo.com/web#id=2638518&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
