### PR TITLE
[FIX] chart: correctly copy chart when duplicating a sheet

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -11,6 +11,43 @@ export function stringify(obj: any): string {
 }
 
 /**
+ * Deep copy arrays, plain objects and primitive values.
+ * Throws an error for other types such as class instances.
+ * Sparse arrays remain sparse.
+ */
+export function deepCopy<T>(obj: T): T {
+  const result: any = Array.isArray(obj) ? [] : {};
+  switch (typeof obj) {
+    case "object": {
+      if (obj === null) {
+        return obj;
+      } else if (!(isPlainObject(obj) || obj instanceof Array)) {
+        throw new Error("Unsupported type: only objects and arrays are supported");
+      }
+      for (const key in obj) {
+        result[key] = deepCopy(obj[key]);
+      }
+      return result;
+    }
+    case "number":
+    case "string":
+    case "boolean":
+    case "function":
+    case "undefined":
+      return obj;
+    default:
+      throw new Error(`Unsupported type: ${typeof obj}`);
+  }
+}
+
+/**
+ * Check if the object is a plain old javascript object.
+ */
+function isPlainObject(obj: unknown): boolean {
+  return typeof obj === "object" && obj?.constructor === Object;
+}
+
+/**
  * Sanitize the name of a sheet, by eventually removing quotes
  * @param sheetName name of the sheet, potentially quoted with single quotes
  */

--- a/src/plugins/figures.ts
+++ b/src/plugins/figures.ts
@@ -1,5 +1,4 @@
 import { BasePlugin } from "../base_plugin";
-import { uuidv4 } from "../helpers/index";
 import { Command, Figure, Viewport, WorkbookData } from "../types/index";
 
 export class FigurePlugin extends BasePlugin {
@@ -15,15 +14,6 @@ export class FigurePlugin extends BasePlugin {
   // ---------------------------------------------------------------------------
   handle(cmd: Command) {
     switch (cmd.type) {
-      case "DUPLICATE_SHEET":
-        for (let fig of this.sheetFigures[cmd.sheet] || []) {
-          const figure = Object.assign({}, fig, { id: uuidv4() });
-          this.dispatch("CREATE_FIGURE", {
-            sheet: cmd.id,
-            figure,
-          });
-        }
-        break;
       case "DELETE_SHEET":
         this.deleteSheet(cmd.sheet);
         break;

--- a/tests/helpers/misc_test.ts
+++ b/tests/helpers/misc_test.ts
@@ -1,0 +1,95 @@
+import { deepCopy } from "../../src/helpers";
+
+describe("deepCopy", () => {
+  test.each([
+    {},
+    [],
+    [{}],
+    [1, 2],
+    ["1", "2"],
+    [undefined],
+    [null],
+    { a: 1 },
+    { a: undefined },
+    { a: null },
+    { a: {} },
+    { a: [] },
+    { a: { b: {} } },
+    { a: { b: [] } },
+    { a: { b: 1 } },
+    { a: { b: "1" } },
+    [{ a: 1 }],
+    [, , "a"],
+    () => 4,
+    1,
+    "1",
+    true,
+    false,
+    undefined,
+    null,
+  ])("deepCopy %s", (obj) => {
+    expect(deepCopy(obj)).toEqual(obj);
+  });
+
+  test.each([new Set(), new Map(), new Set([1]), new Date()])(
+    "unsupported type %s throws an error",
+    (obj) => {
+      expect(() => deepCopy(obj)).toThrow();
+    }
+  );
+
+  test("object is not mutated", () => {
+    const obj = { a: 1 };
+    const copy = deepCopy(obj);
+    copy["a"] = 2;
+    copy["b"] = 2;
+    expect(obj["a"]).toBe(1);
+    expect("b" in obj).toBe(false);
+  });
+
+  test("nested objects is not mutated", () => {
+    const obj = { z: { a: 1 } };
+    const copy = deepCopy(obj);
+    copy["z"]["a"] = 2;
+    copy["z"]["b"] = 2;
+    expect(obj["z"]["a"]).toBe(1);
+    expect("b" in obj["z"]).toBe(false);
+  });
+
+  test("nested nested objects is not mutated", () => {
+    const obj = { y: { z: { a: 1 } } };
+    const copy = deepCopy(obj);
+    copy["y"]["z"]["a"] = 2;
+    copy["y"]["z"]["b"] = 2;
+    expect(obj["y"]["z"]["a"]).toBe(1);
+    expect("b" in obj["y"]["z"]).toBe(false);
+  });
+
+  test("array is not mutated", () => {
+    const arr = [1];
+    const copy = deepCopy(arr);
+    copy.push(2);
+    expect(arr).toEqual([1]);
+  });
+
+  test("nested array is not mutated", () => {
+    const arr = [[1]];
+    const copy = deepCopy(arr);
+    copy[0].push(2);
+    expect(arr[0]).toEqual([1]);
+  });
+
+  test("nested nested array is not mutated", () => {
+    const arr = [[[1]]];
+    const copy = deepCopy(arr);
+    copy[0][0].push(2);
+    expect(arr[0][0]).toEqual([1]);
+  });
+
+  test("preserves sparse arrays", () => {
+    const copy = deepCopy([, , "a"]);
+    expect("0" in copy).toBe(false);
+    expect("1" in copy).toBe(false);
+    expect("2" in copy).toBe(true);
+  });
+});

--- a/tests/plugins/sheets_test.ts
+++ b/tests/plugins/sheets_test.ts
@@ -525,35 +525,6 @@ describe("sheets", () => {
     expect(getText(model, "A1")).toBe("42");
   });
 
-  test("Figures are correctly duplicated", () => {
-    const model = new Model();
-    const sheet = model.getters.getActiveSheet();
-    model.dispatch("CREATE_FIGURE", {
-      sheet,
-      figure: {
-        id: "someuuid",
-        tag: "hey",
-        width: 100,
-        height: 100,
-        x: 100,
-        y: 100,
-        data: undefined,
-      },
-    });
-    model.dispatch("DUPLICATE_SHEET", { sheet, id: "42", name: "dup" });
-    model.dispatch("UPDATE_FIGURE", { id: "someuuid", x: 40 });
-    const data = model.exportData();
-
-    const sheet1 = data.sheets.find((s) => s.id === sheet)!;
-    const sheet2 = data.sheets.find((s) => s.id === "42")!;
-
-    expect(sheet1.figures).toEqual([
-      { id: "someuuid", height: 100, tag: "hey", width: 100, x: 40, y: 100 },
-    ]);
-    const id = sheet2.figures[0].id;
-    expect(sheet2.figures).toEqual([{ id, height: 100, tag: "hey", width: 100, x: 100, y: 100 }]);
-  });
-
   test("Cols and Rows are correctly duplicated", () => {
     const model = new Model();
     const sheet = model.getters.getActiveSheet();


### PR DESCRIPTION
## Description:
Add a chart on a sheet, then duplicate the sheet
=> the chart is broken

A new `deepCopy` helper is introduced. It has two main advantages compared to
the JSON stringify/parse technique.
1. It throws an error for unsupported types (class instances)
2. sparse arrays remain sparse

Odoo task ID : [2714872](https://www.odoo.com/web#id=2714872&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
