### PR TITLE
[FIX] Conditional Format: reset rules when switching to list

### DIFF
--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -564,6 +564,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetEnv>
     this.state.currentCF = undefined;
     this.state.currentCFType = undefined;
     this.state.errors = [];
+    this.state.rules = this.getDefaultRules();
   }
 
   getStyle(rule: SingleColorRules | ColorScaleRule): string {

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -88,6 +88,7 @@ describe("UI of conditional formats", () => {
     cfTabSelector: ".o-cf-type-selector .o_form_label",
     buttonSave: ".o-sidePanelButtons .o-cf-save",
     buttonDelete: ".o-cf-delete-button",
+    buttonCancel: ".o-sidePanelButtons .o-cf-cancel",
     buttonAdd: ".o-cf-add",
     error: ".o-cf-error",
     closePanel: ".o-sidePanelClose",
@@ -1360,5 +1361,24 @@ describe("UI of conditional formats", () => {
         ) as HTMLInputElement
       ).value
     ).toBe("BeginsWith");
+  });
+
+  test("switching to list resets the rules to their default value", async () => {
+    triggerMouseEvent(selectors.buttonAdd, "click");
+    await nextTick();
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B5:C7", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B5:C7", "input");
+    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
+    await nextTick();
+    triggerMouseEvent(selectors.buttonCancel, "click");
+    await nextTick();
+    triggerMouseEvent(selectors.buttonAdd, "click");
+    await nextTick();
+    expect((document.querySelector(selectors.ruleEditor.range) as HTMLInputElement).value).toBe(
+      "A1"
+    );
+    expect(
+      (document.querySelector(selectors.ruleEditor.editor.operatorInput) as HTMLSelectElement).value
+    ).toBe("IsNotEmpty");
   });
 });


### PR DESCRIPTION
How to reproduce
----------------

- Create a "CellIsRule" CF with values that differ from the defaults,
- save the CF of cancel it,
- Form the list of cf, click on  "Add another rule"
-> the values displayed come from the previous CF

This functionality was lost during the last refactoring of cf
See 6c5959083316fe9a100ab39aebeaafadd7c0e8df

It is now properly tested :)

Co-authored-by: Alexis Lacroix <laa@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2790203](https://www.odoo.com/web#id=2790203&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo