### PR TITLE
[FIX] merge: correctly update merge map when duplicating sheet

### DIFF
--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -88,24 +88,11 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
         break;
       case "DUPLICATE_SHEET":
         const merges = this.merges[cmd.sheetId];
-        if (!merges) return;
-        const mergesCopy: Record<UID, Range> = {};
+        if (!merges) break;
+        const sheet = this.getters.getSheet(cmd.sheetIdTo);
         for (const range of Object.values(merges).filter(isDefined)) {
-          mergesCopy[this.nextId++] = {
-            sheetId: cmd.sheetIdTo,
-            zone: { ...range.zone },
-            parts: [...range.parts],
-            prefixSheet: range.prefixSheet,
-            invalidSheetName: range.invalidSheetName,
-            invalidXc: range.invalidXc,
-          };
+          this.addMerge(sheet, range.zone);
         }
-        this.history.update("merges", cmd.sheetIdTo, mergesCopy);
-        this.history.update(
-          "mergeCellMap",
-          cmd.sheetIdTo,
-          Object.assign({}, this.mergeCellMap[cmd.sheetId])
-        );
         break;
       case "ADD_MERGE":
         for (const zone of cmd.target) {

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -6,6 +6,7 @@ import { CommandResult, Style } from "../../src/types/index";
 import {
   addColumns,
   deleteRows,
+  deleteSheet,
   merge,
   redo,
   selectCell,
@@ -96,6 +97,21 @@ describe("merges", () => {
       { ...toZone("C2:C3"), id: 2, topLeft: toPosition("C2") },
       { ...toZone("B2:B3"), id: 3, topLeft: toPosition("B2") },
     ]);
+    expect(model.getters.getMerge(secondSheetId, 2, 1)?.id).toBe(2);
+    expect(model.getters.getMerge(secondSheetId, 1, 1)?.id).toBe(3);
+  });
+
+  test("delete a duplicated sheet with merge", () => {
+    const model = new Model();
+    const firstSheetId = model.getters.getActiveSheetId();
+    const secondSheetId = "42";
+    merge(model, "C2:C3", firstSheetId);
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: firstSheetId,
+      sheetIdTo: secondSheetId,
+    });
+    deleteSheet(model, secondSheetId);
+    expect(model.getters.getMerges(secondSheetId)).toEqual([]);
   });
 
   test("a single cell is not merged", () => {


### PR DESCRIPTION
## Description:

In the demo spreadsheet, duplicate the first sheet, then
delete the duplicated sheet: crash

Since 72f76ad, a duplicated merge have a different id then the
original merge but the merge map was not correctly updated with
the new id.

Odoo task ID : [2742642](https://www.odoo.com/web#id=2742642&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo