### PR TITLE
[REF] collaborative: lazy operation transformations

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -9,7 +9,7 @@ import {
   MIN_CF_ICON_MARGIN,
 } from "../constants";
 import { fontSizeMap } from "../fonts";
-import { ConsecutiveIndexes, Link, Style, UID } from "../types";
+import { ConsecutiveIndexes, Lazy, Link, Style, UID } from "../types";
 import { parseDateTime } from "./dates";
 /**
  * Stringify an object, like JSON.stringify, except that the first level of keys
@@ -312,4 +312,21 @@ export function concat(chars: string[]): string {
     output += chars[i];
   }
   return output;
+}
+
+/**
+ * Lazy value computed by the provided function.
+ */
+export function lazy<T>(fn: () => T): Lazy<T> {
+  let isMemoized = false;
+  let memo: T | undefined;
+  const lazyValue = () => {
+    if (!isMemoized) {
+      memo = fn();
+      isMemoized = true;
+    }
+    return memo!;
+  };
+  lazyValue.map = (callback) => lazy(() => callback(lazyValue()));
+  return lazyValue as Lazy<T>;
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -208,3 +208,26 @@ export type Increment = 1 | -1 | 0;
 export interface Ref<T> {
   el: T | null;
 }
+
+/**
+ * Container for a lazy computed value
+ */
+export interface Lazy<T> {
+  /**
+   * Return the computed value.
+   * The value is computed only once and memoized.
+   */
+  (): T;
+  /**
+   * Map a lazy value to another lazy value.
+   *
+   * ```ts
+   * // neither function is called here
+   * const lazyValue = lazy(() => veryExpensive(...)).map((result) => alsoVeryExpensive(result));
+   *
+   * // both values are computed now
+   * const value = lazyValue()
+   * ```
+   */
+  map: <U>(callback: (value: T) => U) => Lazy<U>;
+}

--- a/tests/helpers/misc.test.ts
+++ b/tests/helpers/misc.test.ts
@@ -1,5 +1,5 @@
 import { deepCopy } from "../../src/helpers";
-import { groupConsecutive, range } from "../../src/helpers/misc";
+import { groupConsecutive, lazy, range } from "../../src/helpers/misc";
 
 describe("Misc", () => {
   test("range", () => {
@@ -121,5 +121,68 @@ describe("deepCopy", () => {
     expect("0" in copy).toBe(false);
     expect("1" in copy).toBe(false);
     expect("2" in copy).toBe(true);
+  });
+});
+
+describe("lazy", () => {
+  test("simple lazy value", () => {
+    const lazyValue = lazy(() => 5);
+    expect(lazyValue()).toBe(5);
+  });
+
+  test("map a lazy value", () => {
+    const lazyValue = lazy(() => 5).map((v) => v + 1);
+    expect(lazyValue()).toBe(6);
+  });
+
+  test("multiple lazy map", () => {
+    const lazyValue = lazy(() => 5)
+      .map((v) => v + 1)
+      .map((v) => v + 1);
+    expect(lazyValue()).toBe(7);
+  });
+
+  test("map does not evaluates original lazy value", () => {
+    let count = 0;
+    const lazyValue = lazy(() => ++count).map((v) => v + 1);
+    expect(count).toBe(0);
+    expect(lazyValue()).toBe(2);
+    expect(count).toBe(1);
+  });
+
+  test("mapped value and original value are independent", () => {
+    const lazyValue = lazy(() => 5);
+    const mappedValue = lazyValue.map((v) => v + 1);
+    expect(lazyValue()).toBe(5);
+    expect(mappedValue()).toBe(6);
+  });
+
+  test("value is memoized", () => {
+    let count = 0;
+    const lazyValue = lazy(() => ++count);
+    expect(lazyValue()).toBe(1);
+    expect(lazyValue()).toBe(1);
+    expect(count).toBe(1);
+  });
+
+  test("mapped value is memoized", () => {
+    let count = 0;
+    let countMap = 0;
+    const lazyValue = lazy(() => ++count).map((v) => v + ++countMap);
+    expect(lazyValue()).toBe(2);
+    expect(lazyValue()).toBe(2);
+    expect(count).toBe(1);
+    expect(countMap).toBe(1);
+  });
+
+  test("lazy undefined is memoized", () => {
+    let count = 0;
+    const lazyValue = lazy(() => {
+      ++count;
+      return undefined;
+    });
+    expect(lazyValue()).toBe(undefined);
+    expect(lazyValue()).toBe(undefined);
+    expect(count).toBe(1);
   });
 });


### PR DESCRIPTION
## Description:

This commit greatly reduces the number of transformation at each operation.

A bit of context:
Every "undo" creates a new "branch" in the history. Every following operation
must be inserted (and transformed) in all branches.

The more undos branches, the more transformations at *every* new operation (from
the local user or from collaborative users). Some transformations can be
expensive (see https://github.com/odoo/o-spreadsheet/commit/f6ea663838dcbe702a0cc40716eaa7bb1bd47e34).
Insertions in some undo branches might be completely useless because they won't
ever be redone.

With this commits, transformations when inserting operations in "undo branches"
are computed lazily. They only happen when a "redo" happens.

This means slower redos: transformations must be computed at that time
while there were already computed prior to this commit. Note that it won't
compute *all* transformations, only those on the execution path after the redo
operation.

Without any redo, the total number of transformation is divided by:
SUM(branch[i] * branch[i].length) for all branches
This quickly grows to hundreds/thousands of transformations

This also greatly improves loading time since every pending command/undo/redo
are performed.

so:
\+ improved performance at every new operation
\+ improved loading time
\- slower redos

Some really basic testing:
Blank sheet, then 2 cell updates, then 2 undos
=> 7 transformation in master to 2 transformations

random stuff with some undos/redos
test 1) 688 => 105
test 2) 177 => 24

I'm sure benefits are even more important with long lived spreadsheets
which were not snapshotted recently

Odoo task ID : [2785019](https://www.odoo.com/web#id=2785019&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo