### PR TITLE
[FIX] evaluation: correctly handle cells in error state

### DIFF
--- a/src/plugins/evaluation.ts
+++ b/src/plugins/evaluation.ts
@@ -188,7 +188,16 @@ export class EvaluationPlugin extends BasePlugin {
     const params = this.getFormulaParameters(computeValue);
     const visited: { [sheetId: string]: { [xc: string]: boolean | null } } = {};
 
-    for (let cell of cells) {
+    const _cells = [...cells];
+
+    for (let cell of _cells) {
+      // Do not reset error when it's during the compilation
+      if (cell.value !== "#BAD_EXPR") {
+        cell.error = undefined;
+      }
+    }
+
+    for (let cell of _cells) {
       computeValue(cell, sheetId);
     }
 


### PR DESCRIPTION
Before this commit, the cells in error were not reset before a new
evaluation. So, if a cell positioned before another cell in error mode, and
the given cell depends on the cell in error, the evaluation detected the
dependency as an error and thus mark the given cell as error.

Note that it has been fixed in 15.0+ here: https://github.com/odoo/o-spreadsheet/commit/35b67d3e9f815bdf4d6b7cd55e01a24c06899c57

Task-id 2735439

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [x] exportable in excel
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [x] track breaking changes
- [x] doc is rebuild (npm run doc)
- [x] status is correct in Odoo