### PR TITLE
[REF] composer: remove t-ref on text value provider

### DIFF
--- a/src/components/composer/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown.ts
@@ -75,9 +75,16 @@ interface Props {
   filter?: (searchTerm: string, vals: AutocompleteValue[]) => AutocompleteValue[];
   search: string;
   borderStyle: string;
+  exposeAPI: (api: TextValueProviderApi) => void;
 }
 
-export abstract class TextValueProvider extends Component<Props> {
+export interface TextValueProviderApi {
+  moveUp: () => void;
+  moveDown: () => void;
+  getValueToFill: () => string | undefined;
+}
+
+export abstract class TextValueProvider extends Component<Props> implements TextValueProviderApi {
   static template = TEMPLATE;
   static style = CSS;
 
@@ -89,6 +96,11 @@ export abstract class TextValueProvider extends Component<Props> {
   setup() {
     onMounted(() => this.filter(this.props.search));
     onWillUpdateProps((nextProps: Props) => this.checkUpdateProps(nextProps));
+    this.props.exposeAPI({
+      getValueToFill: () => this.getValueToFill(),
+      moveDown: () => this.moveDown(),
+      moveUp: () => this.moveUp(),
+    });
   }
 
   checkUpdateProps(nextProps: any) {
@@ -127,9 +139,10 @@ export abstract class TextValueProvider extends Component<Props> {
     }
   }
 
-  getValueToFill(): string | void {
+  getValueToFill(): string | undefined {
     if (this.state.values.length) {
       return this.state.values[this.state.selectedIndex].text;
     }
+    return undefined;
   }
 }


### PR DESCRIPTION
This commit is a step to owl 2 compatibility.

With this commit, we remove the t-ref on text value provider. To remove
it, we should give a way (via props) to give access to the api of
autocomplete dropdown to the composer.

Task-id 2734841

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2734841](https://www.odoo.com/web#id=2734841&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
