### PR TITLE
[IMP] tests: Avoid recompiling templates at each test

### DIFF
--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -99,13 +99,17 @@ export function testUndoRedo(model: Model, expect: jest.Expect, command: Command
   expect(model).toExport(after);
 }
 
+let templates: any = {};
+
 // Requires to be called wit jest realTimers
 export async function mountSpreadsheet(
   fixture: HTMLElement,
   props: SpreadsheetProps = { model: new Model() }
 ): Promise<{ app: App; parent: Spreadsheet }> {
   const app = new App(Spreadsheet, { props, test: true });
+  app.templates = templates;
   const parent = (await app.mount(fixture)) as Spreadsheet;
+  templates = app.templates;
   return { app, parent };
 }
 


### PR DESCRIPTION
## Description:

Issue
-----
With the help of this magnificent tool https://github.com/GoogleChromeLabs/ndb,
Lucas (lul) has identified that the components tests were spending a lot of time
compiling the different components templates. Since Owl2, the compiled templates
are linked to an instance of `App` and are therefore destroyed with the latter.

Solution
--------

The compiled templates (including their names) do not change over time.
Therefore, we can store the templates of a current `App` instance and feed it to
the next one created.
This prevents the recompilation of the templates for several tests in a same
process (i.e. per test file).

Task 2724282

Odoo task ID : [2724282](https://www.odoo.com/web#id=2724282&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo