### PR TITLE
[REF] components: remove lifecycle methods

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -5,7 +5,7 @@ owl.config.mode = "dev";
 const { whenReady } = owl.utils;
 const { Component, useState } = owl;
 const { xml, css } = owl.tags;
-const { useSubEnv } = owl.hooks;
+const { useSubEnv, onWillStart, onMounted } = owl.hooks;
 
 const { Spreadsheet } = o_spreadsheet;
 const { topbarMenuRegistry } = o_spreadsheet.registries;
@@ -39,8 +39,7 @@ topbarMenuRegistry.addChild("xlsx", ["file"], {
 let start;
 
 class App extends Component {
-  constructor() {
-    super();
+  setup() {
     this.key = 1;
     this.data = demoData;
     // this.data = makeLargeDataset(20, 10_000);
@@ -67,9 +66,13 @@ class App extends Component {
         this.state.isReadonly = false;
       },
     });
+
+    onWillStart(() => this.initiateConnection());
+
+    onMounted(() => console.log("Mounted: ", Date.now() - start));
   }
 
-  async willStart() {
+  async initiateConnection() {
     this.transportService = new WebsocketTransport();
     try {
       const [history, _] = await Promise.all([
@@ -85,10 +88,6 @@ class App extends Component {
       this.transportService = undefined;
       this.stateUpdateMessages = [];
     }
-  }
-
-  mounted() {
-    console.log("Mounted: ", Date.now() - start);
   }
 
   askConfirmation(ev) {

--- a/src/components/bottom_bar.ts
+++ b/src/components/bottom_bar.ts
@@ -6,7 +6,7 @@ import { LIST, PLUS, TRIANGLE_DOWN_ICON } from "./icons";
 import { Menu, MenuState } from "./menu";
 const { Component } = owl;
 const { xml, css } = owl.tags;
-const { useState } = owl.hooks;
+const { useState, onMounted, onPatched } = owl.hooks;
 
 // -----------------------------------------------------------------------------
 // SpreadSheet
@@ -129,12 +129,9 @@ export class BottomBar extends Component<{}, SpreadsheetEnv> {
   getters = this.env.getters;
   menuState: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
 
-  mounted() {
-    this.focusSheet();
-  }
-
-  patched() {
-    this.focusSheet();
+  setup() {
+    onMounted(() => this.focusSheet());
+    onPatched(() => this.focusSheet());
   }
 
   focusSheet() {

--- a/src/components/composer/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown.ts
@@ -1,9 +1,9 @@
 import * as owl from "@odoo/owl";
 import { functionRegistry } from "../../functions/index";
 import { Registry } from "../../registry";
-
 const { Component, useState } = owl;
 const { xml, css } = owl.tags;
+const { onMounted, onWillUpdateProps } = owl.hooks;
 const functions = functionRegistry.content;
 
 // -----------------------------------------------------------------------------
@@ -86,15 +86,15 @@ export abstract class TextValueProvider extends Component<Props> {
     selectedIndex: 0,
   });
 
-  mounted() {
-    this.filter(this.props.search);
+  setup() {
+    onMounted(() => this.filter(this.props.search));
+    onWillUpdateProps((nextProps: Props) => this.checkUpdateProps(nextProps));
   }
 
-  willUpdateProps(nextProps: any): Promise<void> {
+  checkUpdateProps(nextProps: any) {
     if (nextProps.search !== this.props.search) {
       this.filter(nextProps.search);
     }
-    return super.willUpdateProps(nextProps);
   }
 
   async filter(searchTerm: string) {

--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -11,7 +11,7 @@ import { FunctionDescriptionProvider } from "./formula_assistant";
 import { Dimension } from "./grid_composer";
 
 const { Component } = owl;
-const { useRef, useState } = owl.hooks;
+const { useRef, useState, onMounted, onPatched, onWillUnmount } = owl.hooks;
 const { xml, css } = owl.tags;
 const functions = functionRegistry.content;
 
@@ -233,25 +233,28 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     this.contentHelper = new ContentEditableHelper(this.composerRef.el!);
   }
 
-  mounted() {
-    DEBUG.composer = this;
+  setup() {
+    onMounted(() => {
+      DEBUG.composer = this;
 
-    const el = this.composerRef.el!;
+      const el = this.composerRef.el!;
 
-    this.contentHelper.updateEl(el);
-    this.processContent();
-  }
-
-  willUnmount(): void {
-    delete DEBUG.composer;
-    this.trigger("composer-unmounted");
-  }
-
-  patched() {
-    if (!this.isKeyStillDown) {
+      this.contentHelper.updateEl(el);
       this.processContent();
-    }
+    });
+
+    onWillUnmount(() => {
+      delete DEBUG.composer;
+      this.trigger("composer-unmounted");
+    });
+
+    onPatched(() => {
+      if (!this.isKeyStillDown) {
+        this.processContent();
+      }
+    });
   }
+
   // ---------------------------------------------------------------------------
   // Handlers
   // ---------------------------------------------------------------------------

--- a/src/components/composer/formula_assistant.ts
+++ b/src/components/composer/formula_assistant.ts
@@ -4,7 +4,7 @@ import { formulaAssistantTerms } from "./translation_terms";
 
 const { Component } = owl;
 const { xml, css } = owl.tags;
-const { useState } = owl.hooks;
+const { useState, onWillUnmount } = owl.hooks;
 
 // -----------------------------------------------------------------------------
 // Formula Assistant component
@@ -134,10 +134,12 @@ export class FunctionDescriptionProvider extends Component<Props> {
 
   private timeOutId = 0;
 
-  willUnmount() {
-    if (this.timeOutId) {
-      clearTimeout(this.timeOutId);
-    }
+  setup() {
+    onWillUnmount(() => {
+      if (this.timeOutId) {
+        clearTimeout(this.timeOutId);
+      }
+    });
   }
 
   getContext(): Props {

--- a/src/components/composer/grid_composer.ts
+++ b/src/components/composer/grid_composer.ts
@@ -6,7 +6,7 @@ import { getTextDecoration } from "../helpers/dom_helpers";
 import { Composer } from "./composer";
 
 const { Component } = owl;
-const { useState } = owl.hooks;
+const { useState, onMounted } = owl.hooks;
 const { xml, css } = owl.tags;
 
 const SCROLLBAR_WIDTH = 14;
@@ -78,6 +78,24 @@ export class GridComposer extends Component<Props, SpreadsheetEnv> {
     this.rect = this.getters.getRect(this.zone, this.getters.getActiveSnappedViewport());
   }
 
+  setup() {
+    onMounted(() => {
+      const el = this.el!;
+
+      const maxHeight = el.parentElement!.clientHeight - this.rect[1] - SCROLLBAR_HIGHT;
+      el.style.maxHeight = (maxHeight + "px") as string;
+
+      const maxWidth = el.parentElement!.clientWidth - this.rect[0] - SCROLLBAR_WIDTH;
+      el.style.maxWidth = (maxWidth + "px") as string;
+
+      this.composerState.rect = [this.rect[0], this.rect[1], el!.clientWidth, el!.clientHeight];
+      this.composerState.delimitation = {
+        width: el!.parentElement!.clientWidth,
+        height: el!.parentElement!.clientHeight,
+      };
+    });
+  }
+
   get containerStyle(): string {
     const isFormula = this.getters.getCurrentContent().startsWith("=");
     const style = this.getters.getCurrentStyle();
@@ -127,22 +145,6 @@ export class GridComposer extends Component<Props, SpreadsheetEnv> {
       max-height: inherit;
       overflow: hidden;
     `;
-  }
-
-  mounted() {
-    const el = this.el!;
-
-    const maxHeight = el.parentElement!.clientHeight - this.rect[1] - SCROLLBAR_HIGHT;
-    el.style.maxHeight = (maxHeight + "px") as string;
-
-    const maxWidth = el.parentElement!.clientWidth - this.rect[0] - SCROLLBAR_WIDTH;
-    el.style.maxWidth = (maxWidth + "px") as string;
-
-    this.composerState.rect = [this.rect[0], this.rect[1], el!.clientWidth, el!.clientHeight];
-    this.composerState.delimitation = {
-      width: el!.parentElement!.clientWidth,
-      height: el!.parentElement!.clientHeight,
-    };
   }
 
   onKeydown(ev: KeyboardEvent) {

--- a/src/components/figures/container.ts
+++ b/src/components/figures/container.ts
@@ -7,6 +7,7 @@ import { startDnd } from "../helpers/drag_and_drop";
 import { ChartFigure } from "./chart";
 
 const { xml, css } = owl.tags;
+const { onMounted } = owl.hooks;
 const { useState } = owl;
 
 interface FigureInfo {
@@ -186,15 +187,17 @@ export class FiguresContainer extends Component<{ sidePanelIsOpen: Boolean }, Sp
     }px; height:${height - correctionY + offset}px`;
   }
 
-  mounted() {
-    // horrible, but necessary
-    // the following line ensures that we render the figures with the correct
-    // viewport.  The reason is that whenever we initialize the grid
-    // component, we do not know yet the actual size of the viewport, so the
-    // first owl rendering is done with an empty viewport.  Only then we can
-    // compute which figures should be displayed, so we have to force a
-    // new rendering
-    this.render();
+  setup() {
+    onMounted(() => {
+      // horrible, but necessary
+      // the following line ensures that we render the figures with the correct
+      // viewport.  The reason is that whenever we initialize the grid
+      // component, we do not know yet the actual size of the viewport, so the
+      // first owl rendering is done with an empty viewport.  Only then we can
+      // compute which figures should be displayed, so we have to force a
+      // new rendering
+      this.render();
+    });
   }
 
   resize(figure: Figure, dirX: number, dirY: number, ev: MouseEvent) {

--- a/src/components/link/link_editor.ts
+++ b/src/components/link/link_editor.ts
@@ -8,7 +8,7 @@ import { Menu } from "./../menu";
 import { LinkEditorTerms } from "./../side_panel/translations_terms";
 const { Component, tags, hooks, useState } = owl;
 const { xml, css } = tags;
-const { useRef } = hooks;
+const { useRef, onMounted } = hooks;
 
 const MENU_OFFSET_X = 320;
 const MENU_OFFSET_Y = 100;
@@ -141,8 +141,8 @@ export class LinkEditor extends Component<LinkEditorProps, SpreadsheetEnv> {
   private position = useAbsolutePosition();
   urlInput = useRef("urlInput");
 
-  mounted() {
-    this.urlInput.el?.focus();
+  setup() {
+    onMounted(() => this.urlInput.el?.focus());
   }
 
   get defaultState(): State {

--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -136,20 +136,18 @@ export class Menu extends Component<Props, SpreadsheetEnv> {
   static defaultProps = {
     depth: 1,
   };
-  private subMenu: MenuState;
+  private subMenu: MenuState = useState({
+    isOpen: false,
+    position: null,
+    scrollOffset: 0,
+    menuItems: [],
+  });
   private position = useAbsolutePosition(useRef("menu"));
   subMenuRef = useRef("subMenuRef");
 
-  constructor() {
-    super(...arguments);
+  setup() {
     useExternalListener(window, "click", this.onClick);
     useExternalListener(window, "contextmenu", this.onContextMenu);
-    this.subMenu = useState({
-      isOpen: false,
-      position: null,
-      scrollOffset: 0,
-      menuItems: [],
-    });
   }
 
   get subMenuPosition(): DOMCoordinates {

--- a/src/components/selection_input.ts
+++ b/src/components/selection_input.ts
@@ -7,6 +7,7 @@ import { SpreadsheetEnv } from "../types";
 const { Component, useState } = owl;
 
 const { xml, css } = owl.tags;
+const { onMounted, onWillUnmount, onPatched } = owl.hooks;
 
 const uuidGenerator = new UuidGenerator();
 
@@ -153,7 +154,13 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
     return this.props.isInvalid || this.state.isMissing;
   }
 
-  mounted() {
+  setup() {
+    onMounted(() => this.enableNewSelectionInput());
+    onWillUnmount(async () => this.disableNewSelectionInput());
+    onPatched(() => this.checkChange());
+  }
+
+  enableNewSelectionInput() {
     this.dispatch("ENABLE_NEW_SELECTION_INPUT", {
       id: this.id,
       initialRanges: this.props.ranges,
@@ -161,11 +168,11 @@ export class SelectionInput extends Component<Props, SpreadsheetEnv> {
     });
   }
 
-  async willUnmount() {
+  disableNewSelectionInput() {
     this.dispatch("DISABLE_SELECTION_INPUT", { id: this.id });
   }
 
-  async patched() {
+  checkChange() {
     const value = this.getters.getSelectionInputValue(this.id);
     if (this.previousRanges.join() !== value.join()) {
       this.triggerChange();

--- a/src/components/side_panel/chart_panel.ts
+++ b/src/components/side_panel/chart_panel.ts
@@ -15,6 +15,7 @@ import { chartTerms } from "./translations_terms";
 
 const { Component, useState } = owl;
 const { xml, css } = owl.tags;
+const { onWillUpdateProps } = owl.hooks;
 
 const CONFIGURATION_TEMPLATE = xml/* xml */ `
 <div>
@@ -169,21 +170,23 @@ export class ChartPanel extends Component<Props, SpreadsheetEnv> {
 
   private state: ChartPanelState = useState(this.initialState(this.props.figure));
 
-  async willUpdateProps(nextProps: Props) {
-    if (!this.getters.getChartDefinition(nextProps.figure.id)) {
-      this.trigger("close-side-panel");
-      return;
-    }
-    if (nextProps.figure.id !== this.props.figure.id) {
-      this.state.panel = "configuration";
-      this.state.fillColorTool = false;
-      this.state.datasetDispatchResult = undefined;
-      this.state.labelsDispatchResult = undefined;
-      this.state.chart = this.env.getters.getChartDefinitionUI(
-        this.env.getters.getActiveSheetId(),
-        nextProps.figure.id
-      );
-    }
+  setup() {
+    onWillUpdateProps((nextProps: Props) => {
+      if (!this.getters.getChartDefinition(nextProps.figure.id)) {
+        this.trigger("close-side-panel");
+        return;
+      }
+      if (nextProps.figure.id !== this.props.figure.id) {
+        this.state.panel = "configuration";
+        this.state.fillColorTool = false;
+        this.state.datasetDispatchResult = undefined;
+        this.state.labelsDispatchResult = undefined;
+        this.state.chart = this.env.getters.getChartDefinitionUI(
+          this.env.getters.getActiveSheetId(),
+          nextProps.figure.id
+        );
+      }
+    });
   }
 
   get errorMessages(): string[] {

--- a/src/components/side_panel/conditional_formatting/cell_is_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cell_is_rule_editor.ts
@@ -152,8 +152,7 @@ export class CellIsRuleEditor extends Component<Props, SpreadsheetEnv> {
       underline: this.props.rule.style.underline,
     },
   });
-  constructor() {
-    super(...arguments);
+  setup() {
     useExternalListener(window as any, "click", this.closeMenus);
   }
 

--- a/src/components/side_panel/conditional_formatting/color_scale_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/color_scale_rule_editor.ts
@@ -154,8 +154,7 @@ export class ColorScaleRuleEditor extends Component<Props, SpreadsheetEnv> {
     midpointColorTool: false,
   });
 
-  constructor() {
-    super(...arguments);
+  setup() {
     useExternalListener(window as any, "click", this.closeMenus);
   }
 

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -20,7 +20,7 @@ import { IconSetRuleEditor } from "./icon_set_rule_editor";
 
 const { Component, useState } = owl;
 const { xml, css } = owl.tags;
-const { useRef } = owl.hooks;
+const { useRef, onWillUpdateProps } = owl.hooks;
 
 // TODO vsc: add ordering of rules
 const PREVIEW_TEMPLATE = xml/* xml */ `
@@ -370,6 +370,23 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
     }
   }
 
+  setup() {
+    onWillUpdateProps((nextProps: Props) => {
+      if (nextProps.selection !== this.props.selection) {
+        const sheetId = this.getters.getActiveSheetId();
+        const rules = this.getters.getRulesSelection(sheetId, nextProps.selection || []);
+        if (rules.length === 1) {
+          const cf = this.conditionalFormats.find((c) => c.id === rules[0]);
+          if (cf) {
+            this.editConditionalFormat(cf);
+          }
+        } else {
+          this.switchToList();
+        }
+      }
+    });
+  }
+
   get conditionalFormats(): ConditionalFormat[] {
     return this.getters.getConditionalFormats(this.getters.getActiveSheetId());
   }
@@ -382,21 +399,6 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
     return this.env._t(
       conditionalFormattingTerms.Errors[error] || conditionalFormattingTerms.Errors.unexpected
     );
-  }
-
-  async willUpdateProps(nextProps: Props) {
-    if (nextProps.selection !== this.props.selection) {
-      const sheetId = this.getters.getActiveSheetId();
-      const rules = this.getters.getRulesSelection(sheetId, nextProps.selection || []);
-      if (rules.length === 1) {
-        const cf = this.conditionalFormats.find((c) => c.id === rules[0]);
-        if (cf) {
-          this.editConditionalFormat(cf);
-        }
-      } else {
-        this.switchToList();
-      }
-    }
   }
 
   /**

--- a/src/components/side_panel/conditional_formatting/icon_set_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/icon_set_rule_editor.ts
@@ -256,8 +256,7 @@ export class IconSetRuleEditor extends Component<Props, SpreadsheetEnv> {
     lowerIconTool: false,
   });
 
-  constructor() {
-    super(...arguments);
+  setup() {
     useExternalListener(window as any, "click", this.closeMenus);
   }
 

--- a/src/components/side_panel/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace.ts
@@ -4,6 +4,7 @@ import { FindAndReplaceTerms } from "./translations_terms";
 
 const { Component, useState } = owl;
 const { xml, css } = owl.tags;
+const { onMounted, onWillUnmount } = owl.hooks;
 
 const TEMPLATE = xml/* xml */ `
 <div class="o-find-and-replace" tabindex="0" t-on-focusin="onFocusSidePanel">
@@ -134,12 +135,10 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetEnv> {
     return this.env.getters.getCurrentSelectedMatchIndex() !== null;
   }
 
-  mounted() {
-    this.focusInput();
-  }
+  setup() {
+    onMounted(() => this.focusInput());
 
-  async willUnmount() {
-    this.env.dispatch("CLEAR_SEARCH");
+    onWillUnmount(() => this.env.dispatch("CLEAR_SEARCH"));
   }
 
   onInput(ev) {

--- a/src/components/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel.ts
@@ -5,7 +5,7 @@ import { SpreadsheetEnv } from "../../types";
 
 const { Component } = owl;
 const { xml, css } = owl.tags;
-const { useState } = owl.hooks;
+const { useState, onWillUpdateProps } = owl.hooks;
 
 const TEMPLATE = xml/* xml */ `
   <div class="o-sidePanel" >
@@ -135,8 +135,10 @@ export class SidePanel extends Component<Props, SpreadsheetEnv> {
     panel: sidePanelRegistry.get(this.props.component),
   });
 
-  async willUpdateProps(nextProps: Props) {
-    this.state.panel = sidePanelRegistry.get(nextProps.component);
+  setup() {
+    onWillUpdateProps(
+      (nextProps: Props) => (this.state.panel = sidePanelRegistry.get(nextProps.component))
+    );
   }
 
   getTitle() {

--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -14,7 +14,7 @@ import { Menu, MenuState } from "./menu";
 
 const { Component, useState, hooks } = owl;
 const { xml, css } = owl.tags;
-const { useExternalListener, useRef } = hooks;
+const { useExternalListener, useRef, onWillUpdateProps, onWillStart } = hooks;
 
 type Tool =
   | ""
@@ -375,22 +375,16 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
     background-color: white;
   `;
 
-  constructor() {
-    super(...arguments);
+  setup() {
     useExternalListener(window as any, "click", this.onClick);
+    onWillStart(() => this.updateCellState());
+    onWillUpdateProps(() => this.updateCellState());
   }
 
   get topbarComponents() {
     return topbarComponentRegistry
       .getAll()
       .filter((item) => !item.isVisible || item.isVisible(this.env));
-  }
-
-  async willStart() {
-    this.updateCellState();
-  }
-  async willUpdateProps() {
-    this.updateCellState();
   }
 
   onClick(ev: MouseEvent) {

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -8,7 +8,7 @@ import { makeTestFixture, mockUuidV4To, nextTick } from "../test_helpers/helpers
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
 const { xml } = tags;
-const { useSubEnv } = hooks;
+const { useSubEnv, onMounted, onWillUnmount } = hooks;
 
 let fixture: HTMLElement;
 
@@ -32,12 +32,9 @@ class Parent extends Component<any, any> {
     });
     this.model = model;
   }
-  mounted() {
-    this.model.on("update", this, this.render);
-  }
-
-  willUnmount() {
-    this.model.off("update", this);
+  setup() {
+    onMounted(() => this.model.on("update", this, this.render));
+    onWillUnmount(() => this.model.off("update", this));
   }
 }
 

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -6,7 +6,7 @@ import { simulateClick } from "../test_helpers/dom_helper";
 import { makeTestFixture, nextTick } from "../test_helpers/helpers";
 
 const { xml } = tags;
-const { useSubEnv, useRef } = hooks;
+const { useSubEnv, useRef, onMounted, onWillUnmount } = hooks;
 
 let model: Model;
 let fixture: HTMLElement;
@@ -63,13 +63,12 @@ class Parent extends Component<any> {
     return (this.ref.comp as any).id;
   }
 
-  mounted() {
-    this.model.on("update", this, this.render);
-    this.render();
-  }
-
-  willUnmount() {
-    this.model.off("update", this);
+  setup() {
+    onMounted(() => {
+      this.model.on("update", this, this.render);
+      this.render();
+    });
+    onWillUnmount(() => this.model.off("update", this));
   }
 }
 
@@ -97,13 +96,12 @@ class MultiParent extends Component<any> {
     this.model = model;
   }
 
-  mounted() {
-    this.model.on("update", this, this.render);
-    this.render();
-  }
-
-  willUnmount() {
-    this.model.off("update", this);
+  setup() {
+    onMounted(() => {
+      this.model.on("update", this, this.render);
+      this.render();
+    });
+    onWillUnmount(() => this.model.off("update", this));
   }
 }
 

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -21,7 +21,7 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 );
 
 const { xml } = tags;
-const { useSubEnv } = hooks;
+const { useSubEnv, onMounted, onWillUnmount } = hooks;
 
 let fixture: HTMLElement;
 let parent: Parent;
@@ -50,16 +50,13 @@ class Parent extends Component<any, SpreadsheetEnv> {
     this.state.focusComposer = focusComposer;
   }
 
+  setup() {
+    onMounted(() => this.model.on("update", this, this.render));
+    onWillUnmount(() => this.model.off("update", this));
+  }
+
   setFocusComposer(isFocused: boolean) {
     this.state.focusComposer = isFocused;
-  }
-
-  mounted() {
-    this.model.on("update", this, this.render);
-  }
-
-  willUnmount() {
-    this.model.off("update", this);
   }
 }
 


### PR DESCRIPTION
This task is a part of the upgrade to owl 2 (#2693778)
The goal is to remove all the lifecycle methods of components (mounted,
willUpdateProps, ...) and replace them by their hook (onMounted,
onWillUpdateProps), as the lifecycle methods will be removed in owl 2.

Task-id 2695055

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
