### PR TITLE
[IMP] tokenizer, parser: recognize #REF

### DIFF
--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -143,6 +143,8 @@ function parsePrefix(current: Token, tokens: Token[]): AST {
         type: "REFERENCE",
         value: parseInt(current.value, 10),
       };
+    case "INVALID_REFERENCE":
+      throw new Error(_lt("Invalid reference"));
     case "SYMBOL":
       if (["TRUE", "FALSE"].includes(current.value.toUpperCase())) {
         return { type: "BOOLEAN", value: current.value.toUpperCase() === "TRUE" } as AST;

--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -1,3 +1,4 @@
+import { INCORRECT_RANGE_STRING } from "../constants";
 import { functionRegistry } from "../functions/index";
 import { formulaNumberRegexp } from "../helpers/index";
 import { _lt } from "../translation";
@@ -35,6 +36,7 @@ export type TokenType =
   | "LEFT_PAREN"
   | "RIGHT_PAREN"
   | "REFERENCE"
+  | "INVALID_REFERENCE"
   | "UNKNOWN";
 
 export interface Token {
@@ -64,6 +66,7 @@ export function tokenize(str: string): Token[] {
       tokenizeString(chars) ||
       tokenizeDebugger(chars) ||
       tokenizeNormalizedReferences(chars) ||
+      tokenizeInvalidRange(chars) ||
       tokenizeSymbol(chars);
 
     if (!token) {
@@ -226,6 +229,14 @@ function tokenizeSpace(chars: string[]): Token | null {
 
   if (length) {
     return { type: "SPACE", value: " ".repeat(length) };
+  }
+  return null;
+}
+
+function tokenizeInvalidRange(chars: string[]): Token | null {
+  if (startsWith(chars, INCORRECT_RANGE_STRING)) {
+    chars.splice(0, INCORRECT_RANGE_STRING.length);
+    return { type: "INVALID_REFERENCE", value: INCORRECT_RANGE_STRING };
   }
   return null;
 }

--- a/tests/formulas/parser.test.ts
+++ b/tests/formulas/parser.test.ts
@@ -120,6 +120,10 @@ describe("parser", () => {
     });
   });
 
+  test("Can parse invalid references", () => {
+    expect(() => parse("#REF")).toThrowError("Invalid reference");
+  });
+
   test("AND", () => {
     expect(parse("=AND(true, false)")).toEqual({
       type: "FUNCALL",

--- a/tests/formulas/tokenizer.test.ts
+++ b/tests/formulas/tokenizer.test.ts
@@ -56,6 +56,17 @@ describe("tokenizer", () => {
       { type: "NUMBER", value: "1" },
     ]);
   });
+
+  test("#REF formula token", () => {
+    expect(tokenize("#REF")).toEqual([{ type: "INVALID_REFERENCE", value: "#REF" }]);
+    expect(tokenize("=#REF+1")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "INVALID_REFERENCE", value: "#REF" },
+      { type: "OPERATOR", value: "+" },
+      { type: "NUMBER", value: "1" },
+    ]);
+  });
+
   test("String", () => {
     expect(tokenize('"hello"')).toEqual([{ type: "STRING", value: '"hello"' }]);
     expect(tokenize("'hello'")).toEqual([{ type: "SYMBOL", value: "'hello'" }]);

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -10,7 +10,13 @@ import {
   setCellContent,
   undo,
 } from "../test_helpers/commands_helpers";
-import { getBorder, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
+import {
+  getBorder,
+  getCell,
+  getCellContent,
+  getCellError,
+  getCellText,
+} from "../test_helpers/getters_helpers";
 import { createEqualCF, getGrid, target } from "../test_helpers/helpers";
 
 function getClipboardVisibleZones(model: Model): Zone[] {
@@ -1337,6 +1343,15 @@ describe("clipboard: pasting outside of sheet", () => {
     model.dispatch("PASTE", { target: [toZone("B2")] });
     expect(activeSheet.cols.length).toBe(currentColNumber + 1);
     expect(getCellContent(model, "B2")).toBe("txt");
+  });
+
+  test("Copy a formula which lead to #REF", () => {
+    const model = new Model();
+    setCellContent(model, "B3", "=A1");
+    model.dispatch("COPY", { target: target("B3") });
+    model.dispatch("PASTE", { target: target("B2") });
+    expect(getCellContent(model, "B2", "#BAD_EXPR"));
+    expect(getCellError(model, "B2")).toEqual("Invalid reference");
   });
 
   test("Can cut & paste a formula", () => {


### PR DESCRIPTION
Before this commit, a cell with #REF was not correctly tokenized as #REF
was unknown. We had an error like 'Unexpected token: #'. Now, we have a
better error message: "Invalid reference".

Task-id 2648058

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
