### PR TITLE
[FIX] composer: display text with the cell color

### DIFF
--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -846,6 +846,10 @@ describe("composer", () => {
       await typeInComposer("Hello");
       const gridComposer = fixture.querySelector(".o-grid-composer")! as HTMLElement;
       expect(gridComposer.style.color).toBe("rgb(18, 52, 86)");
+      // @ts-ignore
+      const contentColors = (window.mockContentHelper as ContentEditableHelper).colors;
+      // the composer doesn't force any color
+      expect(contentColors["Hello"]).toBeUndefined();
     });
 
     test("with background color", async () => {


### PR DESCRIPTION

## Description:
Commit c807948 fixed the issue described below, but didn't add any test. This commit
adds the missing test.

1. Set the cell text color to red
2. open the grid composer
=> the text is black instead of red

Task 2636412

Odoo task ID : [2636412](https://www.odoo.com/web#id=2636412&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
