### PR TITLE
[ADD] package: post-checkout with npm install (on demand)

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,8 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+if [ "$HUSKY_POST_CHECKOUT" != 0 ]; then
+    if [ "$1" != "$2" ]; then
+        npm install >/dev/null 2>&1
+    fi
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+if [ "$HUSKY_PRE_COMMIT" != 0 ]; then
+    npx lint-staged
+fi


### PR DESCRIPTION
Adds a post-checkout hook to update the packages automatically after a
checkout. This will address the necessity to run `npm install`every time
we switch between branches that depend on a different versions of owl.

task [2786583](https://www.odoo.com/web#cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form&id=2786583)