### PR TITLE
[FIX] conditional_formatting: remove bracket of scss string

### DIFF
--- a/src/components/side_panel/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting.ts
@@ -80,15 +80,15 @@ const TEMPLATE = xml/* xml */ `
 const CSS = css/* scss */ `
   .o-cf {
     min-width: 350px;
-    .o-cf-type-selector{
+    .o-cf-type-selector {
       margin-top: 20px;
       display: flex;
-      .o-cf-type-tab{
-        cursor:pointer;
+      .o-cf-type-tab {
+        cursor: pointer;
         flex-grow: 1;
         text-align: center;
       }
-      .o-cf-tab-selected{
+      .o-cf-tab-selected {
         text-decoration: underline;
       }
     }
@@ -126,16 +126,16 @@ const CSS = css/* scss */ `
           margin-bottom: 4px;
           overflow: hidden;
         }
-        .o-cf-preview-description-values{
+        .o-cf-preview-description-values {
           overflow: hidden;
         }
-        .o-cf-preview-range{
+        .o-cf-preview-range {
           text-overflow: ellipsis;
           font-size: 12px;
           overflow: hidden;
         }
       }
-      .o-cf-delete{
+      .o-cf-delete {
         height: 56px;
         left: 90%;
         line-height: 56px;
@@ -226,7 +226,7 @@ const CSS = css/* scss */ `
       cursor: pointer;
     }
   }
-  }`;
+`;
 interface Props {
   selection: Zone | undefined;
 }


### PR DESCRIPTION
An unnecessary trailing bracket as present in the css string which
prevented it from being properly formatted. We'd expect an error to be
raised by the css compiler but apparently, it's not the case.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
