### PR TITLE
[IMP] add conditional formatting rules priority

### DIFF
--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -46,6 +46,10 @@ export const UNLINK = `<svg class="o-icon" viewBox="0 0 512 512"><path fill="cur
  *  http://fontawesome.io/
  *  https://fontawesome.com/license
  */
+export const CARET_UP =
+  '<svg xmlns="http://www.w3.org/2000/svg" class="caret-up" viewBox="0 0 320 512"><path fill="currentColor" d="M288.662 352H31.338c-17.818 0-26.741-21.543-14.142-34.142l128.662-128.662c7.81-7.81 20.474-7.81 28.284 0l128.662 128.662c12.6 12.599 3.676 34.142-14.142 34.142z"></path></svg>';
+export const CARET_DOWN =
+  '<svg xmlns="http://www.w3.org/2000/svg" class="caret-down"  viewBox="0 0 320 512"><path fill="currentColor" d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"></path></svg>';
 
 export const TRASH =
   '<svg xmlns ="http://www.w3.org/2000/svg" class="o-cf-icon trash" viewBox = "0 0 448 512" > <path fill="currentColor" d = "M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z" > </path></svg >';

--- a/src/components/side_panel/translations_terms.ts
+++ b/src/components/side_panel/translations_terms.ts
@@ -41,6 +41,8 @@ export const conditionalFormattingTerms = {
   ColorScale: _lt("Color scale"),
   IconSet: _lt("Icon set"),
   newRule: _lt("Add another rule"),
+  reorderRules: _lt("Reorder rules"),
+  exitReorderMode: _lt("Stop reordering rules"),
   FixedNumber: _lt("Number"),
   Percentage: _lt("Percentage"),
   Percentile: _lt("Percentile"),

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -69,6 +69,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       case "REDO":
       case "DELETE_CELL":
       case "INSERT_CELL":
+      case "MOVE_CONDITIONAL_FORMAT":
         this.isStale = true;
         break;
     }
@@ -119,7 +120,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
     this.computedStyles[activeSheetId] = {};
     this.computedIcons[activeSheetId] = {};
     const computedStyle = this.computedStyles[activeSheetId];
-    for (let cf of this.getters.getConditionalFormats(activeSheetId)) {
+    for (let cf of this.getters.getConditionalFormats(activeSheetId).reverse()) {
       try {
         switch (cf.rule.type) {
           case "ColorScaleRule":

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,5 +1,6 @@
 import { ComposerSelection } from "../plugins/ui/edition";
 import { ReplaceOptions, SearchOptions } from "../plugins/ui/find_and_replace";
+import { UpDown } from "./conditional_formatting";
 import {
   BorderCommand,
   ChartUIDefinition,
@@ -146,6 +147,7 @@ export const coreTypes = new Set<CoreCommandTypes>([
   /** CONDITIONAL FORMAT */
   "ADD_CONDITIONAL_FORMAT",
   "REMOVE_CONDITIONAL_FORMAT",
+  "MOVE_CONDITIONAL_FORMAT",
 
   /** FIGURES */
   "CREATE_FIGURE",
@@ -295,6 +297,12 @@ export interface AddConditionalFormatCommand extends SheetDependentCommand, Targ
 export interface RemoveConditionalFormatCommand extends SheetDependentCommand {
   type: "REMOVE_CONDITIONAL_FORMAT";
   id: string;
+}
+
+export interface MoveConditionalFormatCommand extends SheetDependentCommand {
+  type: "MOVE_CONDITIONAL_FORMAT";
+  cfId: UID;
+  direction: UpDown;
 }
 
 //------------------------------------------------------------------------------
@@ -820,6 +828,7 @@ export type CoreCommand =
   /** CONDITIONAL FORMAT */
   | AddConditionalFormatCommand
   | RemoveConditionalFormatCommand
+  | MoveConditionalFormatCommand
 
   /** FIGURES */
   | CreateFigureCommand
@@ -998,6 +1007,7 @@ export const enum CommandResult {
   InvalidOffset,
   InvalidViewportSize,
   FigureDoesNotExist,
+  InvalidConditionalFormatId,
 }
 
 export interface CommandHandler<T> {

--- a/src/types/conditional_formatting.ts
+++ b/src/types/conditional_formatting.ts
@@ -156,3 +156,5 @@ export type ConditionalFormattingOperatorValues =
   | "NotBetween"
   | "NotContains"
   | "NotEqual";
+
+export type UpDown = "up" | "down";

--- a/tests/components/__snapshots__/conditional_formatting.test.ts.snap
+++ b/tests/components/__snapshots__/conditional_formatting.test.ts.snap
@@ -29,7 +29,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
       >
         <div>
           <div
-            class="o-cf-preview"
+            class="o-cf-preview o-cf-cursor-ptr"
           >
             
             <div
@@ -53,11 +53,8 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
                   class="o-cf-preview-description-rule"
                 >
                   Is equal to
-                </div>
-                <div
-                  class="o-cf-preview-description-values"
-                >
-                  2
+                   2
+                  
                   
                 </div>
               </div>
@@ -67,6 +64,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
                 A1:A2
               </div>
             </div>
+            
             <div
               class="o-cf-delete"
             >
@@ -89,11 +87,12 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
                 </svg>
               </div>
             </div>
+            
           </div>
         </div>
         <div>
           <div
-            class="o-cf-preview"
+            class="o-cf-preview o-cf-cursor-ptr"
           >
             
             <div
@@ -113,10 +112,8 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
                   class="o-cf-preview-description-rule"
                 >
                   Color scale
+                  
                 </div>
-                <div
-                  class="o-cf-preview-description-values"
-                />
               </div>
               <div
                 class="o-cf-preview-range"
@@ -124,6 +121,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
                 B1:B5
               </div>
             </div>
+            
             <div
               class="o-cf-delete"
             >
@@ -146,15 +144,22 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
                 </svg>
               </div>
             </div>
+            
           </div>
         </div>
         
       </div>
       <div
-        class="btn btn-link o-cf-add"
+        class="btn btn-link o-cf-btn-link o-cf-add"
       >
         + Add another rule
       </div>
+      <div
+        class="btn btn-link o-cf-btn-link o-cf-reorder"
+      >
+        Reorder rules
+      </div>
+      
       
       
       

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -90,10 +90,16 @@ describe("UI of conditional formats", () => {
       colorPickerOrange: ".o-color-picker div[data-color='#ff9900']",
       colorPickerYellow: ".o-color-picker div[data-color='#ffff00']",
     },
+    cfReorder: {
+      buttonUp: ".o-cf-reorder-button-up",
+      buttonDown: ".o-cf-reorder-button-down",
+    },
     cfTabSelector: ".o-cf-type-selector .o_form_label",
     buttonSave: ".o-sidePanelButtons .o-cf-save",
     buttonDelete: ".o-cf-delete-button",
     buttonAdd: ".o-cf-add",
+    buttonReoder: ".o-cf-reorder",
+    buttonExitReorder: ".o-cf-exit-reorder",
     error: ".o-cf-error",
     closePanel: ".o-sidePanelClose",
   };
@@ -126,10 +132,7 @@ describe("UI of conditional formats", () => {
 
       // --> should be the style for CellIsRule
       expect(previews[0].querySelector(selectors.description.ruletype.rule)!.textContent).toBe(
-        "Is equal to"
-      );
-      expect(previews[0].querySelector(selectors.description.ruletype.values)!.textContent).toBe(
-        "2"
+        "Is equal to 2"
       );
       expect(previews[0].querySelector(selectors.description.range)!.textContent).toBe("A1:A2");
       expect(
@@ -346,7 +349,52 @@ describe("UI of conditional formats", () => {
         sheetId: model.getters.getActiveSheetId(),
       });
     });
+
+    test("can the reordering CF Rules menu be opened/closed", async () => {
+      const previews = document.querySelectorAll(selectors.listPreview);
+
+      expect(document.querySelector(selectors.buttonExitReorder)).toBeFalsy();
+      expect(document.querySelector(selectors.cfReorder.buttonUp)).toBeFalsy();
+      expect(document.querySelector(selectors.cfReorder.buttonDown)).toBeFalsy();
+
+      triggerMouseEvent(selectors.buttonReoder, "click");
+      await nextTick();
+
+      expect(document.querySelector(selectors.buttonExitReorder)).toBeTruthy();
+      // Minus one because top rule has no up button, bottom rule no down button
+      expect(document.querySelectorAll(selectors.cfReorder.buttonUp).length).toEqual(
+        previews.length - 1
+      );
+      expect(document.querySelectorAll(selectors.cfReorder.buttonDown).length).toEqual(
+        previews.length - 1
+      );
+
+      triggerMouseEvent(selectors.buttonExitReorder, "click");
+      await nextTick();
+
+      expect(document.querySelector(selectors.buttonExitReorder)).toBeFalsy();
+      expect(document.querySelector(selectors.cfReorder.buttonUp)).toBeFalsy();
+      expect(document.querySelector(selectors.cfReorder.buttonDown)).toBeFalsy();
+    });
+
+    test("can reorder CF rules with up/down buttons", async () => {
+      const sheetId = model.getters.getActiveSheetId();
+
+      triggerMouseEvent(selectors.buttonReoder, "click");
+      await nextTick();
+
+      let previews = document.querySelectorAll(selectors.listPreview);
+      triggerMouseEvent(previews[0].querySelector(selectors.cfReorder.buttonDown), "click");
+      await nextTick();
+      expect(model.getters.getConditionalFormats(sheetId)[0].id).toEqual("2");
+
+      previews = document.querySelectorAll(selectors.listPreview);
+      triggerMouseEvent(previews[1].querySelector(selectors.cfReorder.buttonUp), "click");
+      await nextTick();
+      expect(model.getters.getConditionalFormats(sheetId)[0].id).toEqual("1");
+    });
   });
+
   test("can create a new ColorScaleRule with cell values", async () => {
     mockUuidV4To(model, "43");
     triggerMouseEvent(selectors.buttonAdd, "click");

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -11,6 +11,7 @@ import {
   Increment,
   SortDirection,
   UID,
+  UpDown,
 } from "../../src/types";
 import { target } from "./helpers";
 
@@ -367,6 +368,22 @@ export function setAnchorCorner(model: Model, xc: string): DispatchResult {
 export function addCellToSelection(model: Model, xc: string): DispatchResult {
   const [col, row] = toCartesian(xc);
   return model.selection.addCellToSelection(col, row);
+}
+
+/**
+ * Move a conditianal formatting rule
+ */
+export function moveConditionalFormat(
+  model: Model,
+  cfId: UID,
+  direction: UpDown,
+  sheetId: UID
+): DispatchResult {
+  return model.dispatch("MOVE_CONDITIONAL_FORMAT", {
+    cfId: cfId,
+    direction: direction,
+    sheetId,
+  });
 }
 
 export function setSelection(


### PR DESCRIPTION
## Description:

Currently conditional formatting rules are sorted and applied by creation date. We wanted to add the possibility to reorder the rules, ie. to decide which rule should apply in priority.

It was done by adding a button to the conditionnal formatting side pannel that displays up/down arrows to reorder the rules.

Odoo task ID : [2525705](https://www.odoo.com/web#id=2525705&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
