### PR TITLE
[IMP] keyboard shortcuts: move/alter selection to next cluster

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -294,7 +294,7 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
 
     const direction = ev.shiftKey ? "left" : "right";
     this.env.model.dispatch("STOP_EDITION");
-    this.env.model.selection.moveAnchorCell(direction);
+    this.env.model.selection.moveAnchorCell(direction, "one");
   }
 
   private processEnterKey(ev: KeyboardEvent) {
@@ -310,7 +310,7 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
     }
     this.env.model.dispatch("STOP_EDITION");
     const direction = ev.shiftKey ? "up" : "down";
-    this.env.model.selection.moveAnchorCell(direction);
+    this.env.model.selection.moveAnchorCell(direction, "one");
   }
 
   private processEscapeKey() {

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -465,8 +465,8 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         ? this.props.onGridComposerCellFocused()
         : this.props.onComposerContentFocused();
     },
-    TAB: () => this.env.model.selection.moveAnchorCell("right"),
-    "SHIFT+TAB": () => this.env.model.selection.moveAnchorCell("left"),
+    TAB: () => this.env.model.selection.moveAnchorCell("right", "one"),
+    "SHIFT+TAB": () => this.env.model.selection.moveAnchorCell("left", "one"),
     F2: () => {
       const cell = this.env.model.getters.getActiveCell();
       !cell || cell.isEmpty()
@@ -848,7 +848,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     const { direction, delta } = arrowMap[ev.key];
     if (ev.shiftKey) {
       const oldZone = this.env.model.getters.getSelectedZone();
-      this.env.model.selection.resizeAnchorZone(direction);
+      this.env.model.selection.resizeAnchorZone(direction, ev.ctrlKey ? "end" : "one");
       const newZone = this.env.model.getters.getSelectedZone();
       const viewport = this.env.model.getters.getActiveSnappedViewport();
       const sheet = this.env.model.getters.getActiveSheet();
@@ -865,7 +865,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         });
       }
     } else {
-      this.env.model.selection.moveAnchorCell(direction);
+      this.env.model.selection.moveAnchorCell(direction, ev.ctrlKey ? "end" : "one");
     }
 
     if (this.env.model.getters.isPaintingFormat()) {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -7,11 +7,11 @@ import {
   ChartUIDefinitionUpdate,
   ConditionalFormat,
   Figure,
-  Increment,
   Style,
   Zone,
 } from "./index";
 import { Border, CellPosition, ClipboardOptions, Dimension, UID } from "./misc";
+import { SelectionDirection, SelectionStep } from "./selection";
 
 // -----------------------------------------------------------------------------
 // Grid commands
@@ -488,7 +488,8 @@ export interface SelectAllCommand {
 
 export interface AlterSelectionCommand {
   type: "ALTER_SELECTION";
-  delta?: [Increment, Increment];
+  direction?: SelectionDirection;
+  step?: SelectionStep;
   cell?: [number, number];
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,4 +22,5 @@ export * from "./getters";
 export * from "./history";
 export * from "./misc";
 export * from "./rendering";
+export * from "./selection";
 export * from "./workbook_data";

--- a/src/types/selection.ts
+++ b/src/types/selection.ts
@@ -1,1 +1,3 @@
 export type SelectionDirection = "up" | "down" | "left" | "right";
+
+export type SelectionStep = "one" | "end";

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -12,7 +12,7 @@ import {
   UID,
   UpDown,
 } from "../../src/types";
-import { SelectionDirection } from "../../src/types/selection";
+import { SelectionDirection, SelectionStep } from "../../src/types/selection";
 import { target } from "./helpers";
 
 /**
@@ -344,12 +344,20 @@ export function selectCell(model: Model, xc: string): DispatchResult {
   return model.selection.selectCell(col, row);
 }
 
-export function moveAnchorCell(model: Model, direction: SelectionDirection): DispatchResult {
-  return model.selection.moveAnchorCell(direction);
+export function moveAnchorCell(
+  model: Model,
+  direction: SelectionDirection,
+  step: SelectionStep = "one"
+): DispatchResult {
+  return model.selection.moveAnchorCell(direction, step);
 }
 
-export function resizeAnchorZone(model: Model, direction: SelectionDirection): DispatchResult {
-  return model.selection.resizeAnchorZone(direction);
+export function resizeAnchorZone(
+  model: Model,
+  direction: SelectionDirection,
+  step: SelectionStep = "one"
+): DispatchResult {
+  return model.selection.resizeAnchorZone(direction, step);
 }
 
 export function setAnchorCorner(model: Model, xc: string): DispatchResult {


### PR DESCRIPTION
## Description:

Adds the possibility to move/alter the selection to the next
non-null cluster boundary.
e.g.
   -----------------------------
 /  A  B   C   D   E   F   G
1 :| x | y | z | / | / | f | g |
   -----------------------------

assume moving right:

A1 > C1 > F1 > G1
B1 > C1 > F1 > G1
D1 > F1 > G1
E1 > F1 > G1

The shortcuts are the following:

Ctrl + Down arrow: Jump to the next "non-null cell cluster bound" down
Ctrl + Left arrow: Jump to the next "non-null cell cluster bound" left
Ctrl + Right arrow: Jump to the next "non-null cell cluster bound" right
Ctrl + Up arrow: Jump to the next "non-null cell cluster bound" up

Simply loop through positions in the grid to find the next empty cell (or non-empty
depending on the mode) .

Odoo task ID : [2628623](https://www.odoo.com/web#id=2628623&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
