### PR TITLE
[FIX] Add a row inside cut area clears clipboard

### DIFF
--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -6,6 +6,8 @@ import { CellValueType, CommandResult, Zone } from "../../src/types/index";
 import {
   activateSheet,
   addCellToSelection,
+  addColumns,
+  addRows,
   createSheet,
   createSheetWithName,
   deleteColumns,
@@ -1621,5 +1623,97 @@ describe("clipboard: pasting outside of sheet", () => {
     expect(getCellContent(model, "B3")).toBe("que");
     expect(getCellContent(model, "C3")).toBe("coucou");
     expect(getCellContent(model, "D3")).toBe("Patrick");
+  });
+
+  test("adding a column inside a cut zone is invalidating the clipboard", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "B1", "2");
+
+    model.dispatch("CUT", { target: target("A1:B1") });
+    addColumns(model, "after", "A", 1);
+
+    model.dispatch("PASTE", { target: [toZone("A2")] });
+
+    expect(getCellContent(model, "A1")).toBe("1");
+    expect(getCellContent(model, "C1")).toBe("2");
+    expect(getCellContent(model, "A2")).toBe("");
+    expect(getCellContent(model, "C2")).toBe("");
+  });
+
+  test("adding multiple columns inside a cut zone is invalidating the clipboard", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "B1", "2");
+
+    model.dispatch("CUT", { target: target("A1:B1") });
+    addColumns(model, "after", "A", 3);
+
+    model.dispatch("PASTE", { target: [toZone("A2")] });
+
+    expect(getCellContent(model, "A1")).toBe("1");
+    expect(getCellContent(model, "E1")).toBe("2");
+    expect(getCellContent(model, "A2")).toBe("");
+    expect(getCellContent(model, "E2")).toBe("");
+  });
+
+  test("adding a column at the right of zone don't invalidate clipboard", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "B1", "2");
+
+    model.dispatch("CUT", { target: target("A1:B1") });
+    addColumns(model, "after", "B", 1);
+    model.dispatch("PASTE", { target: [toZone("A2")] });
+    expect(getCellContent(model, "A1")).toBe("");
+    expect(getCellContent(model, "B1")).toBe("");
+    expect(getCellContent(model, "A2")).toBe("1");
+    expect(getCellContent(model, "B2")).toBe("2");
+  });
+
+  test("adding a row inside a cut zone is invalidating the clipboard", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+
+    model.dispatch("CUT", { target: target("A1:A2") });
+    addRows(model, "after", 0, 1);
+
+    model.dispatch("PASTE", { target: [toZone("C1")] });
+
+    expect(getCellContent(model, "A1")).toBe("1");
+    expect(getCellContent(model, "A3")).toBe("2");
+    expect(getCellContent(model, "C1")).toBe("");
+    expect(getCellContent(model, "C3")).toBe("");
+  });
+
+  test("adding multiple rows inside a cut zone is invalidating the clipboard", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+
+    model.dispatch("CUT", { target: target("A1:A2") });
+    addRows(model, "after", 0, 5);
+
+    model.dispatch("PASTE", { target: [toZone("C1")] });
+
+    expect(getCellContent(model, "A1")).toBe("1");
+    expect(getCellContent(model, "A7")).toBe("2");
+    expect(getCellContent(model, "C1")).toBe("");
+    expect(getCellContent(model, "C7")).toBe("");
+  });
+
+  test("adding a row below a zone don't invalidate clipboard", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "B1", "2");
+
+    model.dispatch("CUT", { target: target("A1:B1") });
+    addRows(model, "after", 1, 1);
+    model.dispatch("PASTE", { target: [toZone("A2")] });
+    expect(getCellContent(model, "A1")).toBe("");
+    expect(getCellContent(model, "B1")).toBe("");
+    expect(getCellContent(model, "A2")).toBe("1");
+    expect(getCellContent(model, "B2")).toBe("2");
   });
 });


### PR DESCRIPTION
## Description:

Before, if you cut an area to clipboard, then added a row/column inside the are the comportment made no sense. 

Example:
- Set some content in A1 and B1
- cut A1:B1
- insert column between A and B
- paste anywhere
=> the pasted content is ok, but C1 (previously B1) is not cleared. It makes no sense.

Now we clear the clipboard if a row/column is added inside the cut area.

Odoo task ID : [2684607](https://www.odoo.com/web#id=2684607&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
