### PR TITLE
Revert "[FIX] viewport,grid: prevent scrolling loop"

### DIFF
--- a/src/components/autofill.ts
+++ b/src/components/autofill.ts
@@ -98,7 +98,7 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
   onMouseDown(ev: MouseEvent) {
     this.state.handler = true;
     this.state.position = { left: 0, top: 0 };
-    const { offsetY, offsetX } = this.env.model.getters.getActiveViewport();
+    const { offsetY, offsetX } = this.env.model.getters.getActiveSnappedViewport();
     const start = {
       left: ev.clientX + offsetX,
       top: ev.clientY + offsetY,
@@ -118,7 +118,7 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
         left: viewportLeft,
         offsetY,
         offsetX,
-      } = this.env.model.getters.getActiveViewport();
+      } = this.env.model.getters.getActiveSnappedViewport();
       this.state.position = {
         left: ev.clientX - start.left + offsetX,
         top: ev.clientY - start.top + offsetY,

--- a/src/components/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag.ts
@@ -38,7 +38,7 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
 
   get tagStyle(): string {
     const { col, row, color } = this.props;
-    const viewport = this.env.model.getters.getActiveViewport();
+    const viewport = this.env.model.getters.getActiveSnappedViewport();
     const { height } = this.env.model.getters.getViewportDimensionWithHeaders();
     const [x, y, ,] = this.env.model.getters.getRect(
       { left: col, top: row, right: col, bottom: row },

--- a/src/components/composer/grid_composer.ts
+++ b/src/components/composer/grid_composer.ts
@@ -77,7 +77,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     });
     this.rect = this.env.model.getters.getRect(
       this.zone,
-      this.env.model.getters.getActiveViewport()
+      this.env.model.getters.getActiveSnappedViewport()
     );
     onMounted(() => {
       const el = this.gridComposerRef.el!;

--- a/src/components/figures/container.ts
+++ b/src/components/figures/container.ts
@@ -164,7 +164,7 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
 
   getStyle(info: FigureInfo) {
     const { figure, isSelected } = info;
-    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
     const target = figure.id === (isSelected && this.dnd.figureId) ? this.dnd : figure;
     const { width, height } = target;
     let x = target.x - offsetX + HEADER_WIDTH - 1;

--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -47,33 +47,26 @@ export function dragAndDropBeyondTheViewport(
     const offsetY = currentEv.clientY - position.top;
     const edgeScrollInfoX = env.model.getters.getEdgeScrollCol(offsetX);
     const edgeScrollInfoY = env.model.getters.getEdgeScrollRow(offsetY);
-    const {
-      top,
-      left,
-      bottom,
-      right,
-      offsetX: viewportOffsetX,
-      offsetY: viewportOffsetY,
-    } = env.model.getters.getActiveViewport();
+    const { top, left, bottom, right } = env.model.getters.getActiveSnappedViewport();
 
     let colIndex: number;
     if (edgeScrollInfoX.canEdgeScroll) {
       colIndex = edgeScrollInfoX.direction > 0 ? right : left - 1;
     } else {
-      colIndex = env.model.getters.getColIndex(offsetX, viewportOffsetX);
+      colIndex = env.model.getters.getColIndex(offsetX, left);
     }
 
     let rowIndex: number;
     if (edgeScrollInfoY.canEdgeScroll) {
       rowIndex = edgeScrollInfoY.direction > 0 ? bottom : top - 1;
     } else {
-      rowIndex = env.model.getters.getRowIndex(offsetY, viewportOffsetY);
+      rowIndex = env.model.getters.getRowIndex(offsetY, top);
     }
 
     cbMouseMove(colIndex, rowIndex);
 
     if (edgeScrollInfoX.canEdgeScroll) {
-      const { left, offsetY } = env.model.getters.getActiveViewport();
+      const { left, offsetY } = env.model.getters.getActiveSnappedViewport();
       const { cols } = env.model.getters.getActiveSheet();
       const offsetX = cols[left + edgeScrollInfoX.direction].start;
       env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
@@ -84,7 +77,7 @@ export function dragAndDropBeyondTheViewport(
     }
 
     if (edgeScrollInfoY.canEdgeScroll) {
-      const { top, offsetX } = env.model.getters.getActiveViewport();
+      const { top, offsetX } = env.model.getters.getActiveSnappedViewport();
       const { rows } = env.model.getters.getActiveSheet();
       const offsetY = rows[top + edgeScrollInfoY.direction].start;
       env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });

--- a/src/components/highlight/border.ts
+++ b/src/components/highlight/border.ts
@@ -62,7 +62,7 @@ export class Border extends Component<Props, SpreadsheetChildEnv> {
     const widthValue = isHorizontal ? right - left : lineWidth;
     const heightValue = isVertical ? bottom - top : lineWidth;
 
-    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
     return `
         left:${leftValue + HEADER_WIDTH - offsetX}px;
         top:${topValue + HEADER_HEIGHT - offsetY}px;

--- a/src/components/highlight/corner.ts
+++ b/src/components/highlight/corner.ts
@@ -58,7 +58,7 @@ export class Corner extends Component<Props, SpreadsheetChildEnv> {
   private isLeft = this.props.orientation[1] === "w";
 
   get style() {
-    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
     const s = this.env.model.getters.getActiveSheet();
     const z = this.props.zone;
     const leftValue = this.isLeft ? s.cols[z.left].start : s.cols[z.right].end;

--- a/src/components/highlight/highlight.ts
+++ b/src/components/highlight/highlight.ts
@@ -105,11 +105,11 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
     const parent = this.highlightRef.el!.parentElement!;
     const position = parent.getBoundingClientRect();
     const activeSheet = this.env.model.getters.getActiveSheet();
-    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
+    const { top: viewportTop, left: viewportLeft } =
+      this.env.model.getters.getActiveSnappedViewport();
 
-    // TODO: probably false, should be offsetX and offsetY from viewport
-    const initCol = this.env.model.getters.getColIndex(clientX - position.left, offsetX);
-    const initRow = this.env.model.getters.getRowIndex(clientY - position.top, offsetY);
+    const initCol = this.env.model.getters.getColIndex(clientX - position.left, viewportLeft);
+    const initRow = this.env.model.getters.getRowIndex(clientY - position.top, viewportTop);
 
     const deltaColMin = -z.left;
     const deltaColMax = activeSheet.cols.length - z.right - 1;

--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -19,12 +19,7 @@ import * as icons from "./icons";
 // Resizer component
 // -----------------------------------------------------------------------------
 
-interface Props {
-  onOpenContextMenu: (type: ContextMenuType, x: number, y: number) => void;
-  onSetScrollbarValue: (offsetX: number, offsetY: number) => void;
-}
-
-abstract class AbstractResizer extends Component<Props, SpreadsheetChildEnv> {
+abstract class AbstractResizer extends Component<any, SpreadsheetChildEnv> {
   PADDING: number = 0;
   MAX_SIZE_MARGIN: number = 0;
   MIN_ELEMENT_SIZE: number = 0;
@@ -425,11 +420,11 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getStateOffset(): number {
-    return this.env.model.getters.getActiveViewport().offsetX - HEADER_WIDTH;
+    return this.env.model.getters.getActiveSnappedViewport().offsetX - HEADER_WIDTH;
   }
 
   _getViewportOffset(): number {
-    return this.env.model.getters.getActiveViewport().left;
+    return this.env.model.getters.getActiveSnappedViewport().left;
   }
 
   _getClientPosition(ev: MouseEvent): number {
@@ -439,7 +434,7 @@ export class ColResizer extends AbstractResizer {
   _getElementIndex(index: number): number {
     return this.env.model.getters.getColIndex(
       index,
-      this.env.model.getters.getActiveViewport().offsetX
+      this.env.model.getters.getActiveSnappedViewport().left
     );
   }
 
@@ -456,7 +451,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getBoundaries(): { first: number; last: number } {
-    const { left, right } = this.env.model.getters.getActiveViewport();
+    const { left, right } = this.env.model.getters.getActiveSnappedViewport();
     return { first: left, last: right };
   }
 
@@ -517,10 +512,10 @@ export class ColResizer extends AbstractResizer {
   }
 
   _adjustViewport(direction: number): void {
-    const { left, offsetY } = this.env.model.getters.getActiveViewport();
+    const { left, offsetY } = this.env.model.getters.getActiveSnappedViewport();
     const { cols } = this.env.model.getters.getActiveSheet();
     const offsetX = cols[left + direction].start;
-    this.props.onSetScrollbarValue(offsetX, offsetY);
+    this.env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
   }
 
   _fitElementSize(index: number): void {
@@ -673,11 +668,11 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getStateOffset(): number {
-    return this.env.model.getters.getActiveViewport().offsetY - HEADER_HEIGHT;
+    return this.env.model.getters.getActiveSnappedViewport().offsetY - HEADER_HEIGHT;
   }
 
   _getViewportOffset(): number {
-    return this.env.model.getters.getActiveViewport().top;
+    return this.env.model.getters.getActiveSnappedViewport().top;
   }
 
   _getClientPosition(ev: MouseEvent): number {
@@ -687,7 +682,7 @@ export class RowResizer extends AbstractResizer {
   _getElementIndex(index: number): number {
     return this.env.model.getters.getRowIndex(
       index,
-      this.env.model.getters.getActiveViewport().offsetY
+      this.env.model.getters.getActiveSnappedViewport().top
     );
   }
 
@@ -704,7 +699,7 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getBoundaries(): { first: number; last: number } {
-    const { top, bottom } = this.env.model.getters.getActiveViewport();
+    const { top, bottom } = this.env.model.getters.getActiveSnappedViewport();
     return { first: top, last: bottom };
   }
 
@@ -761,10 +756,10 @@ export class RowResizer extends AbstractResizer {
   }
 
   _adjustViewport(direction: number): void {
-    const { top, offsetX } = this.env.model.getters.getActiveViewport();
+    const { top, offsetX } = this.env.model.getters.getActiveSnappedViewport();
     const { rows } = this.env.model.getters.getActiveSheet();
     const offsetY = rows[top + direction].start;
-    this.props.onSetScrollbarValue(offsetX, offsetY);
+    this.env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
   }
 
   _fitElementSize(index: number): void {
@@ -826,11 +821,11 @@ css/* scss */ `
   }
 `;
 
-export class Overlay extends Component<Props, SpreadsheetChildEnv> {
+export class Overlay extends Component<any, SpreadsheetChildEnv> {
   static template = xml/* xml */ `
     <div class="o-overlay">
-      <ColResizer onOpenContextMenu="props.onOpenContextMenu" onSetScrollbarValue="props.onSetScrollbarValue"/>
-      <RowResizer onOpenContextMenu="props.onOpenContextMenu" onSetScrollbarValue="props.onSetScrollbarValue"/>
+      <ColResizer onOpenContextMenu="props.onOpenContextMenu" />
+      <RowResizer onOpenContextMenu="props.onOpenContextMenu" />
       <div class="all" t-on-mousedown.self="selectAll"/>
     </div>`;
 

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -1,4 +1,4 @@
-import { Position, Zone, ZoneDimension } from "../types";
+import { Position, Viewport, Zone, ZoneDimension } from "../types";
 import { toCartesian, toXC } from "./coordinates";
 import { range } from "./misc";
 
@@ -469,7 +469,11 @@ export function mergeOverlappingZones(zones: Zone[]) {
  * This function will compare the modifications of selection to determine
  * a cell that is part of the new zone and not the previous one.
  */
-export function findCellInNewZone(oldZone: Zone, currentZone: Zone): [number, number] {
+export function findCellInNewZone(
+  oldZone: Zone,
+  currentZone: Zone,
+  viewport: Viewport
+): [number, number] {
   let col: number, row: number;
   const { left: oldLeft, right: oldRight, top: oldTop, bottom: oldBottom } = oldZone!;
   const { left, right, top, bottom } = currentZone;
@@ -478,14 +482,14 @@ export function findCellInNewZone(oldZone: Zone, currentZone: Zone): [number, nu
   } else if (right != oldRight) {
     col = right;
   } else {
-    col = left;
+    col = viewport.left;
   }
   if (top != oldTop) {
     row = top;
   } else if (bottom != oldBottom) {
     row = bottom;
   } else {
-    row = top;
+    row = viewport.top;
   }
   return [col, row];
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -432,7 +432,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
    * canvas and need to draw the grid on it.  This is then done by calling this
    * method, which will dispatch the call to all registered plugins.
    *
-   * Note that nothing prevents multiple grid components from calling this method
+   * Note that nothing prevent multiple grid components from calling this method
    * each, or one grid component calling it multiple times with a different
    * context. This is probably the way we should do if we want to be able to
    * freeze a part of the grid (so, we would need to render different zones)
@@ -440,6 +440,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   drawGrid(context: GridRenderingContext) {
     // we make sure here that the viewport is properly positioned: the offsets
     // correspond exactly to a cell
+    context.viewport = this.getters.getActiveSnappedViewport(); //snaped one
     for (let [renderer, layer] of this.renderers) {
       context.ctx.save();
       renderer.drawGrid(context, layer);

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -81,21 +81,21 @@ export class RendererPlugin extends UIPlugin {
    * Return the index of a column given an offset x and a visible left col index.
    * It returns -1 if no column is found.
    */
-  getColIndex(x: number, offsetLeft: number, sheet?: Sheet): number {
+  getColIndex(x: number, left: number, sheet?: Sheet): number {
     if (x < HEADER_WIDTH) {
       return -1;
     }
     const cols = (sheet || this.getters.getActiveSheet()).cols;
-    const adjustedX = x - HEADER_WIDTH + offsetLeft + 1;
+    const adjustedX = x - HEADER_WIDTH + cols[left].start + 1;
     return searchIndex(cols, adjustedX);
   }
 
-  getRowIndex(y: number, offsetTop: number, sheet?: Sheet): number {
+  getRowIndex(y: number, top: number, sheet?: Sheet): number {
     if (y < HEADER_HEIGHT) {
       return -1;
     }
     const rows = (sheet || this.getters.getActiveSheet()).rows;
-    const adjustedY = y - HEADER_HEIGHT + offsetTop + 1;
+    const adjustedY = y - HEADER_HEIGHT + rows[top].start + 1;
     return searchIndex(rows, adjustedY);
   }
 
@@ -124,7 +124,7 @@ export class RendererPlugin extends UIPlugin {
     let delay = 0;
     const { width } = this.getters.getViewportDimensionWithHeaders();
     const { width: gridWidth } = this.getters.getMaxViewportSize(this.getters.getActiveSheet());
-    const { left, offsetX } = this.getters.getActiveViewport();
+    const { left, offsetX } = this.getters.getActiveSnappedViewport();
     if (x < HEADER_WIDTH && left > 0) {
       canEdgeScroll = true;
       direction = -1;
@@ -144,7 +144,7 @@ export class RendererPlugin extends UIPlugin {
     let delay = 0;
     const { height } = this.getters.getViewportDimensionWithHeaders();
     const { height: gridHeight } = this.getters.getMaxViewportSize(this.getters.getActiveSheet());
-    const { top, offsetY } = this.getters.getActiveViewport();
+    const { top, offsetY } = this.getters.getActiveSnappedViewport();
     if (y < HEADER_HEIGHT && top > 0) {
       canEdgeScroll = true;
       direction = -1;
@@ -433,12 +433,6 @@ export class RendererPlugin extends UIPlugin {
       ctx.lineTo(HEADER_WIDTH, row.end - offsetY);
     }
 
-    ctx.stroke();
-
-    // draw over the text for the top-left rectangle
-    ctx.beginPath();
-    ctx.fillStyle = BACKGROUND_HEADER_COLOR;
-    ctx.fillRect(0, 0, HEADER_WIDTH, HEADER_HEIGHT);
     ctx.stroke();
   }
 

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -453,7 +453,7 @@ export class GridSelectionPlugin extends UIPlugin {
     const sheetId = this.getters.getActiveSheetId();
     const result: Figure[] = [];
     const figures = this.getters.getFigures(sheetId);
-    const { offsetX, offsetY } = this.getters.getActiveViewport();
+    const { offsetX, offsetY } = this.getters.getActiveSnappedViewport();
     const { width, height } = this.getters.getViewportDimensionWithHeaders();
     for (let figure of figures) {
       if (figure.x >= offsetX + width || figure.x + figure.width <= offsetX) {

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -41,7 +41,11 @@ export interface GridDimension {
   height: number;
 }
 
-export interface ViewportOffsets {
+/**
+ * The viewport is the visible area of a sheet.
+ * Column and row headers are not included in the viewport.
+ */
+export interface Viewport extends Zone {
   /**
    * The offset in the X coordinate between the viewport left side and
    * the grid left side (left of column "A").
@@ -53,12 +57,6 @@ export interface ViewportOffsets {
    */
   offsetY: number;
 }
-
-/**
- * The viewport is the visible area of a sheet.
- * Column and row headers are not included in the viewport.
- */
-export interface Viewport extends Zone, ViewportOffsets {}
 
 export interface GridRenderingContext {
   ctx: CanvasRenderingContext2D;

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -3,10 +3,4 @@ export interface NotificationUIEvent {
   text: string;
 }
 
-export interface ScrollUIEvent {
-  type: "SCROLL";
-  offsetX: number;
-  offsetY: number;
-}
-
-export type NotifyUIEvent = NotificationUIEvent | ScrollUIEvent;
+export type NotifyUIEvent = NotificationUIEvent;

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -567,8 +567,7 @@ describe("Multi users synchronisation", () => {
     alice.dispatch("START_EDITION", { text: "hello" });
     const spy = jest.spyOn(alice["config"], "notifyUI");
     alice.dispatch("DELETE_SHEET", { sheetId: activeSheetId });
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).not.toHaveBeenCalledWith({ type: "SCROLL" });
+    expect(spy).toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
   });
 
@@ -578,8 +577,7 @@ describe("Multi users synchronisation", () => {
     alice.dispatch("STOP_EDITION");
     const spy = jest.spyOn(alice["config"], "notifyUI");
     deleteRows(bob, [3]);
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({ type: "SCROLL", offsetX: 0, offsetY: 0 });
+    expect(spy).not.toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
   });
 
@@ -589,8 +587,7 @@ describe("Multi users synchronisation", () => {
     alice.dispatch("STOP_EDITION");
     const spy = jest.spyOn(alice["config"], "notifyUI");
     deleteColumns(bob, ["A"]);
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({ type: "SCROLL", offsetX: 0, offsetY: 0 });
+    expect(spy).not.toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
   });
 

--- a/tests/components/__mocks__/scrollbar.ts
+++ b/tests/components/__mocks__/scrollbar.ts
@@ -14,6 +14,5 @@ export class ScrollBar {
 
   set scroll(value: number) {
     this.scrollValue = value;
-    this.el.dispatchEvent(new MouseEvent("scroll", { bubbles: true }));
   }
 }

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -771,6 +771,14 @@ describe("Events on Grid update viewport correctly", () => {
       offsetX: 0,
       offsetY: 1200,
     });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 52,
+      bottom: 93,
+      left: 0,
+      right: 9,
+      offsetX: 0,
+      offsetY: 1196,
+    });
   });
   test("Horizontal scroll", async () => {
     fixture
@@ -783,6 +791,14 @@ describe("Events on Grid update viewport correctly", () => {
       left: 2,
       right: 11,
       offsetX: 200,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 0,
+      bottom: 41,
+      left: 2,
+      right: 11,
+      offsetX: 192,
       offsetY: 0,
     });
   });
@@ -842,15 +858,15 @@ describe("Events on Grid update viewport correctly", () => {
         bubbles: true,
       })
     );
-    const viewport = model.getters.getActiveViewport();
+    const viewport = model.getters.getActiveSnappedViewport();
     selectCell(model, "Y1");
     await nextTick();
-    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", shiftKey: true, bubbles: true })
     );
     await nextTick();
-    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
   });
 
   test("A resize of the grid DOM element impacts the viewport", async () => {
@@ -885,10 +901,10 @@ describe("Events on Grid update viewport correctly", () => {
         bubbles: true,
       })
     );
-    const viewport = model.getters.getActiveViewport();
-    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
+    const viewport = model.getters.getActiveSnappedViewport();
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
     await clickCell(model, "Y1", { shiftKey: true });
-    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
   });
 
   describe("Edge-Scrolling on mouseMove in selection", () => {
@@ -904,7 +920,7 @@ describe("Events on Grid update viewport correctly", () => {
       jest.advanceTimersByTime(advanceTimer);
       triggerMouseEvent("canvas", "mouseup", 1.5 * width, y);
 
-      expect(model.getters.getActiveViewport()).toMatchObject({
+      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
         left: 6,
         right: 15,
         top: 0,
@@ -917,7 +933,7 @@ describe("Events on Grid update viewport correctly", () => {
       jest.advanceTimersByTime(advanceTimer2);
       triggerMouseEvent("canvas", "mouseup", -0.5 * width, y);
 
-      expect(model.getters.getActiveViewport()).toMatchObject({
+      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
         left: 3,
         right: 12,
         top: 0,
@@ -934,7 +950,7 @@ describe("Events on Grid update viewport correctly", () => {
       jest.advanceTimersByTime(advanceTimer);
       triggerMouseEvent("canvas", "mouseup", x, 1.5 * height);
 
-      expect(model.getters.getActiveViewport()).toMatchObject({
+      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
         left: 0,
         right: 9,
         top: 6,
@@ -947,7 +963,7 @@ describe("Events on Grid update viewport correctly", () => {
       jest.advanceTimersByTime(advanceTimer2);
       triggerMouseEvent("canvas", "mouseup", x, -0.5 * height);
 
-      expect(model.getters.getActiveViewport()).toMatchObject({
+      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
         left: 0,
         right: 9,
         top: 3,

--- a/tests/components/highlight.test.ts
+++ b/tests/components/highlight.test.ts
@@ -1,11 +1,6 @@
 import { App, Component, useSubEnv, xml } from "@odoo/owl";
 import { Highlight } from "../../src/components/highlight/highlight";
-import {
-  DEFAULT_CELL_HEIGHT,
-  DEFAULT_CELL_WIDTH,
-  HEADER_HEIGHT,
-  HEADER_WIDTH,
-} from "../../src/constants";
+import { HEADER_HEIGHT, HEADER_WIDTH } from "../../src/constants";
 import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { DispatchResult } from "../../src/types/commands";
@@ -14,35 +9,19 @@ import { triggerMouseEvent } from "../test_helpers/dom_helper";
 import { makeTestFixture, nextTick } from "../test_helpers/helpers";
 
 function getColStartPosition(col: number) {
-  return (
-    HEADER_WIDTH +
-    model.getters.getCol(model.getters.getActiveSheetId(), col)!.start -
-    model.getters.getActiveViewport().offsetX
-  );
+  return HEADER_WIDTH + model.getters.getCol(model.getters.getActiveSheetId(), col)!.start;
 }
 
 function getColEndPosition(col: number) {
-  return (
-    HEADER_WIDTH +
-    model.getters.getCol(model.getters.getActiveSheetId(), col)!.end -
-    model.getters.getActiveViewport().offsetX
-  );
+  return HEADER_WIDTH + model.getters.getCol(model.getters.getActiveSheetId(), col)!.end;
 }
 
 function getRowStartPosition(row: number) {
-  return (
-    HEADER_HEIGHT +
-    model.getters.getRow(model.getters.getActiveSheetId(), row)!.start -
-    model.getters.getActiveViewport().offsetY
-  );
+  return HEADER_HEIGHT + model.getters.getRow(model.getters.getActiveSheetId(), row)!.start;
 }
 
 function getRowEndPosition(row: number) {
-  return (
-    HEADER_HEIGHT +
-    model.getters.getRow(model.getters.getActiveSheetId(), row)!.end -
-    model.getters.getActiveViewport().offsetY
-  );
+  return HEADER_HEIGHT + model.getters.getRow(model.getters.getActiveSheetId(), row)!.end;
 }
 
 async function selectNWCellCorner(el: Element, xc: string) {
@@ -64,7 +43,6 @@ async function selectSWCellCorner(el: Element, xc: string) {
 }
 
 async function selectSECellCorner(el: Element, xc: string) {
-  debugger;
   const { top, left } = toZone(xc);
   triggerMouseEvent(el, "mousedown", getColEndPosition(left), getRowEndPosition(top));
   await nextTick();
@@ -462,42 +440,6 @@ describe("Border component", () => {
     moveToCell(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
       zone: toZone("B1:C1"),
-    });
-  });
-
-  test("resize highlights on a scrolled viewport", async () => {
-    //scroll between B2/C3
-    model.dispatch("SET_VIEWPORT_OFFSET", {
-      offsetX: (DEFAULT_CELL_WIDTH * 3) / 2,
-      offsetY: (DEFAULT_CELL_HEIGHT * 3) / 2,
-    });
-    parent = await mountHighlight("A1:D4", "#666");
-    borderEl = fixture.querySelector(".o-corner-se")!;
-    selectSECellCorner(borderEl, "D4");
-    expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1:D4"),
-    });
-    moveToCell(borderEl, "E5");
-    expect(parent.model.dispatch).toHaveBeenLastCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("A1:E5"),
-    });
-  });
-
-  test("drag highlights on a scrolled viewport", async () => {
-    //scroll between B2/C3
-    model.dispatch("SET_VIEWPORT_OFFSET", {
-      offsetX: (DEFAULT_CELL_WIDTH * 3) / 2,
-      offsetY: (DEFAULT_CELL_HEIGHT * 3) / 2,
-    });
-    parent = await mountHighlight("A1:D4", "#666");
-    borderEl = fixture.querySelector(".o-border-s")!;
-    selectBottomCellBorder(borderEl, "D4");
-    expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1:D4"),
-    });
-    moveToCell(borderEl, "E5");
-    expect(parent.model.dispatch).toHaveBeenLastCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B2:E5"),
     });
   });
 

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -23,7 +23,6 @@ import {
 import { triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell } from "../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
-jest.mock("../../src/components/scrollbar", () => require("./__mocks__/scrollbar"));
 
 let fixture: HTMLElement;
 let model: Model;
@@ -776,7 +775,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-col-resizer", "mouseup", 1.5 * width, y);
 
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       left: 6,
       right: 15,
       top: 0,
@@ -790,7 +789,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-col-resizer", "mouseup", -0.5 * width, y);
 
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       left: 3,
       right: 12,
       top: 0,
@@ -807,7 +806,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-row-resizer", "mouseup", x, 1.5 * height);
 
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 6,
@@ -820,7 +819,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-row-resizer", "mouseup", x, -0.5 * height);
 
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 3,

--- a/tests/plugins/__snapshots__/renderer.test.ts.snap
+++ b/tests/plugins/__snapshots__/renderer.test.ts.snap
@@ -384,10 +384,6 @@ Array [
   "context.moveTo(0, 1015)",
   "context.lineTo(48, 1015)",
   "context.stroke()",
-  "context.beginPath()",
-  "context.fillStyle=\\"#F8F9FA\\";",
-  "context.fillRect(0, 0, 48, 26)",
-  "context.stroke()",
   "context.restore()",
 ]
 `;

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -472,7 +472,7 @@ describe("renderer", () => {
     setCellContent(model, "A1", "1");
     setCellContent(model, "C1", "1");
     model.drawGrid(ctx);
-    expect(textAligns).toEqual(["right", "left", "right", "right", "center"]); // A1-C1-A2:B2-C2:D2 and center for headers. C1 is still in overflow
+    expect(textAligns).toEqual(["right", "left", "right", "right", "center"]); // A1-C1-A2:B2-C2:D2 and center for headers. C1 is stil lin overflow
   });
 
   test("formulas in a merge, evaluating to a boolean are properly aligned", () => {

--- a/tests/plugins/viewport.test.ts
+++ b/tests/plugins/viewport.test.ts
@@ -7,7 +7,6 @@ import {
 } from "../../src/constants";
 import { numberToLetters, range, toXC, toZone, zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
-import { ViewportOffsets } from "../../src/types";
 import {
   activateSheet,
   addColumns,
@@ -31,17 +30,6 @@ import {
 
 let model: Model;
 
-function getMaximumOffsets(model: Model): ViewportOffsets {
-  const sheet = model.getters.getActiveSheet();
-  const { height: gridHeight, width: gridWidth } = model.getters.getMaxViewportSize(sheet);
-  const { height: viewportHeight, width: viewportWidth } =
-    model.getters.getViewportDimensionWithHeaders();
-  return {
-    offsetX: gridWidth - viewportWidth + HEADER_WIDTH,
-    offsetY: gridHeight - viewportHeight + HEADER_HEIGHT,
-  };
-}
-
 describe("Viewport of Simple sheet", () => {
   beforeEach(async () => {
     model = new Model();
@@ -58,6 +46,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 6 * DEFAULT_CELL_WIDTH,
       offsetY: 0,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     selectCell(model, "A79");
     expect(model.getters.getActiveViewport()).toMatchObject({
       top: 36,
@@ -67,6 +58,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: 36 * DEFAULT_CELL_HEIGHT,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     // back to topleft
     selectCell(model, "A1");
     expect(model.getters.getActiveViewport()).toMatchObject({
@@ -77,6 +71,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: 0,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     selectCell(model, "U51");
     expect(model.getters.getActiveViewport()).toMatchObject({
       top: 8,
@@ -91,7 +88,7 @@ describe("Viewport of Simple sheet", () => {
     model.getters.getActiveViewport();
     addRows(model, "before", 0, 70);
     selectCell(model, "B170");
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       left: 0,
       right: 10,
       top: 127,
@@ -100,23 +97,22 @@ describe("Viewport of Simple sheet", () => {
       offsetY: DEFAULT_CELL_HEIGHT * 127,
     });
     undo(model);
-    const { offsetY } = getMaximumOffsets(model);
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       left: 0,
       right: 10,
       top: 57,
       bottom: 99,
       offsetX: 0,
-      offsetY: offsetY,
+      offsetY: DEFAULT_CELL_HEIGHT * 57,
     });
     redo(model); // should not alter offset
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       left: 0,
       right: 10,
       top: 57,
-      bottom: 101,
+      bottom: 100,
       offsetX: 0,
-      offsetY: offsetY,
+      offsetY: DEFAULT_CELL_HEIGHT * 57,
     });
   });
 
@@ -154,6 +150,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH * 2,
       offsetY: 0,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: DEFAULT_CELL_WIDTH * 16,
       offsetY: 0,
@@ -166,6 +165,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH * 16,
       offsetY: 0,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: DEFAULT_CELL_WIDTH * 12.6,
       offsetY: 0,
@@ -176,6 +178,14 @@ describe("Viewport of Simple sheet", () => {
       left: 12,
       right: 23,
       offsetX: DEFAULT_CELL_WIDTH * 12.6,
+      offsetY: 0,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 0,
+      bottom: 43,
+      left: 12,
+      right: 22,
+      offsetX: DEFAULT_CELL_WIDTH * 12,
       offsetY: 0,
     });
   });
@@ -211,6 +221,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 2,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 57,
@@ -223,6 +236,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 57,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 12.6,
@@ -234,6 +250,14 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 12.6,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 12,
+      bottom: 55,
+      left: 0,
+      right: 10,
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 12,
     });
   });
 
@@ -290,6 +314,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: offsetX,
       offsetY: 0,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
   });
 
   test("Resize (reduce) columns correctly changes offset", () => {
@@ -303,13 +330,19 @@ describe("Viewport of Simple sheet", () => {
       [...Array(cols.length).keys()].map(numberToLetters),
       DEFAULT_CELL_WIDTH / 2
     );
-    const { offsetX } = getMaximumOffsets(model);
     expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 7,
       right: 25,
-      offsetX,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 0,
+      bottom: 43,
+      left: 7,
+      right: 25,
+      offsetX: (DEFAULT_CELL_WIDTH / 2) * 7,
+      offsetY: 0,
     });
   });
 
@@ -329,6 +362,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: offsetY,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
   });
 
   test("Resize (reduce) rows correctly changes offset", () => {
@@ -343,19 +379,25 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     resizeRows(model, [...Array(rows.length).keys()], DEFAULT_CELL_HEIGHT / 2);
-    const { offsetY } = getMaximumOffsets(model);
     expect(model.getters.getActiveViewport()).toMatchObject({
       top: 15,
       bottom: 99,
       left: 0,
       right: 10,
-      offsetY,
+    });
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      top: 15,
+      bottom: 99,
+      left: 0,
+      right: 10,
+      offsetX: 0,
+      offsetY: (DEFAULT_CELL_HEIGHT / 2) * 15,
     });
   });
 
   test("Hide/unhide Columns from leftest column", () => {
     hideColumns(model, [0, 1, 2, 4, 5].map(numberToLetters)); // keep 3
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 3,
@@ -368,21 +410,20 @@ describe("Viewport of Simple sheet", () => {
   test("Hide/unhide Columns from rightest column", () => {
     selectCell(model, "Z1");
     const viewport = model.getters.getActiveViewport();
-    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
     hideColumns(model, range(13, 26).map(numberToLetters));
-    const { offsetX } = getMaximumOffsets(model);
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       top: viewport.top,
       bottom: viewport.bottom,
       left: 3,
       right: viewport.right,
+      offsetX: DEFAULT_CELL_WIDTH * 3,
       offsetY: 0,
-      offsetX,
     });
   });
   test("Hide/unhide Row from top row", () => {
     hideRows(model, [0, 1, 2, 4, 5]); // keep 3
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       top: 3,
       bottom: 48,
       left: 0,
@@ -394,16 +435,15 @@ describe("Viewport of Simple sheet", () => {
   test("Hide/unhide Rows from bottom row", () => {
     selectCell(model, "A100");
     const viewport = model.getters.getActiveViewport();
-    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
     hideRows(model, range(60, 100));
-    const { offsetY } = getMaximumOffsets(model);
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       top: 17,
       bottom: 99,
       left: viewport.left,
       right: viewport.right,
       offsetX: 0,
-      offsetY,
+      offsetY: DEFAULT_CELL_HEIGHT * 17,
     });
   });
   test("Horizontally move position to top right then back to top left correctly affects offset", () => {
@@ -418,6 +458,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH,
       offsetY: 0,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     moveAnchorCell(model, 1, 0);
     moveAnchorCell(model, 1, 0);
     expect(model.getters.getActiveViewport()).toMatchObject({
@@ -428,8 +471,11 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH * 3,
       offsetY: 0,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
 
-    const { left } = model.getters.getActiveViewport();
+    const { left } = model.getters.getActiveSnappedViewport();
     selectCell(model, toXC(left, 0));
     moveAnchorCell(model, -1, 0);
     moveAnchorCell(model, -1, 0);
@@ -441,6 +487,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH,
       offsetY: 0,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
   });
 
   test("Vertically move position to bottom left then back to top left correctly affects offset", () => {
@@ -455,6 +504,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     moveAnchorCell(model, 0, 1);
     moveAnchorCell(model, 0, 1);
     expect(model.getters.getActiveViewport()).toMatchObject({
@@ -465,6 +517,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 3,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
     const { top } = model.getters.getActiveViewport();
     selectCell(model, toXC(0, top));
     moveAnchorCell(model, 0, -1);
@@ -477,6 +532,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
   });
 
   test("Move position on cells that are taller than the client's height", () => {
@@ -499,6 +557,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: height + 50, // row1 + row2
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
   });
 
   test("Move position on cells wider than the client's width", () => {
@@ -521,6 +582,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: width + 50, // colA + colB
       offsetY: 0,
     });
+    expect(model.getters.getActiveViewport()).toMatchObject(
+      model.getters.getActiveSnappedViewport()
+    );
   });
   test("Select Column while updating range does not update viewport", () => {
     selectCell(model, "C51");
@@ -537,15 +601,15 @@ describe("Viewport of Simple sheet", () => {
   test("Resize Viewport is correctly computed and does not adjust position", () => {
     selectCell(model, "K71");
     model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 100, offsetY: 112 });
-    const viewport = model.getters.getActiveViewport();
+    const viewport = model.getters.getActiveSnappedViewport();
     model.dispatch("RESIZE_VIEWPORT", {
       width: 500,
       height: 500,
     });
-    expect(model.getters.getActiveViewport()).toMatchObject({
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
       ...viewport,
-      right: Math.floor((viewport.offsetX + 500) / DEFAULT_CELL_WIDTH),
-      bottom: Math.floor((viewport.offsetY + 500) / DEFAULT_CELL_HEIGHT),
+      bottom: viewport.top + Math.ceil(500 / DEFAULT_CELL_HEIGHT) - 1,
+      right: viewport.left + Math.ceil(500 / DEFAULT_CELL_WIDTH) - 1,
     });
   });
 
@@ -684,11 +748,11 @@ describe("shift viewport up/down", () => {
   });
 
   test("basic move viewport", () => {
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().top).toBe(bottom);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().top).toBe(0);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(0);
   });
 
   test("move viewport with non-default size", () => {
@@ -696,70 +760,70 @@ describe("shift viewport up/down", () => {
       height: 100,
       width: 100,
     });
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().top).toBe(bottom);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().top).toBe(0);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(0);
   });
 
   test("RENAME move viewport not starting from the top", () => {
     selectCell(model, "A4");
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 3,
     });
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().top).toBe(bottom + 3);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom + 3);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().top).toBe(3);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(3);
   });
 
   test("RENAME move viewport not starting from the top", () => {
     selectCell(model, "A4");
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 3 + 1,
     });
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().top).toBe(bottom + 3);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom + 3);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().top).toBe(3);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(3);
   });
 
   test("RENAME move viewport not starting from the top", () => {
     selectCell(model, "A4");
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 3 - 1,
     });
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().top).toBe(bottom + 2);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom + 2);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().top).toBe(2);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(2);
   });
 
   test("move all the way down and up again", () => {
     const sheetId = model.getters.getActiveSheetId();
     const numberOfRows = model.getters.getNumberRows(sheetId);
-    let { bottom } = model.getters.getActiveViewport();
+    let { bottom } = model.getters.getActiveSnappedViewport();
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().top).toBe(bottom);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().bottom).toBe(numberOfRows - 1);
+    expect(model.getters.getActiveSnappedViewport().bottom).toBe(numberOfRows - 1);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().bottom).toBe(numberOfRows - 1);
+    expect(model.getters.getActiveSnappedViewport().bottom).toBe(numberOfRows - 1);
 
-    let { top } = model.getters.getActiveViewport();
+    let { top } = model.getters.getActiveSnappedViewport();
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().bottom).toBe(top);
+    expect(model.getters.getActiveSnappedViewport().bottom).toBe(top);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().top).toBe(0);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(0);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().top).toBe(0);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(0);
   });
 
   test("move viewport does not changes its dimension", () => {
@@ -777,13 +841,13 @@ describe("shift viewport up/down", () => {
       offsetY: 0,
     });
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
+    expect(model.getters.getActiveSnappedViewport().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
+    expect(model.getters.getActiveSnappedViewport().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
   });
 
   test("anchor cell at the viewport top is shifted", () => {
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     selectCell(model, "A1");
     model.dispatch("SHIFT_VIEWPORT_DOWN");
     expect(model.getters.getSelectedZones()).toHaveLength(1);
@@ -794,7 +858,7 @@ describe("shift viewport up/down", () => {
   });
 
   test("anchor cell not at the viewport top is shifted", () => {
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     selectCell(model, "B4");
     model.dispatch("SHIFT_VIEWPORT_DOWN");
     expect(model.getters.getSelectedZone()).toEqual({
@@ -811,7 +875,7 @@ describe("shift viewport up/down", () => {
     setSelection(model, ["A1:A2", "B5", "D1:D2"], {
       anchor: "D1",
     });
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     model.dispatch("SHIFT_VIEWPORT_DOWN");
     expect(model.getters.getSelectedZones()).toHaveLength(1);
     expect(model.getters.getSelectedZone()).toEqual({
@@ -823,22 +887,22 @@ describe("shift viewport up/down", () => {
   });
 
   test("hidden rows are skipped", () => {
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     model.dispatch("HIDE_COLUMNS_ROWS", {
       dimension: "ROW",
       elements: [2, 3, 4],
       sheetId: model.getters.getActiveSheetId(),
     });
-    const { bottom: bottomWithHiddenRows } = model.getters.getActiveViewport();
+    const { bottom: bottomWithHiddenRows } = model.getters.getActiveSnappedViewport();
     expect(bottomWithHiddenRows).toBe(bottom + 3);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().top).toBe(bottomWithHiddenRows);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(bottomWithHiddenRows);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().bottom).toBe(bottomWithHiddenRows);
+    expect(model.getters.getActiveSnappedViewport().bottom).toBe(bottomWithHiddenRows);
   });
 
   test("bottom cell is in a merge and new anchor in the merge", () => {
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     const mergeTop = bottom - 1;
     const mergeBottom = bottom + 1;
     merge(
@@ -851,13 +915,13 @@ describe("shift viewport up/down", () => {
       })
     );
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().top).toBe(mergeTop);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(mergeTop);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveViewport().bottom).toBe(bottom);
+    expect(model.getters.getActiveSnappedViewport().bottom).toBe(bottom);
   });
 
   test("bottom cell is in a merge and new anchor *not* in the merge", () => {
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     const mergeTop = bottom - 1;
     const mergeBottom = bottom + 1;
     merge(
@@ -871,11 +935,11 @@ describe("shift viewport up/down", () => {
     );
     selectCell(model, "B1");
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveViewport().top).toBe(bottom);
+    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom);
   });
 
   test("anchor ends up at the last row", () => {
-    const { bottom } = model.getters.getActiveViewport();
+    const { bottom } = model.getters.getActiveSnappedViewport();
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("RESIZE_VIEWPORT", {
       width: 1000,
@@ -883,7 +947,7 @@ describe("shift viewport up/down", () => {
     });
     deleteRows(model, range(bottom + 1, model.getters.getNumberRows(sheetId)));
     selectCell(model, toXC(0, bottom));
-    expect(model.getters.getActiveViewport().bottom).toBe(bottom);
+    expect(model.getters.getActiveSnappedViewport().bottom).toBe(bottom);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
     expect(model.getters.getSelectedZone()).toEqual({
       top: bottom,
@@ -901,10 +965,10 @@ describe("shift viewport up/down", () => {
       deleteRows(model, range(2, model.getters.getNumberRows(sheetId)));
       selectCell(model, selectedCell);
       model.dispatch("SHIFT_VIEWPORT_DOWN");
-      expect(model.getters.getActiveViewport().top).toBe(0);
+      expect(model.getters.getActiveSnappedViewport().top).toBe(0);
       expect(model.getters.getSelectedZone()).toEqual(toZone(selectedCell));
       model.dispatch("SHIFT_VIEWPORT_UP");
-      expect(model.getters.getActiveViewport().top).toBe(0);
+      expect(model.getters.getActiveSnappedViewport().top).toBe(0);
       expect(model.getters.getSelectedZone()).toEqual(toZone(selectedCell));
     }
   );
@@ -912,7 +976,7 @@ describe("shift viewport up/down", () => {
   test.each(["A1", "A2", "A15"])(
     "anchor %s is shifted by the correct amount when the sheet end is reached",
     (selectedCell) => {
-      const { bottom } = model.getters.getActiveViewport();
+      const { bottom } = model.getters.getActiveSnappedViewport();
       const sheetId = model.getters.getActiveSheetId();
       // delete all rows after the viewport except three
       deleteRows(model, range(bottom + 3, model.getters.getNumberRows(sheetId)));


### PR DESCRIPTION
This reverts commit d7f64decdab79916e521fc1870208188d0272007.

The commit failed to address the actual scrolling issue, it just moved
the problem somewhere else. Namely, it broke the ability to scroll the
grid while onlt changing the viewport offset. This broke some of the
edgescrolling abilities (e.g. highlights).

The current edgescrolling flow might be wrong: the move of the cursor
changes the selection (or equivalent) and the grid is scrolled in
consequence of this change. Maybe the scroll should happen first and the
change would be a consequence of that change; this is typically what
happens when we move the mouse around  normally around the screen.

Furthermore, if we wanted to keep the current edgescrolling flow
(which I think we don't) we should at least make good use of the
`SelectionStreamProcessor`.

This feels like a reason good enough to take a step back a try a new
approach.
