### PR TITLE
[REF] drag and drop helpers functions: improve usability

### DIFF
--- a/src/components/autofill.ts
+++ b/src/components/autofill.ts
@@ -2,7 +2,7 @@ import * as owl from "@odoo/owl";
 import { AUTOFILL_EDGE_LENGTH } from "../constants";
 import { clip } from "../helpers/misc";
 import { SpreadsheetEnv } from "../types";
-import { startDnd } from "./helpers/drag_and_drop";
+import { dragAndDrop } from "./helpers/drag_and_drop";
 
 const { Component } = owl;
 const { xml, css } = owl.tags;
@@ -114,7 +114,7 @@ export class Autofill extends Component<Props, SpreadsheetEnv> {
       this.env.dispatch("AUTOFILL");
     };
 
-    const onMouseMove = (ev: MouseEvent) => {
+    const onMouseMove = (x, y) => {
       const parent = this.el!.parentElement! as HTMLElement;
       const position = parent.getBoundingClientRect();
       const {
@@ -124,11 +124,11 @@ export class Autofill extends Component<Props, SpreadsheetEnv> {
         offsetX,
       } = this.env.getters.getActiveSnappedViewport();
       this.state.position = {
-        left: ev.clientX - start.left + offsetX,
-        top: ev.clientY - start.top + offsetY,
+        left: x - start.left + offsetX,
+        top: y - start.top + offsetY,
       };
-      const col = this.env.getters.getColIndex(ev.clientX - position.left, viewportLeft);
-      const row = this.env.getters.getRowIndex(ev.clientY - position.top, viewportTop);
+      const col = this.env.getters.getColIndex(x - position.left, viewportLeft);
+      const row = this.env.getters.getRowIndex(y - position.top, viewportTop);
       if (lastCol !== col || lastRow !== row) {
         const activeSheet = this.env.getters.getActiveSheet();
         lastCol = col === -1 ? lastCol : clip(col, 0, activeSheet.cols.length);
@@ -138,7 +138,7 @@ export class Autofill extends Component<Props, SpreadsheetEnv> {
         }
       }
     };
-    startDnd(onMouseMove, onMouseUp);
+    dragAndDrop({ onMouseMove, onMouseUp });
   }
 
   onDblClick() {

--- a/src/components/figures/container.ts
+++ b/src/components/figures/container.ts
@@ -3,7 +3,7 @@ import { Component } from "@odoo/owl";
 import { HEADER_HEIGHT, HEADER_WIDTH, SELECTION_BORDER_COLOR } from "../../constants";
 import { figureRegistry } from "../../registries/index";
 import { Figure, SpreadsheetEnv } from "../../types/index";
-import { startDnd } from "../helpers/drag_and_drop";
+import { dragAndDrop } from "../helpers/drag_and_drop";
 import { ChartFigure } from "./chart";
 
 const { xml, css } = owl.tags;
@@ -210,9 +210,9 @@ export class FiguresContainer extends Component<{ sidePanelIsOpen: Boolean }, Sp
     this.dnd.width = figure.width;
     this.dnd.height = figure.height;
 
-    const onMouseMove = (ev: MouseEvent) => {
-      const deltaX = dirX * (ev.clientX - initialX);
-      const deltaY = dirY * (ev.clientY - initialY);
+    const onMouseMove = (x, y) => {
+      const deltaX = dirX * (x - initialX);
+      const deltaY = dirY * (y - initialY);
       this.dnd.width = Math.max(figure.width + deltaX, MIN_FIG_SIZE);
       this.dnd.height = Math.max(figure.height + deltaY, MIN_FIG_SIZE);
       if (dirX < 0) {
@@ -222,7 +222,7 @@ export class FiguresContainer extends Component<{ sidePanelIsOpen: Boolean }, Sp
         this.dnd.y = figure.y - deltaY;
       }
     };
-    const onMouseUp = (ev: MouseEvent) => {
+    const onMouseUp = () => {
       this.dnd.figureId = "";
       const update: Partial<Figure> = {
         x: this.dnd.x,
@@ -240,7 +240,7 @@ export class FiguresContainer extends Component<{ sidePanelIsOpen: Boolean }, Sp
         ...update,
       });
     };
-    startDnd(onMouseMove, onMouseUp);
+    dragAndDrop({ onMouseMove, onMouseUp });
   }
 
   onMouseDown(figure: Figure, ev: MouseEvent) {
@@ -260,11 +260,11 @@ export class FiguresContainer extends Component<{ sidePanelIsOpen: Boolean }, Sp
     this.dnd.width = figure.width;
     this.dnd.height = figure.height;
 
-    const onMouseMove = (ev: MouseEvent) => {
-      this.dnd.x = Math.max(figure.x - initialX + ev.clientX, 0);
-      this.dnd.y = Math.max(figure.y - initialY + ev.clientY, 0);
+    const onMouseMove = (x, y) => {
+      this.dnd.x = Math.max(figure.x - initialX + x, 0);
+      this.dnd.y = Math.max(figure.y - initialY + y, 0);
     };
-    const onMouseUp = (ev: MouseEvent) => {
+    const onMouseUp = () => {
       this.dnd.figureId = "";
       this.dispatch("UPDATE_FIGURE", {
         sheetId: this.getters.getActiveSheetId(),
@@ -273,7 +273,7 @@ export class FiguresContainer extends Component<{ sidePanelIsOpen: Boolean }, Sp
         y: this.dnd.y,
       });
     };
-    startDnd(onMouseMove, onMouseUp);
+    dragAndDrop({ onMouseMove, onMouseUp });
   }
 
   onKeyDown(figure: Figure, ev: KeyboardEvent) {

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -27,7 +27,7 @@ import { ClientTag } from "./collaborative_client_tag";
 import { GridComposer } from "./composer/grid_composer";
 import { ErrorToolTip } from "./error_tooltip";
 import { FiguresContainer } from "./figures/container";
-import { dragAndDropCellHandler, dragAndDropWithEdgeScrolling } from "./helpers/drag_and_drop";
+import { dragAndDropWithEdgeScrolling, mouseMoveReactToCellChange } from "./helpers/drag_and_drop";
 import { Highlight } from "./highlight/highlight";
 import { LinkDisplay } from "./link/link_display";
 import { LinkEditor } from "./link/link_editor";
@@ -704,10 +704,13 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
         });
       }
     };
-    dragAndDropWithEdgeScrolling(
-      this.env,
-      dragAndDropCellHandler(this.env, onCellChange, onMouseUp)
-    );
+
+    const selectionHandlers = {
+      onMouseMove: mouseMoveReactToCellChange(this.env, onCellChange),
+      onMouseUp,
+    };
+
+    dragAndDropWithEdgeScrolling(this.env, selectionHandlers);
   }
 
   onDoubleClick(ev) {

--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -120,17 +120,21 @@ export function dragAndDropWithEdgeScrolling(
   });
 }
 
-export function dragAndDropCellHandler(
+/**
+ * Custom event handler that reacts when the mouse is moved to a different cell.
+ *
+ * It also ensures that the cell indices used in the custom event conform to the
+ * current sheet.
+ */
+export function mouseMoveReactToCellChange(
   env: SpreadsheetEnv,
-  onCellChange: (colIndex: number, rowIndex: number) => void,
-  onMouseUp: EventHandler
-): DragAndDropHandlers {
+  onCellChange: (colIndex: number, rowIndex: number) => void
+): (x: number, y: number) => void {
   let prevCol: undefined | number = undefined;
   let prevRow: undefined | number = undefined;
 
   const onMouseMove = (offsetX, offsetY) => {
     const { left, top } = env.getters.getActiveSnappedViewport();
-
     let colIndex = env.getters.getColIndex(offsetX, left);
     let rowIndex = env.getters.getRowIndex(offsetY, top);
 
@@ -152,5 +156,5 @@ export function dragAndDropCellHandler(
       onCellChange(colIndex, rowIndex);
     }
   };
-  return { onMouseMove, onMouseUp };
+  return onMouseMove;
 }

--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -1,7 +1,10 @@
+import { TOPBAR_HEIGHT } from "../../constants";
+import { MAX_DELAY } from "../../helpers";
 import { SpreadsheetEnv } from "../../types/env";
-type EventFn = (ev: MouseEvent) => void;
 
-export function startDnd(onMouseMove: EventFn, onMouseUp: EventFn) {
+type EventHandler = (ev: MouseEvent) => void;
+
+function startDragAndDrop(onMouseMove: EventHandler, onMouseUp: EventHandler) {
   const _onMouseUp = (ev: MouseEvent) => {
     onMouseUp(ev);
     window.removeEventListener("mouseup", _onMouseUp);
@@ -19,79 +22,135 @@ export function startDnd(onMouseMove: EventFn, onMouseUp: EventFn) {
   window.addEventListener("wheel", onMouseMove);
 }
 
-/**
- * Function to be used during a mousedown event, this function allows to
- * perform actions related to the mousemove and mouseup events and adjusts the viewport
- * when the new position related to the mousemove event is outside of it.
- * Among inputs are two callback functions. First intended for actions performed during
- * the mousemove event, it receives as parameters the current position of the mousemove
- * (occurrence of the current column and the current row). Second intended for actions
- * performed during the mouseup event.
- */
-export function dragAndDropBeyondTheViewport(
-  element: HTMLElement,
-  env: SpreadsheetEnv,
-  cbMouseMove: (col: number, row: number) => void,
-  cbMouseUp: () => void
-) {
-  const position = element.getBoundingClientRect();
-  let timeOutId: any = null;
-  let currentEv: MouseEvent;
+export interface DragAndDropHandlers {
+  onMouseMove?: (x: number, y: number) => void;
+  onMouseUp?: (ev: MouseEvent) => void;
+}
 
+/**
+ * This function allows to define actions that must be executed during a mousemove
+ * followed by a mouseup event. Actions are then ignored after the mouseup.
+ *
+ * This function is particularly useful when it is called during a mousedown event
+ * to define actions to be taken when dragging and dropping elements.
+ */
+export function dragAndDrop(...handlers: DragAndDropHandlers[]) {
   const onMouseMove = (ev: MouseEvent) => {
-    currentEv = ev;
+    const position = spreadsheetPosition();
+    const x = ev.clientX - position.left;
+    const y = ev.clientY - position.top - TOPBAR_HEIGHT;
+    for (let handler of handlers) {
+      handler.onMouseMove?.(x, y);
+    }
+  };
+  const onMouseUp = (ev: MouseEvent) => {
+    for (let handler of handlers) {
+      handler.onMouseUp?.(ev);
+    }
+  };
+  startDragAndDrop(onMouseMove, onMouseUp);
+}
+
+export function spreadsheetPosition() {
+  const spreadsheetElement = document.querySelector(".o-spreadsheet");
+  if (spreadsheetElement) {
+    const { top, left } = spreadsheetElement?.getBoundingClientRect();
+    return { top, left };
+  }
+  throw new Error("Can't find spreadsheet position");
+}
+/**
+ * Like the "dragAndDrop" function, this function allows to define actions to be
+ * taken when dragging and dropping elements. It adds the possibility to update
+ * the viewport position when the mousemove event tries to be executed beyond the
+ * viewport.
+ */
+export function dragAndDropWithEdgeScrolling(
+  env: SpreadsheetEnv,
+  ...handlers: DragAndDropHandlers[]
+) {
+  let isEdgeScrolling: boolean = false;
+  let timeOutId: any = null;
+  let timeoutDelay: number = 0;
+  let currentX: number = 0;
+  let currentY: number = 0;
+  const onMouseMoveWithEdgeScrolling = (x: number, y: number) => {
+    currentX = x;
+    currentY = y;
     if (timeOutId) {
       return;
     }
-    const offsetX = currentEv.clientX - position.left;
-    const offsetY = currentEv.clientY - position.top;
-    const edgeScrollInfoX = env.getters.getEdgeScrollCol(offsetX);
-    const edgeScrollInfoY = env.getters.getEdgeScrollRow(offsetY);
-    const { top, left, bottom, right } = env.getters.getActiveSnappedViewport();
+    isEdgeScrolling = false;
+    timeoutDelay = 0;
+    const edgeScrollInfoX = env.getters.getEdgeScrollCol(x);
+    const edgeScrollInfoY = env.getters.getEdgeScrollRow(y);
+    isEdgeScrolling = edgeScrollInfoX.canEdgeScroll || edgeScrollInfoY.canEdgeScroll;
+    timeoutDelay = Math.min(
+      edgeScrollInfoX.canEdgeScroll ? edgeScrollInfoX.delay : MAX_DELAY,
+      edgeScrollInfoY.canEdgeScroll ? edgeScrollInfoY.delay : MAX_DELAY
+    );
 
-    let colIndex: number;
-    if (edgeScrollInfoX.canEdgeScroll) {
-      colIndex = edgeScrollInfoX.direction > 0 ? right : left - 1;
-    } else {
-      colIndex = env.getters.getColIndex(offsetX, left);
+    for (let handler of handlers) {
+      handler.onMouseMove?.(x, y);
     }
 
-    let rowIndex: number;
-    if (edgeScrollInfoY.canEdgeScroll) {
-      rowIndex = edgeScrollInfoY.direction > 0 ? bottom : top - 1;
-    } else {
-      rowIndex = env.getters.getRowIndex(offsetY, top);
-    }
-
-    cbMouseMove(colIndex, rowIndex);
-
-    if (edgeScrollInfoX.canEdgeScroll) {
-      const { left, offsetY } = env.getters.getActiveSnappedViewport();
-      const { cols } = env.getters.getActiveSheet();
+    if (isEdgeScrolling) {
+      const { top, left } = env.getters.getActiveSnappedViewport();
+      const { cols, rows } = env.getters.getActiveSheet();
       const offsetX = cols[left + edgeScrollInfoX.direction].start;
-      env.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
-      timeOutId = setTimeout(() => {
-        timeOutId = null;
-        onMouseMove(currentEv);
-      }, Math.round(edgeScrollInfoX.delay));
-    }
-
-    if (edgeScrollInfoY.canEdgeScroll) {
-      const { top, offsetX } = env.getters.getActiveSnappedViewport();
-      const { rows } = env.getters.getActiveSheet();
       const offsetY = rows[top + edgeScrollInfoY.direction].start;
       env.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
       timeOutId = setTimeout(() => {
         timeOutId = null;
-        onMouseMove(currentEv);
-      }, Math.round(edgeScrollInfoX.delay));
+        onMouseMoveWithEdgeScrolling(currentX, currentY);
+      }, Math.round(timeoutDelay));
     }
   };
 
-  const onMouseUp = () => {
+  const onMouseUpWithEdgeScrolling = (ev: MouseEvent) => {
     clearTimeout(timeOutId);
-    cbMouseUp();
+    for (let dndHandler of handlers) {
+      dndHandler.onMouseUp?.(ev);
+    }
   };
 
-  startDnd(onMouseMove, onMouseUp);
+  dragAndDrop({
+    onMouseMove: onMouseMoveWithEdgeScrolling,
+    onMouseUp: onMouseUpWithEdgeScrolling,
+  });
+}
+
+export function dragAndDropCellHandler(
+  env: SpreadsheetEnv,
+  onCellChange: (colIndex: number, rowIndex: number) => void,
+  onMouseUp: EventHandler
+): DragAndDropHandlers {
+  let prevCol: undefined | number = undefined;
+  let prevRow: undefined | number = undefined;
+
+  const onMouseMove = (offsetX, offsetY) => {
+    const { left, top } = env.getters.getActiveSnappedViewport();
+
+    let colIndex = env.getters.getColIndex(offsetX, left);
+    let rowIndex = env.getters.getRowIndex(offsetY, top);
+
+    // special case when using onMouseMove for the first time
+    if (prevRow === undefined || prevCol === undefined) {
+      prevCol = colIndex;
+      prevRow = rowIndex;
+
+      onCellChange(colIndex, rowIndex);
+      return;
+    }
+
+    // other cases
+    colIndex = colIndex === -1 ? prevCol : colIndex;
+    rowIndex = rowIndex === -1 ? prevRow : rowIndex;
+    if (colIndex !== prevCol || rowIndex !== prevRow) {
+      prevCol = colIndex;
+      prevRow = rowIndex;
+      onCellChange(colIndex, rowIndex);
+    }
+  };
+  return { onMouseMove, onMouseUp };
 }

--- a/src/components/highlight/highlight.ts
+++ b/src/components/highlight/highlight.ts
@@ -2,7 +2,7 @@ import * as owl from "@odoo/owl";
 import { useState } from "@odoo/owl";
 import { clip } from "../../helpers";
 import { SpreadsheetEnv, Zone } from "../../types";
-import { dragAndDropCellHandler, dragAndDropWithEdgeScrolling } from "../helpers/drag_and_drop";
+import { dragAndDropWithEdgeScrolling, mouseMoveReactToCellChange } from "../helpers/drag_and_drop";
 import { Border } from "./border";
 import { Corner } from "./corner";
 
@@ -85,7 +85,11 @@ export class Highlight extends Component<Props, SpreadsheetEnv> {
       this.env.dispatch("STOP_COMPOSER_RANGE_SELECTION");
     };
 
-    const resizeHighlightHandler = dragAndDropCellHandler(this.env, onCellChange, onMouseUp);
+    const resizeHighlightHandler = {
+      onMouseMove: mouseMoveReactToCellChange(this.env, onCellChange),
+      onMouseUp,
+    };
+
     dragAndDropWithEdgeScrolling(this.env, resizeHighlightHandler);
   }
 
@@ -134,7 +138,11 @@ export class Highlight extends Component<Props, SpreadsheetEnv> {
       this.env.dispatch("STOP_COMPOSER_RANGE_SELECTION");
     };
 
-    const moveHighlightHandler = dragAndDropCellHandler(this.env, onCellChange, onMouseUp);
+    const moveHighlightHandler = {
+      onMouseMove: mouseMoveReactToCellChange(this.env, onCellChange),
+      onMouseUp,
+    };
+
     dragAndDropWithEdgeScrolling(this.env, moveHighlightHandler);
   }
 }

--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -12,8 +12,8 @@ import { Col, EdgeScrollInfo, Row, SpreadsheetEnv } from "../types/index";
 import { ContextMenuType } from "./grid";
 import {
   dragAndDrop,
-  dragAndDropCellHandler,
   dragAndDropWithEdgeScrolling,
+  mouseMoveReactToCellChange,
 } from "./helpers/drag_and_drop";
 import * as icons from "./icons";
 
@@ -231,13 +231,17 @@ abstract class AbstractResizer extends Component<any, SpreadsheetEnv> {
         this.state.base = this._getSelectedZoneStart();
       }
     };
-    const onMouseUp = () => {
-      this.state.isMoving = false;
-      if (this.state.base !== this._getSelectedZoneStart()) {
-        this._moveElements();
-      }
+
+    const draggerLinePositionHandler = {
+      onMouseMove: mouseMoveReactToCellChange(this.env, onCellChange),
+      onMouseUp: () => {
+        this.state.isMoving = false;
+        if (this.state.base !== this._getSelectedZoneStart()) {
+          this._moveElements();
+        }
+      },
     };
-    const draggerLinePositionHandler = dragAndDropCellHandler(this.env, onCellChange, onMouseUp);
+
     dragAndDropWithEdgeScrolling(this.env, shadowPositionHandler, draggerLinePositionHandler);
   }
 
@@ -265,7 +269,10 @@ abstract class AbstractResizer extends Component<any, SpreadsheetEnv> {
       this._computeGrabDisplay(ev);
     };
 
-    const draggerSelectionHandler = dragAndDropCellHandler(this.env, onCellChange, onMouseUp);
+    const draggerSelectionHandler = {
+      onMouseMove: mouseMoveReactToCellChange(this.env, onCellChange),
+      onMouseUp,
+    };
     dragAndDropWithEdgeScrolling(this.env, draggerSelectionHandler);
   }
 

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -79,21 +79,16 @@ export class RendererPlugin extends UIPlugin {
 
   /**
    * Return the index of a column given an offset x and a visible left col index.
+   * Offsets are relative top the upper left grid corner (including headers).
    * It returns -1 if no column is found.
    */
   getColIndex(x: number, left: number, sheet?: Sheet): number {
-    if (x < HEADER_WIDTH) {
-      return -1;
-    }
     const cols = (sheet || this.getters.getActiveSheet()).cols;
     const adjustedX = x - HEADER_WIDTH + cols[left].start + 1;
     return searchIndex(cols, adjustedX);
   }
 
   getRowIndex(y: number, top: number, sheet?: Sheet): number {
-    if (y < HEADER_HEIGHT) {
-      return -1;
-    }
     const rows = (sheet || this.getters.getActiveSheet()).rows;
     const adjustedY = y - HEADER_HEIGHT + rows[top].start + 1;
     return searchIndex(rows, adjustedY);


### PR DESCRIPTION
## Description:

This commit allows to define more simply if 'drag and drop' functions
must be executed with or without the update of the viewport.

It also adds in the 'drag and drop' functions the possibility of
distinguishing the following cases:
- either we use a callback function to react to the mousemove event
- either we use a callback function to react when the cursor moves and
hovers a new cell


Odoo task ID : [2666549](https://www.odoo.com/web#id=2666549&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
