### PR TITLE
[FIX] renderer: clip large numbers when right cell is not empty

### DIFF
--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -475,7 +475,7 @@ export class RendererPlugin extends UIPlugin {
     }
     const { align } = this.getters.getCellStyle(cell);
     if (isOverflowing && cell.evaluated.type === CellValueType.number) {
-      return align === "right" ? "left" : align;
+      return align !== "center" ? "left" : align;
     }
     return align || cell.defaultAlign;
   }

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -634,46 +634,92 @@ describe("renderer", () => {
     expect(fillStyle).toEqual([{ color: "#DC6CDF", h: 23, w: 96, x: 48, y: 26 }]);
   });
 
-  test("Overflowing left-aligned text is correctly clipped", () => {
-    const overflowingText = "I am a very long text";
-    let box: Box;
-    const model = new Model({
-      sheets: [
-        {
-          id: "sheet1",
-          colNumber: 3,
-          rowNumber: 1,
-          cols: { 1: { size: 5 } },
-          cells: { B1: { content: overflowingText, style: 1 } },
-        },
-      ],
-      styles: { 1: { align: "left" } },
-    });
+  test.each(["I am a very long text", "100000000000000"])(
+    "Overflowing left-aligned content is correctly clipped",
+    (overflowingContent) => {
+      let box: Box;
+      const model = new Model({
+        sheets: [
+          {
+            id: "sheet1",
+            colNumber: 3,
+            rowNumber: 1,
+            cols: { 1: { size: 5 } },
+            cells: { B1: { content: overflowingContent, style: 1 } },
+          },
+        ],
+        styles: { 1: { align: "left" } },
+      });
 
-    let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+      let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
+      model.drawGrid(ctx);
 
-    box = getBoxFromText(model, overflowingText);
-    // no clip
-    expect(box.clipRect).toBeUndefined();
+      box = getBoxFromText(model, overflowingContent);
+      // no clip
+      expect(box.clipRect).toBeUndefined();
 
-    // no clipping at the left
-    setCellContent(model, "A1", "Content at the left");
-    model.drawGrid(ctx);
-    box = getBoxFromText(model, overflowingText);
-    expect(box.clipRect).toBeUndefined();
+      // no clipping at the left
+      setCellContent(model, "A1", "Content at the left");
+      model.drawGrid(ctx);
+      box = getBoxFromText(model, overflowingContent);
+      expect(box.clipRect).toBeUndefined();
 
-    // clipping at the right
-    setCellContent(model, "C1", "Content at the right");
-    model.drawGrid(ctx);
-    box = getBoxFromText(model, overflowingText);
-    expect(box.clipRect).toEqual([
-      HEADER_WIDTH + DEFAULT_CELL_WIDTH,
-      HEADER_HEIGHT,
-      5,
-      DEFAULT_CELL_HEIGHT,
-    ]);
-  });
+      // clipping at the right
+      setCellContent(model, "C1", "Content at the right");
+      model.drawGrid(ctx);
+      box = getBoxFromText(model, overflowingContent);
+      expect(box.clipRect).toEqual([
+        HEADER_WIDTH + DEFAULT_CELL_WIDTH,
+        HEADER_HEIGHT,
+        5,
+        DEFAULT_CELL_HEIGHT,
+      ]);
+    }
+  );
+
+  test.each([{ align: "left" }, { align: undefined }])(
+    "Overflowing number with % align is correctly clipped",
+    (style) => {
+      const overflowingNumber = "100000000000000";
+      let box: Box;
+      const model = new Model({
+        sheets: [
+          {
+            id: "sheet1",
+            colNumber: 3,
+            rowNumber: 1,
+            cols: { 1: { size: 5 } },
+            cells: { B1: { content: overflowingNumber, style: 1 } },
+          },
+        ],
+        styles: { 1: style },
+      });
+
+      let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
+      model.drawGrid(ctx);
+
+      box = getBoxFromText(model, overflowingNumber);
+      // no clip
+      expect(box.clipRect).toBeUndefined();
+
+      // no clipping at the left
+      setCellContent(model, "A1", "Content at the left");
+      model.drawGrid(ctx);
+      box = getBoxFromText(model, overflowingNumber);
+      expect(box.clipRect).toBeUndefined();
+
+      // clipping at the right
+      setCellContent(model, "C1", "Content at the right");
+      model.drawGrid(ctx);
+      box = getBoxFromText(model, overflowingNumber);
+      expect(box.clipRect).toEqual([
+        HEADER_WIDTH + DEFAULT_CELL_WIDTH,
+        HEADER_HEIGHT,
+        5,
+        DEFAULT_CELL_HEIGHT,
+      ]);
+    }
+  );
 
   test("Overflowing right-aligned text is correctly clipped", () => {
     const overflowingText = "I am a very long text";
@@ -716,51 +762,53 @@ describe("renderer", () => {
     ]);
   });
 
-  test("Overflowing centered text is clipped on both sides", () => {
-    const overflowingText = "I am a very long text";
-    let centeredBox: Box;
-    const model = new Model({
-      sheets: [
-        {
-          id: "sheet1",
-          colNumber: 3,
-          rowNumber: 1,
-          cols: { 1: { size: 5 } },
-          cells: { B1: { content: overflowingText, style: 1 } },
-        },
-      ],
-      styles: { 1: { align: "center" } },
-    });
+  test.each(["I am a very long text", "100000000000000"])(
+    "Overflowing centered content is clipped on both sides",
+    (overflowingContent) => {
+      let centeredBox: Box;
+      const model = new Model({
+        sheets: [
+          {
+            id: "sheet1",
+            colNumber: 3,
+            rowNumber: 1,
+            cols: { 1: { size: 5 } },
+            cells: { B1: { content: overflowingContent, style: 1 } },
+          },
+        ],
+        styles: { 1: { align: "center" } },
+      });
 
-    let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+      let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
+      model.drawGrid(ctx);
 
-    centeredBox = getBoxFromText(model, overflowingText);
-    // // spans from A1 to C1 <-> no clip
-    expect(centeredBox.clipRect).toBeUndefined();
+      centeredBox = getBoxFromText(model, overflowingContent);
+      // // spans from A1 to C1 <-> no clip
+      expect(centeredBox.clipRect).toBeUndefined();
 
-    setCellContent(model, "A1", "left");
-    model.drawGrid(ctx);
+      setCellContent(model, "A1", "left");
+      model.drawGrid(ctx);
 
-    centeredBox = getBoxFromText(model, overflowingText);
-    expect(centeredBox.clipRect).toEqual([
-      HEADER_WIDTH + DEFAULT_CELL_WIDTH, // clipped to the left
-      HEADER_HEIGHT,
-      5 + DEFAULT_CELL_WIDTH,
-      DEFAULT_CELL_HEIGHT,
-    ]);
+      centeredBox = getBoxFromText(model, overflowingContent);
+      expect(centeredBox.clipRect).toEqual([
+        HEADER_WIDTH + DEFAULT_CELL_WIDTH, // clipped to the left
+        HEADER_HEIGHT,
+        5 + DEFAULT_CELL_WIDTH,
+        DEFAULT_CELL_HEIGHT,
+      ]);
 
-    setCellContent(model, "C1", "right");
-    model.drawGrid(ctx);
+      setCellContent(model, "C1", "right");
+      model.drawGrid(ctx);
 
-    centeredBox = getBoxFromText(model, overflowingText);
-    expect(centeredBox.clipRect).toEqual([
-      HEADER_WIDTH + DEFAULT_CELL_WIDTH, //clipped to the left
-      HEADER_HEIGHT,
-      5, // clipped to the right
-      DEFAULT_CELL_HEIGHT,
-    ]);
-  });
+      centeredBox = getBoxFromText(model, overflowingContent);
+      expect(centeredBox.clipRect).toEqual([
+        HEADER_WIDTH + DEFAULT_CELL_WIDTH, //clipped to the left
+        HEADER_HEIGHT,
+        5, // clipped to the right
+        DEFAULT_CELL_HEIGHT,
+      ]);
+    }
+  );
 
   test("cells with a fontsize too big for the row height are clipped", () => {
     const overflowingText = "TOO HIGH";


### PR DESCRIPTION
## Description:

Type a large number "100000000000000" in A1 such that it overflows in B1
Set some content in B1
=> the number is not clipped and overlaps the content in B1.

Broken by 5e2a78d

Odoo task ID : [2744001](https://www.odoo.com/web#id=2744001&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo