### PR TITLE
[REF] export: normalize formats

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -1,5 +1,4 @@
 // HELPERS
-
 import { numberToJsDate, parseDateTime } from "../helpers/dates";
 import { isNumber, parseNumber } from "../helpers/numbers";
 import { _lt } from "../translation";

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -203,3 +203,22 @@ export function isDefined<T>(argument: T | undefined): argument is T {
 }
 
 export const DEBUG: { [key: string]: any } = {};
+
+/**
+ * Get the id of the given item (its key in the given dictionnary).
+ * If the given item does not exist in the dictionary, it creates one with a new id.
+ */
+export function getItemId<T>(item: T, itemsDic: { [id: number]: T }) {
+  for (let [key, value] of Object.entries(itemsDic)) {
+    if (stringify(value) === stringify(item)) {
+      return parseInt(key, 10);
+    }
+  }
+
+  // Generate new Id if the item didn't exist in the dictionary
+  const ids = Object.keys(itemsDic);
+  const maxId = ids.length === 0 ? 0 : Math.max(...ids.map((id) => parseInt(id, 10)));
+
+  itemsDic[maxId + 1] = item;
+  return maxId + 1;
+}

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -15,7 +15,7 @@ export interface CellData {
   formula?: NormalizedFormula;
   style?: number;
   border?: number;
-  format?: string;
+  format?: number;
 }
 
 export interface HeaderData {
@@ -51,6 +51,7 @@ export interface WorkbookData {
   version: number;
   sheets: SheetData[];
   styles: { [key: number]: Style };
+  formats: { [key: number]: string };
   borders: { [key: number]: Border };
   entities: { [key: string]: { [key: string]: any } };
   revisionId: UID;

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -52,6 +52,7 @@ export function extractStyle(cell: CellData, data: WorkbookData): ExtractedStyle
   if (cell.style) {
     style = data.styles[cell.style];
   }
+  const format = cell.format ? data.formats[cell.format] : undefined;
   let border: Border = {};
   if (cell.border) {
     border = data.borders[cell.border];
@@ -68,7 +69,7 @@ export function extractStyle(cell: CellData, data: WorkbookData): ExtractedStyle
           fgColor: style!.fillColor,
         }
       : { reservedAttribute: "none" },
-    numFmt: cell.format,
+    numFmt: format,
     border: border || {},
     verticalAlignment: "center" as Align, // we always center vertically for now
     horizontalAlignment: style?.align,

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -8,6 +8,7 @@ describe("load data", () => {
       version: CURRENT_VERSION,
       borders: {},
       styles: {},
+      formats: {},
       entities: {},
       revisionId: DEFAULT_REVISION_ID,
       sheets: [
@@ -30,6 +31,7 @@ describe("load data", () => {
       version: CURRENT_VERSION,
       borders: {},
       styles: {},
+      formats: {},
       entities: {},
       revisionId: DEFAULT_REVISION_ID,
       sheets: [
@@ -58,6 +60,7 @@ describe("load data", () => {
       version: CURRENT_VERSION,
       borders: {},
       styles: {},
+      formats: {},
       entities: {},
       revisionId: DEFAULT_REVISION_ID,
       sheets: [
@@ -86,6 +89,7 @@ describe("load data", () => {
       version: CURRENT_VERSION,
       borders: {},
       styles: {},
+      formats: {},
       entities: {},
       revisionId: DEFAULT_REVISION_ID,
       sheets: [
@@ -151,6 +155,7 @@ describe("load data", () => {
       version: CURRENT_VERSION,
       borders: {},
       styles: {},
+      formats: {},
       entities: {},
       revisionId: DEFAULT_REVISION_ID,
       sheets: [

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -562,9 +562,9 @@ describe("history", () => {
             colNumber: 10,
             rowNumber: 10,
             cells: {
-              A1: { content: "1000", format: "#,##0" },
-              A3: { content: "2000", format: "#,##0" },
-              B2: { content: "TRUE", format: "#,##0" },
+              A1: { content: "1000", format: 1 },
+              A3: { content: "2000", format: 1 },
+              B2: { content: "TRUE", format: 1 },
             },
           },
           {
@@ -572,12 +572,16 @@ describe("history", () => {
             colNumber: 10,
             rowNumber: 10,
             cells: {
-              A1: { content: "21000", format: "#,##0" },
-              A3: { content: "12-31-2020", format: "mm/dd/yyyy" },
-              B2: { content: "TRUE", format: "#,##0" },
+              A1: { content: "21000", format: 1 },
+              A3: { content: "12-31-2020", format: 2 },
+              B2: { content: "TRUE", format: 1 },
             },
           },
         ],
+        formats: {
+          "1": "#,##0",
+          "2": "mm/dd/yyyy",
+        },
       });
       activateSheet(model, sheet2Id); // evaluate Sheet2
       expect(getRangeFormattedValues(model, "A1:A3", sheet1Id)).toEqual(["1,000", "", "2,000"]);

--- a/tests/plugins/grid_manipulation.test.ts
+++ b/tests/plugins/grid_manipulation.test.ts
@@ -563,7 +563,7 @@ describe("Columns", () => {
               A3: { style: 1, border: 1 },
               B1: { style: 1 },
               B2: { border: 1 },
-              B3: { style: 1, border: 1, format: "0.00%" },
+              B3: { style: 1, border: 1, format: 1 },
               B4: { style: 1, border: 1 },
               D1: { style: 1 },
               D2: { border: 1 },
@@ -573,6 +573,7 @@ describe("Columns", () => {
           },
         ],
         styles: { 1: { textColor: "#fe0000" } },
+        formats: { 1: "0.00%" },
         borders: { 1: border },
       });
     });
@@ -1306,7 +1307,7 @@ describe("Rows", () => {
               B2: { border: 1 },
               B4: { border: 1 },
               C1: { style: 1, border: 1 },
-              C2: { style: 1, border: 1, format: "0.00%" },
+              C2: { style: 1, border: 1, format: 1 },
               C4: { style: 1, border: 1 },
               D2: { style: 1, border: 1 },
             },
@@ -1314,6 +1315,7 @@ describe("Rows", () => {
           },
         ],
         styles: { 1: { textColor: "#fe0000" } },
+        formats: { 1: "0.00%" },
         borders: { 1: { top: ["thin", "#000"] } },
       });
     });

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -26,9 +26,9 @@ const simpleData = {
         C20: { content: "left", border: 1 },
         E20: { content: "top", border: 2 },
         G20: { content: "all", border: 3 },
-        C23: { content: "0.43", format: "0.00%" },
-        C24: { content: "10", format: "#,##0.00" },
-        C25: { content: "10.123", format: "#,##0.00" },
+        C23: { content: "0.43", format: 1 },
+        C24: { content: "10", format: 2 },
+        C25: { content: "10.123", format: 2 },
         A27: { content: "Emily Anderson (Emmy)" },
         A28: { content: "Sophie Allen (Saffi)" },
         A29: { content: "Chloe Adams" },
@@ -58,6 +58,10 @@ const simpleData = {
       },
     },
   ],
+  formats: {
+    1: "0.00%",
+    2: "#,##0.00",
+  },
   styles: {
     1: { bold: true, textColor: "#3A3791", fontSize: 12 },
     2: { italic: true },


### PR DESCRIPTION
## Description:

Normalize cell formats at export, for example instead of having a cell :
cell:{content:"", format:"thisIsAFormat"}

we have :
cell:{content:"", format:1}
...
formats:{"1", "thisIsAFormat"}

Set CURRENT_VERSION of documents to 10.
Didn't have to change the export data for excel, everything stills looks like it works.

Odoo task ID : [2714345](https://www.odoo.com/web#id=2714345&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
