### PR TITLE
[IMP] model: allow custom config

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -304,6 +304,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     };
     const transportService = config.transportService || new LocalTransportService();
     return {
+      ...config,
       mode: config.mode || "normal",
       evalContext: config.evalContext || {},
       transportService,

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1,7 +1,7 @@
 import { CommandResult, CorePlugin } from "../src";
 import { toZone } from "../src/helpers";
 import { LocalHistory } from "../src/history/local_history";
-import { Mode, Model } from "../src/model";
+import { Mode, Model, ModelConfig } from "../src/model";
 import { BordersPlugin } from "../src/plugins/core/borders";
 import { CellPlugin } from "../src/plugins/core/cell";
 import { ChartPlugin } from "../src/plugins/core/chart";
@@ -189,5 +189,10 @@ describe("Model", () => {
   test("Moving the selection is allowed in readonly mode", () => {
     const model = new Model({}, { isReadonly: true });
     expect(selectCell(model, "A15")).toBeSuccessfullyDispatched();
+  });
+
+  test("Can add custom elements in the config of model", () => {
+    const model = new Model({}, { custom: "42" } as unknown as ModelConfig);
+    expect(model["config"]["custom"]).toBe("42");
   });
 });


### PR DESCRIPTION
With this commit, it's now possible to give a custom config attribute
to the plugins.

Part of task-id 2750822

