### PR TITLE
[FIX] chart: figure menu position

### DIFF
--- a/src/components/helpers/position_hook.ts
+++ b/src/components/helpers/position_hook.ts
@@ -5,13 +5,26 @@ const { useComponent, useState, onPatched, useRef, onMounted } = hooks;
 // type Ref is not exported by owl :(
 type Ref = ReturnType<typeof useRef>;
 
-function spreadsheetPosition() {
-  const spreadsheetElement = document.querySelector(".o-spreadsheet");
-  if (spreadsheetElement) {
-    const { top, left } = spreadsheetElement?.getBoundingClientRect();
-    return { top, left };
+/**
+ * Return the o-spreadsheet element position relative
+ * to the browser viewport.
+ */
+function useSpreadsheetPosition(): DOMCoordinates {
+  const position = useState({ x: 0, y: 0 });
+  let spreadsheetElement = document.querySelector(".o-spreadsheet");
+  function updatePosition() {
+    if (!spreadsheetElement) {
+      spreadsheetElement = document.querySelector(".o-spreadsheet");
+    }
+    if (spreadsheetElement) {
+      const { top, left } = spreadsheetElement.getBoundingClientRect();
+      position.x = left;
+      position.y = top;
+    }
   }
-  return { top: 0, left: 0 };
+  onMounted(updatePosition);
+  onPatched(updatePosition);
+  return position;
 }
 
 /**
@@ -24,12 +37,12 @@ function spreadsheetPosition() {
 export function useAbsolutePosition(ref?: Ref): DOMCoordinates {
   const position = useState({ x: 0, y: 0 });
   const component = useComponent();
-  const { top: spreadsheetTop, left: spreadsheetLeft } = spreadsheetPosition();
+  const spreadsheet = useSpreadsheetPosition();
   function updateElPosition() {
     const el = ref?.el || component.el;
     const { top, left } = el!.getBoundingClientRect();
-    const x = left - spreadsheetLeft;
-    const y = top - spreadsheetTop;
+    const x = left - spreadsheet.x;
+    const y = top - spreadsheet.y;
     if (x !== position.x || y !== position.y) {
       position.x = x;
       position.y = y;

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1,6 +1,6 @@
 import { ChartConfiguration } from "chart.js";
 import { Model, Spreadsheet } from "../../src";
-import { BACKGROUND_CHART_COLOR } from "../../src/constants";
+import { BACKGROUND_CHART_COLOR, MENU_WIDTH } from "../../src/constants";
 import { DispatchResult } from "../../src/types";
 import { createChart } from "../test_helpers/commands_helpers";
 import {
@@ -142,6 +142,27 @@ describe("figures", () => {
     expect(fixture.querySelector(".o-chart-menu")).toBeDefined();
     await simulateClick(".o-chart-menu");
     expect(fixture.querySelector(".o-menu")).toBeDefined();
+  });
+
+  test("Context menu is positioned according to the spreadsheet position", async () => {
+    const originalGetBoundingClientRect = HTMLDivElement.prototype.getBoundingClientRect;
+    jest
+      .spyOn(HTMLDivElement.prototype, "getBoundingClientRect")
+      // @ts-ignore the mock should return a complete DOMRect, not only { top, left }
+      .mockImplementation(function (this: HTMLDivElement) {
+        if (this.className.includes("o-spreadsheet")) {
+          return { top: 100, left: 200 };
+        } else if (this.className.includes("o-chart-container")) {
+          return { top: 500, left: 500 };
+        }
+        return originalGetBoundingClientRect.call(this);
+      });
+
+    await simulateClick(".o-figure");
+    await simulateClick(".o-chart-menu");
+    const menuPopover = fixture.querySelector(".o-menu")?.parentElement;
+    expect(menuPopover?.style.top).toBe(`${500 - 100}px`);
+    expect(menuPopover?.style.left).toBe(`${500 - 200 - MENU_WIDTH}px`);
   });
 
   test("Click on Delete button will delete the chart", async () => {


### PR DESCRIPTION
## Description:

In Odoo, the menu on a chart figure is wrongly positioned.
It is shifted down be the height of the nav bar and the control panel.

The reason is because the `useAbsolutePosition` hook gets the reference
position of `.o-spreadsheet` before the spreadsheet is mounted
(it falls back to {0, 0}) and it's never updated once the spreadsheet is
mounted.

Odoo task ID : [2662408](https://www.odoo.com/web#id=2662408&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
