### PR TITLE
[FIX] autofill: don't move tootip when scrolling

### DIFF
--- a/src/components/autofill.ts
+++ b/src/components/autofill.ts
@@ -101,7 +101,11 @@ export class Autofill extends Component<Props, SpreadsheetEnv> {
   onMouseDown(ev: MouseEvent) {
     this.state.handler = true;
     this.state.position = { left: 0, top: 0 };
-    const start = { left: ev.clientX, top: ev.clientY };
+    const { offsetY, offsetX } = this.env.getters.getActiveSnappedViewport();
+    const start = {
+      left: ev.clientX + offsetX,
+      top: ev.clientY + offsetY,
+    };
     let lastCol: number | undefined;
     let lastRow: number | undefined;
 
@@ -111,13 +115,18 @@ export class Autofill extends Component<Props, SpreadsheetEnv> {
     };
 
     const onMouseMove = (ev: MouseEvent) => {
-      this.state.position = {
-        left: ev.clientX - start.left,
-        top: ev.clientY - start.top,
-      };
       const parent = this.el!.parentElement! as HTMLElement;
       const position = parent.getBoundingClientRect();
-      const { top: viewportTop, left: viewportLeft } = this.env.getters.getActiveSnappedViewport();
+      const {
+        top: viewportTop,
+        left: viewportLeft,
+        offsetY,
+        offsetX,
+      } = this.env.getters.getActiveSnappedViewport();
+      this.state.position = {
+        left: ev.clientX - start.left + offsetX,
+        top: ev.clientY - start.top + offsetY,
+      };
       const col = this.env.getters.getColIndex(ev.clientX - position.left, viewportLeft);
       const row = this.env.getters.getRowIndex(ev.clientY - position.top, viewportTop);
       if (lastCol !== col || lastRow !== row) {

--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -7,6 +7,7 @@ export function startDnd(onMouseMove: EventFn, onMouseUp: EventFn) {
     window.removeEventListener("mouseup", _onMouseUp);
     window.removeEventListener("dragstart", _onDragStart);
     window.removeEventListener("mousemove", onMouseMove);
+    window.removeEventListener("wheel", onMouseMove);
   };
   function _onDragStart(ev: DragEvent) {
     ev.preventDefault();
@@ -15,6 +16,7 @@ export function startDnd(onMouseMove: EventFn, onMouseUp: EventFn) {
   window.addEventListener("mouseup", _onMouseUp);
   window.addEventListener("dragstart", _onDragStart);
   window.addEventListener("mousemove", onMouseMove);
+  window.addEventListener("wheel", onMouseMove);
 }
 
 /**

--- a/tests/components/autofill.test.ts
+++ b/tests/components/autofill.test.ts
@@ -76,6 +76,94 @@ describe("Autofill component", () => {
     expect(parent.env.dispatch).toHaveBeenCalledWith("AUTOFILL_AUTO");
   });
 
+  test("tooltip position when moving the mouse", async () => {
+    const autofill = fixture.querySelector(".o-autofill");
+    expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
+    setCellContent(model, "A1", "test");
+    await nextTick();
+    triggerMouseEvent(autofill, "mousedown", 40, 40);
+    await nextTick();
+    expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
+    const sheetId = parent.env.getters.getActiveSheetId();
+    const x = HEADER_WIDTH + parent.env.getters.getCol(sheetId, 1)!.end + 20;
+    const y = HEADER_HEIGHT + parent.env.getters.getRow(sheetId, 0)!.start + 20;
+    triggerMouseEvent(autofill, "mousemove", x, y);
+    await nextTick();
+    expect(fixture.querySelector(".o-autofill")).not.toBeNull();
+    expect(fixture.querySelector(".o-autofill-nextvalue")).toMatchInlineSnapshot(`
+      <div
+        class="o-autofill-nextvalue"
+        style="top:11px;left:235px;"
+      >
+        <div>
+          test
+        </div>
+      </div>
+    `);
+  });
+
+  test("tooltip position when scrolling", async () => {
+    const autofill = fixture.querySelector(".o-autofill");
+    expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
+    setCellContent(model, "A1", "test");
+    await nextTick();
+    triggerMouseEvent(autofill, "mousedown", 40, 40);
+    await nextTick();
+    expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
+    const sheetId = parent.env.getters.getActiveSheetId();
+    const x = HEADER_WIDTH + parent.env.getters.getCol(sheetId, 1)!.end + 20;
+    const y = HEADER_HEIGHT + parent.env.getters.getRow(sheetId, 0)!.start + 20;
+    fixture.querySelector(".o-grid")!.dispatchEvent(
+      new WheelEvent("wheel", {
+        clientX: x,
+        clientY: y,
+        bubbles: true,
+      })
+    );
+    await nextTick();
+    expect(fixture.querySelector(".o-autofill")).not.toBeNull();
+    expect(fixture.querySelector(".o-autofill-nextvalue")).toMatchInlineSnapshot(`
+      <div
+        class="o-autofill-nextvalue"
+        style="top:11px;left:235px;"
+      >
+        <div>
+          test
+        </div>
+      </div>
+    `);
+  });
+
+  test("tooltip position when viewport is not at the top", async () => {
+    const autofill = fixture.querySelector(".o-autofill");
+    expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: 500,
+      offsetY: 500,
+    });
+    setCellContent(model, "A1", "test");
+    await nextTick();
+    triggerMouseEvent(autofill, "mousedown", 40, 40);
+    await nextTick();
+    expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
+    const sheetId = parent.env.getters.getActiveSheetId();
+    const x = HEADER_WIDTH + parent.env.getters.getCol(sheetId, 1)!.end + 20;
+    const y = HEADER_HEIGHT + parent.env.getters.getRow(sheetId, 0)!.start + 20;
+    triggerMouseEvent(autofill, "mousemove", x, y);
+    await nextTick();
+    expect(fixture.querySelector(".o-autofill")).not.toBeNull();
+    expect(fixture.querySelector(".o-autofill-nextvalue")).toMatchInlineSnapshot(`
+      <div
+        class="o-autofill-nextvalue"
+        style="top:11px;left:235px;"
+      >
+        <div>
+          test
+        </div>
+      </div>
+    `);
+  });
+
   test("Can display tooltip with autofill", async () => {
     const autofill = fixture.querySelector(".o-autofill");
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();


### PR DESCRIPTION

## Description:

Scroll while autofilling => the tooltip position is wrong.

Could be fixed in 14.0 as well but...the bug is minor and non-blocking,
the viewport code changed, I don't want to risk breaking 14.0 (this diff
has been tested with chrome and Firefox but)


Odoo task ID : [2339870](https://www.odoo.com/web#id=2339870&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
