### PR TITLE
[REF] menu: remove direct reference to sub menu

### DIFF
--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -14,7 +14,7 @@ import { Menu, MenuState } from "./menu";
 
 const { Component, useState, hooks } = owl;
 const { xml, css } = owl.tags;
-const { useExternalListener, useRef, onWillUpdateProps, onWillStart } = hooks;
+const { useExternalListener, onWillUpdateProps, onWillStart } = hooks;
 
 type Tool =
   | ""
@@ -61,7 +61,6 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
           <Menu t-if="state.menuState.isOpen"
                 position="state.menuState.position"
                 menuItems="state.menuState.menuItems"
-                t-ref="menuRef"
                 t-on-close="state.menuState.isOpen=false"/>
         </div>
         <div class="o-topbar-topright">
@@ -367,7 +366,6 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
   fillColor: string = "white";
   textColor: string = "black";
   menus: FullMenuItem[] = [];
-  menuRef = useRef("menuRef");
   composerStyle = `
     line-height: 34px;
     padding-left: 8px;
@@ -439,9 +437,6 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
     this.state.menuState.isOpen = false;
     this.isSelectingMenu = false;
     this.openedEl = null;
-    if (this.menuRef.comp) {
-      (<Menu>this.menuRef.comp).closeSubMenus();
-    }
   }
 
   updateCellState() {


### PR DESCRIPTION

## Description:

In the Menu component, there's a direct reference to the sub menu
component to call one of its methods. That's not the best "Owlish" way to
communicate with child components.
That's the first motivation to change this. The second motivation is to
prepare compatibility with Owl 2. `t-ref` will no longer work on components.

Part of task [2693778](https://www.odoo.com/web#id=2693778&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

Odoo task ID : [2694750](https://www.odoo.com/web#id=2694750&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
