### PR TITLE
[IMP] topbar: alignment tool value

### DIFF
--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -451,9 +451,6 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   updateCellState() {
-    this.style = this.env.model.getters.getCurrentStyle();
-    this.fillColor = this.style.fillColor || "white";
-    this.textColor = this.style.textColor || "black";
     const zones = this.env.model.getters.getSelectedZones();
     const { top, left, right, bottom } = zones[0];
     this.cannotMerge = zones.length > 1 || (top === bottom && left === right);
@@ -478,6 +475,11 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
     } else {
       this.currentFormat = "general";
     }
+    this.style = { ...this.env.model.getters.getCurrentStyle() };
+    this.style.align = this.style.align || cell?.defaultAlign;
+    this.fillColor = this.style.fillColor || "white";
+    this.textColor = this.style.textColor || "black";
+
     this.menus = topbarMenuRegistry
       .getAll()
       .filter((item) => !item.isVisible || item.isVisible(this.env));

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -110,3 +110,11 @@ export async function keyUp(key: string, options: any = {}): Promise<void> {
   );
   return await nextTick();
 }
+
+/**
+ * Will replace "<path ...></path>" by "<path ... />" in the given html string. This is needed to compare icons html,
+ * as our icon constants use the second syntax, but the compiled HTML use the first syntax.
+ */
+export function sanitizeIconHTML(html: string): string {
+  return html.replace(/<path (.*)><\/path>/, "<path $1/>");
+}


### PR DESCRIPTION
Before the alignment tool didn't display the correct align for number/formulas,
as their default align were "right" but their style was undefined.

Also added missing tests for the align tool in the toolbar.

Odoo task ID : [2620615](https://www.odoo.com/web#id=2620615&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo