### PR TITLE
[FIX] evaluation: references with async references on different sheets

### DIFF
--- a/tests/plugins/evaluation_async_test.ts
+++ b/tests/plugins/evaluation_async_test.ts
@@ -278,4 +278,55 @@ describe("evaluateCells, async formulas", () => {
     await waitForRecompute();
     expect(model.getters.getCell(...toCartesian("A2"))!.value).toBe(200);
   });
+
+  describe("Async evaluation with cells that are at the same position on different sheets", () => {
+    test("Sheet at position 1", async () => {
+      const model = new Model({
+        sheets: [
+          {
+            id: "Sheet1",
+            name: "Sheet1",
+            cells: {
+              B2: { content: "=Sheet2!B2" },
+            },
+          },
+          {
+            id: "Sheet2",
+            name: "Sheet2",
+            cells: {
+              B1: { content: "=WAIT(50)" },
+              B2: { content: "=B1" },
+            },
+          },
+        ],
+        activeSheet: "Sheet1",
+      });
+      await waitForRecompute();
+      expect(model.getters.getCell(1, 1, "Sheet1")!.value).toBe(50);
+    });
+    test("Sheet at position 2", async () => {
+      const model = new Model({
+        sheets: [
+          {
+            id: "Sheet1",
+            name: "Sheet1",
+            cells: {
+              A1: { content: "=WAIT(50)" },
+              A2: { content: "=A1" },
+            },
+          },
+          {
+            id: "Sheet2",
+            name: "Sheet2",
+            cells: {
+              A2: { content: "=Sheet1!A2" },
+            },
+          },
+        ],
+        activeSheet: "Sheet2",
+      });
+      await waitForRecompute();
+      expect(model.getters.getCell(0, 1, "Sheet2")!.value).toBe(50);
+    });
+  });
 });


### PR DESCRIPTION
before this commit, if a spreadsheet had multiple sheets and that,
- in the first sheet we references on the same position (let's say A1) a cell on the other sheet
- in the second sheet in A1 we have a reference to an async formula of the same sheet or any sheet
--> during the evaluation, after the async formula is evaluated, the first sheet's A1 was never
evaluation and stayed in 'Loading...'

The problem was due to the fact that the cells in WAITING (in evaluation) where not categorized
by sheet and were processed as if they were all in the active sheet

After this commit, the cells in WAITING are now sheet dependant and this fixes the evaluation problem
