### PR TITLE
[IMP] make handling of #ref coherent

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -431,6 +431,7 @@ function compilationCacheKey(
         case "NUMBER":
           return `|N${constantValues.numbers.indexOf(parseNumber(token.value))}|`;
         case "REFERENCE":
+        case "INVALID_REFERENCE":
           return `|${dependencies.indexOf(token.value)}|`;
         default:
           return token.value;
@@ -450,6 +451,7 @@ function formulaArguments(tokens: Token[]) {
   const dependencies: string[] = [];
   for (const token of tokens) {
     switch (token.type) {
+      case "INVALID_REFERENCE":
       case "REFERENCE":
         dependencies.push(token.value);
         break;

--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_ERROR_MESSAGE } from "../constants";
 import { parseNumber, removeStringQuotes } from "../helpers/index";
 import { _lt } from "../translation";
+import { InvalidReferenceError } from "../types/errors";
 import { Token, tokenize } from "./tokenizer";
 
 const UNARY_OPERATORS = ["-", "+"];
@@ -143,7 +144,7 @@ function parsePrefix(current: Token, tokens: Token[]): AST {
         return { type: "FUNCALL", value: current.value, args };
       }
     case "INVALID_REFERENCE":
-      throw new Error(_lt("Invalid reference"));
+      throw new InvalidReferenceError();
     case "REFERENCE":
       if (tokens[0]?.value === ":" && tokens[1]?.type === "REFERENCE") {
         tokens.shift();

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -60,12 +60,13 @@ export function toZone(xc: string): Zone {
  * the correct order.
  */
 export function isZoneValid(zone: Zone): boolean {
+  const { bottom, top, left, right } = zone;
   // Typescript *should* prevent this kind of errors but
   // it's better to be on the safe side at runtime as well.
-  if (isNaN(zone.bottom) || isNaN(zone.top) || isNaN(zone.left) || isNaN(zone.right)) {
+  if (isNaN(bottom) || isNaN(top) || isNaN(left) || isNaN(right)) {
     return false;
   }
-  return zone.bottom >= zone.top && zone.right >= zone.left;
+  return bottom >= top && right >= left && bottom >= 0 && top >= 0 && right >= 0 && left >= 0;
 }
 
 /**

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -1,9 +1,11 @@
+import { INCORRECT_RANGE_STRING } from "../../constants";
 import { compile } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
 import { isZoneValid, range as rangeSequence, toXC } from "../../helpers/index";
 import { Mode, ModelConfig } from "../../model";
 import { StateObserver } from "../../state_observer";
 import { _lt } from "../../translation";
+import { InvalidReferenceError } from "../../types/errors";
 import {
   Cell,
   CellValue,
@@ -141,11 +143,10 @@ export class EvaluationPlugin extends UIPlugin {
         e = new Error(e);
       }
       if (cell.evaluated.type !== CellValueType.error) {
-        cell.assignValue("#ERROR");
-
+        const msg = e instanceof InvalidReferenceError ? INCORRECT_RANGE_STRING : "#ERROR";
         // apply function name
         const __lastFnCalled = params[2].__lastFnCalled || "";
-        cell.assignError("#ERROR", e.message.replace("[[FUNCTION_NAME]]", __lastFnCalled));
+        cell.assignError(msg, e.message.replace("[[FUNCTION_NAME]]", __lastFnCalled));
       }
     }
 
@@ -222,7 +223,7 @@ export class EvaluationPlugin extends UIPlugin {
       const sheetId = range.sheetId;
 
       if (!isZoneValid(range.zone)) {
-        throw new Error(_lt("Invalid reference"));
+        throw new InvalidReferenceError();
       }
 
       const zone = range.zone;
@@ -259,7 +260,7 @@ export class EvaluationPlugin extends UIPlugin {
       }
 
       if (!isZoneValid(range.zone)) {
-        throw new Error(_lt("Invalid reference"));
+        throw new InvalidReferenceError();
       }
 
       // if the formula definition could have accepted a range, we would pass through the _range function and not here

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,0 +1,7 @@
+import { _lt } from "../translation";
+
+export class InvalidReferenceError extends Error {
+  constructor() {
+    super(_lt("Invalid reference"));
+  }
+}

--- a/tests/formulas/parser.test.ts
+++ b/tests/formulas/parser.test.ts
@@ -1,4 +1,5 @@
 import { astToFormula, parse } from "../../src";
+import { InvalidReferenceError } from "../../src/types/errors";
 
 describe("parser", () => {
   test("can parse a function call with no argument", () => {
@@ -120,7 +121,7 @@ describe("parser", () => {
   });
 
   test("Can parse invalid references", () => {
-    expect(() => parse("#REF")).toThrowError("Invalid reference");
+    expect(() => parse("#REF")).toThrowError(new InvalidReferenceError().message);
   });
 
   test("AND", () => {

--- a/tests/helpers/zones.test.ts
+++ b/tests/helpers/zones.test.ts
@@ -1,4 +1,4 @@
-import { overlap, positions, recomputeZones, toZone } from "../../src/helpers/index";
+import { isZoneValid, overlap, positions, recomputeZones, toZone } from "../../src/helpers/index";
 import { Zone } from "../../src/types";
 
 describe("overlap", () => {
@@ -10,6 +10,27 @@ describe("overlap", () => {
   });
 });
 
+describe("isZoneValid", () => {
+  test("single cell zone", () => {
+    expect(isZoneValid({ bottom: 1, top: 1, right: 1, left: 1 })).toBe(true);
+    expect(isZoneValid({ bottom: 0, top: 0, right: 0, left: 0 })).toBe(true);
+  });
+  test("multiple cells zone", () => {
+    expect(isZoneValid({ bottom: 10, top: 1, right: 10, left: 1 })).toBe(true);
+  });
+  test("bottom before top", () => {
+    expect(isZoneValid({ bottom: 1, top: 2, right: 1, left: 1 })).toBe(false);
+  });
+  test("right before left", () => {
+    expect(isZoneValid({ bottom: 1, top: 1, right: 1, left: 2 })).toBe(false);
+  });
+  test("negative values", () => {
+    expect(isZoneValid({ bottom: -1, top: 1, right: 1, left: 1 })).toBe(false);
+    expect(isZoneValid({ bottom: 1, top: -1, right: 1, left: 1 })).toBe(false);
+    expect(isZoneValid({ bottom: 1, top: 1, right: -1, left: 1 })).toBe(false);
+    expect(isZoneValid({ bottom: 1, top: 1, right: 1, left: -1 })).toBe(false);
+  });
+});
 describe("recomputeZones", () => {
   test("add a cell to zone(1)", () => {
     const toKeep = ["A1:C3", "A4"];


### PR DESCRIPTION
## Description:

Before there were problems in the handling of invalid references (#REF):
  - Set "=B1" in the cell A1, then remove the column B. A1 is in error.
  - Then copy paste A1 elsewhere => the new cell is bad_expr.
  - Both cells should be in the same state.

Now #REF is evaluated as a reference in the normalization, and at the
evaluation we now end up with a range with an invalidXc (#REF).

Odoo task ID : [2692366](https://www.odoo.com/web#id=2692366&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
