### PR TITLE
[REF] tests: remove helper component GridParent

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -16,6 +16,7 @@ import { Grid } from "./grid";
 import { LinkEditor } from "./link/link_editor";
 import { SidePanel } from "./side_panel/side_panel";
 import { TopBar } from "./top_bar";
+import { SpreadsheetEnv } from "../types";
 
 const { Component, useState } = owl;
 const { useRef, useExternalListener } = owl.hooks;
@@ -96,7 +97,7 @@ interface Props {
 
 const t = (s: string): string => s;
 
-export class Spreadsheet extends Component<Props> {
+export class Spreadsheet extends Component<Props, SpreadsheetEnv> {
   static template = TEMPLATE;
   static style = CSS;
   static components = { TopBar, Grid, BottomBar, SidePanel, LinkEditor };
@@ -141,8 +142,8 @@ export class Spreadsheet extends Component<Props> {
     "CTRL+H": () => this.toggleSidePanel("FindAndReplace", {}),
     "CTRL+F": () => this.toggleSidePanel("FindAndReplace", {}),
   };
-  constructor() {
-    super(...arguments);
+  constructor(parent?: owl.Component<any, SpreadsheetEnv> | null, props: Props = {}) {
+    super(parent, props);
     useSubEnv({
       openSidePanel: (panel: string, panelProps: any = {}) => this.openSidePanel(panel, panelProps),
       toggleSidePanel: (panel: string, panelProps: any = {}) =>

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Grid component simple rendering snapshot 1`] = `
 <div
-  class="o-grid"
+  class="o-grid o-two-columns"
 >
   <canvas
     height="985"
@@ -57,7 +57,7 @@ exports[`error tooltip can display error tooltip 1`] = `
       z-index: 5;
       top:250px;
       left:336px;
-      max-height:949px;
+      max-height:934px;
       width:180px;
       overflow-y: auto;
       overflow-x: hidden;

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -4,14 +4,15 @@ import { Model } from "../../src/model";
 import { selectCell } from "../test_helpers/commands_helpers";
 import { getCellText } from "../test_helpers/getters_helpers";
 import {
-  GridParent,
   makeTestFixture,
   nextTick,
   resetFunctions,
   startGridComposition,
   typeInComposer as typeInComposerHelper,
+  mountSpreadsheet,
 } from "../test_helpers/helpers";
 import { ContentEditableHelper } from "./__mocks__/content_editable_helper";
+import { Spreadsheet } from "../../src";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("./__mocks__/content_editable_helper")
 );
@@ -19,7 +20,7 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 let model: Model;
 let composerEl: Element;
 let fixture: HTMLElement;
-let parent: any;
+let parent: Spreadsheet;
 async function typeInComposer(text: string, fromScratch: boolean = true) {
   if (fromScratch) {
     composerEl = await startGridComposition();
@@ -29,12 +30,11 @@ async function typeInComposer(text: string, fromScratch: boolean = true) {
 
 beforeEach(async () => {
   fixture = makeTestFixture();
-  model = new Model();
-  parent = new GridParent(model);
-  await parent.mount(fixture);
+  parent = await mountSpreadsheet(fixture);
+  model = parent.model;
 
   // start composition
-  parent.grid.el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+  parent.grid.el!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
   await nextTick();
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
 });
@@ -268,7 +268,7 @@ describe("Autocomplete parenthesis", () => {
     await nextTick();
     selectCell(model, "A1");
     //edit A1
-    parent.grid.el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    parent.grid.el!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
     await nextTick();
     composerEl = fixture.querySelector(".o-grid div.o-composer")!;
     // @ts-ignore

--- a/tests/components/autofill.test.ts
+++ b/tests/components/autofill.test.ts
@@ -4,7 +4,8 @@ import { Model } from "../../src/model";
 import { DispatchResult } from "../../src/types/commands";
 import { setCellContent } from "../test_helpers/commands_helpers";
 import { triggerMouseEvent } from "../test_helpers/dom_helper";
-import { GridParent, makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { makeTestFixture, nextTick, mountSpreadsheet } from "../test_helpers/helpers";
+import { Spreadsheet } from "../../src";
 
 const { Component } = owl;
 const { xml } = owl.tags;
@@ -14,13 +15,12 @@ jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation((
 
 let fixture: HTMLElement;
 let model: Model;
-let parent: GridParent;
+let parent: Spreadsheet;
 
 beforeEach(async () => {
   fixture = makeTestFixture();
-  model = new Model();
-  parent = new GridParent(model);
-  await parent.mount(fixture);
+  parent = await mountSpreadsheet(fixture);
+  model = parent.model;
 });
 
 afterEach(() => {

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1,5 +1,5 @@
 import { ChartConfiguration } from "chart.js";
-import { Model } from "../../src";
+import { Model, Spreadsheet } from "../../src";
 import { BACKGROUND_CHART_COLOR } from "../../src/constants";
 import { DispatchResult } from "../../src/types";
 import { createChart } from "../test_helpers/commands_helpers";
@@ -8,7 +8,7 @@ import {
   simulateClick,
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
-import { GridParent, makeTestFixture, nextTick, textContentAll } from "../test_helpers/helpers";
+import { makeTestFixture, nextTick, textContentAll, mountSpreadsheet } from "../test_helpers/helpers";
 
 const mockChart = () => {
   const mockChartData: ChartConfiguration = {
@@ -50,13 +50,13 @@ let model: Model;
 let mockChartData = mockChart();
 let chartId: string;
 
-let parent: GridParent;
+let parent: Spreadsheet;
 describe("figures", () => {
   beforeEach(async () => {
     fixture = makeTestFixture();
     mockChartData = mockChart();
     chartId = "someuuid";
-    model = new Model({
+    const data = {
       sheets: [
         {
           name: "Sheet1",
@@ -80,9 +80,9 @@ describe("figures", () => {
           },
         },
       ],
-    });
-    parent = new GridParent(model);
-    await parent.mount(fixture);
+    };
+    parent = await mountSpreadsheet(fixture, { data });
+    model = parent.model;
     await nextTick();
     createChart(
       model,
@@ -438,7 +438,7 @@ describe("charts with multiple sheets", () => {
   beforeEach(async () => {
     fixture = makeTestFixture();
     mockChartData = mockChart();
-    model = new Model({
+    const data = {
       sheets: [
         {
           name: "Sheet1",
@@ -477,9 +477,9 @@ describe("charts with multiple sheets", () => {
           ],
         },
       ],
-    });
-    parent = new GridParent(model);
-    await parent.mount(fixture);
+    };
+    parent = await mountSpreadsheet(fixture, { data });
+    model = parent.model;
     await nextTick();
   });
   afterEach(() => {

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -20,13 +20,14 @@ import {
 import { clickCell, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
-  GridParent,
   makeTestFixture,
   nextTick,
   startGridComposition as startComposition,
   typeInComposer as typeInComposerHelper,
+  mountSpreadsheet,
 } from "../test_helpers/helpers";
 import { ContentEditableHelper } from "./__mocks__/content_editable_helper";
+import { Spreadsheet } from "../../src";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("./__mocks__/content_editable_helper")
 );
@@ -35,7 +36,7 @@ let model: Model;
 let composerEl: Element;
 let canvasEl: Element;
 let fixture: HTMLElement;
-let parent: GridParent;
+let parent: Spreadsheet;
 
 function getHighlights(model: Model): any[] {
   const highlightPlugin = (model as any).handlers.find((h) => h instanceof HighlightPlugin);
@@ -66,14 +67,13 @@ async function keyup(key: string, options: any = {}) {
 
 beforeEach(async () => {
   fixture = makeTestFixture();
-  model = new Model();
-  parent = new GridParent(model);
-  await parent.mount(fixture);
+  parent = await mountSpreadsheet(fixture);
+  model = parent.model;
   model.dispatch("RESIZE_VIEWPORT", {
     width: 1000,
     height: 1000,
   });
-  canvasEl = parent.grid.el;
+  canvasEl = parent.el?.querySelector(".o-grid")!;
 });
 
 afterEach(() => {
@@ -798,7 +798,8 @@ describe("composer", () => {
   });
 
   test("Select a right-to-left range with the keyboard", async () => {
-    await typeInComposer("Hello");
+    setCellContent(model, "A1", "Hello");
+    await keydown("Enter");
     const { end } = model.getters.getComposerSelection();
     await keydown("ArrowLeft", { shiftKey: true });
     await keyup("ArrowLeft", { shiftKey: true });

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -1,4 +1,4 @@
-import { Model } from "../../src";
+import { Model, Spreadsheet } from "../../src";
 import { CellIsRuleEditor } from "../../src/components/side_panel/conditional_formatting/cell_is_rule_editor";
 import { ColorScaleRuleEditor } from "../../src/components/side_panel/conditional_formatting/color_scale_rule_editor";
 import { IconSetRuleEditor } from "../../src/components/side_panel/conditional_formatting/icon_set_rule_editor";
@@ -9,11 +9,11 @@ import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_
 import {
   createColorScale,
   createEqualCF,
-  GridParent,
   makeTestFixture,
   mockUuidV4To,
   nextTick,
   textContentAll,
+  mountSpreadsheet,
 } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
@@ -21,14 +21,12 @@ let model: Model;
 
 describe("UI of conditional formats", () => {
   let fixture: HTMLElement;
-  let parent: GridParent;
+  let parent: Spreadsheet;
 
   beforeEach(async () => {
     fixture = makeTestFixture();
-    model = new Model();
-    parent = new GridParent(model);
-    await parent.mount(fixture);
-
+    parent = await mountSpreadsheet(fixture);
+    model = parent.model;
     parent.env.openSidePanel("ConditionalFormatting");
     await nextTick();
   });

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -1,5 +1,5 @@
 import { Component, tags } from "@odoo/owl";
-import { Model } from "../../src";
+import { Spreadsheet } from "../../src";
 import { corePluginRegistry } from "../../src/plugins";
 import { CorePlugin } from "../../src/plugins/core_plugin";
 import { figureRegistry } from "../../src/registries/figure_registry";
@@ -7,14 +7,14 @@ import { BaseCommand, Command, Figure, SpreadsheetEnv, UID } from "../../src/typ
 import { activateSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
-import { GridParent, makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { makeTestFixture, nextTick, mountSpreadsheet } from "../test_helpers/helpers";
 
 jest.spyOn(HTMLDivElement.prototype, "clientWidth", "get").mockImplementation(() => 1000);
 jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 1000);
 
 let fixture: HTMLElement;
 let model;
-let parent: GridParent;
+let parent: Spreadsheet;
 
 //Test Plugin
 interface CreateTextFigure extends BaseCommand {
@@ -78,9 +78,8 @@ figureRegistry.add("text", { Component: TextFigure });
 describe("figures", () => {
   beforeEach(async () => {
     fixture = makeTestFixture();
-    model = new Model();
-    parent = new GridParent(model);
-    await parent.mount(fixture);
+    parent = await mountSpreadsheet(fixture);
+    model = parent.model;
   });
 
   afterEach(() => {

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -1,7 +1,7 @@
-import { Model } from "../../src";
+import { Model, Spreadsheet } from "../../src";
 import { DispatchResult } from "../../src/types/commands";
 import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { GridParent, makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { makeTestFixture, nextTick, mountSpreadsheet } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 jest.useFakeTimers();
 
@@ -32,12 +32,11 @@ const selectors = {
 
 describe("find and replace sidePanel component", () => {
   let fixture: HTMLElement;
-  let parent: GridParent;
+  let parent: Spreadsheet;
   beforeEach(async () => {
-    model = new Model();
     fixture = makeTestFixture();
-    parent = new GridParent(model);
-    await parent.mount(fixture);
+    parent = await mountSpreadsheet(fixture);
+    model = parent.model;
     parent.env.openSidePanel("FindAndReplace");
     await nextTick();
   });

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -1,12 +1,13 @@
 import { args, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import {
-  GridParent,
   makeTestFixture,
   nextTick,
   resetFunctions,
   typeInComposer as typeInComposerHelper,
+  mountSpreadsheet,
 } from "../test_helpers/helpers";
+import { Spreadsheet } from "../../src";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("./__mocks__/content_editable_helper")
 );
@@ -14,19 +15,18 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 let model: Model;
 let composerEl: Element;
 let fixture: HTMLElement;
-let parent: any;
+let parent: Spreadsheet;
 async function typeInComposer(text: string) {
   await typeInComposerHelper(composerEl, text);
 }
 
 beforeEach(async () => {
   fixture = makeTestFixture();
-  model = new Model();
-  parent = new GridParent(model);
-  await parent.mount(fixture);
+  parent = await mountSpreadsheet(fixture);
+  model = parent.model;
 
   // start composition
-  parent.grid.el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+  parent.grid.el!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
   await nextTick();
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
 });

--- a/tests/components/grid_manipulation.test.ts
+++ b/tests/components/grid_manipulation.test.ts
@@ -3,7 +3,8 @@ import { Model } from "../../src/model";
 import { DispatchResult } from "../../src/types/commands";
 import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getActiveXc } from "../test_helpers/getters_helpers";
-import { GridParent, makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { makeTestFixture, nextTick, mountSpreadsheet } from "../test_helpers/helpers";
+import { Spreadsheet } from "../../src";
 
 const COLUMN_D = { x: 340, y: 10 };
 const ROW_5 = { x: 30, y: 100 };
@@ -11,16 +12,15 @@ const OUTSIDE_CM = { x: 50, y: 50 };
 
 let fixture: HTMLElement;
 let model: Model;
-let parent: GridParent;
+let parent: Spreadsheet;
 
 jest.spyOn(HTMLDivElement.prototype, "clientWidth", "get").mockImplementation(() => 1000);
 jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 1000);
 
 beforeEach(async () => {
   fixture = makeTestFixture();
-  model = new Model();
-  parent = new GridParent(model);
-  await parent.mount(fixture);
+  parent = await mountSpreadsheet(fixture);
+  model = parent.model;
 });
 
 afterEach(() => {

--- a/tests/components/highlight.test.ts
+++ b/tests/components/highlight.test.ts
@@ -3,7 +3,8 @@ import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { DispatchResult } from "../../src/types/commands";
 import { triggerMouseEvent } from "../test_helpers/dom_helper";
-import { GridParent, makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { makeTestFixture, nextTick, mountSpreadsheet } from "../test_helpers/helpers";
+import { Spreadsheet } from "../../src";
 
 function getColStartPosition(col: number) {
   return (
@@ -81,15 +82,14 @@ async function moveToCell(el: Element, xc: string) {
 
 let model: Model;
 let fixture: HTMLElement;
-let parent: GridParent;
+let parent: Spreadsheet;
 let cornerEl: Element;
 let borderEl: Element;
 
 beforeEach(async () => {
   fixture = makeTestFixture();
-  model = new Model();
-  parent = new GridParent(model);
-  await parent.mount(fixture);
+  parent = await mountSpreadsheet(fixture);
+  model = parent.model;
 
   model.dispatch("RESIZE_VIEWPORT", {
     width: 1000,

--- a/tests/components/link/link_display.test.ts
+++ b/tests/components/link/link_display.test.ts
@@ -1,21 +1,20 @@
-import { Model } from "../../../src";
+import { Model, Spreadsheet } from "../../../src";
 import { buildSheetLink } from "../../../src/helpers";
 import { isLink } from "../../../src/helpers/cells/index";
 import { clearCell, createSheet, setCellContent } from "../../test_helpers/commands_helpers";
 import { clickCell, rightClickCell, simulateClick } from "../../test_helpers/dom_helper";
 import { getCell } from "../../test_helpers/getters_helpers";
-import { GridParent, makeTestFixture, nextTick } from "../../test_helpers/helpers";
+import { makeTestFixture, nextTick, mountSpreadsheet } from "../../test_helpers/helpers";
 
 describe("link display component", () => {
   let fixture: HTMLElement;
   let model: Model;
-  let grid: GridParent;
+  let grid: Spreadsheet;
 
   beforeEach(async () => {
     fixture = makeTestFixture();
-    model = new Model();
-    grid = new GridParent(model);
-    await grid.mount(fixture);
+    grid = await mountSpreadsheet(fixture);
+    model = grid.model;
   });
 
   afterEach(() => {

--- a/tests/components/link/link_editor.test.ts
+++ b/tests/components/link/link_editor.test.ts
@@ -1,4 +1,4 @@
-import { Model } from "../../../src";
+import { Model, Spreadsheet } from "../../../src";
 import { buildSheetLink } from "../../../src/helpers";
 import { LinkCell } from "../../../src/types";
 import { createSheet, setCellContent } from "../../test_helpers/commands_helpers";
@@ -8,12 +8,12 @@ import {
   simulateClick,
 } from "../../test_helpers/dom_helper";
 import { getCell } from "../../test_helpers/getters_helpers";
-import { GridParent, makeTestFixture, nextTick } from "../../test_helpers/helpers";
+import { makeTestFixture, nextTick, mountSpreadsheet } from "../../test_helpers/helpers";
 
 describe("link editor component", () => {
   let fixture: HTMLElement;
   let model: Model;
-  let grid: GridParent;
+  let grid: Spreadsheet;
 
   async function openLinkEditor(model: Model, xc: string) {
     await rightClickCell(model, xc);
@@ -31,9 +31,8 @@ describe("link editor component", () => {
 
   beforeEach(async () => {
     fixture = makeTestFixture();
-    model = new Model();
-    grid = new GridParent(model);
-    await grid.mount(fixture);
+    grid = await mountSpreadsheet(fixture);
+    model = grid.model;
   });
 
   afterEach(() => {

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -21,7 +21,8 @@ import {
 } from "../test_helpers/commands_helpers";
 import { triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell } from "../test_helpers/getters_helpers";
-import { GridParent, makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { makeTestFixture, nextTick, mountSpreadsheet } from "../test_helpers/helpers";
+import { Spreadsheet } from "../../src";
 
 let fixture: HTMLElement;
 let model: Model;
@@ -144,21 +145,23 @@ async function dblClickRow(index: number) {
 }
 
 describe("Resizer component", () => {
+  let parent: Spreadsheet;
   beforeEach(async () => {
     fixture = makeTestFixture();
-    model = new Model({
+    const data = {
       sheets: [
         {
           colNumber: 10,
           rowNumber: 10,
         },
       ],
-    });
-    const parent = new GridParent(model);
-    await parent.mount(fixture);
+    };
+    parent = await mountSpreadsheet(fixture, { data });
+    model = parent.model;
   });
 
   afterEach(() => {
+    parent.destroy();
     fixture.remove();
   });
 
@@ -766,15 +769,16 @@ describe("Resizer component", () => {
 });
 
 describe("Edge-Scrolling on mouseMove in selection", () => {
+  let parent: Spreadsheet;
   beforeEach(async () => {
     jest.useFakeTimers();
     fixture = makeTestFixture();
-    model = new Model();
-    const parent = new GridParent(model);
-    await parent.mount(fixture);
+    parent = await mountSpreadsheet(fixture);
+    model = parent.model;
   });
 
   afterEach(() => {
+    parent.destroy();
     fixture.remove();
   });
   test("Can edge-scroll horizontally", async () => {
@@ -791,7 +795,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
       left: 6,
       right: 15,
       top: 0,
-      bottom: 42,
+      bottom: 41,
     });
 
     triggerMouseEvent(".o-col-resizer", "mousedown", width / 2, y);
@@ -804,7 +808,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
       left: 3,
       right: 12,
       top: 0,
-      bottom: 42,
+      bottom: 41,
     });
   });
 
@@ -821,7 +825,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
       left: 0,
       right: 9,
       top: 6,
-      bottom: 48,
+      bottom: 47,
     });
 
     triggerMouseEvent(".o-row-resizer", "mousedown", x, height / 2);
@@ -834,15 +838,16 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
       left: 0,
       right: 9,
       top: 3,
-      bottom: 45,
+      bottom: 44,
     });
   });
 });
 
 describe("move selected element(s)", () => {
+  let parent: Spreadsheet;
   beforeEach(async () => {
     fixture = makeTestFixture();
-    model = new Model({
+    const data = {
       sheets: [
         {
           id: "sheet1",
@@ -850,12 +855,13 @@ describe("move selected element(s)", () => {
           rowNumber: 10,
         },
       ],
-    });
-    const parent = new GridParent(model);
-    await parent.mount(fixture);
+    };
+    parent = await mountSpreadsheet(fixture, { data });
+    model = parent.model;
   });
 
   afterEach(() => {
+    parent.destroy();
     fixture.remove();
   });
 

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -9,7 +9,7 @@ import { ConditionalFormat, SpreadsheetEnv } from "../../src/types";
 import { selectCell, setCellContent, setSelection } from "../test_helpers/commands_helpers";
 import { triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getBorder, getCell } from "../test_helpers/getters_helpers";
-import { GridParent, makeTestFixture, nextTick, typeInComposer } from "../test_helpers/helpers";
+import { makeTestFixture, nextTick, typeInComposer, mountSpreadsheet } from "../test_helpers/helpers";
 
 jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("./__mocks__/content_editable_helper")
@@ -386,9 +386,7 @@ test("Can show/hide a TopBarComponent based on condition", async () => {
 
 describe("TopBar - CF", () => {
   test("open sidepanel with no CF in selected zone", async () => {
-    const model = new Model();
-    const parent = new GridParent(model);
-    await parent.mount(fixture);
+    const parent = await mountSpreadsheet(fixture);
     triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
     await nextTick();
     triggerMouseEvent(".o-menu-item[data-name='format_cf']", "click");
@@ -403,9 +401,8 @@ describe("TopBar - CF", () => {
   });
 
   test("open sidepanel with one CF in selected zone", async () => {
-    const model = new Model();
-    const parent = new GridParent(model);
-    await parent.mount(fixture);
+    const parent = await mountSpreadsheet(fixture);
+    const model = parent.model;
 
     const cfRule: ConditionalFormat = {
       ranges: ["A1:C7"],
@@ -438,9 +435,8 @@ describe("TopBar - CF", () => {
   });
 
   test("open sidepanel with with more then one CF in selected zone", async () => {
-    const model = new Model();
-    const parent = new GridParent(model);
-    await parent.mount(fixture);
+    const parent = await mountSpreadsheet(fixture);
+    const model = parent.model;
 
     const cfRule1: ConditionalFormat = {
       ranges: ["A1:C7"],


### PR DESCRIPTION

## Description:

The component `GridParent` used in tests has grown to an
half-duplicated implementation of the `Spreadsheet` component.

Small comment about adapted tests:
The `GridParent` component set the viewport size to the size
of its `el`, which contains the top bar. However, the real
implementation set the viewport size to the grid size.

closes #808


Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
