### PR TITLE
[FIX] selection_input: fix single range inputs

### DIFF
--- a/src/components/selection_input.ts
+++ b/src/components/selection_input.ts
@@ -97,7 +97,7 @@ const CSS = css/* scss */ `
 
 interface Props {
   ranges: string[];
-  maximumRanges?: number;
+  hasSingleRange?: boolean;
   required?: boolean;
   isInvalid?: boolean;
 }
@@ -149,7 +149,7 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
   }
 
   get canAddRange(): boolean {
-    return !this.props.maximumRanges || this.ranges.length < this.props.maximumRanges;
+    return !this.props.hasSingleRange;
   }
 
   get isInvalid(): boolean {
@@ -160,7 +160,7 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
     this.dispatch("ENABLE_NEW_SELECTION_INPUT", {
       id: this.id,
       initialRanges: this.props.ranges,
-      maximumRanges: this.props.maximumRanges,
+      hasSingleRange: this.props.hasSingleRange,
     });
   }
 

--- a/src/components/side_panel/chart_panel.ts
+++ b/src/components/side_panel/chart_panel.ts
@@ -47,7 +47,7 @@ const CONFIGURATION_TEMPLATE = xml/* xml */ `
     <SelectionInput t-key="getKey('label')"
                     ranges="[state.labelRange || '']"
                     isInvalid="isLabelInvalid"
-                    maximumRanges="1"
+                    hasSingleRange="true"
                     t-on-selection-changed="onLabelRangeChanged"
                     t-on-selection-confirmed="updateLabelRange" />
   </div>

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -683,9 +683,9 @@ export interface NewInputCommand extends BaseCommand {
    */
   initialRanges?: string[];
   /**
-   * Maximum number of ranges allowed
+   * is the input limited to one range or has no limit ?
    */
-  maximumRanges?: number;
+  hasSingleRange?: boolean;
 }
 
 /**

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -27,7 +27,7 @@ async function writeInput(index: number, text: string) {
 
 interface SelectionInputTestConfig {
   initialRanges?: string[];
-  maximumRanges?: number;
+  hasSingleRange?: boolean;
   onChanged?: jest.Mock<void, [any]>;
 }
 
@@ -36,13 +36,13 @@ class Parent extends Component<any> {
     <SelectionInput
       t-ref="selection-input"
       ranges="initialRanges"
-      maximumRanges="maximumRanges"
+      hasSingleRange="hasSingleRange"
       t-on-selection-changed="onChanged"/>
   `;
   static components = { SelectionInput };
   model: Model;
   initialRanges: string[] | undefined;
-  maximumRanges: number | undefined;
+  hasSingleRange: boolean | undefined;
   ref = useRef("selection-input");
   onChanged: jest.Mock<void, [any]>;
 
@@ -54,7 +54,7 @@ class Parent extends Component<any> {
       uuidGenerator: model.uuidGenerator,
     });
     this.initialRanges = config.initialRanges;
-    this.maximumRanges = config.maximumRanges;
+    this.hasSingleRange = config.hasSingleRange;
     this.model = model;
     this.onChanged = config.onChanged || jest.fn();
   }
@@ -159,14 +159,14 @@ describe("Selection Input", () => {
   });
 
   test("input is not filled with highlight when maximum ranges reached", async () => {
-    const { model } = await createSelectionInput({ maximumRanges: 1 });
+    const { model } = await createSelectionInput({ hasSingleRange: true });
     expect(fixture.querySelectorAll("input")).toHaveLength(1);
     model.dispatch("PREPARE_SELECTION_EXPANSION");
     model.dispatch("START_SELECTION_EXPANSION");
     selectCell(model, "B2");
     await nextTick();
     expect(fixture.querySelectorAll("input")).toHaveLength(1);
-    expect(fixture.querySelector("input")!.value).toBe("A1");
+    expect(fixture.querySelector("input")!.value).toBe("B2");
     expect(fixture.querySelector(".o-add-selection")).toBeNull();
   });
 
@@ -175,16 +175,6 @@ describe("Selection Input", () => {
     expect(fixture.querySelectorAll("input").length).toBe(1);
     await simulateClick(".o-add-selection");
     expect(fixture.querySelectorAll("input").length).toBe(2);
-  });
-
-  test("cannot add more ranges than the maximum", async () => {
-    await createSelectionInput({ maximumRanges: 2 });
-    expect(fixture.querySelectorAll("input").length).toBe(1);
-    await simulateClick(".o-add-selection");
-    expect(fixture.querySelectorAll("input").length).toBe(2);
-    expect(fixture.querySelector(".o-add-selection")).toBeNull();
-    await simulateClick(".o-remove-selection");
-    expect(fixture.querySelector(".o-add-selection")).toBeDefined();
   });
 
   test("can set initial ranges", async () => {


### PR DESCRIPTION
When selecting the ranges of a single range input (namely, the label
range of a chart), the extension of a selection was not properly
supported and we could still add several ranges[1]. A part of the code
was assuming that only one range would exist which would lead to crashes
[2].

Right now, we only use two kinds of inputs, the ones with a single
range and those with unlimited number of ranges. This commit adapts the
code to that specific situation and drops the possibility of having
limited amounts of ranges (different than 1).

[1] - focus your input
    - key Ctrl pushed (= extending the selection)
    - Add several cells at once
   => you now have multiple ranges in your labelRange input.

[2] - Once [1] is done and you have several ranges in labelRange, switch
to the 'Design' tab, then back ton 'Configuration'.
    - Only one range is visible
    - Repeat [1] but by adding several zones of multiple cells
   => there is a crash at the rendering level.

Task 2677909

Co-authored-by: Lucas Lefèvre <lul@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2677909](https://www.odoo.com/web#id=2677909&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
