### PR TITLE
[FIX] evaluation: correctly handle cells in error state

### DIFF
--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -239,6 +239,10 @@ export class FormulaCell extends AbstractCell implements IFormulaCell {
     return this.buildFormulaString(this.normalizedText, this.dependencies);
   }
 
+  startEvaluation() {
+    this.evaluated = { value: LOADING, type: CellValueType.text };
+  }
+
   assignValue(value: CellValue) {
     switch (typeof value) {
       case "number":

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -130,14 +130,16 @@ export class EvaluationPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
 
   private evaluate(sheetId: UID) {
-    this.evaluateCells(makeObjectIterator(this.getters.getCells(sheetId)), sheetId);
-  }
-
-  private evaluateCells(cells: Generator<Cell>, sheetId: string) {
+    const cells = this.getters.getCells(sheetId);
     const params = this.getFormulaParameters(computeValue);
     const visited: { [sheetId: string]: { [xc: string]: boolean | null } } = {};
+    for (let cell of makeObjectIterator(cells)) {
+      if (isFormula(cell)) {
+        cell.startEvaluation();
+      }
+    }
 
-    for (let cell of cells) {
+    for (let cell of makeObjectIterator(cells)) {
       computeValue(cell, sheetId);
     }
 

--- a/src/types/cells.ts
+++ b/src/types/cells.ts
@@ -46,6 +46,7 @@ export interface ICell {
 export interface FormulaCell extends ICell {
   assignValue: (value: CellValue) => void;
   assignError: (value: string, errorMessage: string) => void;
+  startEvaluation: () => void;
   readonly normalizedText: string;
   readonly compiledFormula: CompiledFormula;
   readonly dependencies: Range[];

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -1,5 +1,6 @@
 import { args, functionRegistry } from "../../src/functions";
 import { Model } from "../../src/model";
+import { CellValueType } from "../../src/types";
 import { activateSheet, createSheet, setCellContent } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent, getCellError } from "../test_helpers/getters_helpers";
 import { evaluateCell, evaluateGrid, target } from "../test_helpers/helpers";
@@ -1007,5 +1008,23 @@ describe("evaluate formula getter", () => {
     resetAllMocks();
     setCellContent(model, "A2", "1");
     expect(mockCompute).toHaveBeenCalledTimes(1);
+  });
+
+  test("cells in error are correctly reset", () => {
+    let value: string | number = "LOADING...";
+    functionRegistry.add("GETVALUE", {
+      description: "Get value",
+      compute: () => value,
+      args: args(``),
+      returns: ["ANY"],
+    });
+    setCellContent(model, "A1", "=SUM(A2)");
+    setCellContent(model, "A2", "=-GETVALUE()");
+    expect(getCell(model, "A1")!.evaluated.type).toBe(CellValueType.error);
+    expect(getCell(model, "A1")!.evaluated.type).toBe(CellValueType.error);
+    value = 2;
+    model.dispatch("EVALUATE_CELLS", { sheetId: model.getters.getActiveSheetId() });
+    expect(getCell(model, "A1")!.evaluated.value).toBe(-2);
+    expect(getCell(model, "A1")!.evaluated.value).toBe(-2);
   });
 });


### PR DESCRIPTION
Before this commit, the cells in error were not reset before a new
evaluation. So, if a cell positioned before another cell in error mode, and
the given cell depends on the cell in error, the evaluation detected the
dependency as an error and thus mark the given cell as error.

Task-id 2634778

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
