### PR TITLE
[IMP] spreadsheet : Improve the ediText api

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -137,8 +137,13 @@ class Demo extends Component {
     window.alert(content);
   }
 
-  editText(title, placeholder, callback) {
-    const text = window.prompt(title, placeholder);
+  editText(title, callback, options = {}) {
+    let text;
+    if (!options.error) {
+      text = window.prompt(title, options.placeholder);
+    } else {
+      text = window.prompt(options.error, options.placeholder);
+    }
     callback(text);
   }
 

--- a/src/helpers/ui/sheet.ts
+++ b/src/helpers/ui/sheet.ts
@@ -2,11 +2,10 @@ import { FORBIDDEN_SHEET_CHARS } from "../../constants";
 import { _lt } from "../../translation";
 import { CommandResult, SpreadsheetChildEnv, UID } from "../../types";
 
-export function interactiveRenameSheet(env: SpreadsheetChildEnv, sheetId: UID, message?: string) {
+export function interactiveRenameSheet(env: SpreadsheetChildEnv, sheetId: UID, errorText?: string) {
   const placeholder = env.model.getters.getSheetName(sheetId);
-  //TODO We should update editText to take a message in addition to the title
-  const t = _lt("Rename Sheet") + (message ? " - " + message : "");
-  env.editText(t, placeholder, (name: string | null) => {
+  const title = _lt("Rename Sheet");
+  const callback = (name: string | null) => {
     if (name === null || name === placeholder) {
       return;
     }
@@ -33,5 +32,9 @@ export function interactiveRenameSheet(env: SpreadsheetChildEnv, sheetId: UID, m
         );
       }
     }
+  };
+  env.editText(title, callback, {
+    placeholder: placeholder,
+    error: errorText,
   });
 }

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -1,10 +1,19 @@
 import { Model } from "..";
 import { TranslationFunction } from "../translation";
 
+export interface EditTextOptions {
+  error?: string;
+  placeholder?: string;
+}
+
 export interface SpreadsheetEnv {
   notifyUser: (content: string) => any;
   askConfirmation: (content: string, confirm: () => any, cancel?: () => any) => any;
-  editText: (title: string, placeholder: string, callback: (text: string | null) => any) => any;
+  editText: (
+    title: string,
+    callback: (text: string | null) => any,
+    options?: EditTextOptions
+  ) => any;
 }
 
 export interface SpreadsheetChildEnv extends SpreadsheetEnv {

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -184,7 +184,7 @@ describe("BottomBar component", () => {
           model: this.props.model,
           _t: (s: string) => s,
           askConfirmation: jest.fn(),
-          editText: jest.fn((title, placeholder, callback) => callback("new_name")),
+          editText: jest.fn((title, callback, options) => callback("new_name")),
         });
         onMounted(() => this.props.model.on("update", this, this.render));
         onWillUnmount(() => this.props.model.off("update", this));
@@ -221,7 +221,7 @@ describe("BottomBar component", () => {
           model: this.props.model,
           _t: (s: string) => s,
           askConfirmation: jest.fn(),
-          editText: jest.fn((title, placeholder, callback) => callback("new_name")),
+          editText: jest.fn((title, callback, options) => callback("new_name")),
         });
         onMounted(() => this.props.model.on("update", this, this.render));
         onWillUnmount(() => this.props.model.off("update", this));

--- a/tests/helpers/ui.test.ts
+++ b/tests/helpers/ui.test.ts
@@ -1,5 +1,6 @@
 import { interactiveRenameSheet } from "../../src/helpers/ui/sheet";
 import { Model } from "../../src/model";
+import { EditTextOptions } from "../../src/types";
 import { createSheetWithName } from "../test_helpers/commands_helpers";
 import { makeInteractiveTestEnv } from "../test_helpers/helpers";
 
@@ -14,45 +15,54 @@ describe("UI Helpers", () => {
     "Rename a sheet with interaction with wrong name %s",
     async (sheetName, expectedErrorMessage) => {
       const nameCallback = jest.fn().mockReturnValueOnce(sheetName).mockReturnValueOnce("new name");
-      const editTextSpy = jest.fn();
+      const titleTextSpy = jest.fn();
+      const errorTextSpy = jest.fn();
       const editText = (
         title: string,
-        placeholder: string,
-        callback: (text: string | null) => any
+        callback: (text: string | null) => any,
+        options: EditTextOptions
       ) => {
-        editTextSpy(title.toString());
+        titleTextSpy(title.toString());
+        errorTextSpy(options?.error?.toString());
         callback(nameCallback());
       };
       const model = new Model({});
       const env = makeInteractiveTestEnv(model, { editText });
       interactiveRenameSheet(env, model.getters.getActiveSheetId());
-      expect(editTextSpy).toHaveBeenCalledTimes(2);
-      expect(editTextSpy).toHaveBeenNthCalledWith(1, "Rename Sheet");
-      expect(editTextSpy).toHaveBeenNthCalledWith(2, "Rename Sheet - " + expectedErrorMessage);
+      expect(titleTextSpy).toHaveBeenCalledTimes(2);
+      expect(titleTextSpy).toHaveBeenNthCalledWith(1, "Rename Sheet");
+      expect(titleTextSpy).toHaveBeenNthCalledWith(2, "Rename Sheet");
+      expect(errorTextSpy).toHaveBeenCalledTimes(2);
+      expect(errorTextSpy).toHaveBeenNthCalledWith(1, undefined);
+      expect(errorTextSpy).toHaveBeenNthCalledWith(2, expectedErrorMessage);
     }
   );
 
   test("Rename a sheet with interaction with same name as other sheet", async () => {
     const sheetName = "existing sheet";
     const nameCallback = jest.fn().mockReturnValueOnce(sheetName).mockReturnValueOnce("new name");
-    const editTextSpy = jest.fn();
+    const titleTextSpy = jest.fn();
+    const errorTextSpy = jest.fn();
     const editText = (
       title: string,
-      placeholder: string,
-      callback: (text: string | null) => any
+      callback: (text: string | null) => any,
+      options: EditTextOptions
     ) => {
-      editTextSpy(title.toString());
+      titleTextSpy(title.toString());
+      errorTextSpy(options?.error?.toString());
       callback(nameCallback());
     };
     const model = new Model({});
     const env = makeInteractiveTestEnv(model, { editText });
     createSheetWithName(model, { sheetId: "42", activate: false }, sheetName);
     interactiveRenameSheet(env, model.getters.getActiveSheetId());
-    expect(editTextSpy).toHaveBeenCalledTimes(2);
-    expect(editTextSpy).toHaveBeenNthCalledWith(1, "Rename Sheet");
-    expect(editTextSpy).toHaveBeenNthCalledWith(
+    expect(titleTextSpy).toHaveBeenCalledTimes(2);
+    expect(titleTextSpy).toHaveBeenCalledWith("Rename Sheet");
+    expect(errorTextSpy).toHaveBeenCalledTimes(2);
+    expect(errorTextSpy).toHaveBeenNthCalledWith(1, undefined);
+    expect(errorTextSpy).toHaveBeenNthCalledWith(
       2,
-      `Rename Sheet - A sheet with the name ${sheetName} already exists. Please select another name.`
+      `A sheet with the name ${sheetName} already exists. Please select another name.`
     );
   });
 });


### PR DESCRIPTION
Improve the editText dialog window by adding the possibility to display
an error message separated from the title

enterprise pr : https://github.com/odoo/enterprise/pull/23450

Odoo task ID : [2691916](https://www.odoo.com/web#id=2691916&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo