### PR TITLE
[FIX] spreadsheet: Open the sheet at the first position

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -150,6 +150,7 @@ export class Spreadsheet extends Component<Props> {
     useExternalListener(document.body, "paste", this.paste);
     useExternalListener(document.body, "keyup", this.onKeyup.bind(this));
     useExternalListener(window, "beforeunload", this.leaveCollaborativeSession.bind(this));
+    this.activateFirstSheet();
   }
 
   get focusTopBarComposer(): boolean {
@@ -178,6 +179,14 @@ export class Spreadsheet extends Component<Props> {
   private leaveCollaborativeSession() {
     this.model.off("update", this);
     this.model.leaveSession();
+  }
+
+  private activateFirstSheet() {
+    const sheetId = this.model.getters.getActiveSheetId();
+    const [firstSheet] = this.model.getters.getSheets();
+    if (firstSheet.id !== sheetId) {
+      this.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: sheetId, sheetIdTo: firstSheet.id });
+    }
   }
 
   destroy() {


### PR DESCRIPTION
Before this commit, the spreadsheet was opened in the sheet at the first
position **before** the loading of the pending messages. Now, it's the
sheet at the first position **after** the initial loading.

Task-id 2542550

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
