### PR TITLE
[FIX] viewport,grid: prevent scrolling loop

### DIFF
--- a/src/components/autofill.ts
+++ b/src/components/autofill.ts
@@ -98,7 +98,7 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
   onMouseDown(ev: MouseEvent) {
     this.state.handler = true;
     this.state.position = { left: 0, top: 0 };
-    const { offsetY, offsetX } = this.env.model.getters.getActiveSnappedViewport();
+    const { offsetY, offsetX } = this.env.model.getters.getActiveViewport();
     const start = {
       left: ev.clientX + offsetX,
       top: ev.clientY + offsetY,
@@ -118,7 +118,7 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
         left: viewportLeft,
         offsetY,
         offsetX,
-      } = this.env.model.getters.getActiveSnappedViewport();
+      } = this.env.model.getters.getActiveViewport();
       this.state.position = {
         left: ev.clientX - start.left + offsetX,
         top: ev.clientY - start.top + offsetY,

--- a/src/components/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag.ts
@@ -38,7 +38,7 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
 
   get tagStyle(): string {
     const { col, row, color } = this.props;
-    const viewport = this.env.model.getters.getActiveSnappedViewport();
+    const viewport = this.env.model.getters.getActiveViewport();
     const { height } = this.env.model.getters.getViewportDimensionWithHeaders();
     const [x, y, ,] = this.env.model.getters.getRect(
       { left: col, top: row, right: col, bottom: row },

--- a/src/components/composer/grid_composer.ts
+++ b/src/components/composer/grid_composer.ts
@@ -77,7 +77,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     });
     this.rect = this.env.model.getters.getRect(
       this.zone,
-      this.env.model.getters.getActiveSnappedViewport()
+      this.env.model.getters.getActiveViewport()
     );
     onMounted(() => {
       const el = this.gridComposerRef.el!;

--- a/src/components/figures/container.ts
+++ b/src/components/figures/container.ts
@@ -163,7 +163,7 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
 
   getStyle(info: FigureInfo) {
     const { figure, isSelected } = info;
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
     const target = figure.id === (isSelected && this.dnd.figureId) ? this.dnd : figure;
     const { width, height } = target;
     let x = target.x - offsetX + HEADER_WIDTH - 1;

--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -47,26 +47,33 @@ export function dragAndDropBeyondTheViewport(
     const offsetY = currentEv.clientY - position.top;
     const edgeScrollInfoX = env.model.getters.getEdgeScrollCol(offsetX);
     const edgeScrollInfoY = env.model.getters.getEdgeScrollRow(offsetY);
-    const { top, left, bottom, right } = env.model.getters.getActiveSnappedViewport();
+    const {
+      top,
+      left,
+      bottom,
+      right,
+      offsetX: viewportOffsetX,
+      offsetY: viewportOffsetY,
+    } = env.model.getters.getActiveViewport();
 
     let colIndex: number;
     if (edgeScrollInfoX.canEdgeScroll) {
       colIndex = edgeScrollInfoX.direction > 0 ? right : left - 1;
     } else {
-      colIndex = env.model.getters.getColIndex(offsetX, left);
+      colIndex = env.model.getters.getColIndex(offsetX, viewportOffsetX);
     }
 
     let rowIndex: number;
     if (edgeScrollInfoY.canEdgeScroll) {
       rowIndex = edgeScrollInfoY.direction > 0 ? bottom : top - 1;
     } else {
-      rowIndex = env.model.getters.getRowIndex(offsetY, top);
+      rowIndex = env.model.getters.getRowIndex(offsetY, viewportOffsetY);
     }
 
     cbMouseMove(colIndex, rowIndex);
 
     if (edgeScrollInfoX.canEdgeScroll) {
-      const { left, offsetY } = env.model.getters.getActiveSnappedViewport();
+      const { left, offsetY } = env.model.getters.getActiveViewport();
       const { cols } = env.model.getters.getActiveSheet();
       const offsetX = cols[left + edgeScrollInfoX.direction].start;
       env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
@@ -77,7 +84,7 @@ export function dragAndDropBeyondTheViewport(
     }
 
     if (edgeScrollInfoY.canEdgeScroll) {
-      const { top, offsetX } = env.model.getters.getActiveSnappedViewport();
+      const { top, offsetX } = env.model.getters.getActiveViewport();
       const { rows } = env.model.getters.getActiveSheet();
       const offsetY = rows[top + edgeScrollInfoY.direction].start;
       env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });

--- a/src/components/highlight/border.ts
+++ b/src/components/highlight/border.ts
@@ -62,7 +62,7 @@ export class Border extends Component<Props, SpreadsheetChildEnv> {
     const widthValue = isHorizontal ? right - left : lineWidth;
     const heightValue = isVertical ? bottom - top : lineWidth;
 
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
     return `
         left:${leftValue + HEADER_WIDTH - offsetX}px;
         top:${topValue + HEADER_HEIGHT - offsetY}px;

--- a/src/components/highlight/corner.ts
+++ b/src/components/highlight/corner.ts
@@ -58,7 +58,7 @@ export class Corner extends Component<Props, SpreadsheetChildEnv> {
   private isLeft = this.props.orientation[1] === "w";
 
   get style() {
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
     const s = this.env.model.getters.getActiveSheet();
     const z = this.props.zone;
     const leftValue = this.isLeft ? s.cols[z.left].start : s.cols[z.right].end;

--- a/src/components/highlight/highlight.ts
+++ b/src/components/highlight/highlight.ts
@@ -105,11 +105,11 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
     const parent = this.highlightRef.el!.parentElement!;
     const position = parent.getBoundingClientRect();
     const activeSheet = this.env.model.getters.getActiveSheet();
-    const { top: viewportTop, left: viewportLeft } =
-      this.env.model.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
 
-    const initCol = this.env.model.getters.getColIndex(clientX - position.left, viewportLeft);
-    const initRow = this.env.model.getters.getRowIndex(clientY - position.top, viewportTop);
+    // TODO: probably false, should be offsetX and offsetY from viewport
+    const initCol = this.env.model.getters.getColIndex(clientX - position.left, offsetX);
+    const initRow = this.env.model.getters.getRowIndex(clientY - position.top, offsetY);
 
     const deltaColMin = -z.left;
     const deltaColMax = activeSheet.cols.length - z.right - 1;

--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -19,7 +19,12 @@ import * as icons from "./icons";
 // Resizer component
 // -----------------------------------------------------------------------------
 
-abstract class AbstractResizer extends Component<any, SpreadsheetChildEnv> {
+interface Props {
+  onOpenContextMenu: (type: ContextMenuType, x: number, y: number) => void;
+  onSetScrollbarValue: (offsetX: number, offsetY: number) => void;
+}
+
+abstract class AbstractResizer extends Component<Props, SpreadsheetChildEnv> {
   PADDING: number = 0;
   MAX_SIZE_MARGIN: number = 0;
   MIN_ELEMENT_SIZE: number = 0;
@@ -420,11 +425,11 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getStateOffset(): number {
-    return this.env.model.getters.getActiveSnappedViewport().offsetX - HEADER_WIDTH;
+    return this.env.model.getters.getActiveViewport().offsetX - HEADER_WIDTH;
   }
 
   _getViewportOffset(): number {
-    return this.env.model.getters.getActiveSnappedViewport().left;
+    return this.env.model.getters.getActiveViewport().left;
   }
 
   _getClientPosition(ev: MouseEvent): number {
@@ -434,7 +439,7 @@ export class ColResizer extends AbstractResizer {
   _getElementIndex(index: number): number {
     return this.env.model.getters.getColIndex(
       index,
-      this.env.model.getters.getActiveSnappedViewport().left
+      this.env.model.getters.getActiveViewport().offsetX
     );
   }
 
@@ -451,7 +456,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getBoundaries(): { first: number; last: number } {
-    const { left, right } = this.env.model.getters.getActiveSnappedViewport();
+    const { left, right } = this.env.model.getters.getActiveViewport();
     return { first: left, last: right };
   }
 
@@ -512,10 +517,10 @@ export class ColResizer extends AbstractResizer {
   }
 
   _adjustViewport(direction: number): void {
-    const { left, offsetY } = this.env.model.getters.getActiveSnappedViewport();
+    const { left, offsetY } = this.env.model.getters.getActiveViewport();
     const { cols } = this.env.model.getters.getActiveSheet();
     const offsetX = cols[left + direction].start;
-    this.env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
+    this.props.onSetScrollbarValue(offsetX, offsetY);
   }
 
   _fitElementSize(index: number): void {
@@ -668,11 +673,11 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getStateOffset(): number {
-    return this.env.model.getters.getActiveSnappedViewport().offsetY - HEADER_HEIGHT;
+    return this.env.model.getters.getActiveViewport().offsetY - HEADER_HEIGHT;
   }
 
   _getViewportOffset(): number {
-    return this.env.model.getters.getActiveSnappedViewport().top;
+    return this.env.model.getters.getActiveViewport().top;
   }
 
   _getClientPosition(ev: MouseEvent): number {
@@ -682,7 +687,7 @@ export class RowResizer extends AbstractResizer {
   _getElementIndex(index: number): number {
     return this.env.model.getters.getRowIndex(
       index,
-      this.env.model.getters.getActiveSnappedViewport().top
+      this.env.model.getters.getActiveViewport().offsetY
     );
   }
 
@@ -699,7 +704,7 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getBoundaries(): { first: number; last: number } {
-    const { top, bottom } = this.env.model.getters.getActiveSnappedViewport();
+    const { top, bottom } = this.env.model.getters.getActiveViewport();
     return { first: top, last: bottom };
   }
 
@@ -756,10 +761,10 @@ export class RowResizer extends AbstractResizer {
   }
 
   _adjustViewport(direction: number): void {
-    const { top, offsetX } = this.env.model.getters.getActiveSnappedViewport();
+    const { top, offsetX } = this.env.model.getters.getActiveViewport();
     const { rows } = this.env.model.getters.getActiveSheet();
     const offsetY = rows[top + direction].start;
-    this.env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
+    this.props.onSetScrollbarValue(offsetX, offsetY);
   }
 
   _fitElementSize(index: number): void {
@@ -821,11 +826,11 @@ css/* scss */ `
   }
 `;
 
-export class Overlay extends Component<any, SpreadsheetChildEnv> {
+export class Overlay extends Component<Props, SpreadsheetChildEnv> {
   static template = xml/* xml */ `
     <div class="o-overlay">
-      <ColResizer onOpenContextMenu="props.onOpenContextMenu" />
-      <RowResizer onOpenContextMenu="props.onOpenContextMenu" />
+      <ColResizer onOpenContextMenu="props.onOpenContextMenu" onSetScrollbarValue="props.onSetScrollbarValue"/>
+      <RowResizer onOpenContextMenu="props.onOpenContextMenu" onSetScrollbarValue="props.onSetScrollbarValue"/>
       <div class="all" t-on-mousedown.self="selectAll"/>
     </div>`;
 

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -1,4 +1,4 @@
-import { Position, Viewport, Zone, ZoneDimension } from "../types";
+import { Position, Zone, ZoneDimension } from "../types";
 import { toCartesian, toXC } from "./coordinates";
 import { range } from "./misc";
 
@@ -469,11 +469,7 @@ export function mergeOverlappingZones(zones: Zone[]) {
  * This function will compare the modifications of selection to determine
  * a cell that is part of the new zone and not the previous one.
  */
-export function findCellInNewZone(
-  oldZone: Zone,
-  currentZone: Zone,
-  viewport: Viewport
-): [number, number] {
+export function findCellInNewZone(oldZone: Zone, currentZone: Zone): [number, number] {
   let col: number, row: number;
   const { left: oldLeft, right: oldRight, top: oldTop, bottom: oldBottom } = oldZone!;
   const { left, right, top, bottom } = currentZone;
@@ -482,14 +478,14 @@ export function findCellInNewZone(
   } else if (right != oldRight) {
     col = right;
   } else {
-    col = viewport.left;
+    col = left;
   }
   if (top != oldTop) {
     row = top;
   } else if (bottom != oldBottom) {
     row = bottom;
   } else {
-    row = viewport.top;
+    row = top;
   }
   return [col, row];
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -437,7 +437,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
    * canvas and need to draw the grid on it.  This is then done by calling this
    * method, which will dispatch the call to all registered plugins.
    *
-   * Note that nothing prevent multiple grid components from calling this method
+   * Note that nothing prevents multiple grid components from calling this method
    * each, or one grid component calling it multiple times with a different
    * context. This is probably the way we should do if we want to be able to
    * freeze a part of the grid (so, we would need to render different zones)
@@ -445,7 +445,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   drawGrid(context: GridRenderingContext) {
     // we make sure here that the viewport is properly positioned: the offsets
     // correspond exactly to a cell
-    context.viewport = this.getters.getActiveSnappedViewport(); //snaped one
     for (let [renderer, layer] of this.renderers) {
       context.ctx.save();
       renderer.drawGrid(context, layer);

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -81,21 +81,21 @@ export class RendererPlugin extends UIPlugin {
    * Return the index of a column given an offset x and a visible left col index.
    * It returns -1 if no column is found.
    */
-  getColIndex(x: number, left: number, sheet?: Sheet): number {
+  getColIndex(x: number, offsetLeft: number, sheet?: Sheet): number {
     if (x < HEADER_WIDTH) {
       return -1;
     }
     const cols = (sheet || this.getters.getActiveSheet()).cols;
-    const adjustedX = x - HEADER_WIDTH + cols[left].start + 1;
+    const adjustedX = x - HEADER_WIDTH + offsetLeft + 1;
     return searchIndex(cols, adjustedX);
   }
 
-  getRowIndex(y: number, top: number, sheet?: Sheet): number {
+  getRowIndex(y: number, offsetTop: number, sheet?: Sheet): number {
     if (y < HEADER_HEIGHT) {
       return -1;
     }
     const rows = (sheet || this.getters.getActiveSheet()).rows;
-    const adjustedY = y - HEADER_HEIGHT + rows[top].start + 1;
+    const adjustedY = y - HEADER_HEIGHT + offsetTop + 1;
     return searchIndex(rows, adjustedY);
   }
 
@@ -124,7 +124,7 @@ export class RendererPlugin extends UIPlugin {
     let delay = 0;
     const { width } = this.getters.getViewportDimensionWithHeaders();
     const { width: gridWidth } = this.getters.getMaxViewportSize(this.getters.getActiveSheet());
-    const { left, offsetX } = this.getters.getActiveSnappedViewport();
+    const { left, offsetX } = this.getters.getActiveViewport();
     if (x < HEADER_WIDTH && left > 0) {
       canEdgeScroll = true;
       direction = -1;
@@ -144,7 +144,7 @@ export class RendererPlugin extends UIPlugin {
     let delay = 0;
     const { height } = this.getters.getViewportDimensionWithHeaders();
     const { height: gridHeight } = this.getters.getMaxViewportSize(this.getters.getActiveSheet());
-    const { top, offsetY } = this.getters.getActiveSnappedViewport();
+    const { top, offsetY } = this.getters.getActiveViewport();
     if (y < HEADER_HEIGHT && top > 0) {
       canEdgeScroll = true;
       direction = -1;
@@ -433,6 +433,12 @@ export class RendererPlugin extends UIPlugin {
       ctx.lineTo(HEADER_WIDTH, row.end - offsetY);
     }
 
+    ctx.stroke();
+
+    // draw over the text for the top-left rectangle
+    ctx.beginPath();
+    ctx.fillStyle = BACKGROUND_HEADER_COLOR;
+    ctx.fillRect(0, 0, HEADER_WIDTH, HEADER_HEIGHT);
     ctx.stroke();
   }
 

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -453,7 +453,7 @@ export class GridSelectionPlugin extends UIPlugin {
     const sheetId = this.getters.getActiveSheetId();
     const result: Figure[] = [];
     const figures = this.getters.getFigures(sheetId);
-    const { offsetX, offsetY } = this.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.getters.getActiveViewport();
     const { width, height } = this.getters.getViewportDimensionWithHeaders();
     for (let figure of figures) {
       if (figure.x >= offsetX + width || figure.x + figure.width <= offsetX) {

--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -28,16 +28,13 @@ interface ViewportPluginState {
  *
  * This plugin manages all things related to all viewport states.
  *
- * There are two types of viewports :
- *  1. The viewport related to the scrollbar absolute position
- *  2. The snappedViewport which represents the previous one but but 'snapped' to
- *     the col/row structure, so, the offsets are correct for computations necessary
- *     to align elements to the grid.
+ * The viewport is a representation of the current visible cells
+ * via a Zone and the the scrollbar absolute position (defined as offsetX and offsetY)
+ *
  */
 export class ViewportPlugin extends UIPlugin {
   static getters = [
     "getActiveViewport",
-    "getActiveSnappedViewport",
     "getViewportDimensionWithHeaders",
     "getMaxViewportSize",
     "getMaximumViewportOffset",
@@ -45,8 +42,6 @@ export class ViewportPlugin extends UIPlugin {
   static modes: Mode[] = ["normal"];
 
   readonly viewports: ViewportPluginState["viewports"] = {};
-  readonly snappedViewports: ViewportPluginState["viewports"] = {};
-  private updateSnap: boolean = false;
   /**
    * The viewport dimensions are usually set by one of the components
    * (i.e. when grid component is mounted) to properly reflect its state in the DOM.
@@ -80,22 +75,20 @@ export class ViewportPlugin extends UIPlugin {
       case "AlterZoneCorner":
         break;
       case "ZonesSelected":
+        const sheetId = this.getters.getActiveSheetId();
         if (event.mode === "updateAnchor") {
           // altering a zone should not move the viewport
-          const [col, row] = findCellInNewZone(
-            event.previousAnchor.zone,
-            event.anchor.zone,
-            this.getActiveSnappedViewport()
-          );
-          this.refreshViewport(this.getters.getActiveSheetId(), { col, row });
+          const [col, row] = findCellInNewZone(event.previousAnchor.zone, event.anchor.zone);
+          this.refreshViewport(sheetId, { col, row });
         } else {
-          this.refreshViewport(this.getters.getActiveSheetId());
+          this.refreshViewport(sheetId);
         }
         break;
     }
   }
 
   handle(cmd: Command) {
+    const sheetId = this.getters.getActiveSheetId();
     switch (cmd.type) {
       case "START":
         this.selection.observe(this, {
@@ -106,23 +99,30 @@ export class ViewportPlugin extends UIPlugin {
       case "REDO":
         this.cleanViewports();
         this.resetViewports();
+        this._scroll(sheetId);
         break;
       case "RESIZE_VIEWPORT":
         this.cleanViewports();
         this.resizeViewport(cmd.height, cmd.width);
+        this._scroll(sheetId);
         break;
       case "SET_VIEWPORT_OFFSET":
         this.setViewportOffset(cmd.offsetX, cmd.offsetY);
         break;
       case "SHIFT_VIEWPORT_DOWN":
+        const { maxOffsetY } = this.getMaximumViewportOffset(this.getters.getActiveSheet());
         const topRow = this.getActiveTopRow();
-        const shiftedOffsetY = this.clipOffsetY(topRow.start + this.viewportHeight);
-        this.shiftVertically(shiftedOffsetY);
+        const shiftedOffsetY = Math.min(maxOffsetY, topRow.start + this.viewportHeight);
+        const newRowIndex = this.getters.getRowIndex(shiftedOffsetY + HEADER_HEIGHT, 0);
+        this.shiftVertically(this.getters.getRow(sheetId, newRowIndex).start);
+        this._scroll(sheetId);
         break;
       case "SHIFT_VIEWPORT_UP": {
         const topRow = this.getActiveTopRow();
-        const shiftedOffsetY = this.clipOffsetY(topRow.end - this.viewportHeight);
-        this.shiftVertically(shiftedOffsetY);
+        const shiftedOffsetY = Math.max(topRow.end - this.viewportHeight, 0);
+        const newRowIndex = this.getters.getRowIndex(shiftedOffsetY + HEADER_HEIGHT, 0);
+        this.shiftVertically(this.getters.getRow(sheetId, newRowIndex).start);
+        this._scroll(sheetId);
         break;
       }
       case "REMOVE_COLUMNS_ROWS":
@@ -133,6 +133,7 @@ export class ViewportPlugin extends UIPlugin {
         } else {
           this.adjustViewportOffsetY(cmd.sheetId, this.getViewport(cmd.sheetId));
         }
+        this._scroll(sheetId);
         break;
       case "ADD_COLUMNS_ROWS":
       case "UNHIDE_COLUMNS_ROWS":
@@ -141,17 +142,12 @@ export class ViewportPlugin extends UIPlugin {
         } else {
           this.adjustViewportZoneY(cmd.sheetId, this.getViewport(cmd.sheetId));
         }
+        this._scroll(sheetId);
         break;
       case "ACTIVATE_SHEET":
         this.refreshViewport(cmd.sheetIdTo);
+        this._scroll(sheetId);
         break;
-    }
-  }
-
-  finalize() {
-    if (this.updateSnap) {
-      this.snapViewportToCell(this.getters.getActiveSheetId());
-      this.updateSnap = false;
     }
   }
 
@@ -169,11 +165,6 @@ export class ViewportPlugin extends UIPlugin {
   getActiveViewport(): Viewport {
     const sheetId = this.getters.getActiveSheetId();
     return this.getViewport(sheetId);
-  }
-
-  getActiveSnappedViewport(): Viewport {
-    const sheetId = this.getters.getActiveSheetId();
-    return this.getSnappedViewport(sheetId);
   }
 
   /**
@@ -213,6 +204,15 @@ export class ViewportPlugin extends UIPlugin {
   // Private
   // ---------------------------------------------------------------------------
 
+  /**
+   * Broadcasts the expected viewport scroll value following the alteration of a sheet structure.
+   * Meant to be caught by the rendering side to synchronize.
+   */
+  private _scroll(sheetId: UID) {
+    const { offsetX, offsetY } = this.getViewport(sheetId);
+    this.ui.notifyUI({ type: "SCROLL", offsetX, offsetY });
+  }
+
   private checkOffsetValidity(offsetX: number, offsetY: number): CommandResult {
     const sheet = this.getters.getActiveSheet();
     const { maxOffsetX, maxOffsetY } = this.getMaximumViewportOffset(sheet);
@@ -222,14 +222,11 @@ export class ViewportPlugin extends UIPlugin {
     return CommandResult.Success;
   }
 
-  private getSnappedViewport(sheetId: UID) {
-    this.snapViewportToCell(sheetId);
-    return this.snappedViewports[sheetId];
-  }
-
   private getViewport(sheetId: UID): Viewport {
     if (!this.viewports[sheetId]) {
-      return this.generateViewportState(sheetId);
+      const viewport = this.generateViewportState(sheetId);
+      this.adjustViewportZone(sheetId, viewport);
+      this.adjustViewportsPosition(sheetId);
     }
     return this.viewports[sheetId];
   }
@@ -254,7 +251,7 @@ export class ViewportPlugin extends UIPlugin {
   }
 
   /** Corrects the viewport's horizontal offset based on the current structure
-   *  To make sure that at least on column is visible inside the viewport.
+   *  To make sure that at least one column is visible inside the viewport.
    */
   private adjustViewportOffsetX(sheetId: UID, viewport: Viewport) {
     const { offsetX } = viewport;
@@ -267,7 +264,7 @@ export class ViewportPlugin extends UIPlugin {
   }
 
   /** Corrects the viewport's vertical offset based on the current structure
-   *  To make sure that at least on row is visible inside the viewport.
+   *  To make sure that at least one row is visible inside the viewport.
    */
   private adjustViewportOffsetY(sheetId: UID, viewport: Viewport) {
     const { offsetY } = viewport;
@@ -298,18 +295,6 @@ export class ViewportPlugin extends UIPlugin {
     this.viewports[sheetId].offsetX = offsetX;
     this.viewports[sheetId].offsetY = offsetY;
     this.adjustViewportZone(sheetId, this.viewports[sheetId]);
-  }
-
-  /**
-   * Clip the vertical offset within the allowed range.
-   * Not above the sheet, nor below the sheet.
-   */
-  private clipOffsetY(offsetY: number): number {
-    const { height } = this.getters.getMaxViewportSize(this.getters.getActiveSheet());
-    const maxOffset = height - this.viewportHeight;
-    offsetY = Math.min(offsetY, maxOffset);
-    offsetY = Math.max(offsetY, 0);
-    return offsetY;
   }
 
   private generateViewportState(sheetId: UID): Viewport {
@@ -351,7 +336,6 @@ export class ViewportPlugin extends UIPlugin {
         break;
       }
     }
-    this.updateSnap = true;
   }
 
   /** Updates the viewport zone based on its vertical offset (will find Top) and its width (will find Bottom) */
@@ -367,20 +351,17 @@ export class ViewportPlugin extends UIPlugin {
         break;
       }
     }
-    this.updateSnap = true;
   }
 
   /**
    * This function will make sure that the provided cell position (or current selected position) is part of
-   * the viewport that is actually displayed on the client, that is, the snapped one. We therefore adjust
-   * the offset of the snapped viewport until it contains the cell completely.
-   * In order to keep the coherence of both viewports, it is also necessary to update the standard viewport
-   * if the zones of both viewports don't match.
+   * the viewport that is actually displayed on the client. We therefore adjust
+   * the offset of the viewport until it contains the cell completely.
    */
   private adjustViewportsPosition(sheetId: UID, position?: Position) {
     const sheet = this.getters.getSheet(sheetId);
     const { cols, rows } = sheet;
-    const adjustedViewport = this.getSnappedViewport(sheetId);
+    const adjustedViewport = this.getViewport(sheetId);
     if (!position) {
       const sheetPosition = this.getters.getSheetPosition(sheetId);
       position = { col: sheetPosition[0], row: sheetPosition[1] };
@@ -419,25 +400,6 @@ export class ViewportPlugin extends UIPlugin {
       adjustedViewport.offsetY = rows[adjustedViewport.top - 1 - step].start;
       this.adjustViewportZoneY(sheetId, adjustedViewport);
     }
-    // cast the new snappedViewport in the standard viewport
-    const { top, left } = this.viewports[sheetId];
-    if (top !== adjustedViewport.top || left !== adjustedViewport.left)
-      this.viewports[sheetId] = adjustedViewport;
-    this.updateSnap = false;
-  }
-
-  /** Will update the snapped viewport based on the "standard" viewport to ensure its
-   * offsets match the start of the viewport left (resp. top) column (resp. row). */
-  private snapViewportToCell(sheetId: UID) {
-    const { cols, rows } = this.getters.getSheet(sheetId);
-    const viewport = this.getViewport(sheetId);
-    const adjustedViewport = Object.assign({}, viewport);
-    this.adjustViewportOffsetX(sheetId, adjustedViewport);
-    this.adjustViewportOffsetY(sheetId, adjustedViewport);
-    adjustedViewport.offsetX = cols[adjustedViewport.left].start;
-    adjustedViewport.offsetY = rows[adjustedViewport.top].start;
-    this.adjustViewportZone(sheetId, adjustedViewport);
-    this.snappedViewports[sheetId] = adjustedViewport;
   }
 
   /**
@@ -446,10 +408,10 @@ export class ViewportPlugin extends UIPlugin {
    * viewport top.
    */
   private shiftVertically(offset: number) {
-    const { top, offsetX } = this.getActiveSnappedViewport();
+    const { top, offsetX } = this.getActiveViewport();
     this.setViewportOffset(offsetX, offset);
     const { anchor } = this.getters.getSelection();
-    const deltaRow = this.getActiveSnappedViewport().top - top;
+    const deltaRow = this.getActiveViewport().top - top;
     this.selection.selectCell(anchor[0], anchor[1] + deltaRow);
   }
 
@@ -457,8 +419,8 @@ export class ViewportPlugin extends UIPlugin {
    * Return the row at the viewport's top
    */
   private getActiveTopRow(): Row {
-    const { top } = this.getActiveSnappedViewport();
+    const { top } = this.getActiveViewport();
     const sheet = this.getters.getActiveSheet();
-    return this.getters.getRow(sheet.id, top)!;
+    return this.getters.getRow(sheet.id, top);
   }
 }

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -41,11 +41,7 @@ export interface GridDimension {
   height: number;
 }
 
-/**
- * The viewport is the visible area of a sheet.
- * Column and row headers are not included in the viewport.
- */
-export interface Viewport extends Zone {
+export interface ViewportOffsets {
   /**
    * The offset in the X coordinate between the viewport left side and
    * the grid left side (left of column "A").
@@ -57,6 +53,12 @@ export interface Viewport extends Zone {
    */
   offsetY: number;
 }
+
+/**
+ * The viewport is the visible area of a sheet.
+ * Column and row headers are not included in the viewport.
+ */
+export interface Viewport extends Zone, ViewportOffsets {}
 
 export interface GridRenderingContext {
   ctx: CanvasRenderingContext2D;

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -3,4 +3,10 @@ export interface NotificationUIEvent {
   text: string;
 }
 
-export type NotifyUIEvent = NotificationUIEvent;
+export interface ScrollUIEvent {
+  type: "SCROLL";
+  offsetX: number;
+  offsetY: number;
+}
+
+export type NotifyUIEvent = NotificationUIEvent | ScrollUIEvent;

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -566,7 +566,8 @@ describe("Multi users synchronisation", () => {
     alice.dispatch("START_EDITION", { text: "hello" });
     const spy = jest.spyOn(alice["config"], "notifyUI");
     alice.dispatch("DELETE_SHEET", { sheetId: activeSheetId });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).not.toHaveBeenCalledWith({ type: "SCROLL" });
     expect(alice.getters.getEditionMode()).toBe("inactive");
   });
 
@@ -576,7 +577,8 @@ describe("Multi users synchronisation", () => {
     alice.dispatch("STOP_EDITION");
     const spy = jest.spyOn(alice["config"], "notifyUI");
     deleteRows(bob, [3]);
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({ type: "SCROLL", offsetX: 0, offsetY: 0 });
     expect(alice.getters.getEditionMode()).toBe("inactive");
   });
 
@@ -586,7 +588,8 @@ describe("Multi users synchronisation", () => {
     alice.dispatch("STOP_EDITION");
     const spy = jest.spyOn(alice["config"], "notifyUI");
     deleteColumns(bob, ["A"]);
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({ type: "SCROLL", offsetX: 0, offsetY: 0 });
     expect(alice.getters.getEditionMode()).toBe("inactive");
   });
 

--- a/tests/components/__mocks__/scrollbar.ts
+++ b/tests/components/__mocks__/scrollbar.ts
@@ -14,5 +14,6 @@ export class ScrollBar {
 
   set scroll(value: number) {
     this.scrollValue = value;
+    this.el.dispatchEvent(new MouseEvent("scroll", { bubbles: true }));
   }
 }

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -760,14 +760,6 @@ describe("Events on Grid update viewport correctly", () => {
       offsetX: 0,
       offsetY: 1200,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
-      top: 52,
-      bottom: 93,
-      left: 0,
-      right: 9,
-      offsetX: 0,
-      offsetY: 1196,
-    });
   });
   test("Horizontal scroll", async () => {
     fixture
@@ -780,14 +772,6 @@ describe("Events on Grid update viewport correctly", () => {
       left: 2,
       right: 11,
       offsetX: 200,
-      offsetY: 0,
-    });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
-      top: 0,
-      bottom: 41,
-      left: 2,
-      right: 11,
-      offsetX: 192,
       offsetY: 0,
     });
   });
@@ -847,15 +831,15 @@ describe("Events on Grid update viewport correctly", () => {
         bubbles: true,
       })
     );
-    const viewport = model.getters.getActiveSnappedViewport();
+    const viewport = model.getters.getActiveViewport();
     selectCell(model, "Y1");
     await nextTick();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", shiftKey: true, bubbles: true })
     );
     await nextTick();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
   });
 
   test("A resize of the grid DOM element impacts the viewport", async () => {
@@ -890,10 +874,10 @@ describe("Events on Grid update viewport correctly", () => {
         bubbles: true,
       })
     );
-    const viewport = model.getters.getActiveSnappedViewport();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    const viewport = model.getters.getActiveViewport();
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
     await clickCell(model, "Y1", { shiftKey: true });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
   });
 
   describe("Edge-Scrolling on mouseMove in selection", () => {
@@ -909,7 +893,7 @@ describe("Events on Grid update viewport correctly", () => {
       jest.advanceTimersByTime(advanceTimer);
       triggerMouseEvent("canvas", "mouseup", 1.5 * width, y);
 
-      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      expect(model.getters.getActiveViewport()).toMatchObject({
         left: 6,
         right: 15,
         top: 0,
@@ -922,7 +906,7 @@ describe("Events on Grid update viewport correctly", () => {
       jest.advanceTimersByTime(advanceTimer2);
       triggerMouseEvent("canvas", "mouseup", -0.5 * width, y);
 
-      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      expect(model.getters.getActiveViewport()).toMatchObject({
         left: 3,
         right: 12,
         top: 0,
@@ -939,7 +923,7 @@ describe("Events on Grid update viewport correctly", () => {
       jest.advanceTimersByTime(advanceTimer);
       triggerMouseEvent("canvas", "mouseup", x, 1.5 * height);
 
-      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      expect(model.getters.getActiveViewport()).toMatchObject({
         left: 0,
         right: 9,
         top: 6,
@@ -952,7 +936,7 @@ describe("Events on Grid update viewport correctly", () => {
       jest.advanceTimersByTime(advanceTimer2);
       triggerMouseEvent("canvas", "mouseup", x, -0.5 * height);
 
-      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      expect(model.getters.getActiveViewport()).toMatchObject({
         left: 0,
         right: 9,
         top: 3,

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -23,6 +23,7 @@ import {
 import { triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell } from "../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+jest.mock("../../src/components/scrollbar", () => require("./__mocks__/scrollbar"));
 
 let fixture: HTMLElement;
 let model: Model;
@@ -775,7 +776,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-col-resizer", "mouseup", 1.5 * width, y);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 6,
       right: 15,
       top: 0,
@@ -789,7 +790,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-col-resizer", "mouseup", -0.5 * width, y);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 3,
       right: 12,
       top: 0,
@@ -806,7 +807,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-row-resizer", "mouseup", x, 1.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 6,
@@ -819,7 +820,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-row-resizer", "mouseup", x, -0.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 3,

--- a/tests/plugins/__snapshots__/renderer.test.ts.snap
+++ b/tests/plugins/__snapshots__/renderer.test.ts.snap
@@ -384,6 +384,10 @@ Array [
   "context.moveTo(0, 1015)",
   "context.lineTo(48, 1015)",
   "context.stroke()",
+  "context.beginPath()",
+  "context.fillStyle=\\"#F8F9FA\\";",
+  "context.fillRect(0, 0, 48, 26)",
+  "context.stroke()",
   "context.restore()",
 ]
 `;

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -472,7 +472,7 @@ describe("renderer", () => {
     setCellContent(model, "A1", "1");
     setCellContent(model, "C1", "1");
     model.drawGrid(ctx);
-    expect(textAligns).toEqual(["right", "left", "right", "right", "center"]); // A1-C1-A2:B2-C2:D2 and center for headers. C1 is stil lin overflow
+    expect(textAligns).toEqual(["right", "left", "right", "right", "center"]); // A1-C1-A2:B2-C2:D2 and center for headers. C1 is still in overflow
   });
 
   test("formulas in a merge, evaluating to a boolean are properly aligned", () => {


### PR DESCRIPTION
The new viewport implementation introduced a loop when drawing the grid.
It could trigger a dispatch to update the viewport offset, which in turn
would trigger a render, thus a `drawGrid`, etc...

The issue is the following:
- We scroll which a mousewheel, edge-scroll, ...;
- this will dispatch `SET_VIEWPORT_OFFSET` - Since we have a snapping
viewport, this operation might alter the offset we actually store inside
the plugin;
- the dispatch ends up with a rerendering;
- Once rendered, we redraw the grid;
- When drawing, since the viewport might have altered the offset, **we
set the scrollbars offsets with the valule stored in the plugin**.

If the values differ, then we redispatch `SET_VIEWPORT_OFFSET`.

This commit removes the loop by avoiding to assign the scroll value at
render. To do so, we take advantage of the `eventBus` of `Model` to set
the scrolling value of the scrollbars which will then dispatch a
`SEVT_VIEWPORT_OFFSET` that will ultimately trigger a render.

Task 2620080

Co-authored-by: Lucas Lefèvre <lul@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2620080](https://www.odoo.com/web#id=2620080&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] feature is organized in plugin, or UI components
- [ ] exportable in excel
- [ ] importable from excel
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] new/updated/removed commands are documented
- [ ] track breaking changes
- [ ] public API change (index.ts) must rebuild doc (npm run doc)
- [ ] code is prettified with prettier (in each commit, no separate commit)
- [ ] status is correct in Odoo
