### PR TITLE
[FIX] menu_items: multiple zones of rows/cols

### DIFF
--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -118,6 +118,9 @@ export const SET_GRID_LINES_VISIBILITY_ACTION = (env: SpreadsheetChildEnv) => {
 //------------------------------------------------------------------------------
 
 export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetChildEnv) => {
+  if (env.model.getters.getSelectedZones().length > 1) {
+    return _lt("Clear rows");
+  }
   let first: number;
   let last: number;
   const activesRows = env.model.getters.getActiveRows();
@@ -147,6 +150,9 @@ export const DELETE_CONTENT_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
 };
 
 export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
+  if (env.model.getters.getSelectedZones().length > 1) {
+    return _lt("Clear columns");
+  }
   let first: number;
   let last: number;
   const activeCols = env.model.getters.getActiveCols();
@@ -176,6 +182,9 @@ export const DELETE_CONTENT_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
 };
 
 export const REMOVE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
+  if (env.model.getters.getSelectedZones().length > 1) {
+    return _lt("Delete rows");
+  }
   let first: number;
   let last: number;
   const activesRows = env.model.getters.getActiveRows();
@@ -209,6 +218,9 @@ export const REMOVE_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
 };
 
 export const REMOVE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
+  if (env.model.getters.getSelectedZones().length > 1) {
+    return _lt("Delete columns");
+  }
   let first: number;
   let last: number;
   const activeCols = env.model.getters.getActiveCols();

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -211,14 +211,26 @@ describe("Menu Item actions", () => {
     const path = ["edit", "edit_delete_row"];
 
     test("A selected row", () => {
-      selectRow(model, 4, "newAnchor");
+      selectRow(model, 4, "overrideSelection");
       expect(getName(path, env)).toBe("Delete row 5");
     });
 
     test("Multiple selected rows", () => {
-      selectRow(model, 4, "newAnchor");
+      selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
       expect(getName(path, env)).toBe("Delete rows 5 - 6");
+      doAction(path, env);
+      expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        dimension: "ROW",
+        elements: [4, 5],
+      });
+    });
+
+    test("Multiple zones of selected rows", () => {
+      selectRow(model, 4, "newAnchor");
+      selectRow(model, 5, "updateAnchor");
+      expect(getName(path, env)).toBe("Delete rows");
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -249,7 +261,7 @@ describe("Menu Item actions", () => {
     const path = ["edit", "edit_delete_column"];
 
     test("A selected column", () => {
-      selectColumn(model, 4, "newAnchor");
+      selectColumn(model, 4, "overrideSelection");
       expect(getName(path, env)).toBe("Delete column E");
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
@@ -260,9 +272,21 @@ describe("Menu Item actions", () => {
     });
 
     test("Multiple selected columns", () => {
-      selectColumn(model, 4, "newAnchor");
+      selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
       expect(getName(path, env)).toBe("Delete columns E - F");
+      doAction(path, env);
+      expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        dimension: "COL",
+        elements: [4, 5],
+      });
+    });
+
+    test("Multiple zones of selected columns", () => {
+      selectColumn(model, 4, "newAnchor");
+      selectColumn(model, 5, "updateAnchor");
+      expect(getName(path, env)).toBe("Delete columns");
       doAction(path, env);
       expect(dispatch).toHaveBeenLastCalledWith("REMOVE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),


### PR DESCRIPTION
With this commit if the user select more than one zone of columns/rows,
the menu item title for clear or delete cols/rows does not contain
the letters/number anymore.

ID-2714318

