### PR TITLE
[FIX] Menus: superimposed menus

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -190,10 +190,11 @@ const TEMPLATE = xml/* xml */ `
       <Autofill position="getAutofillPosition()" viewport="snappedViewport"/>
     </t>
     <Overlay t-on-open-contextmenu="onOverlayContextMenu" viewport="snappedViewport"/>
-    <Menu t-if="menuState.isOpen"
-      menuItems="menuState.menuItems"
-      position="menuState.position"
-      t-on-close.stop="menuState.isOpen=false"/>
+    <div class="o-grid-context-menu">
+      <Menu t-if="props.contextMenuIsOpen"
+        menuItems="menuState.menuItems"
+        position="menuState.position"/>
+    </div>
     <t t-set="gridSize" t-value="getters.getGridSize()"/>
     <FiguresContainer viewport="snappedViewport" model="props.model" t-on-figure-deleted="focus" />
     <div class="o-scrollbar vertical" t-on-scroll="onScroll" t-ref="vscrollbar">
@@ -262,7 +263,6 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
   static components = { Composer, Overlay, Menu, Autofill, FiguresContainer };
 
   private menuState: MenuState = useState({
-    isOpen: false,
     position: null,
     menuItems: [],
   });
@@ -621,7 +621,6 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
   }
 
   toggleContextMenu(type: ContextMenuType, x: number, y: number) {
-    this.menuState.isOpen = true;
     this.menuState.position = {
       x,
       y,
@@ -631,5 +630,6 @@ export class Grid extends Component<{ model: Model }, SpreadsheetEnv> {
     this.menuState.menuItems = registries[type]
       .getAll()
       .filter((item) => !item.isVisible || item.isVisible(this.env));
+    this.trigger("open-menu", { menu: "contextMenu" });
   }
 }

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -104,7 +104,7 @@ interface Props {
 }
 
 export interface MenuState {
-  isOpen: boolean;
+  isOpen?: boolean;
   position: null | MenuPosition;
   scrollOffset?: number;
   menuItems: FullMenuItem[];

--- a/tests/components/__snapshots__/bottom_bar_test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar_test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BottomBar component simple rendering 1`] = `
+exports[`Bottombar simple rendering 1`] = `
 <div
   class="o-spreadsheet-bottom-bar"
 >
@@ -48,7 +48,7 @@ exports[`BottomBar component simple rendering 1`] = `
   >
     <div
       class="o-sheet-item o-sheet active"
-      data-id="1"
+      data-id="89"
       title="Sheet1"
     >
       <span
@@ -70,6 +70,93 @@ exports[`BottomBar component simple rendering 1`] = `
         </svg>
       </span>
     </div>
+  </div>
+</div>
+`;
+
+exports[`Context Menu context menu simple rendering 1`] = `
+<div
+  class="o-menu"
+  style="top:200px;left:300px;max-height:1000px"
+>
+  <div
+    class="o-menu-item"
+    data-name="cut"
+    title="Cut"
+  >
+    Cut
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="copy"
+    title="Copy"
+  >
+    Copy
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="paste"
+    title="Paste"
+  >
+    Paste
+  </div>
+  <div
+    class="o-menu-item o-menu-root o-separator"
+    data-name="paste_special"
+    title="Paste special"
+  >
+    Paste special
+    <svg
+      class="o-icon"
+    >
+      <polygon
+        fill="#000000"
+        points="0 0 4 4 0 8"
+        transform="translate(5 3)"
+      />
+    </svg>
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="add_row_before"
+    title="Insert row"
+  >
+    Insert row
+  </div>
+  <div
+    class="o-menu-item o-separator"
+    data-name="add_column_before"
+    title="Insert column"
+  >
+    Insert column
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="delete_row"
+    title="Delete row 8"
+  >
+    Delete row 8
+  </div>
+  <div
+    class="o-menu-item o-separator"
+    data-name="delete_column"
+    title="Delete column C"
+  >
+    Delete column C
+  </div>
+  <div
+    class="o-menu-item disabled"
+    data-name="clear_cell"
+    title="Clear cell"
+  >
+    Clear cell
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="conditional_formatting"
+    title="Conditional formatting"
+  >
+    Conditional formatting
   </div>
 </div>
 `;

--- a/tests/components/__snapshots__/grid_test.ts.snap
+++ b/tests/components/__snapshots__/grid_test.ts.snap
@@ -32,6 +32,9 @@ exports[`Grid component simple rendering snapshot 1`] = `
       class="all"
     />
   </div>
+  <div
+    class="o-grid-context-menu"
+  />
   <div />
   <div
     class="o-scrollbar vertical"

--- a/tests/components/__snapshots__/spreadsheet_test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet_test.ts.snap
@@ -364,6 +364,9 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
         class="all"
       />
     </div>
+    <div
+      class="o-grid-context-menu"
+    />
     <div />
     <div
       class="o-scrollbar vertical"

--- a/tests/components/__snapshots__/top_bar_test.ts.snap
+++ b/tests/components/__snapshots__/top_bar_test.ts.snap
@@ -2,372 +2,376 @@
 
 exports[`TopBar component can set cell format 1`] = `
 <div
-  class="o-spreadsheet-topbar"
+  class="parent"
 >
   <div
-    class="o-topbar-top"
+    class="o-spreadsheet-topbar"
   >
-    <!-- Menus -->
     <div
-      class="o-topbar-topleft"
+      class="o-topbar-top"
     >
+      <!-- Menus -->
       <div
-        class="o-topbar-menu"
-        data-id="file"
-      >
-        File
-      </div>
-      <div
-        class="o-topbar-menu"
-        data-id="edit"
-      >
-        Edit
-      </div>
-      <div
-        class="o-topbar-menu"
-        data-id="view"
-      >
-        View
-      </div>
-      <div
-        class="o-topbar-menu"
-        data-id="insert"
-      >
-        Insert
-      </div>
-      <div
-        class="o-topbar-menu"
-        data-id="format"
-      >
-        Format
-      </div>
-    </div>
-    <div
-      class="o-topbar-topright"
-    />
-  </div>
-  <!-- Toolbar and Cell Content -->
-  <div
-    class="o-topbar-toolbar"
-  >
-    <!-- Toolbar -->
-    <div
-      class="o-toolbar-tools"
-    >
-      <div
-        class="o-tool o-disabled"
-        title="Undo"
-      >
-        <svg
-          class="o-icon"
-        >
-          <path
-            d="M11.5656391,4.43436088 L9,7 L16,7 L16,0 L13.0418424,2.95815758 C11.5936787,1.73635959 9.72260775,1 7.67955083,1 C4.22126258,1 1.25575599,3.10984908 0,6 L2,7 C2.93658775,4.60974406 5.12943697,3.08011229 7.67955083,3 C9.14881247,3.0528747 10.4994783,3.57862053 11.5656391,4.43436088 Z"
-            fill="#000000"
-            transform="matrix(-1 0 0 1 17 5)"
-          />
-        </svg>
-      </div>
-      <div
-        class="o-tool o-disabled"
-        title="Redo"
-      >
-        <svg
-          class="o-icon"
-        >
-          <path
-            d="M11.5656391,4.43436088 L9,7 L16,7 L16,0 L13.0418424,2.95815758 C11.5936787,1.73635959 9.72260775,1 7.67955083,1 C4.22126258,1 1.25575599,3.10984908 0,6 L2,7 C2.93658775,4.60974406 5.12943697,3.08011229 7.67955083,3 C9.14881247,3.0528747 10.4994783,3.57862053 11.5656391,4.43436088 Z"
-            fill="#000000"
-            transform="translate(1 5)"
-          />
-        </svg>
-      </div>
-      <div
-        class="o-tool"
-        title="Paint Format"
-      >
-        <svg
-          class="o-icon"
-        >
-          <path
-            d="M9,0 L1,0 C0.45,0 0,0.45 0,1 L0,4 C0,4.55 0.45,5 1,5 L9,5 C9.55,5 10,4.55 10,4 L10,3 L11,3 L11,6 L4,6 L4,14 L6,14 L6,8 L13,8 L13,2 L10,2 L10,1 C10,0.45 9.55,0 9,0 Z"
-            fill="#000000"
-            transform="translate(3 2)"
-          />
-        </svg>
-      </div>
-      <div
-        class="o-tool"
-        title="Clear Format"
-      >
-        <svg
-          class="o-icon"
-        >
-          <path
-            d="M0.27,1.55 L5.43,6.7 L3,12 L5.5,12 L7.14,8.42 L11.73,13 L13,11.73 L1.55,0.27 L0.27,1.55 L0.27,1.55 Z M3.82,0 L5.82,2 L7.58,2 L7.03,3.21 L8.74,4.92 L10.08,2 L14,2 L14,0 L3.82,0 L3.82,0 Z"
-            fill="#000000"
-            transform="translate(2 3)"
-          />
-        </svg>
-      </div>
-      <div
-        class="o-divider"
-      />
-      <div
-        class="o-tool"
-        title="Format as percent"
-      >
-        %
-      </div>
-      <div
-        class="o-tool"
-        title="Decrease decimal places"
-      >
-        .0
-      </div>
-      <div
-        class="o-tool"
-        title="Increase decimal places"
-      >
-        .00
-      </div>
-      <div
-        class="o-tool o-dropdown"
-        title="More formats"
+        class="o-topbar-topleft"
       >
         <div
-          class="o-text-icon"
+          class="o-topbar-menu"
+          data-id="file"
         >
-          123
-          <svg
-            class="o-icon"
-          >
-            <polygon
-              fill="#000000"
-              points="0 0 4 4 8 0"
-              transform="translate(5 7)"
-            />
-          </svg>
+          File
         </div>
         <div
-          class="o-dropdown-content o-text-options o-format-tool"
+          class="o-topbar-menu"
+          data-id="edit"
         >
-          <div
-            class="active"
-            data-format="auto"
-          >
-            Automatic
-          </div>
-          <div
-            data-format="number"
-          >
-            Number (1,000.12)
-          </div>
-          <div
-            data-format="percent"
-          >
-            Percent (10.12%)
-          </div>
-          <div
-            data-format="date"
-          >
-            Date (9/26/2008)
-          </div>
-          <div
-            data-format="time"
-          >
-            Time (10:43:00 PM)
-          </div>
-          <div
-            data-format="datetime"
-          >
-            Date time (9/26/2008 22:43:00)
-          </div>
-          <div
-            data-format="duration"
-          >
-            Duration (27:51:38)
-          </div>
+          Edit
+        </div>
+        <div
+          class="o-topbar-menu"
+          data-id="view"
+        >
+          View
+        </div>
+        <div
+          class="o-topbar-menu"
+          data-id="insert"
+        >
+          Insert
+        </div>
+        <div
+          class="o-topbar-menu"
+          data-id="format"
+        >
+          Format
         </div>
       </div>
       <div
-        class="o-divider"
-      />
-      <!-- &lt;div class="o-tool" title="Font"&gt;&lt;span&gt;Roboto&lt;/span&gt; &lt;svg class="o-icon"&gt;&lt;polygon fill="#000000" points="0 0 4 4 8 0" transform="translate(5 7)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
-      <div
-        class="o-tool o-dropdown"
-        title="Font Size"
-      >
-        <div
-          class="o-text-icon"
-        >
-          10
-           
-          <svg
-            class="o-icon"
-          >
-            <polygon
-              fill="#000000"
-              points="0 0 4 4 8 0"
-              transform="translate(5 7)"
-            />
-          </svg>
-        </div>
-      </div>
-      <div
-        class="o-divider"
-      />
-      <div
-        class="o-tool"
-        title="Bold"
-      >
-        <svg
-          class="o-icon"
-        >
-          <path
-            d="M9,3.5 C9,1.57 7.43,0 5.5,0 L1.77635684e-15,0 L1.77635684e-15,12 L6.25,12 C8.04,12 9.5,10.54 9.5,8.75 C9.5,7.45 8.73,6.34 7.63,5.82 C8.46,5.24 9,4.38 9,3.5 Z M5,2 C5.82999992,2 6.5,2.67 6.5,3.5 C6.5,4.33 5.82999992,5 5,5 L3,5 L3,2 L5,2 Z M3,10 L3,7 L5.5,7 C6.32999992,7 7,7.67 7,8.5 C7,9.33 6.32999992,10 5.5,10 L3,10 Z"
-            fill="#000000"
-            fill-rule="evenodd"
-            transform="translate(4 3)"
-          />
-        </svg>
-      </div>
-      <div
-        class="o-tool"
-        title="Italic"
-      >
-        <svg
-          class="o-icon"
-        >
-          <polygon
-            fill="#000000"
-            fill-rule="evenodd"
-            points="4 0 4 2 6.58 2 2.92 10 0 10 0 12 8 12 8 10 5.42 10 9.08 2 12 2 12 0"
-            transform="translate(3 3)"
-          />
-        </svg>
-      </div>
-      <div
-        class="o-tool"
-        title="Strikethrough"
-      >
-        <svg
-          class="o-icon"
-        >
-          <path
-            d="M2.8875,3.06 C2.8875,2.6025 2.985,2.18625 3.18375,1.8075 C3.3825,1.42875 3.66,1.10625 4.02,0.84 C4.38,0.57375 4.80375,0.3675 5.29875,0.22125 C5.79375,0.075 6.33375,0 6.92625,0 C7.53375,0 8.085,0.0825 8.58,0.25125 C9.075,0.42 9.49875,0.6525 9.85125,0.95625 C10.20375,1.25625 10.47375,1.6125 10.665,2.02875 C10.85625,2.44125 10.95,2.895 10.95,3.38625 L8.6925,3.38625 C8.6925,3.1575 8.655,2.94375 8.58375,2.74875 C8.5125,2.55 8.4,2.38125 8.25,2.2425 C8.1,2.10375 7.9125,1.99125 7.6875,1.91625 C7.4625,1.8375 7.19625,1.8 6.88875,1.8 C6.5925,1.8 6.3375,1.83375 6.11625,1.8975 C5.89875,1.96125 5.71875,2.05125 5.57625,2.1675 C5.43375,2.28375 5.325,2.41875 5.25375,2.5725 C5.1825,2.72625 5.145,2.895 5.145,3.0675 C5.145,3.4275 5.32875,3.73125 5.69625,3.975 C5.71780203,3.98908066 5.73942012,4.00311728 5.76118357,4.01733315 C6.02342923,4.18863185 6.5,4.5 7,5 L4,5 C4,5 3.21375,4.37625 3.17625,4.30875 C2.985,3.9525 2.8875,3.53625 2.8875,3.06 Z M14,6 L0,6 L0,8 L7.21875,8 C7.35375,8.0525 7.51875,8.105 7.63125,8.15375 C7.90875,8.2775 8.12625,8.40875 8.28375,8.53625 C8.44125,8.6675 8.54625,8.81 8.6025,8.96 C8.65875,9.11375 8.685,9.28625 8.685,9.47375 C8.685,9.65 8.65125,9.815 8.58375,9.965 C8.51625,10.11875 8.41125,10.25 8.2725,10.35875 C8.13375,10.4675 7.95375,10.55375 7.74,10.6175 C7.5225,10.68125 7.27125,10.71125 6.97875,10.71125 C6.6525,10.71125 6.35625,10.6775 6.09,10.61375 C5.82375,10.55 5.59875,10.445 5.41125,10.3025 C5.22375,10.16 5.0775,9.9725 4.9725,9.74375 C4.8675,9.515 4.78125,9.17 4.78125,9 L2.55,9 C2.55,9.2525 2.61,9.6875 2.72625,10.025 C2.8425,10.3625 3.0075,10.66625 3.21375,10.9325 C3.42,11.19875 3.6675,11.4275 3.94875,11.6225 C4.23,11.8175 4.53375,11.9825 4.86375,12.11 C5.19375,12.24125 5.535,12.33875 5.89875,12.39875 C6.25875,12.4625 6.6225,12.4925 6.9825,12.4925 C7.5825,12.4925 8.13,12.425 8.6175,12.28625 C9.105,12.1475 9.525,11.94875 9.87,11.69375 C10.215,11.435 10.48125,11.12 10.6725,10.74125 C10.86375,10.3625 10.95375,9.935 10.95375,9.455 C10.95375,9.005 10.875,8.6 10.72125,8.24375 C10.68375,8.1575 10.6425,8.075 10.59375,7.9925 L14,8 L14,6 Z"
-            fill="#010101"
-            fill-rule="evenodd"
-            transform="translate(2 3)"
-          />
-        </svg>
-      </div>
-      <div
-        class="o-tool o-dropdown o-with-color"
-      >
-        <span
-          style="border-color:black"
-          title="Text Color"
-        >
-          <svg
-            class="o-icon"
-          >
-            <path
-              d="M7,0 L5,0 L0.5,12 L2.5,12 L3.62,9 L8.37,9 L9.49,12 L11.49,12 L7,0 L7,0 Z M4.38,7 L6,2.67 L7.62,7 L4.38,7 L4.38,7 Z"
-              fill="#000000"
-              transform="translate(3 1)"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="o-divider"
-      />
-      <div
-        class="o-tool o-dropdown o-with-color"
-      >
-        <span
-          style="border-color:white"
-          title="Fill Color"
-        >
-          <svg
-            class="o-icon"
-          >
-            <path
-              d="M14.5,8.87 C14.5,8.87 13,10.49 13,11.49 C13,12.32 13.67,12.99 14.5,12.99 C15.33,12.99 16,12.32 16,11.49 C16,10.5 14.5,8.87 14.5,8.87 L14.5,8.87 Z M12.71,6.79 L5.91,0 L4.85,1.06 L6.44,2.65 L2.29,6.79 C1.9,7.18 1.9,7.81 2.29,8.2 L6.79,12.7 C6.99,12.9 7.24,13 7.5,13 C7.76,13 8.01,12.9 8.21,12.71 L12.71,8.21 C13.1,7.82 13.1,7.18 12.71,6.79 L12.71,6.79 Z M4.21,7 L7.5,3.71 L10.79,7 L4.21,7 L4.21,7 Z"
-              fill="#000000"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="o-tool o-dropdown"
-      >
-        <span
-          title="Borders"
-        >
-          <svg
-            class="o-icon"
-          >
-            <path
-              d="M0,0 L0,14 L14,14 L14,0 L0,0 L0,0 Z M6,12 L2,12 L2,8 L6,8 L6,12 L6,12 Z M6,6 L2,6 L2,2 L6,2 L6,6 L6,6 Z M12,12 L8,12 L8,8 L12,8 L12,12 L12,12 Z M12,6 L8,6 L8,2 L12,2 L12,6 L12,6 Z"
-              fill="#000000"
-              transform="translate(2 2)"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="o-tool o-disabled"
-        title="Merge Cells"
-      >
-        <svg
-          class="o-icon"
-        >
-          <path
-            d="M3,6 L1,6 L1,2 L8,2 L8,4 L3,4 L3,6 Z M10,4 L10,2 L17,2 L17,6 L15,6 L15,4 L10,4 Z M10,14 L15,14 L15,12 L17,12 L17,16 L10,16 L10,14 Z M1,12 L3,12 L3,14 L8,14 L8,16 L1,16 L1,12 Z M1,8 L5,8 L5,6 L8,9 L5,12 L5,10 L1,10 L1,8 Z M10,9 L13,6 L13,8 L17,8 L17,10 L13,10 L13,12 L10,9 Z"
-            fill="#000000"
-          />
-        </svg>
-      </div>
-      <div
-        class="o-divider"
-      />
-      <div
-        class="o-tool o-dropdown"
-        title="Horizontal align"
-      >
-        <span>
-          <svg
-            class="o-icon"
-          >
-            <path
-              d="M0,14 L10,14 L10,12 L0,12 L0,14 Z M10,4 L0,4 L0,6 L10,6 L10,4 Z M0,0 L0,2 L14,2 L14,0 L0,0 Z M0,10 L14,10 L14,8 L0,8 L0,10 Z"
-              fill="#000000"
-              transform="translate(2 2)"
-            />
-          </svg>
-          <svg
-            class="o-icon"
-          >
-            <polygon
-              fill="#000000"
-              points="0 0 4 4 8 0"
-              transform="translate(5 7)"
-            />
-          </svg>
-        </span>
-      </div>
-      <!-- &lt;div class="o-tool" title="Vertical align"&gt;&lt;span&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M9.5,3 L7,3 L7,0 L5,0 L5,3 L2.5,3 L6,6.5 L9.5,3 L9.5,3 Z M0,8 L0,10 L12,10 L12,8 L0,8 L0,8 Z M2.5,15 L5,15 L5,18 L7,18 L7,15 L9.5,15 L6,11.5 L2.5,15 L2.5,15 Z" transform="translate(3)"/&gt;&lt;/svg&gt;&lt;/span&gt; &lt;svg class="o-icon"&gt;&lt;polygon fill="#000000" points="0 0 4 4 8 0" transform="translate(5 7)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
-      <!-- &lt;div class="o-tool" title="Text Wrapping"&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M14,0 L0,0 L0,2 L14,2 L14,0 Z M0,12 L4,12 L4,10 L0,10 L0,12 Z M11.5,5 L0,5 L0,7 L11.75,7 C12.58,7 13.25,7.67 13.25,8.5 C13.25,9.33 12.58,10 11.75,10 L9,10 L9,8 L6,11 L9,14 L9,12 L11.5,12 C13.43,12 15,10.43 15,8.5 C15,6.57 13.43,5 11.5,5 Z" transform="translate(2 3)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
-      <div
-        class="o-divider"
+        class="o-topbar-topright"
       />
     </div>
-    <!-- Cell content -->
+    <!-- Toolbar and Cell Content -->
     <div
-      class="o-toolbar-cell-content"
-    />
+      class="o-topbar-toolbar"
+    >
+      <!-- Toolbar -->
+      <div
+        class="o-toolbar-tools"
+      >
+        <div
+          class="o-tool o-disabled"
+          title="Undo"
+        >
+          <svg
+            class="o-icon"
+          >
+            <path
+              d="M11.5656391,4.43436088 L9,7 L16,7 L16,0 L13.0418424,2.95815758 C11.5936787,1.73635959 9.72260775,1 7.67955083,1 C4.22126258,1 1.25575599,3.10984908 0,6 L2,7 C2.93658775,4.60974406 5.12943697,3.08011229 7.67955083,3 C9.14881247,3.0528747 10.4994783,3.57862053 11.5656391,4.43436088 Z"
+              fill="#000000"
+              transform="matrix(-1 0 0 1 17 5)"
+            />
+          </svg>
+        </div>
+        <div
+          class="o-tool o-disabled"
+          title="Redo"
+        >
+          <svg
+            class="o-icon"
+          >
+            <path
+              d="M11.5656391,4.43436088 L9,7 L16,7 L16,0 L13.0418424,2.95815758 C11.5936787,1.73635959 9.72260775,1 7.67955083,1 C4.22126258,1 1.25575599,3.10984908 0,6 L2,7 C2.93658775,4.60974406 5.12943697,3.08011229 7.67955083,3 C9.14881247,3.0528747 10.4994783,3.57862053 11.5656391,4.43436088 Z"
+              fill="#000000"
+              transform="translate(1 5)"
+            />
+          </svg>
+        </div>
+        <div
+          class="o-tool"
+          title="Paint Format"
+        >
+          <svg
+            class="o-icon"
+          >
+            <path
+              d="M9,0 L1,0 C0.45,0 0,0.45 0,1 L0,4 C0,4.55 0.45,5 1,5 L9,5 C9.55,5 10,4.55 10,4 L10,3 L11,3 L11,6 L4,6 L4,14 L6,14 L6,8 L13,8 L13,2 L10,2 L10,1 C10,0.45 9.55,0 9,0 Z"
+              fill="#000000"
+              transform="translate(3 2)"
+            />
+          </svg>
+        </div>
+        <div
+          class="o-tool"
+          title="Clear Format"
+        >
+          <svg
+            class="o-icon"
+          >
+            <path
+              d="M0.27,1.55 L5.43,6.7 L3,12 L5.5,12 L7.14,8.42 L11.73,13 L13,11.73 L1.55,0.27 L0.27,1.55 L0.27,1.55 Z M3.82,0 L5.82,2 L7.58,2 L7.03,3.21 L8.74,4.92 L10.08,2 L14,2 L14,0 L3.82,0 L3.82,0 Z"
+              fill="#000000"
+              transform="translate(2 3)"
+            />
+          </svg>
+        </div>
+        <div
+          class="o-divider"
+        />
+        <div
+          class="o-tool"
+          title="Format as percent"
+        >
+          %
+        </div>
+        <div
+          class="o-tool"
+          title="Decrease decimal places"
+        >
+          .0
+        </div>
+        <div
+          class="o-tool"
+          title="Increase decimal places"
+        >
+          .00
+        </div>
+        <div
+          class="o-tool o-dropdown o-dropdown-selected"
+          title="More formats"
+        >
+          <div
+            class="o-text-icon"
+          >
+            123
+            <svg
+              class="o-icon"
+            >
+              <polygon
+                fill="#000000"
+                points="0 0 4 4 8 0"
+                transform="translate(5 7)"
+              />
+            </svg>
+          </div>
+          <div
+            class="o-dropdown-content o-text-options o-format-tool"
+          >
+            <div
+              class="active"
+              data-format="auto"
+            >
+              Automatic
+            </div>
+            <div
+              data-format="number"
+            >
+              Number (1,000.12)
+            </div>
+            <div
+              data-format="percent"
+            >
+              Percent (10.12%)
+            </div>
+            <div
+              data-format="date"
+            >
+              Date (9/26/2008)
+            </div>
+            <div
+              data-format="time"
+            >
+              Time (10:43:00 PM)
+            </div>
+            <div
+              data-format="datetime"
+            >
+              Date time (9/26/2008 22:43:00)
+            </div>
+            <div
+              data-format="duration"
+            >
+              Duration (27:51:38)
+            </div>
+          </div>
+        </div>
+        <div
+          class="o-divider"
+        />
+        <!-- &lt;div class="o-tool" title="Font"&gt;&lt;span&gt;Roboto&lt;/span&gt; &lt;svg class="o-icon"&gt;&lt;polygon fill="#000000" points="0 0 4 4 8 0" transform="translate(5 7)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
+        <div
+          class="o-tool o-dropdown"
+          title="Font Size"
+        >
+          <div
+            class="o-text-icon"
+          >
+            10
+             
+            <svg
+              class="o-icon"
+            >
+              <polygon
+                fill="#000000"
+                points="0 0 4 4 8 0"
+                transform="translate(5 7)"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="o-divider"
+        />
+        <div
+          class="o-tool"
+          title="Bold"
+        >
+          <svg
+            class="o-icon"
+          >
+            <path
+              d="M9,3.5 C9,1.57 7.43,0 5.5,0 L1.77635684e-15,0 L1.77635684e-15,12 L6.25,12 C8.04,12 9.5,10.54 9.5,8.75 C9.5,7.45 8.73,6.34 7.63,5.82 C8.46,5.24 9,4.38 9,3.5 Z M5,2 C5.82999992,2 6.5,2.67 6.5,3.5 C6.5,4.33 5.82999992,5 5,5 L3,5 L3,2 L5,2 Z M3,10 L3,7 L5.5,7 C6.32999992,7 7,7.67 7,8.5 C7,9.33 6.32999992,10 5.5,10 L3,10 Z"
+              fill="#000000"
+              fill-rule="evenodd"
+              transform="translate(4 3)"
+            />
+          </svg>
+        </div>
+        <div
+          class="o-tool"
+          title="Italic"
+        >
+          <svg
+            class="o-icon"
+          >
+            <polygon
+              fill="#000000"
+              fill-rule="evenodd"
+              points="4 0 4 2 6.58 2 2.92 10 0 10 0 12 8 12 8 10 5.42 10 9.08 2 12 2 12 0"
+              transform="translate(3 3)"
+            />
+          </svg>
+        </div>
+        <div
+          class="o-tool"
+          title="Strikethrough"
+        >
+          <svg
+            class="o-icon"
+          >
+            <path
+              d="M2.8875,3.06 C2.8875,2.6025 2.985,2.18625 3.18375,1.8075 C3.3825,1.42875 3.66,1.10625 4.02,0.84 C4.38,0.57375 4.80375,0.3675 5.29875,0.22125 C5.79375,0.075 6.33375,0 6.92625,0 C7.53375,0 8.085,0.0825 8.58,0.25125 C9.075,0.42 9.49875,0.6525 9.85125,0.95625 C10.20375,1.25625 10.47375,1.6125 10.665,2.02875 C10.85625,2.44125 10.95,2.895 10.95,3.38625 L8.6925,3.38625 C8.6925,3.1575 8.655,2.94375 8.58375,2.74875 C8.5125,2.55 8.4,2.38125 8.25,2.2425 C8.1,2.10375 7.9125,1.99125 7.6875,1.91625 C7.4625,1.8375 7.19625,1.8 6.88875,1.8 C6.5925,1.8 6.3375,1.83375 6.11625,1.8975 C5.89875,1.96125 5.71875,2.05125 5.57625,2.1675 C5.43375,2.28375 5.325,2.41875 5.25375,2.5725 C5.1825,2.72625 5.145,2.895 5.145,3.0675 C5.145,3.4275 5.32875,3.73125 5.69625,3.975 C5.71780203,3.98908066 5.73942012,4.00311728 5.76118357,4.01733315 C6.02342923,4.18863185 6.5,4.5 7,5 L4,5 C4,5 3.21375,4.37625 3.17625,4.30875 C2.985,3.9525 2.8875,3.53625 2.8875,3.06 Z M14,6 L0,6 L0,8 L7.21875,8 C7.35375,8.0525 7.51875,8.105 7.63125,8.15375 C7.90875,8.2775 8.12625,8.40875 8.28375,8.53625 C8.44125,8.6675 8.54625,8.81 8.6025,8.96 C8.65875,9.11375 8.685,9.28625 8.685,9.47375 C8.685,9.65 8.65125,9.815 8.58375,9.965 C8.51625,10.11875 8.41125,10.25 8.2725,10.35875 C8.13375,10.4675 7.95375,10.55375 7.74,10.6175 C7.5225,10.68125 7.27125,10.71125 6.97875,10.71125 C6.6525,10.71125 6.35625,10.6775 6.09,10.61375 C5.82375,10.55 5.59875,10.445 5.41125,10.3025 C5.22375,10.16 5.0775,9.9725 4.9725,9.74375 C4.8675,9.515 4.78125,9.17 4.78125,9 L2.55,9 C2.55,9.2525 2.61,9.6875 2.72625,10.025 C2.8425,10.3625 3.0075,10.66625 3.21375,10.9325 C3.42,11.19875 3.6675,11.4275 3.94875,11.6225 C4.23,11.8175 4.53375,11.9825 4.86375,12.11 C5.19375,12.24125 5.535,12.33875 5.89875,12.39875 C6.25875,12.4625 6.6225,12.4925 6.9825,12.4925 C7.5825,12.4925 8.13,12.425 8.6175,12.28625 C9.105,12.1475 9.525,11.94875 9.87,11.69375 C10.215,11.435 10.48125,11.12 10.6725,10.74125 C10.86375,10.3625 10.95375,9.935 10.95375,9.455 C10.95375,9.005 10.875,8.6 10.72125,8.24375 C10.68375,8.1575 10.6425,8.075 10.59375,7.9925 L14,8 L14,6 Z"
+              fill="#010101"
+              fill-rule="evenodd"
+              transform="translate(2 3)"
+            />
+          </svg>
+        </div>
+        <div
+          class="o-tool o-dropdown o-with-color"
+        >
+          <span
+            style="border-color:black"
+            title="Text Color"
+          >
+            <svg
+              class="o-icon"
+            >
+              <path
+                d="M7,0 L5,0 L0.5,12 L2.5,12 L3.62,9 L8.37,9 L9.49,12 L11.49,12 L7,0 L7,0 Z M4.38,7 L6,2.67 L7.62,7 L4.38,7 L4.38,7 Z"
+                fill="#000000"
+                transform="translate(3 1)"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="o-divider"
+        />
+        <div
+          class="o-tool o-dropdown o-with-color"
+        >
+          <span
+            style="border-color:white"
+            title="Fill Color"
+          >
+            <svg
+              class="o-icon"
+            >
+              <path
+                d="M14.5,8.87 C14.5,8.87 13,10.49 13,11.49 C13,12.32 13.67,12.99 14.5,12.99 C15.33,12.99 16,12.32 16,11.49 C16,10.5 14.5,8.87 14.5,8.87 L14.5,8.87 Z M12.71,6.79 L5.91,0 L4.85,1.06 L6.44,2.65 L2.29,6.79 C1.9,7.18 1.9,7.81 2.29,8.2 L6.79,12.7 C6.99,12.9 7.24,13 7.5,13 C7.76,13 8.01,12.9 8.21,12.71 L12.71,8.21 C13.1,7.82 13.1,7.18 12.71,6.79 L12.71,6.79 Z M4.21,7 L7.5,3.71 L10.79,7 L4.21,7 L4.21,7 Z"
+                fill="#000000"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="o-tool o-dropdown"
+        >
+          <span
+            title="Borders"
+          >
+            <svg
+              class="o-icon"
+            >
+              <path
+                d="M0,0 L0,14 L14,14 L14,0 L0,0 L0,0 Z M6,12 L2,12 L2,8 L6,8 L6,12 L6,12 Z M6,6 L2,6 L2,2 L6,2 L6,6 L6,6 Z M12,12 L8,12 L8,8 L12,8 L12,12 L12,12 Z M12,6 L8,6 L8,2 L12,2 L12,6 L12,6 Z"
+                fill="#000000"
+                transform="translate(2 2)"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="o-tool o-disabled"
+          title="Merge Cells"
+        >
+          <svg
+            class="o-icon"
+          >
+            <path
+              d="M3,6 L1,6 L1,2 L8,2 L8,4 L3,4 L3,6 Z M10,4 L10,2 L17,2 L17,6 L15,6 L15,4 L10,4 Z M10,14 L15,14 L15,12 L17,12 L17,16 L10,16 L10,14 Z M1,12 L3,12 L3,14 L8,14 L8,16 L1,16 L1,12 Z M1,8 L5,8 L5,6 L8,9 L5,12 L5,10 L1,10 L1,8 Z M10,9 L13,6 L13,8 L17,8 L17,10 L13,10 L13,12 L10,9 Z"
+              fill="#000000"
+            />
+          </svg>
+        </div>
+        <div
+          class="o-divider"
+        />
+        <div
+          class="o-tool o-dropdown"
+          title="Horizontal align"
+        >
+          <span>
+            <svg
+              class="o-icon"
+            >
+              <path
+                d="M0,14 L10,14 L10,12 L0,12 L0,14 Z M10,4 L0,4 L0,6 L10,6 L10,4 Z M0,0 L0,2 L14,2 L14,0 L0,0 Z M0,10 L14,10 L14,8 L0,8 L0,10 Z"
+                fill="#000000"
+                transform="translate(2 2)"
+              />
+            </svg>
+            <svg
+              class="o-icon"
+            >
+              <polygon
+                fill="#000000"
+                points="0 0 4 4 8 0"
+                transform="translate(5 7)"
+              />
+            </svg>
+          </span>
+        </div>
+        <!-- &lt;div class="o-tool" title="Vertical align"&gt;&lt;span&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M9.5,3 L7,3 L7,0 L5,0 L5,3 L2.5,3 L6,6.5 L9.5,3 L9.5,3 Z M0,8 L0,10 L12,10 L12,8 L0,8 L0,8 Z M2.5,15 L5,15 L5,18 L7,18 L7,15 L9.5,15 L6,11.5 L2.5,15 L2.5,15 Z" transform="translate(3)"/&gt;&lt;/svg&gt;&lt;/span&gt; &lt;svg class="o-icon"&gt;&lt;polygon fill="#000000" points="0 0 4 4 8 0" transform="translate(5 7)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
+        <!-- &lt;div class="o-tool" title="Text Wrapping"&gt;&lt;svg class="o-icon"&gt;&lt;path fill="#000000" d="M14,0 L0,0 L0,2 L14,2 L14,0 Z M0,12 L4,12 L4,10 L0,10 L0,12 Z M11.5,5 L0,5 L0,7 L11.75,7 C12.58,7 13.25,7.67 13.25,8.5 C13.25,9.33 12.58,10 11.75,10 L9,10 L9,8 L6,11 L9,14 L9,12 L11.5,12 C13.43,12 15,10.43 15,8.5 C15,6.57 13.43,5 11.5,5 Z" transform="translate(2 3)"/&gt;&lt;/svg&gt;&lt;/div&gt; -->
+        <div
+          class="o-divider"
+        />
+      </div>
+      <!-- Cell content -->
+      <div
+        class="o-toolbar-cell-content"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/tests/components/bottom_bar_test.ts
+++ b/tests/components/bottom_bar_test.ts
@@ -1,20 +1,32 @@
-import { Component, hooks, tags } from "@odoo/owl";
+import * as owl from "@odoo/owl";
 import { BottomBar } from "../../src/components/bottom_bar";
+import { Menus, OpenMenuEvent } from "../../src/components/spreadsheet";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import { triggerMouseEvent } from "../dom_helper";
-import { makeTestFixture, mockUuidV4To, nextTick } from "../helpers";
+import { makeTestFixture, mockUuidV4To, nextTick, SpreadSheetParent } from "../helpers";
+import { simulateContextMenu } from "./context_menu_test";
+const { Component, useState, hooks, tags } = owl;
+const { useExternalListener } = owl.hooks;
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
 const { xml } = tags;
 const { useSubEnv } = hooks;
 
 let fixture: HTMLElement;
-
+let model: Model;
+let parent: Parent | SpreadSheetParent;
 class Parent extends Component<any, any> {
-  static template = xml`<BottomBar model="model"/>`;
+  static template = xml`
+  <div class="parent" t-on-open-menu="openMenu">
+    <BottomBar menuIsOpen="menu.isOpen==='bottomBarMenu'"/>
+  </div>`;
+
   static components = { BottomBar };
   model: Model;
+  menu = useState({ isOpen: "" } as {
+    isOpen: "" | Menus;
+  });
   constructor(model: Model) {
     super();
     useSubEnv({
@@ -24,6 +36,7 @@ class Parent extends Component<any, any> {
       _t: (s: string) => s,
       askConfirmation: jest.fn(),
     });
+    useExternalListener(window as any, "click", this.onClick);
     this.model = model;
   }
   mounted() {
@@ -33,47 +46,60 @@ class Parent extends Component<any, any> {
   willUnmount() {
     this.model.off("update", this);
   }
+
+  openMenu(ev: OpenMenuEvent) {
+    this.menu.isOpen = ev.detail.menu;
+  }
+
+  onClick() {
+    this.menu.isOpen = "";
+  }
 }
 
-beforeEach(() => {
-  fixture = makeTestFixture();
-});
-
-afterEach(() => {
-  fixture.remove();
-});
-
-describe("BottomBar component", () => {
-  test("simple rendering", async () => {
-    const parent = new Parent(new Model());
+describe("Bottombar", () => {
+  beforeEach(async () => {
+    fixture = makeTestFixture();
+    model = new Model();
+    parent = new Parent(model);
     await parent.mount(fixture);
+  });
 
+  afterEach(() => {
+    fixture.remove();
+    parent.destroy();
+  });
+
+  test("simple rendering", async () => {
     expect(fixture.querySelector(".o-spreadsheet-bottom-bar")).toMatchSnapshot();
   });
 
   test("Can create a new sheet", async () => {
-    const parent = new Parent(new Model());
-    await parent.mount(fixture);
-
     mockUuidV4To(42);
     triggerMouseEvent(".o-add-sheet", "click");
-    expect(parent.env.dispatch).toHaveBeenCalledWith("CREATE_SHEET", { activate: true, id: "42" });
+    expect(parent.env.dispatch).toHaveBeenCalledWith("CREATE_SHEET", {
+      activate: true,
+      id: "42",
+    });
   });
 
   test("Can activate a sheet", async () => {
-    const parent = new Parent(new Model());
-    await parent.mount(fixture);
-
     triggerMouseEvent(".o-sheet", "click");
     const from = parent.model.getters.getActiveSheet();
     const to = from;
     expect(parent.env.dispatch).toHaveBeenCalledWith("ACTIVATE_SHEET", { from, to });
   });
 
-  test("Can open context menu of a sheet", async () => {
-    const parent = new Parent(new Model());
-    await parent.mount(fixture);
+  test("Can rename a sheet with dblclick", async () => {
+    triggerMouseEvent(".o-sheet-name", "dblclick");
+    await nextTick();
+    const sheet = model.getters.getActiveSheet();
+    expect(parent.env.dispatch).toHaveBeenCalledWith("RENAME_SHEET", {
+      sheet,
+      interactive: true,
+    });
+  });
 
+  test("Can open context menu of a sheet", async () => {
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
@@ -81,9 +107,6 @@ describe("BottomBar component", () => {
   });
 
   test("Can open context menu of a sheet with the arrow", async () => {
-    const parent = new Parent(new Model());
-    await parent.mount(fixture);
-
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     triggerMouseEvent(".o-sheet-icon", "click");
     await nextTick();
@@ -91,9 +114,6 @@ describe("BottomBar component", () => {
   });
 
   test("Click on the arrow when the context menu is open should close it", async () => {
-    const parent = new Parent(new Model());
-    await parent.mount(fixture);
-
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     triggerMouseEvent(".o-sheet-icon", "click");
     await nextTick();
@@ -104,11 +124,7 @@ describe("BottomBar component", () => {
   });
 
   test("Can move right a sheet", async () => {
-    const model = new Model();
     model.dispatch("CREATE_SHEET", { id: "42" });
-    const parent = new Parent(model);
-    await parent.mount(fixture);
-
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheet = model.getters.getActiveSheet();
@@ -117,11 +133,7 @@ describe("BottomBar component", () => {
   });
 
   test("Can move left a sheet", async () => {
-    const model = new Model();
     model.dispatch("CREATE_SHEET", { id: "42", activate: true });
-    const parent = new Parent(model);
-    await parent.mount(fixture);
-
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheet = model.getters.getActiveSheet();
@@ -130,10 +142,6 @@ describe("BottomBar component", () => {
   });
 
   test("Move right and left are not visible when it's not possible to move", async () => {
-    const model = new Model();
-    const parent = new Parent(model);
-    await parent.mount(fixture);
-
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     expect(fixture.querySelector(".o-menu-item[data-name='move_left'")).toBeNull();
@@ -141,70 +149,32 @@ describe("BottomBar component", () => {
   });
 
   test("Can rename a sheet", async () => {
-    const model = new Model();
-    const parent = new Parent(model);
-    await parent.mount(fixture);
-
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheet = model.getters.getActiveSheet();
     triggerMouseEvent(".o-menu-item[data-name='rename'", "click");
-    expect(parent.env.dispatch).toHaveBeenCalledWith("RENAME_SHEET", { sheet, interactive: true });
-  });
-
-  test("Can rename a sheet with dblclick", async () => {
-    const model = new Model();
-    const parent = new Parent(model);
-    await parent.mount(fixture);
-
-    triggerMouseEvent(".o-sheet-name", "dblclick");
-    await nextTick();
-    const sheet = model.getters.getActiveSheet();
-    expect(parent.env.dispatch).toHaveBeenCalledWith("RENAME_SHEET", { sheet, interactive: true });
+    expect(parent.env.dispatch).toHaveBeenCalledWith("RENAME_SHEET", {
+      sheet,
+      interactive: true,
+    });
   });
 
   test("Can duplicate a sheet", async () => {
-    const model = new Model();
-    const parent = new Parent(model);
-    await parent.mount(fixture);
     mockUuidV4To(123);
-
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheet = model.getters.getActiveSheet();
     const name = `Copy of ${model.getters.getSheets()[0].name}`;
     triggerMouseEvent(".o-menu-item[data-name='duplicate'", "click");
-    expect(parent.env.dispatch).toHaveBeenCalledWith("DUPLICATE_SHEET", { sheet, id: "123", name });
-  });
-
-  test("Can duplicate a sheet", async () => {
-    const model = new Model({
-      sheets: [
-        {
-          name: "test",
-        },
-        {
-          name: "Copy of test",
-        },
-      ],
+    expect(parent.env.dispatch).toHaveBeenCalledWith("DUPLICATE_SHEET", {
+      sheet,
+      id: "123",
+      name,
     });
-    const parent = new Parent(model);
-    await parent.mount(fixture);
-    triggerMouseEvent(".o-sheet", "contextmenu");
-    await nextTick();
-    const sheet = model.getters.getActiveSheet();
-    const name = `Copy of test (1)`;
-    mockUuidV4To(123);
-    triggerMouseEvent(".o-menu-item[data-name='duplicate'", "click");
-    expect(parent.env.dispatch).toHaveBeenCalledWith("DUPLICATE_SHEET", { sheet, id: "123", name });
   });
 
   test("Can delete a sheet", async () => {
-    const model = new Model();
     model.dispatch("CREATE_SHEET", { id: "42" });
-    const parent = new Parent(model);
-    await parent.mount(fixture);
-
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheet = model.getters.getActiveSheet();
@@ -213,31 +183,14 @@ describe("BottomBar component", () => {
   });
 
   test("Delete sheet is not visible when there is only one sheet", async () => {
-    const model = new Model();
-    const parent = new Parent(model);
-    await parent.mount(fixture);
-
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     expect(fixture.querySelector(".o-menu-item[data-name='delete'")).toBeNull();
   });
 
   test("Can open the list of sheets", async () => {
-    const parent = new Parent(new Model());
-    await parent.mount(fixture);
-
-    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    triggerMouseEvent(".o-list-sheets", "click");
-    await nextTick();
-    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
-  });
-
-  test("Can open the list of sheets", async () => {
-    const model = new Model();
-    const parent = new Parent(model);
     const sheet = model.getters.getActiveSheet();
     model.dispatch("CREATE_SHEET", { id: "42" });
-    await parent.mount(fixture);
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     triggerMouseEvent(".o-list-sheets", "click");
     await nextTick();
@@ -249,14 +202,63 @@ describe("BottomBar component", () => {
   });
 
   test("Can activate a sheet from the list of sheets", async () => {
-    const model = new Model();
-    const parent = new Parent(model);
     const sheet = model.getters.getActiveSheet();
     model.dispatch("CREATE_SHEET", { id: "42" });
-    await parent.mount(fixture);
     triggerMouseEvent(".o-list-sheets", "click");
     await nextTick();
     triggerMouseEvent(".o-menu-item[data-name='42'", "click");
     expect(parent.env.dispatch).toHaveBeenCalledWith("ACTIVATE_SHEET", { from: sheet, to: "42" });
+  });
+});
+
+describe("Spreadsheet menu interactions", () => {
+  beforeEach(async () => {
+    fixture = makeTestFixture();
+    model = new Model();
+    parent = new SpreadSheetParent(model);
+    await parent.mount(fixture);
+  });
+
+  afterEach(() => {
+    fixture.remove();
+    parent.destroy();
+  });
+  test("opening topbar tool menu closes bottom bar menu", async () => {
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
+    expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
+    triggerMouseEvent(".o-sheet", "contextmenu"); //opens bottombarMenu
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
+    expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
+    fixture.querySelector('span[title="Borders"]')!.dispatchEvent(new Event("click")); //opens topbar tool menu
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
+  });
+
+  test("opening topbar context menu closes bottom bar menu", async () => {
+    expect(fixture.querySelectorAll(".o-spreadsheet-bottom-bar .o-menu")).toHaveLength(0);
+    expect(fixture.querySelectorAll(".o-topbar-topleft .o-menu")).toHaveLength(0);
+    triggerMouseEvent(".o-sheet", "contextmenu"); //opens bottombarMenu
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-spreadsheet-bottom-bar .o-menu")).toHaveLength(1);
+    expect(fixture.querySelectorAll(".o-topbar-topleft .o-menu")).toHaveLength(0);
+    triggerMouseEvent(".o-topbar-menu[data-id='file']", "click"); //opens topbar context menu
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-spreadsheet-bottom-bar .o-menu")).toHaveLength(0);
+    expect(fixture.querySelectorAll(".o-topbar-topleft .o-menu")).toHaveLength(1);
+  });
+
+  test("opening grid context menu closes bottom bar menu", async () => {
+    expect(fixture.querySelectorAll(".o-spreadsheet-bottom-bar .o-menu")).toHaveLength(0);
+    expect(fixture.querySelectorAll(".o-grid-context-menu .o-menu")).toHaveLength(0);
+    triggerMouseEvent(".o-sheet", "contextmenu"); //opens bottombarMenu
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-spreadsheet-bottom-bar .o-menu")).toHaveLength(1);
+    expect(fixture.querySelectorAll(".o-grid-context-menu .o-menu")).toHaveLength(0);
+    simulateContextMenu(300, 200); //grid context menu
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-spreadsheet-bottom-bar .o-menu")).toHaveLength(0);
+    expect(fixture.querySelectorAll(".o-grid-context-menu .o-menu")).toHaveLength(1);
   });
 });

--- a/tests/components/spreadsheet_test.ts
+++ b/tests/components/spreadsheet_test.ts
@@ -1,17 +1,11 @@
-import { Component, hooks, tags } from "@odoo/owl";
-import { Model } from "../../src";
-import { Spreadsheet } from "../../src/components";
 import { args, functionRegistry } from "../../src/functions";
 import { DEBUG } from "../../src/helpers";
 import { SelectionMode } from "../../src/plugins/selection";
 import { simulateClick, triggerMouseEvent } from "../dom_helper";
-import { makeTestFixture, MockClipboard, nextTick } from "../helpers";
-
-const { xml } = tags;
-const { useRef } = hooks;
+import { makeTestFixture, MockClipboard, nextTick, SpreadSheetParent } from "../helpers";
 
 let fixture: HTMLElement;
-let parent: Parent;
+let parent: SpreadSheetParent;
 const clipboard = new MockClipboard();
 
 Object.defineProperty(navigator, "clipboard", {
@@ -21,24 +15,9 @@ Object.defineProperty(navigator, "clipboard", {
   configurable: true,
 });
 
-class Parent extends Component<any> {
-  static template = xml`<Spreadsheet t-ref="spreadsheet" data="data"/>`;
-  static components = { Spreadsheet };
-  private spreadsheet: any = useRef("spreadsheet");
-  readonly data: any;
-  get model(): Model {
-    return this.spreadsheet.comp.model;
-  }
-
-  constructor(data?) {
-    super();
-    this.data = data;
-  }
-}
-
 beforeEach(async () => {
   fixture = makeTestFixture();
-  parent = new Parent({
+  parent = new SpreadSheetParent({
     sheets: [
       {
         id: 1,
@@ -50,6 +29,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   fixture.remove();
+  parent.destroy();
 });
 
 describe("Spreadsheet", () => {
@@ -95,7 +75,7 @@ describe("Spreadsheet", () => {
       args: args(``),
       returns: ["STRING"],
     });
-    const parent = new Parent({
+    const parent = new SpreadSheetParent({
       version: 2,
       sheets: [
         {


### PR DESCRIPTION
## [FIX] Menus: superimposed menus
Currently it is possible to have two menus open at the same time.
this is not ideal, espacially when they are opened on top of each other
this commit will fix this issue by make it impossible to have more
than one menu open.

Odoo task ID : [2636446](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
