### PR TITLE
[IMP] functions: Only allow valid function names in registry

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,4 +1,5 @@
 import { Registry } from "../registry";
+import { _lt } from "../translation";
 import { AddFunctionDescription, FunctionDescription } from "../types";
 import { addMetaInfoFromArg, validateArguments } from "./arguments";
 import * as database from "./module_database";
@@ -29,6 +30,8 @@ const functions: { [category: string]: { [name: string]: AddFunctionDescription 
   engineering,
 };
 
+const functionNameRegex = /^[A-Z0-9\.]+$/;
+
 //------------------------------------------------------------------------------
 // Function registry
 //------------------------------------------------------------------------------
@@ -36,7 +39,15 @@ class FunctionRegistry extends Registry<FunctionDescription> {
   mapping: { [key: string]: Function } = {};
 
   add(name: string, addDescr: AddFunctionDescription) {
-    name = name.toUpperCase().replace("_", ".");
+    name = name.toUpperCase();
+    if (!name.match(functionNameRegex)) {
+      throw new Error(
+        _lt(
+          "Invalid function name %s. Function names can exclusively contain alphanumerical values separated by dots (.)",
+          name
+        )
+      );
+    }
     const descr = addMetaInfoFromArg(addDescr);
     validateArguments(descr.args);
     this.mapping[name] = descr.compute;
@@ -52,6 +63,7 @@ for (let category in functions) {
   for (let name in fns) {
     const addDescr = fns[name];
     addDescr.category = category;
+    name = name.replace("_", ".");
     functionRegistry.add(name, { isExported: false, ...addDescr });
   }
 }

--- a/tests/functions/functions.test.ts
+++ b/tests/functions/functions.test.ts
@@ -17,6 +17,20 @@ describe("addFunction", () => {
     expect(evaluateCell("A1", { A1: "=DOUBLEDOUBLE(3)" })).toBe(6);
   });
 
+  test("can not add a function with invalid name", () => {
+    const createBadFunction = () => {
+      functionRegistry.add("TEST_FUNCTION", {
+        description: "Double the first argument",
+        compute: () => 0,
+        args: [],
+        returns: ["NUMBER"],
+      });
+    };
+    expect(createBadFunction).toThrow(
+      "Invalid function name TEST_FUNCTION. Function names can exclusively contain alphanumerical values separated by dots (.)"
+    );
+  });
+
   test("Can use a custom evaluation context in a function", () => {
     const model = new Model(
       {},


### PR DESCRIPTION
Currently, one can add a new function to the functionRegistry by
providing a key containing an underscore and it will magically be
adapted so the actual key contains a dot (.) instead.

There a two  issues with this:

1. The existence of this feature is only justified by the way we
   organized our functions files: We export the function under some
   variable and use those to populate the registry. Since variables
   can not contain dots, we used underscore. The functionRegistry
   should not be aware of such a specificity.

2. The goal is to propose a generic formula name, only containing
   dots and alphanumerical characters. However, the current
   implementation will only replace the first occurence of
   an underscore, basically defeating the purpose.

This commit tries to address both issues by forcing a proper format of
alphanumeric and dot  format to the keys of the registry.

Task 2715250
