### PR TITLE
[FIX] edition: check merge cell in the correct sheet

### DIFF
--- a/src/plugins/edition.ts
+++ b/src/plugins/edition.ts
@@ -105,7 +105,9 @@ export class EditionPlugin extends BasePlugin {
     if (this.mode !== "inactive") {
       this.cancelEdition();
       let xc = toXC(this.col, this.row);
-      const { mergeCellMap, merges, cells } = this.workbook.activeSheet;
+      const { mergeCellMap, merges, cells } = this.getters
+        .getSheets()
+        .find((sheet) => sheet.id === this.sheet)!;
       if (xc in mergeCellMap) {
         const mergeId = mergeCellMap[xc];
         xc = merges[mergeId].topLeft;

--- a/tests/plugins/edition_test.ts
+++ b/tests/plugins/edition_test.ts
@@ -1,3 +1,4 @@
+import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import "../helpers"; // to have getcontext mocks
 import { getCell } from "../helpers";
@@ -76,5 +77,24 @@ describe("edition", () => {
     expect(model.getters.getEditionMode()).toBe("inactive");
     model.dispatch("STOP_COMPOSER_SELECTION");
     expect(model.getters.getEditionMode()).toBe("inactive");
+  });
+
+  test("start editing where theres a merge on other sheet, change sheet, and stop edition", () => {
+    const model = new Model();
+    const sheetId1 = model.getters.getActiveSheet();
+    const sheetId2 = "42";
+    model.dispatch("ADD_MERGE", {
+      sheet: sheetId1,
+      zone: toZone("A1:D5"),
+    });
+    model.dispatch("CREATE_SHEET", { activate: true, id: sheetId2 });
+    model.dispatch("SELECT_CELL", { col: 2, row: 2 });
+
+    model.dispatch("START_EDITION", { text: "=" });
+    model.dispatch("START_COMPOSER_SELECTION");
+    model.dispatch("ACTIVATE_SHEET", { from: sheetId2, to: sheetId1 });
+    model.dispatch("STOP_EDITION");
+    expect(model.getters.getCell(2, 2, "Sheet2")?.content).toBe("=");
+    expect(model.getters.getCell(0, 0, "Sheet2")).toBeNull();
   });
 });


### PR DESCRIPTION

## Description:

On sheet1, merge A1:D5,
create another sheet, and type "=" in B2,
Return to sheet1 and type Enter in your composer.
The composer content is set in A1 instead of B2

Co-authored-by: rrahir <rar@odoo.com>

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo