### PR TITLE
[FIX] evaluation: correctly handle incorrect references in formula

### DIFF
--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -1,7 +1,7 @@
 import { MAXIMUM_EVALUATION_CHECK_DELAY_MS } from "../../constants";
 import { compile, normalize } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { mapCellsInZone, toXC, toZone } from "../../helpers/index";
+import { isZoneValid, mapCellsInZone, toXC, toZone } from "../../helpers/index";
 import { Mode, ModelConfig } from "../../model";
 import { StateObserver } from "../../state_observer";
 import { _lt } from "../../translation";
@@ -376,6 +376,9 @@ export class EvaluationPlugin extends UIPlugin {
         right: Math.min(range.zone.right, sheet.cols.length - 1),
         bottom: Math.min(range.zone.bottom, sheet.rows.length - 1),
       };
+      if (!isZoneValid(zone)) {
+        throw new Error(_lt("Invalid range: %s", evalContext.getters.getRangeString(range)));
+      }
       return mapCellsInZone(zone, sheet, (cell) => getCellValue(cell, range.sheetId));
     }
 

--- a/tests/plugins/__snapshots__/grid_manipulation.test.ts.snap
+++ b/tests/plugins/__snapshots__/grid_manipulation.test.ts.snap
@@ -572,7 +572,7 @@ Object {
         },
       },
     ],
-    "error": "Cannot read property 'length' of undefined",
+    "error": "Invalid range: #REF",
     "formula": Object {
       "compiledFormula": [Function],
       "text": "=SUM(|0|)",
@@ -1474,14 +1474,14 @@ Object {
         },
       },
     ],
-    "error": undefined,
+    "error": "Invalid range: #REF",
     "formula": Object {
       "compiledFormula": [Function],
       "text": "=SUM(|0|)",
     },
     "id": "11",
     "type": "formula",
-    "value": 0,
+    "value": "#ERROR",
   },
 }
 `;

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -1,7 +1,12 @@
 import { args, functionRegistry } from "../../src/functions";
 import { Model } from "../../src/model";
-import { activateSheet, createSheet, setCellContent } from "../test_helpers/commands_helpers";
-import { getCell, getCellContent } from "../test_helpers/getters_helpers";
+import {
+  activateSheet,
+  createSheet,
+  deleteRows,
+  setCellContent,
+} from "../test_helpers/commands_helpers";
+import { getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import { evaluateCell, evaluateGrid, target } from "../test_helpers/helpers";
 import resetAllMocks = jest.resetAllMocks;
 
@@ -972,6 +977,20 @@ describe("evaluate formula getter", () => {
     value = 2;
     model.dispatch("EVALUATE_CELLS", { sheetId: model.getters.getActiveSheetId() });
     expect(getCell(model, "A1")!.value).toBe(2);
+  });
+
+  test("Formula with #REF is correctly marked as error", () => {
+    setCellContent(model, "A5", "=SUM(A1:A2,A3:A4)");
+    deleteRows(model, [0, 1]);
+    expect(getCellText(model, "A3")).toBe("=SUM(#REF,A1:A2)");
+    const cell = getCell(model, "A3")!;
+    expect(cell.error).toEqual("Invalid range: #REF");
+  });
+
+  test("Formula with invalid range", () => {
+    setCellContent(model, "A1", "=SUM(AZ100)");
+    const cell = getCell(model, "A1")!;
+    expect(cell.error).toEqual("Invalid range: Sheet1!AZ100");
   });
 
   test("using cells in other sheets", () => {


### PR DESCRIPTION
Before this commit, invalid references in formulas could causes some
issues:
- =SUM(AZ100) => Invalid array length
- In E5: =SUM(A1:B1,C1:D1) then remove A and B => Cannot read property "length" of undefined

Task-id 2620152

