### PR TITLE
[FIX] edition: cancel edition if sheet is deleted

### DIFF
--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -201,8 +201,12 @@ export class EditionPlugin extends UIPlugin {
         this.selectionEnd = this.currentContent.length;
         break;
       case "DELETE_SHEET":
-        if (cmd.sheetId === this.sheet && this.mode !== "inactive") {
-          this.dispatch("STOP_EDITION", { cancel: true });
+      case "UNDO":
+      case "REDO":
+        const sheetIdExists = !!this.getters.tryGetSheet(this.sheet);
+        if (!sheetIdExists && this.mode !== "inactive") {
+          this.cancelEdition();
+          this.resetContent();
           this.ui.notifyUser(CELL_DELETED_MESSAGE);
         }
         break;

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -13,6 +13,7 @@ import {
   deleteColumns,
   deleteRows,
   merge,
+  redo,
   selectCell,
   setCellContent,
   undo,
@@ -634,6 +635,30 @@ describe("Multi users synchronisation", () => {
     const spy = jest.spyOn(alice["config"], "notifyUser");
     alice.dispatch("START_EDITION", { text: "hello" });
     bob.dispatch("DELETE_SHEET", { sheetId: "42" });
+    expect(spy).toHaveBeenCalled();
+    expect(alice.getters.getEditionMode()).toBe("inactive");
+  });
+
+  test("Composing in a sheet when a sheet deletion is redone", () => {
+    createSheet(alice, { sheetId: "42" });
+    selectCell(alice, "A4");
+    const spy = jest.spyOn(alice["config"], "notifyUser");
+    bob.dispatch("DELETE_SHEET", { sheetId: "42" });
+    undo(bob);
+    activateSheet(alice, "42");
+    alice.dispatch("START_EDITION", { text: "hello" });
+    redo(bob);
+    expect(spy).toHaveBeenCalled();
+    expect(alice.getters.getEditionMode()).toBe("inactive");
+  });
+
+  test("Composing in a sheet when a sheet creation is undone", () => {
+    createSheet(bob, { sheetId: "42" });
+    selectCell(alice, "A4");
+    const spy = jest.spyOn(alice["config"], "notifyUser");
+    activateSheet(alice, "42");
+    alice.dispatch("START_EDITION", { text: "hello" });
+    undo(bob);
     expect(spy).toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
   });


### PR DESCRIPTION

## Description:

If one user is editing a cell and the sheet is deleted
by another user with undo/redo, the composer is not closed.

Co-authored-by: rrahir <rar@odoo.com>

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo