### PR TITLE
[IMP] model: mark model as "raw" (not reactive)

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -1,3 +1,4 @@
+import { markRaw } from "@odoo/owl";
 import { LocalTransportService } from "./collaborative/local_transport_service";
 import { Session } from "./collaborative/session";
 import { DEFAULT_REVISION_ID } from "./constants";
@@ -197,6 +198,9 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     if (config.snapshotRequested) {
       this.session.snapshot(this.exportData());
     }
+    // mark all models as "raw", so they will not be turned into reactive objects
+    // by owl, since we do not rely on reactivity
+    markRaw(this);
   }
 
   get handlers(): CommandHandler<Command>[] {


### PR DESCRIPTION
With this commit, we mark all models as "raw", which means that the Owl
framework will not turn them into reactive object at any point.

This is important because the code is designed to work by updating the
complete UI, and we do not want any interference by some sub components
rerendering at a wrong time.  Also, not doing this may cause performance issues,
since everything will be wrapped in proxy objects, and the spreadsheet
model may contain a lot of sub objects/elements.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo