### PR TITLE
[IMP] formulas : handle % symbol in formulas

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -26,6 +26,7 @@ const OPERATOR_MAP = {
 const UNARY_OPERATOR_MAP = {
   "-": "UMINUS",
   "+": "UPLUS",
+  "%": "UNARY.PERCENT",
 };
 
 /**
@@ -299,12 +300,12 @@ export function compile(formula: string): CompiledFormula {
         case "UNARY_OPERATION": {
           id = nextId++;
           fnName = UNARY_OPERATOR_MAP[ast.value];
-          const right = compileAST(ast.right, false, false, false, {
+          const operand = compileAST(ast.operand, false, false, false, {
             functionName: fnName,
           });
-          codeBlocks.push(right.code);
+          codeBlocks.push(operand.code);
           codeBlocks.push(`ctx.__lastFnCalled = '${fnName}';`);
-          statement = `ctx['${fnName}']( ${right.id})`;
+          statement = `ctx['${fnName}']( ${operand.id})`;
           break;
         }
         case "BIN_OPERATION": {
@@ -374,7 +375,7 @@ export function compile(formula: string): CompiledFormula {
           }
           break;
         case "UNARY_OPERATION":
-          return formatAST(ast.right);
+          return formatAST(ast.operand);
         case "BIN_OPERATION":
           // the BIN_OPERATION ast is the only function case where we will look
           // at the following argument when the current argument has't format.

--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -21,7 +21,8 @@ import { _lt } from "../translation";
  */
 
 const functions = functionRegistry.content;
-const OPERATORS = "+,-,*,/,:,=,<>,>=,>,<=,<,%,^,&".split(",");
+export const POSTFIX_UNARY_OPERATORS = ["%"];
+const OPERATORS = "+,-,*,/,:,=,<>,>=,>,<=,<,^,&".split(",").concat(POSTFIX_UNARY_OPERATORS);
 
 export type TokenType =
   | "OPERATOR"

--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -6,8 +6,9 @@
  *   only needs to find the number at the start of a string
  * - it does not accept "," as thousand separator, because when we tokenize a
  *   formula, commas are used to separate arguments
+ * - it does not support % symbol, in formulas % is an operator
  */
-export const formulaNumberRegexp = /^-?\d+(\.?\d*(e\d+)?)?(\s*%)?|^-?\.\d+(\s*%)?/;
+export const formulaNumberRegexp = /^-?\d+(\.?\d*(e\d+)?)?|^-?\.\d+/;
 
 const pIntegerAndDecimals = "(\\d+(,\\d{3,})*(\\.\\d*)?)"; // pattern that match integer number with or without decimal digits
 const pOnlyDecimals = "(\\.\\d+)"; // pattern that match only expression with decimal digits

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -1,4 +1,5 @@
 import { composerTokenize, EnrichedToken } from "../../formulas/index";
+import { POSTFIX_UNARY_OPERATORS } from "../../formulas/tokenizer";
 import {
   colors,
   concat,
@@ -569,7 +570,7 @@ export class EditionPlugin extends UIPlugin {
   /**
    * Function used to determine when composer selection can start.
    * Three conditions are necessary:
-   * - the previous token is among ["COMMA", "LEFT_PAREN", "OPERATOR"]
+   * - the previous token is among ["COMMA", "LEFT_PAREN", "OPERATOR"], and is not a postfix unary operator
    * - the next token is missing or is among ["COMMA", "RIGHT_PAREN", "OPERATOR"]
    * - Previous and next tokens can be separated by spaces
    */
@@ -585,7 +586,10 @@ export class EditionPlugin extends UIPlugin {
       let count = tokenIdex;
       let currentToken = tokenAtCursor;
       // check previous token
-      while (!["COMMA", "LEFT_PAREN", "OPERATOR"].includes(currentToken.type)) {
+      while (
+        !["COMMA", "LEFT_PAREN", "OPERATOR"].includes(currentToken.type) ||
+        POSTFIX_UNARY_OPERATORS.includes(currentToken.value)
+      ) {
         if (currentToken.type !== "SPACE" || count < 1) {
           return false;
         }

--- a/tests/formulas/__snapshots__/compiler.test.ts.snap
+++ b/tests/formulas/__snapshots__/compiler.test.ts.snap
@@ -289,6 +289,42 @@ return _1;
 }"
 `;
 
+exports[`expression compiler some arithmetic expressions 13`] = `
+"function anonymous(deps,sheetId,ref,range,ctx
+) {
+// =|N0|%
+let _2 = this.constantValues.numbers[0];
+ctx.__lastFnCalled = 'UNARY.PERCENT';
+let _1 = ctx['UNARY.PERCENT']( _2);
+return _1;
+}"
+`;
+
+exports[`expression compiler some arithmetic expressions 14`] = `
+"function anonymous(deps,sheetId,ref,range,ctx
+) {
+// =(|N0|+|N1|)%
+let _3 = this.constantValues.numbers[0];
+let _4 = this.constantValues.numbers[1];
+ctx.__lastFnCalled = 'ADD';
+let _2 = ctx['ADD'](_3, _4);
+ctx.__lastFnCalled = 'UNARY.PERCENT';
+let _1 = ctx['UNARY.PERCENT']( _2);
+return _1;
+}"
+`;
+
+exports[`expression compiler some arithmetic expressions 15`] = `
+"function anonymous(deps,sheetId,ref,range,ctx
+) {
+// =|0|%
+let _2 = ref(0, deps, sheetId, false, \\"UNARY.PERCENT\\",  undefined);
+ctx.__lastFnCalled = 'UNARY.PERCENT';
+let _1 = ctx['UNARY.PERCENT']( _2);
+return _1;
+}"
+`;
+
 exports[`expression compiler with the same reference multiple times 1`] = `
 "function anonymous(deps,sheetId,ref,range,ctx
 ) {

--- a/tests/formulas/compiler.test.ts
+++ b/tests/formulas/compiler.test.ts
@@ -43,6 +43,11 @@ describe("expression compiler", () => {
     }
   );
 
+  test.each(["=1%", "=(2+5)%", "=A1%"])("some arithmetic expressions", (formula) => {
+    const compiledFormula = compiledBaseFunction(formula);
+    expect(compiledFormula.execute.toString()).toMatchSnapshot();
+  });
+
   test("read some values and functions", () => {
     const compiledFormula = compiledBaseFunction("=A1 + sum(A2:C3)");
     expect(compiledFormula.execute.toString()).toMatchSnapshot();
@@ -160,6 +165,8 @@ describe("compile dependencies format", () => {
     ["=+RETURNFORMAT()", [format.specificFormat]],
     ["=+RETURNARGSFORMAT(B1)", [0]],
     ["=-1", []],
+    ["=1%", []],
+    ["=B1%", [0]],
     ["=-TRUE", []],
     ["=-B1", [0]],
     ["=-ANYFUNCTION(21)", []],

--- a/tests/formulas/parser.test.ts
+++ b/tests/formulas/parser.test.ts
@@ -81,25 +81,35 @@ describe("parser", () => {
     expect(parse("-1")).toEqual({
       type: "UNARY_OPERATION",
       value: "-",
-      right: { type: "NUMBER", value: 1 },
+      operand: { type: "NUMBER", value: 1 },
     });
     expect(parse("+1")).toEqual({
       type: "UNARY_OPERATION",
       value: "+",
-      right: { type: "NUMBER", value: 1 },
+      operand: { type: "NUMBER", value: 1 },
     });
   });
+
+  test("can parse % operator", () => {
+    expect(parse("1%")).toEqual({
+      type: "UNARY_OPERATION",
+      value: "%",
+      operand: { type: "NUMBER", value: 1 },
+      postfix: true,
+    });
+    expect(parse("100 %")).toEqual({
+      type: "UNARY_OPERATION",
+      value: "%",
+      operand: { type: "NUMBER", value: 100 },
+      postfix: true,
+    });
+  });
+
   test("can parse numeric values", () => {
     expect(parse("1")).toEqual({ type: "NUMBER", value: 1 });
     expect(parse("1.5")).toEqual({ type: "NUMBER", value: 1.5 });
     expect(parse("1.")).toEqual({ type: "NUMBER", value: 1 });
     expect(parse(".5")).toEqual({ type: "NUMBER", value: 0.5 });
-  });
-
-  test("can parse number expressed as percent", () => {
-    expect(parse("1%")).toEqual({ type: "NUMBER", value: 0.01 });
-    expect(parse("100%")).toEqual({ type: "NUMBER", value: 1 });
-    expect(parse("50.0%")).toEqual({ type: "NUMBER", value: 0.5 });
   });
 
   test("can parse binary operations", () => {
@@ -168,6 +178,8 @@ describe("Converting AST to string", () => {
     expect(astToFormula(parse("-SUM(1)"))).toBe("-SUM(1)");
     expect(astToFormula(parse("-(1+2)/5"))).toBe("-(1+2)/5");
     expect(astToFormula(parse("1*-(1+2)"))).toBe("1*-(1+2)");
+    expect(astToFormula(parse("1%"))).toBe("1%");
+    expect(astToFormula(parse("(1+2)%"))).toBe("(1+2)%");
   });
   test("Convert binary operator", () => {
     expect(astToFormula(parse("89-45"))).toBe("89-45");

--- a/tests/formulas/tokenizer.test.ts
+++ b/tests/formulas/tokenizer.test.ts
@@ -42,9 +42,21 @@ describe("tokenizer", () => {
     ]);
   });
 
+  test("percent operator", () => {
+    expect(tokenize("=1%")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "NUMBER", value: "1" },
+      { type: "OPERATOR", value: "%" },
+    ]);
+    expect(tokenize("=50 %")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "NUMBER", value: "50" },
+      { type: "SPACE", value: " " },
+      { type: "OPERATOR", value: "%" },
+    ]);
+  });
+
   test("can tokenize various number expressions", () => {
-    expect(tokenize("1%")).toEqual([{ type: "NUMBER", value: "1%" }]);
-    expect(tokenize("1 %")).toEqual([{ type: "NUMBER", value: "1 %" }]);
     expect(tokenize("1.1")).toEqual([{ type: "NUMBER", value: "1.1" }]);
     expect(tokenize("1e3")).toEqual([{ type: "NUMBER", value: "1e3" }]);
   });

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -177,6 +177,22 @@ describe("edition", () => {
     expect(result).toBeCancelledBecause(CommandResult.WrongComposerSelection);
   });
 
+  test("dont show selection indicator after percent operator", () => {
+    const model = new Model();
+    model.dispatch("START_EDITION", { text: "=5%" });
+    expect(model.getters.showSelectionIndicator()).toBe(false);
+  });
+
+  test("typing percent operator dont show selection indicator", () => {
+    const model = new Model();
+    model.dispatch("START_EDITION", { text: "=5" });
+    model.dispatch("SET_CURRENT_CONTENT", {
+      content: "5%",
+      selection: { start: 2, end: 2 },
+    });
+    expect(model.getters.showSelectionIndicator()).toBe(false);
+  });
+
   test("change selection", () => {
     const model = new Model();
     expect(model.getters.getComposerSelection()).toEqual({

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -94,6 +94,11 @@ describe("evaluateCells", () => {
     expect(evaluateCell("C1", grid)).toBe(0);
   });
 
+  test("Percent operator", () => {
+    const grid = { A1: "1", B1: "=(5+A1)%" };
+    expect(evaluateCell("B1", grid)).toBe(0.06);
+  });
+
   test("handling some errors", () => {
     const grid = { A1: "=A1", A2: "=A1", A3: "=+", A4: "=1 + A3", A5: "=sum('asdf')" };
     const result = evaluateGrid(grid);


### PR DESCRIPTION
Before the % symbol was only parsed along a number (eg. 10% => number 0.1).
This didn't work for things like =A1%, which is supported in GSheet. In Gsheet and Excel, `2%` in formulas is equivalent to do `(2/100)` (with parenthesis for operation priority)
I though of several options to implement this : 

- Option 1 - replace '%' by '/ 100' at tokenisation
	- not really possible : 
		- operation priority. 10^2% isn't the same as 10^2 / 100 and we cannot realistically add parenthesis in the token list, how to know where to put the opening parenthesis?

- Option 2 - % is Unary Operator, replace by function DIV(.., 100) at compilation
	- problem : 
		- we don't have the constant 100 in the compiledFormula dependencies
			- naive solution would be to add it at the compilation, but this won't work if we don't recompile the function (already in function cache)
			- we have to add it in the method `formulaArguments`

- Option 3 - make a PERCENTAGE() function, replace % operator by this at compilation (same way as other unary operators)
	- easy, but this means that user have a PERCENTAGE function now. Is it really a problem ?

### replace % at compilation:
  pros : 
  	+ everything stays in the compilation
  	+ can be reused for other possibilities (for example handling `²` symbol)
  cons : 
    - make compilation a bit more complex and obscure
    - normalized formula isn't really the same as the actual formula, but from my understanding the normalized formula is now just used for the cache key? So it shouldn't be a problem.
### Use UNARY.PERCENTAGE function
  pros :
  	+ easy 
  cons :
  	- not reusable (if we wanted to add  `²` we would have to add a SQUARED function)
  	
I simply used the UNARY.PERCENTAGE function atm.

Odoo task ID : [2773880](https://www.odoo.com/web#id=2773880&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo