### PR TITLE
[FIX] topbar: translate titles

### DIFF
--- a/src/components/link/link_display.ts
+++ b/src/components/link/link_display.ts
@@ -5,7 +5,7 @@ import { LinkCell, Position, SpreadsheetChildEnv } from "../../types";
 import { css } from "../helpers/css";
 import { EDIT, UNLINK } from "../icons";
 import { Menu } from "../menu";
-import { LinkEditorTerms } from "../side_panel/translations_terms";
+import { LinkEditorTerms } from "../translations_terms";
 
 const TEMPLATE = xml/* xml */ `
   <div class="o-link-tool">

--- a/src/components/link/link_editor.ts
+++ b/src/components/link/link_editor.ts
@@ -4,9 +4,9 @@ import { linkMenuRegistry } from "../../registries/menus/link_menu_registry";
 import { DOMCoordinates, Link, Position, SpreadsheetChildEnv } from "../../types";
 import { css } from "../helpers/css";
 import { useAbsolutePosition } from "../helpers/position_hook";
+import { GenericTerms, LinkEditorTerms } from "../translations_terms";
 import { LIST } from "./../icons";
 import { Menu } from "./../menu";
-import { LinkEditorTerms } from "./../side_panel/translations_terms";
 
 const MENU_OFFSET_X = 320;
 const MENU_OFFSET_Y = 100;
@@ -39,8 +39,8 @@ const TEMPLATE = xml/* xml */ `
         onMenuClicked="(ev) => this.onSpecialLink(ev)"
         onClose="() => this.menu.isOpen=false"/>
       <div class="o-buttons">
-        <button t-on-click="cancel" class="o-button o-cancel" t-esc="env._t('${LinkEditorTerms.Cancel}')"></button>
-        <button t-on-click="save" class="o-button o-save" t-esc="env._t('${LinkEditorTerms.Confirm}')" t-att-disabled="!state.link.url" ></button>
+        <button t-on-click="cancel" class="o-button o-cancel" t-esc="env._t('${GenericTerms.Cancel}')"></button>
+        <button t-on-click="save" class="o-button o-save" t-esc="env._t('${GenericTerms.Confirm}')" t-att-disabled="!state.link.url" ></button>
       </div>
     </div>`;
 

--- a/src/components/side_panel/chart_panel.ts
+++ b/src/components/side_panel/chart_panel.ts
@@ -12,36 +12,36 @@ import { ColorPicker } from "../color_picker";
 import { css } from "../helpers/css";
 import * as icons from "../icons";
 import { SelectionInput } from "../selection_input";
-import { chartTerms } from "./translations_terms";
+import { ChartTerms } from "../translations_terms";
 
 const CONFIGURATION_TEMPLATE = xml/* xml */ `
 <div>
   <div class="o-section">
-    <div class="o-section-title" t-esc="env._t('${chartTerms.ChartType}')"/>
+    <div class="o-section-title" t-esc="env._t('${ChartTerms.ChartType}')"/>
     <select t-model="state.chart.type" class="o-input o-type-selector" t-on-change="(ev) => this.updateSelect('type', ev)">
-      <option value="bar" t-esc="env._t('${chartTerms.Bar}')"/>
-      <option value="line" t-esc="env._t('${chartTerms.Line}')"/>
-      <option value="pie" t-esc="env._t('${chartTerms.Pie}')"/>
+      <option value="bar" t-esc="env._t('${ChartTerms.Bar}')"/>
+      <option value="line" t-esc="env._t('${ChartTerms.Line}')"/>
+      <option value="pie" t-esc="env._t('${ChartTerms.Pie}')"/>
     </select>
     <t t-if="state.chart.type === 'bar'">
       <div class="o_checkbox">
         <input type="checkbox" name="stackedBar" t-model="state.chart.stackedBar" t-on-change="updateStacked"/>
-        <t t-esc="env._t('${chartTerms.StackedBar}')"/>
+        <t t-esc="env._t('${ChartTerms.StackedBar}')"/>
       </div>
     </t>
   </div>
   <div class="o-section o-data-series">
-    <div class="o-section-title" t-esc="env._t('${chartTerms.DataSeries}')"/>
+    <div class="o-section-title" t-esc="env._t('${ChartTerms.DataSeries}')"/>
     <SelectionInput t-key="getKey('dataSets')"
                     ranges="state.chart.dataSets"
                     isInvalid="isDatasetInvalid"
                     required="true"
                     onSelectionChanged="(ranges) => this.onSeriesChanged(ranges)"
                     onSelectionConfirmed="() => this.updateDataSet()" />
-    <input type="checkbox" t-model="state.chart.dataSetsHaveTitle" t-on-change="() => this.updateDataSet()"/><t t-esc="env._t('${chartTerms.MyDataHasTitle}')"/>
+    <input type="checkbox" t-model="state.chart.dataSetsHaveTitle" t-on-change="() => this.updateDataSet()"/><t t-esc="env._t('${ChartTerms.MyDataHasTitle}')"/>
   </div>
   <div class="o-section o-data-labels">
-    <div class="o-section-title" t-esc="env._t('${chartTerms.DataCategories}')"/>
+    <div class="o-section-title" t-esc="env._t('${ChartTerms.DataCategories}')"/>
     <SelectionInput t-key="getKey('label')"
                     ranges="[state.chart.labelRange || '']"
                     isInvalid="isLabelInvalid"
@@ -60,32 +60,32 @@ const CONFIGURATION_TEMPLATE = xml/* xml */ `
 const DESIGN_TEMPLATE = xml/* xml */ `
 <div>
   <div class="o-section o-chart-title">
-    <div class="o-section-title" t-esc="env._t('${chartTerms.BackgroundColor}')"/>
+    <div class="o-section-title" t-esc="env._t('${ChartTerms.BackgroundColor}')"/>
     <div class="o-with-color-picker">
-      <t t-esc="env._t('${chartTerms.SelectColor}')"/>
+      <t t-esc="env._t('${ChartTerms.SelectColor}')"/>
       <span t-attf-style="border-color:{{state.chart.background}}"
             t-on-click.stop="toggleColorPicker">${icons.FILL_COLOR_ICON}</span>
       <ColorPicker t-if="state.fillColorTool" onColorPicked="(color) => this.setColor(color)" t-key="backgroundColor"/>
     </div>
   </div>
   <div class="o-section o-chart-title">
-    <div class="o-section-title" t-esc="env._t('${chartTerms.Title}')"/>
-    <input type="text" t-model="state.chart.title" t-on-change="updateTitle" class="o-input" t-att-placeholder="env._t('${chartTerms.TitlePlaceholder}')"/>
+    <div class="o-section-title" t-esc="env._t('${ChartTerms.Title}')"/>
+    <input type="text" t-model="state.chart.title" t-on-change="updateTitle" class="o-input" placeholder="${ChartTerms.TitlePlaceholder}"/>
   </div>
   <div class="o-section">
-    <div class="o-section-title"><t t-esc="env._t('${chartTerms.VerticalAxisPosition}')"/></div>
+    <div class="o-section-title"><t t-esc="env._t('${ChartTerms.VerticalAxisPosition}')"/></div>
     <select t-model="state.chart.verticalAxisPosition" class="o-input o-type-selector" t-on-change="(ev) => this.updateSelect('verticalAxisPosition', ev)">
-      <option value="left" t-esc="env._t('${chartTerms.Left}')"/>
-      <option value="right" t-esc="env._t('${chartTerms.Right}')"/>
+      <option value="left" t-esc="env._t('${ChartTerms.Left}')"/>
+      <option value="right" t-esc="env._t('${ChartTerms.Right}')"/>
     </select>
   </div>
   <div class="o-section">
-    <div class="o-section-title"><t t-esc="env._t('${chartTerms.LegendPosition}')"/></div>
+    <div class="o-section-title"><t t-esc="env._t('${ChartTerms.LegendPosition}')"/></div>
     <select t-model="state.chart.legendPosition" class="o-input o-type-selector" t-on-change="(ev) => this.updateSelect('legendPosition', ev)">
-      <option value="top" t-esc="env._t('${chartTerms.Top}')"/>
-      <option value="bottom" t-esc="env._t('${chartTerms.Bottom}')"/>
-      <option value="left" t-esc="env._t('${chartTerms.Left}')"/>
-      <option value="right" t-esc="env._t('${chartTerms.Right}')"/>
+      <option value="top" t-esc="env._t('${ChartTerms.Top}')"/>
+      <option value="bottom" t-esc="env._t('${ChartTerms.Bottom}')"/>
+      <option value="left" t-esc="env._t('${ChartTerms.Left}')"/>
+      <option value="right" t-esc="env._t('${ChartTerms.Right}')"/>
     </select>
   </div>
 </div>
@@ -190,8 +190,8 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
       ...(this.state.datasetDispatchResult?.reasons || []),
       ...(this.state.labelsDispatchResult?.reasons || []),
     ];
-    return cancelledReasons.map((error) =>
-      this.env._t(chartTerms.Errors[error] || chartTerms.Errors.unexpected)
+    return cancelledReasons.map(
+      (error) => ChartTerms.Errors[error] || ChartTerms.Errors.Unexpected
     );
   }
 

--- a/src/components/side_panel/conditional_formatting/cell_is_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cell_is_rule_editor.ts
@@ -1,6 +1,6 @@
 import { xml } from "@odoo/owl";
 import * as icons from "../../icons";
-import { conditionalFormattingTerms } from "../translations_terms";
+import { CfTerms, GenericTerms } from "../../translations_terms";
 
 const PREVIEW_TEMPLATE = xml/* xml */ `
     <div class="o-cf-preview-line"
@@ -10,12 +10,12 @@ const PREVIEW_TEMPLATE = xml/* xml */ `
                        color:{{currentStyle.textColor}};
                        border-radius: 4px;
                        background-color:{{currentStyle.fillColor}};"
-         t-esc="previewText || env._t('${conditionalFormattingTerms.PREVIEW_TEXT}')" />
+         t-esc="previewText || env._t('${CfTerms.PreviewText}')" />
 `;
 
 export const TEMPLATE_CELL_IS_RULE_EDITOR = xml/* xml */ `
 <div class="o-cf-cell-is-rule">
-    <div class="o-cf-title-text" t-esc="env._t('${conditionalFormattingTerms.IS_RULE}')"></div>
+    <div class="o-cf-title-text" t-esc="env._t('${CfTerms.IsRule}')"></div>
     <select t-model="rule.operator" class="o-input o-cell-is-operator">
         <t t-foreach="Object.keys(cellIsOperators)" t-as="op" t-key="op_index">
             <option t-att-value="op" t-esc="cellIsOperators[op]"/>
@@ -23,38 +23,38 @@ export const TEMPLATE_CELL_IS_RULE_EDITOR = xml/* xml */ `
     </select>
     <t t-if="rule.operator !== 'IsEmpty' and rule.operator !== 'IsNotEmpty'">
       <input type="text"
-             placeholder="Value"
+             placeholder="${GenericTerms.Value}"
              t-model="rule.values[0]"
              t-att-class="{ 'o-invalid': isValue1Invalid }"
              class="o-input o-cell-is-value o-required"/>
       <t t-if="rule.operator === 'Between' || rule.operator === 'NotBetween'">
           <input type="text"
-                 placeholder="and value"
+                 placeholder="${GenericTerms.AndValue}"
                  t-model="rule.values[1]"
                  t-att-class="{ 'o-invalid': isValue2Invalid }"
                  class="o-input o-cell-is-value o-required"/>
       </t>
     </t>
-    <div class="o-cf-title-text" t-esc="env._t('${conditionalFormattingTerms.FORMATTING_STYLE}')"></div>
+    <div class="o-cf-title-text" t-esc="env._t('${CfTerms.FormattingStyle}')"></div>
 
     <t t-call="${PREVIEW_TEMPLATE}">
         <t t-set="currentStyle" t-value="rule.style"/>
     </t>
     <div class="o-tools">
-        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.BOLD}')" t-att-class="{active:rule.style.bold}" t-on-click="() => this.toggleStyle('bold')">
+        <div class="o-tool" title="${GenericTerms.Bold}" t-att-class="{active:rule.style.bold}" t-on-click="() => this.toggleStyle('bold')">
             ${icons.BOLD_ICON}
         </div>
-        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.ITALIC}')" t-att-class="{active:rule.style.italic}" t-on-click="() => this.toggleStyle('italic')">
+        <div class="o-tool" title="${GenericTerms.Italic}" t-att-class="{active:rule.style.italic}" t-on-click="() => this.toggleStyle('italic')">
             ${icons.ITALIC_ICON}
         </div>
-        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.UNDERLINE}')" t-att-class="{active:rule.style.underline}"
+        <div class="o-tool" title="${GenericTerms.Underline}" t-att-class="{active:rule.style.underline}"
              t-on-click="(ev) => this.toggleStyle('underline', ev)">${icons.UNDERLINE_ICON}
         </div>
-        <div class="o-tool" t-att-title="env._t('${conditionalFormattingTerms.STRIKE_THROUGH}')" t-att-class="{active:rule.style.strikethrough}"
+        <div class="o-tool" title="${GenericTerms.Strikethrough}" t-att-class="{active:rule.style.strikethrough}"
              t-on-click="(ev) => this.toggleStyle('strikethrough', ev)">${icons.STRIKE_ICON}
         </div>
         <div class="o-tool o-dropdown o-with-color">
-              <span t-att-title="env._t('${conditionalFormattingTerms.TEXT_COLOR}')" t-attf-style="border-color:{{rule.style.textColor}}"
+              <span title="${GenericTerms.TextColor}" t-attf-style="border-color:{{rule.style.textColor}}"
                     t-on-click.stop="(ev) => this.toggleMenu('cellIsRule-textColor', ev)">
                     ${icons.TEXT_COLOR_ICON}
               </span>
@@ -62,7 +62,7 @@ export const TEMPLATE_CELL_IS_RULE_EDITOR = xml/* xml */ `
         </div>
         <div class="o-divider"/>
         <div class="o-tool o-dropdown o-with-color">
-          <span t-att-title="env._t('${conditionalFormattingTerms.FILL_COLOR}')" t-attf-style="border-color:{{rule.style.fillColor}}"
+          <span title="${GenericTerms.FillColor}" t-attf-style="border-color:{{rule.style.fillColor}}"
                 t-on-click.stop="(ev) => this.toggleMenu('cellIsRule-fillColor', ev)">
                 ${icons.FILL_COLOR_ICON}
           </span>

--- a/src/components/side_panel/conditional_formatting/color_scale_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/color_scale_rule_editor.ts
@@ -1,10 +1,10 @@
 import { xml } from "@odoo/owl";
 import * as icons from "../../icons";
-import { colorScale, conditionalFormattingTerms } from ".././translations_terms";
+import { CfTerms, ColorScale } from "../../translations_terms";
 
 const PREVIEW_TEMPLATE = xml/* xml */ `
   <div class="o-cf-preview-gradient" t-attf-style="{{getPreviewGradient()}}">
-    <t t-esc="env._t('${conditionalFormattingTerms.PREVIEW_TEXT}')"/>
+    <t t-esc="env._t('${CfTerms.PreviewText}')"/>
   </div>
 `;
 
@@ -13,20 +13,20 @@ const THRESHOLD_TEMPLATE = xml/* xml */ `
       <t t-if="thresholdType === 'midpoint'">
         <t t-set="type" t-value="threshold and threshold.type"/>
         <select class="o-input" name="valueType" t-on-change="onMidpointChange" t-on-click="closeMenus">
-          <option value="none" t-esc="env._t('${colorScale.None}')" t-att-selected="threshold === undefined"/>
-          <option value="number" t-esc="env._t('${conditionalFormattingTerms.FixedNumber}')" t-att-selected="type === 'number'"/>
-          <option value="percentage" t-esc="env._t('${conditionalFormattingTerms.Percentage}')" t-att-selected="type === 'percentage'"/>
-          <option value="percentile" t-esc="env._t('${conditionalFormattingTerms.Percentile}')" t-att-selected="type === 'percentile'"/>
-          <option value="formula" t-esc="env._t('${conditionalFormattingTerms.Formula}')" t-att-selected="type === 'formula'"/>
+          <option value="none" t-esc="env._t('${ColorScale.None}')" t-att-selected="threshold === undefined"/>
+          <option value="number" t-esc="env._t('${CfTerms.FixedNumber}')" t-att-selected="type === 'number'"/>
+          <option value="percentage" t-esc="env._t('${CfTerms.Percentage}')" t-att-selected="type === 'percentage'"/>
+          <option value="percentile" t-esc="env._t('${CfTerms.Percentile}')" t-att-selected="type === 'percentile'"/>
+          <option value="formula" t-esc="env._t('${CfTerms.Formula}')" t-att-selected="type === 'formula'"/>
         </select>
       </t>
       <t t-else="">
         <select class="o-input" name="valueType" t-model="threshold.type" t-on-click="closeMenus">
-          <option value="value" t-esc="env._t('${colorScale.CellValues}')"/>
-          <option value="number" t-esc="env._t('${conditionalFormattingTerms.FixedNumber}')"/>
-          <option value="percentage" t-esc="env._t('${conditionalFormattingTerms.Percentage}')"/>
-          <option value="percentile" t-esc="env._t('${conditionalFormattingTerms.Percentile}')"/>
-          <option value="formula" t-esc="env._t('${conditionalFormattingTerms.Formula}')"/>
+          <option value="value" t-esc="env._t('${ColorScale.CellValues}')"/>
+          <option value="number" t-esc="env._t('${CfTerms.FixedNumber}')"/>
+          <option value="percentage" t-esc="env._t('${CfTerms.Percentage}')"/>
+          <option value="percentile" t-esc="env._t('${CfTerms.Percentile}')"/>
+          <option value="formula" t-esc="env._t('${CfTerms.Formula}')"/>
         </select>
       </t>
       <input type="text" class="o-input o-threshold-value o-required"
@@ -49,25 +49,25 @@ const THRESHOLD_TEMPLATE = xml/* xml */ `
 export const TEMPLATE_COLOR_SCALE_EDITOR = xml/* xml */ `
   <div class="o-cf-color-scale-editor">
       <div class="o-cf-title-text">
-        <t t-esc="env._t('${colorScale.Preview}')"/>
+        <t t-esc="env._t('${ColorScale.Preview}')"/>
       </div>
       <t t-call="${PREVIEW_TEMPLATE}"/>
       <div class="o-cf-title-text">
-        <t t-esc="env._t('${colorScale.Minpoint}')"/>
+        <t t-esc="env._t('${ColorScale.Minpoint}')"/>
       </div>
       <t t-call="${THRESHOLD_TEMPLATE}">
           <t t-set="threshold" t-value="rule.minimum" ></t>
           <t t-set="thresholdType" t-value="'minimum'" ></t>
       </t>
       <div class="o-cf-title-text">
-        <t t-esc="env._t('${colorScale.MidPoint}')"/>
+        <t t-esc="env._t('${ColorScale.MidPoint}')"/>
       </div>
       <t t-call="${THRESHOLD_TEMPLATE}">
           <t t-set="threshold" t-value="rule.midpoint" ></t>
           <t t-set="thresholdType" t-value="'midpoint'" ></t>
       </t>
       <div class="o-cf-title-text">
-        <t t-esc="env._t('${colorScale.MaxPoint}')"/>
+        <t t-esc="env._t('${ColorScale.MaxPoint}')"/>
       </div>
       <t t-call="${THRESHOLD_TEMPLATE}">
           <t t-set="threshold" t-value="rule.maximum" ></t>

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -22,7 +22,7 @@ import { getTextDecoration } from "../../helpers/dom_helpers";
 import { CARET_DOWN, CARET_UP, ICONS, ICON_SETS, TRASH } from "../../icons";
 import { IconPicker } from "../../icon_picker";
 import { SelectionInput } from "../../selection_input";
-import { cellIsOperators, conditionalFormattingTerms, GenericWords } from "../translations_terms";
+import { CellIsOperators, CfTerms, GenericTerms, GenericWords } from "../../translations_terms";
 import { TEMPLATE_CELL_IS_RULE_EDITOR } from "./cell_is_rule_editor";
 import { TEMPLATE_COLOR_SCALE_EDITOR } from "./color_scale_rule_editor";
 import { TEMPLATE_ICON_SET_EDITOR } from "./icon_set_rule_editor";
@@ -90,22 +90,22 @@ const TEMPLATE = xml/* xml */ `
       </div>
       <t t-if="state.mode === 'list'">
         <div class="btn btn-link o-cf-btn-link o-cf-add" t-on-click.prevent.stop="addConditionalFormat">
-          <t t-esc="'+ ' + env._t('${conditionalFormattingTerms.newRule}')"/>
+          <t t-esc="'+ ' + env._t('${CfTerms.NewRule}')"/>
         </div>
         <div class="btn btn-link o-cf-btn-link o-cf-reorder" t-on-click="reorderConditionalFormats">
-          <t t-esc="env._t('${conditionalFormattingTerms.reorderRules}')"/>
+          <t t-esc="env._t('${CfTerms.ReorderRules}')"/>
         </div>
       </t>
       <t t-if="state.mode === 'reorder'">
         <div class="btn btn-link o-cf-btn-link o-cf-exit-reorder" t-on-click="switchToList">
-            <t t-esc="env._t('${conditionalFormattingTerms.exitReorderMode}')"/>
+            <t t-esc="env._t('${CfTerms.ExitReorderMode}')"/>
         </div>
       </t>
     </t>
     <t t-if="state.mode === 'edit' || state.mode === 'add'" t-key="state.currentCF.id">
         <div class="o-cf-ruleEditor">
             <div class="o-section o-cf-range">
-              <div class="o-section-title">Apply to range</div>
+              <div class="o-section-title" t-esc="env._t('${CfTerms.ApplyToRange}')"></div>
               <div class="o-selection-cf">
                 <SelectionInput
                   ranges="state.currentCF.ranges"
@@ -114,25 +114,25 @@ const TEMPLATE = xml/* xml */ `
                   onSelectionChanged="(ranges) => this.onRangesChanged(ranges)"
                   required="true"/>
               </div>
-              <div class="o-section-title" t-esc="env._t('${conditionalFormattingTerms.CF_TITLE}')"></div>
+              <div class="o-section-title" t-esc="env._t('${CfTerms.CfTitle}')"></div>
               <div class="o_field_radio o_horizontal o_field_widget o-cf-type-selector">
                 <div class="custom-control custom-radio o_cf_radio_item" t-on-click="() => this.changeRuleType('CellIsRule')">
                   <input class="custom-control-input o_radio_input" t-attf-checked="{{state.currentCFType === 'CellIsRule'}}" type="radio" id="cellIsRule" name="ruleType" value="CellIsRule"/>
                   <label for="cellIsRule" class="custom-control-label o_form_label">
-                    <t t-esc="env._t('${conditionalFormattingTerms.SingleColor}')"/>
+                    <t t-esc="env._t('${CfTerms.SingleColor}')"/>
                   </label>
                 </div>
                 <div class="custom-control custom-radio o_cf_radio_item" t-on-click="() => this.changeRuleType('ColorScaleRule')">
                   <input class="custom-control-input o_radio_input" t-attf-checked="{{state.currentCFType === 'ColorScaleRule'}}" type="radio" id="colorScaleRule" name="ruleType" value="ColorScaleRule"/>
                   <label for="colorScaleRule" class="custom-control-label o_form_label">
-                  <t t-esc="env._t('${conditionalFormattingTerms.ColorScale}')"/>
+                  <t t-esc="env._t('${CfTerms.ColorScale}')"/>
                   </label>
                 </div>
 
                 <div class="custom-control custom-radio o_cf_radio_item" t-on-click="() => this.changeRuleType('IconSetRule')">
                   <input class="custom-control-input o_radio_input" t-attf-checked="{{state.currentCFType === 'IconSetRule'}}" type="radio" id="iconSetRule" name="ruleType" value="IconSetRule"/>
                   <label for="iconSetRule" class="custom-control-label o_form_label">
-                  <t t-esc="env._t('${conditionalFormattingTerms.IconSet}')"/>
+                  <t t-esc="env._t('${CfTerms.IconSet}')"/>
                   </label>
                 </div>
               </div>
@@ -151,8 +151,14 @@ const TEMPLATE = xml/* xml */ `
                 <t t-set="rule" t-value="state.rules.iconSet"/>
               </t>
               <div class="o-sidePanelButtons">
-                <button t-on-click="switchToList" class="o-sidePanelButton o-cf-cancel" t-esc="env._t('${conditionalFormattingTerms.CANCEL}')"></button>
-                <button t-on-click="saveConditionalFormat" class="o-sidePanelButton o-cf-save" t-esc="env._t('${conditionalFormattingTerms.SAVE}')"></button>
+                <button
+                  t-on-click="switchToList"
+                  class="o-sidePanelButton o-cf-cancel"
+                  t-esc="env._t('${GenericTerms.Cancel}')"></button>
+                <button
+                  t-on-click="saveConditionalFormat"
+                  class="o-sidePanelButton o-cf-save"
+                  t-esc="env._t('${GenericTerms.Save}')"></button>
               </div>
             </div>
             <div class="o-section">
@@ -542,8 +548,8 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
   static components = { SelectionInput, IconPicker, ColorPicker };
 
   icons = ICONS;
+  cellIsOperators = CellIsOperators;
   iconSets = ICON_SETS;
-  cellIsOperators = cellIsOperators;
   getTextDecoration = getTextDecoration;
   colorNumberString = colorNumberString;
 
@@ -595,9 +601,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
   }
 
   errorMessage(error: CancelledReason): string {
-    return this.env._t(
-      conditionalFormattingTerms.Errors[error] || conditionalFormattingTerms.Errors.unexpected
-    );
+    return CfTerms.Errors[error] || CfTerms.Errors.Unexpected;
   }
 
   /**
@@ -637,11 +641,11 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
   getDescription(cf: ConditionalFormat): string {
     switch (cf.rule.type) {
       case "CellIsRule":
-        return cellIsOperators[cf.rule.operator];
+        return CellIsOperators[cf.rule.operator];
       case "ColorScaleRule":
-        return this.env._t("Color scale");
+        return CfTerms.ColorScale;
       case "IconSetRule":
-        return this.env._t("Icon Set");
+        return CfTerms.IconSet;
       default:
         return "";
     }

--- a/src/components/side_panel/conditional_formatting/icon_set_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/icon_set_rule_editor.ts
@@ -1,11 +1,11 @@
 import { xml } from "@odoo/owl";
 import { REFRESH } from "../../icons";
-import { conditionalFormattingTerms, iconSetRule } from "../translations_terms";
+import { CfTerms, GenericTerms, IconSetRule } from "../../translations_terms";
 
 const ICON_SETS_TEMPLATE = xml/* xml */ `
   <div>
   <div class="o-cf-title-text">
-    <t t-esc="env._t('${iconSetRule.Icons}')"/>
+    <t t-esc="env._t('${IconSetRule.Icons}')"/>
   </div>
     <div class="o-cf-iconsets">
       <div class="o-cf-iconset" t-foreach="['arrows', 'smiley', 'dots']" t-as="iconSet" t-key="iconSet" t-on-click="(ev) => this.setIconSet(iconSet, ev)">
@@ -34,7 +34,7 @@ const INFLECTION_POINTS_TEMPLATE_ROW = xml/* xml */ `
       <IconPicker t-if="state.openedMenu === 'iconSet-'+icon+'Icon'" onIconPicked="(i) => this.setIcon(icon, i)"/>
     </td>
     <td>
-      <t t-esc="env._t('${iconSetRule.WhenValueIs}')"/>
+      <t t-esc="env._t('${IconSetRule.WhenValueIs}')"/>
     </td>
     <td>
       <select class="o-input" name="valueType" t-model="inflectionPointValue.operator">
@@ -55,16 +55,16 @@ const INFLECTION_POINTS_TEMPLATE_ROW = xml/* xml */ `
     <td>
       <select class="o-input" name="valueType" t-model="inflectionPointValue.type">
       <option value="number">
-        <t t-esc="env._t('${conditionalFormattingTerms.FixedNumber}')"/>
+        <t t-esc="env._t('${CfTerms.FixedNumber}')"/>
       </option>
       <option value="percentage">
-        <t t-esc="env._t('${conditionalFormattingTerms.Percentage}')"/>
+        <t t-esc="env._t('${CfTerms.Percentage}')"/>
       </option>
       <option value="percentile">
-        <t t-esc="env._t('${conditionalFormattingTerms.Percentile}')"/>
+        <t t-esc="env._t('${CfTerms.Percentile}')"/>
       </option>
       <option value="formula">
-        <t t-esc="env._t('${conditionalFormattingTerms.Formula}')"/>
+        <t t-esc="env._t('${CfTerms.Formula}')"/>
       </option>
       </select>
     </td>
@@ -79,10 +79,10 @@ const INFLECTION_POINTS_TEMPLATE = xml/* xml */ `
       <th class="o-cf-iconset-text"></th>
       <th class="o-cf-iconset-operator"></th>
       <th class="o-cf-iconset-value">
-      <t t-esc="env._t('${iconSetRule.Value}')"/>
+      <t t-esc="env._t('${GenericTerms.Value}')"/>
       </th>
       <th class="o-cf-iconset-type">
-      <t t-esc="env._t('${iconSetRule.Type}')"/>
+      <t t-esc="env._t('${IconSetRule.Type}')"/>
       </th>
     </tr>
     <t t-call="${INFLECTION_POINTS_TEMPLATE_ROW}">
@@ -106,7 +106,7 @@ const INFLECTION_POINTS_TEMPLATE = xml/* xml */ `
         </div>
         <IconPicker t-if="state.openedMenu === 'iconSet-lowerIcon'" onIconPicked="(icon) => setIcon('lower', icon)"/>
       </td>
-      <td><t t-esc="env._t('${iconSetRule.Else}')"/></td>
+      <td><t t-esc="env._t('${IconSetRule.Else}')"/></td>
       <td></td>
       <td></td>
       <td></td>
@@ -122,6 +122,6 @@ export const TEMPLATE_ICON_SET_EDITOR = xml/* xml */ `
         <div class="mr-1 d-inline-block">
           ${REFRESH}
         </div>
-        <t t-esc="env._t('${iconSetRule.ReverseIcons}')"/>
+        <t t-esc="env._t('${IconSetRule.ReverseIcons}')"/>
       </div>
   </div>`;

--- a/src/components/side_panel/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace.ts
@@ -1,7 +1,7 @@
 import { Component, onMounted, onWillUnmount, useRef, useState, xml } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../types/index";
 import { css } from "../helpers/css";
-import { FindAndReplaceTerms } from "./translations_terms";
+import { FindAndReplaceTerms } from "../translations_terms";
 
 const TEMPLATE = xml/* xml */ `
 <div class="o-find-and-replace" tabindex="0" t-on-focusin="onFocusSidePanel" t-ref="findAndReplace">

--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -21,6 +21,7 @@ import { isChildEvent } from "./helpers/dom_helpers";
 import * as icons from "./icons";
 import { Menu, MenuState } from "./menu";
 import { ComposerFocusType } from "./spreadsheet";
+import { GenericTerms, TopBarTerms } from "./translations_terms";
 
 type Tool =
   | ""
@@ -272,19 +273,19 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
         <!-- Toolbar -->
         <div t-if="env.model.getters.isReadonly()" class="o-readonly-toolbar text-muted">
           <span>
-            <i class="fa fa-eye" /> <t t-esc="env._t('Readonly Access')" />
+            <i class="fa fa-eye" /> <t t-esc="env._t('${TopBarTerms.ReadonlyAccess}')" />
           </span>
         </div>
         <div t-else="" class="o-toolbar-tools">
-          <div class="o-tool" title="Undo" t-att-class="{'o-disabled': !undoTool}" t-on-click="undo" >${icons.UNDO_ICON}</div>
-          <div class="o-tool" t-att-class="{'o-disabled': !redoTool}" title="Redo"  t-on-click="redo">${icons.REDO_ICON}</div>
-          <div class="o-tool" title="Paint Format" t-att-class="{active:paintFormatTool}" t-on-click="paintFormat">${icons.PAINT_FORMAT_ICON}</div>
-          <div class="o-tool" title="Clear Format" t-on-click="clearFormatting">${icons.CLEAR_FORMAT_ICON}</div>
+          <div class="o-tool" title="${GenericTerms.Undo}" t-att-class="{'o-disabled': !undoTool}" t-on-click="undo" >${icons.UNDO_ICON}</div>
+          <div class="o-tool" t-att-class="{'o-disabled': !redoTool}" title="${GenericTerms.Redo}"  t-on-click="redo">${icons.REDO_ICON}</div>
+          <div class="o-tool" title="${TopBarTerms.PaintFormat}" t-att-class="{active:paintFormatTool}" t-on-click="paintFormat">${icons.PAINT_FORMAT_ICON}</div>
+          <div class="o-tool" title="${TopBarTerms.ClearFormat}" t-on-click="clearFormatting">${icons.CLEAR_FORMAT_ICON}</div>
           <div class="o-divider"/>
-          <div class="o-tool" title="Format as percent" t-on-click="(ev) => this.toogleFormat('percent', ev)">%</div>
-          <div class="o-tool" title="Decrease decimal places" t-on-click="(ev) => this.setDecimal(-1, ev)">.0</div>
-          <div class="o-tool" title="Increase decimal places" t-on-click="(ev) => this.setDecimal(+1, ev)">.00</div>
-          <div class="o-tool o-dropdown" title="More formats" t-on-click="(ev) => this.toggleDropdownTool('formatTool', ev)">
+          <div class="o-tool" title="${TopBarTerms.FormatPercent}" t-on-click="(ev) => this.toogleFormat('percent', ev)">%</div>
+          <div class="o-tool" title="${TopBarTerms.DecreaseDecimal}" t-on-click="(ev) => this.setDecimal(-1, ev)">.0</div>
+          <div class="o-tool" title="${TopBarTerms.IncreaseDecimal}" t-on-click="(ev) => this.setDecimal(+1, ev)">.00</div>
+          <div class="o-tool o-dropdown" title="${TopBarTerms.MoreFormat}" t-on-click="(ev) => this.toggleDropdownTool('formatTool', ev)">
             <div class="o-text-icon">123${icons.TRIANGLE_DOWN_ICON}</div>
             <div class="o-dropdown-content o-text-options  o-format-tool "  t-if="state.activeTool === 'formatTool'" t-on-click="setFormat">
               <t t-foreach="formats" t-as="format" t-key="format.name">
@@ -294,7 +295,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
           </div>
           <div class="o-divider"/>
           <!-- <div class="o-tool" title="Font"><span>Roboto</span> ${icons.TRIANGLE_DOWN_ICON}</div> -->
-          <div class="o-tool o-dropdown" title="Font Size" t-on-click="(ev) => this.toggleDropdownTool('fontSizeTool', ev)">
+          <div class="o-tool o-dropdown" title="${TopBarTerms.FontSize}" t-on-click="(ev) => this.toggleDropdownTool('fontSizeTool', ev)">
             <div class="o-text-icon"><t t-esc="style.fontSize || ${DEFAULT_FONT_SIZE}"/> ${icons.TRIANGLE_DOWN_ICON}</div>
             <div class="o-dropdown-content o-text-options "  t-if="state.activeTool === 'fontSizeTool'" t-on-click="setSize">
               <t t-foreach="fontSizes" t-as="font" t-key="font_index">
@@ -303,20 +304,20 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
             </div>
           </div>
           <div class="o-divider"/>
-          <div class="o-tool" title="Bold" t-att-class="{active:style.bold}" t-on-click="(ev) => this.toogleStyle('bold', ev)">${icons.BOLD_ICON}</div>
-          <div class="o-tool" title="Italic" t-att-class="{active:style.italic}" t-on-click="(ev) => this.toogleStyle('italic', ev)">${icons.ITALIC_ICON}</div>
-          <div class="o-tool" title="Strikethrough"  t-att-class="{active:style.strikethrough}" t-on-click="(ev) => this.toogleStyle('strikethrough', ev)">${icons.STRIKE_ICON}</div>
+          <div class="o-tool" title="${GenericTerms.Bold}" t-att-class="{active:style.bold}" t-on-click="(ev) => this.toogleStyle('bold', ev)">${icons.BOLD_ICON}</div>
+          <div class="o-tool" title="${GenericTerms.Italic}" t-att-class="{active:style.italic}" t-on-click="(ev) => this.toogleStyle('italic', ev)">${icons.ITALIC_ICON}</div>
+          <div class="o-tool" title="${GenericTerms.Strikethrough}"  t-att-class="{active:style.strikethrough}" t-on-click="(ev) => this.toogleStyle('strikethrough', ev)">${icons.STRIKE_ICON}</div>
           <div class="o-tool o-dropdown o-with-color">
-            <span t-attf-style="border-color:{{textColor}}" title="Text Color" t-on-click="(ev) => this.toggleDropdownTool('textColorTool', ev)">${icons.TEXT_COLOR_ICON}</span>
+            <span t-attf-style="border-color:{{textColor}}" title="${GenericTerms.TextColor}" t-on-click="(ev) => this.toggleDropdownTool('textColorTool', ev)">${icons.TEXT_COLOR_ICON}</span>
             <ColorPicker t-if="state.activeTool === 'textColorTool'" onColorPicked="(color) => this.setColor('textColor', color)" t-key="textColor"/>
           </div>
           <div class="o-divider"/>
           <div class="o-tool  o-dropdown o-with-color">
-            <span t-attf-style="border-color:{{fillColor}}" title="Fill Color" t-on-click="(ev) => this.toggleDropdownTool('fillColorTool', ev)">${icons.FILL_COLOR_ICON}</span>
+            <span t-attf-style="border-color:{{fillColor}}" title="${GenericTerms.FillColor}" t-on-click="(ev) => this.toggleDropdownTool('fillColorTool', ev)">${icons.FILL_COLOR_ICON}</span>
             <ColorPicker t-if="state.activeTool === 'fillColorTool'" onColorPicked="(color) => this.setColor('fillColor', color)" t-key="fillColor"/>
           </div>
           <div class="o-tool o-dropdown">
-            <span title="Borders" t-on-click="(ev) => this.toggleDropdownTool('borderTool', ev)">${icons.BORDERS_ICON}</span>
+            <span title="${TopBarTerms.Borders}" t-on-click="(ev) => this.toggleDropdownTool('borderTool', ev)">${icons.BORDERS_ICON}</span>
             <div class="o-dropdown-content o-border" t-if="state.activeTool === 'borderTool'">
               <div class="o-dropdown-line">
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('all', ev)">${icons.BORDERS_ICON}</span>
@@ -334,9 +335,9 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
               </div>
             </div>
           </div>
-          <div class="o-tool o-merge-tool" title="Merge Cells"  t-att-class="{active:inMerge, 'o-disabled': cannotMerge}" t-on-click="toggleMerge">${icons.MERGE_CELL_ICON}</div>
+          <div class="o-tool o-merge-tool" title="${TopBarTerms.MergeCells}"  t-att-class="{active:inMerge, 'o-disabled': cannotMerge}" t-on-click="toggleMerge">${icons.MERGE_CELL_ICON}</div>
           <div class="o-divider"/>
-          <div class="o-tool o-dropdown" title="Horizontal align" t-on-click="(ev) => this.toggleDropdownTool('alignTool', ev)">
+          <div class="o-tool o-dropdown" title="${TopBarTerms.HorizontalAlign}" t-on-click="(ev) => this.toggleDropdownTool('alignTool', ev)">
             <span>
               <t t-if="style.align === 'right'">${icons.ALIGN_RIGHT_ICON}</t>
               <t t-elif="style.align === 'center'">${icons.ALIGN_CENTER_ICON}</t>

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -1,19 +1,11 @@
-import { _lt } from "../../translation";
-import { CommandResult } from "../../types/index";
+import { _lt } from "../translation";
+import { CommandResult } from "../types/index";
 
-export const conditionalFormattingTerms = {
-  CF_TITLE: _lt("Format rules"),
-  IS_RULE: _lt("Format cells if..."),
-  FORMATTING_STYLE: _lt("Formatting style"),
-  BOLD: _lt("Bold"),
-  ITALIC: _lt("Italic"),
-  UNDERLINE: _lt("Underline"),
-  STRIKE_THROUGH: _lt("Strikethrough"),
-  TEXT_COLOR: _lt("Text Color"),
-  FILL_COLOR: _lt("Fill Color"),
-  CANCEL: _lt("Cancel"),
-  SAVE: _lt("Save"),
-  PREVIEW_TEXT: _lt("Preview text"),
+export const CfTerms = {
+  CfTitle: _lt("Format rules"),
+  IsRule: _lt("Format cells if..."),
+  FormattingStyle: _lt("Formatting style"),
+  PreviewText: _lt("Preview text"),
   Errors: {
     [CommandResult.InvalidRange]: _lt("The range is invalid"),
     [CommandResult.FirstArgMissing]: _lt("The argument is missing. Please provide a value"),
@@ -35,20 +27,21 @@ export const conditionalFormattingTerms = {
     [CommandResult.ValueUpperInvalidFormula]: _lt("Invalid upper inflection point formula"),
     [CommandResult.ValueLowerInvalidFormula]: _lt("Invalid lower inflection point formula"),
     [CommandResult.EmptyRange]: _lt("A range needs to be defined"),
-    unexpected: _lt("The rule is invalid for an unknown reason"),
+    Unexpected: _lt("The rule is invalid for an unknown reason"),
   },
   SingleColor: _lt("Single color"),
   ColorScale: _lt("Color scale"),
   IconSet: _lt("Icon set"),
-  newRule: _lt("Add another rule"),
-  reorderRules: _lt("Reorder rules"),
-  exitReorderMode: _lt("Stop reordering rules"),
+  NewRule: _lt("Add another rule"),
+  ReorderRules: _lt("Reorder rules"),
+  ExitReorderMode: _lt("Stop reordering rules"),
   FixedNumber: _lt("Number"),
   Percentage: _lt("Percentage"),
   Percentile: _lt("Percentile"),
   Formula: _lt("Formula"),
+  ApplyToRange: _lt("Apply to range"),
 };
-export const colorScale = {
+export const ColorScale = {
   CellValues: _lt("Cell values"),
   None: _lt("None"),
   Preview: _lt("Preview"),
@@ -57,16 +50,15 @@ export const colorScale = {
   MidPoint: _lt("Midpoint"),
 };
 
-export const iconSetRule = {
+export const IconSetRule = {
   WhenValueIs: _lt("When value is"),
   Else: _lt("Else"),
   ReverseIcons: _lt("Reverse icons"),
   Icons: _lt("Icons"),
   Type: _lt("Type"),
-  Value: _lt("Value"),
 };
 
-export const cellIsOperators = {
+export const CellIsOperators = {
   IsEmpty: _lt("Is empty"),
   IsNotEmpty: _lt("Is not empty"),
   ContainsText: _lt("Contains"),
@@ -83,7 +75,7 @@ export const cellIsOperators = {
   NotBetween: _lt("Is not between"),
 };
 
-export const chartTerms = {
+export const ChartTerms = {
   ChartType: _lt("Chart type"),
   Line: _lt("Line"),
   Bar: _lt("Bar"),
@@ -114,7 +106,7 @@ export const chartTerms = {
     [CommandResult.EmptyDataSet]: _lt("A dataset needs to be defined"),
     [CommandResult.InvalidDataSet]: _lt("The dataset is invalid"),
     [CommandResult.InvalidLabelRange]: _lt("Labels are invalid"),
-    unexpected: _lt("The chart definition is invalid for an unknown reason"),
+    Unexpected: _lt("The chart definition is invalid for an unknown reason"),
   },
 };
 
@@ -133,10 +125,38 @@ export const FindAndReplaceTerms = {
 export const LinkEditorTerms = {
   Text: _lt("Text"),
   Link: _lt("Link"),
-  Confirm: _lt("Confirm"),
-  Cancel: _lt("Cancel"),
   Edit: _lt("Edit link"),
   Remove: _lt("Remove link"),
+};
+
+export const TopBarTerms = {
+  ReadonlyAccess: _lt("Readonly Access"),
+  PaintFormat: _lt("Paint Format"),
+  ClearFormat: _lt("Clear Format"),
+  FormatPercent: _lt("Format as percent"),
+  DecreaseDecimal: _lt("Decrease decimal places"),
+  IncreaseDecimal: _lt("Increase decimal places"),
+  MoreFormat: _lt("More formats"),
+  FontSize: _lt("Font Size"),
+  Borders: _lt("Borders"),
+  MergeCells: _lt("Merge Cells"),
+  HorizontalAlign: _lt("Horizontal align"),
+};
+
+export const GenericTerms = {
+  Undo: _lt("Undo"),
+  Redo: _lt("Redo"),
+  Bold: _lt("Bold"),
+  Italic: _lt("Italic"),
+  Strikethrough: _lt("Strikethrough"),
+  Underline: _lt("Underline"),
+  FillColor: _lt("Fill Color"),
+  TextColor: _lt("Text Color"),
+  Cancel: _lt("Cancel"),
+  Save: _lt("Save"),
+  Confirm: _lt("Confirm"),
+  Value: _lt("Value"),
+  AndValue: _lt("and value"),
 };
 
 export const GenericWords = {

--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -6,7 +6,7 @@ import {
   ChartLegendOptions,
   ChartTooltipItem,
 } from "chart.js";
-import { chartTerms } from "../../components/side_panel/translations_terms";
+import { ChartTerms } from "../../components/translations_terms";
 import { MAX_CHAR_LABEL } from "../../constants";
 import { ChartColors } from "../../helpers/chart";
 import { isDefined, isInside, overlap, recomputeZones, zoneToXc } from "../../helpers/index";
@@ -326,9 +326,9 @@ export class EvaluationChartPlugin extends UIPlugin {
         label =
           cell && labelRange
             ? this.truncateLabel(cell.formattedValue)
-            : (label = `${chartTerms.Series} ${parseInt(dsIndex) + 1}`);
+            : (label = `${ChartTerms.Series} ${parseInt(dsIndex) + 1}`);
       } else {
-        label = label = `${chartTerms.Series} ${parseInt(dsIndex) + 1}`;
+        label = label = `${ChartTerms.Series} ${parseInt(dsIndex) + 1}`;
       }
       const color = definition.type !== "pie" ? colors.next() : "#FFFFFF"; // white border for pie chart
       const dataset: ChartDataSets = {

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../src";
-import { chartTerms } from "../../src/components/side_panel/translations_terms";
+import { ChartTerms } from "../../src/components/translations_terms";
 import { toZone } from "../../src/helpers/zones";
 import { ChartUIDefinition, CommandResult } from "../../src/types";
 import {
@@ -1386,10 +1386,10 @@ describe("Chart without labels", () => {
 
     createChart(model, { ...defaultChart, dataSets: ["A1:A2", "A3:A4"] }, "43");
     expect(model.getters.getChartRuntime("43")?.data?.datasets![0].label).toEqual(
-      `${chartTerms.Series.toString()} 1`
+      `${ChartTerms.Series.toString()} 1`
     );
     expect(model.getters.getChartRuntime("43")?.data?.datasets![1].label).toEqual(
-      `${chartTerms.Series.toString()} 2`
+      `${ChartTerms.Series.toString()} 2`
     );
 
     setCellContent(model, "B1", "B1");


### PR DESCRIPTION

## Description:

- group duplicated and generic terms
- use PascalCase everywhere for consistency
- move the file outside folder 'side_panel' because it's used for other things.

Note: we don't need to write `title="env._t(${TranslatedTerms.Undo})"` because
`title` attributes are automatically translated by owl[1] but the regex detecting
translatable strings in Odoo does not parses xml strings in js files. That's why we
extract those terms outside the xml string. Same for `placeholder`

This commit also fixes some non translated terms, mainly topbar titles.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [x] exportable in excel
- [x] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [x] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo