### PR TITLE
[IMP] Add support of ranges of full rows/cols

### DIFF
--- a/src/collaborative/ot/ot_helpers.ts
+++ b/src/collaborative/ot/ot_helpers.ts
@@ -1,7 +1,10 @@
 import { expandZoneOnInsertion, reduceZoneOnDeletion } from "../../helpers";
-import { CoreCommand, Zone } from "../../types";
+import { CoreCommand, UnboundedZone, Zone } from "../../types";
 
-export function transformZone(zone: Zone, executed: CoreCommand): Zone | undefined {
+export function transformZone<Z extends Zone | UnboundedZone>(
+  zone: Z,
+  executed: CoreCommand
+): Z | undefined {
   if (executed.type === "REMOVE_COLUMNS_ROWS") {
     return reduceZoneOnDeletion(
       zone,

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -2,7 +2,7 @@ import { Component, onMounted, onPatched, onWillUnmount, useRef, useState } from
 import { ComponentsImportance, SELECTION_BORDER_COLOR } from "../../../constants";
 import { EnrichedToken } from "../../../formulas/index";
 import { functionRegistry } from "../../../functions/index";
-import { isEqual, rangeReference, toZone, zoneToDimension } from "../../../helpers/index";
+import { isEqual, rangeReference, zoneToDimension } from "../../../helpers/index";
 import { ComposerSelection, SelectionIndicator } from "../../../plugins/ui/edition";
 import { FunctionDescription, Rect, SpreadsheetChildEnv } from "../../../types/index";
 import { css } from "../../helpers/css";
@@ -495,7 +495,9 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
 
     const highlight = highlights.find((highlight) => {
       if (highlight.sheetId !== refSheet) return false;
-      let zone = toZone(xc);
+
+      const range = this.env.model.getters.getRangeFromSheetXC(refSheet, xc);
+      let zone = range.zone;
       const { height, width } = zoneToDimension(zone);
       zone = height * width === 1 ? this.env.model.getters.expandZone(refSheet, zone) : zone;
       return isEqual(zone, highlight.zone);

--- a/src/components/highlight/highlight/highlight.ts
+++ b/src/components/highlight/highlight/highlight.ts
@@ -35,6 +35,8 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
   });
 
   onResizeHighlight(isLeft: boolean, isTop: boolean) {
+    const activeSheet = this.env.model.getters.getActiveSheet();
+
     this.highlightState.shiftingMode = "isResizing";
     const z = this.props.zone;
 
@@ -44,7 +46,9 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
     let lastRow = isTop ? z.top : z.bottom;
     let currentZone = z;
 
-    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
+    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", {
+      range: this.env.model.getters.getRangeDataFromZone(activeSheet.id, currentZone),
+    });
 
     const mouseMove = (col, row) => {
       if (lastCol !== col || lastRow !== row) {
@@ -70,7 +74,9 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
         newZone = this.env.model.getters.expandZone(activeSheetId, newZone);
 
         if (!isEqual(newZone, currentZone)) {
-          this.env.model.dispatch("CHANGE_HIGHLIGHT", { zone: newZone });
+          this.env.model.dispatch("CHANGE_HIGHLIGHT", {
+            range: this.env.model.getters.getRangeDataFromZone(activeSheet.id, newZone),
+          });
           currentZone = newZone;
         }
       }
@@ -110,7 +116,9 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
     const deltaRowMax = this.env.model.getters.getNumberRows(activeSheetId) - z.bottom - 1;
 
     let currentZone = z;
-    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
+    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", {
+      range: this.env.model.getters.getRangeDataFromZone(activeSheetId, currentZone),
+    });
 
     let lastCol = initCol;
     let lastRow = initRow;
@@ -132,7 +140,9 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
         newZone = this.env.model.getters.expandZone(activeSheetId, newZone);
 
         if (!isEqual(newZone, currentZone)) {
-          this.env.model.dispatch("CHANGE_HIGHLIGHT", { zone: newZone });
+          this.env.model.dispatch("CHANGE_HIGHLIGHT", {
+            range: this.env.model.getters.getRangeDataFromZone(activeSheetId, newZone),
+          });
           currentZone = newZone;
         }
       }

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -1,6 +1,6 @@
 import { Component, onWillUpdateProps, useExternalListener, useState } from "@odoo/owl";
 import { DEFAULT_COLOR_SCALE_MIDPOINT_COLOR } from "../../../constants";
-import { colorNumberString, rangeReference, toZone } from "../../../helpers/index";
+import { colorNumberString, rangeReference } from "../../../helpers/index";
 import {
   CancelledReason,
   CellIsRule,
@@ -442,6 +442,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
         this.state.errors = [CommandResult.InvalidRange];
         return;
       }
+      const sheetId = this.env.model.getters.getActiveSheetId();
       const result = this.env.model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: {
           rule: this.getEditorRule(),
@@ -450,8 +451,10 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
               ? this.state.currentCF.id
               : this.env.model.uuidGenerator.uuidv4(),
         },
-        target: this.state.currentCF.ranges.map(toZone),
-        sheetId: this.env.model.getters.getActiveSheetId(),
+        ranges: this.state.currentCF.ranges.map((xc) =>
+          this.env.model.getters.getRangeDataFromXc(sheetId, xc)
+        ),
+        sheetId,
       });
       if (!result.isSuccessful) {
         this.state.errors = result.reasons;

--- a/src/formulas/range_tokenizer.ts
+++ b/src/formulas/range_tokenizer.ts
@@ -1,4 +1,4 @@
-import { concat } from "../helpers";
+import { concat, isColReference, isRowReference } from "../helpers";
 import { Token, tokenize } from "./tokenizer";
 
 /**
@@ -7,30 +7,50 @@ import { Token, tokenize } from "./tokenizer";
  *  ?spaces symbol ?spaces operator: ?spaces symbol ?spaces
  */
 export function mergeSymbolsIntoRanges(result: Token[], removeSpace = false): Token[] {
-  let operator: number | void = undefined;
-  let refStart: number | void = undefined;
-  let refEnd: number | void = undefined;
-  let startIncludingSpaces: number | void = undefined;
+  let operator: number | void = undefined; // Index of operator ":" in range
+  let refStart: number | void = undefined; // Index of start of range
+  let refEnd: number | void = undefined; // Index of end of range
+  let startIncludingSpaces: number | void = undefined; // Index of start of range, including spaces before range
+  let isRefOfFullRow: boolean = false; // If we work on a range of a full row (eg. 1:1)
+  let isRefOfFullCol: boolean = false; // If we work on a range of a full column (eg. A2:A)
 
   const reset = () => {
     startIncludingSpaces = undefined;
     refStart = undefined;
     operator = undefined;
     refEnd = undefined;
+    isRefOfFullRow = false;
+    isRefOfFullCol = false;
   };
 
   for (let i = 0; i < result.length; i++) {
     const token = result[i];
 
+    // If we already have a token that could be the start of a range, or a SPACE token
     if (startIncludingSpaces) {
+      // If we already have a token that could be the start of a range
       if (refStart) {
+        // Skip spaces
         if (token.type === "SPACE") {
           continue;
-        } else if (token.type === "OPERATOR" && token.value === ":") {
+        }
+        // Find the ":" operator of a range
+        else if (token.type === "OPERATOR" && token.value === ":") {
           operator = i;
-        } else if (operator && token.type === "REFERENCE") {
+        }
+        // Find the second symbol of a range
+        // Be careful not to build a range A:1 or A:1. A2:3 and A:A2 are both valid ranges.
+        else if (
+          operator &&
+          (token.type === "REFERENCE" ||
+            (token.type === "SYMBOL" && !isRefOfFullRow && isColReference(token.value)) ||
+            (token.type === "NUMBER" && !isRefOfFullCol))
+        ) {
           refEnd = i;
-        } else {
+        }
+        // Cannot add the current token to the range we're currently building
+        else {
+          // We have all the token needed to build a new range
           if (startIncludingSpaces && refStart && operator && refEnd) {
             const newToken: Token = {
               type: "REFERENCE",
@@ -44,34 +64,56 @@ export function mergeSymbolsIntoRanges(result: Token[], removeSpace = false): To
             result.splice(startIncludingSpaces, i - startIncludingSpaces, newToken);
             i = startIncludingSpaces + 1;
             reset();
-          } else {
-            if (token.type === "REFERENCE") {
+          }
+          // Cannot build a range with the current tokens
+          else {
+            // Start building a new range beginning with the current token if possible, else reset
+            if (["REFERENCE", "NUMBER", "SYMBOL"].includes(token.type)) {
               startIncludingSpaces = i;
-              refStart = i;
               operator = undefined;
+              isRefOfFullRow = isRowReference(token.value);
+              isRefOfFullCol = isColReference(token.value);
+              if (token.type === "REFERENCE" || isRefOfFullRow || isRefOfFullCol) {
+                refStart = i;
+              } else reset();
             } else {
               reset();
             }
           }
         }
-      } else {
-        if (token.type === "REFERENCE") {
-          refStart = i;
+      }
+      // If we only have found a SPACE token
+      else {
+        // Start building a new range beginning with the current token if possible, else reset
+        if (["REFERENCE", "NUMBER", "SYMBOL"].includes(token.type)) {
           operator = refEnd = undefined;
+          isRefOfFullRow = isRowReference(token.value);
+          isRefOfFullCol = isColReference(token.value);
+          if (token.type === "REFERENCE" || isRefOfFullRow || isRefOfFullCol) {
+            refStart = i;
+          } else reset();
         } else {
           reset();
         }
       }
-    } else {
-      if (["SPACE", "REFERENCE"].includes(token.type)) {
-        startIncludingSpaces = i;
-        refStart = token.type === "REFERENCE" ? i : undefined;
+    }
+    // We found nothing yet, try to find a token that could be the beginning of a range
+    else {
+      if (["SPACE", "REFERENCE", "NUMBER", "SYMBOL"].includes(token.type)) {
         operator = refEnd = undefined;
+        startIncludingSpaces = i;
+        isRefOfFullRow = isRowReference(token.value);
+        isRefOfFullCol = isColReference(token.value);
+        if (token.type === "REFERENCE" || isRefOfFullRow || isRefOfFullCol) {
+          refStart = i;
+        }
       } else {
         reset();
       }
     }
   }
+
+  // Try to build a range with the last tokens we used
   const i = result.length - 1;
   if (startIncludingSpaces && refStart && operator && refEnd) {
     const newToken: Token = {

--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -24,7 +24,6 @@ import {
 import { CellErrorType, EvaluationError } from "../../types/errors";
 import { formatValue } from "../format";
 import { markdownLink, parseMarkdownLink, parseSheetLink } from "../misc";
-
 /**
  * Abstract base implementation of a cell.
  * Concrete cell classes are responsible to build the raw cell `content` based on

--- a/src/helpers/charts/chart_ui_common.ts
+++ b/src/helpers/charts/chart_ui_common.ts
@@ -6,7 +6,6 @@ import { DataSet, DatasetValues, LabelValues } from "../../types/chart/chart";
 import { range } from "../misc";
 import { recomputeZones, zoneToXc } from "../zones";
 import { AbstractChart } from "./abstract_chart";
-
 /**
  * This file contains helpers that are common to different runtime charts (mainly
  * line, bar and pie charts)

--- a/src/helpers/charts/gauge_chart.ts
+++ b/src/helpers/charts/gauge_chart.ts
@@ -17,8 +17,8 @@ import {
   Range,
   RemoveColumnsRowsCommand,
   UID,
+  UnboundedZone,
   Validation,
-  Zone,
 } from "../../types";
 import { ChartCreationContext } from "../../types/chart/chart";
 import {
@@ -30,7 +30,7 @@ import { Validator } from "../../types/validator";
 import { clip } from "../index";
 import { createRange } from "../range";
 import { rangeReference } from "../references";
-import { toZone, zoneToXc } from "../zones";
+import { toUnboundedZone, zoneToXc } from "../zones";
 import { AbstractChart } from "./abstract_chart";
 import { adaptChartRange, chartFontColor, copyLabelRangeWithNewSheetId } from "./chart_common";
 import { getDefaultChartJsRuntime } from "./chart_ui_common";
@@ -179,9 +179,9 @@ export class GaugeChart extends AbstractChart {
     definition: GaugeChartDefinition,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
   ): GaugeChartDefinition {
-    let dataRangeZone: Zone | undefined;
+    let dataRangeZone: UnboundedZone | undefined;
     if (definition.dataRange) {
-      dataRangeZone = transformZone(toZone(definition.dataRange), executed);
+      dataRangeZone = transformZone(toUnboundedZone(definition.dataRange), executed);
     }
 
     return {

--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -49,7 +49,6 @@ import {
   getChartLabelValues,
   getDefaultChartJsRuntime,
 } from "./chart_ui_common";
-
 chartRegistry.add("pie", {
   match: (type) => type === "pie",
   createChart: (definition, sheetId, getters) =>

--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -10,14 +10,14 @@ import {
   Range,
   RemoveColumnsRowsCommand,
   UID,
-  Zone,
+  UnboundedZone,
 } from "../../types";
 import { ChartCreationContext } from "../../types/chart/chart";
 import { ScorecardChartDefinition, ScorecardChartRuntime } from "../../types/chart/scorecard_chart";
 import { Validator } from "../../types/validator";
 import { createRange } from "../range";
 import { rangeReference } from "../references";
-import { toZone, zoneToXc } from "../zones";
+import { toUnboundedZone, zoneToXc } from "../zones";
 import { AbstractChart } from "./abstract_chart";
 import {
   adaptChartRange,
@@ -102,14 +102,14 @@ export class ScorecardChart extends AbstractChart {
     definition: ScorecardChartDefinition,
     executed: AddColumnsRowsCommand | RemoveColumnsRowsCommand
   ): ScorecardChartDefinition {
-    let baselineZone: Zone | undefined;
-    let keyValueZone: Zone | undefined;
+    let baselineZone: UnboundedZone | undefined;
+    let keyValueZone: UnboundedZone | undefined;
 
     if (definition.baseline) {
-      baselineZone = transformZone(toZone(definition.baseline), executed);
+      baselineZone = transformZone(toUnboundedZone(definition.baseline), executed);
     }
     if (definition.keyValue) {
-      keyValueZone = transformZone(toZone(definition.keyValue), executed);
+      keyValueZone = transformZone(toUnboundedZone(definition.keyValue), executed);
     }
     return {
       ...definition,

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -5,6 +5,7 @@ export * from "./edge_scrolling";
 export * from "./format";
 export * from "./misc";
 export * from "./numbers";
+export * from "./range";
 export * from "./references";
 export * from "./sheet";
 export * from "./uuid";

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -9,7 +9,7 @@ import {
   MIN_CF_ICON_MARGIN,
 } from "../constants";
 import { fontSizeMap } from "../fonts";
-import { ConsecutiveIndexes, Lazy, Link, Style, UID } from "../types";
+import { Cloneable, ConsecutiveIndexes, Lazy, Link, Style, UID } from "../types";
 import { parseDateTime } from "./dates";
 /**
  * Stringify an object, like JSON.stringify, except that the first level of keys
@@ -36,6 +36,10 @@ export function removeStringQuotes(str: string): string {
   return str;
 }
 
+function isCloneable<T>(obj: T | Cloneable<T>): obj is Cloneable<T> {
+  return "clone" in obj && obj.clone instanceof Function;
+}
+
 /**
  * Deep copy arrays, plain objects and primitive values.
  * Throws an error for other types such as class instances.
@@ -47,6 +51,8 @@ export function deepCopy<T>(obj: T): T {
     case "object": {
       if (obj === null) {
         return obj;
+      } else if (isCloneable(obj)) {
+        return obj.clone();
       } else if (!(isPlainObject(obj) || obj instanceof Array)) {
         throw new Error("Unsupported type: only objects and arrays are supported");
       }

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -1,14 +1,177 @@
-import { CoreGetters, Range, UID } from "../types";
+import { _lt } from "../translation";
+import {
+  CoreGetters,
+  Range,
+  RangeData,
+  RangePart,
+  UID,
+  UnboundedZone,
+  Zone,
+  ZoneDimension,
+} from "../types";
+import { isRowReference } from "./references";
+
+interface ConstructorArgs {
+  zone: Zone | UnboundedZone;
+  parts: RangePart[];
+  invalidXc?: string;
+  /** true if the user provided the range with the sheet name */
+  prefixSheet: boolean;
+  /** the name of any sheet that is invalid */
+  invalidSheetName?: string;
+  /** the sheet on which the range is defined */
+  sheetId: UID;
+}
+
+export class RangeImpl implements Range {
+  private readonly _zone: Zone | UnboundedZone;
+  readonly parts: RangePart[];
+  readonly invalidXc?: string | undefined;
+  readonly prefixSheet: boolean = false;
+  readonly sheetId: UID; // the sheet on which the range is defined
+  readonly invalidSheetName?: string; // the name of any sheet that is invalid
+
+  constructor(args: ConstructorArgs, private getSheetSize: (sheetId: UID) => ZoneDimension) {
+    this._zone = args.zone;
+    this.parts = args.parts;
+    this.prefixSheet = args.prefixSheet;
+    this.invalidXc = args.invalidXc;
+
+    this.sheetId = args.sheetId;
+    this.invalidSheetName = args.invalidSheetName;
+  }
+
+  static fromRange(range: Range, getters: CoreGetters): RangeImpl {
+    if (range instanceof RangeImpl) {
+      return range;
+    }
+    return new RangeImpl(range, getters.getSheetSize);
+  }
+
+  get unboundedZone(): UnboundedZone {
+    return this._zone;
+  }
+
+  get zone(): Zone {
+    const { left, top, bottom, right } = this._zone;
+    if (right !== undefined && bottom !== undefined) return { left, top, right, bottom };
+    else if (bottom === undefined && right !== undefined) {
+      return { right, top, left, bottom: this.getSheetSize(this.sheetId).height - 1 };
+    } else if (right === undefined && bottom !== undefined) {
+      return { bottom, left, top, right: this.getSheetSize(this.sheetId).width - 1 };
+    }
+    throw new Error(_lt("Bad zone format"));
+  }
+
+  static getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {
+    const parts: RangePart[] = xc.split(":").map((p) => {
+      const isFullRow = isRowReference(p);
+      return {
+        colFixed: isFullRow ? false : p.startsWith("$"),
+        rowFixed: isFullRow ? p.startsWith("$") : p.includes("$", 1),
+      };
+    });
+
+    const isFullCol = zone.bottom === undefined;
+    const isFullRow = zone.right === undefined;
+    if (isFullCol) {
+      parts[0].rowFixed = parts[0].rowFixed || parts[1].rowFixed;
+      parts[1].rowFixed = parts[0].rowFixed || parts[1].rowFixed;
+      if (zone.left === zone.right) {
+        parts[0].colFixed = parts[0].colFixed || parts[1].colFixed;
+        parts[1].colFixed = parts[0].colFixed || parts[1].colFixed;
+      }
+    }
+    if (isFullRow) {
+      parts[0].colFixed = parts[0].colFixed || parts[1].colFixed;
+      parts[1].colFixed = parts[0].colFixed || parts[1].colFixed;
+
+      if (zone.top === zone.bottom) {
+        parts[0].rowFixed = parts[0].rowFixed || parts[1].rowFixed;
+        parts[1].rowFixed = parts[0].rowFixed || parts[1].rowFixed;
+      }
+    }
+
+    return parts;
+  }
+
+  get isFullCol(): boolean {
+    return this._zone.bottom === undefined;
+  }
+
+  get isFullRow(): boolean {
+    return this._zone.right === undefined;
+  }
+
+  get rangeData(): RangeData {
+    return {
+      _zone: this._zone,
+      _sheetId: this.sheetId,
+    };
+  }
+
+  /**
+   * Check that a zone is valid regarding the order of top-bottom and left-right.
+   * Left should be smaller than right, top should be smaller than bottom.
+   * If it's not the case, simply invert them, and invert the linked parts
+   * (in place!)
+   */
+  orderZone() {
+    if (this._zone.right !== undefined && this._zone.right < this._zone.left) {
+      let right = this._zone.right;
+      this._zone.right = this._zone.left;
+      this._zone.left = right;
+
+      let rightFixed = this.parts[1].colFixed;
+      this.parts[1].colFixed = this.parts[0].colFixed;
+      this.parts[0].colFixed = rightFixed;
+    }
+
+    if (this._zone.bottom !== undefined && this._zone.bottom < this._zone.top) {
+      let bottom = this._zone.bottom;
+      this._zone.bottom = this._zone.top;
+      this._zone.top = bottom;
+
+      let bottomFixed = this.parts[1].rowFixed;
+      this.parts[1].rowFixed = this.parts[0].rowFixed;
+      this.parts[0].rowFixed = bottomFixed;
+    }
+  }
+
+  /**
+   *
+   * @param rangeParams optional, values to put in the cloned range instead of the current values of the range
+   */
+  clone(rangeParams?: Partial<ConstructorArgs>): RangeImpl {
+    return new RangeImpl(
+      {
+        zone: rangeParams?.zone ? rangeParams.zone : { ...this._zone },
+        sheetId: rangeParams?.sheetId ? rangeParams.sheetId : this.sheetId,
+        invalidSheetName:
+          rangeParams && "invalidSheetName" in rangeParams // 'attr in obj' instead of just 'obj.attr' because we accept undefined values
+            ? rangeParams.invalidSheetName
+            : this.invalidSheetName,
+        invalidXc:
+          rangeParams && "invalidXc" in rangeParams ? rangeParams.invalidXc : this.invalidXc,
+        parts: rangeParams?.parts
+          ? rangeParams.parts
+          : this.parts.map((part) => {
+              return { rowFixed: part.rowFixed, colFixed: part.colFixed };
+            }),
+        prefixSheet: rangeParams?.prefixSheet ? rangeParams.prefixSheet : this.prefixSheet,
+      },
+      this.getSheetSize
+    );
+  }
+}
 
 /**
  * Copy a range. If the range is on the sheetIdFrom, the range will target
  * sheetIdTo.
  */
 export function copyRangeWithNewSheetId(sheetIdFrom: UID, sheetIdTo: UID, range: Range): Range {
-  return {
-    ...range,
-    sheetId: range.sheetId === sheetIdFrom ? sheetIdTo : range.sheetId,
-  };
+  const sheetId = range.sheetId === sheetIdFrom ? sheetIdTo : range.sheetId;
+  return range.clone({ sheetId });
 }
 
 /**

--- a/src/helpers/references.ts
+++ b/src/helpers/references.ts
@@ -1,8 +1,34 @@
-/**
- * Regex that detect cell reference and a range reference (without the sheetName)
- */
+/** Reference of a cell (eg. A1, $B$5) */
 export const cellReference = new RegExp(/\$?([A-Z]{1,3})\$?([0-9]{1,7})/, "i");
+
+/** Reference of a column (eg. A, $CA, Sheet1!B) */
+const colReference = new RegExp(/^\s*('.+'!|[^']+!)?\$?([A-Z]{1,3})$/, "i");
+
+/** Reference of a row (eg. 1, 59, Sheet1!9) */
+const rowReference = new RegExp(/^\s*('.+'!|[^']+!)?\$?([0-9]{1,7})$/, "i");
+
+/** Reference of a normal range or a full row range (eg. A1:B1, 1:$5, $A2:5) */
+const fullRowXc = /(\$?[A-Z]{1,3})?\$?[0-9]{1,7}\s*:\s*(\$?[A-Z]{1,3})?\$?[0-9]{1,7}\s*/i;
+
+/** Reference of a normal range or a column row range (eg. A1:B1, A:$B, $A1:C) */
+const fullColXc = /\$?[A-Z]{1,3}(\$?[0-9]{1,7})?\s*:\s*\$?[A-Z]{1,3}(\$?[0-9]{1,7})?\s*/i;
+
+/** Reference of a cell or a range, it can be a bounded range, a full row or a full column */
 export const rangeReference = new RegExp(
-  /^\s*('.+'!|[^']+!)?\$?[A-Z]{1,3}\$?[0-9]{1,7}(\s*:\s*\$?[A-Z]{1,3}\$?[0-9]{1,7})?$/,
+  /^\s*('.+'!|[^']+!)?/.source +
+    "(" +
+    [cellReference.source, fullRowXc.source, fullColXc.source].join("|") +
+    ")" +
+    /$/.source,
   "i"
 );
+
+// Return true if the given xc is the reference of a column (eg. A or AC or Sheet1!A)
+export function isColReference(xc: string) {
+  return colReference.test(xc);
+}
+
+// Return true if the given xc is the reference of a column (eg. 1 or Sheet1!1)
+export function isRowReference(xc: string) {
+  return rowReference.test(xc);
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -167,6 +167,10 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.getters.getRangeString = this.range.getRangeString.bind(this.range);
     this.getters.getRangeFromSheetXC = this.range.getRangeFromSheetXC.bind(this.range);
     this.getters.createAdaptedRanges = this.range.createAdaptedRanges.bind(this.range);
+    this.getters.getRangeDataFromXc = this.range.getRangeDataFromXc.bind(this.range);
+    this.getters.getRangeDataFromZone = this.range.getRangeDataFromZone.bind(this.range);
+    this.getters.getRangeFromRangeData = this.range.getRangeFromRangeData.bind(this.range);
+    this.getters.getSelectionRangeString = this.range.getSelectionRangeString.bind(this.range);
 
     this.uuidGenerator.setIsFastStrategy(true);
 

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -1,5 +1,5 @@
 import { compile } from "../../formulas/index";
-import { isInside, zoneToXc } from "../../helpers/index";
+import { isInside } from "../../helpers/index";
 import {
   AddConditionalFormatCommand,
   ApplyRangeChange,
@@ -133,7 +133,9 @@ export class ConditionalFormatPlugin
       case "ADD_CONDITIONAL_FORMAT":
         const cf = {
           ...cmd.cf,
-          ranges: cmd.target.map(zoneToXc),
+          ranges: cmd.ranges.map((rangeData) =>
+            this.getters.getRangeString(this.getters.getRangeFromRangeData(rangeData), cmd.sheetId)
+          ),
         };
         this.addConditionalFormatting(cf, cmd.sheetId);
         break;
@@ -277,7 +279,7 @@ export class ConditionalFormatPlugin
   }
 
   private checkEmptyRange(cmd: AddConditionalFormatCommand) {
-    return cmd.target.length ? CommandResult.Success : CommandResult.EmptyRange;
+    return cmd.ranges.length ? CommandResult.Success : CommandResult.EmptyRange;
   }
 
   private checkCFRule(cmd: AddConditionalFormatCommand) {

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -27,6 +27,7 @@ import {
   UpdateCellPositionCommand,
   WorkbookData,
   Zone,
+  ZoneDimension,
 } from "../../types/index";
 import { CorePlugin } from "../core_plugin";
 
@@ -62,6 +63,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "getGridLinesVisibility",
     "getNextSheetName",
     "isEmpty",
+    "getSheetSize",
   ] as const;
 
   readonly sheetIdsMapName: Record<string, UID | undefined> = {};
@@ -390,6 +392,13 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
       i++;
     }
     return name;
+  }
+
+  getSheetSize(sheetId: UID): ZoneDimension {
+    return {
+      height: this.getNumberRows(sheetId),
+      width: this.getNumberCols(sheetId),
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -895,6 +904,11 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     }
     if ("target" in cmd && Array.isArray(cmd.target)) {
       zones.push(...cmd.target);
+    }
+    if ("ranges" in cmd && Array.isArray(cmd.ranges)) {
+      zones.push(
+        ...cmd.ranges.map((rangeData) => this.getters.getRangeFromRangeData(rangeData).zone)
+      );
     }
     if (!zones.every(isZoneValid)) {
       return CommandResult.InvalidRange;

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -1,6 +1,6 @@
 import { compile } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { intersection, isZoneValid, toXC } from "../../helpers/index";
+import { intersection, isZoneValid, toXC, zoneToXc } from "../../helpers/index";
 import { ModelConfig } from "../../model";
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
 import { StateObserver } from "../../state_observer";
@@ -288,7 +288,8 @@ export class EvaluationPlugin extends UIPlugin {
       paramNumber?: number
     ): any | any[][] {
       if (isMeta) {
-        return evalContext.getters.getRangeString(range, range.sheetId);
+        // Use zoneToXc of zone instead of getRangeString to avoid sending unbounded ranges
+        return zoneToXc(range.zone);
       }
 
       if (!isZoneValid(range.zone)) {

--- a/src/plugins/ui/selection_input.ts
+++ b/src/plugins/ui/selection_input.ts
@@ -2,7 +2,6 @@ import {
   getComposerSheetName,
   getNextColor,
   positionToZone,
-  toZone,
   UuidGenerator,
   zoneToXc,
 } from "../../helpers/index";
@@ -243,7 +242,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
       .filter((range) => this.getters.isRangeValid(range))
       .filter((reference) => this.shouldBeHighlighted(this.activeSheet, reference));
     return XCs.map((xc) => ({
-      zone: toZone(xc),
+      zone: this.getters.getRangeFromSheetXC(this.activeSheet, xc).zone,
       sheetId: this.activeSheet,
       color,
     }));

--- a/src/types/cells.ts
+++ b/src/types/cells.ts
@@ -1,7 +1,8 @@
 import { SpreadsheetChildEnv } from "./env";
 import { EvaluationError } from "./errors";
 import { Format, FormattedValue } from "./format";
-import { CompiledFormula, Link, Range, Style, UID } from "./misc";
+import { CompiledFormula, Link, Style, UID } from "./misc";
+import { Range } from "./range";
 
 export enum CellValueType {
   boolean = "boolean",

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -1,4 +1,4 @@
-import { Range } from "../misc";
+import { Range } from "../../types";
 import { XlsxHexColor } from "../xlsx";
 import { BarChartDefinition, BarChartRuntime } from "./bar_chart";
 import { GaugeChartDefinition, GaugeChartRuntime } from "./gauge_chart";

--- a/src/types/conditional_formatting.ts
+++ b/src/types/conditional_formatting.ts
@@ -1,4 +1,5 @@
-import { Range, Style, UID } from "./misc";
+import { Style, UID } from "./misc";
+import { Range } from "./range";
 
 // -----------------------------------------------------------------------------
 // Conditional Formatting

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ export * from "./functions";
 export * from "./getters";
 export * from "./history";
 export * from "./misc";
+export * from "./range";
 export * from "./rendering";
 export * from "./selection";
 export * from "./workbook_data";

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -5,6 +5,7 @@ import { Token } from "../formulas";
 import { Cell, CellValue } from "./cells";
 import { CommandResult } from "./commands";
 import { Format } from "./format";
+import { Range } from "./range";
 
 export type UID = string;
 /**
@@ -52,6 +53,14 @@ export interface AnchorZone {
 export interface Selection {
   anchor: AnchorZone;
   zones: Zone[];
+}
+
+export interface UnboundedZone {
+  top: number;
+  bottom: number | undefined;
+  left: number;
+  right: number | undefined;
+  hasHeader?: boolean;
 }
 
 export interface ZoneDimension {
@@ -104,19 +113,6 @@ export interface Border {
   right?: BorderDescr;
 }
 
-export interface RangePart {
-  colFixed: boolean;
-  rowFixed: boolean;
-}
-
-export type Range = {
-  zone: Zone; // the zone the range actually spans
-  sheetId: UID; // the sheet on which the range is defined
-  invalidSheetName?: string; // the name of any sheet that is invalid
-  invalidXc?: string;
-  parts: RangePart[];
-  prefixSheet: boolean; // true if the user provided the range with the sheet name, so it has to be recomputed with the sheet name too
-};
 export type ReferenceDenormalizer = (
   range: Range,
   isMeta: boolean,
@@ -243,4 +239,8 @@ export interface Lazy<T> {
    * ```
    */
   map: <U>(callback: (value: T) => U) => Lazy<U>;
+}
+
+export interface Cloneable<T> {
+  clone: (args?: Partial<T>) => T;
 }

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -1,0 +1,23 @@
+import { Cloneable, UID, UnboundedZone, Zone } from "./misc";
+
+export interface RangePart {
+  colFixed: boolean;
+  rowFixed: boolean;
+}
+
+export interface Range extends Cloneable<Range> {
+  zone: Zone;
+  parts: RangePart[];
+  invalidXc?: string;
+  /** true if the user provided the range with the sheet name */
+  prefixSheet: boolean;
+  /** the name of any sheet that is invalid */
+  invalidSheetName?: string;
+  /** the sheet on which the range is defined */
+  sheetId: UID;
+}
+
+export interface RangeData {
+  _zone: Zone | UnboundedZone;
+  _sheetId: UID;
+}

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -1,9 +1,11 @@
 import { DEFAULT_FONT_SIZE } from "../../constants";
+import { toUnboundedZone } from "../../helpers";
 import {
   Align,
   Border,
   CellData,
   ConditionalFormattingOperatorValues,
+  ExcelWorkbookData,
   Format,
   Style,
   UID,
@@ -198,4 +200,29 @@ export function convertChartId(chartId: UID) {
 export function convertDotValueToEMU(value: number) {
   const DPI = 96;
   return Math.round((value * 914400) / DPI);
+}
+
+export function getRangeSize(xc: string, defaultSheetIndex: string, data: ExcelWorkbookData) {
+  const xcSplit = xc.split("!");
+  let rangeSheetIndex: number;
+  if (xcSplit.length > 1) {
+    const index = data.sheets.findIndex((sheet) => sheet.name === xcSplit[0]);
+    if (index < 0) {
+      throw new Error("Unable to find a sheet with the name " + xcSplit[0]);
+    }
+    rangeSheetIndex = index;
+    xc = xcSplit[1];
+  } else {
+    rangeSheetIndex = Number(defaultSheetIndex);
+  }
+
+  const zone = toUnboundedZone(xc);
+  if (zone.right === undefined) {
+    zone.right = data.sheets[rangeSheetIndex].colNumber;
+  }
+  if (zone.bottom === undefined) {
+    zone.bottom = data.sheets[rangeSheetIndex].rowNumber;
+  }
+
+  return (zone.right - zone.left + 1) * (zone.bottom - zone.top + 1);
 }

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -119,7 +119,13 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
           }
         );
         chartRelIds.push(chartRelId);
-        files.push(createXMLFile(createChart(chart), `xl/charts/chart${xlsxChartId}.xml`, "chart"));
+        files.push(
+          createXMLFile(
+            createChart(chart, sheetIndex, data),
+            `xl/charts/chart${xlsxChartId}.xml`,
+            "chart"
+          )
+        );
       }
 
       const drawingRelId = addRelsToFile(

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -22,7 +22,7 @@ import {
   undo,
 } from "../test_helpers/commands_helpers";
 import { getBorder, getCell, getCellContent } from "../test_helpers/getters_helpers";
-import { createEqualCF, target } from "../test_helpers/helpers";
+import { createEqualCF, target, toRangesData } from "../test_helpers/helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
 import { setupCollaborativeEnv } from "./collaborative_helpers";
 
@@ -749,17 +749,17 @@ describe("Multi users synchronisation", () => {
     setCellContent(alice, "A1", "1");
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1")],
+      ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#0000FF" }, "2"),
-      target: [toZone("A1")],
+      ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#00FF00" }, "3"),
-      target: [toZone("A1")],
+      ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
     network.concurrent(() => {
@@ -790,12 +790,12 @@ describe("Multi users synchronisation", () => {
     setCellContent(alice, "A1", "1");
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1")],
+      ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#0000FF" }, "2"),
-      target: [toZone("A1")],
+      ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
     network.concurrent(() => {

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -22,7 +22,7 @@ import {
   updateChart,
 } from "../test_helpers/commands_helpers";
 import { getCellContent, getCellError } from "../test_helpers/getters_helpers";
-import { createEqualCF } from "../test_helpers/helpers";
+import { createEqualCF, toRangesData } from "../test_helpers/helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
 import { setupCollaborativeEnv } from "./collaborative_helpers";
 
@@ -465,7 +465,7 @@ describe("Collaborative Sheet manipulation", () => {
         bob.dispatch("ADD_CONDITIONAL_FORMAT", {
           sheetId,
           cf,
-          target: [toZone("A1:A3"), toZone("C1:D3"), toZone("F1:F3")],
+          ranges: toRangesData(sheetId, "A1:A3,C1:D3,F1:F3"),
         });
       });
       expect([alice, bob, charlie]).toHaveSynchronizedValue(
@@ -488,7 +488,7 @@ describe("Collaborative Sheet manipulation", () => {
         bob.dispatch("ADD_CONDITIONAL_FORMAT", {
           sheetId,
           cf,
-          target: [toZone("A1:A3"), toZone("C1:D3"), toZone("F1:G3")],
+          ranges: toRangesData(sheetId, "A1:A3,C1:D3,F1:G3"),
         });
       });
       expect([alice, bob, charlie]).toHaveSynchronizedValue(
@@ -511,7 +511,7 @@ describe("Collaborative Sheet manipulation", () => {
         bob.dispatch("ADD_CONDITIONAL_FORMAT", {
           sheetId,
           cf,
-          target: [toZone("A1:A3"), toZone("A4:A10"), toZone("A11:A12")],
+          ranges: toRangesData(sheetId, "A1:A3,A4:A10,A11:A12"),
         });
       });
       expect([alice, bob, charlie]).toHaveSynchronizedValue(
@@ -534,7 +534,7 @@ describe("Collaborative Sheet manipulation", () => {
         bob.dispatch("ADD_CONDITIONAL_FORMAT", {
           sheetId,
           cf,
-          target: [toZone("A1:A3"), toZone("A4:A5"), toZone("A11:A12")],
+          ranges: toRangesData(sheetId, "A1:A3,A4:A5,A11:A12"),
         });
       });
       expect([alice, bob, charlie]).toHaveSynchronizedValue(
@@ -594,7 +594,7 @@ describe("Collaborative Sheet manipulation", () => {
           bob,
           {
             ...chartDef,
-            dataSets: ["A1:A3", "C1:C3", "F1:G3"],
+            dataSets: ["A1:A3", "C1:C3", "F:G"],
           },
           chartId
         );
@@ -603,7 +603,7 @@ describe("Collaborative Sheet manipulation", () => {
         (user) => user.getters.getChartDefinition(chartId),
         {
           ...chartDef,
-          dataSets: ["A1:A3", "E1:E3"],
+          dataSets: ["A1:A3", "E:E"],
           labelRange: undefined,
         }
       );
@@ -690,14 +690,14 @@ describe("Collaborative Sheet manipulation", () => {
       );
       network.concurrent(() => {
         deleteRows(alice, [3, 4, 10]);
-        updateChart(bob, chartId, { dataSets: ["A1:A3", "A4:A5", "A11:A12"], labelRange: "F10" });
+        updateChart(bob, chartId, { dataSets: ["A1:A3", "A4:A5", "A11:A12"], labelRange: "10:10" });
       });
       expect([alice, bob, charlie]).toHaveSynchronizedValue(
         (user) => user.getters.getChartDefinition(chartId),
         {
           ...chartDef,
           dataSets: ["A1:A3", "A9"],
-          labelRange: "F8",
+          labelRange: "8:8",
         }
       );
     });

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -247,33 +247,63 @@ describe("ranges and highlights", () => {
   describe("change highlight position in the grid", () => {
     test("change the associated range in the composer ", async () => {
       composerEl = await typeInComposerGrid("=SUM(B2)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C3") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B2"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "C3"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(C3)");
     });
 
+    test("highlights change handle unbounded ranges ", async () => {
+      composerEl = await typeInComposerGrid("=SUM(B:B)");
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B:B"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "C:C"),
+      });
+      await nextTick();
+      expect(composerEl.textContent).toBe("=SUM(C:C)");
+    });
+
     test("change the first associated range in the composer when ranges are the same", async () => {
       composerEl = await typeInComposerGrid("=SUM(B2, B2)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C3") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B2"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "C3"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(C3, B2)");
     });
 
     test("the first range doesn't change if other highlight transit by the first range state ", async () => {
       composerEl = await typeInComposerGrid("=SUM(B2, B1)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B3") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B2"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B3"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(B2, B3)");
     });
 
     test("can change references of different length", async () => {
       composerEl = await typeInComposerGrid("=SUM(B1)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1:B2"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(B1:B2)");
     });
@@ -281,8 +311,12 @@ describe("ranges and highlights", () => {
     test("can change references with sheetname", async () => {
       composerEl = await typeInComposerGrid("=Sheet42!B1");
       createSheetWithName(model, { sheetId: "42", activate: true }, "Sheet42");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B2"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=Sheet42!B2");
     });
@@ -290,8 +324,12 @@ describe("ranges and highlights", () => {
     test("change references of the current sheet", async () => {
       composerEl = await typeInComposerGrid("=SUM(B1,Sheet42!B1)");
       createSheetWithName(model, { sheetId: "42", activate: true }, "Sheet42");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B2"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(B1,Sheet42!B2)");
     });
@@ -301,8 +339,12 @@ describe("ranges and highlights", () => {
       ["=$b1", "=$C1"],
     ])("can change cells reference with index fixed", async (ref, resultRef) => {
       composerEl = await typeInComposerGrid(ref);
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "C1"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe(resultRef);
     });
@@ -319,8 +361,12 @@ describe("ranges and highlights", () => {
       ["=$B$1:$B$2", "=$C$1:$C$2"],
     ])("can change ranges reference with index fixed", async (ref, resultRef) => {
       composerEl = await typeInComposerGrid(ref);
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1:C2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1:B2"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "C1:C2"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe(resultRef);
     });
@@ -328,14 +374,22 @@ describe("ranges and highlights", () => {
     test("can change cells merged reference", async () => {
       merge(model, "B1:B2");
       composerEl = await typeInComposerGrid("=B1");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1:B2"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "C1"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=C1");
 
       composerEl = await typeInComposerGrid("+B2");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1:B2"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "C2"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=C1+C2");
     });
@@ -343,16 +397,37 @@ describe("ranges and highlights", () => {
     test("can change cells merged reference with index fixed", async () => {
       merge(model, "B1:B2");
       composerEl = await typeInComposerGrid("=B$2");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1:C2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1:B2"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "C1:C2"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=C$1:C$2");
     });
 
+    test("references are expanded to include merges", async () => {
+      merge(model, "C1:D1");
+      composerEl = await typeInComposerGrid("=A1:B1");
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "A1:B1"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1:C1"),
+      });
+      await nextTick();
+      expect(composerEl.textContent).toBe("=B1:D1");
+    });
+
     test("can change references of different length with index fixed", async () => {
       composerEl = await typeInComposerGrid("=SUM($B$1)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1"),
+      });
+      model.dispatch("CHANGE_HIGHLIGHT", {
+        range: model.getters.getRangeDataFromXc(model.getters.getActiveSheetId(), "B1:B2"),
+      });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM($B$1:$B$2)");
     });
@@ -469,6 +544,12 @@ describe("composer", () => {
     await keyDown("Enter");
     expect(model.getters.getEditionMode()).toBe("inactive");
     expect(getCellText(model, "A1")).toBe("=C8");
+  });
+
+  test("full rows/cols ranges are correctly displayed", async () => {
+    composerEl = await typeInComposerGrid("=SUM(A:A)");
+    await keyDown("Enter");
+    expect(getCellText(model, "A1")).toBe("=SUM(A:A)");
   });
 
   test("clicking on the composer while typing text (not formula) does not duplicates text", async () => {

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -21,6 +21,7 @@ import {
   nextTick,
   spyDispatch,
   textContentAll,
+  toRangesData,
 } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
@@ -113,10 +114,11 @@ describe("UI of conditional formats", () => {
 
   describe("Conditional format list", () => {
     beforeEach(async () => {
+      const sheetId = model.getters.getActiveSheetId();
       model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1:A2")],
+        ranges: toRangesData(sheetId, "A1:A2"),
       });
       model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: createColorScale(
@@ -124,8 +126,8 @@ describe("UI of conditional formats", () => {
           { type: "value", color: 0xff00ff, value: "" },
           { type: "value", color: 0x123456, value: "" }
         ),
-        target: [toZone("B1:B5")],
-        sheetId: model.getters.getActiveSheetId(),
+        ranges: toRangesData(sheetId, "B1:B5"),
+        sheetId,
       });
       await nextTick();
     });
@@ -190,16 +192,17 @@ describe("UI of conditional formats", () => {
             values: ["3"],
           },
         },
-        target: [toZone("A1:A3")],
+        ranges: toRangesData(model.getters.getActiveSheetId(), "A1:A3"),
         sheetId: model.getters.getActiveSheetId(),
       });
     });
 
     test("the preview should be bold when the rule is bold", async () => {
+      const sheetId = model.getters.getActiveSheetId();
       model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: createEqualCF("2", { bold: true, fillColor: "#ff0000" }, "99"),
-        target: [toZone("C1:C5")],
-        sheetId: model.getters.getActiveSheetId(),
+        ranges: toRangesData(sheetId, "C1:C5"),
+        sheetId,
       });
 
       await nextTick();
@@ -245,7 +248,7 @@ describe("UI of conditional formats", () => {
             type: "ColorScaleRule",
           },
         },
-        target: [toZone("B2:B5")],
+        ranges: toRangesData(model.getters.getActiveSheetId(), "B2:B5"),
         sheetId: model.getters.getActiveSheetId(),
       });
     });
@@ -315,7 +318,7 @@ describe("UI of conditional formats", () => {
             values: ["3"],
           },
         },
-        target: [toZone("A1:A3")],
+        ranges: toRangesData(model.getters.getActiveSheetId(), "A1:A3"),
         sheetId: model.getters.getActiveSheetId(),
       });
     });
@@ -438,7 +441,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      ranges: toRangesData(model.getters.getActiveSheetId(), "B2:B5"),
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -489,7 +492,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      ranges: toRangesData(model.getters.getActiveSheetId(), "B2:B5"),
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -540,7 +543,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      ranges: toRangesData(model.getters.getActiveSheetId(), "B2:B5"),
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -591,7 +594,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      ranges: toRangesData(model.getters.getActiveSheetId(), "B2:B5"),
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -655,7 +658,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      ranges: toRangesData(model.getters.getActiveSheetId(), "B2:B5"),
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -686,11 +689,12 @@ describe("UI of conditional formats", () => {
   });
 
   test("switching sheet resets CF Editor to list", async () => {
+    const sheetId = model.getters.getActiveSheetId();
     triggerMouseEvent(selectors.closePanel, "click");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { bold: true, fillColor: "#ff0000" }, "99"),
-      target: [toZone("A1:A2")],
-      sheetId: model.getters.getActiveSheetId(),
+      ranges: toRangesData(sheetId, "A1:A2"),
+      sheetId,
     });
     createSheet(model, { sheetId: "42" });
     await nextTick();
@@ -1191,7 +1195,7 @@ describe("UI of conditional formats", () => {
             },
           },
         },
-        target: [toZone("B2:B5")],
+        ranges: toRangesData(model.getters.getActiveSheetId(), "B2:B5"),
         sheetId: model.getters.getActiveSheetId(),
       });
     });
@@ -1252,7 +1256,7 @@ describe("UI of conditional formats", () => {
             },
           },
         },
-        target: [toZone("A1")],
+        ranges: toRangesData(model.getters.getActiveSheetId(), "A1"),
         sheetId: model.getters.getActiveSheetId(),
       });
     });
@@ -1302,7 +1306,7 @@ describe("UI of conditional formats", () => {
           },
         },
       },
-      target: [toZone("A1")],
+      ranges: toRangesData(model.getters.getActiveSheetId(), "A1"),
       sheetId: model.getters.getActiveSheetId(),
     });
   });

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -9,7 +9,7 @@ import {
   MENU_WIDTH,
   TOPBAR_HEIGHT,
 } from "../../src/constants";
-import { toXC, toZone } from "../../src/helpers";
+import { toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { createFullMenuItem, FullMenuItem } from "../../src/registries";
 import { cellMenuRegistry } from "../../src/registries/menus/cell_menu_registry";
@@ -24,6 +24,7 @@ import {
   MockClipboard,
   mountSpreadsheet,
   nextTick,
+  toRangesData,
   Touch,
 } from "../test_helpers/helpers";
 
@@ -767,10 +768,11 @@ describe("Context Menu - CF", () => {
         style: { fillColor: "#FF0000" },
       },
     };
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule,
-      sheetId: model.getters.getActiveSheetId(),
-      target: cfRule.ranges.map(toZone),
+      sheetId,
+      ranges: toRangesData(sheetId, cfRule.ranges.join(",")),
     });
     setSelection(model, ["A1:K11"]);
     await rightClickCell(model, "C5");
@@ -804,15 +806,16 @@ describe("Context Menu - CF", () => {
         style: { fillColor: "#FE0001" },
       },
     };
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule1,
-      sheetId: model.getters.getActiveSheetId(),
-      target: cfRule1.ranges.map(toZone),
+      sheetId,
+      ranges: toRangesData(sheetId, cfRule1.ranges.join(",")),
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule2,
-      sheetId: model.getters.getActiveSheetId(),
-      target: cfRule2.ranges.map(toZone),
+      sheetId,
+      ranges: toRangesData(sheetId, cfRule2.ranges.join(",")),
     });
     setSelection(model, ["A1:K11"]);
     await rightClickCell(model, "C5");
@@ -836,10 +839,11 @@ describe("Context Menu - CF", () => {
         style: { fillColor: "#FF1200" },
       },
     };
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule1,
-      sheetId: model.getters.getActiveSheetId(),
-      target: cfRule1.ranges.map(toZone),
+      sheetId,
+      ranges: toRangesData(sheetId, cfRule1.ranges.join(",")),
     });
     setSelection(model, ["A1:A11"]);
     await rightClickCell(model, "A2");

--- a/tests/components/highlight.test.ts
+++ b/tests/components/highlight.test.ts
@@ -151,12 +151,12 @@ describe("Corner component", () => {
       // select B2 nw corner
       selectNWCellCorner(cornerEl, "B2");
       expect(model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        range: { _zone: toZone("B2"), _sheetId: model.getters.getActiveSheetId() },
       });
       // move to A1
       moveToCell(cornerEl, "A1");
       expect(model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("A1:B2"),
+        range: { _zone: toZone("A1:B2"), _sheetId: model.getters.getActiveSheetId() },
       });
     });
 
@@ -167,13 +167,13 @@ describe("Corner component", () => {
       // select B2 ne corner
       selectNECellCorner(cornerEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        range: { _zone: toZone("B2"), _sheetId: model.getters.getActiveSheetId() },
       });
 
       // move to C1
       moveToCell(cornerEl, "C1");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("B1:C2"),
+        range: { _zone: toZone("B1:C2"), _sheetId: model.getters.getActiveSheetId() },
       });
     });
 
@@ -184,13 +184,13 @@ describe("Corner component", () => {
       // select B2 sw corner
       selectSWCellCorner(cornerEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        range: { _zone: toZone("B2"), _sheetId: model.getters.getActiveSheetId() },
       });
 
       // move to A3
       moveToCell(cornerEl, "A3");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("A2:B3"),
+        range: { _zone: toZone("A2:B3"), _sheetId: model.getters.getActiveSheetId() },
       });
     });
 
@@ -201,13 +201,13 @@ describe("Corner component", () => {
       // select B2 se corner
       selectSECellCorner(cornerEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        range: { _zone: toZone("B2"), _sheetId: model.getters.getActiveSheetId() },
       });
 
       // move to C3
       moveToCell(cornerEl, "C3");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("B2:C3"),
+        range: { _zone: toZone("B2:C3"), _sheetId: model.getters.getActiveSheetId() },
       });
     });
   });
@@ -219,7 +219,7 @@ describe("Corner component", () => {
     // select A1 nw corner
     selectNWCellCorner(cornerEl, "A1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1"),
+      range: { _zone: toZone("A1"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move outside the grid
@@ -241,13 +241,13 @@ describe("Corner component", () => {
     // select B2 se corner
     selectNWCellCorner(cornerEl, "B2");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("B2"),
+      range: { _zone: toZone("B2"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to B1
     moveToCell(cornerEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C2"),
+      range: { _zone: toZone("B1:C2"), _sheetId: model.getters.getActiveSheetId() },
     });
   });
 
@@ -265,7 +265,7 @@ describe("Corner component", () => {
     // select B1 nw corner
     selectNWCellCorner(cornerEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("B1"),
+      range: { _zone: toZone("B1"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to C1
@@ -290,7 +290,7 @@ describe("Corner component", () => {
     // select A2 nw corner
     selectTopCellBorder(cornerEl, "A2");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A2"),
+      range: { _zone: toZone("A2"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to A3
@@ -313,13 +313,13 @@ describe("Border component", () => {
       // select B2 top border
       selectTopCellBorder(borderEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        range: { _zone: toZone("B2"), _sheetId: model.getters.getActiveSheetId() },
       });
 
       // move to C2
       moveToCell(borderEl, "C2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("C2"),
+        range: { _zone: toZone("C2"), _sheetId: model.getters.getActiveSheetId() },
       });
     });
 
@@ -330,13 +330,13 @@ describe("Border component", () => {
       // select B2 left border
       selectLeftCellBorder(borderEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        range: { _zone: toZone("B2"), _sheetId: model.getters.getActiveSheetId() },
       });
 
       // move to C2
       moveToCell(borderEl, "C2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("C2"),
+        range: { _zone: toZone("C2"), _sheetId: model.getters.getActiveSheetId() },
       });
     });
 
@@ -347,13 +347,13 @@ describe("Border component", () => {
       // select B2 right border
       selectRightCellBorder(borderEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        range: { _zone: toZone("B2"), _sheetId: model.getters.getActiveSheetId() },
       });
 
       // move to C2
       moveToCell(borderEl, "C2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("C2"),
+        range: { _zone: toZone("C2"), _sheetId: model.getters.getActiveSheetId() },
       });
     });
 
@@ -364,13 +364,13 @@ describe("Border component", () => {
       // select B2 bottom border
       selectBottomCellBorder(borderEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        range: { _zone: toZone("B2"), _sheetId: model.getters.getActiveSheetId() },
       });
 
       // move to C2
       moveToCell(borderEl, "C2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("C2"),
+        range: { _zone: toZone("C2"), _sheetId: model.getters.getActiveSheetId() },
       });
     });
   });
@@ -382,19 +382,19 @@ describe("Border component", () => {
     // select A1 top border
     selectTopCellBorder(borderEl, "A1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1:B2"),
+      range: { _zone: toZone("A1:B2"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to B1
     moveToCell(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C2"),
+      range: { _zone: toZone("B1:C2"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to C1
     moveToCell(borderEl, "C1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("C1:D2"),
+      range: { _zone: toZone("C1:D2"), _sheetId: model.getters.getActiveSheetId() },
     });
   });
 
@@ -405,13 +405,13 @@ describe("Border component", () => {
     // select B1 top border
     selectTopCellBorder(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1:B2"),
+      range: { _zone: toZone("A1:B2"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to C1
     moveToCell(borderEl, "C1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C2"),
+      range: { _zone: toZone("B1:C2"), _sheetId: model.getters.getActiveSheetId() },
     });
   });
 
@@ -422,7 +422,7 @@ describe("Border component", () => {
     // select B2 bottom border
     selectBottomCellBorder(borderEl, "B2");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1:B2"),
+      range: { _zone: toZone("A1:B2"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to A2
@@ -438,13 +438,13 @@ describe("Border component", () => {
     // select A1 top border
     selectTopCellBorder(borderEl, "A1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1"),
+      range: { _zone: toZone("A1"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to B1
     moveToCell(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C1"),
+      range: { _zone: toZone("B1:C1"), _sheetId: model.getters.getActiveSheetId() },
     });
   });
 
@@ -456,13 +456,13 @@ describe("Border component", () => {
     // select A1 top border
     selectTopCellBorder(borderEl, "A1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1"),
+      range: { _zone: toZone("A1"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to B1
     moveToCell(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C1"),
+      range: { _zone: toZone("B1:C1"), _sheetId: model.getters.getActiveSheetId() },
     });
   });
 
@@ -480,7 +480,7 @@ describe("Border component", () => {
     // select B1 top border
     selectTopCellBorder(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("B1"),
+      range: { _zone: toZone("B1"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to C1
@@ -505,7 +505,7 @@ describe("Border component", () => {
     // select A2 top border
     selectTopCellBorder(borderEl, "A2");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A2"),
+      range: { _zone: toZone("A2"), _sheetId: model.getters.getActiveSheetId() },
     });
 
     // move to A3

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -18,7 +18,7 @@ import {
   mountSpreadsheet,
   nextTick,
   startGridComposition,
-  target,
+  toRangesData,
   typeInComposerGrid,
   typeInComposerTopBar,
 } from "../test_helpers/helpers";
@@ -307,9 +307,10 @@ describe("Composer interactions", () => {
 
 describe("Composer / selectionInput interactions", () => {
   beforeEach(async () => {
+    const sheetId = parent.model.getters.getActiveSheetId();
     parent.model.dispatch("ADD_CONDITIONAL_FORMAT", {
-      sheetId: parent.model.getters.getActiveSheetId(),
-      target: target("B2:C4"),
+      sheetId,
+      ranges: toRangesData(sheetId, "B2:C4"),
       cf: {
         id: "42",
         rule: {

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -21,6 +21,7 @@ import {
   mountSpreadsheet,
   nextTick,
   target,
+  toRangesData,
   typeInComposerTopBar,
 } from "../test_helpers/helpers";
 
@@ -539,10 +540,11 @@ describe("TopBar - CF", () => {
         style: { fillColor: "#FF0000" },
       },
     };
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule,
-      sheetId: model.getters.getActiveSheetId(),
-      target: cfRule.ranges.map(toZone),
+      sheetId,
+      ranges: toRangesData(sheetId, cfRule.ranges.join(",")),
     });
     setSelection(model, ["A1:K11"]);
 
@@ -583,15 +585,16 @@ describe("TopBar - CF", () => {
         style: { fillColor: "#FE0001" },
       },
     };
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule1,
-      sheetId: model.getters.getActiveSheetId(),
-      target: cfRule1.ranges.map(toZone),
+      sheetId,
+      ranges: toRangesData(sheetId, cfRule1.ranges.join(",")),
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule2,
-      sheetId: model.getters.getActiveSheetId(),
-      target: cfRule2.ranges.map(toZone),
+      sheetId,
+      ranges: toRangesData(sheetId, cfRule2.ranges.join(",")),
     });
     setSelection(model, ["A1:K11"]);
 

--- a/tests/formulas/compiler.test.ts
+++ b/tests/formulas/compiler.test.ts
@@ -119,8 +119,8 @@ describe("compile dependencies format", () => {
     expect(compiledFormula.dependenciesFormat.length).toEqual(0);
   });
 
-  test.each(["=A1", "=A1:B9", "=Sheet34!B3"])(
-    "expression with ref return ref dependency",
+  test.each(["=A1", "=A1:B9", "=Sheet34!B3", "=A:A", "=Sheet2!1:B1"])(
+    "expression with ref %s return ref dependency",
     (formula) => {
       const compiledFormula = compiledBaseFunction(formula);
       expect(compiledFormula.dependenciesFormat).toEqual([0]);

--- a/tests/formulas/composer_tokenizer.test.ts
+++ b/tests/formulas/composer_tokenizer.test.ts
@@ -1,11 +1,13 @@
 import { composerTokenize } from "../../src/formulas/composer_tokenizer";
 
 describe("composerTokenizer", () => {
-  test("only range", () => {
-    expect(composerTokenize("=A1:A2")).toEqual([
-      { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
-      { start: 1, end: 6, length: 5, type: "REFERENCE", value: "A1:A2" },
-    ]);
+  describe.each(["A1:B1", "A:A", "1:1", "A1:A", "B3:4"])("tokenise ranges", (xc) => {
+    test(`range ${xc}`, () => {
+      expect(composerTokenize("=" + xc)).toEqual([
+        { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
+        { start: 1, end: 1 + xc.length, length: xc.length, type: "REFERENCE", value: xc },
+      ]);
+    });
   });
   test("operation and no range", () => {
     expect(composerTokenize("=A3+A1")).toEqual([
@@ -23,6 +25,14 @@ describe("composerTokenizer", () => {
       { start: 4, end: 9, length: 5, type: "REFERENCE", value: "A1:A2" },
     ]);
   });
+
+  test("unbound range with spaces", () => {
+    expect(composerTokenize("= A : A ")).toEqual([
+      { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
+      { start: 1, end: 8, length: 7, type: "REFERENCE", value: " A : A " },
+    ]);
+  });
+
   test("operation and range with spaces", () => {
     expect(composerTokenize("=A3+  A1 : A2   ")).toEqual([
       { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },

--- a/tests/formulas/range_tokenizer.test.ts
+++ b/tests/formulas/range_tokenizer.test.ts
@@ -52,6 +52,23 @@ describe("rangeTokenizer", () => {
       { type: "RIGHT_PAREN", value: ")" },
     ]);
   });
+
+  test("=A:A", () => {
+    expect(rangeTokenize("=A:A")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "REFERENCE", value: "A:A" },
+    ]);
+  });
+
+  test("=SUM(A:A)", () => {
+    expect(rangeTokenize("=SUM(A:A)")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "FUNCTION", value: "SUM" },
+      { type: "LEFT_PAREN", value: "(" },
+      { type: "REFERENCE", value: "A:A" },
+      { type: "RIGHT_PAREN", value: ")" },
+    ]);
+  });
 });
 
 describe("knows what's a reference and what's not", () => {
@@ -142,6 +159,13 @@ describe("knows what's a reference and what's not", () => {
       { type: "REFERENCE", value: "'S ''h i t'!a1" },
     ]);
   });
+
+  test.each(["Sheet3!A:A", "Sheet3!1:1", "Sheet3!A1:A"])("sheet, full column/row range", (xc) => {
+    expect(rangeTokenize("=" + xc)).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "REFERENCE", value: xc },
+    ]);
+  });
 });
 
 describe("tokenize ranges", () => {
@@ -157,34 +181,5 @@ describe("tokenize ranges", () => {
       { type: "OPERATOR", value: "=" },
       { type: "REFERENCE", value: "B1:A2" },
     ]);
-  });
-
-  test.skip("column", () => {
-    expect(rangeTokenize("=A:A")).toEqual({
-      type: "BIN_OPERATION",
-      value: ":",
-      left: {
-        type: "REFERENCE",
-        value: "A",
-      },
-      right: {
-        type: "REFERENCE",
-        value: "A",
-      },
-    });
-  });
-  test.skip("row", () => {
-    expect(rangeTokenize("=1:1")).toEqual({
-      type: "BIN_OPERATION",
-      value: ":",
-      left: {
-        type: "REFERENCE",
-        value: "1",
-      },
-      right: {
-        type: "REFERENCE",
-        value: "1",
-      },
-    });
   });
 });

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -14,7 +14,12 @@ import {
 } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent, getCellText, getMerges } from "../test_helpers/getters_helpers"; // to have getcontext mocks
 import "../test_helpers/helpers";
-import { getMergeCellMap, getPlugin, XCToMergeCellMap } from "../test_helpers/helpers";
+import {
+  getMergeCellMap,
+  getPlugin,
+  toRangesData,
+  XCToMergeCellMap,
+} from "../test_helpers/helpers";
 
 let autoFill: AutofillPlugin;
 let model: Model;
@@ -147,10 +152,11 @@ describe("Autofill", () => {
         },
       },
     };
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf,
-      sheetId: model.getters.getActiveSheetId(),
-      target: cf.ranges.map(toZone),
+      sheetId,
+      ranges: toRangesData(sheetId, cf.ranges.join(",")),
     });
     let col: number, row: number;
     ({ col, row } = toCartesian("A1"));

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -146,6 +146,22 @@ describe("datasource tests", function () {
     expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
   });
 
+  test("create chart with full rows/columns datasets", () => {
+    createChart(
+      model,
+      {
+        dataSets: ["8:8", "A:B"],
+        type: "line",
+      },
+      "1"
+    );
+    expect((model.getters.getChartDefinition("1") as LineChartDefinition)?.dataSets).toMatchObject([
+      "8:8",
+      "A:A",
+      "B:B",
+    ]);
+  });
+
   test("create chart with row datasets without series title", () => {
     createChart(
       model,
@@ -604,21 +620,24 @@ describe("datasource tests", function () {
     );
     expect(result).toBeSuccessfullyDispatched();
   });
-  test("update chart with invalid dataset", () => {
-    createChart(
-      model,
-      {
-        dataSets: ["Sheet1!B1:B4", "Sheet1!B1:B4"],
-        labelRange: "",
-      },
-      "1"
-    );
-    expect(
-      updateChart(model, "1", {
-        dataSets: ["Sheet1!B1:B4", "This is invalid"],
-      })
-    ).toBeCancelledBecause(CommandResult.InvalidDataSet);
-  });
+  test.each([[["Sheet1!B1:B4", "This is invalid"]], [["1:4"]]])(
+    "update chart with invalid dataset",
+    (invalidDataset: string[]) => {
+      createChart(
+        model,
+        {
+          dataSets: ["Sheet1!B1:B4", "Sheet1!B1:B4"],
+          labelRange: "",
+        },
+        "1"
+      );
+      expect(
+        updateChart(model, "1", {
+          dataSets: invalidDataset,
+        })
+      ).toBeCancelledBecause(CommandResult.InvalidDataSet);
+    }
+  );
 
   test("update chart with invalid labels", () => {
     createChart(

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -36,6 +36,7 @@ import {
   makeInteractiveTestEnv,
   target,
   toCartesianArray,
+  toRangesData,
 } from "../test_helpers/helpers";
 
 function getClipboardVisibleZones(model: Model): Zone[] {
@@ -1239,10 +1240,11 @@ describe("clipboard", () => {
     setCellContent(model, "A2", "2");
     setCellContent(model, "C1", "1");
     setCellContent(model, "C2", "2");
+    const sheetId = model.getters.getActiveSheetId();
     let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
-      sheetId: model.getters.getActiveSheetId(),
+      ranges: toRangesData(sheetId, "A1,A2"),
+      sheetId,
     });
 
     expect(result).toBeSuccessfullyDispatched();
@@ -1523,6 +1525,18 @@ describe("clipboard", () => {
     });
   });
 
+  test.each([
+    ["=SUM(1:2)", "=SUM(2:3)"],
+    ["=$C1:1", "=$C2:2"],
+    ["=SUM($A:D$2)", "=SUM($A$2:E)"],
+  ])("can copy and paste formula with full cols/rows", (value, expected) => {
+    const model = new Model();
+    setCellContent(model, "A1", value);
+    model.dispatch("COPY", { target: target("A1") });
+    model.dispatch("PASTE", { target: target("B2") });
+    expect(getCellText(model, "B2")).toBe(expected);
+  });
+
   test("can copy format from empty cell to another cell to clear format", () => {
     const model = new Model();
 
@@ -1559,10 +1573,11 @@ describe("clipboard", () => {
     setCellContent(model, "A2", "2");
     setCellContent(model, "C1", "1");
     setCellContent(model, "C2", "2");
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1"), toZone("A2")],
+      sheetId,
+      ranges: toRangesData(sheetId, "A1,A2"),
     });
     copy(model, "A1");
     paste(model, "C1");
@@ -1590,10 +1605,11 @@ describe("clipboard", () => {
     setCellContent(model, "A2", "2");
     setCellContent(model, "C1", "1");
     setCellContent(model, "C2", "2");
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
-      sheetId: model.getters.getActiveSheetId(),
+      ranges: toRangesData(sheetId, "A1,A2"),
+      sheetId,
     });
     cut(model, "A1");
     paste(model, "C1");
@@ -1618,10 +1634,11 @@ describe("clipboard", () => {
     });
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
-      sheetId: model.getters.getActiveSheetId(),
+      ranges: toRangesData(sheetId, "A1,A2"),
+      sheetId,
     });
     copy(model, "A1:A2");
     paste(model, "B1");
@@ -1657,10 +1674,11 @@ describe("clipboard", () => {
     });
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
-      sheetId: model.getters.getActiveSheetId(),
+      ranges: toRangesData(sheetId, "A1,A2"),
+      sheetId,
     });
     cut(model, "A1:A2");
     paste(model, "B1");
@@ -1695,10 +1713,11 @@ describe("clipboard", () => {
     });
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
-      sheetId: model.getters.getActiveSheetId(),
+      ranges: toRangesData(sheetId, "A1,A2"),
+      sheetId,
     });
     copy(model, "A1:A2");
     activateSheet(model, "s2");
@@ -1732,10 +1751,11 @@ describe("clipboard", () => {
     const sheet2 = model.getters.getSheetIds()[1];
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
-      sheetId: model.getters.getActiveSheetId(),
+      ranges: toRangesData(sheetId, "A1,A2"),
+      sheetId,
     });
     cut(model, "A1:A2");
     activateSheet(model, sheet2);

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -249,11 +249,12 @@ describe("edition", () => {
     ]);
 
     model.dispatch("SET_CURRENT_CONTENT", {
-      content: "=SUM(B2:B3, C5)",
+      content: "=SUM(B2:B3, C5, B2:B)",
     });
     expect(model.getters.getHighlights().map((h) => h.zone)).toEqual([
       toZone("B2:B3"),
       toZone("C5"),
+      model.getters.getRangeFromSheetXC(model.getters.getActiveSheetId(), "B2:B").zone,
     ]);
   });
 

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -21,7 +21,7 @@ import {
   resizeRows,
   setCellContent,
 } from "../test_helpers/commands_helpers";
-import { createEqualCF, getPlugin, target } from "../test_helpers/helpers";
+import { createEqualCF, getPlugin, target, toRangesData } from "../test_helpers/helpers";
 import { watchClipboardOutline } from "../test_helpers/renderer_helpers";
 
 MockCanvasRenderingContext2D.prototype.measureText = function (text: string) {
@@ -344,10 +344,11 @@ describe("renderer", () => {
         },
       ],
     });
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#DC6CDF" }, "1"),
-      sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1")],
+      sheetId,
+      ranges: toRangesData(sheetId, "A1"),
     });
 
     let fillStyle: any[] = [];
@@ -387,7 +388,7 @@ describe("renderer", () => {
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#DC6CDF" }, "1"),
-      target: [toZone("A1")],
+      ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
     merge(model, "A1:A3");
@@ -665,10 +666,11 @@ describe("renderer", () => {
     model.drawGrid(ctx);
     expect(fillStyle).toEqual([]);
     fillStyle = [];
+    const sheetId = model.getters.getActiveSheetId();
     let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("", { fillColor: "#DC6CDF" }, "1"),
-      target: [toZone("A1")],
-      sheetId: model.getters.getActiveSheetId(),
+      ranges: toRangesData(sheetId, "A1"),
+      sheetId,
     });
     expect(result).toBeSuccessfullyDispatched();
     model.drawGrid(ctx);

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -287,6 +287,22 @@ describe("selection input plugin", () => {
     expect(highlightedZones(model)).toStrictEqual(["C5"]);
   });
 
+  test("selection input updates handle full column ranges", () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
+    model.dispatch("ADD_EMPTY_RANGE", { id });
+    model.dispatch("CHANGE_RANGE", { id, rangeId: idOfRange(model, id, 0), value: "A3:A" });
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("A3:A");
+    expect(highlightedZones(model)).toEqual(["A3:A100"]);
+  });
+
+  test("selection input updates handle full row ranges", () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
+    model.dispatch("ADD_EMPTY_RANGE", { id });
+    model.dispatch("CHANGE_RANGE", { id, rangeId: idOfRange(model, id, 0), value: "F3:3" });
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("F3:3");
+    expect(highlightedZones(model)).toEqual(["F3:Z3"]);
+  });
+
   test("manually changing the input with existing range", () => {
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, initialRanges: ["A8"] });
     model.dispatch("CHANGE_RANGE", { id, rangeId: idOfRange(model, id, 0), value: "A8, C5" });

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -23,7 +23,7 @@ import {
 } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import "../test_helpers/helpers";
-import { createEqualCF, testUndoRedo } from "../test_helpers/helpers";
+import { createEqualCF, testUndoRedo, toRangesData } from "../test_helpers/helpers";
 
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
@@ -662,10 +662,11 @@ describe("sheets", () => {
       fillColor: "orange",
     });
     expect(model.getters.getConditionalFormats(newSheetId)).toHaveLength(1);
+    const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("42", { fillColor: "blue" }, "1"),
-      target: [toZone("A1:A2")],
-      sheetId: model.getters.getActiveSheetId(),
+      ranges: toRangesData(sheetId, "A1:A2"),
+      sheetId,
     });
     expect(model.getters.getConditionalStyle(col, row)).toEqual({ fillColor: "blue" });
     expect(model.getters.getConditionalFormats(newSheetId)).toHaveLength(1);

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -3,7 +3,7 @@ import { ChartConfiguration } from "chart.js";
 import format from "xml-formatter";
 import { Spreadsheet, SpreadsheetProps } from "../../src/components/spreadsheet/spreadsheet";
 import { functionRegistry } from "../../src/functions/index";
-import { toCartesian, toXC, toZone } from "../../src/helpers/index";
+import { toCartesian, toUnboundedZone, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { MergePlugin } from "../../src/plugins/core/merge";
 import {
@@ -11,8 +11,10 @@ import {
   ColorScaleThreshold,
   CommandTypes,
   ConditionalFormat,
+  RangeData,
   SpreadsheetChildEnv,
   Style,
+  UID,
   Zone,
 } from "../../src/types";
 import { XLSXExport } from "../../src/types/xlsx";
@@ -232,6 +234,10 @@ export function zone(str: string): Zone {
 
 export function target(str: string): Zone[] {
   return str.split(",").map(zone);
+}
+
+export function toRangesData(sheetId: UID, str: string): RangeData[] {
+  return str.split(",").map((xc) => ({ _zone: toUnboundedZone(xc), _sheetId: sheetId }));
 }
 
 export function createEqualCF(

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -3,7 +3,7 @@ import { Model } from "../src/model";
 import { adaptFormulaToExcel } from "../src/xlsx/functions/cells";
 import { escapeXml, parseXML } from "../src/xlsx/helpers/xml_helpers";
 import { createChart, createSheet, merge, setCellContent } from "./test_helpers/commands_helpers";
-import { exportPrettifiedXlsx, target } from "./test_helpers/helpers";
+import { exportPrettifiedXlsx, toRangesData } from "./test_helpers/helpers";
 
 const simpleData = {
   sheets: [
@@ -870,7 +870,7 @@ describe("Test XLSX export", () => {
     );
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
+      ranges: toRangesData(model.getters.getActiveSheetId(), "A1"),
       cf: {
         id: "42",
         rule: {


### PR DESCRIPTION
Add the support of ranges such as A:A or B3:4 in the spreadsheet.

Create a new type UnboundZone that can have its bottom/right undefined
to mark a full column/row. Ranges are now a class, and range.zone will
return a bounded zone based on the size of the spreadsheet.

Change ADD_CONDITIONAL_FORMAT command to be able to handle UnboundZone.

The current way of handling command transformation on the unbound zones of ADD_CONDITIONAL_FORMAT is a bit hacky from a typescript point of view, but it won't cause problems in JS and I'm not good enough at typing things in TS to manage to fix it.

Odoo task ID : [2714366](https://www.odoo.com/web#id=2714366&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
