### PR TITLE
[IMP] clipboard: copy several selection on the same column

### DIFF
--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -445,6 +445,24 @@ export function uniqueZones(zones: Zone[]): Zone[] {
 }
 
 /**
+ * This function will find all overlapping zones in an array and transform them
+ * into an union of each one.
+ * */
+export function mergeOverlappingZones(zones: Zone[]) {
+  return zones.reduce((dissociatedZones: Zone[], zone) => {
+    const nextIndex = dissociatedZones.length;
+    for (let i = 0; i < nextIndex; i++) {
+      if (overlap(dissociatedZones[i], zone)) {
+        dissociatedZones[i] = union(dissociatedZones[i], zone);
+        return dissociatedZones;
+      }
+    }
+    dissociatedZones[nextIndex] = zone;
+    return dissociatedZones;
+  }, []);
+}
+
+/**
  * This function will compare the modifications of selection to determine
  * a cell that is part of the new zone and not the previous one.
  */


### PR DESCRIPTION
## Description:

This commit add the possibility to copy several selections
when they are on the same columns.

This behavior already existed for the rows.

In addition, this commit changes the copy/paste behavior when we
copy overlapping selections: 
- cells common to multiple selections are copied only once
- paste zones selected from different orders does not influence
the final result


Odoo task ID : [2645373](https://www.odoo.com/web#id=2645373&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [x] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
