### PR TITLE
[FIX] clipboard: paste merge overwrite content below the merge

### DIFF
--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -243,6 +243,7 @@ export class ClipboardPlugin extends UIPlugin {
       ({ sheetId, col, row } = target);
       this.dispatch("ADD_MERGE", {
         sheetId,
+        force: true,
         target: [
           {
             left: col,

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -354,6 +354,30 @@ describe("clipboard", () => {
     expect(model.getters.isInMerge("s1", ...toCartesian("C2"))).toBe(false);
   });
 
+  test("Pasting merge on content will remove the content", () => {
+    const model = new Model({
+      sheets: [
+        {
+          id: "s1",
+          colNumber: 5,
+          rowNumber: 5,
+          cells: {
+            A1: { content: "merge" },
+            C1: { content: "a" },
+            D2: { content: "a" },
+          },
+          merges: ["A1:B2"],
+        },
+      ],
+    });
+    model.dispatch("COPY", { target: target("A1") });
+    model.dispatch("PASTE", { target: target("C1") });
+    expect(model.getters.isInMerge("s1", ...toCartesian("C1"))).toBe(true);
+    expect(model.getters.isInMerge("s1", ...toCartesian("D2"))).toBe(true);
+    expect(getCellContent(model, "C1")).toBe("merge");
+    expect(getCellContent(model, "D2")).toBe("");
+  });
+
   test("copy/paste a merge from one page to another", () => {
     const model = new Model({
       sheets: [


### PR DESCRIPTION
## Description:

Before, when pasting a merge in a zone that contained non-empty cells,
the value of the merge was copied but not the merge itself.

Odoo task ID : [2713503](https://www.odoo.com/web#id=2713503&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
