### PR TITLE
[IMP] registry: allow to obtain the keys of the registry

### DIFF
--- a/src/data_source.ts
+++ b/src/data_source.ts
@@ -42,6 +42,13 @@ export class DataSourceRegistry<M, D> extends EventBus<any> {
   }
 
   /**
+   * Get a list of all elements in the registry
+   */
+  getKeys(): string[] {
+    return this.registry.getKeys();
+  }
+
+  /**
    * Remove an item from the registry
    */
   remove(key: string) {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -51,6 +51,13 @@ export class Registry<T> {
   }
 
   /**
+   * Get a list of all keys in the registry
+   */
+  getKeys(): string[] {
+    return Object.keys(this.content);
+  }
+
+  /**
    * Remove an item from the registry
    */
   remove(key: string) {


### PR DESCRIPTION
With this commit, we are now able to obtain the keys in the registry.
It's useful for Odoo to maintain the data sources after UNDO/REDO.

Part of task-id 2714352

