### PR TITLE
[IMP] chart: display only available data

### DIFF
--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -1,11 +1,4 @@
-import {
-  ChartColor,
-  ChartConfiguration,
-  ChartData,
-  ChartDataSets,
-  ChartLegendOptions,
-  ChartTooltipItem,
-} from "chart.js";
+import { ChartConfiguration, ChartLegendOptions, ChartTooltipItem } from "chart.js";
 import { ChartTerms } from "../../components/translations_terms";
 import { MAX_CHAR_LABEL } from "../../constants";
 import { ChartColors } from "../../helpers/chart";
@@ -13,7 +6,7 @@ import { isDefined, isInside, overlap, recomputeZones, zoneToXc } from "../../he
 import { range } from "../../helpers/misc";
 import { Mode } from "../../model";
 import { Cell } from "../../types";
-import { ChartDefinition, DataSet } from "../../types/chart";
+import { ChartData, ChartDataSet, ChartDefinition, DataSet } from "../../types/chart";
 import { Command } from "../../types/commands";
 import { UID, Zone } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
@@ -307,7 +300,7 @@ export class EvaluationChartPlugin extends UIPlugin {
     const runtime = this.getDefaultConfiguration(definition, labels);
 
     const colors = new ChartColors();
-    const pieColors: ChartColor[] = [];
+    const pieColors: string[] = [];
     if (definition.type === "pie") {
       const maxLength = Math.max(
         ...definition.dataSets.map((ds) => this.getData(ds, definition.sheetId).length)
@@ -331,7 +324,7 @@ export class EvaluationChartPlugin extends UIPlugin {
         label = label = `${ChartTerms.Series} ${parseInt(dsIndex) + 1}`;
       }
       const color = definition.type !== "pie" ? colors.next() : "#FFFFFF"; // white border for pie chart
-      const dataset: ChartDataSets = {
+      const dataset: ChartDataSet = {
         label,
         data: ds.dataRange ? this.getData(ds, definition.sheetId) : [],
         lineTension: 0, // 0 -> render straight lines, which is much faster
@@ -340,12 +333,33 @@ export class EvaluationChartPlugin extends UIPlugin {
       };
       if (definition.type === "pie") {
         // In case of pie graph, dataset.backgroundColor is an array of string
-        // @ts-ignore - we know dataset.data is an array
         dataset.backgroundColor = pieColors;
       }
       runtime.data!.datasets!.push(dataset);
     }
-    return runtime;
+    return { ...runtime, data: this.filterEmptyDataPoints(runtime.data as ChartData) };
+  }
+
+  private filterEmptyDataPoints(chartData: ChartData): ChartData {
+    const labels = chartData.labels;
+    const datasets = chartData.datasets;
+    const numberOfDataPoints = Math.max(
+      labels.length,
+      ...datasets.map((dataset) => dataset.data?.length || 0)
+    );
+    const dataPointsIndexes = range(0, numberOfDataPoints).filter((dataPointIndex) => {
+      const label = labels[dataPointIndex];
+      const values = datasets.map((dataset) => dataset.data?.[dataPointIndex]);
+      return label || values.some((value) => value === 0 || Boolean(value));
+    });
+    return {
+      ...chartData,
+      labels: dataPointsIndexes.map((i) => labels[i] || ""),
+      datasets: datasets.map((dataset) => ({
+        ...dataset,
+        data: dataPointsIndexes.map((i) => dataset.data[i]),
+      })),
+    };
   }
 
   // TODO type this with Chart.js types.

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -30,6 +30,22 @@ export interface ChartUIDefinition
   labelRange?: string;
 }
 
+export interface ChartDataSet {
+  label;
+  data: (number | undefined | null)[];
+  lineTension: 0; // 0 -> render straight lines, which is much faster
+  borderColor: string;
+  /**
+   * color or list of color for pie charts
+   */
+  backgroundColor: string | string[];
+}
+
+export interface ChartData {
+  labels: Array<string | string[]>;
+  datasets: ChartDataSet[];
+}
+
 /**
  * Data to be updated on a chart definition.
  */

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -308,7 +308,7 @@ describe("figures", () => {
     setInputValueAndTrigger(dataSeriesValues, "B2:B5", "change");
     triggerMouseEvent(hasTitle, "click");
     await nextTick();
-    expect((mockChartData.data! as any).labels).toEqual(["P1", "P2", "P3"]);
+    expect((mockChartData.data! as any).labels).toEqual(["P1", "P2", "P3", ""]);
     expect((mockChartData.data! as any).datasets[0].data).toEqual([10, 11, 12, 13]);
     expect(mockChartData.type).toBe("pie");
     expect((mockChartData.options!.title as any).text).toBe("hello");


### PR DESCRIPTION
## Description:

### Purpose

Imagine you want to plot the evolution of a daily metric. Every day, you add
the entry of the day (manually or with a LIST formula🚀).

e.g.
10/01/2020    10
11/01/2020    12
12/01/2020    15
13/01/2020    9
14/01/2020    7
15/01/2020    6

you plot this with a larger dataset since you know your data will grow
(A1:A1000, or even A1:A when supported) and you don't want to update your
chart's configuration every day.

Currently, the chart doesn't look good because it will display all values,
most of the chart is empty.

What you want is to only plot those 6 entries and when a 7th is added, the
chart should "grow" and display it.

### Specification

Display the entry if one of the cells in the row is not empty, either in the
data or in the labels

Odoo task ID : [2742114](https://www.odoo.com/web#id=2742114&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo