### PR TITLE
[FIX] evaluation: limit re-evaluations triggered by datasources

### DIFF
--- a/src/data_source.ts
+++ b/src/data_source.ts
@@ -20,7 +20,11 @@ export class DataSourceRegistry<M, D> extends owl.core.EventBus {
    */
   add(key: string, value: DataSource<M, D>): DataSourceRegistry<M, D> {
     this.registry.add(key, value);
-    value.on("data-loaded", this, () => this.trigger("data-loaded", { id: key }));
+    const debouncedLoaded: Function = owl.utils.debounce(
+      () => this.trigger("data-loaded", { id: key }),
+      0
+    );
+    value.on("data-loaded", this, () => debouncedLoaded());
     value.loadMetadata();
     return this;
   }


### PR DESCRIPTION
Currently, datasources are able to notify that they have updated their
data and each of these notification will trigger a full evaluation of
the current sheet.

Unfortunately, we encounter situations where the number of notifications
explodes.
E.g. in [pivot_structure_plugin], each call to this function will trigger an evaluation. Said
evaluation could handle a `PIVOT.HEADER` formula, which will in turn
trigger an evaluation if the cache is not updated yet, etc ...

Concretely, if the triggers occur in batch, only the last one is relevant.
This commit therefore adds a debounce to the event 'data-loaded' triggered
by the dataSource registry, which will  in turn drastically reduce the number
of evaluations.

In case of [pivot_structure_plugin], the number of evaluations is now equal to the number
of groupBys in the pivot.


task 2752589

[pivot_structure_plugin]:https://github.com/odoo/enterprise/blob/15.0/documents_spreadsheet/static/src/js/o_spreadsheet/plugins/ui/pivot_structure_plugin.js#L84-L97

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2752589](https://www.odoo.com/web#id=2752589&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [x] exportable in excel
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [x] status is correct in Odoo