### PR TITLE
[FIX] chart: deterministic duplicated chart id

### DIFF
--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -30,11 +30,13 @@ import { CorePlugin } from "../core_plugin";
 
 interface ChartState {
   readonly chartFigures: Record<UID, ChartDefinition | undefined>;
+  readonly nextId: number;
 }
 
 export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   static getters = ["getChartDefinition", "getChartDefinitionUI", "getChartsIdBySheet"];
   readonly chartFigures: Record<UID, ChartDefinition> = {};
+  readonly nextId = 1;
 
   adaptRanges(applyChange: ApplyRangeChange) {
     for (let [chartId, chart] of Object.entries(this.chartFigures)) {
@@ -160,7 +162,8 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
         const sheetFiguresFrom = this.getters.getFigures(cmd.sheetId);
         for (const fig of sheetFiguresFrom) {
           if (fig.tag === "chart") {
-            const id = this.uuidGenerator.uuidv4();
+            const id = this.nextId.toString();
+            this.history.update("nextId", this.nextId + 1);
             const chartDefinition = { ...deepCopy(this.chartFigures[fig.id]), id };
             chartDefinition.sheetId = cmd.sheetIdTo;
             chartDefinition.dataSets.forEach((dataset) => {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -8,6 +8,7 @@ import {
   addColumns,
   addRows,
   clearCell,
+  createChart,
   createSheet,
   deleteColumns,
   deleteRows,
@@ -443,6 +444,23 @@ describe("Multi users synchronisation", () => {
       (user) => getCellContent(user, "A2"),
       "hello"
     );
+  });
+
+  test("duplicated chart are the same", () => {
+    createChart(
+      alice,
+      {
+        dataSets: ["A8:D8", "A9:D9"],
+        labelRange: "B7:D7",
+        type: "line",
+      },
+      "1"
+    );
+    alice.dispatch("DUPLICATE_SHEET", {
+      sheetId: alice.getters.getActiveSheetId(),
+      sheetIdTo: "Sheet2",
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
   });
 
   test("Composer is moved when column is removed before it", () => {


### PR DESCRIPTION

## Description:

In a collaborative context:
- Add a chart on a sheet
- duplicate the sheet
=> the chart id is different for different users and they end up in
different states.

Odoo task ID : [2746006](https://www.odoo.com/web#id=2746006&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo