### PR TITLE
14.0 delete row yta

### DIFF
--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -115,7 +115,7 @@ export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetEnv) => {
   if (first === last) {
     return _lt("Clear row %s", (first + 1).toString());
   }
-  return _lt("Clear rows %s - %s", (first + 1).toString(), (last + 1).toString());
+  return _lt("Clear selected rows");
 };
 
 export const DELETE_CONTENT_ROWS_ACTION = (env: SpreadsheetEnv) => {
@@ -143,7 +143,7 @@ export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetEnv) => {
   if (first === last) {
     return _lt("Clear column %s", numberToLetters(first));
   }
-  return _lt("Clear columns %s - %s", numberToLetters(first), numberToLetters(last));
+  return _lt("Clear selected columns");
 };
 
 export const DELETE_CONTENT_COLUMNS_ACTION = (env: SpreadsheetEnv) => {
@@ -171,7 +171,7 @@ export const REMOVE_ROWS_NAME = (env: SpreadsheetEnv) => {
   if (first === last) {
     return _lt("Delete row %s", (first + 1).toString());
   }
-  return _lt("Delete rows %s - %s", (first + 1).toString(), (last + 1).toString());
+  return _lt("Delete selected rows");
 };
 
 export const REMOVE_ROWS_ACTION = (env: SpreadsheetEnv) => {
@@ -203,7 +203,7 @@ export const REMOVE_COLUMNS_NAME = (env: SpreadsheetEnv) => {
   if (first === last) {
     return _lt("Delete column %s", numberToLetters(first));
   }
-  return _lt("Delete columns %s - %s", numberToLetters(first), numberToLetters(last));
+  return _lt("Delete selected columns");
 };
 
 export const REMOVE_COLUMNS_ACTION = (env: SpreadsheetEnv) => {


### PR DESCRIPTION
[FIX] o-spreadsheet: Delete rows multiple zones

currently,
1. select multiple rows by clicking on the row header while holding ctrl.
(lets say row 2,6,8,12)
2. right click on a selected row in order to delete
3. the text in the dropdown says "Delete Rows 2-12".
but it does what it needs to do (delete only the 4 selected rows)

same thing happen when try to delete columns.

after this commit,
if multiple rows are selected change menu item to "delete selected rows"  and
"clear selected rows".
if multiple columns are selected change menu item to "delete selected columns"
and "clear selected columns"

because  displaying all selected row or columns cause menu congested if there is
so many selected rows that are not continuous.

