### PR TITLE
[FIX] cfEditor: avoid pulling html viewport down

### DIFF
--- a/src/components/color_picker.ts
+++ b/src/components/color_picker.ts
@@ -102,16 +102,29 @@ const COLORS = [
   ],
 ];
 
+const PICKER_VERTICAL_PADDING = 6;
+
+const LINE_VERTICAL_PADDING = 3;
+const LINE_HORIZONTAL_PADDING = 6;
+
+const ITEM_HORIZONTAL_MARGIN = 2;
+const ITEM_EDGE_LENGTH = 18;
+const ITEM_BORDER_WIDTH = 1;
+
+const ITEMS_PER_LINE = Math.max(...COLORS.map((line) => line.length));
+const PICKER_WIDTH =
+  ITEMS_PER_LINE * (ITEM_EDGE_LENGTH + ITEM_HORIZONTAL_MARGIN * 2 + 2 * ITEM_BORDER_WIDTH) +
+  2 * LINE_HORIZONTAL_PADDING;
+
 interface Props {
-  dropdownDirection?: "left" | "right";
+  dropdownDirection?: "left" | "right" | "center";
 }
 
 export class ColorPicker extends Component<Props, SpreadsheetEnv> {
   static template = xml/* xml */ `
-  <div class="o-color-picker" t-att-class="{
-    'right': isDropdownRight(),
-    'left': !isDropdownRight()
-    }" t-on-click="onColorClick">
+  <div class="o-color-picker"
+    t-att-class="props.dropdownDirection || 'right'"
+    t-on-click="onColorClick">
     <div class="o-color-picker-line" t-foreach="COLORS" t-as="colors" t-key="colors">
       <t t-foreach="colors" t-as="color" t-key="color">
         <div class="o-color-picker-line-item" t-att-data-color="color" t-attf-style="background-color:{{color}};"></div>
@@ -126,17 +139,17 @@ export class ColorPicker extends Component<Props, SpreadsheetEnv> {
       z-index: 10;
       box-shadow: 1px 2px 5px 2px rgba(51, 51, 51, 0.15);
       background-color: white;
-      padding: 6px 0px;
+      padding: ${PICKER_VERTICAL_PADDING}px 0px;
 
       .o-color-picker-line {
         display: flex;
-        padding: 3px 6px;
+        padding: ${LINE_VERTICAL_PADDING}px ${LINE_HORIZONTAL_PADDING}px;
         .o-color-picker-line-item {
-          width: 18px;
-          height: 18px;
-          margin: 0px 2px;
+          width: ${ITEM_EDGE_LENGTH}px;
+          height: ${ITEM_EDGE_LENGTH}px;
+          margin: 0px ${ITEM_HORIZONTAL_MARGIN}px;
           border-radius: 50px;
-          border: 1px solid #c0c0c0;
+          border: ${ITEM_BORDER_WIDTH}px solid #c0c0c0;
           &:hover {
             cursor: pointer;
             background-color: rgba(0, 0, 0, 0.08);
@@ -152,13 +165,12 @@ export class ColorPicker extends Component<Props, SpreadsheetEnv> {
       &.left {
         right: 0;
       }
+      &.center {
+        left: calc(50% - ${PICKER_WIDTH / 2}px);
+      }
     }
   `;
   COLORS = COLORS;
-
-  isDropdownRight() {
-    return this.props.dropdownDirection !== "left";
-  }
 
   onColorClick(ev: MouseEvent) {
     const color = (ev.target as HTMLElement).dataset.color;

--- a/src/components/side_panel/conditional_formatting/cell_is_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cell_is_rule_editor.ts
@@ -67,24 +67,20 @@ const TEMPLATE = xml/* xml */ `
         <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.STRIKE_THROUGH}')" t-att-class="{active:state.style.strikethrough}"
              t-on-click="toggleTool('strikethrough')">${icons.STRIKE_ICON}
         </div>
-        <div class="o-tool o-with-color">
+        <div class="o-tool o-dropdown o-with-color">
               <span t-att-title="env._t('${conditionalFormattingTerms.TEXT_COLOR}')" t-attf-style="border-color:{{state.style.textColor}}"
                     t-on-click.stop="toggleMenu('textColorTool')">
                     ${icons.TEXT_COLOR_ICON}
               </span>
-              <div class="o-colorpicker-container" >
-                <ColorPicker t-if="state.textColorTool" dropdownDirection="'left'" t-on-color-picked="setColor('textColor')" t-key="textColor"/>
-              </div>
+              <ColorPicker t-if="state.textColorTool" dropdownDirection="'center'" t-on-color-picked="setColor('textColor')" t-key="textColor"/>
         </div>
         <div class="o-divider"/>
-        <div class="o-tool o-with-color">
+        <div class="o-tool o-dropdown o-with-color">
           <span t-att-title="env._t('${conditionalFormattingTerms.FILL_COLOR}')" t-attf-style="border-color:{{state.style.fillColor}}"
                 t-on-click.stop="toggleMenu('fillColorTool')">
                 ${icons.FILL_COLOR_ICON}
           </span>
-          <div class="o-colorpicker-container" >
-            <ColorPicker t-if="state.fillColorTool" dropdownDirection="'left'" t-on-color-picked="setColor('fillColor')" t-key="fillColor"/>
-          </div>
+          <ColorPicker t-if="state.fillColorTool" dropdownDirection="'center'" t-on-color-picked="setColor('fillColor')" t-key="fillColor"/>
         </div>
     </div>
 </div>
@@ -103,15 +99,8 @@ const CSS = css/* scss */ `
     margin-bottom: 5px;
     width: 96%;
   }
-  .o-colorpicker-container {
-    position: absolute;
-    padding-left: 20px;
-    padding-bottom: 18px;
-    pointer-events: none;
-
-    .o-color-picker {
-      pointer-events: all;
-    }
+  .o-color-picker {
+    pointer-events: all;
   }
 `;
 
@@ -152,6 +141,7 @@ export class CellIsRuleEditor extends Component<Props, SpreadsheetEnv> {
       underline: this.props.rule.style.underline,
     },
   });
+
   constructor() {
     super(...arguments);
     useExternalListener(window as any, "click", this.closeMenus);
@@ -194,7 +184,7 @@ export class CellIsRuleEditor extends Component<Props, SpreadsheetEnv> {
     };
   }
 
-  toggleMenu(tool: string) {
+  toggleMenu(tool: "textColorTool" | "fillColorTool") {
     const current = this.state[tool];
     this.closeMenus();
     this.state[tool] = !current;

--- a/src/components/side_panel/conditional_formatting/icon_set_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/icon_set_rule_editor.ts
@@ -282,7 +282,7 @@ export class IconSetRuleEditor extends Component<Props, SpreadsheetEnv> {
     }
   }
 
-  toggleMenu(tool) {
+  toggleMenu(tool: "upperIconTool" | "middleIconTool" | "lowerIconTool") {
     const current = this.stateIconSetCF[tool];
     this.closeMenus();
     this.stateIconSetCF[tool] = !current;

--- a/tests/components/color_picker.test.ts
+++ b/tests/components/color_picker.test.ts
@@ -18,6 +18,7 @@ describe("Color Picker tests", () => {
     await colorPicker.mount(fixture);
     expect(document.querySelector(".o-color-picker")?.classList).toContain("right");
     expect(document.querySelector(".o-color-picker")?.classList).not.toContain("left");
+    expect(document.querySelector(".o-color-picker")?.classList).not.toContain("center");
   });
 
   test("Color picker is correctly positioned right", async () => {
@@ -25,6 +26,7 @@ describe("Color Picker tests", () => {
     await colorPicker.mount(fixture);
     expect(document.querySelector(".o-color-picker")?.classList).toContain("right");
     expect(document.querySelector(".o-color-picker")?.classList).not.toContain("left");
+    expect(document.querySelector(".o-color-picker")?.classList).not.toContain("center");
   });
 
   test("Color picker is correctly positioned left", async () => {
@@ -32,5 +34,14 @@ describe("Color Picker tests", () => {
     await colorPicker.mount(fixture);
     expect(document.querySelector(".o-color-picker")?.classList).toContain("left");
     expect(document.querySelector(".o-color-picker")?.classList).not.toContain("right");
+    expect(document.querySelector(".o-color-picker")?.classList).not.toContain("center");
+  });
+
+  test("Color picker is correctly centered", async () => {
+    colorPicker = new ColorPicker(null, { dropdownDirection: "center" });
+    await colorPicker.mount(fixture);
+    expect(document.querySelector(".o-color-picker")?.classList).toContain("center");
+    expect(document.querySelector(".o-color-picker")?.classList).not.toContain("right");
+    expect(document.querySelector(".o-color-picker")?.classList).not.toContain("left");
   });
 });


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2700100](https://www.odoo.com/web#id=2700100&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
