### PR TITLE
[FIX] evaluation: evaluate all sheets forces the evaluation

### DIFF
--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -312,10 +312,8 @@ export class EvaluationPlugin extends UIPlugin {
    */
   private evaluateAllSheets() {
     for (const sheetId of this.getters.getVisibleSheets()) {
-      if (!this.isUpToDate.has(sheetId)) {
-        this.evaluate(sheetId);
-        this.isUpToDate.add(sheetId);
-      }
+      this.evaluate(sheetId);
+      this.isUpToDate.add(sheetId);
     }
   }
 }

--- a/tests/data_source.test.ts
+++ b/tests/data_source.test.ts
@@ -114,4 +114,13 @@ describe("DataSource", () => {
     jest.advanceTimersByTime(2);
     expect(getCellContent(model, "A1")).toBe("data");
   });
+
+  test("evaluate all sheets forces evaluation", async () => {
+    dataSourcePlugin.addDataSource("1", new StringDataSource());
+    setCellContent(model, "A1", "=WAIT2(1)");
+    expect(getCellContent(model, "A1")).toBe("LOADING...");
+    await model.waitForIdle();
+    model.dispatch("EVALUATE_ALL_SHEETS");
+    expect(getCellContent(model, "A1")).toBe("data");
+  });
 });


### PR DESCRIPTION
## Description:

- In odoo, insert a pivot in a spreadsheet.
- From the Documents app kanban view, select the spreadsheet and
  click on the download button
=> all pivot formulas are "Loading..."

Bug introduced by https://github.com/odoo/o-spreadsheet/commit/3eadb34b2133ec1c4f6c07e7814563f3cf0e344c
Since that commit, the event which triggers an evaluation is no longer triggered synchronously.
Before `await dataSources.waitForReady()` would wait "data sources are loaded" which had
the (synchronous) side effect of forcing an evaluation.
Since https://github.com/odoo/o-spreadsheet/commit/3eadb34b2133ec1c4f6c07e7814563f3cf0e344c, the side effect is no longer synchronous because the event which triggers the
evaluation is no longer triggered synchronously

The command "EVALUATE_ALL_SHEETS" should evaluate a sheet even if it's
marked as "up to date".

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [x] exportable in excel
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo