### PR TITLE
[REF] tests: remove t-ref on components

### DIFF
--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -1,10 +1,11 @@
-import { Spreadsheet } from "../../src";
+import { Grid } from "../../src/components/grid";
+import { Spreadsheet } from "../../src/components/spreadsheet";
 import { args, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import { selectCell } from "../test_helpers/commands_helpers";
 import { getCellText } from "../test_helpers/getters_helpers";
 import {
-  getGridFromSpreadsheet,
+  getChildFromComponent,
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
@@ -35,7 +36,7 @@ beforeEach(async () => {
   model = parent.model;
 
   // start composition
-  const grid = getGridFromSpreadsheet(parent);
+  const grid = getChildFromComponent(parent, Grid);
   grid.el!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
   await nextTick();
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
@@ -274,7 +275,7 @@ describe("Autocomplete parenthesis", () => {
     await nextTick();
     selectCell(model, "A1");
     //edit A1
-    const grid = getGridFromSpreadsheet(parent);
+    const grid = getChildFromComponent(parent, Grid);
     grid.el!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
     await nextTick();
     composerEl = fixture.querySelector(".o-grid div.o-composer")!;

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -1,5 +1,6 @@
 import { Component, hooks, tags } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
+import { Grid } from "../../src/components/grid";
 import { Menu } from "../../src/components/menu";
 import { HEADER_HEIGHT, HEADER_WIDTH, MENU_ITEM_HEIGHT, TOPBAR_HEIGHT } from "../../src/constants";
 import { toXC, toZone } from "../../src/helpers";
@@ -11,7 +12,7 @@ import { setCellContent, setSelection } from "../test_helpers/commands_helpers";
 import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getCell, getCellContent } from "../test_helpers/getters_helpers";
 import {
-  getGridFromSpreadsheet,
+  getChildFromComponent,
   makeTestFixture,
   MockClipboard,
   mountSpreadsheet,
@@ -502,7 +503,7 @@ describe("Context Menu", () => {
   });
 
   test("scroll through the menu with the wheel / scrollbar prevents the grid from scrolling", async () => {
-    const grid = getGridFromSpreadsheet(parent as Spreadsheet);
+    const grid = getChildFromComponent(parent as Spreadsheet, Grid);
     const verticalScrollBar = grid["vScrollbar"];
     const horizontalScrollBar = grid["hScrollbar"];
     expect(verticalScrollBar.scroll).toBe(0);
@@ -525,7 +526,7 @@ describe("Context Menu", () => {
   });
 
   test("scroll through the menu with the touch device prevents the grid from scrolling", async () => {
-    const grid = getGridFromSpreadsheet(parent as Spreadsheet);
+    const grid = getChildFromComponent(parent as Spreadsheet, Grid);
     const verticalScrollBar = grid["vScrollbar"];
     const horizontalScrollBar = grid["hScrollbar"];
     expect(verticalScrollBar.scroll).toBe(0);

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -1,8 +1,9 @@
 import { Spreadsheet } from "../../src";
+import { Grid } from "../../src/components/grid";
 import { args, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import {
-  getGridFromSpreadsheet,
+  getChildFromComponent,
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
@@ -24,7 +25,7 @@ beforeEach(async () => {
   model = parent.model;
 
   // start composition
-  const grid = getGridFromSpreadsheet(parent);
+  const grid = getChildFromComponent(parent, Grid);
   grid.el!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
   await nextTick();
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -1,4 +1,5 @@
 import { Spreadsheet, TransportService } from "../../src";
+import { Grid } from "../../src/components/grid";
 import { HEADER_WIDTH, MESSAGE_VERSION, SCROLLBAR_WIDTH } from "../../src/constants";
 import { scrollDelay, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
@@ -14,7 +15,7 @@ import {
 import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
-  getGridFromSpreadsheet,
+  getChildFromComponent,
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
@@ -27,12 +28,12 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 jest.mock("../../src/components/scrollbar", () => require("./__mocks__/scrollbar"));
 
 function getVerticalScroll(): number {
-  const grid = getGridFromSpreadsheet(parent);
+  const grid = getChildFromComponent(parent, Grid);
   return grid["vScrollbar"].scroll;
 }
 
 function getHorizontalScroll(): number {
-  const grid = getGridFromSpreadsheet(parent);
+  const grid = getChildFromComponent(parent, Grid);
   return grid["hScrollbar"].scroll;
 }
 
@@ -227,7 +228,7 @@ describe("Grid component", () => {
     test("pressing ENTER put current cell in edit mode", async () => {
       // note: this behaviour is not like excel. Maybe someone will want to
       // change this
-      const grid = getGridFromSpreadsheet(parent);
+      const grid = getChildFromComponent(parent, Grid);
       grid.el!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
       expect(getActiveXc(model)).toBe("A1");
       expect(model.getters.getEditionMode()).toBe("editing");
@@ -269,7 +270,7 @@ describe("Grid component", () => {
     });
 
     test("pressing TAB move to next cell", async () => {
-      const grid = getGridFromSpreadsheet(parent);
+      const grid = getChildFromComponent(parent, Grid);
       grid.el!.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
       expect(getActiveXc(model)).toBe("B1");
     });
@@ -277,7 +278,7 @@ describe("Grid component", () => {
     test("pressing shift+TAB move to previous cell", async () => {
       selectCell(model, "B1");
       expect(getActiveXc(model)).toBe("B1");
-      const grid = getGridFromSpreadsheet(parent);
+      const grid = getChildFromComponent(parent, Grid);
       grid.el!.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true }));
       expect(getActiveXc(model)).toBe("A1");
     });

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -3,7 +3,7 @@ import { Model } from "../../src";
 import { SelectionInput } from "../../src/components/selection_input";
 import { activateSheet, createSheet, selectCell, undo } from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
-import { makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { getChildFromComponent, makeTestFixture, nextTick } from "../test_helpers/helpers";
 
 const { xml } = tags;
 const { useSubEnv, useRef, onMounted, onWillUnmount } = hooks;
@@ -34,7 +34,6 @@ interface SelectionInputTestConfig {
 class Parent extends Component<any> {
   static template = xml/* xml */ `
     <SelectionInput
-      t-ref="selection-input"
       ranges="initialRanges"
       hasSingleRange="hasSingleRange"
       t-on-selection-changed="onChanged"/>
@@ -60,7 +59,8 @@ class Parent extends Component<any> {
   }
 
   get id(): string {
-    return (this.ref.comp as any).id;
+    const selectionInput = getChildFromComponent(this, SelectionInput);
+    return selectionInput["id"];
   }
 
   setup() {

--- a/tests/components/side_panel.test.ts
+++ b/tests/components/side_panel.test.ts
@@ -1,24 +1,27 @@
-import { Component, hooks, tags } from "@odoo/owl";
+import { Component, tags } from "@odoo/owl";
 import { Spreadsheet } from "../../src/components";
 import { Model } from "../../src/model";
 import { sidePanelRegistry } from "../../src/registries/index";
 import { SidePanelContent } from "../../src/registries/side_panel_registry";
 import { SpreadsheetEnv } from "../../src/types";
 import { simulateClick } from "../test_helpers/dom_helper";
-import { makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { getChildFromComponent, makeTestFixture, nextTick } from "../test_helpers/helpers";
 
-const { useRef } = hooks;
 const { xml } = tags;
 
 class Parent extends Component<any> {
-  static template = xml`<Spreadsheet t-ref="spreadsheet" data="data"/>`;
+  static template = xml`<Spreadsheet data="data"/>`;
   static components = { Spreadsheet };
-  private spreadsheet: any = useRef("spreadsheet");
+
+  get spreadsheet(): Spreadsheet {
+    return getChildFromComponent(this, Spreadsheet);
+  }
+
   get spreadsheetEnv(): SpreadsheetEnv {
-    return this.spreadsheet.comp.env;
+    return this.spreadsheet.env;
   }
   get model(): Model {
-    return this.spreadsheet.comp.model;
+    return this.spreadsheet.model;
   }
 }
 

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -22,6 +22,7 @@ import {
   getMerges,
 } from "../test_helpers/getters_helpers";
 import {
+  getChildFromComponent,
   getMergeCellMap,
   makeTestFixture,
   target,
@@ -30,7 +31,7 @@ import {
 } from "../test_helpers/helpers";
 
 const { xml } = tags;
-const { useRef, useSubEnv } = hooks;
+const { useSubEnv } = hooks;
 
 function getCellsXC(model: Model): string[] {
   return Object.values(model.getters.getCells(model.getters.getActiveSheetId())).map((cell) => {
@@ -280,16 +281,20 @@ describe("merges", () => {
   test("merging destructively a selection ask for confirmation", async () => {
     const askConfirmation = jest.fn();
     class Parent extends Component<any> {
-      static template = xml/* xml */ `<Spreadsheet t-ref="spreadsheet"/>`;
+      static template = xml/* xml */ `<Spreadsheet/>`;
       static components = { Spreadsheet };
-      spreadsheet: any = useRef("spreadsheet");
       setup() {
         useSubEnv({
           askConfirmation,
         });
       }
+
+      get spreadsheet(): Spreadsheet {
+        return getChildFromComponent(this, Spreadsheet);
+      }
+
       get model(): Model {
-        return this.spreadsheet.comp.model;
+        return this.spreadsheet.model;
       }
     }
     const parent = new Parent();

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -1,6 +1,5 @@
 import { Component } from "@odoo/owl";
 import format from "xml-formatter";
-import { Grid } from "../../src/components/grid";
 import { Spreadsheet } from "../../src/components/spreadsheet";
 import { functionRegistry } from "../../src/functions/index";
 import { toCartesian, toXC, toZone } from "../../src/helpers/index";
@@ -34,8 +33,19 @@ export async function nextTick(): Promise<void> {
   });
 }
 
-export function getGridFromSpreadsheet(spreadsheet: Spreadsheet): Grid {
-  return Object.values(spreadsheet.__owl__.children).find((child) => child instanceof Grid) as Grid;
+/**
+ * Get the instance of the given cls, which is a child of the component.
+ *
+ * new (...args: any) => any is a constructor, which ensure us to have
+ * a return value correctly typed.
+ */
+export function getChildFromComponent<T extends new (...args: any) => any>(
+  component: Component,
+  cls: T
+): InstanceType<T> {
+  return Object.values(component.__owl__.children).find(
+    (child) => child instanceof cls
+  ) as unknown as InstanceType<T>;
 }
 
 export function makeTestFixture() {


### PR DESCRIPTION
This commit is a step to owl 2 compatibility. This commit removes all the
t-ref on components in the tests.

Task-id 2734843

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2734843](https://www.odoo.com/web#id=2734843&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
