### PR TITLE
[FIX] compiler: Add missing semicolon + code readability

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -275,7 +275,7 @@ export function compile(str: NormalizedFormula): CompiledFormula {
           const args = compileFunctionArgs(ast);
           codeBlocks.push(splitCodeLines(args.map((arg) => arg.code)).join("\n"));
           fnName = ast.value.toUpperCase();
-          codeBlocks.push(`ctx.__lastFnCalled = '${fnName}'`);
+          codeBlocks.push(`ctx.__lastFnCalled = '${fnName}';`);
           statement = `ctx['${fnName}'](${args.map((arg) => arg.id)})`;
           break;
         case "UNARY_OPERATION": {
@@ -285,7 +285,7 @@ export function compile(str: NormalizedFormula): CompiledFormula {
             functionName: fnName,
           });
           codeBlocks.push(right.code);
-          codeBlocks.push(`ctx.__lastFnCalled = '${fnName}'`);
+          codeBlocks.push(`ctx.__lastFnCalled = '${fnName}';`);
           statement = `ctx['${fnName}']( ${right.id})`;
           break;
         }
@@ -300,7 +300,7 @@ export function compile(str: NormalizedFormula): CompiledFormula {
           });
           codeBlocks.push(left.code);
           codeBlocks.push(right.code);
-          codeBlocks.push(`ctx.__lastFnCalled = '${fnName}'`);
+          codeBlocks.push(`ctx.__lastFnCalled = '${fnName}';`);
           statement = `ctx['${fnName}'](${left.id}, ${right.id})`;
           break;
         }
@@ -313,15 +313,14 @@ export function compile(str: NormalizedFormula): CompiledFormula {
           break;
       }
       if (isLazy) {
-        // prettier-ignore
         const lazyFunction =
-`const _${id} = () => {
-	${splitCodeLines(codeBlocks).join("\n\t")}
-	return ${statement};
-}`;
+          `const _${id} = () => {\n` +
+          `\t${splitCodeLines(codeBlocks).join("\n\t")}\n` +
+          `\treturn ${statement};\n` +
+          "}";
         return { id: `_${id}`, code: lazyFunction };
       } else {
-        codeBlocks.push(`let _${id} = ` + statement);
+        codeBlocks.push(`let _${id} = ${statement};`);
         return { id: `_${id}`, code: splitCodeLines(codeBlocks).join("\n") };
       }
     }

--- a/tests/formulas/__snapshots__/compiler.test.ts.snap
+++ b/tests/formulas/__snapshots__/compiler.test.ts.snap
@@ -7,8 +7,8 @@ exports[`compile functions with lazy arguments functions call requesting lazy pa
 const _2 = () => {
 	return 24;
 }
-ctx.__lastFnCalled = 'USELAZYARG'
-let _1 = ctx['USELAZYARG'](_2)
+ctx.__lastFnCalled = 'USELAZYARG';
+let _1 = ctx['USELAZYARG'](_2);
 return _1;
 }"
 `;
@@ -18,11 +18,11 @@ exports[`compile functions with lazy arguments functions call requesting lazy pa
 ) {
 // =USELAZYARG(1/0)
 const _2 = () => {
-	ctx.__lastFnCalled = 'DIVIDE'
+	ctx.__lastFnCalled = 'DIVIDE';
 	return ctx['DIVIDE'](1, 0);
 }
-ctx.__lastFnCalled = 'USELAZYARG'
-let _1 = ctx['USELAZYARG'](_2)
+ctx.__lastFnCalled = 'USELAZYARG';
+let _1 = ctx['USELAZYARG'](_2);
 return _1;
 }"
 `;
@@ -32,13 +32,13 @@ exports[`compile functions with lazy arguments functions call requesting lazy pa
 ) {
 // =USELAZYARG(1/1/0)
 const _2 = () => {
-	ctx.__lastFnCalled = 'DIVIDE'
-	let _3 = ctx['DIVIDE'](1, 1)
-	ctx.__lastFnCalled = 'DIVIDE'
+	ctx.__lastFnCalled = 'DIVIDE';
+	let _3 = ctx['DIVIDE'](1, 1);
+	ctx.__lastFnCalled = 'DIVIDE';
 	return ctx['DIVIDE'](_3, 0);
 }
-ctx.__lastFnCalled = 'USELAZYARG'
-let _1 = ctx['USELAZYARG'](_2)
+ctx.__lastFnCalled = 'USELAZYARG';
+let _1 = ctx['USELAZYARG'](_2);
 return _1;
 }"
 `;
@@ -51,11 +51,11 @@ const _2 = () => {
 	const _3 = () => {
 		return 24;
 	}
-	ctx.__lastFnCalled = 'USELAZYARG'
+	ctx.__lastFnCalled = 'USELAZYARG';
 	return ctx['USELAZYARG'](_3);
 }
-ctx.__lastFnCalled = 'USELAZYARG'
-let _1 = ctx['USELAZYARG'](_2)
+ctx.__lastFnCalled = 'USELAZYARG';
+let _1 = ctx['USELAZYARG'](_2);
 return _1;
 }"
 `;
@@ -64,9 +64,9 @@ exports[`compile functions with meta arguments function call requesting meta par
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =USEMETAARG(|0|)
-let _2 = ref(0, deps, sheetId, true, \\"USEMETAARG\\",  1)
-ctx.__lastFnCalled = 'USEMETAARG'
-let _1 = ctx['USEMETAARG'](_2)
+let _2 = ref(0, deps, sheetId, true, \\"USEMETAARG\\",  1);
+ctx.__lastFnCalled = 'USEMETAARG';
+let _1 = ctx['USEMETAARG'](_2);
 return _1;
 }"
 `;
@@ -75,9 +75,9 @@ exports[`compile functions with meta arguments function call requesting meta par
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =USEMETAARG(|0|)
-let _2 = ref(0, deps, sheetId, true, \\"USEMETAARG\\",  1)
-ctx.__lastFnCalled = 'USEMETAARG'
-let _1 = ctx['USEMETAARG'](_2)
+let _2 = ref(0, deps, sheetId, true, \\"USEMETAARG\\",  1);
+ctx.__lastFnCalled = 'USEMETAARG';
+let _1 = ctx['USEMETAARG'](_2);
 return _1;
 }"
 `;
@@ -86,9 +86,9 @@ exports[`expression compiler cells are converted to ranges if function require a
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =sum(|0|)
-let _2 = range(0, deps, sheetId)
-ctx.__lastFnCalled = 'SUM'
-let _1 = ctx['SUM'](_2)
+let _2 = range(0, deps, sheetId);
+ctx.__lastFnCalled = 'SUM';
+let _1 = ctx['SUM'](_2);
 return _1;
 }"
 `;
@@ -97,13 +97,13 @@ exports[`expression compiler expression with $ref 1`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =|0|+|1|+|2|
-let _3 = ref(0, deps, sheetId, false, \\"ADD\\",  undefined)
-let _4 = ref(1, deps, sheetId, false, \\"ADD\\",  undefined)
-ctx.__lastFnCalled = 'ADD'
-let _2 = ctx['ADD'](_3, _4)
-let _5 = ref(2, deps, sheetId, false, \\"ADD\\",  undefined)
-ctx.__lastFnCalled = 'ADD'
-let _1 = ctx['ADD'](_2, _5)
+let _3 = ref(0, deps, sheetId, false, \\"ADD\\",  undefined);
+let _4 = ref(1, deps, sheetId, false, \\"ADD\\",  undefined);
+ctx.__lastFnCalled = 'ADD';
+let _2 = ctx['ADD'](_3, _4);
+let _5 = ref(2, deps, sheetId, false, \\"ADD\\",  undefined);
+ctx.__lastFnCalled = 'ADD';
+let _1 = ctx['ADD'](_2, _5);
 return _1;
 }"
 `;
@@ -112,7 +112,7 @@ exports[`expression compiler expression with references with a sheet 1`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =|0|
-let _1 = ref(0, deps, sheetId, false, \\"EQ\\",  undefined)
+let _1 = ref(0, deps, sheetId, false, \\"EQ\\",  undefined);
 return _1;
 }"
 `;
@@ -122,9 +122,9 @@ exports[`expression compiler expressions with a debugger 1`] = `
 ) {
 // =? |0| / 2
 debugger;
-let _2 = ref(0, deps, sheetId, false, \\"DIVIDE\\",  undefined)
-ctx.__lastFnCalled = 'DIVIDE'
-let _1 = ctx['DIVIDE'](_2, 2)
+let _2 = ref(0, deps, sheetId, false, \\"DIVIDE\\",  undefined);
+ctx.__lastFnCalled = 'DIVIDE';
+let _1 = ctx['DIVIDE'](_2, 2);
 return _1;
 }"
 `;
@@ -133,12 +133,12 @@ exports[`expression compiler read some values and functions 1`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =|0| + sum(|1|)
-let _2 = ref(0, deps, sheetId, false, \\"ADD\\",  undefined)
-let _4 = range(1, deps, sheetId)
-ctx.__lastFnCalled = 'SUM'
-let _3 = ctx['SUM'](_4)
-ctx.__lastFnCalled = 'ADD'
-let _1 = ctx['ADD'](_2, _3)
+let _2 = ref(0, deps, sheetId, false, \\"ADD\\",  undefined);
+let _4 = range(1, deps, sheetId);
+ctx.__lastFnCalled = 'SUM';
+let _3 = ctx['SUM'](_4);
+ctx.__lastFnCalled = 'ADD';
+let _1 = ctx['ADD'](_2, _3);
 return _1;
 }"
 `;
@@ -171,8 +171,8 @@ exports[`expression compiler some arithmetic expressions 4`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =1 + 3
-ctx.__lastFnCalled = 'ADD'
-let _1 = ctx['ADD'](1, 3)
+ctx.__lastFnCalled = 'ADD';
+let _1 = ctx['ADD'](1, 3);
 return _1;
 }"
 `;
@@ -181,8 +181,8 @@ exports[`expression compiler some arithmetic expressions 5`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =2 * 3
-ctx.__lastFnCalled = 'MULTIPLY'
-let _1 = ctx['MULTIPLY'](2, 3)
+ctx.__lastFnCalled = 'MULTIPLY';
+let _1 = ctx['MULTIPLY'](2, 3);
 return _1;
 }"
 `;
@@ -191,8 +191,8 @@ exports[`expression compiler some arithmetic expressions 6`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =2 - 3
-ctx.__lastFnCalled = 'MINUS'
-let _1 = ctx['MINUS'](2, 3)
+ctx.__lastFnCalled = 'MINUS';
+let _1 = ctx['MINUS'](2, 3);
 return _1;
 }"
 `;
@@ -201,8 +201,8 @@ exports[`expression compiler some arithmetic expressions 7`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =2 / 3
-ctx.__lastFnCalled = 'DIVIDE'
-let _1 = ctx['DIVIDE'](2, 3)
+ctx.__lastFnCalled = 'DIVIDE';
+let _1 = ctx['DIVIDE'](2, 3);
 return _1;
 }"
 `;
@@ -211,8 +211,8 @@ exports[`expression compiler some arithmetic expressions 8`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =-3
-ctx.__lastFnCalled = 'UMINUS'
-let _1 = ctx['UMINUS']( 3)
+ctx.__lastFnCalled = 'UMINUS';
+let _1 = ctx['UMINUS']( 3);
 return _1;
 }"
 `;
@@ -221,14 +221,14 @@ exports[`expression compiler some arithmetic expressions 9`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =(3 + 1) * (-1 + 4)
-ctx.__lastFnCalled = 'ADD'
-let _2 = ctx['ADD'](3, 1)
-ctx.__lastFnCalled = 'UMINUS'
-let _4 = ctx['UMINUS']( 1)
-ctx.__lastFnCalled = 'ADD'
-let _3 = ctx['ADD'](_4, 4)
-ctx.__lastFnCalled = 'MULTIPLY'
-let _1 = ctx['MULTIPLY'](_2, _3)
+ctx.__lastFnCalled = 'ADD';
+let _2 = ctx['ADD'](3, 1);
+ctx.__lastFnCalled = 'UMINUS';
+let _4 = ctx['UMINUS']( 1);
+ctx.__lastFnCalled = 'ADD';
+let _3 = ctx['ADD'](_4, 4);
+ctx.__lastFnCalled = 'MULTIPLY';
+let _1 = ctx['MULTIPLY'](_2, _3);
 return _1;
 }"
 `;
@@ -237,8 +237,8 @@ exports[`expression compiler some arithmetic expressions 10`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =sum(1,2)
-ctx.__lastFnCalled = 'SUM'
-let _1 = ctx['SUM'](1,2)
+ctx.__lastFnCalled = 'SUM';
+let _1 = ctx['SUM'](1,2);
 return _1;
 }"
 `;
@@ -247,8 +247,8 @@ exports[`expression compiler some arithmetic expressions 11`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =sum(true, \\"\\")
-ctx.__lastFnCalled = 'SUM'
-let _1 = ctx['SUM'](true,\\"\\")
+ctx.__lastFnCalled = 'SUM';
+let _1 = ctx['SUM'](true,\\"\\");
 return _1;
 }"
 `;
@@ -257,8 +257,8 @@ exports[`expression compiler some arithmetic expressions 12`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {
 // =sum(1,,2)
-ctx.__lastFnCalled = 'SUM'
-let _1 = ctx['SUM'](1,undefined,2)
+ctx.__lastFnCalled = 'SUM';
+let _1 = ctx['SUM'](1,undefined,2);
 return _1;
 }"
 `;


### PR DESCRIPTION
Added missing semicolon in the compiled code + rewrote some formatted
string to be "less" ugly and more explicit on their purpose.

Task 2728906

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
