### PR TITLE
[FIX] core: update range references with space in sheet name

### DIFF
--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -1,5 +1,11 @@
 import { functionRegistry } from "../functions/index";
-import { getUnquotedSheetName, parseNumber, toCartesian, toXC } from "../helpers/index";
+import {
+  getComposerSheetName,
+  getUnquotedSheetName,
+  parseNumber,
+  toCartesian,
+  toXC,
+} from "../helpers/index";
 import { _lt } from "../translation";
 import { Token, tokenize } from "./tokenizer";
 
@@ -267,7 +273,7 @@ export function astToFormula(ast: AST): string {
     case "BIN_OPERATION":
       return astToFormula(ast.left) + ast.value + astToFormula(ast.right);
     case "REFERENCE":
-      return ast.sheet ? `${ast.sheet}!${ast.value}` : ast.value;
+      return ast.sheet ? `${getComposerSheetName(ast.sheet)}!${ast.value}` : ast.value;
     default:
       return ast.value;
   }

--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -1124,7 +1124,7 @@ export class CorePlugin extends BasePlugin {
       right,
     });
 
-    return sheet ? `${sheet}!${range}` : range;
+    return sheet ? `${getComposerSheetName(sheet)}!${range}` : range;
   };
 
   /**
@@ -1192,7 +1192,7 @@ export class CorePlugin extends BasePlugin {
       bottom,
     });
 
-    return sheet ? `${sheet}!${range}` : range;
+    return sheet ? `${getComposerSheetName(sheet)}!${range}` : range;
   };
 
   // ---------------------------------------------------------------------------

--- a/tests/formulas/parser_test.ts
+++ b/tests/formulas/parser_test.ts
@@ -329,6 +329,8 @@ describe("Converting AST to string", () => {
     expect(astToFormula(parse("A10"))).toBe("A10");
     expect(astToFormula(parse("$A$10"))).toBe("A10");
     expect(astToFormula(parse("Sheet1!A10"))).toBe("Sheet1!A10");
+    expect(astToFormula(parse("'Sheet 1'!A10"))).toBe("'Sheet 1'!A10");
+    expect(astToFormula(parse("'Sheet 1'!A10:A11"))).toBe("'Sheet 1'!A10:A11");
   });
   test("Convert function", () => {
     expect(astToFormula(parse("SUM(5,9,8)"))).toBe("SUM(5,9,8)");

--- a/tests/plugins/grid_manipulation_test.ts
+++ b/tests/plugins/grid_manipulation_test.ts
@@ -1095,6 +1095,43 @@ describe("Rows", () => {
         B1: { content: "=SUM(A1:A2)" },
       });
     });
+
+    test("with space in the sheet name", () => {
+      model = new Model({
+        sheets: [
+          {
+            id: "sheet1",
+            name: "Sheet 1",
+            colNumber: 3,
+            rowNumber: 3,
+            cells: {
+              C2: { content: "=SUM('Sheet 1'!B2)" },
+              C3: { content: "=SUM('Sheet 1'!B2:B3)" },
+            },
+          },
+        ],
+      });
+      removeRows([0]);
+      expect(getSheet(model, 0).cells).toMatchObject({
+        C1: { content: "=SUM('Sheet 1'!B1)" },
+        C2: { content: "=SUM('Sheet 1'!B1:B2)" },
+      });
+      removeColumns([0]);
+      expect(getSheet(model, 0).cells).toMatchObject({
+        B1: { content: "=SUM('Sheet 1'!A1)" },
+        B2: { content: "=SUM('Sheet 1'!A1:A2)" },
+      });
+      addColumns(0, "before", 1);
+      expect(getSheet(model, 0).cells).toMatchObject({
+        C1: { content: "=SUM('Sheet 1'!B1)" },
+        C2: { content: "=SUM('Sheet 1'!B1:B2)" },
+      });
+      addRows(0, "before", 1);
+      expect(getSheet(model, 0).cells).toMatchObject({
+        C2: { content: "=SUM('Sheet 1'!B2)" },
+        C3: { content: "=SUM('Sheet 1'!B2:B3)" },
+      });
+    });
     test("On multiple row deletion including the first one", () => {
       model = new Model({
         sheets: [


### PR DESCRIPTION

## Description:

1. Rename the sheet with a space: 'Sheet 1'
2. set a formula with a range: =SUM('Sheet 1'!B2:B3)
3. delete column A
=> the reference is not correctly updated, quotes are missing

Odoo task ID : [2691259](https://www.odoo.com/web#id=2691259&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
