### PR TITLE
[FWP] *: Forward port saas-15.1 to saas-15.2

### DIFF
--- a/src/collaborative/ot/ot.ts
+++ b/src/collaborative/ot/ot.ts
@@ -216,10 +216,11 @@ function transformPositionWithGrid(
   const field = executed.dimension === "COL" ? "col" : "row";
   let base = cmd[field];
   if (executed.type === "REMOVE_COLUMNS_ROWS") {
-    if (executed.elements.includes(base)) {
+    const elements = [...executed.elements].sort((a, b) => b - a);
+    if (elements.includes(base)) {
       return "IGNORE_COMMAND";
     }
-    for (let removedElement of executed.elements) {
+    for (let removedElement of elements) {
       if (base >= removedElement) {
         base--;
       }

--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -221,7 +221,11 @@ export class Session extends EventBus<CollaborativeEvent> {
         break;
       case "REVISION_REDONE": {
         this.waitingAck = false;
-        this.revisions.redo(message.redoneRevisionId, message.nextRevisionId);
+        this.revisions.redo(
+          message.redoneRevisionId,
+          message.nextRevisionId,
+          message.serverRevisionId
+        );
         this.trigger("revision-redone", {
           revisionId: message.redoneRevisionId,
           commands: this.revisions.get(message.redoneRevisionId).commands,
@@ -230,7 +234,11 @@ export class Session extends EventBus<CollaborativeEvent> {
       }
       case "REVISION_UNDONE":
         this.waitingAck = false;
-        this.revisions.undo(message.undoneRevisionId, message.nextRevisionId);
+        this.revisions.undo(
+          message.undoneRevisionId,
+          message.nextRevisionId,
+          message.serverRevisionId
+        );
         this.trigger("revision-undone", {
           revisionId: message.undoneRevisionId,
           commands: this.revisions.get(message.undoneRevisionId).commands,
@@ -304,11 +312,27 @@ export class Session extends EventBus<CollaborativeEvent> {
     this.sendPendingMessage();
   }
 
+  /**
+   * Send the next pending message
+   */
   private sendPendingMessage() {
     let message = this.pendingMessages[0];
     if (!message) return;
     if (message.type === "REMOTE_REVISION") {
       const revision = this.revisions.get(message.nextRevisionId);
+      if (revision.commands.length === 0) {
+        /**
+         * The command is empty, we have to drop all the next local revisions
+         * to avoid issues with undo/redo
+         */
+        this.revisions.drop(revision.id);
+        const revisionIds = this.pendingMessages
+          .filter((message) => message.type === "REMOTE_REVISION")
+          .map((message) => message.nextRevisionId);
+        this.trigger("pending-revisions-dropped", { revisionIds });
+        this.pendingMessages = [];
+        return;
+      }
       message = {
         ...message,
         clientId: revision.clientId,

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -91,7 +91,9 @@ export function expandZoneOnInsertion(
   const dimension = start === "left" ? "columns" : "rows";
   const baseElement = position === "before" ? base - 1 : base;
   const end = start === "left" ? "right" : "bottom";
-  if (zone[start] <= baseElement && zone[end] >= baseElement) {
+  const shouldIncludeEnd =
+    position === "before" ? zone[end] > baseElement : zone[end] >= baseElement;
+  if (zone[start] <= baseElement && shouldIncludeEnd) {
     return createAdaptedZone(zone, dimension, "RESIZE", quantity);
   }
   if (baseElement < zone[start]) {

--- a/src/history/branch.ts
+++ b/src/history/branch.ts
@@ -79,7 +79,14 @@ export class Branch<T> {
   }
 
   /**
-   * Create and return a copy of this branch, starting at the given operationId
+   * Append operations in the given branch to this branch.
+   */
+  appendBranch(branch: Branch<T>) {
+    this.operations = this.operations.concat(branch.operations);
+  }
+
+  /**
+   * Create and return a copy of this branch, starting after the given operationId
    */
   fork(operationId: UID): Branch<T> {
     const { after } = this.locateOperation(operationId);
@@ -90,9 +97,23 @@ export class Branch<T> {
    * Transform all the operations in this branch with the given transformation
    */
   transform(transformation: Transformation<T>) {
-    this.operations = this.operations.map((operation) =>
-      operation.transformed(transformation, false)
-    );
+    this.operations = this.operations.map((operation) => operation.transformed(transformation));
+  }
+
+  /**
+   * Cut the branch before the operation, meaning the operation
+   * and all following operations are dropped.
+   */
+  cutBefore(operationId: UID) {
+    this.operations = this.locateOperation(operationId).before;
+  }
+
+  /**
+   * Cut the branch after the operation, meaning all following operations are dropped.
+   */
+  cutAfter(operationId: UID) {
+    const { before, operation } = this.locateOperation(operationId);
+    this.operations = before.concat([operation]);
   }
 
   /**

--- a/src/history/local_history.ts
+++ b/src/history/local_history.ts
@@ -39,6 +39,7 @@ export class LocalHistory extends owl.core.EventBus implements CommandHandler<Co
     this.session.on("new-local-state-update", this, this.onNewLocalStateUpdate);
     this.session.on("revision-undone", this, ({ commands }) => this.selectiveUndo(commands));
     this.session.on("revision-redone", this, ({ commands }) => this.selectiveRedo(commands));
+    this.session.on("pending-revisions-dropped", this, ({ revisionIds }) => this.drop(revisionIds));
     this.session.on("snapshot", this, () => {
       this.undoStack = [];
       this.redoStack = [];
@@ -101,6 +102,12 @@ export class LocalHistory extends owl.core.EventBus implements CommandHandler<Co
 
   canRedo(): boolean {
     return this.redoStack.length > 0;
+  }
+
+  private drop(revisionIds: UID[]) {
+    this.undoStack = this.undoStack.filter((id) => !revisionIds.includes(id));
+    this.redoStack = [];
+    this.isWaitingForUndoRedo = false;
   }
 
   private onNewLocalStateUpdate({ id }: { id: UID }) {

--- a/src/history/operation.ts
+++ b/src/history/operation.ts
@@ -11,13 +11,9 @@ import { Transformation, UID } from "../types";
  * to revert it).
  */
 export class Operation<T> {
-  constructor(readonly id: UID, readonly data: T, public readonly isOriginal = true) {}
+  constructor(readonly id: UID, readonly data: T) {}
 
-  transformed(transformation: Transformation<T>, isOriginal?: boolean): Operation<T> {
-    return new Operation(
-      this.id,
-      transformation(this.data),
-      isOriginal !== undefined ? isOriginal : this.isOriginal
-    );
+  transformed(transformation: Transformation<T>): Operation<T> {
+    return new Operation(this.id, transformation(this.data));
   }
 }

--- a/src/history/selective_history.ts
+++ b/src/history/selective_history.ts
@@ -68,34 +68,39 @@ export class SelectiveHistory<T = unknown> {
   insert(operationId: UID, data: T, insertAfter: UID) {
     const operation = new Operation<T>(operationId, data);
     this.revertTo(insertAfter);
-    // insert to branch where it first was executed!
-    const branch = this.tree.findOriginBranch(this.HEAD_BRANCH, insertAfter);
-    this.tree.insertOperationAfter(branch, operation, insertAfter);
+    this.tree.insertOperationAfter(this.HEAD_BRANCH, operation, insertAfter);
     this.fastForward();
   }
 
   /**
    * @param operationId operation to undo
    * @param undoId the id of the "undo operation"
+   * @param insertAfter the id of the operation after which to insert the undo
    */
-  undo(operationId: UID, undoId: UID) {
+  undo(operationId: UID, undoId: UID, insertAfter: UID) {
     const { branch, operation } = this.tree.findOperation(this.HEAD_BRANCH, operationId);
     this.revertBefore(operationId);
     this.tree.undo(branch, operation);
     this.fastForward();
-    this.append(undoId, this.buildEmpty(undoId));
+    this.insert(undoId, this.buildEmpty(undoId), insertAfter);
   }
 
   /**
    * @param operationId operation to redo
    * @param redoId the if of the "redo operation"
+   * @param insertAfter the id of the operation after which to insert the redo
    */
-  redo(operationId: UID, redoId: UID) {
+  redo(operationId: UID, redoId: UID, insertAfter: UID) {
     const { branch } = this.tree.findOperation(this.HEAD_BRANCH, operationId);
     this.revertBefore(operationId);
     this.tree.redo(branch);
     this.fastForward();
-    this.append(redoId, this.buildEmpty(redoId));
+    this.insert(redoId, this.buildEmpty(redoId), insertAfter);
+  }
+
+  drop(operationId: UID) {
+    this.revertBefore(operationId);
+    this.tree.drop(operationId);
   }
 
   /**

--- a/src/history/tree.ts
+++ b/src/history/tree.ts
@@ -163,6 +163,18 @@ export class Tree<T = unknown> {
   }
 
   /**
+   * Drop the operation and all following operations in every
+   * branch
+   */
+  drop(operationId: UID) {
+    for (const branch of this.branches) {
+      if (branch.contains(operationId)) {
+        branch.cutBefore(operationId);
+      }
+    }
+  }
+
+  /**
    * Find the operation in the execution path.
    */
   findOperation(branch: Branch<T>, operationId: UID): OperationSequenceNode<T> {
@@ -172,23 +184,6 @@ export class Tree<T = unknown> {
       }
     }
     throw new Error(`Operation ${operationId} not found`);
-  }
-
-  /**
-   * Find the branch in which the operation was first inserted.
-   */
-  findOriginBranch(branch: Branch<T>, operationId: UID): Branch<T> {
-    let currentBranch: Branch<T> | undefined = branch;
-    while (currentBranch) {
-      if (currentBranch.getOperation(operationId).isOriginal) {
-        return currentBranch;
-      }
-      currentBranch = this.previousBranch(currentBranch);
-    }
-    if (!currentBranch) {
-      throw new Error("Branch not found");
-    }
-    return currentBranch;
   }
 
   /**
@@ -290,7 +285,7 @@ export class Tree<T = unknown> {
   ): Operation<T> {
     const branchingOperation = branch.getOperation(branchingId);
     const branchingTransformation = this.buildTransformation.without(branchingOperation.data);
-    return operation.transformed(branchingTransformation, false);
+    return operation.transformed(branchingTransformation);
   }
 
   /**
@@ -319,8 +314,11 @@ export class Tree<T = unknown> {
     const { previousBranch, branchingOperation } = this.findPreviousBranchingOperation(branch);
     if (!previousBranch || !branchingOperation) return;
     const transformation = this.buildTransformation.with(branchingOperation.data);
-    const operationToInsert = newOperation.transformed(transformation, false);
-    previousBranch.insert(operationToInsert, insertAfter);
+    const branchTail = branch.fork(insertAfter);
+    branchTail.transform(transformation);
+    previousBranch.cutAfter(insertAfter);
+    previousBranch.appendBranch(branchTail);
+    const operationToInsert = newOperation.transformed(transformation);
     this.insertPrevious(previousBranch, operationToInsert, insertAfter);
   }
 

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -7,7 +7,6 @@ import {
   ApplyRangeChange,
   Cell,
   CellData,
-  CellPosition,
   CellValueType,
   CommandResult,
   CompiledFormula,
@@ -362,9 +361,12 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
 
     for (let _sheet of data.sheets) {
       const cells: { [key: string]: CellData } = {};
-      for (let [cellId, cell] of Object.entries(this.cells[_sheet.id] || {})) {
-        let position: CellPosition = this.getters.getCellPosition(cellId);
-        let xc = toXC(position.col, position.row);
+      const positions = Object.keys(this.cells[_sheet.id] || {})
+        .map((cellId) => this.getters.getCellPosition(cellId))
+        .sort((a, b) => (a.col === b.col ? a.row - b.row : a.col - b.col));
+      for (const { col, row } of positions) {
+        const cell = this.getters.getCell(_sheet.id, col, row)!;
+        const xc = toXC(col, row);
 
         cells[xc] = {
           style: cell.style ? getItemId<Style>(cell.style, styles) : undefined,

--- a/src/plugins/core/figures.ts
+++ b/src/plugins/core/figures.ts
@@ -1,5 +1,12 @@
 import { isDefined } from "../../helpers/index";
-import { CoreCommand, ExcelWorkbookData, Figure, UID, WorkbookData } from "../../types/index";
+import {
+  CommandResult,
+  CoreCommand,
+  ExcelWorkbookData,
+  Figure,
+  UID,
+  WorkbookData,
+} from "../../types/index";
 import { CorePlugin } from "../core_plugin";
 
 interface FigureState {
@@ -14,6 +21,17 @@ export class FigurePlugin extends CorePlugin<FigureState> implements FigureState
   // ---------------------------------------------------------------------------
   // Command Handling
   // ---------------------------------------------------------------------------
+
+  allowDispatch(cmd: CoreCommand) {
+    switch (cmd.type) {
+      case "UPDATE_FIGURE":
+      case "DELETE_FIGURE":
+        return this.checkFigureExists(cmd.sheetId, cmd.id);
+      default:
+        return CommandResult.Success;
+    }
+  }
+
   handle(cmd: CoreCommand) {
     switch (cmd.type) {
       case "CREATE_SHEET":
@@ -68,6 +86,13 @@ export class FigurePlugin extends CorePlugin<FigureState> implements FigureState
 
   private removeFigure(id: string, sheetId: UID) {
     this.history.update("figures", sheetId, id, undefined);
+  }
+
+  private checkFigureExists(sheetId: UID, figureId: UID): CommandResult {
+    if (this.figures[sheetId]?.[figureId] === undefined) {
+      return CommandResult.FigureDoesNotExist;
+    }
+    return CommandResult.Success;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -298,10 +298,8 @@ export class EvaluationPlugin extends UIPlugin {
    */
   private evaluateAllSheets() {
     for (const sheetId of this.getters.getVisibleSheets()) {
-      if (!this.isUpToDate.has(sheetId)) {
-        this.evaluate(sheetId);
-        this.isUpToDate.add(sheetId);
-      }
+      this.evaluate(sheetId);
+      this.isUpToDate.add(sheetId);
     }
   }
 }

--- a/src/registries/inverse_command_registry.ts
+++ b/src/registries/inverse_command_registry.ts
@@ -82,7 +82,8 @@ function inverseDuplicateSheet(cmd: DuplicateSheetCommand): DeleteSheetCommand[]
 
 function inverseRemoveColumnsRows(cmd: RemoveColumnsRowsCommand): AddColumnsRowsCommand[] {
   const commands: AddColumnsRowsCommand[] = [];
-  for (let group of groupConsecutive(cmd.elements.sort((a, b) => a - b))) {
+  const elements = [...cmd.elements].sort((a, b) => a - b);
+  for (let group of groupConsecutive(elements)) {
     const column = group[0] === 0 ? 0 : group[0] - 1;
     const position = group[0] === 0 ? "before" : "after";
     commands.push({

--- a/src/types/collaborative/session.ts
+++ b/src/types/collaborative/session.ts
@@ -51,6 +51,11 @@ export interface NewLocalStateUpdateEvent {
   id: UID;
 }
 
+export interface RevisionsDroppedEvent {
+  type: "pending-revisions-dropped";
+  revisionIds: UID[];
+}
+
 export interface SnapshotEvent {
   type: "snapshot";
 }
@@ -62,6 +67,7 @@ export type CollaborativeEvent =
   | RevisionAcknowledgedEvent
   | RevisionUndone
   | RevisionRedone
+  | RevisionsDroppedEvent
   | SnapshotEvent
   | CollaborativeEventReceived;
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1041,6 +1041,7 @@ export const enum CommandResult {
   Readonly,
   InvalidOffset,
   InvalidViewportSize,
+  FigureDoesNotExist,
 }
 
 export interface CommandHandler<T> {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -1,7 +1,7 @@
 import { Model } from "../../src";
 import { DEFAULT_REVISION_ID, MESSAGE_VERSION } from "../../src/constants";
 import { toZone } from "../../src/helpers";
-import { CoreCommand } from "../../src/types";
+import { CommandResult, CoreCommand } from "../../src/types";
 import { CollaborationMessage } from "../../src/types/collaborative/transport_service";
 import {
   activateSheet,
@@ -266,13 +266,8 @@ describe("Multi users synchronisation", () => {
     ]);
     undo(bob);
     expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "B3"), undefined);
-    expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => getCellContent(user, "C1"),
-      "hello"
-    );
-    undo(bob);
-    expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "B3"), undefined);
     expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "C1"), undefined);
+    expect(undo(bob)).toBeCancelledBecause(CommandResult.EmptyUndoStack);
   });
 
   test("2-Merge a cell and update a cell concurrently, then remove the merge", () => {

--- a/tests/collaborative/collaborative_helpers.ts
+++ b/tests/collaborative/collaborative_helpers.ts
@@ -7,6 +7,15 @@ interface CollaborativeEnv {
   charlie: Model;
 }
 
+/**
+ * Create a spreadsheet model which is edited by three users Alice, Bob and Charlie
+ * at the same time.
+ *
+ * There's a bias in the order of messages: when multiple commands are
+ * dispatched concurrently by different users, Alice will receive messages
+ * first, meaning she will also resend her pending messages first.
+ * Similarly, Bob's messages are resent before Charlie's.
+ */
 export function setupCollaborativeEnv(): CollaborativeEnv {
   const network = new MockTransportService();
   const emptySheetData = new Model().exportData();

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -15,6 +15,7 @@ import {
   undo,
 } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent } from "../test_helpers/getters_helpers";
+import { target } from "../test_helpers/helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
 import { setupCollaborativeEnv } from "./collaborative_helpers";
 
@@ -621,5 +622,179 @@ describe("Collaborative local history", () => {
       type: "REDO",
       commands: [{ ...command, col: 1 }],
     });
+  });
+  test("dispatch command after concurrent action with another user", () => {
+    addColumns(bob, "before", "A", 1);
+    network.concurrent(() => {
+      undo(bob);
+      setCellContent(charlie, "D25", "D");
+    });
+    setCellContent(bob, "A13", "A");
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getCellContent(user, "A13"),
+      "A"
+    );
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+  });
+
+  test("Concurrent undo with actions from at least two users", () => {
+    setCellContent(bob, "A1", "Hello");
+    network.concurrent(() => {
+      undo(bob);
+      addColumns(alice, "before", "A", 1);
+      setCellContent(charlie, "B2", "Alice");
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+  });
+
+  test("Concurrent redo with actions from at least two users", () => {
+    setCellContent(bob, "A1", "Hello");
+    undo(bob);
+    network.concurrent(() => {
+      redo(bob);
+      addColumns(alice, "before", "A", 1);
+      setCellContent(charlie, "B2", "Alice");
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+  });
+
+  test("transform target command with column addition before the target edge", () => {
+    addColumns(charlie, "before", "B", 1);
+    network.concurrent(() => {
+      undo(charlie);
+      bob.dispatch("SET_FORMATTING", {
+        sheetId: "Sheet1",
+        target: target("A1"),
+        style: { bold: true },
+      });
+    });
+    expect(all).toHaveSynchronizedValue((user) => getCell(user, "A1")?.style, { bold: true });
+    expect(all).toHaveSynchronizedValue((user) => getCell(user, "B1")?.style, undefined);
+    redo(charlie);
+    expect(all).toHaveSynchronizedValue((user) => getCell(user, "A1")?.style, { bold: true });
+    expect(all).toHaveSynchronizedValue((user) => getCell(user, "B1")?.style, undefined);
+    expect(all).toHaveSynchronizedExportedData();
+  });
+
+  test("Concurrently undo a command on which another is based", () => {
+    /**
+     * This test is a bit tricky. Let's begin with the use case:
+     * 1) A command is created by Alice
+     * 2) Concurrently, Alice undo her command, and Bob do a command that is
+     * valid with the command of Alice, but not anymore without. (Ex: insert
+     * a cell in a sheet that was created by Alice. If the command of Alice
+     * is removed (aka undo-ed), the sheet does not exist anymore).
+     * 3) Alice redo her command.
+     *
+     * At this point, the command of Bob would be valid as the sheet is here.
+     * But, when Bob try to send his command, the command is empty (have been
+     * transformed with the inverse of CREATE_SHEET). So, if he sends his
+     * command, Alice will not be able to insert his command in all of her
+     * branches, because obviously it's not possible to retrieve the
+     * SET_CELL_CONTENT from an empty command.
+     *
+     * To solve this, the behavior is to drop a command (and all the following)
+     * is the command is *local* and is empty.
+     */
+    createSheet(alice, { sheetId: "sheet2" });
+    network.concurrent(() => {
+      undo(alice);
+      setCellContent(bob, "B2", "B2", "sheet2");
+    });
+    redo(alice);
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+  });
+
+  test("Transform command with preceding concurrent command when previous command is redone", () => {
+    setCellContent(alice, "E10", "hello");
+    addColumns(alice, "before", "F", 3);
+    undo(alice);
+    network.concurrent(() => {
+      addColumns(bob, "before", "B", 2);
+      // Charlie's command should be transformed with Bob's command when Alice redo
+      // her command
+      addColumns(charlie, "before", "E", 1);
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getCellContent(user, "H10"),
+      "hello"
+    );
+    redo(alice);
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getCellContent(user, "G10"),
+      "hello"
+    );
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+  });
+
+  test("inverse delete rows then replay the command", () => {
+    deleteRows(bob, [6, 5, 4, 3, 2]);
+    network.concurrent(() => {
+      undo(bob);
+      setCellContent(alice, "C4", "hello");
+    });
+    redo(bob);
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => getCellContent(user, "C4"),
+      "hello"
+    );
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+  });
+
+  test("All locals commands", () => {
+    createSheet(alice, { sheetId: "sheet2" });
+    network.concurrent(() => {
+      undo(alice);
+      setCellContent(bob, "B2", "B2", "sheet2");
+      setCellContent(bob, "A1", "Hello");
+    });
+    redo(alice);
+    /**
+     * // @implementation-limitation
+     * The UPDATE_CELL command triggered by Bob to insert "Hello" in B2 is done
+     * on the sheet that Alice is currently undoing the creation. So, this command
+     * should be drop.
+     * As the command is drop, the following command (UPDATE_CELL of A1) is also
+     * drop.
+     */
+    expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCellContent(user, "A1"), "");
+    expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+  });
+
+  test("redo dropped command", () => {
+    setCellContent(charlie, "A1", "hi");
+    network.concurrent(() => {
+      deleteRows(bob, [6, 5, 4, 3, 2]);
+      setCellContent(charlie, "C5", "hi");
+      undo(charlie);
+    });
+    const result = redo(charlie);
+    expect(result).not.toBeCancelledBecause(CommandResult.WaitingSessionConfirmation);
+    expect(result).toBeCancelledBecause(CommandResult.EmptyRedoStack);
+    expect(all).toHaveSynchronizedExportedData();
+  });
+
+  test("can undo/redo command previous to dropped command", () => {
+    setCellContent(charlie, "A1", "hello");
+    network.concurrent(() => {
+      deleteRows(bob, [6, 5, 4, 3, 2]);
+      setCellContent(charlie, "C5", "hi");
+    });
+    undo(charlie);
+    expect(all).toHaveSynchronizedValue((user) => getCell(user, "A1"), undefined);
+    redo(charlie);
+    expect(all).toHaveSynchronizedValue((user) => getCellContent(user, "A1"), "hello");
+    expect(all).toHaveSynchronizedExportedData();
+  });
+
+  test("cannot redo command previous to dropped command", () => {
+    setCellContent(charlie, "A1", "hello");
+    undo(charlie);
+    network.concurrent(() => {
+      deleteRows(bob, [6, 5, 4, 3, 2]);
+      setCellContent(charlie, "C5", "hi");
+    });
+    expect(redo(charlie)).toBeCancelledBecause(CommandResult.EmptyRedoStack);
+    expect(all).toHaveSynchronizedExportedData();
   });
 });

--- a/tests/collaborative/ot/ot_columns_added.test.ts
+++ b/tests/collaborative/ot/ot_columns_added.test.ts
@@ -94,6 +94,11 @@ describe("OT with ADD_COLUMNS_ROWS with dimension COL", () => {
         const result = transform(command, addColumnsAfter);
         expect(result).toEqual(command);
       });
+      test(`${cmd.type} in pivot column with columns added before`, () => {
+        const command = { ...cmd, col: 5 };
+        const result = transform(command, addColumnsBefore);
+        expect(result).toEqual(command);
+      });
       test(`${cmd.type} after added columns, in another sheet`, () => {
         const command = { ...cmd, col: 5, sheetId: "42" };
         const result = transform(command, addColumnsAfter);

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -89,6 +89,11 @@ describe("OT with REMOVE_COLUMN", () => {
         const result = transform(command, removeColumns);
         expect(result).toEqual(command);
       });
+      test(`with many col elements in growing order`, () => {
+        const command = { ...cmd, col: 8 };
+        const result = transform(command, { ...removeColumns, elements: [2, 3, 4, 5, 6] });
+        expect(result).toEqual({ ...cmd, col: 3 });
+      });
     }
   );
 

--- a/tests/collaborative/ot/ot_rows_added.test.ts
+++ b/tests/collaborative/ot/ot_rows_added.test.ts
@@ -143,10 +143,15 @@ describe("OT with ADD_COLUMNS_ROWS with dimension ROW", () => {
         const result = transform(command, addRowsAfter);
         expect(result).toEqual({ ...command, target: [toZone("A12:B13")] });
       });
-      test(`add rows in ${cmd.type}`, () => {
+      test(`add rows after in ${cmd.type}`, () => {
         const command = { ...cmd, target: [toZone("A5:B6")] };
         const result = transform(command, addRowsAfter);
         expect(result).toEqual({ ...command, target: [toZone("A5:B8")] });
+      });
+      test(`add rows before in ${cmd.type}`, () => {
+        const command = { ...cmd, target: [toZone("A5:B6")] };
+        const result = transform(command, addRowsBefore);
+        expect(result).toEqual({ ...command, target: [toZone("A5:B6")] });
       });
       test(`${cmd.type} and rows added in different sheets`, () => {
         const command = { ...cmd, target: [toZone("A1:F3")], sheetId: "42" };

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -89,6 +89,11 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
         const result = transform(command, removeRows);
         expect(result).toEqual(command);
       });
+      test(`with many row elements in growing order`, () => {
+        const command = { ...cmd, row: 8 };
+        const result = transform(command, { ...removeRows, elements: [2, 3, 4, 5, 6] });
+        expect(result).toEqual({ ...cmd, row: 3 });
+      });
     }
   );
 

--- a/tests/data_source.test.ts
+++ b/tests/data_source.test.ts
@@ -114,4 +114,13 @@ describe("DataSource", () => {
     jest.advanceTimersByTime(2);
     expect(getCellContent(model, "A1")).toBe("data");
   });
+
+  test("evaluate all sheets forces evaluation", async () => {
+    dataSourcePlugin.addDataSource("1", new StringDataSource());
+    setCellContent(model, "A1", "=WAIT2(1)");
+    expect(getCellContent(model, "A1")).toBe("LOADING...");
+    await model.waitForIdle();
+    model.dispatch("EVALUATE_ALL_SHEETS");
+    expect(getCellContent(model, "A1")).toBe("data");
+  });
 });

--- a/tests/plugins/figures.test.ts
+++ b/tests/plugins/figures.test.ts
@@ -1,3 +1,4 @@
+import { CommandResult } from "../../src";
 import { Model } from "../../src/model";
 import { activateSheet, createSheet, selectCell, undo } from "../test_helpers/commands_helpers";
 
@@ -225,6 +226,26 @@ describe("figure plugin", () => {
     const { x, y } = model.getters.getVisibleFigures()[0];
     expect(x).toBe(0);
     expect(y).toBe(50);
+  });
+
+  test("cannot update a figure which doesn't exist", () => {
+    const model = new Model();
+    const result = model.dispatch("UPDATE_FIGURE", {
+      sheetId: model.getters.getActiveSheetId(),
+      id: "someuuid",
+      x: -10,
+      y: 50,
+    });
+    expect(result).toBeCancelledBecause(CommandResult.FigureDoesNotExist);
+  });
+
+  test("cannot delete a figure which doesn't exist", () => {
+    const model = new Model();
+    const result = model.dispatch("DELETE_FIGURE", {
+      sheetId: model.getters.getActiveSheetId(),
+      id: "someuuid",
+    });
+    expect(result).toBeCancelledBecause(CommandResult.FigureDoesNotExist);
   });
 
   test("can delete a figure", () => {

--- a/tests/selective_history.test.ts
+++ b/tests/selective_history.test.ts
@@ -110,13 +110,15 @@ class MiniEditor {
   }
 
   undo(commandId: UID, undoId: UID = this.uuidGenerator.uuidv4()) {
+    const last = [...this.revisionIds].pop()!;
     this.revisionIds.add(undoId);
-    this.history.undo(commandId, undoId);
+    this.history.undo(commandId, undoId, last);
   }
 
   redo(commandId: UID, redoId: UID = this.uuidGenerator.uuidv4()) {
+    const last = [...this.revisionIds].pop()!;
     this.revisionIds.add(redoId);
-    this.history.redo(commandId, redoId);
+    this.history.redo(commandId, redoId, last);
   }
 }
 
@@ -429,7 +431,7 @@ describe("Undo/Redo manager", () => {
       editor.add("3", "C", 2);
 
       editor.undo("2");
-      editor.execAfter("3", ["4", "D", 3]);
+      editor.execAfter("3", ["4", "D", 2]);
       expect(editor.text).toBe("ACD");
       editor.undo("1");
       expect(editor.text).toBe("CD");
@@ -441,7 +443,7 @@ describe("Undo/Redo manager", () => {
       editor.add("2", "B", 1);
       editor.add("3", "C", 2);
       editor.undo("2");
-      editor.execAfter("3", ["4", "D", 3]);
+      editor.execAfter("3", ["4", "D", 2]);
       expect(editor.text).toBe("ACD");
       editor.redo("2");
       expect(editor.text).toBe("ABCD");

--- a/tests/test_helpers/debug_helpers.ts
+++ b/tests/test_helpers/debug_helpers.ts
@@ -10,7 +10,6 @@ interface Data {
 interface Instruction {
   data: Data;
   id: UID;
-  isOriginal: boolean;
 }
 
 export function getDebugInfo(tree: Tree) {
@@ -33,7 +32,6 @@ export function getDebugInfo(tree: Tree) {
         // @ts-ignore
         data: instruction.data,
         id: instruction.id,
-        isOriginal: instruction.isOriginal,
       };
     }
     allStrings.push(stringArray.join(""));
@@ -59,7 +57,7 @@ export function getDebugInfo(tree: Tree) {
     const data = instruction.data._commands
       ? JSON.stringify(instruction.data._commands)
       : JSON.stringify(instruction.data);
-    allStrings.push(`${id}: ${data} : ${instruction.isOriginal ? "original" : "transformed"}`);
+    allStrings.push(`${id}: ${data}`);
   }
   return allStrings.join("\n");
 }
@@ -69,5 +67,5 @@ export function getDebugInfo(tree: Tree) {
  */
 export function printDebugModel(model: Model) {
   // @ts-ignore
-  console.log(getDebugInfo(model["session"]["revisions"]["HEAD_BRANCH"]));
+  console.log(getDebugInfo(model["session"]["revisions"]["tree"]));
 }


### PR DESCRIPTION
## Description:

Forward ported from saas-15.1:
https://github.com/odoo/o-spreadsheet/commit/9864df25825cf80d48adae799cfad742f4b770d3 [FIX] viewport: Allow valid non-integer offsets

Forward ported from 15.0:
https://github.com/odoo/o-spreadsheet/commit/f05e1b2d27763ab4fc75ddb282b2fe3b92576169 [FIX] evaluation: evaluate all sheets forces the evaluation
https://github.com/odoo/o-spreadsheet/commit/9144a84437ca330e47c5d784517f8598ed3019fc [FIX] collaborative: export cell styles in the same order
https://github.com/odoo/o-spreadsheet/commit/069ccd53eaadb1ba49699c9ef6608bc72ce082c5 [FIX] collaborative: don't expand zone when col/row is added before next col
https://github.com/odoo/o-spreadsheet/commit/00830c35f9bc1ea954a912f102a4d7f076d7de65 [FIX] collaborative: don't mutate command when computing inverse
https://github.com/odoo/o-spreadsheet/commit/2f5e0929463b3437a0725a07105f0d7dc6996c8a [FIX] collaborative: compute transformation with last received commands
https://github.com/odoo/o-spreadsheet/commit/55b4f540e0ae911b91c574994353ac96c4694920 [FIX] collaborative: drop local revisions after empty commands
https://github.com/odoo/o-spreadsheet/commit/745a7f5b2fde9e59090295898c2d0aede5609398 [FIX] collaborative: correctly insert undo/redo revisions
https://github.com/odoo/o-spreadsheet/commit/36b75ab49a11c7e59c1b5f54f1da29ecf7395549 [FIX] collaborative: insert revision into last selective history branch
https://github.com/odoo/o-spreadsheet/commit/a63de39d7bdc07315e0af8fc62c361dbb29cd85a [FIX] figures: check if figure exists before updating or deleting
## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo