### PR TITLE
[IMP] clipboard: don't overwrite borders

### DIFF
--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -539,7 +539,15 @@ export class ClipboardPlugin extends UIPlugin {
     const targetCell = this.getters.getCell(sheetId, col, row);
 
     if (pasteOption !== "onlyValue") {
-      this.dispatch("SET_BORDER", { sheetId, col, row, border: origin.border });
+      const targetBorders = this.getters.getCellBorder(sheetId, col, row);
+      const originBorders = origin.border;
+      const border = {
+        top: targetBorders?.top || originBorders?.top,
+        bottom: targetBorders?.bottom || originBorders?.bottom,
+        left: targetBorders?.left || originBorders?.left,
+        right: targetBorders?.right || originBorders?.right,
+      };
+      this.dispatch("SET_BORDER", { sheetId, col, row, border });
     }
     if (origin.cell) {
       if (pasteOption === "onlyFormat") {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -253,6 +253,25 @@ describe("clipboard", () => {
     expect(getBorder(model, "C2")).toEqual({ bottom: ["thin", "#000"] });
   });
 
+  test("paste cell does not overwrite existing borders", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: target("A1"),
+      border: "all",
+    });
+    model.dispatch("COPY", { target: target("B2") });
+    model.dispatch("PASTE", { target: target("A1") });
+    const border = ["thin", "#000"];
+    expect(model.getters.getCellBorder(sheetId, 0, 0)).toEqual({
+      top: border,
+      bottom: border,
+      left: border,
+      right: border,
+    });
+  });
+
   test("can copy a cell with a format", () => {
     const model = new Model();
     setCellContent(model, "B2", "0.451");


### PR DESCRIPTION

## Description:

Steps:
    - set borders to A1
    - copy an empty cell, paste it beside A1
   => the empty cell overwrite the shared border with A1


Odoo task ID : [2746205](https://www.odoo.com/web#id=2746205&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [x] exportable in excel
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo