### PR TITLE
[FIX] import: can import cells outside sheet size

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -1348,14 +1348,15 @@ export class CorePlugin extends BasePlugin {
   importSheet(data: SheetData) {
     let { sheets, visibleSheets } = this.workbook;
     const name = data.name || `Sheet${Object.keys(sheets).length + 1}`;
+    const { colNumber, rowNumber } = getSheetSize(data);
     const sheet: Sheet = {
       id: data.id,
       name: name,
       cells: {},
-      colNumber: data.colNumber,
-      rowNumber: data.rowNumber,
-      cols: createCols(data.cols || {}, data.colNumber),
-      rows: createRows(data.rows || {}, data.rowNumber),
+      colNumber,
+      rowNumber,
+      cols: createCols(data.cols || {}, colNumber),
+      rows: createRows(data.rows || {}, rowNumber),
       merges: {},
       mergeCellMap: {},
     };
@@ -1398,6 +1399,14 @@ export class CorePlugin extends BasePlugin {
     });
     data.activeSheet = this.workbook.activeSheet.id;
   }
+}
+
+function getSheetSize(data: SheetData): { rowNumber: number; colNumber: number } {
+  const positions = Object.keys(data.cells).map(toCartesian);
+  return {
+    rowNumber: Math.max(data.rowNumber, ...positions.map(([col, row]) => row + 1)),
+    colNumber: Math.max(data.colNumber, ...positions.map(([col, row]) => col + 1)),
+  };
 }
 
 function createDefaultCols(colNumber: number): Col[] {

--- a/tests/plugins/import_export_test.ts
+++ b/tests/plugins/import_export_test.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { CURRENT_VERSION } from "../../src/data";
+import { toCartesian } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { BorderDescr } from "../../src/types/index";
 import "../helpers"; // to have getcontext mocks
@@ -223,6 +224,29 @@ test("complete import, then export", () => {
   // We test here a that two import with the same data give the same result.
   const model2 = new Model(modelData);
   expect(model2.exportData()).toEqual(modelData);
+});
+
+test("can import cells outside sheet size", () => {
+  const sheetId = "someuuid";
+  const modelData = {
+    version: CURRENT_VERSION,
+    sheets: [
+      {
+        id: sheetId,
+        colNumber: 10,
+        rowNumber: 10,
+        cols: {},
+        rows: {},
+        cells: {
+          Z100: { content: "hello" },
+        },
+      },
+    ],
+  };
+  const model = new Model(modelData);
+  expect(model.getters.getNumberRows(sheetId)).toBe(100);
+  expect(model.getters.getNumberCols(sheetId)).toBe(26);
+  expect(model.getters.getCell(...toCartesian("Z100"))?.content).toBe("hello");
 });
 
 test("import then export (figures)", () => {


### PR DESCRIPTION
## Description:

We have a case where `rowNumber` is wrong in the exported json data.
It says there are 63 rows, but there are cells below that row: in A64, A65, ...
Importing those cells crashes and the spreadsheet can't be opened anymore.

With this commit, the import tries to save the day by checking the max col/row
of cells and use that number if it's it's bigger.

We don't know how the data was corrupted in the first place. We have a bug
lurking somewhere... but let's fix the customer's spreadsheet first

Odoo task ID : [2746389](https://www.odoo.com/web#id=2746389&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [ ] exportable in excel
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo