### PR TITLE
[REF]*: faster chars join everywhere

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -1,6 +1,6 @@
 import { Token } from ".";
 import { functionRegistry } from "../functions/index";
-import { parseNumber, removeStringQuotes } from "../helpers";
+import { concat, parseNumber, removeStringQuotes } from "../helpers";
 import { _lt } from "../translation";
 import { CompiledFormula, FunctionDescription } from "../types/index";
 import { AST, ASTFuncall, parseTokens } from "./parser";
@@ -422,8 +422,8 @@ function compilationCacheKey(
   dependencies: string[],
   constantValues: ConstantValues
 ): string {
-  return tokens
-    .map((token) => {
+  return concat(
+    tokens.map((token) => {
       switch (token.type) {
         case "STRING":
           const value = removeStringQuotes(token.value);
@@ -437,7 +437,7 @@ function compilationCacheKey(
           return token.value;
       }
     })
-    .join("");
+  );
 }
 
 /**

--- a/src/formulas/range_tokenizer.ts
+++ b/src/formulas/range_tokenizer.ts
@@ -1,3 +1,4 @@
+import { concat } from "../helpers";
 import { Token, tokenize } from "./tokenizer";
 
 /**
@@ -33,11 +34,12 @@ export function mergeSymbolsIntoRanges(result: Token[], removeSpace = false): To
           if (startIncludingSpaces && refStart && operator && refEnd) {
             const newToken: Token = {
               type: "REFERENCE",
-              value: result
-                .slice(startIncludingSpaces, i)
-                .filter((x) => !removeSpace || x.type !== "SPACE")
-                .map((x) => x.value)
-                .join(""),
+              value: concat(
+                result
+                  .slice(startIncludingSpaces, i)
+                  .filter((x) => !removeSpace || x.type !== "SPACE")
+                  .map((x) => x.value)
+              ),
             };
             result.splice(startIncludingSpaces, i - startIncludingSpaces, newToken);
             i = startIncludingSpaces + 1;
@@ -74,11 +76,12 @@ export function mergeSymbolsIntoRanges(result: Token[], removeSpace = false): To
   if (startIncludingSpaces && refStart && operator && refEnd) {
     const newToken: Token = {
       type: "REFERENCE",
-      value: result
-        .slice(startIncludingSpaces, i + 1)
-        .filter((x) => !removeSpace || x.type !== "SPACE")
-        .map((x) => x.value)
-        .join(""),
+      value: concat(
+        result
+          .slice(startIncludingSpaces, i + 1)
+          .filter((x) => !removeSpace || x.type !== "SPACE")
+          .map((x) => x.value)
+      ),
     };
     result.splice(startIncludingSpaces, i - startIncludingSpaces + 1, newToken);
   }

--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -1,6 +1,6 @@
 import { INCORRECT_RANGE_STRING } from "../constants";
 import { functionRegistry } from "../functions/index";
-import { formulaNumberRegexp, rangeReference } from "../helpers/index";
+import { concat, formulaNumberRegexp, rangeReference } from "../helpers/index";
 import { _lt } from "../translation";
 
 /**
@@ -226,16 +226,4 @@ function tokenizeInvalidRange(chars: string[]): Token | null {
     return { type: "INVALID_REFERENCE", value: INCORRECT_RANGE_STRING };
   }
   return null;
-}
-
-/**
- * Concatenate an array of strings.
- */
-function concat(chars: string[]): string {
-  // ~40% faster than chars.join("")
-  let output = "";
-  for (let i = 0, len = chars.length; i < len; i++) {
-    output += chars[i];
-  }
-  return output;
 }

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -1,3 +1,5 @@
+import { concat } from ".";
+
 export const colors = [
   "#eb6d00",
   "#0074d9",
@@ -62,10 +64,10 @@ export function toHex6(color: string): string {
  * >> "1E5010"
  */
 function rgbToHex6(color: string): string {
-  return color
-    .slice(4, -1)
-    .split(",")
-    .map((valueString) => parseInt(valueString, 10).toString(16).padStart(2, "0"))
-    .join("")
-    .toUpperCase();
+  return concat(
+    color
+      .slice(4, -1)
+      .split(",")
+      .map((valueString) => parseInt(valueString, 10).toString(16).padStart(2, "0"))
+  ).toUpperCase();
 }

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -301,3 +301,15 @@ export function debounce(func: Function, wait: number, immediate?: boolean): Fun
     }
   };
 }
+
+/*
+ * Concatenate an array of strings.
+ */
+export function concat(chars: string[]): string {
+  // ~40% faster than chars.join("")
+  let output = "";
+  for (let i = 0, len = chars.length; i < len; i++) {
+    output += chars[i];
+  }
+  return output;
+}

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -1,7 +1,14 @@
 import { DATETIME_FORMAT, NULL_FORMAT } from "../../constants";
 import { cellFactory } from "../../helpers/cells/cell_factory";
-import { isInside, maximumDecimalPlaces, range, toCartesian, toXC } from "../../helpers/index";
-import { getItemId } from "../../helpers/misc";
+import {
+  concat,
+  getItemId,
+  isInside,
+  maximumDecimalPlaces,
+  range,
+  toCartesian,
+  toXC,
+} from "../../helpers/index";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -460,15 +467,15 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
    */
   buildFormulaContent(sheetId: UID, cell: FormulaCell, dependencies?: Range[]): string {
     const ranges = dependencies || [...cell.dependencies];
-    return cell.compiledFormula.tokens
-      .map((token) => {
+    return concat(
+      cell.compiledFormula.tokens.map((token) => {
         if (token.type === "REFERENCE") {
           const range = ranges.shift()!;
           return this.getters.getRangeString(range, sheetId);
         }
         return token.value;
       })
-      .join("");
+    );
   }
 
   getFormulaCellContent(sheetId: UID, cell: FormulaCell): string {

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -1,5 +1,6 @@
 import { INCORRECT_RANGE_STRING } from "../../constants";
 import {
+  concat,
   createAdaptedZone,
   getComposerSheetName,
   groupConsecutive,
@@ -340,7 +341,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       return INCORRECT_RANGE_STRING;
     }
 
-    let ref: string[] = Array(9);
+    let ref: string[] = Array(9).fill("");
     ref[0] = range.parts && range.parts[0].colFixed ? "$" : "";
     ref[1] = numberToLetters(range.zone.left);
     ref[2] = range.parts && range.parts[0].rowFixed ? "$" : "";
@@ -363,7 +364,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       }
     }
 
-    return `${prefixSheet ? sheetName + "!" : ""}${ref.join("")}`;
+    return `${prefixSheet ? sheetName + "!" : ""}${concat(ref)}`;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -1,6 +1,7 @@
 import { composerTokenize, EnrichedToken } from "../../formulas/index";
 import {
   colors,
+  concat,
   getComposerSheetName,
   isEqual,
   isNumber,
@@ -396,7 +397,7 @@ export class EditionPlugin extends UIPlugin {
           const right = this.currentTokens.filter((t) => t.type === "RIGHT_PAREN").length;
           const missing = left - right;
           if (missing > 0) {
-            content += new Array(missing).fill(")").join("");
+            content += concat(new Array(missing).fill(")"));
           }
         } else if (cell?.isLink()) {
           content = markdownLink(content, cell.link.url);

--- a/src/xlsx/helpers/xml_helpers.ts
+++ b/src/xlsx/helpers/xml_helpers.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FONT_SIZE } from "../../constants";
+import { concat } from "../../helpers";
 import {
   XLSXExportFile,
   XLSXStructure,
@@ -104,5 +105,5 @@ export function escapeXml(strings: TemplateStringsArray, ...expressions): XMLStr
     const value = expressions[i] instanceof XMLString ? expressions[i] : xmlEscape(expressions[i]);
     str.push(value + strings[i + 1]);
   }
-  return new XMLString(str.join(""));
+  return new XMLString(concat(str));
 }

--- a/tests/test_helpers/debug_helpers.ts
+++ b/tests/test_helpers/debug_helpers.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../src";
+import { concat } from "../../src/helpers";
 import { Branch } from "../../src/history/branch";
 import { Tree } from "../../src/history/tree";
 import { UID } from "../../src/types";
@@ -34,7 +35,7 @@ export function getDebugInfo(tree: Tree) {
         id: instruction.id,
       };
     }
-    allStrings.push(stringArray.join(""));
+    allStrings.push(concat(stringArray));
   }
   let level = 0;
   for (const branch of tree["branches"]) {


### PR DESCRIPTION
The `concat` function introduced in d66ed79b3d62dbe855ed49626fa5f3841d198d18
can be generalized everywhere we were using <Array>.join("").

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo