### PR TITLE
[IMP] split composer test for parallelization

### DIFF
--- a/tests/components/composer/composer_helper.ts
+++ b/tests/components/composer/composer_helper.ts
@@ -1,0 +1,21 @@
+import { Model } from "../../../src/model";
+import { nextTick } from "../../test_helpers/helpers";
+
+export function getHighlights(model: Model): any[] {
+  return model.getters.getHighlights();
+}
+
+export async function keydown(key: string, options: any = {}) {
+  document.activeElement!.dispatchEvent(
+    new KeyboardEvent("keydown", Object.assign({ key, bubbles: true }, options))
+  );
+  await nextTick();
+  await nextTick();
+}
+export async function keyup(key: string, options: any = {}) {
+  document.activeElement!.dispatchEvent(
+    new KeyboardEvent("keyup", Object.assign({ key, bubbles: true }, options))
+  );
+  await nextTick();
+  await nextTick();
+}

--- a/tests/components/composer/composer_selection_mode.test.ts
+++ b/tests/components/composer/composer_selection_mode.test.ts
@@ -1,0 +1,144 @@
+import { Spreadsheet } from "../../../src";
+import { Model } from "../../../src/model";
+import {
+  makeTestFixture,
+  mountSpreadsheet,
+  startGridComposition,
+  typeInComposerGrid as typeInComposerGridHelper,
+} from "../../test_helpers/helpers";
+import { ContentEditableHelper } from "../__mocks__/content_editable_helper";
+
+jest.mock("../../../src/components/composer/content_editable_helper", () =>
+  require("../__mocks__/content_editable_helper")
+);
+
+let model: Model;
+let composerEl: Element;
+let fixture: HTMLElement;
+let parent: Spreadsheet;
+let cehMock: ContentEditableHelper;
+
+async function startComposition(key?: string) {
+  const composerEl = await startGridComposition(key);
+  // @ts-ignore
+  cehMock = window.mockContentHelper;
+  return composerEl;
+}
+
+async function typeInComposerGrid(text: string, fromScratch: boolean = true) {
+  const composerEl = await typeInComposerGridHelper(text, fromScratch);
+  // @ts-ignore
+  cehMock = window.mockContentHelper;
+  return composerEl;
+}
+
+beforeEach(async () => {
+  fixture = makeTestFixture();
+  parent = await mountSpreadsheet(fixture);
+  model = parent.model;
+});
+
+afterEach(() => {
+  parent.destroy();
+  fixture.remove();
+});
+
+describe("change selecting mode when typing specific token value", () => {
+  const matchingValues = [",", "+", "*", "="];
+  const mismatchingValues = ["1", '"coucou"', "TRUE", "SUM", "A2"];
+  const formulas = ["=", "=SUM("];
+
+  describe.each(formulas)("typing %s followed by", (formula) => {
+    test.each(matchingValues.concat(["("]))(
+      "a matching value --> activate 'waitingForRangeSelection' mode",
+      async (matchingValue) => {
+        const content = formula + matchingValue;
+        await startComposition();
+        composerEl = await typeInComposerGrid(content);
+        expect(model.getters.getEditionMode()).toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(content);
+        expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
+        expect(cehMock.selectionState.position).toBe(content.length);
+      }
+    );
+
+    test.each(mismatchingValues.concat([")"]))(
+      "a mismatching value --> not activate 'waitingForRangeSelection' mode",
+      async (mismatchingValue) => {
+        const content = formula + mismatchingValue;
+        await startComposition();
+        composerEl = await typeInComposerGrid(content);
+        expect(model.getters.getEditionMode()).not.toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(content);
+        expect(cehMock.selectionState.isSelectingRange).toBeFalsy();
+      }
+    );
+
+    test.each(matchingValues.concat(["("]))(
+      "a matching value & spaces --> activate 'waitingForRangeSelection' mode",
+      async (matchingValue) => {
+        const content = formula + matchingValue;
+        const newContent = content + "   ";
+        await startComposition();
+        composerEl = await typeInComposerGrid(newContent);
+        expect(model.getters.getEditionMode()).toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(newContent);
+        expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
+        expect(cehMock.selectionState.position).toBe(newContent.length);
+      }
+    );
+
+    test.each(mismatchingValues.concat([")"]))(
+      "a mismatching value & spaces --> not activate 'waitingForRangeSelection' mode",
+      async (mismatchingValue) => {
+        const content = formula + mismatchingValue;
+        await startComposition();
+        composerEl = await typeInComposerGrid(content + "   ");
+        expect(model.getters.getEditionMode()).not.toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(content + "   ");
+        expect(cehMock.selectionState.isSelectingRange).toBeFalsy();
+      }
+    );
+
+    test.each(mismatchingValues.concat([")"]))(
+      "a UNKNOWN token & a matching value --> not activate 'waitingForRangeSelection' mode",
+      async (matchingValue) => {
+        const content = formula + "'" + matchingValue;
+        await startComposition();
+        composerEl = await typeInComposerGrid(content);
+        expect(model.getters.getEditionMode()).not.toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(content);
+      }
+    );
+  });
+
+  test.each([",", "+", "*", ")", "("])(
+    "typing a matching values (except '=') --> not activate 'waitingForRangeSelection' mode",
+    async (value) => {
+      await startComposition();
+      composerEl = await typeInComposerGrid(value);
+      expect(model.getters.getEditionMode()).not.toBe("waitingForRangeSelection");
+      expect(cehMock.selectionState.isSelectingRange).toBeFalsy();
+      expect(composerEl.textContent).toBe(value);
+    }
+  );
+
+  test("typing '='--> activate 'waitingForRangeSelection' mode", async () => {
+    await startComposition();
+    composerEl = await typeInComposerGrid("=");
+    expect(model.getters.getEditionMode()).toBe("waitingForRangeSelection");
+    expect(composerEl.textContent).toBe("=");
+    expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
+    expect(cehMock.selectionState.position).toBe(1);
+  });
+
+  test("typing '=' & spaces --> activate 'waitingForRangeSelection' mode", async () => {
+    await startComposition();
+    const content = "=   ";
+    composerEl = await typeInComposerGrid(content);
+    expect(model.getters.getEditionMode()).toBe("waitingForRangeSelection");
+    expect(composerEl.textContent).toBe("=   ");
+    expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
+    expect(cehMock.selectionState.position).toBe(content.length);
+  });
+});

--- a/tests/components/composer/composer_selection_mode2.test.ts
+++ b/tests/components/composer/composer_selection_mode2.test.ts
@@ -1,0 +1,140 @@
+import { Spreadsheet } from "../../../src";
+import { Model } from "../../../src/model";
+import {
+  makeTestFixture,
+  mountSpreadsheet,
+  nextTick,
+  startGridComposition,
+  typeInComposerGrid as typeInComposerGridHelper,
+} from "../../test_helpers/helpers";
+import { ContentEditableHelper } from "../__mocks__/content_editable_helper";
+
+jest.mock("../../../src/components/composer/content_editable_helper", () =>
+  require("../__mocks__/content_editable_helper")
+);
+
+let model: Model;
+let composerEl: Element;
+let fixture: HTMLElement;
+let parent: Spreadsheet;
+let cehMock: ContentEditableHelper;
+
+async function startComposition(key?: string) {
+  const composerEl = await startGridComposition(key);
+  // @ts-ignore
+  cehMock = window.mockContentHelper;
+  return composerEl;
+}
+
+async function typeInComposerGrid(text: string, fromScratch: boolean = true) {
+  const composerEl = await typeInComposerGridHelper(text, fromScratch);
+  // @ts-ignore
+  cehMock = window.mockContentHelper;
+  return composerEl;
+}
+
+beforeEach(async () => {
+  fixture = makeTestFixture();
+  parent = await mountSpreadsheet(fixture);
+  model = parent.model;
+});
+
+afterEach(() => {
+  parent.destroy();
+  fixture.remove();
+});
+
+describe("change selecting mode when typing specific token value", () => {
+  const matchingValues = [",", "+", "*", "="];
+  const mismatchingValues = ["1", '"coucou"', "TRUE", "SUM", "A2"];
+  const formulas = ["=", "=SUM("];
+
+  async function moveToStart() {
+    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 0, end: 0 });
+    await nextTick();
+    model.dispatch("STOP_COMPOSER_RANGE_SELECTION");
+    await nextTick();
+  }
+  describe.each(formulas)("typing %s followed by", (formula) => {
+    test.each(matchingValues.concat([")"]))(
+      "a matching value & located before matching value --> activate 'waitingForRangeSelection' mode",
+      async (matchingValue) => {
+        await startComposition();
+        await typeInComposerGrid(matchingValue);
+        await moveToStart();
+        composerEl = await typeInComposerGrid(formula + ",");
+        expect(model.getters.getEditionMode()).toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(formula + "," + matchingValue);
+        expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
+        expect(cehMock.selectionState.position).toBe((formula + ",").length);
+      }
+    );
+
+    test.each(mismatchingValues.concat(["("]))(
+      "a matching value & located before mismatching value --> not activate 'waitingForRangeSelection' mode",
+      async (mismatchingValue) => {
+        await startComposition();
+        await typeInComposerGrid(mismatchingValue);
+        await moveToStart();
+        composerEl = await typeInComposerGrid(formula + ",");
+        expect(model.getters.getEditionMode()).not.toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(formula + "," + mismatchingValue);
+      }
+    );
+
+    test.each(matchingValues.concat([")"]))(
+      "a matching value & spaces & located before matching value --> activate 'waitingForRangeSelection' mode",
+      async (matchingValue) => {
+        await startComposition();
+        await typeInComposerGrid(matchingValue);
+        await moveToStart();
+        const formulaInput = formula + ",  ";
+        composerEl = await typeInComposerGrid(formulaInput);
+        expect(model.getters.getEditionMode()).toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(formulaInput + matchingValue);
+        expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
+        expect(cehMock.selectionState.position).toBe(formulaInput.length);
+      }
+    );
+
+    test.each(mismatchingValues.concat(["("]))(
+      "a matching value & spaces & located before mismatching value --> not activate 'waitingForRangeSelection' mode",
+      async (mismatchingValue) => {
+        await startComposition();
+        await typeInComposerGrid(mismatchingValue);
+        await moveToStart();
+        composerEl = await typeInComposerGrid(formula + ",  ");
+        expect(model.getters.getEditionMode()).not.toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(formula + ",  " + mismatchingValue);
+        expect(cehMock.selectionState.isSelectingRange).toBeFalsy();
+      }
+    );
+
+    test.each(matchingValues.concat([")"]))(
+      "a matching value & located before spaces & matching value --> activate 'waitingForRangeSelection' mode",
+      async (matchingValue) => {
+        await startComposition();
+        await typeInComposerGrid("   " + matchingValue);
+        await moveToStart();
+        composerEl = await typeInComposerGrid(formula + ",");
+        expect(model.getters.getEditionMode()).toBe("waitingForRangeSelection");
+        expect(composerEl.textContent).toBe(formula + ",   " + matchingValue);
+        expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
+        expect(cehMock.selectionState.position).toBe((formula + ",").length);
+      }
+    );
+
+    test.each(mismatchingValues.concat(["("]))(
+      "a matching value & located before spaces & mismatching value --> not activate 'waitingForRangeSelection' mode",
+      async (mismatchingValue) => {
+        await startComposition();
+        await typeInComposerGrid("   " + mismatchingValue);
+        await moveToStart();
+        composerEl = await typeInComposerGrid(formula + ",");
+        expect(model.getters.getEditionMode()).not.toBe("waitingForRangeSelection");
+        expect(cehMock.selectionState.isSelectingRange).toBeFalsy();
+        expect(composerEl.textContent).toBe(formula + ",   " + mismatchingValue);
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Description:

The tests of the composer takes a long long time, and most of it is spent
in await nextTick(). The main problem is that jest runs all the tests
sequentially. We can speed up the testing by splitting the composer tests
into multiple test files, so jest run them in parallel.

The slow tests might be a windows-specific issue.

I went from ~55sec for npm run test to ~30sec.

Odoo task ID : [4720](https://www.odoo.com/web#id=4720&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] feature is organized in plugin, or UI components
- [x] exportable in excel
- [x] importable from excel
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] new/updated/removed commands are documented
- [x] track breaking changes
- [x] public API change (index.ts) must rebuild doc (npm run doc)
- [x] code is prettified with prettier (in each commit, no separate commit)
- [x] status is correct in Odoo
