### PR TITLE
[FIX] core: correctly keep absolute references on grid manipulation

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -1120,13 +1120,23 @@ export class CorePlugin extends BasePlugin {
 
     const left = base < leftZone.left ? leftZone.left + step : leftZone.left;
     const right = base < rightZone.right ? rightZone.right + step : rightZone.right;
-    const range = this.zoneToXC({
-      ...leftZone,
-      left,
-      right,
-    });
 
-    return sheet ? `${getComposerSheetName(sheet)}!${range}` : range;
+    const [leftXc, rightXc] = ref.split(":");
+    const sheetId = this.getters.getSheetIdByName(sheet);
+    const newLeft = this.updateReference(leftXc, left - currentZone.left, 0, sheetId, false, false);
+    const newRight = this.updateReference(
+      rightXc,
+      right - currentZone.right,
+      0,
+      sheetId,
+      false,
+      false
+    );
+    if (newLeft === newRight) {
+      return newLeft;
+    }
+    //As updateReference put the sheet in the ref, we need to remove it from the right part
+    return `${newLeft}:${newRight.split("!").pop()!}`;
   };
 
   /**
@@ -1188,13 +1198,23 @@ export class CorePlugin extends BasePlugin {
 
     const top = base < topZone.top ? topZone.top + step : topZone.top;
     const bottom = base < bottomZone.bottom ? bottomZone.bottom + step : bottomZone.bottom;
-    const range = this.zoneToXC({
-      ...topZone,
-      top,
-      bottom,
-    });
 
-    return sheet ? `${getComposerSheetName(sheet)}!${range}` : range;
+    const [left, right] = ref.split(":");
+    const sheetId = this.getters.getSheetIdByName(sheet);
+    const newLeft = this.updateReference(left, 0, top - currentZone.top, sheetId, false, false);
+    const newRight = this.updateReference(
+      right,
+      0,
+      bottom - currentZone.bottom,
+      sheetId,
+      false,
+      false
+    );
+    if (newLeft === newRight) {
+      return newLeft;
+    }
+    //As updateReference put the sheet in the ref, we need to remove it from the right part
+    return `${newLeft}:${newRight.split("!").pop()!}`;
   };
 
   // ---------------------------------------------------------------------------

--- a/tests/plugins/core_test.ts
+++ b/tests/plugins/core_test.ts
@@ -258,6 +258,102 @@ describe("core", () => {
     expect(model.getters.getNumberRows("2")).toEqual(29);
     expect(model.getters.getNumberCols("2")).toEqual(19);
   });
+
+  test("Range with absolute references are correctly updated on rows manipulation", () => {
+    const model = new Model();
+    model.dispatch("UPDATE_CELL", {
+      col: 0,
+      row: 0,
+      sheet: model.getters.getActiveSheet(),
+      content: "=SUM($C$1:$C$5)",
+    });
+    model.dispatch("ADD_ROWS", {
+      position: "after",
+      row: 2,
+      quantity: 1,
+      sheet: model.getters.getActiveSheet(),
+    });
+    expect(model.getters.getCell(0, 0)!.content).toBe("=SUM($C$1:$C$6)");
+    model.dispatch("ADD_ROWS", {
+      position: "before",
+      row: 0,
+      quantity: 1,
+      sheet: model.getters.getActiveSheet(),
+    });
+    expect(model.getters.getCell(0, 1)!.content).toBe("=SUM($C$2:$C$7)");
+  });
+
+  test("Absolute references are correctly updated on rows manipulation", () => {
+    const model = new Model();
+    model.dispatch("UPDATE_CELL", {
+      col: 0,
+      row: 0,
+      sheet: model.getters.getActiveSheet(),
+      content: "=SUM($C$1)",
+    });
+    model.dispatch("ADD_ROWS", {
+      position: "after",
+      row: 2,
+      quantity: 1,
+      sheet: model.getters.getActiveSheet(),
+    });
+    expect(model.getters.getCell(0, 0)!.content).toBe("=SUM($C$1)");
+    model.dispatch("ADD_ROWS", {
+      position: "before",
+      row: 0,
+      quantity: 1,
+      sheet: model.getters.getActiveSheet(),
+    });
+    expect(model.getters.getCell(0, 1)!.content).toBe("=SUM($C$2)");
+  });
+
+  test("Range with absolute references are correctly updated on columns manipulation", () => {
+    const model = new Model();
+    model.dispatch("UPDATE_CELL", {
+      col: 0,
+      row: 0,
+      sheet: model.getters.getActiveSheet(),
+      content: "=SUM($A$2:$E$2)",
+    });
+    model.dispatch("ADD_COLUMNS", {
+      position: "after",
+      column: 2,
+      quantity: 1,
+      sheet: model.getters.getActiveSheet(),
+    });
+    expect(model.getters.getCell(0, 0)!.content).toBe("=SUM($A$2:$F$2)");
+    model.dispatch("ADD_COLUMNS", {
+      position: "before",
+      column: 0,
+      quantity: 1,
+      sheet: model.getters.getActiveSheet(),
+    });
+    expect(model.getters.getCell(1, 0)!.content).toBe("=SUM($B$2:$G$2)");
+  });
+
+  test("Absolute references are correctly updated on columns manipulation", () => {
+    const model = new Model();
+    model.dispatch("UPDATE_CELL", {
+      col: 0,
+      row: 0,
+      sheet: model.getters.getActiveSheet(),
+      content: "=SUM($A$2)",
+    });
+    model.dispatch("ADD_COLUMNS", {
+      position: "after",
+      column: 2,
+      quantity: 1,
+      sheet: model.getters.getActiveSheet(),
+    });
+    expect(model.getters.getCell(0, 0)!.content).toBe("=SUM($A$2)");
+    model.dispatch("ADD_COLUMNS", {
+      position: "before",
+      column: 0,
+      quantity: 1,
+      sheet: model.getters.getActiveSheet(),
+    });
+    expect(model.getters.getCell(1, 0)!.content).toBe("=SUM($B$2)");
+  });
 });
 
 describe("history", () => {


### PR DESCRIPTION
Before this commit, absolute references ($) were not kept when the
reference was updated due to grid manipulation (add columns/rows)

Task-id 2745045

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2745045](https://www.odoo.com/web#id=2745045&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)