### PR TITLE
[FIX] sheet: translate sheet names

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -1,6 +1,7 @@
 import { BACKGROUND_CHART_COLOR, DEFAULT_REVISION_ID, FORBIDDEN_IN_EXCEL_REGEX } from "./constants";
 import { normalize } from "./formulas/index";
 import { toXC, toZone } from "./helpers/index";
+import { _t } from "./translation";
 import { ExcelSheetData, ExcelWorkbookData, SheetData, WorkbookData } from "./types/index";
 
 /**
@@ -241,7 +242,7 @@ const MIGRATIONS: Migration[] = [
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
-function createEmptySheet(name: string = "Sheet1"): SheetData {
+function createEmptySheet(name: string = _t("Sheet") + 1): SheetData {
   return {
     id: name,
     name,
@@ -259,7 +260,7 @@ function createEmptySheet(name: string = "Sheet1"): SheetData {
 export function createEmptyWorkbookData(): WorkbookData {
   const data = {
     version: CURRENT_VERSION,
-    sheets: [createEmptySheet("Sheet1")],
+    sheets: [createEmptySheet(_t("Sheet") + 1)],
     entities: {},
     styles: {},
     borders: {},
@@ -268,7 +269,7 @@ export function createEmptyWorkbookData(): WorkbookData {
   return data;
 }
 
-function createEmptyExcelSheet(name: string = "Sheet1"): ExcelSheetData {
+function createEmptyExcelSheet(name: string = _t("Sheet") + 1): ExcelSheetData {
   return {
     ...createEmptySheet(name),
     charts: [],
@@ -278,6 +279,6 @@ function createEmptyExcelSheet(name: string = "Sheet1"): ExcelSheetData {
 export function createEmptyExcelWorkbookData(): ExcelWorkbookData {
   return {
     ...createEmptyWorkbookData(),
-    sheets: [createEmptyExcelSheet("Sheet1")],
+    sheets: [createEmptyExcelSheet(_t("Sheet") + 1)],
   };
 }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -14,7 +14,7 @@ import {
   mapCellsInZone,
   numberToLetters,
 } from "../../helpers/index";
-import { _lt } from "../../translation";
+import { _lt, _t } from "../../translation";
 import {
   Cell,
   CellPosition,
@@ -208,7 +208,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     }
 
     for (let sheetData of data.sheets) {
-      const name = sheetData.name || `Sheet${Object.keys(this.sheets).length + 1}`;
+      const name = sheetData.name || _t("Sheet") + (Object.keys(this.sheets).length + 1);
       const sheet: Sheet = {
         id: sheetData.id,
         name: name,

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -10,7 +10,7 @@ export type TranslationFunction = (
 ) => string;
 
 // define a mock translation function, when o-spreadsheet runs in standalone it doesn't translate any string
-let _t: TranslationFunction = (s) => s;
+let _translate: TranslationFunction = (s) => s;
 
 function sprintf(s: string, ...values: string[] | [{ [key: string]: string }]): string {
   if (values.length === 1 && typeof values[0] === "object") {
@@ -27,8 +27,15 @@ function sprintf(s: string, ...values: string[] | [{ [key: string]: string }]): 
  * @param tfn the function that will do the translation
  */
 export function setTranslationMethod(tfn: TranslationFunction) {
-  _t = tfn;
+  _translate = tfn;
 }
+
+export const _t: TranslationFunction = function (
+  s: string,
+  ...values: string[] | [{ [key: string]: string }]
+) {
+  return sprintf(_translate(s), ...values);
+};
 
 export const _lt: TranslationFunction = function (
   s,
@@ -36,7 +43,7 @@ export const _lt: TranslationFunction = function (
 ) {
   return {
     toString: function () {
-      return sprintf(_t(s), ...values);
+      return sprintf(_translate(s), ...values);
     },
     // casts the object to unknown then to string to trick typescript into thinking that the object it receives is actually a string
     // this way it will be typed correctly (behaves like a string) but tests like typeof _lt("whatever") will be object and not string !


### PR DESCRIPTION
Before this commit, sheet names were not translated.
To be able to translate the sheet names, we need to expose _t from
translation.
