### PR TITLE
[FIX] 15.0 Function with range out of sheet error

### DIFF
--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -84,6 +84,11 @@ describe("evaluateCells", () => {
     expect(evaluateCell("C1", grid)).toBe(1);
   });
 
+  test("With cell outside of sheet", () => {
+    const grid = { C1: "=SUM(A11111,AAA1)" };
+    expect(evaluateCell("C1", grid)).toBe(0);
+  });
+
   test("handling some errors", () => {
     const grid = { A1: "=A1", A2: "=A1", A3: "=+", A4: "=1 + A3", A5: "=sum('asdf')" };
     const result = evaluateGrid(grid);
@@ -187,6 +192,21 @@ describe("evaluateCells", () => {
     setCellContent(model, "A1", "=sum(A2:Z10)");
 
     expect(getCell(model, "A1")!.evaluated.value).toBe(42);
+  });
+
+  test("range partially outside of sheet", () => {
+    const model = new Model();
+    setCellContent(model, "D4", "42");
+    setCellContent(model, "A1", "=sum(B2:AZ999)");
+
+    expect(getCell(model, "A1")!.evaluated.value).toBe(42);
+  });
+
+  test("range totally outside of sheet", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=sum(AB1:AZ999)");
+
+    expect(getCell(model, "A1")!.evaluated.value).toBe(0);
   });
 
   test("=Range", () => {


### PR DESCRIPTION
## Description:

=SUM(AA1) (with AA1 outside of sheet) had an error at the evaluation.
The expected behaviour is to have =0.

This happened because the _range function of evaluation.ts threw an error
when receiving a range outside of the sheet.

Now the _range function returns an array with undefined instead of throwing
an error.

Odoo task ID : [2722593](https://www.odoo.com/web#id=2722593&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
