### PR TITLE
[IMP] bottom-bar: add statistic information list

### DIFF
--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -1,5 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BottomBar component Can open the list of statistics 1`] = `
+<div
+  class="o-menu"
+>
+  <div
+    class="o-menu-item"
+    data-name="Sum"
+    title="Sum: 24"
+  >
+    Sum: 24
+    <span
+      class="o-menu-item-shortcut"
+    >
+      
+    </span>
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="Avg"
+    title="Avg: 24"
+  >
+    Avg: 24
+    <span
+      class="o-menu-item-shortcut"
+    >
+      
+    </span>
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="Min"
+    title="Min: 24"
+  >
+    Min: 24
+    <span
+      class="o-menu-item-shortcut"
+    >
+      
+    </span>
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="Max"
+    title="Max: 24"
+  >
+    Max: 24
+    <span
+      class="o-menu-item-shortcut"
+    >
+      
+    </span>
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="Count"
+    title="Count: 1"
+  >
+    Count: 1
+    <span
+      class="o-menu-item-shortcut"
+    >
+      
+    </span>
+  </div>
+  <div
+    class="o-menu-item"
+    data-name="Count Numbers"
+    title="Count Numbers: 1"
+  >
+    Count Numbers: 1
+    <span
+      class="o-menu-item-shortcut"
+    >
+      
+    </span>
+  </div>
+</div>
+`;
+
 exports[`BottomBar component simple rendering 1`] = `
 <div
   class="o-spreadsheet-bottom-bar"


### PR DESCRIPTION
## Description:

This commit replaces the displayed information "Sum ..." located
in the bottom-bar to a button list offering other statistics.

The functionality has been developed to be able to easily add other statistic functions thanks to a registry.

Odoo task ID : [2575296](https://www.odoo.com/web#id=2575296&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
