### PR TITLE
[IMP] Add support of ranges of full rows/cols

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -41,7 +41,7 @@ let start;
 class App extends Component {
   setup() {
     this.key = 1;
-    this.data = demoData;
+    this.data = {};//demoData;
     // this.data = makeLargeDataset(20, 10_000);
     this.stateUpdateMessages = [];
     this.state = useState({ isReadonly: false });

--- a/src/collaborative/ot/ot_helpers.ts
+++ b/src/collaborative/ot/ot_helpers.ts
@@ -7,7 +7,7 @@ export function transformZone(zone: Zone, executed: CoreCommand): Zone | undefin
       zone,
       executed.dimension === "COL" ? "left" : "top",
       executed.elements
-    );
+    ) as Zone; //TODO maybe improve that
   }
   if (executed.type === "ADD_COLUMNS_ROWS") {
     return expandZoneOnInsertion(
@@ -16,7 +16,7 @@ export function transformZone(zone: Zone, executed: CoreCommand): Zone | undefin
       executed.base,
       executed.position,
       executed.quantity
-    );
+    ) as Zone; //TODO maybe improve that
   }
   return { ...zone };
 }

--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -2,7 +2,7 @@ import * as owl from "@odoo/owl";
 import { SELECTION_BORDER_COLOR } from "../../constants";
 import { EnrichedToken } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { DEBUG, isEqual, rangeReference, toZone } from "../../helpers/index";
+import { DEBUG, isEqual, rangeReference, toZoneStateful } from "../../helpers/index";
 import { ComposerSelection, SelectionIndicator } from "../../plugins/ui/edition";
 import { FunctionDescription, Rect, SpreadsheetEnv } from "../../types/index";
 import { TextValueProvider } from "./autocomplete_dropdown";
@@ -527,7 +527,13 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     const highlight = highlights.find(
       (highlight) =>
         highlight.sheet === refSheet &&
-        isEqual(this.getters.expandZone(refSheet, toZone(xc)), highlight.zone)
+        isEqual(
+          this.getters.expandZone(
+            refSheet,
+            toZoneStateful(xc, this.getters.getSheetSize(refSheet))
+          ),
+          highlight.zone
+        )
     );
     return highlight && highlight.color ? highlight.color : undefined;
   }

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -1,5 +1,5 @@
 import * as owl from "@odoo/owl";
-import { colorNumberString, rangeReference, toZone } from "../../../helpers/index";
+import { colorNumberString, rangeReference, toUnboundZone } from "../../../helpers/index";
 import {
   CancelledReason,
   ColorScaleRule,
@@ -464,7 +464,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
           id:
             this.state.mode === "edit" ? this.state.currentCF.id : this.env.uuidGenerator.uuidv4(),
         },
-        target: this.state.currentCF.ranges.map(toZone),
+        target: this.state.currentCF.ranges.map(toUnboundZone),
         sheetId: this.getters.getActiveSheetId(),
       });
       if (!result.isSuccessful) {

--- a/src/formulas/normalize.ts
+++ b/src/formulas/normalize.ts
@@ -1,4 +1,4 @@
-import { cellReference } from "../helpers";
+import { rangeReference } from "../helpers";
 import { NormalizedFormula } from "../types";
 import { rangeTokenize } from "./range_tokenizer";
 import { FORMULA_REF_IDENTIFIER } from "./tokenizer";
@@ -18,7 +18,7 @@ export function normalize(formula: string): NormalizedFormula {
 
   let noRefFormula = "".concat(
     ...tokens.map<string>((token) => {
-      if (token.type === "SYMBOL" && cellReference.test(token.value)) {
+      if (token.type === "SYMBOL" && rangeReference.test(token.value)) {
         const value = token.value.trim();
         if (!references.includes(value)) {
           references.push(value);

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -62,6 +62,8 @@ export const COLUMN: AddFunctionDescription = {
 // COLUMNS
 // -----------------------------------------------------------------------------
 
+// TODO add check we don't try to count cols in 1:1 OR add a way to get the sheet size OR use args (range)
+// and allow (range) to give value for range out of bound of sheet
 export const COLUMNS: AddFunctionDescription = {
   description: _lt("Number of columns in a specified array or range."),
   args: args(`range (meta) ${_lt("The range whose column count will be returned.")}`),
@@ -265,6 +267,8 @@ export const ROW: AddFunctionDescription = {
 // ROWS
 // -----------------------------------------------------------------------------
 
+// TODO add check we don't try to count rows in A:A OR add a way to get the sheet size OR use args (range)
+// and allow (range) to give value for range out of bound of sheet
 export const ROWS: AddFunctionDescription = {
   description: _lt("Number of rows in a specified array or range."),
   args: args(`range (meta) ${_lt("The range whose row count will be returned.")}`),

--- a/src/helpers/references.ts
+++ b/src/helpers/references.ts
@@ -1,8 +1,32 @@
-/**
- * Regex that detect cell reference and a range reference (without the sheetName)
- */
+/** Reference of a cell (eg. A1, $B$5) */
 export const cellReference = new RegExp(/\$?([A-Z]{1,3})\$?([0-9]{1,7})/, "i");
+
+/** Reference of a column (eg. A, CA) */
+export const colReference = new RegExp(/^\$?([A-Z]{1,3})$/, "i");
+
+/** Reference of a row (eg. 1, 59) */
+export const rowReference = new RegExp(/^\$?([0-9]{1,7})$/, "i");
+
+/** Reference of a bound range, ie. a range that doesn't contain a full row/column (eg. A1:B1, $A3:$B$2) */
+export const boundRangeXc = /\$?[A-Z]{1,3}\$?[0-9]{1,7}\s*(\s*:\s*\$?[A-Z]{1,3}\$?[0-9]{1,7}\s*)?/i;
+
+/** Reference of a normal range or a full row range (eg. A1:B1, 1:$5, $A2:5) */
+const fullRowXc = /(\$?[A-Z]{1,3})?\$?[0-9]{1,7}\s*:\s*(\$?[A-Z]{1,3})?\$?[0-9]{1,7}\s*/i;
+
+/** Reference of a normal range or a column row range (eg. A1:B1, A:$B, $A1:C) */
+const fullColXc = /\$?[A-Z]{1,3}(\$?[0-9]{1,7})?\s*:\s*\$?[A-Z]{1,3}(\$?[0-9]{1,7})?\s*/i;
+
+/** Reference of a cell or a range, it can be a bound range, a full row or a full column */
 export const rangeReference = new RegExp(
-  /^\s*(.*!)?\$?[A-Z]{1,3}\$?[0-9]{1,7}\s*(\s*:\s*\$?[A-Z]{1,3}\$?[0-9]{1,7}\s*)?$/,
+  /^\s*(.*!)?/.source +
+    "(" +
+    [cellReference.source, fullRowXc.source, fullColXc.source].join("|") +
+    ")" +
+    /$/.source,
   "i"
 );
+
+// Return true if the given xc is the reference of a column (eg. A or AC)
+export function isColumnReference(xc: string) {
+  return colReference.test(xc);
+}

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -258,10 +258,8 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
       }
     }
 
-    const dataRange = {
-      ...ds.dataRange,
-      zone: dataZone,
-    };
+    const dataRange = ds.dataRange.clone();
+    dataRange.zone = dataZone;
 
     return {
       label: ds.labelCell

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -91,14 +91,9 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
         if (!merges) return;
         const mergesCopy: Record<UID, Range> = {};
         for (const range of Object.values(merges).filter(isDefined)) {
-          mergesCopy[this.nextId++] = {
-            sheetId: cmd.sheetIdTo,
-            zone: { ...range.zone },
-            parts: [...range.parts],
-            prefixSheet: range.prefixSheet,
-            invalidSheetName: range.invalidSheetName,
-            invalidXc: range.invalidXc,
-          };
+          const copy = range.clone();
+          copy.sheetId = cmd.sheetIdTo;
+          mergesCopy[this.nextId++] = copy;
         }
         this.history.update("merges", cmd.sheetIdTo, mergesCopy);
         this.history.update(

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -5,7 +5,7 @@ import {
   isEqual,
   markdownLink,
   rangeReference,
-  toZone,
+  toZoneStateful,
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
 } from "../../helpers/index";
@@ -18,7 +18,7 @@ import {
   RemoveColumnsRowsCommand,
   Zone,
 } from "../../types/index";
-import { Range, RangePart } from "../../types/misc";
+import { Range, RangePart } from "../../types/range";
 import { UIPlugin } from "../ui_plugin";
 import { SelectionMode } from "./selection";
 
@@ -180,8 +180,13 @@ export class EditionPlugin extends UIPlugin {
             const sheetName = sheet || this.getters.getSheetName(this.sheet);
             const activeSheetId = this.getters.getActiveSheetId();
             return (
-              isEqual(this.getters.expandZone(activeSheetId, toZone(xc)), cmd.zone) &&
-              this.getters.getSheetName(activeSheetId) === sheetName
+              isEqual(
+                this.getters.expandZone(
+                  activeSheetId,
+                  toZoneStateful(xc, this.getters.getSheetSize(activeSheetId))
+                ),
+                cmd.zone
+              ) && this.getters.getSheetName(activeSheetId) === sheetName
             );
           });
         this.previousRef = previousRefToken!.value;

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -1,4 +1,11 @@
-import { colorNumberString, isInside, recomputeZones, toXC, toZone } from "../../helpers/index";
+import {
+  colorNumberString,
+  isInside,
+  recomputeZones,
+  toUnboundZone,
+  toXC,
+  toZoneStateful,
+} from "../../helpers/index";
 import { clip, isDefined } from "../../helpers/misc";
 import { Mode } from "../../model";
 import { _lt } from "../../translation";
@@ -133,7 +140,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
             break;
           default:
             for (let ref of cf.ranges) {
-              const zone: Zone = toZone(ref);
+              const zone: Zone = toZoneStateful(ref, this.getters.getSheetSize(activeSheetId));
               for (let row = zone.top; row <= zone.bottom; row++) {
                 for (let col = zone.left; col <= zone.right; col++) {
                   const pr: (cell: Cell | undefined, rule: CellIsRule) => boolean =
@@ -195,8 +202,8 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
     ) {
       return;
     }
-    const zone: Zone = toZone(range);
     const activeSheetId = this.getters.getActiveSheetId();
+    const zone: Zone = toZoneStateful(range, this.getters.getSheetSize(activeSheetId));
     const computedIcons = this.computedIcons[activeSheetId];
     const iconSet: string[] = [rule.icons.upper, rule.icons.middle, rule.icons.lower];
     for (let row = zone.top; row <= zone.bottom; row++) {
@@ -254,8 +261,8 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
     ) {
       return;
     }
-    const zone: Zone = toZone(range);
     const activeSheetId = this.getters.getActiveSheetId();
+    const zone: Zone = toZoneStateful(range, this.getters.getSheetSize(activeSheetId));
     const computedStyle = this.computedStyles[activeSheetId];
     const colorCellArgs: {
       minValue: number;
@@ -459,7 +466,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
         rule: cf.rule,
         stopIfTrue: cf.stopIfTrue,
       },
-      target: newRange.map(toZone),
+      target: newRange.map(toUnboundZone),
       sheetId,
     });
   }
@@ -468,7 +475,13 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
     const xc = toXC(target.col, target.row);
     for (let rule of this.getters.getConditionalFormats(origin.sheetId)) {
       for (let range of rule.ranges) {
-        if (isInside(origin.col, origin.row, toZone(range))) {
+        if (
+          isInside(
+            origin.col,
+            origin.row,
+            toZoneStateful(range, this.getters.getSheetSize(origin.sheetId))
+          )
+        ) {
           const cf = rule;
           const toRemoveRange: string[] = [];
           if (operation === "CUT") {

--- a/src/plugins/ui/highlight.ts
+++ b/src/plugins/ui/highlight.ts
@@ -1,4 +1,4 @@
-import { isEqual, toZone } from "../../helpers/index";
+import { isEqual, toZoneStateful } from "../../helpers/index";
 import { Mode } from "../../model";
 import { GridRenderingContext, Highlight, LAYERS, Zone } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
@@ -35,7 +35,10 @@ export class HighlightPlugin extends UIPlugin {
       const [xc, sheet] = r1c1.split("!").reverse();
       const sheetId = sheet ? this.getters.getSheetIdByName(sheet) : activeSheetId;
       if (sheetId) {
-        const zone: Zone = this.getters.expandZone(activeSheetId, toZone(xc));
+        const zone: Zone = this.getters.expandZone(
+          activeSheetId,
+          toZoneStateful(xc, this.getters.getSheetSize(sheetId))
+        );
         preparedHighlights.push({ zone, color, sheet: sheetId });
       }
     }

--- a/src/types/cells.ts
+++ b/src/types/cells.ts
@@ -1,5 +1,6 @@
 import { SpreadsheetEnv } from "./env";
-import { CompiledFormula, Link, Range, Style, UID } from "./misc";
+import { CompiledFormula, Link, Style, UID } from "./misc";
+import { Range } from "./range";
 
 export enum CellValueType {
   boolean = "boolean",

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -10,7 +10,7 @@ import {
   Style,
   Zone,
 } from "./index";
-import { Border, CellPosition, ClipboardOptions, Dimension, UID } from "./misc";
+import { Border, CellPosition, ClipboardOptions, Dimension, UID, UnboundZone } from "./misc";
 
 // -----------------------------------------------------------------------------
 // Grid commands
@@ -55,6 +55,10 @@ export function isGridDependent(cmd: CoreCommand): boolean {
 
 export interface TargetDependentCommand {
   target: Zone[];
+}
+
+export interface UnboundTargetDependentCommand {
+  target: UnboundZone[];
 }
 
 export function isTargetDependent(cmd: CoreCommand): boolean {
@@ -286,7 +290,9 @@ export interface RenameSheetCommand extends SheetDependentCommand {
  * todo: use id instead of a list. this is not safe to serialize and send to
  * another user
  */
-export interface AddConditionalFormatCommand extends SheetDependentCommand, TargetDependentCommand {
+export interface AddConditionalFormatCommand
+  extends SheetDependentCommand,
+    UnboundTargetDependentCommand {
   type: "ADD_CONDITIONAL_FORMAT";
   cf: Omit<ConditionalFormat, "ranges">;
 }

--- a/src/types/conditional_formatting.ts
+++ b/src/types/conditional_formatting.ts
@@ -1,4 +1,5 @@
-import { Range, Style, UID } from "./misc";
+import { Style, UID } from "./misc";
+import { Range } from "./range";
 
 // -----------------------------------------------------------------------------
 // Conditional Formatting

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,5 +21,6 @@ export * from "./functions";
 export * from "./getters";
 export * from "./history";
 export * from "./misc";
+export * from "./range";
 export * from "./rendering";
 export * from "./workbook_data";

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -4,6 +4,7 @@
 
 import { Cell, CellValue } from "./cells";
 import { CommandResult } from "./commands";
+import { Range } from "./range";
 import { NormalizedFormula } from "./workbook_data";
 
 export type UID = string;
@@ -22,6 +23,15 @@ export interface Zone {
   right: number;
   top: number;
   bottom: number;
+}
+
+export interface UnboundZone {
+  left: number;
+  right: number | undefined;
+  top: number;
+  bottom: number | undefined;
+  // Indicate if a full col/row zone begins at the start of the col/row or have an offset (eg. B2:C vs B:C)
+  hasHeader?: boolean;
 }
 
 export interface ZoneDimension {
@@ -75,19 +85,6 @@ export interface Border {
   right?: BorderDescr;
 }
 
-export interface RangePart {
-  colFixed: boolean;
-  rowFixed: boolean;
-}
-
-export type Range = {
-  zone: Zone; // the zone the range actually spans
-  sheetId: UID; // the sheet on which the range is defined
-  invalidSheetName?: string; // the name of any sheet that is invalid
-  invalidXc?: string;
-  parts: RangePart[];
-  prefixSheet: boolean; // true if the user provided the range with the sheet name, so it has to be recomputed with the sheet name too
-};
 export type ReferenceDenormalizer = (
   position: number,
   references: Range[],

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -1,0 +1,110 @@
+import { _lt } from "../translation";
+import { UID, UnboundZone, Zone, ZoneDimension } from "./misc";
+
+export interface RangePart {
+  colFixed: boolean;
+  rowFixed: boolean;
+}
+
+interface RangeInterface {
+  zone: Zone | UnboundZone; // the zone the range actually spans
+  sheetId: UID; // the sheet on which the range is defined
+  invalidSheetName?: string; // the name of any sheet that is invalid
+  invalidXc?: string;
+  parts: RangePart[];
+  prefixSheet: boolean; // true if the user provided the range with the sheet name, so it has to be recomputed with the sheet name too
+}
+
+export class Range {
+  _zone: Zone | UnboundZone; // the zone the range actually spans
+  sheetId: UID; // the sheet on which the range is defined
+  invalidSheetName?: string; // the name of any sheet that is invalid
+  invalidXc?: string;
+  parts: RangePart[];
+  prefixSheet: boolean; // true if the user provided the range with the sheet name, so it has to be recomputed with the sheet name too
+  _getSheetSize: (sheetId: UID) => ZoneDimension;
+
+  constructor(rangeArgs: RangeInterface, getSheetSize: (sheetId: UID) => ZoneDimension) {
+    this._zone = rangeArgs.zone;
+    this.sheetId = rangeArgs.sheetId;
+    this.invalidSheetName = rangeArgs.invalidSheetName;
+    this.invalidXc = rangeArgs.invalidXc;
+    this.parts = rangeArgs.parts;
+    this.prefixSheet = rangeArgs.prefixSheet;
+    this._getSheetSize = getSheetSize;
+  }
+
+  get isFullCol(): boolean {
+    return this._zone.bottom === undefined;
+  }
+
+  get isFullRow(): boolean {
+    return this._zone.right === undefined;
+  }
+
+  get unboundZone(): UnboundZone {
+    return this._zone;
+  }
+
+  set unboundZone(zone: UnboundZone) {
+    this._zone = zone;
+  }
+
+  get zone(): Zone {
+    const { left, top, bottom, right } = this._zone;
+    if (right !== undefined && bottom !== undefined) return { left, top, right, bottom };
+    else if (bottom === undefined && right !== undefined) {
+      return { right, top, left, bottom: this._getSheetSize(this.sheetId).height - 1 };
+    } else if (right === undefined && bottom !== undefined) {
+      return { bottom, left, top, right: this._getSheetSize(this.sheetId).width - 1 };
+    }
+
+    throw new Error(_lt("Bad zone format"));
+  }
+
+  set zone(zone: Zone) {
+    this._zone = zone;
+  }
+
+  /**
+   * Check that a zone is valid regarding the order of top-bottom and left-right.
+   * Left should be smaller than right, top should be smaller than bottom.
+   * If it's not the case, simply invert them, and invert the linked parts
+   * (in place!)
+   */
+  orderZone() {
+    if (this._zone.right !== undefined && this._zone.right < this._zone.left) {
+      let right = this._zone.right;
+      this._zone.right = this._zone.left;
+      this._zone.left = right;
+
+      let rightFixed = this.parts[1].colFixed;
+      this.parts[1].colFixed = this.parts[0].colFixed;
+      this.parts[0].colFixed = rightFixed;
+    }
+
+    if (this._zone.bottom !== undefined && this._zone.bottom < this._zone.top) {
+      let bottom = this._zone.bottom;
+      this._zone.bottom = this._zone.top;
+      this._zone.top = bottom;
+
+      let bottomFixed = this.parts[1].rowFixed;
+      this.parts[1].rowFixed = this.parts[0].rowFixed;
+      this.parts[0].rowFixed = bottomFixed;
+    }
+  }
+
+  clone(): Range {
+    return new Range(
+      {
+        zone: { ...this._zone },
+        sheetId: this.sheetId,
+        invalidSheetName: this.invalidSheetName,
+        invalidXc: this.invalidXc,
+        parts: this.parts,
+        prefixSheet: this.prefixSheet,
+      },
+      this._getSheetSize
+    );
+  }
+}

--- a/tests/collaborative/ot/ot_columns_added.test.ts
+++ b/tests/collaborative/ot/ot_columns_added.test.ts
@@ -1,5 +1,5 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers/zones";
+import { toUnboundZone, toZone } from "../../../src/helpers/zones";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
@@ -149,6 +149,23 @@ describe("OT with ADD_COLUMNS_ROWS with dimension COL", () => {
       });
     }
   );
+  describe.each([addConditionalFormat])("target commands with unbound zones", (cmd) => {
+    test(`add columns  before ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("A:A")] };
+      const result = transform(command, addColumnsAfter);
+      expect(result).toEqual(command);
+    });
+    test(`add columns after ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("M5:O")] };
+      const result = transform(command, addColumnsAfter);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("O5:Q")] });
+    });
+    test(`add columns in ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("F:G")] };
+      const result = transform(command, addColumnsAfter);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("F:I")] });
+    });
+  });
   const addMerge: Omit<AddMergeCommand, "target"> = {
     type: "ADD_MERGE",
     sheetId,

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -1,5 +1,5 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers";
+import { toUnboundZone, toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
@@ -150,6 +150,33 @@ describe("OT with REMOVE_COLUMN", () => {
       });
     }
   );
+  describe.each([addConditionalFormat])("target commands with unbound zones", (cmd) => {
+    test(`remove columns before ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("A:A")] };
+      const result = transform(command, removeColumns);
+      expect(result).toEqual(command);
+    });
+    test(`remove columns after ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("M5:O")] };
+      const result = transform(command, removeColumns);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("J5:L")] });
+    });
+    test(`${cmd.type} in removed columns`, () => {
+      const command = { ...cmd, target: [toUnboundZone("F:G")] };
+      const result = transform(command, removeColumns);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("D:D")] });
+    });
+    test(`${cmd.type} with a target removed`, () => {
+      const command = { ...cmd, target: [toUnboundZone("C:D")] };
+      const result = transform(command, removeColumns);
+      expect(result).toBeUndefined();
+    });
+    test(`${cmd.type} with a target removed, but another valid`, () => {
+      const command = { ...cmd, target: [toUnboundZone("C:D"), toUnboundZone("A2:A")] };
+      const result = transform(command, removeColumns);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("A2:A")] });
+    });
+  });
 
   describe("OT with RemoveColumns - AddColumns", () => {
     const toTransform: Omit<AddColumnsRowsCommand, "base"> = {

--- a/tests/collaborative/ot/ot_rows_added.test.ts
+++ b/tests/collaborative/ot/ot_rows_added.test.ts
@@ -1,5 +1,5 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers";
+import { toUnboundZone, toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
@@ -149,6 +149,23 @@ describe("OT with ADD_COLUMNS_ROWS with dimension ROW", () => {
       });
     }
   );
+  describe.each([addConditionalFormat])("target commands with unbound zones", (cmd) => {
+    test(`add rows before ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("1:1")] };
+      const result = transform(command, addRowsAfter);
+      expect(result).toEqual(command);
+    });
+    test(`add rows after ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("A10:11")] };
+      const result = transform(command, addRowsAfter);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("A12:13")] });
+    });
+    test(`add rows in ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("5:6")] };
+      const result = transform(command, addRowsAfter);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("5:8")] });
+    });
+  });
 
   const resizeRowsCommand: Omit<ResizeColumnsRowsCommand, "elements"> = {
     type: "RESIZE_COLUMNS_ROWS",

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -1,5 +1,5 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers";
+import { toUnboundZone, toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
@@ -150,6 +150,33 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
       });
     }
   );
+  describe.each([addConditionalFormat])("target commands with unbound zones", (cmd) => {
+    test(`remove rows before ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("1:1")] };
+      const result = transform(command, removeRows);
+      expect(result).toEqual(command);
+    });
+    test(`remove rows after ${cmd.type}`, () => {
+      const command = { ...cmd, target: [toUnboundZone("A12:14")] };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("A9:11")] });
+    });
+    test(`${cmd.type} in removed rows`, () => {
+      const command = { ...cmd, target: [toUnboundZone("6:7")] };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("4:4")] });
+    });
+    test(`${cmd.type} with a target removed`, () => {
+      const command = { ...cmd, target: [toZone("C3:4")] };
+      const result = transform(command, removeRows);
+      expect(result).toBeUndefined();
+    });
+    test(`${cmd.type} with a target removed, but another valid`, () => {
+      const command = { ...cmd, target: [toUnboundZone("3:4"), toUnboundZone("1:1")] };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, target: [toUnboundZone("1:1")] });
+    });
+  });
 
   describe("OT with RemoveRows - ADD_COLUMNS_ROWS with dimension ROW", () => {
     const toTransform: Omit<AddColumnsRowsCommand, "base"> = {

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -490,6 +490,12 @@ describe("composer", () => {
     expect(getCellText(model, "A1")).toBe("=C8");
   });
 
+  test("full rows/cols ranges are correctly displayed", async () => {
+    composerEl = await typeInComposerGrid("=SUM(A:A)");
+    await keydown("Enter");
+    expect(getCellText(model, "A1")).toBe("=SUM(A:A)");
+  });
+
   test("clicking on the composer while typing text (not formula) does not duplicates text", async () => {
     composerEl = await typeInComposerGrid("a");
     composerEl.dispatchEvent(new MouseEvent("click"));

--- a/tests/formulas/compiler.test.ts
+++ b/tests/formulas/compiler.test.ts
@@ -118,7 +118,7 @@ describe("compile dependencies format", () => {
     expect(compiledFormula.dependenciesFormat.length).toEqual(0);
   });
 
-  test.each(["=A1", "=A1:B9", "=Sheet34!B3"])(
+  test.each(["=A1", "=A1:B9", "=Sheet34!B3", "=A:A", "=Sheet2!1:B1"])(
     "expression with ref return ref dependency",
     (formula) => {
       const compiledFormula = compiledBaseFunction(formula);

--- a/tests/formulas/composer_tokenizer.test.ts
+++ b/tests/formulas/composer_tokenizer.test.ts
@@ -1,11 +1,13 @@
 import { composerTokenize } from "../../src/formulas/composer_tokenizer";
 
 describe("composerTokenizer", () => {
-  test("only range", () => {
-    expect(composerTokenize("=A1:A2")).toEqual([
-      { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
-      { start: 1, end: 6, length: 5, type: "SYMBOL", value: "A1:A2" },
-    ]);
+  describe.each(["A1:B1", "A:A", "1:1", "A1:A", "B3:4"])("tokenise ranges", (xc) => {
+    test(`range ${xc}`, () => {
+      expect(composerTokenize("=" + xc)).toEqual([
+        { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
+        { start: 1, end: 1 + xc.length, length: xc.length, type: "SYMBOL", value: xc },
+      ]);
+    });
   });
   test("operation and no range", () => {
     expect(composerTokenize("=A3+A1")).toEqual([

--- a/tests/formulas/range_tokenizer.test.ts
+++ b/tests/formulas/range_tokenizer.test.ts
@@ -52,6 +52,16 @@ describe("rangeTokenizer", () => {
       { type: "RIGHT_PAREN", value: ")" },
     ]);
   });
+
+  test("=SUM(A:A)", () => {
+    expect(rangeTokenize("=SUM(A:A)")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "FUNCTION", value: "SUM" },
+      { type: "LEFT_PAREN", value: "(" },
+      { type: "SYMBOL", value: "A:A" },
+      { type: "RIGHT_PAREN", value: ")" },
+    ]);
+  });
 });
 
 describe("knows what's a reference and what's not", () => {

--- a/tests/helpers/zones.test.ts
+++ b/tests/helpers/zones.test.ts
@@ -23,6 +23,12 @@ describe("recomputeZones", () => {
     expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
   });
 
+  test("add a cell to a full column zone", () => {
+    const toKeep = ["A:B", "A4"];
+    const expectedZone = ["A:B"];
+    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+  });
+
   test("add a row to a zone", () => {
     const toKeep = ["A1:C3", "A4:C4"];
     const expectedZone = ["A1:C4"];

--- a/tests/plugins/__snapshots__/grid_manipulation.test.ts.snap
+++ b/tests/plugins/__snapshots__/grid_manipulation.test.ts.snap
@@ -6,8 +6,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 3,
+          "right": 3,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -16,12 +24,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 3,
-          "right": 3,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -37,8 +39,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 3,
+          "right": 3,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -47,12 +57,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 3,
-          "right": 3,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -68,8 +72,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -78,12 +90,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -99,8 +105,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 5,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -113,12 +127,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 5,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -134,8 +142,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 4,
+          "right": 5,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -148,12 +164,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 4,
-          "right": 5,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -169,8 +179,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 3,
+          "right": 3,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -183,12 +201,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 1,
-          "left": 3,
-          "right": 3,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -204,8 +216,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -214,12 +234,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -235,8 +249,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 3,
+          "right": 3,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -245,12 +267,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 3,
-          "right": 3,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -266,8 +282,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 6,
+          "right": 6,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": true,
@@ -276,12 +300,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 6,
-          "right": 6,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -297,8 +315,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 2,
+          "left": 5,
+          "right": 5,
+          "top": 2,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -307,12 +333,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 2,
-          "left": 5,
-          "right": 5,
-          "top": 2,
-        },
       },
     ],
     "evaluated": Object {
@@ -333,8 +353,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -343,12 +371,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -364,8 +386,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 3,
+          "right": 3,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -374,12 +404,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 3,
-          "right": 3,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -395,8 +419,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -405,12 +437,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -431,8 +457,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -441,12 +475,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -463,8 +491,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -473,12 +509,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -495,8 +525,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -505,12 +543,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -526,8 +558,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -540,12 +580,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -562,8 +596,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -576,12 +618,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -598,8 +634,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 1,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -612,12 +656,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 1,
-          "left": 1,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -634,8 +672,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -644,12 +690,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -666,8 +706,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -676,12 +724,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -698,8 +740,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 2,
+          "right": 2,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": true,
@@ -708,12 +758,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 2,
-          "right": 2,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -729,8 +773,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 2,
+          "left": 1,
+          "right": 1,
+          "top": 2,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -739,12 +791,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 2,
-          "left": 1,
-          "right": 1,
-          "top": 2,
-        },
       },
     ],
     "evaluated": Object {
@@ -765,8 +811,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -775,12 +829,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -796,8 +844,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -806,12 +862,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -827,8 +877,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -837,12 +895,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -863,8 +915,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 3,
+          "left": 0,
+          "right": 0,
+          "top": 3,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -873,12 +933,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 3,
-          "left": 0,
-          "right": 0,
-          "top": 3,
-        },
       },
     ],
     "evaluated": Object {
@@ -894,8 +948,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -904,12 +966,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -925,8 +981,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 3,
+          "left": 0,
+          "right": 0,
+          "top": 3,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -935,12 +999,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 3,
-          "left": 0,
-          "right": 0,
-          "top": 3,
-        },
       },
     ],
     "evaluated": Object {
@@ -956,8 +1014,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -966,12 +1032,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -987,8 +1047,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -997,12 +1065,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1018,8 +1080,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 6,
+          "left": 0,
+          "right": 0,
+          "top": 6,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1028,12 +1098,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 6,
-          "left": 0,
-          "right": 0,
-          "top": 6,
-        },
       },
     ],
     "evaluated": Object {
@@ -1049,8 +1113,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 5,
+          "left": 2,
+          "right": 2,
+          "top": 5,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1059,12 +1131,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 5,
-          "left": 2,
-          "right": 2,
-          "top": 5,
-        },
       },
     ],
     "evaluated": Object {
@@ -1080,8 +1146,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 5,
+          "left": 0,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1094,12 +1168,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 5,
-          "left": 0,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -1115,8 +1183,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 5,
+          "left": 0,
+          "right": 0,
+          "top": 4,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1129,12 +1205,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 5,
-          "left": 0,
-          "right": 0,
-          "top": 4,
-        },
       },
     ],
     "evaluated": Object {
@@ -1150,8 +1220,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 3,
+          "left": 1,
+          "right": 2,
+          "top": 3,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1164,12 +1242,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 3,
-          "left": 1,
-          "right": 2,
-          "top": 3,
-        },
       },
     ],
     "evaluated": Object {
@@ -1190,8 +1262,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1200,12 +1280,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1221,8 +1295,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 3,
+          "left": 0,
+          "right": 0,
+          "top": 3,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1231,12 +1313,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 3,
-          "left": 0,
-          "right": 0,
-          "top": 3,
-        },
       },
     ],
     "evaluated": Object {
@@ -1252,8 +1328,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1262,12 +1346,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1288,8 +1366,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1298,12 +1384,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1320,8 +1400,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1330,12 +1418,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -1352,8 +1434,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1362,12 +1452,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1384,8 +1468,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1394,12 +1486,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -1416,8 +1502,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1426,12 +1520,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1447,8 +1535,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 2,
+          "left": 0,
+          "right": 0,
+          "top": 2,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1457,12 +1553,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 2,
-          "left": 0,
-          "right": 0,
-          "top": 2,
-        },
       },
     ],
     "evaluated": Object {
@@ -1478,8 +1568,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 2,
+          "right": 2,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1488,12 +1586,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 1,
-          "left": 2,
-          "right": 2,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1509,8 +1601,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1523,12 +1623,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -1545,8 +1639,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1559,12 +1661,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -1581,8 +1677,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 2,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1595,12 +1699,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 2,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1622,8 +1720,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1632,12 +1738,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1653,8 +1753,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1663,12 +1771,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet1",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1684,8 +1786,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1694,12 +1804,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "sheet2",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1720,8 +1824,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1730,12 +1842,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "s1",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1751,8 +1857,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1761,12 +1875,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "s2",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -1787,8 +1895,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 1,
+          "right": 1,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1797,12 +1913,6 @@ Object {
         ],
         "prefixSheet": false,
         "sheetId": "s2",
-        "zone": Object {
-          "bottom": 0,
-          "left": 1,
-          "right": 1,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {
@@ -1818,8 +1928,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 1,
+          "left": 0,
+          "right": 0,
+          "top": 1,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1828,12 +1946,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "s1",
-        "zone": Object {
-          "bottom": 1,
-          "left": 0,
-          "right": 0,
-          "top": 1,
-        },
       },
     ],
     "evaluated": Object {
@@ -1849,8 +1961,16 @@ Object {
     "buildFormulaString": [Function],
     "compiledFormula": [Function],
     "dependencies": Array [
-      Object {
+      Range {
+        "_getSheetSize": [Function],
+        "_zone": Object {
+          "bottom": 0,
+          "left": 0,
+          "right": 0,
+          "top": 0,
+        },
         "invalidSheetName": undefined,
+        "invalidXc": undefined,
         "parts": Array [
           Object {
             "colFixed": false,
@@ -1859,12 +1979,6 @@ Object {
         ],
         "prefixSheet": true,
         "sheetId": "s2",
-        "zone": Object {
-          "bottom": 0,
-          "left": 0,
-          "right": 0,
-          "top": 0,
-        },
       },
     ],
     "evaluated": Object {

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -1,4 +1,4 @@
-import { toCartesian, toZone } from "../../src/helpers";
+import { toCartesian, toUnboundZone, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult, ConditionalFormattingOperatorValues } from "../../src/types";
 import {
@@ -35,7 +35,7 @@ describe("conditional format", () => {
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("4", { fillColor: "#0000FF" }, "2"),
-      target: [toZone("A1:A4")],
+      target: [toUnboundZone("A:A")],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toEqual([
@@ -61,7 +61,7 @@ describe("conditional format", () => {
           },
         },
         id: "2",
-        ranges: ["A1:A4"],
+        ranges: ["A:A"],
       },
     ]);
     expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toBeUndefined();

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -1,4 +1,4 @@
-import { toCartesian, toZone } from "../../src/helpers";
+import { toCartesian, toZone, toZoneStateful } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
@@ -212,11 +212,12 @@ describe("edition", () => {
     ]);
 
     model.dispatch("SET_CURRENT_CONTENT", {
-      content: "=SUM(B2:B3, C5)",
+      content: "=SUM(B2:B3, C5, B2:B)",
     });
     expect(model.getters.getHighlights().map((h) => h.zone)).toEqual([
       toZone("B2:B3"),
       toZone("C5"),
+      toZoneStateful("B2:B", model.getters.getSheetSize(model.getters.getActiveSheetId())),
     ]);
   });
 

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -317,6 +317,19 @@ describe("range plugin", () => {
       expect(m.getters.getRangeString(r, "s1")).toBe("'s 2'!A1");
     });
 
+    test.each([["A:B"], ["1:2"], ["A2:B"], ["B2:3"]])("test full column/row", (range) => {
+      let r = m.getters.getRangeFromSheetXC("s1", range);
+      expect(m.getters.getRangeString(r, "s1")).toBe(range);
+    });
+
+    test("test full column/row (2)", () => {
+      let r = m.getters.getRangeFromSheetXC("s1", "A:B2");
+      expect(m.getters.getRangeString(r, "s1")).toBe("A2:B");
+
+      r = m.getters.getRangeFromSheetXC("s1", "1:B2");
+      expect(m.getters.getRangeString(r, "s1")).toBe("B1:2");
+    });
+
     test.each([
       ["$A1"],
       ["$A$1"],
@@ -342,6 +355,14 @@ describe("range plugin", () => {
       ["s1!$A1:$B1"],
       ["s1!A$1:B$1"],
       ["s1!$A$1:$B$1"],
+      ["A:$B"],
+      ["$A:B"],
+      ["$A:$B"],
+      ["s1!A:B"],
+      ["s1!A:$B"],
+      ["s1!A2:$B"],
+      ["s1!$A:B"],
+      ["s1!$A:$B"],
       ["#REF"],
       ["invalid xc"],
     ])("test withing a fixed row", (range) => {
@@ -374,6 +395,15 @@ describe("range plugin", () => {
       ["s1!$A1:$B1", "s1!$A1:$B1"],
       ["s1!A$1:B$1", "s1!A$1:B$1"],
       ["s1!$A$1:$B$1", "s1!$A$1:$B$1"],
+      ["A:$B", "s1!A:$B"],
+      ["A:$B2", "s1!A2:$B"],
+      ["$A:B", "s1!$A:B"],
+      ["$A:$B", "s1!$A:$B"],
+      ["s1!A:B", "s1!A:B"],
+      ["s1!A:$B", "s1!A:$B"],
+      ["s1!$A:B", "s1!$A:B"],
+      ["s1!$A2:B", "s1!$A2:B"],
+      ["s1!$A:$B", "s1!$A:$B"],
       ["#REF", "#REF"],
       ["invalid xc", "invalid xc"],
     ])("test withing a fixed row, displayed for another sheet", (range, expectedString) => {
@@ -398,5 +428,111 @@ describe("range plugin", () => {
         expect(m.getters.getRangeString(range, "tao")).toBe(`'${name}'!A1`);
       }
     );
+  });
+});
+
+describe("full column range", () => {
+  beforeEach(() => {
+    m = new Model({
+      sheets: [{ id: "s1", name: "s1", rows: 10, cols: 10 }],
+    });
+    m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["B:C"] });
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  test("delete col before range", () => {
+    deleteColumns(m, ["A"]);
+    expect(m.getters.getUsedRanges()).toEqual(["A:B"]);
+  });
+  test("delete col inside range", () => {
+    deleteColumns(m, ["C"]);
+    expect(m.getters.getUsedRanges()).toEqual(["B:B"]);
+  });
+  test("delete col after range", () => {
+    deleteColumns(m, ["D"]);
+    expect(m.getters.getUsedRanges()).toEqual(["B:C"]);
+  });
+  test("delete row", () => {
+    deleteRows(m, [3, 4, 5, 6]);
+    expect(m.getters.getUsedRanges()).toEqual(["B:C"]);
+  });
+  test("insert col before range", () => {
+    addColumns(m, "before", "B", 1);
+    expect(m.getters.getUsedRanges()).toEqual(["C:D"]);
+  });
+  test("insert col inside range", () => {
+    addColumns(m, "before", "C", 1);
+    expect(m.getters.getUsedRanges()).toEqual(["B:D"]);
+  });
+  test("insert col after range", () => {
+    addColumns(m, "after", "C", 1);
+    expect(m.getters.getUsedRanges()).toEqual(["B:C"]);
+  });
+  test("insert row inside", () => {
+    addRows(m, "after", 1, 5);
+    expect(m.getters.getUsedRanges()).toEqual(["B:C"]);
+  });
+  test("insert row before'", () => {
+    addRows(m, "before", 0, 1);
+    expect(m.getters.getUsedRanges()).toEqual(["B:C"]);
+  });
+  test("insert row before (2)", () => {
+    m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["B1:C"] });
+    addRows(m, "before", 0, 1);
+    expect(m.getters.getUsedRanges()[1]).toEqual("B2:C");
+  });
+});
+
+describe("full row range", () => {
+  beforeEach(() => {
+    m = new Model({
+      sheets: [{ id: "s1", name: "s1", rows: 10, cols: 10 }],
+    });
+    m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["2:3"] });
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  test("delete row before range", () => {
+    deleteRows(m, [0]);
+    expect(m.getters.getUsedRanges()).toEqual(["1:2"]);
+  });
+  test("delete row inside range", () => {
+    deleteRows(m, [1]);
+    expect(m.getters.getUsedRanges()).toEqual(["2:2"]);
+  });
+  test("delete row after range", () => {
+    deleteRows(m, [4]);
+    expect(m.getters.getUsedRanges()).toEqual(["2:3"]);
+  });
+  test("delete col", () => {
+    deleteColumns(m, ["A", "B", "C"]);
+    expect(m.getters.getUsedRanges()).toEqual(["2:3"]);
+  });
+  test("insert row before range", () => {
+    addRows(m, "before", 0, 1);
+    expect(m.getters.getUsedRanges()).toEqual(["3:4"]);
+  });
+  test("insert row inside range", () => {
+    addRows(m, "after", 1, 1);
+    expect(m.getters.getUsedRanges()).toEqual(["2:4"]);
+  });
+  test("insert row after range", () => {
+    addRows(m, "after", 5, 1);
+    expect(m.getters.getUsedRanges()).toEqual(["2:3"]);
+  });
+  test("insert col in range", () => {
+    addColumns(m, "after", "C", 5);
+    expect(m.getters.getUsedRanges()).toEqual(["2:3"]);
+  });
+  test("insert col before range", () => {
+    addColumns(m, "before", "A", 1);
+    expect(m.getters.getUsedRanges()).toEqual(["2:3"]);
+  });
+  test("insert col before range (1)", () => {
+    m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["A2:3"] });
+    addColumns(m, "before", "A", 1);
+    expect(m.getters.getUsedRanges()[1]).toEqual("B2:3");
   });
 });


### PR DESCRIPTION
## Description:

Add the support of ranges such as A:A or B3:4 in the spreadsheet.

Create a new type UnboundZone that can have its bottom/right undefined
to mark a full column/row. Ranges are now a class, and range.zone will
return a bounded zone based on the size of the spreadsheet.

Change ADD_CONDITIONAL_FORMAT command to be able to handle UnboundZone.

The current way of handling command transformation on the unbound zones of ADD_CONDITIONAL_FORMAT  is a bit hacky from a typescript point of view, but it won't cause problems in JS and I'm pretty sure that we cannot improve it
without having to do command migrations. Is it really worth it?

Chart don't work with full rows/cols ATM.

Odoo task ID : [2714366](https://www.odoo.com/web#id=2714366&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
