### PR TITLE
[REF] cells: use OO API to narrow the type of a cell

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -10,8 +10,6 @@ import {
   SCROLLBAR_WIDTH,
   TOPBAR_HEIGHT,
 } from "../constants";
-import { isEmpty } from "../helpers/cells";
-import { isLink } from "../helpers/cells/index";
 import {
   findCellInNewZone,
   findVisibleHeader,
@@ -373,7 +371,8 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
     const cell = this.getters.getCell(sheetId, col, row);
     return (
       this.getters.isVisibleInViewport(col, row, viewport) &&
-      isLink(cell) &&
+      !!cell &&
+      cell.isLink() &&
       !this.menuState.isOpen &&
       !this.props.linkEditorIsOpen &&
       !this.props.sidePanelIsOpen
@@ -406,7 +405,7 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
   private keyDownMapping: { [key: string]: Function } = {
     ENTER: () => {
       const cell = this.getters.getActiveCell();
-      isEmpty(cell)
+      !cell || cell.isEmpty()
         ? this.trigger("composer-cell-focused")
         : this.trigger("composer-content-focused");
     },
@@ -414,7 +413,7 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
     "SHIFT+TAB": () => this.dispatch("MOVE_POSITION", { deltaX: -1, deltaY: 0 }),
     F2: () => {
       const cell = this.getters.getActiveCell();
-      isEmpty(cell)
+      !cell || cell.isEmpty()
         ? this.trigger("composer-cell-focused")
         : this.trigger("composer-content-focused");
     },
@@ -669,7 +668,7 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
     const sheetId = this.getters.getActiveSheetId();
     const [mainCol, mainRow] = this.getters.getMainCell(sheetId, col, row);
     const cell = this.getters.getCell(sheetId, mainCol, mainRow);
-    if (!isLink(cell)) {
+    if (!cell?.isLink()) {
       this.closeLinkEditor();
     }
 
@@ -761,7 +760,7 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
     const [col, row] = this.getCartesianCoordinates(ev);
     if (this.clickedCol === col && this.clickedRow === row) {
       const cell = this.getters.getActiveCell();
-      isEmpty(cell)
+      !cell || cell.isEmpty()
         ? this.trigger("composer-cell-focused")
         : this.trigger("composer-content-focused");
     }

--- a/src/components/link/link_display.ts
+++ b/src/components/link/link_display.ts
@@ -1,7 +1,6 @@
 import * as owl from "@odoo/owl";
 import { LINK_COLOR } from "../../constants";
 import { toXC } from "../../helpers";
-import { isLink } from "../../helpers/cells/index";
 import { LinkCell, Position, SpreadsheetEnv } from "../../types";
 import { EDIT, UNLINK } from "../icons";
 import { Menu } from "../menu";
@@ -80,7 +79,7 @@ export class LinkDisplay extends Component<{ cellPosition: Position }, Spreadshe
     const { col, row } = this.props.cellPosition;
     const sheetId = this.getters.getActiveSheetId();
     const cell = this.getters.getCell(sheetId, col, row);
-    if (isLink(cell)) {
+    if (cell?.isLink()) {
       return cell;
     }
     throw new Error(

--- a/src/components/link/link_editor.ts
+++ b/src/components/link/link_editor.ts
@@ -1,5 +1,4 @@
 import * as owl from "@odoo/owl";
-import { isLink } from "../../helpers/cells/index";
 import { markdownLink } from "../../helpers/index";
 import { linkMenuRegistry } from "../../registries/menus/link_menu_registry";
 import { DOMCoordinates, Link, Position, SpreadsheetEnv } from "../../types";
@@ -150,7 +149,7 @@ export class LinkEditor extends Component<LinkEditorProps, SpreadsheetEnv> {
     const { col, row } = this.props.cellPosition;
     const sheetId = this.getters.getActiveSheetId();
     const cell = this.getters.getCell(sheetId, col, row);
-    if (isLink(cell)) {
+    if (cell?.isLink()) {
       return {
         link: { url: cell.link.url, label: cell.formattedValue },
         urlRepresentation: cell.urlRepresentation,

--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -2,7 +2,6 @@ import { DATETIME_FORMAT, LINK_COLOR, LOADING } from "../../constants";
 import { _lt } from "../../translation";
 import {
   BooleanEvaluation,
-  Cell,
   CellDisplayProperties,
   CellEvaluation,
   CellValue,
@@ -39,6 +38,17 @@ abstract class AbstractCell<T extends CellEvaluation = CellEvaluation> implement
   constructor(readonly id: UID, public evaluated: T, properties: CellDisplayProperties) {
     this.style = properties.style;
     this.format = properties.format;
+  }
+  isFormula(): this is IFormulaCell {
+    return false;
+  }
+
+  isLink(): this is ILinkCell {
+    return false;
+  }
+
+  isEmpty(): boolean {
+    return false;
   }
 
   get formattedValue() {
@@ -94,6 +104,10 @@ export class EmptyCell extends AbstractCell<EmptyEvaluation> {
   readonly content = "";
   constructor(id: UID, properties: CellDisplayProperties = {}) {
     super(id, { value: "", type: CellValueType.empty }, properties);
+  }
+
+  isEmpty() {
+    return true;
   }
 }
 
@@ -155,6 +169,10 @@ export abstract class LinkCell extends AbstractCell<TextEvaluation> implements I
     this.content = content;
   }
   abstract action(env: SpreadsheetEnv): void;
+
+  isLink() {
+    return true;
+  }
 
   get composerContent() {
     return this.link.label;
@@ -240,6 +258,10 @@ export class FormulaCell extends AbstractCell implements IFormulaCell {
     return this.buildFormulaString(this.normalizedText, this.dependencies);
   }
 
+  isFormula() {
+    return true;
+  }
+
   startEvaluation() {
     this.evaluated = { value: LOADING, type: CellValueType.text };
   }
@@ -305,16 +327,4 @@ export class BadExpressionCell extends AbstractCell<InvalidEvaluation> {
   constructor(id: UID, readonly content: string, error: string, properties: CellDisplayProperties) {
     super(id, { value: "#BAD_EXPR", type: CellValueType.error, error }, properties);
   }
-}
-
-export function isFormula(cell: ICell): cell is IFormulaCell {
-  return cell instanceof FormulaCell;
-}
-
-export function isEmpty(cell: Cell | undefined): boolean {
-  return !cell || cell instanceof EmptyCell;
-}
-
-export function isLink(cell: ICell | undefined): cell is ILinkCell {
-  return cell instanceof LinkCell;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "./constants";
 import { toBoolean, toNumber, toString } from "./functions/helpers";
 import { args, functionRegistry } from "./functions/index";
-import { isFormula, LinkCell } from "./helpers/cells/index";
+import { LinkCell } from "./helpers/cells/index";
 import {
   computeTextWidth,
   formatDecimal,
@@ -121,7 +121,6 @@ export const helpers = {
   UuidGenerator,
   formatDecimal,
   computeTextWidth,
-  isFormula,
   isMarkdownLink,
   parseMarkdownLink,
   markdownLink,

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -2,7 +2,7 @@ import { DATETIME_FORMAT, NULL_FORMAT } from "../../constants";
 import { compile } from "../../formulas/index";
 import { FORMULA_REF_IDENTIFIER } from "../../formulas/tokenizer";
 import { cellFactory } from "../../helpers/cells/cell_factory";
-import { FormulaCell, isEmpty, isFormula } from "../../helpers/cells/index";
+import { FormulaCell } from "../../helpers/cells/index";
 import {
   isInside,
   maximumDecimalPlaces,
@@ -61,7 +61,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID) {
     for (const sheet of Object.keys(this.cells)) {
       for (const cell of Object.values(this.cells[sheet] || {})) {
-        if (isFormula(cell)) {
+        if (cell.isFormula()) {
           for (const range of cell.dependencies) {
             if (!sheetId || range.sheetId === sheetId) {
               const change = applyChange(range);
@@ -391,7 +391,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
           style: cell.style && getStyleId(cell.style),
           format: cell.format,
         };
-        if (isFormula(cell)) {
+        if (cell.isFormula()) {
           cells[xc].formula = {
             text: cell.normalizedText || "",
             dependencies:
@@ -601,7 +601,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
      *  */
     if (
       ((hasContent && !afterContent && !after.formula) ||
-        (!hasContent && (isEmpty(before) || !before))) &&
+        (!hasContent && (!before || before.isEmpty()))) &&
       !style &&
       !format
     ) {

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from "../../helpers/cells/index";
 import {
   updateAddColumns,
   updateAddRows,
@@ -307,7 +306,7 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
       for (let col = left; col <= right; col++) {
         if (col !== left || row !== top) {
           const cell = actualRow.cells[col];
-          if (cell && !isEmpty(cell)) {
+          if (cell && !cell.isEmpty()) {
             return true;
           }
         }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -1,5 +1,4 @@
 import { FORBIDDEN_IN_EXCEL_REGEX } from "../../constants";
-import { isEmpty } from "../../helpers/cells/index";
 import {
   createCols,
   createDefaultCols,
@@ -381,7 +380,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     const sheet = this.getSheet(sheetId);
     return mapCellsInZone(zone, sheet, (cell) => cell, undefined)
       .flat()
-      .every(isEmpty);
+      .every((cell) => !cell || cell.isEmpty());
   }
 
   private setHeaderSize(sheet: Sheet, dimension: "cols" | "rows", index: number, size: number) {

--- a/src/plugins/ui/autofill.ts
+++ b/src/plugins/ui/autofill.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from "../../helpers/cells/index";
 import { clip, isInside, toCartesian, toXC, union } from "../../helpers/index";
 import { Mode } from "../../model";
 import { autofillModifiersRegistry, autofillRulesRegistry } from "../../registries/index";
@@ -278,7 +277,7 @@ export class AutofillPlugin extends UIPlugin {
     let row = zone.bottom;
     if (col > 0) {
       let left = this.getters.getCell(sheetId, col - 1, row);
-      while (!isEmpty(left)) {
+      while (left && !left.isEmpty()) {
         row += 1;
         left = this.getters.getCell(sheetId, col - 1, row);
       }
@@ -287,7 +286,7 @@ export class AutofillPlugin extends UIPlugin {
       col = zone.right;
       if (col <= this.getters.getActiveSheet().cols.length) {
         let right = this.getters.getCell(sheetId, col + 1, row);
-        while (!isEmpty(right)) {
+        while (right && !right.isEmpty()) {
           row += 1;
           right = this.getters.getCell(sheetId, col + 1, row);
         }

--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -1,5 +1,5 @@
 import { SELECTION_BORDER_COLOR } from "../../constants";
-import { formatValue, isFormula } from "../../helpers/cells/index";
+import { formatValue } from "../../helpers/cells/index";
 import { clip, overlap } from "../../helpers/index";
 import { Mode } from "../../model";
 import { _lt } from "../../translation";
@@ -568,7 +568,7 @@ export class ClipboardPlugin extends UIPlugin {
       }
       let content = origin.cell.content;
 
-      if (isFormula(origin.cell)) {
+      if (origin.cell.isFormula()) {
         const offsetX = col - origin.position.col;
         const offsetY = row - origin.position.row;
         content = this.getUpdatedContent(sheetId, origin.cell, offsetX, offsetY, zones, operation);

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -1,5 +1,4 @@
 import { composerTokenize, EnrichedToken } from "../../formulas/index";
-import { isLink } from "../../helpers/cells/index";
 import {
   colors,
   getComposerSheetName,
@@ -378,7 +377,7 @@ export class EditionPlugin extends UIPlugin {
           if (missing > 0) {
             content += new Array(missing).fill(")").join("");
           }
-        } else if (isLink(cell)) {
+        } else if (cell?.isLink()) {
           content = markdownLink(content, cell.link.url);
         }
         this.dispatch("UPDATE_CELL", {

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -1,6 +1,5 @@
 import { compile, normalize } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { isEmpty, isFormula } from "../../helpers/cells/index";
 import { mapCellsInZone, toXC } from "../../helpers/index";
 import { Mode, ModelConfig } from "../../model";
 import { StateObserver } from "../../state_observer";
@@ -134,7 +133,7 @@ export class EvaluationPlugin extends UIPlugin {
     const params = this.getFormulaParameters(computeValue);
     const visited: { [sheetId: string]: { [xc: string]: boolean | null } } = {};
     for (let cell of makeObjectIterator(cells)) {
-      if (isFormula(cell)) {
+      if (cell.isFormula()) {
         cell.startEvaluation();
       }
     }
@@ -157,7 +156,7 @@ export class EvaluationPlugin extends UIPlugin {
     }
 
     function computeValue(cell: Cell, sheetId: string) {
-      if (!isFormula(cell)) {
+      if (!cell.isFormula()) {
         return;
       }
       const position = params[2].getters.getCellPosition(cell.id);
@@ -203,7 +202,7 @@ export class EvaluationPlugin extends UIPlugin {
       } else {
         throw new Error(_lt("Invalid sheet name"));
       }
-      if (!cell || isEmpty(cell)) {
+      if (!cell || cell.isEmpty()) {
         // magic "empty" value
         return null;
       }
@@ -211,7 +210,7 @@ export class EvaluationPlugin extends UIPlugin {
     }
 
     function getCellValue(cell: Cell, sheetId: UID): any {
-      if (isFormula(cell) && cell.evaluated.type === CellValueType.error) {
+      if (cell.isFormula() && cell.evaluated.type === CellValueType.error) {
         throw new Error(_lt("This formula depends on invalid values"));
       }
       computeValue(cell, sheetId);

--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -1,4 +1,3 @@
-import { isFormula } from "../../helpers/cells/index";
 import { Cell, Command, GridRenderingContext, LAYERS, UID } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
@@ -152,7 +151,7 @@ export class FindAndReplacePlugin extends UIPlugin {
           this.currentSearchRegex &&
           this.currentSearchRegex.test(
             this.searchOptions.searchFormulas
-              ? isFormula(cell)
+              ? cell.isFormula()
                 ? cell.content
                 : String(cell.evaluated.value)
               : String(cell.evaluated.value)
@@ -271,9 +270,9 @@ export class FindAndReplacePlugin extends UIPlugin {
    */
   private toReplace(cell: Cell | undefined, sheetId: UID): string | null {
     if (cell) {
-      if (this.searchOptions.searchFormulas && isFormula(cell)) {
+      if (this.searchOptions.searchFormulas && cell.isFormula()) {
         return cell.content;
-      } else if (this.replaceOptions.modifyFormulas || !isFormula(cell)) {
+      } else if (this.replaceOptions.modifyFormulas || !cell.isFormula()) {
         return (cell.evaluated.value as any).toString();
       }
     }

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -16,7 +16,6 @@ import {
   TEXT_HEADER_COLOR,
 } from "../../constants";
 import { fontSizeMap } from "../../fonts";
-import { isEmpty, isFormula } from "../../helpers/cells/index";
 import { overlap, scrollDelay } from "../../helpers/index";
 import { Mode } from "../../model";
 import {
@@ -40,7 +39,7 @@ import { UIPlugin } from "../ui_plugin";
 // -----------------------------------------------------------------------------
 
 function computeAlign(cell: Cell, isShowingFormulas: boolean): "right" | "center" | "left" {
-  if (isFormula(cell) && isShowingFormulas) {
+  if (cell.isFormula() && isShowingFormulas) {
     return "left";
   }
   return cell.defaultAlign;
@@ -453,7 +452,7 @@ export class RendererPlugin extends UIPlugin {
   private hasContent(col: number, row: number): boolean {
     const sheetId = this.getters.getActiveSheetId();
     const cell = this.getters.getCell(sheetId, col, row);
-    return !isEmpty(cell) || this.getters.isInMerge(sheetId, col, row);
+    return (cell && !cell.isEmpty()) || this.getters.isInMerge(sheetId, col, row);
   }
 
   private getGridBoxes(renderingContext: GridRenderingContext): Box[] {

--- a/src/plugins/ui/sort.ts
+++ b/src/plugins/ui/sort.ts
@@ -1,4 +1,3 @@
-import { isFormula } from "../../helpers/cells/index";
 import { isEqual, isInside, mapCellsInZone, overlap, zoneToDimension } from "../../helpers/index";
 import { _lt } from "../../translation";
 import {
@@ -430,7 +429,7 @@ export class SortPlugin extends UIPlugin {
         };
         if (cell) {
           let content: string = cell.content;
-          if (isFormula(cell)) {
+          if (cell.isFormula()) {
             const position = this.getters.getCellPosition(cell.id);
             const offsetY = newRow - position.row;
             // we only have a vertical offset

--- a/src/plugins/ui/ui_sheet.ts
+++ b/src/plugins/ui/ui_sheet.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_FONT_SIZE, PADDING_AUTORESIZE } from "../../constants";
 import { fontSizeMap } from "../../fonts";
-import { isFormula } from "../../helpers/cells/index";
 import { computeIconWidth, computeTextWidth } from "../../helpers/index";
 import { _lt } from "../../translation";
 import { Cell, CellValueType, Command, CommandResult, UID, Zone } from "../../types";
@@ -100,7 +99,7 @@ export class SheetUIPlugin extends UIPlugin {
   }
 
   getCellText(cell: Cell, showFormula: boolean = false): string {
-    if (showFormula && (isFormula(cell) || cell.evaluated.type === CellValueType.error)) {
+    if (showFormula && (cell.isFormula() || cell.evaluated.type === CellValueType.error)) {
       return cell.content;
     } else {
       return cell.formattedValue;

--- a/src/registries/autofill_modifiers.ts
+++ b/src/registries/autofill_modifiers.ts
@@ -1,4 +1,4 @@
-import { formatValue, isFormula } from "../helpers/cells/index";
+import { formatValue } from "../helpers/cells/index";
 import { Registry } from "../registry";
 import {
   AutofillData,
@@ -71,7 +71,7 @@ autofillModifiersRegistry
           y = 0;
           break;
       }
-      if (!data.cell || !isFormula(data.cell)) {
+      if (!data.cell || !data.cell.isFormula()) {
         return { cellData: {} };
       }
       const sheetId = data.sheetId;

--- a/src/registries/autofill_rules.ts
+++ b/src/registries/autofill_rules.ts
@@ -1,5 +1,4 @@
 import { DATETIME_FORMAT } from "../constants";
-import { isFormula } from "../helpers/cells/index";
 import { Registry } from "../registry";
 import { AutofillModifier, Cell, CellValueType } from "../types/index";
 
@@ -58,7 +57,7 @@ function getAverageIncrement(group: number[]) {
 autofillRulesRegistry
   .add("simple_value_copy", {
     condition: (cell: Cell, cells: (Cell | undefined)[]) => {
-      return cells.length === 1 && !isFormula(cell) && !cell.format?.match(DATETIME_FORMAT);
+      return cells.length === 1 && !cell.isFormula() && !cell.format?.match(DATETIME_FORMAT);
     },
     generateRule: () => {
       return { type: "COPY_MODIFIER" };
@@ -66,14 +65,14 @@ autofillRulesRegistry
     sequence: 10,
   })
   .add("copy_text", {
-    condition: (cell: Cell) => !isFormula(cell) && cell.evaluated.type === CellValueType.text,
+    condition: (cell: Cell) => !cell.isFormula() && cell.evaluated.type === CellValueType.text,
     generateRule: () => {
       return { type: "COPY_MODIFIER" };
     },
     sequence: 20,
   })
   .add("update_formula", {
-    condition: isFormula,
+    condition: (cell: Cell) => cell.isFormula(),
     generateRule: (_, cells: (Cell | undefined)[]) => {
       return { type: "FORMULA_MODIFIER", increment: cells.length, current: 0 };
     },

--- a/src/types/cells.ts
+++ b/src/types/cells.ts
@@ -41,6 +41,9 @@ export interface ICell {
    * Return a copy of the cell with new display properties.
    */
   withDisplayProperties: (properties: CellDisplayProperties) => this;
+  isFormula(): this is FormulaCell;
+  isLink(): this is LinkCell;
+  isEmpty(): boolean;
 }
 
 export interface FormulaCell extends ICell {

--- a/tests/components/link/link_display.test.ts
+++ b/tests/components/link/link_display.test.ts
@@ -1,6 +1,5 @@
 import { Model } from "../../../src";
 import { buildSheetLink } from "../../../src/helpers";
-import { isLink } from "../../../src/helpers/cells/index";
 import { clearCell, createSheet, setCellContent } from "../../test_helpers/commands_helpers";
 import { clickCell, rightClickCell, simulateClick } from "../../test_helpers/dom_helper";
 import { getCell } from "../../test_helpers/getters_helpers";
@@ -102,7 +101,7 @@ describe("link display component", () => {
     await simulateClick(".o-unlink");
     expect(fixture.querySelector(".o-link-tool")).toBeFalsy();
     const cell = getCell(model, "A1");
-    expect(isLink(cell)).toBeFalsy();
+    expect(cell?.isLink()).toBeFalsy();
     expect(cell?.content).toBe("label");
   });
 


### PR DESCRIPTION
## Description:
Given that cells are now classes, `cell.isFormula()` is a more natural API
than isFormula(cell). The same applies for `isLink` and `isEmpty`.

For the record: https://github.com/odoo/o-spreadsheet/pull/984#discussion_r698407925

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
