### PR TITLE
[FIX] tests: destroy top bar parent component

### DIFF
--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -19,6 +19,7 @@ const { xml } = tags;
 const { useSubEnv } = hooks;
 
 let fixture: HTMLElement;
+let parent: Parent;
 const t = (s: string): string => s;
 
 class Parent extends Component<any, SpreadsheetEnv> {
@@ -62,22 +63,22 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  parent.destroy();
   fixture.remove();
 });
 
 describe("TopBar component", () => {
   test("simple rendering", async () => {
-    const parent = new Parent(new Model());
+    parent = new Parent(new Model());
     await parent.mount(fixture);
 
     expect(fixture.querySelector(".o-spreadsheet-topbar")).toMatchSnapshot();
-    parent.destroy();
   });
 
   test("opening a second menu closes the first one", async () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
 
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
@@ -91,7 +92,6 @@ describe("TopBar component", () => {
     await nextTick();
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
     expect(fixture.querySelectorAll(".o-color-line").length).toBe(0);
-    parent.destroy();
   });
 
   test("merging cell button state is correct", async () => {
@@ -105,7 +105,7 @@ describe("TopBar component", () => {
         },
       ],
     });
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
     const mergeTool = fixture.querySelector('.o-tool[title="Merge Cells"]')!;
     expect(mergeTool.classList.contains("active")).toBeTruthy();
@@ -115,14 +115,13 @@ describe("TopBar component", () => {
     model.dispatch("ALTER_SELECTION", { cell: [0, 1] });
     await nextTick();
     expect(mergeTool.classList.contains("active")).toBeFalsy();
-    parent.destroy();
   });
 
   test("multiple selection zones => merge tools is disabled", async () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
 
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
     const mergeTool = fixture.querySelector('.o-tool[title="Merge Cells"]')!;
 
@@ -140,13 +139,12 @@ describe("TopBar component", () => {
     await nextTick();
     // should be disabled, because multiple zones are selected
     expect(mergeTool.classList.contains("o-disabled")).toBeTruthy();
-    parent.destroy();
   });
 
   test("undo/redo tools", async () => {
     const model = new Model();
 
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
     const undoTool = fixture.querySelector('.o-tool[title="Undo"]')!;
     const redoTool = fixture.querySelector('.o-tool[title="Redo"]')!;
@@ -171,13 +169,12 @@ describe("TopBar component", () => {
     expect(redoTool.classList.contains("o-disabled")).toBeFalsy();
 
     expect(getCell(model, "A1")).toBeUndefined();
-    parent.destroy();
   });
 
   test("paint format tools", async () => {
     const model = new Model();
 
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
     const paintFormatTool = fixture.querySelector('.o-tool[title="Paint Format"]')!;
 
@@ -187,7 +184,6 @@ describe("TopBar component", () => {
     await nextTick();
 
     expect(paintFormatTool.classList.contains("active")).toBeTruthy();
-    parent.destroy();
   });
 
   test("can clear formatting", async () => {
@@ -199,18 +195,17 @@ describe("TopBar component", () => {
       border: "all",
     });
     expect(getBorder(model, "B1")).toBeDefined();
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
     const clearFormatTool = fixture.querySelector('.o-tool[title="Clear Format"]')!;
     clearFormatTool.dispatchEvent(new Event("click"));
     expect(getCell(model, "B1")).toBeUndefined();
-    parent.destroy();
   });
 
   test("can set cell format", async () => {
     const model = new Model();
     expect(getCell(model, "A1")).toBeUndefined();
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
     const formatTool = fixture.querySelector('.o-tool[title="More formats"]')!;
     formatTool.dispatchEvent(new Event("click"));
@@ -221,12 +216,11 @@ describe("TopBar component", () => {
       .dispatchEvent(new Event("click", { bubbles: true }));
     await nextTick();
     expect(getCell(model, "A1")!.format).toEqual("0.00%");
-    parent.destroy();
   });
 
   test("can set font size", async () => {
     const model = new Model();
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
     const fontSizeTool = fixture.querySelector('.o-tool[title="Font Size"]')!;
     expect(fontSizeTool.textContent!.trim()).toBe(DEFAULT_FONT_SIZE.toString());
@@ -239,13 +233,12 @@ describe("TopBar component", () => {
     expect(fontSizeTool.textContent!.trim()).toBe("8");
     const style = model.getters.getCellStyle(getCell(model, "A1")!);
     expect(style.fontSize).toBe(8);
-    parent.destroy();
   });
 
   test("opening, then closing same menu", async () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
 
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
@@ -255,11 +248,10 @@ describe("TopBar component", () => {
     fixture.querySelector('span[title="Borders"]')!.dispatchEvent(new Event("click"));
     await nextTick();
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
-    parent.destroy();
   });
 
   test("Can open a Topbar menu", async () => {
-    const parent = new Parent(new Model());
+    parent = new Parent(new Model());
     await parent.mount(fixture);
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     const items = topbarMenuRegistry.getAll();
@@ -276,11 +268,10 @@ describe("TopBar component", () => {
     triggerMouseEvent(".o-spreadsheet-topbar", "click");
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    parent.destroy();
   });
 
   test("Can open a Topbar menu with mousemove", async () => {
-    const parent = new Parent(new Model());
+    parent = new Parent(new Model());
     await parent.mount(fixture);
     triggerMouseEvent(".o-topbar-menu[data-id='file']", "click");
     await nextTick();
@@ -298,7 +289,6 @@ describe("TopBar component", () => {
       .filter((item) => item.children.length !== 0 || item.action).length;
     expect(fixture.querySelectorAll(".o-menu-item")).toHaveLength(numberChild);
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
-    parent.destroy();
   });
 
   test("Can click on a menuItem do execute action and close menus", async () => {
@@ -312,7 +302,7 @@ describe("TopBar component", () => {
         number++;
       },
     });
-    const parent = new Parent(new Model());
+    parent = new Parent(new Model());
     await parent.mount(fixture);
     triggerMouseEvent(".o-topbar-menu[data-id='test']", "click");
     await nextTick();
@@ -321,7 +311,6 @@ describe("TopBar component", () => {
     expect(fixture.querySelectorAll(".o-menu-dropdown-content")).toHaveLength(0);
     expect(number).toBe(1);
     topbarMenuRegistry.content = menuDefinitions;
-    parent.destroy();
   });
 
   test("Can add a custom component to topbar", async () => {
@@ -330,16 +319,15 @@ describe("TopBar component", () => {
       static template = xml`<div class="o-topbar-test">Test</div>`;
     }
     topbarComponentRegistry.add("1", { component: Comp });
-    const parent = new Parent(new Model());
+    parent = new Parent(new Model());
     await parent.mount(fixture);
     expect(fixture.querySelectorAll(".o-topbar-test")).toHaveLength(1);
     topbarComponentRegistry.content = compDefinitions;
-    parent.destroy();
   });
 
   test("Readonly spreadsheet has a specific top bar", async () => {
     const model = new Model();
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
 
     expect(fixture.querySelectorAll(".o-readonly-toolbar")).toHaveLength(0);
@@ -354,7 +342,7 @@ describe("TopBar component", () => {
 
   test("Cannot edit cell in a readonly spreadsheet", async () => {
     const model = new Model({}, { isReadonly: true });
-    const parent = new Parent(model);
+    parent = new Parent(model);
     await parent.mount(fixture);
 
     const composerEl = fixture.querySelector(".o-spreadsheet-topbar div.o-composer")!;
@@ -388,7 +376,7 @@ test("Can show/hide a TopBarComponent based on condition", async () => {
     component: Comp2,
     isVisible: (env) => false,
   });
-  const parent = new Parent(new Model());
+  parent = new Parent(new Model());
   await parent.mount(fixture);
   expect(fixture.querySelectorAll(".o-topbar-test1")).toHaveLength(1);
   expect(fixture.querySelectorAll(".o-topbar-test2")).toHaveLength(0);


### PR DESCRIPTION

## Description:

Some tests didn't destroy the component they instanciated. So it was still alive
even if the test was finished. It could lead to weird and undeterministic
behaviors in other tests (depending on the order and execution speed).

Odoo task ID : 

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
