### PR TITLE
[FIX] borders: copy borders when duplicating sheet

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -44,7 +44,12 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
       case "DUPLICATE_SHEET":
         const borders = this.borders[cmd.sheetId];
         if (borders) {
-          this.history.update("borders", cmd.sheetIdTo, JSON.parse(JSON.stringify(borders)));
+          // borders is a sparse 2D array.
+          // map and slice preserve empty values and do not set `undefined` instead
+          const bordersCopy = borders
+            .slice()
+            .map((col) => col?.slice().map((border) => ({ ...border })));
+          this.history.update("borders", cmd.sheetIdTo, bordersCopy);
         }
         break;
       case "DELETE_SHEET":

--- a/tests/plugins/borders.test.ts
+++ b/tests/plugins/borders.test.ts
@@ -326,6 +326,37 @@ describe("Grid manipulation", () => {
     expect(getBorder(model, "D2")).toEqual({ left: b });
   });
 
+  test("move duplicated border when col is inserted before", () => {
+    const model = new Model();
+    const firstSheetId = model.getters.getActiveSheetId();
+    const secondSheetId = "42";
+    setBorder(model, "external", "B2");
+    expect(getBorder(model, "B2", firstSheetId)).toEqual({ top: b, left: b, right: b, bottom: b });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: firstSheetId,
+      sheetIdTo: secondSheetId,
+    });
+    addColumns(model, "before", "A", 1, secondSheetId);
+    expect(getBorder(model, "B2", firstSheetId)).toEqual({ top: b, left: b, right: b, bottom: b });
+    expect(getBorder(model, "B2", secondSheetId)).toEqual({ right: b });
+    expect(getBorder(model, "C2", secondSheetId)).toEqual({ top: b, left: b, right: b, bottom: b });
+  });
+
+  test("move duplicated border when row is inserted before", () => {
+    const model = new Model();
+    const firstSheetId = model.getters.getActiveSheetId();
+    const secondSheetId = "42";
+    setBorder(model, "external", "B2");
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: firstSheetId,
+      sheetIdTo: secondSheetId,
+    });
+    addRows(model, "before", 0, 1, secondSheetId);
+    expect(getBorder(model, "B2", firstSheetId)).toEqual({ top: b, left: b, right: b, bottom: b });
+    expect(getBorder(model, "B2", secondSheetId)).toEqual({ bottom: b });
+    expect(getBorder(model, "B3", secondSheetId)).toEqual({ top: b, left: b, right: b, bottom: b });
+  });
+
   test.skip("[ok] ADD_COLUMNS_ROWS with dimension col before with external borders in the column before", () => {
     setBorder(model, "external", "B2");
     addColumns(model, "before", "C", 1);

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -2,6 +2,7 @@ import { toCartesian, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { CommandResult, Style } from "../../src/types/index";
 import {
+  addColumns,
   deleteRows,
   merge,
   redo,
@@ -66,6 +67,22 @@ describe("merges", () => {
     expect(getCellsXC(model)).toEqual(["B2"]);
     expect(Object.keys(getMergeCellMap(model))).toEqual([]);
     expect(Object.keys(getMerges(model))).toEqual([]);
+  });
+
+  test("add a merge cells in a duplicated sheet", () => {
+    const model = new Model();
+    const firstSheetId = model.getters.getActiveSheetId();
+    const secondSheetId = "42";
+    merge(model, "C2:C3", firstSheetId);
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: firstSheetId,
+      sheetIdTo: secondSheetId,
+    });
+    merge(model, "B2:B3", secondSheetId);
+    expect(model.getters.getMerges(secondSheetId)).toEqual([
+      { ...toZone("C2:C3"), id: 1, topLeft: toPosition("C2") },
+      { ...toZone("B2:B3"), id: 2, topLeft: toPosition("B2") },
+    ]);
   });
 
   test("a single cell is not merged", () => {
@@ -558,6 +575,24 @@ describe("merges", () => {
     merge(model, "A1:A2");
     expect(setCellContent(model, "A2", "hello")).toBeCancelledBecause(CommandResult.CellIsMerged);
     expect(getCell(model, "A2")).toBeUndefined();
+  });
+
+  test("move duplicated merge when col is inserted before", () => {
+    const model = new Model();
+    const firstSheetId = model.getters.getActiveSheetId();
+    const secondSheetId = "42";
+    merge(model, "C1:C2");
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: firstSheetId,
+      sheetIdTo: secondSheetId,
+    });
+    addColumns(model, "before", "A", 1, "42");
+    expect(model.getters.getMerges(firstSheetId)).toEqual([
+      { ...toZone("C1:C2"), id: 1, topLeft: toPosition("C1") },
+    ]);
+    expect(model.getters.getMerges(secondSheetId)).toEqual([
+      { ...toZone("D1:D2"), id: 2, topLeft: toPosition("D1") },
+    ]);
   });
 
   describe("isSingleCellOrMerge getter", () => {


### PR DESCRIPTION

## Description:

On sheet1, add borders on C2
Duplicate sheet1
On sheet2, add a column before "A"

Stringifying and parsing transform `empty` values to
`null` which is a real value. Hence `this.history.update(...)`
sees it as a value and does not create empty datastructures
on the fly (it only sees `undefined` as... value not defined... :upside_down_face: ). It results in errors like
`cannot read property "vertical" of null`

Odoo task ID : [2713259](https://www.odoo.com/web#id=2713259&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [ ] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
