### PR TITLE
[REF] cf: editors are now basic templates

### DIFF
--- a/src/components/side_panel/conditional_formatting/cell_is_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cell_is_rule_editor.ts
@@ -1,20 +1,8 @@
 import * as owl from "@odoo/owl";
-import {
-  CancelledReason,
-  CellIsRule,
-  CommandResult,
-  ConditionalFormatRule,
-  SpreadsheetEnv,
-  Style,
-} from "../../../types";
-import { ColorPicker } from "../../color_picker";
-import { getTextDecoration } from "../../helpers/dom_helpers";
 import * as icons from "../../icons";
-import { cellIsOperators, conditionalFormattingTerms } from "../translations_terms";
+import { conditionalFormattingTerms } from "../translations_terms";
 
-const { Component, useState, hooks } = owl;
-const { useExternalListener } = hooks;
-const { xml, css } = owl.tags;
+const { xml } = owl.tags;
 
 const PREVIEW_TEMPLATE = xml/* xml */ `
     <div class="o-cf-preview-line"
@@ -27,24 +15,24 @@ const PREVIEW_TEMPLATE = xml/* xml */ `
          t-esc="previewText || env._t('${conditionalFormattingTerms.PREVIEW_TEXT}')" />
 `;
 
-const TEMPLATE = xml/* xml */ `
-<div>
+export const TEMPLATE_CELL_IS_RULE_EDITOR = xml/* xml */ `
+<div class="o-cf-cell-is-rule">
     <div class="o-cf-title-text" t-esc="env._t('${conditionalFormattingTerms.IS_RULE}')"></div>
-    <select t-model="state.condition.operator" class="o-input o-cell-is-operator">
+    <select t-model="rule.operator" class="o-input o-cell-is-operator">
         <t t-foreach="Object.keys(cellIsOperators)" t-as="op" t-key="op_index">
             <option t-att-value="op" t-esc="cellIsOperators[op]"/>
         </t>
     </select>
-    <t t-if="state.condition.operator !== 'IsEmpty' and state.condition.operator !== 'IsNotEmpty'">
+    <t t-if="rule.operator !== 'IsEmpty' and rule.operator !== 'IsNotEmpty'">
       <input type="text"
              placeholder="Value"
-             t-model="state.condition.value1"
+             t-model="rule.values[0]"
              t-att-class="{ 'o-invalid': isValue1Invalid }"
              class="o-input o-cell-is-value o-required"/>
-      <t t-if="state.condition.operator === 'Between' || state.condition.operator === 'NotBetween'">
+      <t t-if="rule.operator === 'Between' || rule.operator === 'NotBetween'">
           <input type="text"
                  placeholder="and value"
-                 t-model="state.condition.value2"
+                 t-model="rule.values[1]"
                  t-att-class="{ 'o-invalid': isValue2Invalid }"
                  class="o-input o-cell-is-value o-required"/>
       </t>
@@ -52,167 +40,36 @@ const TEMPLATE = xml/* xml */ `
     <div class="o-cf-title-text" t-esc="env._t('${conditionalFormattingTerms.FORMATTING_STYLE}')"></div>
 
     <t t-call="${PREVIEW_TEMPLATE}">
-        <t t-set="currentStyle" t-value="state.style"/>
+        <t t-set="currentStyle" t-value="rule.style"/>
     </t>
     <div class="o-tools">
-        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.BOLD}')" t-att-class="{active:state.style.bold}" t-on-click="toggleTool('bold')">
+        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.BOLD}')" t-att-class="{active:rule.style.bold}" t-on-click="toggleStyle('bold')">
             ${icons.BOLD_ICON}
         </div>
-        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.ITALIC}')" t-att-class="{active:state.style.italic}" t-on-click="toggleTool('italic')">
+        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.ITALIC}')" t-att-class="{active:rule.style.italic}" t-on-click="toggleStyle('italic')">
             ${icons.ITALIC_ICON}
         </div>
-        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.UNDERLINE}')" t-att-class="{active:state.style.underline}"
-             t-on-click="toggleTool('underline')">${icons.UNDERLINE_ICON}
+        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.UNDERLINE}')" t-att-class="{active:rule.style.underline}"
+             t-on-click="toggleStyle('underline')">${icons.UNDERLINE_ICON}
         </div>
-        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.STRIKE_THROUGH}')" t-att-class="{active:state.style.strikethrough}"
-             t-on-click="toggleTool('strikethrough')">${icons.STRIKE_ICON}
+        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.STRIKE_THROUGH}')" t-att-class="{active:rule.style.strikethrough}"
+             t-on-click="toggleStyle('strikethrough')">${icons.STRIKE_ICON}
         </div>
         <div class="o-tool o-dropdown o-with-color">
-              <span t-att-title="env._t('${conditionalFormattingTerms.TEXT_COLOR}')" t-attf-style="border-color:{{state.style.textColor}}"
-                    t-on-click.stop="toggleMenu('textColorTool')">
+              <span t-att-title="env._t('${conditionalFormattingTerms.TEXT_COLOR}')" t-attf-style="border-color:{{rule.style.textColor}}"
+                    t-on-click.stop="toggleMenu('cellIsRule-textColor')">
                     ${icons.TEXT_COLOR_ICON}
               </span>
-              <ColorPicker t-if="state.textColorTool" dropdownDirection="'center'" t-on-color-picked="setColor('textColor')" t-key="textColor"/>
+              <ColorPicker t-if="state.openedMenu === 'cellIsRule-textColor'" dropdownDirection="'center'" t-on-color-picked="setColor('textColor')" t-key="textColor"/>
         </div>
         <div class="o-divider"/>
         <div class="o-tool o-dropdown o-with-color">
-          <span t-att-title="env._t('${conditionalFormattingTerms.FILL_COLOR}')" t-attf-style="border-color:{{state.style.fillColor}}"
-                t-on-click.stop="toggleMenu('fillColorTool')">
+          <span t-att-title="env._t('${conditionalFormattingTerms.FILL_COLOR}')" t-attf-style="border-color:{{rule.style.fillColor}}"
+                t-on-click.stop="toggleMenu('cellIsRule-fillColor')">
                 ${icons.FILL_COLOR_ICON}
           </span>
-          <ColorPicker t-if="state.fillColorTool" dropdownDirection="'center'" t-on-color-picked="setColor('fillColor')" t-key="fillColor"/>
+          <ColorPicker t-if="state.openedMenu === 'cellIsRule-fillColor'" dropdownDirection="'center'" t-on-color-picked="setColor('fillColor')" t-key="fillColor"/>
         </div>
     </div>
 </div>
 `;
-
-const CSS = css/* scss */ `
-  .o-cf-preview-line {
-    border: 1px solid darkgrey;
-    padding: 10px;
-  }
-  .o-cell-is-operator {
-    margin-bottom: 5px;
-    width: 96%;
-  }
-  .o-cell-is-value {
-    margin-bottom: 5px;
-    width: 96%;
-  }
-  .o-color-picker {
-    pointer-events: all;
-  }
-`;
-
-interface Props {
-  rule: CellIsRule;
-  errors: CancelledReason[];
-}
-
-export class CellIsRuleEditor extends Component<Props, SpreadsheetEnv> {
-  static template = TEMPLATE;
-  static style = CSS;
-  static components = { ColorPicker };
-  static defaultProps = {
-    errors: [],
-  };
-
-  // @ts-ignore used in XML template
-  private cellIsOperators = cellIsOperators;
-  // @ts-ignore used in XML template
-  private getTextDecoration = getTextDecoration;
-
-  state = useState({
-    condition: {
-      operator:
-        this.props.rule && this.props.rule.operator ? this.props.rule.operator : "IsNotEmpty",
-      value1: this.props.rule && this.props.rule.values.length > 0 ? this.props.rule.values[0] : "",
-      value2: this.props.rule.values.length > 1 ? this.props.rule.values[1] : "",
-    },
-
-    textColorTool: false,
-    fillColorTool: false,
-    style: {
-      fillColor: this.props.rule.style.fillColor,
-      textColor: this.props.rule.style.textColor,
-      bold: this.props.rule.style.bold,
-      italic: this.props.rule.style.italic,
-      strikethrough: this.props.rule.style.strikethrough,
-      underline: this.props.rule.style.underline,
-    },
-  });
-  setup() {
-    useExternalListener(window as any, "click", this.closeMenus);
-  }
-
-  get isValue1Invalid(): boolean {
-    return !!this.props.errors?.includes(CommandResult.FirstArgMissing);
-  }
-
-  get isValue2Invalid(): boolean {
-    return !!this.props.errors?.includes(CommandResult.SecondArgMissing);
-  }
-
-  getRule(): CellIsRule {
-    const newStyle: Style = {};
-    const style = this.state.style;
-    if (style.bold !== undefined) {
-      newStyle.bold = style.bold;
-    }
-    if (style.italic !== undefined) {
-      newStyle.italic = style.italic;
-    }
-    if (style.strikethrough !== undefined) {
-      newStyle.strikethrough = style.strikethrough;
-    }
-    if (style.underline !== undefined) {
-      newStyle.underline = style.underline;
-    }
-    if (style.fillColor) {
-      newStyle.fillColor = style.fillColor;
-    }
-    if (style.textColor) {
-      newStyle.textColor = style.textColor;
-    }
-    return {
-      type: "CellIsRule",
-      operator: this.state.condition.operator,
-      values: [this.state.condition.value1, this.state.condition.value2],
-      style: newStyle,
-    };
-  }
-
-  toggleMenu(tool: "textColorTool" | "fillColorTool") {
-    const current = this.state[tool];
-    this.closeMenus();
-    this.state[tool] = !current;
-  }
-
-  toggleTool(tool: string) {
-    this.state.style[tool] = !this.state.style[tool];
-    this.closeMenus();
-  }
-
-  setColor(target: string, ev: CustomEvent) {
-    const color = ev.detail.color;
-    this.state.style[target] = color;
-    this.closeMenus();
-  }
-
-  closeMenus() {
-    this.state.textColorTool = false;
-    this.state.fillColorTool = false;
-  }
-
-  /**
-   * Get a default rule for "CellIsRule"
-   */
-  static getDefaultRule(): ConditionalFormatRule {
-    return {
-      type: "CellIsRule",
-      operator: "IsNotEmpty",
-      values: [],
-      style: { fillColor: "#b6d7a8" },
-    };
-  }
-}

--- a/src/components/side_panel/conditional_formatting/icon_set_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/icon_set_rule_editor.ts
@@ -1,20 +1,9 @@
 import * as owl from "@odoo/owl";
-import {
-  CancelledReason,
-  CommandResult,
-  IconSetRule,
-  IconThreshold,
-  SpreadsheetEnv,
-} from "../../../types";
-import { ICONS, ICON_SETS, REFRESH } from "../../icons";
-import { IconPicker } from "../../icon_picker";
 import { conditionalFormattingTerms, iconSetRule } from "../translations_terms";
 
-const { Component, useState, hooks } = owl;
-const { useExternalListener } = hooks;
-const { xml, css } = owl.tags;
+const { xml } = owl.tags;
 
-export const ICON_SETS_TEMPLATE = xml/* xml */ `
+const ICON_SETS_TEMPLATE = xml/* xml */ `
   <div>
   <div class="o-cf-title-text">
     <t t-esc="env._t('${iconSetRule.Icons}')"/>
@@ -38,12 +27,12 @@ export const ICON_SETS_TEMPLATE = xml/* xml */ `
 const INFLECTION_POINTS_TEMPLATE_ROW = xml/* xml */ `
   <tr>
     <td>
-      <div t-on-click.stop="toggleMenu(icon+'IconTool')">
+      <div t-on-click.stop="toggleMenu('iconSet-'+icon+'Icon')">
         <div class="o-cf-icon-button">
           <t t-raw="icons[iconValue].svg"/>
         </div>
       </div>
-      <IconPicker t-if="stateIconSetCF[icon+'IconTool']" t-on-icon-picked="setIcon(icon)"/>
+      <IconPicker t-if="state.openedMenu === 'iconSet-'+icon+'Icon'" t-on-icon-picked="setIcon(icon)"/>
     </td>
     <td>
       <t t-esc="env._t('${iconSetRule.WhenValueIs}')"/>
@@ -61,7 +50,7 @@ const INFLECTION_POINTS_TEMPLATE_ROW = xml/* xml */ `
     <td>
       <input type="text" class="o-input"
         t-att-class="{ 'o-invalid': isInflectionPointInvalid(inflectionPoint) }"
-        t-model="stateIconSetCF[inflectionPoint].value"
+        t-model="rule[inflectionPoint].value"
       />
     </td>
     <td>
@@ -98,25 +87,25 @@ const INFLECTION_POINTS_TEMPLATE = xml/* xml */ `
       </th>
     </tr>
     <t t-call="${INFLECTION_POINTS_TEMPLATE_ROW}">
-      <t t-set="iconValue" t-value="stateIconSetCF.upperIcon" ></t>
+      <t t-set="iconValue" t-value="rule.icons.upper" ></t>
       <t t-set="icon" t-value="'upper'" ></t>
-      <t t-set="inflectionPointValue" t-value="stateIconSetCF.upperInflectionPoint" ></t>
+      <t t-set="inflectionPointValue" t-value="rule.upperInflectionPoint" ></t>
       <t t-set="inflectionPoint" t-value="'upperInflectionPoint'" ></t>
     </t>
     <t t-call="${INFLECTION_POINTS_TEMPLATE_ROW}">
-      <t t-set="iconValue" t-value="stateIconSetCF.middleIcon" ></t>
+      <t t-set="iconValue" t-value="rule.icons.middle" ></t>
       <t t-set="icon" t-value="'middle'" ></t>
-      <t t-set="inflectionPointValue" t-value="stateIconSetCF.lowerInflectionPoint" ></t>
+      <t t-set="inflectionPointValue" t-value="rule.lowerInflectionPoint" ></t>
       <t t-set="inflectionPoint" t-value="'lowerInflectionPoint'" ></t>
     </t>
     <tr>
       <td>
-        <div t-on-click.stop="toggleMenu('lowerIconTool')">
+        <div t-on-click.stop="toggleMenu('iconSet-lowerIcon')">
           <div class="o-cf-icon-button" >
-            <t t-raw="icons[stateIconSetCF.lowerIcon].svg"/>
+            <t t-raw="icons[rule.icons.lower].svg"/>
           </div>
         </div>
-        <IconPicker t-if="stateIconSetCF['lowerIconTool']" t-on-icon-picked="setIcon('lower')"/>
+        <IconPicker t-if="state.openedMenu === 'iconSet-lowerIcon'" t-on-icon-picked="setIcon('lower')"/>
       </td>
       <td><t t-esc="env._t('${iconSetRule.Else}')"/></td>
       <td></td>
@@ -126,7 +115,7 @@ const INFLECTION_POINTS_TEMPLATE = xml/* xml */ `
   </table>
   </div>`;
 
-const TEMPLATE = xml/* xml */ `
+export const TEMPLATE_ICON_SET_EDITOR = xml/* xml */ `
   <div class="o-cf-iconset-rule">
       <t t-call="${ICON_SETS_TEMPLATE}"/>
       <t t-call="${INFLECTION_POINTS_TEMPLATE}"/>
@@ -137,215 +126,3 @@ const TEMPLATE = xml/* xml */ `
         <t t-esc="env._t('${iconSetRule.ReverseIcons}')"/>
       </div>
   </div>`;
-
-const CSS = css/* scss */ `
-  .o-cf-iconset-rule {
-    font-size: 12;
-    .o-cf-iconsets {
-      display: flex;
-      justify-content: space-between;
-      .o-cf-iconset {
-        border: 1px solid #dadce0;
-        border-radius: 4px;
-        display: inline-flex;
-        padding: 5px 8px;
-        width: 25%;
-        cursor: pointer;
-        justify-content: space-between;
-        .o-cf-icon {
-          display: inline;
-          margin-left: 1%;
-          margin-right: 1%;
-        }
-        svg {
-          vertical-align: baseline;
-        }
-      }
-      .o-cf-iconset:hover {
-        background-color: rgba(0, 0, 0, 0.08);
-      }
-    }
-    .o-inflection {
-      .o-cf-icon-button {
-        display: inline-block;
-        border: 1px solid #dadce0;
-        border-radius: 4px;
-        cursor: pointer;
-        padding: 1px 2px;
-      }
-      .o-cf-icon-button:hover {
-        background-color: rgba(0, 0, 0, 0.08);
-      }
-      table {
-        table-layout: fixed;
-        margin-top: 2%;
-        display: table;
-        text-align: left;
-        font-size: 12px;
-        line-height: 18px;
-        width: 100%;
-      }
-      th.o-cf-iconset-icons {
-        width: 8%;
-      }
-      th.o-cf-iconset-text {
-        width: 28%;
-      }
-      th.o-cf-iconset-operator {
-        width: 14%;
-      }
-      th.o-cf-iconset-type {
-        width: 28%;
-      }
-      th.o-cf-iconset-value {
-        width: 26%;
-      }
-      input,
-      select {
-        width: 100%;
-        height: 100%;
-        box-sizing: border-box;
-      }
-    }
-    .o-cf-iconset-reverse {
-      margin-bottom: 2%;
-      margin-top: 2%;
-      .o-cf-label {
-        display: inline-block;
-        vertical-align: bottom;
-        margin-bottom: 2px;
-      }
-    }
-  }
-`;
-
-interface Props {
-  rule: IconSetRule;
-  errors: CancelledReason[];
-}
-
-interface IconSetRuleState {
-  upperInflectionPoint: IconThreshold;
-  lowerInflectionPoint: IconThreshold;
-  upperIcon: string;
-  middleIcon: string;
-  lowerIcon: string;
-  reversed: boolean;
-  upperIconTool: boolean;
-  middleIconTool: boolean;
-  lowerIconTool: boolean;
-}
-
-export class IconSetRuleEditor extends Component<Props, SpreadsheetEnv> {
-  static template = TEMPLATE;
-  static style = CSS;
-  static components = { IconPicker };
-  icons = ICONS;
-  iconSets = ICON_SETS;
-  reverseIcon = REFRESH;
-
-  stateIconSetCF = useState<IconSetRuleState>({
-    reversed: false,
-    upperInflectionPoint: this.props.rule.upperInflectionPoint,
-    lowerInflectionPoint: this.props.rule.lowerInflectionPoint,
-    upperIcon: this.props.rule.icons.upper,
-    middleIcon: this.props.rule.icons.middle,
-    lowerIcon: this.props.rule.icons.lower,
-    upperIconTool: false,
-    middleIconTool: false,
-    lowerIconTool: false,
-  });
-
-  setup() {
-    useExternalListener(window as any, "click", this.closeMenus);
-  }
-
-  isInflectionPointInvalid(
-    inflectionPoint: "lowerInflectionPoint" | "upperInflectionPoint"
-  ): boolean {
-    switch (inflectionPoint) {
-      case "lowerInflectionPoint":
-        return (
-          this.props.errors.includes(CommandResult.ValueLowerInflectionNaN) ||
-          this.props.errors.includes(CommandResult.ValueLowerInvalidFormula) ||
-          this.props.errors.includes(CommandResult.LowerBiggerThanUpper)
-        );
-      case "upperInflectionPoint":
-        return (
-          this.props.errors.includes(CommandResult.ValueUpperInflectionNaN) ||
-          this.props.errors.includes(CommandResult.ValueUpperInvalidFormula) ||
-          this.props.errors.includes(CommandResult.LowerBiggerThanUpper)
-        );
-      default:
-        return true;
-    }
-  }
-
-  toggleMenu(tool: "upperIconTool" | "middleIconTool" | "lowerIconTool") {
-    const current = this.stateIconSetCF[tool];
-    this.closeMenus();
-    this.stateIconSetCF[tool] = !current;
-  }
-
-  closeMenus() {
-    this.stateIconSetCF.upperIconTool = false;
-    this.stateIconSetCF.middleIconTool = false;
-    this.stateIconSetCF.lowerIconTool = false;
-  }
-
-  setIconSet(iconSet: "arrows" | "smiley" | "dots") {
-    this.stateIconSetCF.upperIcon = this.iconSets[iconSet].good;
-    this.stateIconSetCF.middleIcon = this.iconSets[iconSet].neutral;
-    this.stateIconSetCF.lowerIcon = this.iconSets[iconSet].bad;
-  }
-
-  setIcon(target: string, ev: CustomEvent) {
-    this.stateIconSetCF[target + "Icon"] = ev.detail.icon;
-  }
-
-  getRule(): IconSetRule {
-    const upperInflectionPoint: IconThreshold = { ...this.stateIconSetCF.upperInflectionPoint };
-    const lowerInflectionPoint: IconThreshold = { ...this.stateIconSetCF.lowerInflectionPoint };
-    return {
-      type: "IconSetRule",
-      lowerInflectionPoint,
-      upperInflectionPoint,
-      icons: {
-        upper: this.stateIconSetCF.upperIcon,
-        middle: this.stateIconSetCF.middleIcon,
-        lower: this.stateIconSetCF.lowerIcon,
-      },
-    };
-  }
-
-  getIconsSelction() {
-    return Object.keys(this.icons);
-  }
-
-  reverseIcons() {
-    const upperIcon = this.stateIconSetCF.upperIcon;
-    this.stateIconSetCF.upperIcon = this.stateIconSetCF.lowerIcon;
-    this.stateIconSetCF.lowerIcon = upperIcon;
-  }
-
-  static getDefaultRule(): IconSetRule {
-    return {
-      type: "IconSetRule",
-      icons: {
-        upper: "arrowGood",
-        middle: "arrowNeutral",
-        lower: "arrowBad",
-      },
-      upperInflectionPoint: {
-        type: "percentage",
-        value: "66",
-        operator: "gt",
-      },
-      lowerInflectionPoint: {
-        type: "percentage",
-        value: "33",
-        operator: "gt",
-      },
-    };
-  }
-}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const HEADER_BORDER_COLOR = "#C0C0C0";
 export const CELL_BORDER_COLOR = "#E2E3E3";
 export const BACKGROUND_CHART_COLOR = "#FFFFFF";
 export const MENU_ITEM_DISABLED_COLOR = "#CACACA";
+export const DEFAULT_COLOR_SCALE_MIDPOINT_COLOR = 0xb6d7a8;
 
 // Dimensions
 export const MIN_ROW_HEIGHT = 10;

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -1,7 +1,4 @@
 import { Model, Spreadsheet } from "../../src";
-import { CellIsRuleEditor } from "../../src/components/side_panel/conditional_formatting/cell_is_rule_editor";
-import { ColorScaleRuleEditor } from "../../src/components/side_panel/conditional_formatting/color_scale_rule_editor";
-import { IconSetRuleEditor } from "../../src/components/side_panel/conditional_formatting/icon_set_rule_editor";
 import { toZone } from "../../src/helpers/zones";
 import { CommandResult, DispatchResult } from "../../src/types";
 import { setSelection } from "../test_helpers/commands_helpers";
@@ -174,7 +171,7 @@ describe("UI of conditional formats", () => {
               underline: true,
             },
             type: "CellIsRule",
-            values: ["3", ""],
+            values: ["3"],
           },
         },
         target: [toZone("A1:A3")],
@@ -299,7 +296,7 @@ describe("UI of conditional formats", () => {
               underline: true,
             },
             type: "CellIsRule",
-            values: ["3", ""],
+            values: ["3"],
           },
         },
         target: [toZone("A1:A3")],
@@ -555,11 +552,11 @@ describe("UI of conditional formats", () => {
     await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "0", "input");
 
+    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number", "change");
+    await nextTick();
     triggerMouseEvent(selectors.colorScaleEditor.midColor, "click");
     await nextTick();
     triggerMouseEvent(selectors.colorScaleEditor.colorPickerOrange, "click");
-    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number", "change");
-    await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "50", "input");
 
     triggerMouseEvent(selectors.colorScaleEditor.maxColor, "click");
@@ -1346,46 +1343,5 @@ describe("UI of conditional formats", () => {
         ) as HTMLInputElement
       ).value
     ).toBe("BeginsWith");
-  });
-
-  describe("Default rules", () => {
-    test("Default CellIsRule", () => {
-      expect(CellIsRuleEditor.getDefaultRule()).toEqual({
-        type: "CellIsRule",
-        operator: "IsNotEmpty",
-        values: [],
-        style: { fillColor: "#b6d7a8" },
-      });
-    });
-
-    test("Default ColorScaleRule", () => {
-      expect(ColorScaleRuleEditor.getDefaultRule()).toEqual({
-        type: "ColorScaleRule",
-        minimum: { type: "value", color: 0xffffff },
-        midpoint: undefined,
-        maximum: { type: "value", color: 0x6aa84f },
-      });
-    });
-
-    test("Default IconSetRule", () => {
-      expect(IconSetRuleEditor.getDefaultRule()).toEqual({
-        type: "IconSetRule",
-        icons: {
-          upper: "arrowGood",
-          middle: "arrowNeutral",
-          lower: "arrowBad",
-        },
-        upperInflectionPoint: {
-          type: "percentage",
-          value: "66",
-          operator: "gt",
-        },
-        lowerInflectionPoint: {
-          type: "percentage",
-          value: "33",
-          operator: "gt",
-        },
-      });
-    });
   });
 });


### PR DESCRIPTION
This task is a step to make spreadsheet owl2 compatible.

Before this commit, the three editors (cell is rule, color scale and icon set)
were components.
This design came with some issues:
* To be able to react to input changes, the CF should be observed by the
  editor => we made something like this.state = this.props !
* To be able to save a CF, the main component should ask it child its
  current state => bad communication way

Now, the editors are now basic templates with only one component which
is responsible of the state of the CF.

Task-id 2713118

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2713886](https://www.odoo.com/web#id=2713886&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [X] undo-able commands (uses this.history.update)
- [X] multiuser-able commands (has inverse commands and transformations where needed)
- [X] translations (\_lt("qmsdf %s", abc))
- [X] unit tested
- [X] clean commented code
- [X] feature is organized in plugin, or UI components
- [X] exportable in excel
- [X] importable from excel
- [X] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [X] in model/UI: ranges are strings (to show the user)
- [X] new/updated/removed commands are documented
- [X] track breaking changes
- [X] public API change (index.ts) must rebuild doc (npm run doc)
- [X] code is prettified with prettier (in each commit, no separate commit)
- [X] status is correct in Odoo
