### PR TITLE
[FIX] chart: handle #REF dataset

### DIFF
--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -1,3 +1,4 @@
+import { INCORRECT_RANGE_STRING } from "../../constants";
 import { rangeReference, zoneToDimension, zoneToXc } from "../../helpers/index";
 import {
   ApplyRangeChange,
@@ -79,14 +80,23 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
         case "RESIZE":
         case "MOVE":
         case "CHANGE":
-          this.history.update(
-            "chartFigures",
-            chartId,
-            "dataSets",
-            chart.dataSets.indexOf(ds),
-            "dataRange",
-            dataRangeChange.range
-          );
+          // We have to remove the ranges that are #REF
+          if (
+            this.getters.getRangeString(dataRangeChange.range, dataRangeChange.range.sheetId) !==
+            INCORRECT_RANGE_STRING
+          ) {
+            this.history.update(
+              "chartFigures",
+              chartId,
+              "dataSets",
+              chart.dataSets.indexOf(ds),
+              "dataRange",
+              dataRangeChange.range
+            );
+          } else {
+            const newDataSets = chart.dataSets.filter((dataset) => dataset !== ds);
+            this.history.update("chartFigures", chartId, "dataSets", newDataSets);
+          }
           break;
       }
     }

--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -10,6 +10,7 @@ import { chartTerms } from "../../components/side_panel/translations_terms";
 import { INCORRECT_RANGE_STRING } from "../../constants";
 import { ChartColors } from "../../helpers/chart";
 import { isDefined, isInside, overlap, recomputeZones, zoneToXc } from "../../helpers/index";
+import { range } from "../../helpers/misc";
 import { Mode } from "../../model";
 import { ChartDefinition, DataSet } from "../../types/chart";
 import { Command } from "../../types/commands";
@@ -266,6 +267,11 @@ export class EvaluationChartPlugin extends UIPlugin {
       const rangeString = this.getters.getRangeString(definition.labelRange, definition.sheetId);
       if (rangeString !== INCORRECT_RANGE_STRING) {
         labels = this.getters.getRangeFormattedValues(rangeString, definition.sheetId).flat(1);
+      }
+    } else {
+      if (definition.dataSets[0]) {
+        const ranges = this.getData(definition.dataSets[0], definition.sheetId);
+        labels = range(0, ranges.length).map((r) => r.toString());
       }
     }
     const runtime = this.getDefaultConfiguration(definition.type, definition.title, labels);

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -604,11 +604,11 @@ describe("datasource tests", function () {
     );
     deleteColumns(model, ["A"]);
     // dataset in col B becomes labels in col A
-    expect(model.getters.getChartRuntime("1")!.data!.labels).toEqual([]);
+    expect(model.getters.getChartRuntime("1")!.data!.labels).toEqual(["0", "1", "2"]);
     const chart = model.getters.getChartRuntime("1")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     expect(chart.data!.datasets![1].data).toEqual([20, 19, 18]);
-    expect(chart.data!.labels).toEqual([]);
+    expect(chart.data!.labels).toEqual(["0", "1", "2"]);
   });
 
   test("delete last row of dataset", () => {
@@ -955,6 +955,24 @@ describe("datasource tests", function () {
     expect(model.getters.getChartRuntime("1")).not.toBeUndefined();
     model.dispatch("DELETE_SHEET", { sheetId: "2" });
     expect(model.getters.getChartRuntime("1")).toBeUndefined();
+  });
+
+  test("Chart on columns deletion", () => {
+    createChart(
+      model,
+      {
+        dataSets: ["B1:B4", "C1:C4"],
+        labelRange: "A2:A4",
+        type: "line",
+      },
+      "1"
+    );
+    deleteColumns(model, ["A", "B"]);
+    const sheetId = model.getters.getActiveSheetId();
+    const def = model.getters.getChartDefinitionUI(sheetId, "1");
+    expect(def.dataSets).toHaveLength(1);
+    expect(def.dataSets[0]).toEqual("A1:A4");
+    expect(def.labelRange).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Steps to reproduce:
- Create a chart with label in column A, data in columns B and C.
- Delete columns A and B
 => Traceback

The fix is to remove invalid zones (#REF) from the definition.

Task-id 2618250

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2618250](https://www.odoo.com/web#id=2618250&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
