### PR TITLE
[FIX] conditional format: correctly duplicate ranges when sheet is du…

### DIFF
--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -116,7 +116,10 @@ export class ConditionalFormatPlugin
         this.cfRules[cmd.sheetId] = [];
         break;
       case "DUPLICATE_SHEET":
-        this.history.update("cfRules", cmd.sheetIdTo, this.cfRules[cmd.sheetId].slice());
+        this.history.update("cfRules", cmd.sheetIdTo, []);
+        for (const cf of this.getConditionalFormats(cmd.sheetId)) {
+          this.addConditionalFormatting(cf, cmd.sheetIdTo);
+        }
         break;
       case "DELETE_SHEET":
         const cfRules = Object.assign({}, this.cfRules);

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -101,6 +101,21 @@ describe("conditional format", () => {
     ]);
   });
 
+  test("is correctly duplicated when the sheet is duplicated", () => {
+    model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const cf = createEqualCF("4", { fillColor: "#0000FF" }, "2");
+    model.dispatch("ADD_CONDITIONAL_FORMAT", { cf, target: target("A1:A4"), sheetId });
+    model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "Sheet2" });
+    expect(model.getters.getConditionalFormats("Sheet2")).toEqual([
+      {
+        id: expect.any(String),
+        ranges: ["A1:A4"],
+        rule: cf.rule,
+      },
+    ]);
+  });
+
   test("add conditional format outside the sheet", () => {
     model = new Model();
     createSheet(model, { sheetId: "42" });


### PR DESCRIPTION
…plicated


## Description:


Create a new conditional format, then duplicate the sheet.
The CF in the duplicated sheet is linked to the range in the original sheet.

If you add a row/col in the first sheet, the CF in the second sheet is also
moved.

Odoo task ID : [2714872](https://www.odoo.com/web#id=2714872&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [x] exportable in excel
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [x] status is correct in Odoo