### PR TITLE
[REM] model: remove debug information

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -109,6 +109,8 @@ class Demo extends Component {
       },
       this.stateUpdateMessages
     );
+    o_spreadsheet.__DEBUG__ = o_spreadsheet.__DEBUG__ || {};
+    o_spreadsheet.__DEBUG__.model = this.model;
     this.model.joinSession();
     this.activateFirstSheet();
   }

--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -2,7 +2,7 @@ import { Component, onMounted, onPatched, onWillUnmount, useRef, useState, xml }
 import { SELECTION_BORDER_COLOR } from "../../constants";
 import { EnrichedToken } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { DEBUG, isEqual, rangeReference, toZone } from "../../helpers/index";
+import { isEqual, rangeReference, toZone } from "../../helpers/index";
 import { ComposerSelection, SelectionIndicator } from "../../plugins/ui/edition";
 import { FunctionDescription, Rect, SpreadsheetChildEnv } from "../../types/index";
 import { css } from "../helpers/css";
@@ -226,8 +226,6 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
 
   setup() {
     onMounted(() => {
-      DEBUG.composer = this;
-
       const el = this.composerRef.el!;
 
       this.contentHelper.updateEl(el);
@@ -235,7 +233,6 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
     });
 
     onWillUnmount(() => {
-      delete DEBUG.composer;
       this.props.onComposerUnmounted?.();
     });
 

--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   onMounted,
-  onWillDestroy,
   onWillUnmount,
   useExternalListener,
   useState,
@@ -154,7 +153,6 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     useExternalListener(window, "beforeunload", this.unbindModelEvents.bind(this));
     onMounted(() => this.bindModelEvents());
     onWillUnmount(() => this.unbindModelEvents());
-    onWillDestroy(() => this.model.destroy());
   }
 
   get focusTopBarComposer(): Omit<ComposerFocusType, "cellFocus"> {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -253,8 +253,6 @@ export function isDefined<T>(argument: T | undefined): argument is T {
   return argument !== undefined;
 }
 
-export const DEBUG: { [key: string]: any } = {};
-
 /**
  * Get the id of the given item (its key in the given dictionnary).
  * If the given item does not exist in the dictionary, it creates one with a new id.

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,6 @@ export { DATETIME_FORMAT } from "./constants";
 export { DataSource } from "./data_source";
 export { compile, functionCache } from "./formulas/compiler";
 export { astToFormula, convertAstNodes, parse } from "./formulas/parser";
-export { DEBUG as __DEBUG__ } from "./helpers/index";
 export { Model } from "./model";
 export { CorePlugin } from "./plugins/core_plugin";
 export { UIPlugin } from "./plugins/ui_plugin";

--- a/src/model.ts
+++ b/src/model.ts
@@ -4,7 +4,7 @@ import { Session } from "./collaborative/session";
 import { DEFAULT_REVISION_ID } from "./constants";
 import { DataSourceRegistry } from "./data_source";
 import { EventBus } from "./helpers/event_bus";
-import { DEBUG, UuidGenerator } from "./helpers/index";
+import { UuidGenerator } from "./helpers/index";
 import { buildRevisionLog } from "./history/factory";
 import { LocalHistory } from "./history/local_history";
 import { createEmptyExcelWorkbookData, createEmptyWorkbookData, load } from "./migrations/data";
@@ -136,7 +136,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     uuidGenerator: UuidGenerator = new UuidGenerator()
   ) {
     super();
-    DEBUG.model = this;
 
     const workbookData = load(data);
 
@@ -213,10 +212,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
   leaveSession() {
     this.session.leave();
-  }
-
-  destroy() {
-    delete DEBUG.model;
   }
 
   private setupUiPlugin(Plugin: UIPluginConstructor) {

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -2,7 +2,7 @@ import { App, Component, useSubEnv, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { Spreadsheet } from "../../src/components";
 import { args, functionRegistry } from "../../src/functions";
-import { DEBUG, toZone } from "../../src/helpers";
+import { toZone } from "../../src/helpers";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/registries";
 import {
   createChart,
@@ -122,11 +122,6 @@ describe("Spreadsheet", () => {
 
   test("Clipboard is in spreadsheet env", () => {
     expect(parent.env.clipboard).toBe(clipboard);
-  });
-
-  test("Debug informations are removed when Spreadsheet is destroyed", async () => {
-    parent.__owl__.destroy();
-    expect(Object.keys(DEBUG)).toHaveLength(0);
   });
 
   test("typing opens composer after toolbar clicked", async () => {


### PR DESCRIPTION
Debug information has been removed from the production code. It should
be add only where it's useful, depending on which mode (=owl mode) the
spreadsheet is run.

By doing this, we avoid potential memory leaks.

