### PR TITLE
[FIX] edition/selection_input: component loss of focus was not reflec…

### DIFF
--- a/src/components/selection_input.ts
+++ b/src/components/selection_input.ts
@@ -187,8 +187,9 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
     this.previousRanges = ranges;
   }
 
-  focus(rangeId: string | null) {
+  focus(rangeId: string) {
     this.state.isMissing = false;
+    this.dispatch("STOP_EDITION", { cancel: true });
     this.dispatch("FOCUS_RANGE", {
       id: this.id,
       rangeId,
@@ -217,10 +218,7 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
   }
 
   disable() {
-    this.dispatch("FOCUS_RANGE", {
-      id: this.id,
-      rangeId: null,
-    });
+    this.dispatch("UNFOCUS_SELECTION_INPUT");
     const ranges = this.getters.getSelectionInputValue(this.id);
     if (this.props.required && ranges.length === 0) {
       this.state.isMissing = true;

--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -321,6 +321,7 @@ export class Spreadsheet extends Component<Props, SpreadsheetEnv> {
     this.composer.topBarFocus = "contentFocus";
     this.composer.gridFocusMode = "inactive";
     this.setComposerContent(ev.detail || {});
+    this.env.dispatch("UNFOCUS_SELECTION_INPUT");
   }
 
   onGridComposerContentFocused(ev: ComposerFocusedEvent) {
@@ -330,6 +331,7 @@ export class Spreadsheet extends Component<Props, SpreadsheetEnv> {
     this.composer.topBarFocus = "inactive";
     this.composer.gridFocusMode = "contentFocus";
     this.setComposerContent(ev.detail || {});
+    this.env.dispatch("UNFOCUS_SELECTION_INPUT");
   }
 
   onGridComposerCellFocused(ev: ComposerFocusedEvent) {
@@ -339,6 +341,7 @@ export class Spreadsheet extends Component<Props, SpreadsheetEnv> {
     this.composer.topBarFocus = "inactive";
     this.composer.gridFocusMode = "cellFocus";
     this.setComposerContent(ev.detail || {});
+    this.env.dispatch("UNFOCUS_SELECTION_INPUT");
   }
 
   /**

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -70,12 +70,14 @@ export class SelectionInputPlugin extends UIPlugin {
         break;
       case "DISABLE_SELECTION_INPUT":
         if (this.focusedInputId === cmd.id) {
-          this.focusedRange = null;
-          this.focusedInputId = null;
+          this.unfocus();
         }
         delete this.inputs[cmd.id];
         delete this.activeSheets[cmd.id];
         delete this.inputMaximums[cmd.id];
+        break;
+      case "UNFOCUS_SELECTION_INPUT":
+        this.unfocus();
         break;
       case "FOCUS_RANGE":
         this.focus(cmd.id, this.getIndex(cmd.id, cmd.rangeId));
@@ -207,6 +209,11 @@ export class SelectionInputPlugin extends UIPlugin {
 
   private focusLast(id: UID) {
     this.focus(id, this.inputs[id].length - 1);
+  }
+
+  private unfocus() {
+    this.focusedInputId = null;
+    this.focusedRange = null;
   }
 
   private add(newRanges: string[]) {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -697,6 +697,10 @@ export interface RemoveInputCommand extends BaseCommand {
   id: string;
 }
 
+export interface UnfocusInputCommand extends BaseCommand {
+  type: "UNFOCUS_SELECTION_INPUT";
+}
+
 /**
  * Set the focus on a given range of a SelectionComponent state.
  */
@@ -705,9 +709,9 @@ export interface FocusInputCommand extends BaseCommand {
   /** SelectionComponent id */
   id: string;
   /**
-   * Range to focus. If `null` is given, removes the focus entirely.
+   * Range to focus
    */
-  rangeId: string | null;
+  rangeId: string;
 }
 
 /**
@@ -902,6 +906,7 @@ export type LocalCommand =
   | RedoCommand
   | NewInputCommand
   | RemoveInputCommand
+  | UnfocusInputCommand
   | FocusInputCommand
   | AddEmptyRangeCommand
   | RemoveRangeCommand

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -193,7 +193,7 @@ describe("selection input plugin", () => {
   test("ranges are unfocused", () => {
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
     expect(model.getters.getSelectionInput(id)[0].isFocused).toBe(true);
-    model.dispatch("FOCUS_RANGE", { id, rangeId: null });
+    model.dispatch("UNFOCUS_SELECTION_INPUT");
     expect(model.getters.getSelectionInput(id)[0].isFocused).toBeFalsy();
   });
 
@@ -451,7 +451,7 @@ describe("selection input plugin", () => {
     model.dispatch("FOCUS_RANGE", { id: "1", rangeId: idOfRange(model, "1", 0) });
     const color = model.getters.getSelectionInput(id)[0].color;
     expect(color).toBeTruthy();
-    model.dispatch("FOCUS_RANGE", { id, rangeId: null });
+    model.dispatch("UNFOCUS_SELECTION_INPUT");
     expect(model.getters.getSelectionInput(id)[0].color).toBe(null);
     model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
     expect(model.getters.getSelectionInput(id)[0].color).toBe(color);
@@ -482,7 +482,7 @@ describe("selection input plugin", () => {
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
     select(model, "A1");
     createSheet(model, { sheetId: "42", activate: true });
-    model.dispatch("FOCUS_RANGE", { id, rangeId: null });
+    model.dispatch("UNFOCUS_SELECTION_INPUT");
     let [range] = model.getters.getSelectionInput(id);
     model.dispatch("FOCUS_RANGE", { id, rangeId: range.id });
     [range] = model.getters.getSelectionInput(id);
@@ -547,7 +547,7 @@ describe("selection input plugin", () => {
     model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1 });
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, initialRanges: ["Sheet2!B2"] });
     model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
-    model.dispatch("FOCUS_RANGE", { id, rangeId: null });
+    model.dispatch("UNFOCUS_SELECTION_INPUT");
     expect(model.getters.getSelectionInput(id)[0].isFocused).toBe(false);
     activateSheet(model, "42");
     expect(model.getters.getSelectionInput(id)[0].isFocused).toBe(false);


### PR DESCRIPTION
…ted on the plugins

When switching focus between the composer and a selection_input component,

Form a functional pov, the focus on the composer and a selectionInput
component are mutually exclusive (it's also the case between 2 seletioninput
components).

This was not supported at the plugin level and we could end up with the
focus on a selectionInput while the edition mode was active. This led to
faulty behaviour where the Highlight (resize and move) component was set
for a seletionInput while it only support the composer highlights right now.

Furthermore, the highlights of both the composer and the selection input
were displayed at the same time.

Task 2677071

Co-authored-by: Lucas Lefèvre <lul@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2677071](https://www.odoo.com/web#id=2677071&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
