### PR TITLE
[FIX] evaluation: correctly handle incorrect references in formula

### DIFF
--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -226,7 +226,7 @@ export class EvaluationPlugin extends UIPlugin {
       const sheet = sheets[range.sheetId]!;
 
       if (!isZoneValid(range.zone)) {
-        throw new Error(_lt("Invalid reference"));
+        throw new Error(_lt("Invalid range: %s", evalContext.getters.getRangeString(range)));
       }
 
       // Return an array with undefined if the range is totally outside of the sheet rather than trying

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -1,8 +1,18 @@
 import { args, functionRegistry } from "../../src/functions";
 import { Model } from "../../src/model";
 import { CellValueType, InvalidEvaluation } from "../../src/types";
-import { activateSheet, createSheet, setCellContent } from "../test_helpers/commands_helpers";
-import { getCell, getCellContent, getCellError } from "../test_helpers/getters_helpers";
+import {
+  activateSheet,
+  createSheet,
+  deleteRows,
+  setCellContent,
+} from "../test_helpers/commands_helpers";
+import {
+  getCell,
+  getCellContent,
+  getCellError,
+  getCellText,
+} from "../test_helpers/getters_helpers";
 import { evaluateCell, evaluateGrid, target } from "../test_helpers/helpers";
 import resetAllMocks = jest.resetAllMocks;
 
@@ -1006,6 +1016,13 @@ describe("evaluate formula getter", () => {
     value = 2;
     model.dispatch("EVALUATE_CELLS", { sheetId: model.getters.getActiveSheetId() });
     expect(getCell(model, "A1")!.evaluated.value).toBe(2);
+  });
+
+  test("Formula with #REF is correctly marked as error", () => {
+    setCellContent(model, "A5", "=SUM(A1:A2,A3:A4)");
+    deleteRows(model, [0, 1]);
+    expect(getCellText(model, "A3")).toBe("=SUM(#REF,A1:A2)");
+    expect(getCellError(model, "A3")).toEqual("Invalid range: #REF");
   });
 
   test("using cells in other sheets", () => {


### PR DESCRIPTION
Before this commit, invalid references in formulas could causes some
issues:
- =SUM(AZ100) => Invalid array length
- In E5: =SUM(A1:B1,C1:D1) then remove A and B => Cannot read property "length" of undefined

Task-id 2620152

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo