### PR TITLE
[FWP] *: Forward port 14.0 to 15.0

### DIFF
--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -8,6 +8,7 @@ import {
   ConditionalFormatRule,
   SingleColorRules,
   SpreadsheetEnv,
+  UID,
   Zone,
 } from "../../../types";
 import { getTextDecoration } from "../../helpers/dom_helpers";
@@ -347,6 +348,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
   private cellIsOperators = cellIsOperators;
   private editor = useRef("editorRef");
   private getters = this.env.getters;
+  private activeSheetId: UID;
 
   private state: State = useState({
     mode: "list",
@@ -362,8 +364,8 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
 
   constructor(parent: any, props: Props) {
     super(parent, props);
-    const sheetId = this.getters.getActiveSheetId();
-    const rules = this.getters.getRulesSelection(sheetId, props.selection || []);
+    this.activeSheetId = this.getters.getActiveSheetId();
+    const rules = this.getters.getRulesSelection(this.activeSheetId, props.selection || []);
     if (rules.length === 1) {
       const cf = this.conditionalFormats.find((c) => c.id === rules[0]);
       if (cf) {
@@ -387,7 +389,11 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
   }
 
   async willUpdateProps(nextProps: Props) {
-    if (nextProps.selection !== this.props.selection) {
+    const newActiveSheetId = this.getters.getActiveSheetId();
+    if (newActiveSheetId !== this.activeSheetId) {
+      this.activeSheetId = newActiveSheetId;
+      this.switchToList();
+    } else if (nextProps.selection !== this.props.selection) {
       const sheetId = this.getters.getActiveSheetId();
       const rules = this.getters.getRulesSelection(sheetId, nextProps.selection || []);
       if (rules.length === 1) {

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -3,6 +3,8 @@ import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
   activateSheet,
+  addColumns,
+  addRows,
   createSheet,
   redo,
   resizeColumns,
@@ -287,6 +289,46 @@ describe("core", () => {
     expect(model.getters.getActiveSheetId()).not.toBe("2");
     expect(model.getters.getSheet("2").rows.length).toEqual(29);
     expect(model.getters.getSheet("2").cols.length).toEqual(19);
+  });
+
+  test("Range with absolute references are correctly updated on rows manipulation", () => {
+    const model = new Model();
+    model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
+    setCellContent(model, "A1", "=SUM($C$1:$C$5)");
+    addRows(model, "after", 2, 1);
+    expect(getCellContent(model, "A1")).toBe("=SUM($C$1:$C$6)");
+    addRows(model, "before", 0, 1);
+    expect(getCellContent(model, "A2")).toBe("=SUM($C$2:$C$7)");
+  });
+
+  test("Absolute references are correctly updated on rows manipulation", () => {
+    const model = new Model();
+    model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
+    setCellContent(model, "A1", "=SUM($C$1)");
+    addRows(model, "after", 2, 1);
+    expect(getCellContent(model, "A1")).toBe("=SUM($C$1)");
+    addRows(model, "before", 0, 1);
+    expect(getCellContent(model, "A2")).toBe("=SUM($C$2)");
+  });
+
+  test("Range with absolute references are correctly updated on columns manipulation", () => {
+    const model = new Model();
+    model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
+    setCellContent(model, "A1", "=SUM($A$2:$E$2)");
+    addColumns(model, "after", "C", 1);
+    expect(getCellContent(model, "A1")).toBe("=SUM($A$2:$F$2)");
+    addColumns(model, "before", "A", 1);
+    expect(getCellContent(model, "B1")).toBe("=SUM($B$2:$G$2)");
+  });
+
+  test("Absolute references are correctly updated on columns manipulation", () => {
+    const model = new Model();
+    model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
+    setCellContent(model, "A1", "=SUM($A$2)");
+    addColumns(model, "after", "C", 1);
+    expect(getCellContent(model, "A1")).toBe("=SUM($A$2)");
+    addColumns(model, "before", "A", 1);
+    expect(getCellContent(model, "B1")).toBe("=SUM($B$2)");
   });
 });
 


### PR DESCRIPTION
This contains the following changes:

3151e2 [FIX] CF component: Reset to List on change Sheet
fa130e [FIX] core: correctly keep absolute references on grid manipulation

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo