### PR TITLE
[IMP] UISheet: display error message when sheet name is not valid

### DIFF
--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -263,11 +263,11 @@ async function typeInComposerHelper(selector: string, text: string, fromScratch:
 }
 
 export async function typeInComposerGrid(text: string, fromScratch: boolean = true) {
-  return await typeInComposerHelper(".o-grid .o-composer", text,fromScratch);
+  return await typeInComposerHelper(".o-grid .o-composer", text, fromScratch);
 }
 
 export async function typeInComposerTopBar(text: string, fromScratch: boolean = true) {
-  return await typeInComposerHelper(".o-spreadsheet-topbar .o-composer", text,fromScratch);
+  return await typeInComposerHelper(".o-spreadsheet-topbar .o-composer", text, fromScratch);
 }
 
 export async function startGridComposition(key: string = "Enter") {


### PR DESCRIPTION
currently no feedback is given to the user if he enters a wrong sheet
name when renaming. This commit will give a little feedback to the user

Odoo task ID : [2555127](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
