### PR TITLE
[IMP] clipboard: pasting a marge warn user before overwriting values

### DIFF
--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -58,6 +58,7 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     "getMerges",
     "getMerge",
     "isSingleCellOrMerge",
+    "isMergeDestructive",
   ] as const;
 
   private nextId: number = 1;
@@ -286,16 +287,13 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     const { width, height } = zoneToDimension(zone);
     return width === 1 && height === 1;
   }
-  // ---------------------------------------------------------------------------
-  // Merges
-  // ---------------------------------------------------------------------------
 
   /**
-   * Return true if the current selection requires losing state if it is merged.
+   * Return true if the selected zone requires losing state if it is merged.
    * This happens when there is some textual content in other cells than the
    * top left.
    */
-  private isMergeDestructive(sheet: Sheet, zone: Zone): boolean {
+  isMergeDestructive(sheet: Sheet, zone: Zone): boolean {
     let { left, right, top, bottom } = zone;
     right = clip(right, 0, sheet.cols.length - 1);
     bottom = clip(bottom, 0, sheet.rows.length - 1);
@@ -311,6 +309,10 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     }
     return false;
   }
+
+  // ---------------------------------------------------------------------------
+  // Merges
+  // ---------------------------------------------------------------------------
 
   private getMergeById(sheetId: UID, mergeId: number): Merge | undefined {
     const merges = this.merges[sheetId];

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -448,6 +448,30 @@ describe("clipboard", () => {
     expect(notifyUser).toHaveBeenCalled();
   });
 
+  test("Pasting a merge that will destroy content will ask the user if he wants to continue", async () => {
+    const askConfirmation = jest.fn();
+    const model = new Model({
+      sheets: [
+        {
+          colNumber: 5,
+          rowNumber: 5,
+          merges: ["A1:B2"],
+        },
+        {
+          colNumber: 5,
+          rowNumber: 5,
+        },
+      ],
+    });
+
+    model.dispatch("COPY", { target: target("A1") });
+
+    setCellContent(model, "A4", "a4");
+    const env = makeInteractiveTestEnv(model, { askConfirmation });
+    interactivePaste(env, target("A3"));
+    expect(askConfirmation).toHaveBeenCalled();
+  });
+
   test("Dispatch a PASTE command with interactive=true correctly takes pasteOption into account", async () => {
     const model = new Model();
     const style = { fontSize: 42 };


### PR DESCRIPTION
## Description:

Before, when pasting a merge in a zone that contained non-empty cells, the value of the merge was copied but not the merge itself. (edit: was fixed in PR 1092, now the behavior is that the merge is force copied and all values below overriden)

Now if the user paste a merge over existing values, he will get a prompt
that ask him if he wants to continue, then we force the paste of the merge.

Odoo task ID : [2717447](https://www.odoo.com/web#id=2717447&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
