### PR TITLE
[IMP] composer: add F4 shortcut

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -221,7 +221,7 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
     Enter: this.processEnterKey,
     Escape: this.processEscapeKey,
     F2: () => console.warn("Not implemented"),
-    F4: () => console.warn("Not implemented"),
+    F4: this.processF4Key,
     Tab: (ev: KeyboardEvent) => this.processTabKey(ev),
   };
 
@@ -318,6 +318,11 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
     this.env.model.dispatch("STOP_EDITION", { cancel: true });
   }
 
+  private processF4Key() {
+    this.env.model.dispatch("CYCLE_EDITION_REFERENCES");
+    this.processContent();
+  }
+
   onKeydown(ev: KeyboardEvent) {
     let handler = this.keyMapping[ev.key];
     let isStopped = false;
@@ -354,7 +359,10 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
 
   onKeyup(ev: KeyboardEvent) {
     this.isKeyStillDown = false;
-    if (this.props.focus === "inactive" || ["Control", "Shift", "Tab", "Enter"].includes(ev.key)) {
+    if (
+      this.props.focus === "inactive" ||
+      ["Control", "Shift", "Tab", "Enter", "F4"].includes(ev.key)
+    ) {
       return;
     }
 

--- a/src/helpers/reference_type.ts
+++ b/src/helpers/reference_type.ts
@@ -1,0 +1,95 @@
+// Helper file for the reference types in Xcs (the $ symbol, eg. A$1)
+import { Token } from "../formulas";
+
+type FixedReferenceType = "col" | "row" | "colrow" | "none";
+
+/**
+ * Change the reference types inside the given token, if the token represent a range or a cell
+ *
+ * Eg. :
+ *   A1 => $A$1 => A$1 => $A1 => A1
+ *   A1:$B$1 => $A$1:B$1 => A$1:$B1 => $A1:B1 => A1:$B$1
+ */
+export function loopThroughReferenceType(token: Readonly<Token>): Token {
+  if (token.type !== "REFERENCE") return token;
+  const [range, sheet] = token.value.split("!").reverse() as [string, string | undefined];
+  const [left, right] = range.split(":") as [string, string | undefined];
+
+  const sheetRef = sheet ? `${sheet}!` : "";
+  const updatedLeft = getTokenNextReferenceType(left);
+  const updatedRight = right ? `:${getTokenNextReferenceType(right)}` : "";
+  return { ...token, value: sheetRef + updatedLeft + updatedRight };
+}
+
+/**
+ * Get a new token with a changed type of reference from the given cell token symbol.
+ * Undefined behavior if given a token other than a cell or if the Xc contains a sheet reference
+ *
+ * A1 => $A$1 => A$1 => $A1 => A1
+ */
+function getTokenNextReferenceType(xc: string): string {
+  switch (getReferenceType(xc)) {
+    case "none":
+      xc = setXcToReferenceType(xc, "colrow");
+      break;
+    case "colrow":
+      xc = setXcToReferenceType(xc, "row");
+      break;
+    case "row":
+      xc = setXcToReferenceType(xc, "col");
+      break;
+    case "col":
+      xc = setXcToReferenceType(xc, "none");
+      break;
+  }
+  return xc;
+}
+
+/**
+ * Returns the given XC with the given reference type.
+ */
+function setXcToReferenceType(xc: string, referenceType: FixedReferenceType): string {
+  xc = xc.replace(/\$/g, "");
+  let indexOfNumber: number;
+  switch (referenceType) {
+    case "col":
+      return "$" + xc;
+    case "row":
+      indexOfNumber = xc.search(/[0-9]/);
+      return xc.slice(0, indexOfNumber) + "$" + xc.slice(indexOfNumber);
+      break;
+    case "colrow":
+      indexOfNumber = xc.search(/[0-9]/);
+      xc = xc.slice(0, indexOfNumber) + "$" + xc.slice(indexOfNumber);
+      return "$" + xc;
+    case "none":
+      return xc;
+  }
+}
+
+/**
+ * Return the type of reference used in the given XC of a cell.
+ * Undefined behavior if the XC have a sheet reference
+ */
+function getReferenceType(xcCell: string): FixedReferenceType {
+  if (isColAndRowFixed(xcCell)) {
+    return "colrow";
+  } else if (isColFixed(xcCell)) {
+    return "col";
+  } else if (isRowFixed(xcCell)) {
+    return "row";
+  }
+  return "none";
+}
+
+function isColFixed(xc: string) {
+  return xc.startsWith("$");
+}
+
+function isRowFixed(xc: string) {
+  return xc.includes("$", 1);
+}
+
+function isColAndRowFixed(xc: string) {
+  return xc.startsWith("$") && xc.length > 1 && xc.slice(1).includes("$");
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -540,6 +540,10 @@ export interface ReplaceComposerSelectionCommand {
   text: string;
 }
 
+export interface CycleEditionReferencesCommand {
+  type: "CYCLE_EDITION_REFERENCES";
+}
+
 export interface ShowFormulaCommand {
   type: "SET_FORMULA_VISIBILITY";
   show: boolean;
@@ -871,6 +875,7 @@ export type LocalCommand =
   | SetCurrentContentCommand
   | ChangeComposerSelectionCommand
   | ReplaceComposerSelectionCommand
+  | CycleEditionReferencesCommand
   | StartCommand
   | AutofillCommand
   | AutofillSelectCommand

--- a/tests/components/__mocks__/content_editable_helper.ts
+++ b/tests/components/__mocks__/content_editable_helper.ts
@@ -29,6 +29,8 @@ export class ContentEditableHelper {
     // @ts-ignore
     window.mockContentHelper = this;
     this.manualRange = true;
+    // We cannot set the cursor position beyond the text of the editor
+    if (!this.el || !this.el.textContent || start < 0 || end > this.el.textContent.length) return;
     this.currentState.cursorStart = start;
     this.currentState.cursorEnd = end;
   }

--- a/tests/helpers/reference_types.test.ts
+++ b/tests/helpers/reference_types.test.ts
@@ -1,0 +1,49 @@
+import { loopThroughReferenceType } from "../../src/helpers/reference_type";
+import { Token } from "./../../src/formulas/tokenizer";
+
+function refToken(referenceString: string): Token {
+  return { type: "REFERENCE", value: referenceString };
+}
+
+describe("loopThroughReferenceType", () => {
+  test("on cell", () => {
+    expect(loopThroughReferenceType(refToken("A1"))).toEqual(refToken("$A$1"));
+    expect(loopThroughReferenceType(refToken("$A$1"))).toEqual(refToken("A$1"));
+    expect(loopThroughReferenceType(refToken("A$1"))).toEqual(refToken("$A1"));
+    expect(loopThroughReferenceType(refToken("$A1"))).toEqual(refToken("A1"));
+  });
+
+  test("on range", () => {
+    expect(loopThroughReferenceType(refToken("A1:B1"))).toEqual(refToken("$A$1:$B$1"));
+    expect(loopThroughReferenceType(refToken("$A$1:$B$1"))).toEqual(refToken("A$1:B$1"));
+    expect(loopThroughReferenceType(refToken("A$1:B$1"))).toEqual(refToken("$A1:$B1"));
+    expect(loopThroughReferenceType(refToken("$A1:$B1"))).toEqual(refToken("A1:B1"));
+  });
+
+  test("reference type loop separately on cells of range", () => {
+    expect(loopThroughReferenceType(refToken("$A1:B1"))).toEqual(refToken("A1:$B$1"));
+    expect(loopThroughReferenceType(refToken("A1:$B$1"))).toEqual(refToken("$A$1:B$1"));
+    expect(loopThroughReferenceType(refToken("$A$1:B$1"))).toEqual(refToken("A$1:$B1"));
+    expect(loopThroughReferenceType(refToken("A$1:$B1"))).toEqual(refToken("$A1:B1"));
+  });
+
+  test("can have sheet reference on cell", () => {
+    expect(loopThroughReferenceType(refToken("Sheet2!A1"))).toEqual(refToken("Sheet2!$A$1"));
+    expect(loopThroughReferenceType(refToken("Sheet2!$A$1"))).toEqual(refToken("Sheet2!A$1"));
+    expect(loopThroughReferenceType(refToken("Sheet2!A$1"))).toEqual(refToken("Sheet2!$A1"));
+    expect(loopThroughReferenceType(refToken("Sheet2!$A1"))).toEqual(refToken("Sheet2!A1"));
+  });
+
+  test("can have sheet reference on range", () => {
+    expect(loopThroughReferenceType(refToken("Sheet2!A1:B1"))).toEqual(
+      refToken("Sheet2!$A$1:$B$1")
+    );
+    expect(loopThroughReferenceType(refToken("Sheet2!$A$1:$B$1"))).toEqual(
+      refToken("Sheet2!A$1:B$1")
+    );
+    expect(loopThroughReferenceType(refToken("Sheet2!A$1:B$1"))).toEqual(
+      refToken("Sheet2!$A1:$B1")
+    );
+    expect(loopThroughReferenceType(refToken("Sheet2!$A1:$B1"))).toEqual(refToken("Sheet2!A1:B1"));
+  });
+});


### PR DESCRIPTION
## Description:

Add an F4 shortcut in the composer that will loop through types of reference :
A1 => $A$1 => A$1 => $A1 => A1
Also set the selection in the composer editor to all of the tokens modified by F4.

Odoo task ID : [2714382](https://www.odoo.com/web#id=2714382&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
