### PR TITLE
[FIX] Clipping inside merges + align with big font

### DIFF
--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -526,8 +526,7 @@ export class RendererPlugin extends UIPlugin {
     const text = this.getters.getCellText(cell, showFormula);
     const textWidth = this.getters.getTextWidth(cell);
     const contentWidth = iconBoxWidth + textWidth;
-    const isOverflowing = contentWidth > width || fontSizeMap[fontSize] > height;
-    const align = this.computeCellAlignment(cell, isOverflowing);
+    const align = this.computeCellAlignment(cell, contentWidth > width);
     box.content = {
       text,
       width: textWidth,
@@ -540,6 +539,7 @@ export class RendererPlugin extends UIPlugin {
     }
 
     /** ClipRect */
+    const isOverflowing = contentWidth > width || fontSizeMap[fontSize] > height;
     if (cfIcon) {
       box.clipRect = [box.x + iconBoxWidth, box.y, Math.max(0, width - iconBoxWidth), height];
     } else if (isOverflowing) {

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -128,6 +128,29 @@ describe("renderer", () => {
     expect(textAligns).toEqual(["left", "left", "center"]); // center for headers
   });
 
+  test("numbers are aligned right when overflowing vertically", () => {
+    const model = new Model();
+
+    setCellContent(model, "A1", "1");
+    model.dispatch("SET_FORMATTING", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: target("A1"),
+      style: { fontSize: 36 },
+    });
+
+    let textAligns: string[] = [];
+    let ctx = new MockGridRenderingContext(model, 1000, 1000, {
+      onSet: (key, value) => {
+        if (key === "textAlign") {
+          textAligns.push(value);
+        }
+      },
+    });
+
+    model.drawGrid(ctx);
+    expect(textAligns).toEqual(["right", "center"]); // center for headers
+  });
+
   test("Cells evaluating to a number are properly aligned on overflow", () => {
     const model = new Model({
       sheets: [


### PR DESCRIPTION
5937563 introduced a bug where the content of the merge was clipped into the top-left cell of the merge, instead of the whole merge. Fix the clipRect of the merges, as well as prevent the merge from ever overflowing (simpler + match behaviour of GSheet/Excel)

Odoo task ID : [2765782](https://www.odoo.com/web#id=2765782&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

Second commit is a bug where when numbers were overflowing only vertically, their align were changed from right to left.

Odoo task ID : [2783014](https://www.odoo.com/web#id=2783014&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)


## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo