### PR TITLE
[FIX] CF component: Reset to List on change Sheet

### DIFF
--- a/src/components/side_panel/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting.ts
@@ -5,6 +5,7 @@ import {
   ConditionalFormat,
   SingleColorRules,
   SpreadsheetEnv,
+  UID,
   Zone,
 } from "../../types";
 import { SelectionInput } from "../selection_input";
@@ -228,7 +229,7 @@ const CSS = css/* scss */ `
   }
 `;
 interface Props {
-  selection: Zone | undefined;
+  selection?: [Zone];
 }
 export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv> {
   static template = TEMPLATE;
@@ -236,6 +237,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
   static components = { CellIsRuleEditor, ColorScaleRuleEditor, SelectionInput };
   colorNumberString = colorNumberString;
   getters = this.env.getters;
+  private activeSheetId: UID;
 
   //@ts-ignore --> used in XML template
   private cellIsOperators = cellIsOperators;
@@ -251,14 +253,19 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
     ColorScaleRule: ColorScaleRuleEditor,
   };
 
-  constructor(parent, props) {
+  constructor(parent, props: Props) {
     super(parent, props);
+    this.activeSheetId = this.getters.getActiveSheet();
     if (props.selection && this.getters.getRulesSelection(props.selection).length === 1) {
       this.openCf(this.getters.getRulesSelection(props.selection)[0]);
     }
   }
-  async willUpdateProps(nextProps) {
-    if (nextProps.selection && nextProps.selection !== this.props.selection)
+  async willUpdateProps(nextProps: Props) {
+    const newActiveSheetId = this.getters.getActiveSheet();
+    if (newActiveSheetId !== this.activeSheetId) {
+      this.activeSheetId = newActiveSheetId;
+      this.resetState();
+    } else if (nextProps.selection && nextProps.selection !== this.props.selection)
       if (nextProps.selection && this.getters.getRulesSelection(nextProps.selection).length === 1) {
         this.openCf(this.getters.getRulesSelection(nextProps.selection)[0]);
       } else {

--- a/tests/plugins/conditional_formatting_test.ts
+++ b/tests/plugins/conditional_formatting_test.ts
@@ -1,3 +1,4 @@
+import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import "../canvas.mock";
@@ -1235,5 +1236,18 @@ describe("UI of conditional formats", () => {
     expect(ranges[1]["value"]).toBe("C3");
   });
 
-  test("switching sheet changes the content of CF and cancels the edition", async () => {});
+  test("switching sheet resets CF Editor to list", async () => {
+    triggerMouseEvent(selectors.closePanel, "click");
+    model.dispatch("CREATE_SHEET", { id: "42" });
+    await nextTick();
+    const zone = toZone("A1:A2");
+    parent.env.openSidePanel("ConditionalFormatting", { selection: [zone] });
+    await nextTick();
+    expect(fixture.querySelector(selectors.listPreview)).toBeNull();
+    expect(fixture.querySelector(selectors.ruleEditor.range! as "input")!.value).toBe("A1:A2");
+    model.dispatch("ACTIVATE_SHEET", { from: model.getters.getActiveSheet(), to: "42" });
+    await nextTick();
+    expect(fixture.querySelector(selectors.ruleEditor.range)).toBeNull();
+    expect(fixture.querySelector(selectors.listPreview)).toBeDefined();
+  });
 });


### PR DESCRIPTION
Changing sheet while editing a CF has unexpected results, such as
allocating the CF to the last sheet even if you started it for the first
sheet.
See task description for concrete examples.

Task 2728750

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo