### PR TITLE
[REM] model: remove mode

### DIFF
--- a/src/plugins/base_plugin.ts
+++ b/src/plugins/base_plugin.ts
@@ -1,4 +1,4 @@
-import { Mode, ModelConfig } from "../model";
+import { ModelConfig } from "../model";
 import { StateObserver } from "../state_observer";
 import {
   CommandDispatcher,
@@ -22,11 +22,9 @@ import {
 
 export class BasePlugin<State = any, C = any> implements CommandHandler<C> {
   static getters: readonly string[] = [];
-  static modes: Mode[] = ["headless", "normal"];
 
   protected history: WorkbookHistory<State>;
   protected dispatch: CommandDispatcher["dispatch"];
-  protected currentMode: Mode;
 
   constructor(
     stateObserver: StateObserver,
@@ -38,7 +36,6 @@ export class BasePlugin<State = any, C = any> implements CommandHandler<C> {
       selectCell: () => {},
     });
     this.dispatch = dispatch;
-    this.currentMode = config.mode;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -1,5 +1,5 @@
 import { UuidGenerator } from "../helpers";
-import { Mode, ModelConfig } from "../model";
+import { ModelConfig } from "../model";
 import { StateObserver } from "../state_observer";
 import {
   ApplyRangeChange,
@@ -24,7 +24,6 @@ export interface CorePluginConstructor {
     uuidGenerator: UuidGenerator
   ): CorePlugin;
   getters: readonly string[];
-  modes: Mode[];
 }
 
 /**

--- a/src/plugins/ui/autofill.ts
+++ b/src/plugins/ui/autofill.ts
@@ -1,5 +1,4 @@
 import { clip, isInside, toCartesian, toXC, union } from "../../helpers/index";
-import { Mode } from "../../model";
 import { autofillModifiersRegistry, autofillRulesRegistry } from "../../registries/index";
 import {
   AutofillData,
@@ -82,7 +81,6 @@ class AutofillGenerator {
 export class AutofillPlugin extends UIPlugin {
   static layers = [LAYERS.Autofill];
   static getters = ["getAutofillTooltip"] as const;
-  static modes: Mode[] = ["normal"];
 
   private autofillZone: Zone | undefined;
   private lastCellSelected: { col?: number; row?: number } = {};

--- a/src/plugins/ui/automatic_sum.ts
+++ b/src/plugins/ui/automatic_sum.ts
@@ -8,7 +8,6 @@ import {
   union,
   zoneToDimension,
 } from "../../helpers";
-import { Mode } from "../../model";
 import { Cell, CellValueType, Command, Dimension, Sheet, UID, Zone } from "../../types";
 import { UIPlugin } from "../ui_plugin";
 
@@ -19,7 +18,6 @@ interface AutomaticSum {
 
 export class AutomaticSumPlugin extends UIPlugin {
   static getters = ["getAutomaticSums"] as const;
-  static modes: Mode[] = ["normal", "headless"];
 
   handle(cmd: Command) {
     switch (cmd.type) {

--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -1,6 +1,5 @@
 import { SELECTION_BORDER_COLOR } from "../../constants";
 import { formatValue, mergeOverlappingZones, overlap, positions } from "../../helpers/index";
-import { Mode } from "../../model";
 import {
   CellPosition,
   ClipboardCell,
@@ -43,7 +42,6 @@ interface ClipboardState {
 export class ClipboardPlugin extends UIPlugin {
   static layers = [LAYERS.Clipboard];
   static getters = ["getClipboardContent", "isPaintingFormat"] as const;
-  static modes: Mode[] = ["normal"];
 
   private status: "visible" | "invisible" = "invisible";
   private state?: ClipboardState;

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -13,7 +13,6 @@ import {
   updateSelectionOnInsertion,
 } from "../../helpers/index";
 import { loopThroughReferenceType } from "../../helpers/reference_type";
-import { Mode } from "../../model";
 import { _lt } from "../../translation";
 import { SelectionEvent } from "../../types/event_stream";
 import {
@@ -51,7 +50,6 @@ export class EditionPlugin extends UIPlugin {
     "getTokenAtCursor",
     "getComposerHighlights",
   ] as const;
-  static modes: Mode[] = ["normal"];
 
   private col: number = 0;
   private row: number = 0;

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -2,7 +2,7 @@ import { INCORRECT_RANGE_STRING } from "../../constants";
 import { compile } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
 import { isZoneValid, range as rangeSequence, toXC } from "../../helpers/index";
-import { Mode, ModelConfig } from "../../model";
+import { ModelConfig } from "../../model";
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
 import { StateObserver } from "../../state_observer";
 import { _lt } from "../../translation";
@@ -31,7 +31,6 @@ type FormulaParameters = [ReferenceDenormalizer, EnsureRange, EvalContext];
 
 export class EvaluationPlugin extends UIPlugin {
   static getters = ["evaluateFormula", "getRangeFormattedValues", "getRangeValues"] as const;
-  static modes: Mode[] = ["normal"];
 
   private isUpToDate: Set<UID> = new Set(); // Set<sheetIds>
   private readonly evalContext: EvalContext;

--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -11,7 +11,6 @@ import { MAX_CHAR_LABEL } from "../../constants";
 import { ChartColors } from "../../helpers/chart";
 import { isDefined, isInside, overlap, recomputeZones, zoneToXc } from "../../helpers/index";
 import { range } from "../../helpers/misc";
-import { Mode } from "../../model";
 import { Cell } from "../../types";
 import { ChartDefinition, DataSet } from "../../types/chart";
 import { Command } from "../../types/commands";
@@ -20,7 +19,6 @@ import { UIPlugin } from "../ui_plugin";
 
 export class EvaluationChartPlugin extends UIPlugin {
   static getters = ["getChartRuntime"] as const;
-  static modes: Mode[] = ["normal"];
   // contains the configuration of the chart with it's values like they should be displayed,
   // as well as all the options needed for the chart library to work correctly
   readonly chartRuntime: { [figureId: string]: ChartConfiguration } = {};

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -1,7 +1,6 @@
 import { parsePrimitiveContent } from "../../helpers/cells";
 import { colorNumberString, isInside, recomputeZones, toXC, toZone } from "../../helpers/index";
 import { clip, isDefined } from "../../helpers/misc";
-import { Mode } from "../../model";
 import { _lt } from "../../translation";
 import {
   Cell,
@@ -27,7 +26,6 @@ import { UIPlugin } from "../ui_plugin";
 
 export class EvaluationConditionalFormatPlugin extends UIPlugin {
   static getters = ["getConditionalStyle", "getConditionalIcon"] as const;
-  static modes: Mode[] = ["normal"];
   private isStale: boolean = true;
   // stores the computed styles in the format of computedStyles.sheetName[col][row] = Style
   private computedStyles: { [sheet: string]: { [col: number]: (Style | undefined)[] } } = {};

--- a/src/plugins/ui/highlight.ts
+++ b/src/plugins/ui/highlight.ts
@@ -1,5 +1,4 @@
 import { isEqual, toZone } from "../../helpers/index";
-import { Mode } from "../../model";
 import { GridRenderingContext, Highlight, LAYERS, Zone } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
@@ -7,7 +6,6 @@ import { UIPlugin } from "../ui_plugin";
  * HighlightPlugin
  */
 export class HighlightPlugin extends UIPlugin {
-  static modes: Mode[] = ["normal"];
   static layers = [LAYERS.Highlights];
   static getters = ["getHighlights"] as const;
 

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -17,7 +17,6 @@ import {
 } from "../../constants";
 import { fontSizeMap } from "../../fonts";
 import { overlap, scrollDelay } from "../../helpers/index";
-import { Mode } from "../../model";
 import {
   Align,
   Box,
@@ -69,7 +68,6 @@ export class RendererPlugin extends UIPlugin {
     "getEdgeScrollCol",
     "getEdgeScrollRow",
   ] as const;
-  static modes: Mode[] = ["normal"];
 
   private boxes: Box[] = [];
 

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -12,7 +12,7 @@ import {
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
 } from "../../helpers/index";
-import { Mode, ModelConfig } from "../../model";
+import { ModelConfig } from "../../model";
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
 import { StateObserver } from "../../state_observer";
 import { _lt } from "../../translation";
@@ -91,7 +91,6 @@ const selectionStatisticFunctions: SelectionStatisticFunction[] = [
  */
 export class GridSelectionPlugin extends UIPlugin {
   static layers = [LAYERS.Selection];
-  static modes: Mode[] = ["normal"];
   static getters = [
     "getActiveSheet",
     "getActiveSheetId",

--- a/src/plugins/ui/selection_input.ts
+++ b/src/plugins/ui/selection_input.ts
@@ -1,5 +1,5 @@
 import { getComposerSheetName, getNextColor, UuidGenerator, zoneToXc } from "../../helpers/index";
-import { Mode, ModelConfig } from "../../model";
+import { ModelConfig } from "../../model";
 import { StreamCallbacks } from "../../selection_stream/event_stream";
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
 import { StateObserver } from "../../state_observer";
@@ -23,7 +23,6 @@ export interface RangeInputValue {
  * This plugin handles this internal state.
  */
 export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<SelectionEvent> {
-  static modes: Mode[] = ["normal"];
   static layers = [LAYERS.Highlights];
   static getters = [];
 

--- a/src/plugins/ui/selection_inputs_manager.ts
+++ b/src/plugins/ui/selection_inputs_manager.ts
@@ -1,5 +1,5 @@
 import { positionToZone, rangeReference } from "../../helpers/index";
-import { Mode, ModelConfig } from "../../model";
+import { ModelConfig } from "../../model";
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
 import { StateObserver } from "../../state_observer";
 import { Command, CommandDispatcher, CommandResult, Getters, LAYERS, UID } from "../../types/index";
@@ -20,7 +20,6 @@ export interface RangeInputValue {
  * This plugin handles this internal state.
  */
 export class SelectionInputsManagerPlugin extends UIPlugin {
-  static modes: Mode[] = ["normal"];
   static layers = [LAYERS.Highlights];
   static getters = [
     "getSelectionInput",

--- a/src/plugins/ui/selection_multiuser.ts
+++ b/src/plugins/ui/selection_multiuser.ts
@@ -1,6 +1,5 @@
 import { ClientDisconnectedError } from "../../collaborative/session";
 import { DEFAULT_FONT, DEFAULT_FONT_SIZE } from "../../constants";
-import { Mode } from "../../model";
 import { Client, ClientPosition, GridRenderingContext, LAYERS, UID } from "../../types";
 import { UIPlugin } from "../ui_plugin";
 
@@ -30,7 +29,6 @@ interface ClientToDisplay extends Required<Client> {
 export class SelectionMultiUserPlugin extends UIPlugin {
   static getters = ["getClientsToDisplay"] as const;
   static layers = [LAYERS.Selection];
-  static modes: Mode[] = ["normal"];
   private availableColors = new Set(colors);
   private colors: Record<UID, string> = {};
 

--- a/src/plugins/ui/ui_options.ts
+++ b/src/plugins/ui/ui_options.ts
@@ -1,9 +1,7 @@
-import { Mode } from "../../model";
 import { Command } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
 export class UIOptionsPlugin extends UIPlugin {
-  static modes: Mode[] = ["normal"];
   static getters = ["shouldShowFormulas"] as const;
   private showFormulas: boolean = false;
 

--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -5,7 +5,6 @@ import {
   HEADER_WIDTH,
 } from "../../constants";
 import { findCellInNewZone, findLastVisibleColRow, getNextVisibleCellCoords } from "../../helpers";
-import { Mode } from "../../model";
 import { SelectionEvent } from "../../types/event_stream";
 import {
   Command,
@@ -42,7 +41,6 @@ export class ViewportPlugin extends UIPlugin {
     "getMaxViewportSize",
     "getMaximumViewportOffset",
   ] as const;
-  static modes: Mode[] = ["normal"];
 
   readonly viewports: ViewportPluginState["viewports"] = {};
   readonly snappedViewports: ViewportPluginState["viewports"] = {};

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -1,4 +1,4 @@
-import { Mode, ModelConfig } from "../model";
+import { ModelConfig } from "../model";
 import { SelectionStreamProcessor } from "../selection_stream/selection_stream_processor";
 import { StateObserver } from "../state_observer";
 import { Command, CommandDispatcher, Getters, GridRenderingContext, LAYERS } from "../types/index";
@@ -15,7 +15,6 @@ export interface UIPluginConstructor {
   ): UIPlugin;
   layers: LAYERS[];
   getters: readonly string[];
-  modes: Mode[];
 }
 
 /**

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1,96 +1,13 @@
 import { CommandResult, CorePlugin } from "../src";
 import { toZone } from "../src/helpers";
-import { LocalHistory } from "../src/history/local_history";
-import { Mode, Model, ModelConfig } from "../src/model";
-import { BordersPlugin } from "../src/plugins/core/borders";
-import { CellPlugin } from "../src/plugins/core/cell";
-import { ChartPlugin } from "../src/plugins/core/chart";
-import { ConditionalFormatPlugin } from "../src/plugins/core/conditional_format";
-import { FigurePlugin } from "../src/plugins/core/figures";
-import { MergePlugin } from "../src/plugins/core/merge";
-import { RangeAdapter } from "../src/plugins/core/range";
-import { SheetPlugin } from "../src/plugins/core/sheet";
-import { SortPlugin } from "../src/plugins/core/sort";
+import { Model, ModelConfig } from "../src/model";
 import { corePluginRegistry, uiPluginRegistry } from "../src/plugins/index";
-import { AutomaticSumPlugin } from "../src/plugins/ui/automatic_sum";
-import { FindAndReplacePlugin } from "../src/plugins/ui/find_and_replace";
-import { SheetUIPlugin } from "../src/plugins/ui/ui_sheet";
 import { UIPlugin } from "../src/plugins/ui_plugin";
 import { Command, CoreCommand, DispatchResult } from "../src/types";
 import { selectCell, setCellContent } from "./test_helpers/commands_helpers";
-import { getCell, getCellText } from "./test_helpers/getters_helpers";
-
-function getNbrPlugin(mode: Mode): number {
-  return (
-    corePluginRegistry
-      .getAll()
-      .reduce((acc, plugin) => (plugin.modes.includes(mode) ? acc + 1 : acc), 0) +
-    uiPluginRegistry
-      .getAll()
-      .reduce((acc, plugin) => (plugin.modes.includes(mode) ? acc + 1 : acc), 0)
-  );
-}
+import { getCellText } from "./test_helpers/getters_helpers";
 
 describe("Model", () => {
-  test("can create model in headless mode", () => {
-    const model = new Model({}, { mode: "headless" });
-    expect(model["handlers"]).toHaveLength(13);
-    expect(model["handlers"][0]).toBeInstanceOf(RangeAdapter);
-    expect(model["handlers"][1]).toBeInstanceOf(SheetPlugin);
-    expect(model["handlers"][2]).toBeInstanceOf(CellPlugin);
-    expect(model["handlers"][3]).toBeInstanceOf(MergePlugin);
-    expect(model["handlers"][4]).toBeInstanceOf(BordersPlugin);
-    expect(model["handlers"][5]).toBeInstanceOf(ConditionalFormatPlugin);
-    expect(model["handlers"][6]).toBeInstanceOf(FigurePlugin);
-    expect(model["handlers"][7]).toBeInstanceOf(SortPlugin);
-    expect(model["handlers"][8]).toBeInstanceOf(ChartPlugin);
-    expect(model["handlers"][9]).toBeInstanceOf(SheetUIPlugin);
-    expect(model["handlers"][10]).toBeInstanceOf(FindAndReplacePlugin);
-    expect(model["handlers"][11]).toBeInstanceOf(AutomaticSumPlugin);
-    expect(model["handlers"][12]).toBeInstanceOf(LocalHistory);
-  });
-
-  test("All plugin compatible with normal mode are loaded on normal mode", () => {
-    const model = new Model();
-    const nbr = getNbrPlugin("normal");
-    expect(model["handlers"]).toHaveLength(nbr + 2); //+1 for Range +1 for History
-  });
-
-  test("All plugin compatible with headless mode are loaded on headless mode", () => {
-    const model = new Model({}, { mode: "headless" });
-    const nbr = getNbrPlugin("headless");
-    expect(model["handlers"]).toHaveLength(nbr + 2); //+1 for Range +1 for History
-  });
-
-  test("Model in headless mode should not evaluate cells", () => {
-    const model = new Model({ sheets: [{ id: "sheet1" }] }, { mode: "headless" });
-    setCellContent(model, "A1", "=1", "sheet1");
-    expect(getCell(model, "A1", "sheet1")!.evaluated.value).not.toBe("1");
-  });
-
-  test("can add a Plugin only in headless mode", () => {
-    class NormalPlugin extends UIPlugin {
-      static modes: Mode[] = ["normal"];
-    }
-    class HeadlessPlugin extends UIPlugin {
-      static modes: Mode[] = ["headless"];
-    }
-    uiPluginRegistry.add("normalPlugin", NormalPlugin);
-    uiPluginRegistry.add("headlessPlugin", HeadlessPlugin);
-    const modelNormal = new Model();
-    expect(modelNormal["handlers"].find((handler) => handler instanceof NormalPlugin)).toBeTruthy();
-    expect(
-      modelNormal["handlers"].find((handler) => handler instanceof HeadlessPlugin)
-    ).toBeFalsy();
-    const modelHeadless = new Model({}, { mode: "headless" });
-    expect(
-      modelHeadless["handlers"].find((handler) => handler instanceof NormalPlugin)
-    ).toBeFalsy();
-    expect(
-      modelHeadless["handlers"].find((handler) => handler instanceof HeadlessPlugin)
-    ).toBeTruthy();
-  });
-
   test("core plugin can refuse command from UI plugin", () => {
     class MyCorePlugin extends CorePlugin {
       allowDispatch(cmd: CoreCommand) {


### PR DESCRIPTION
Modes (normal, headless and readonly) have been introduced in order to
be able to load different plugins depending on the mode in which the
model is created. "readonly" has been removed (c807948472c789eaad5700e81fbc88103a4fc177) because readonly is
not as simple as loading or not some plugins. readonly impacts the
dispatching of commands.

Now, headless can be removed as it was introduced to disable the
evaluation at the time where async evaluation was present. As it has
been removed, we do not need it anymore. Also, the other difference with
normal mode is the triggering of "update" which can be listened from
outside. It's not necessary to bypass this trigger.

Task-id 2791206

/!\ Doc will be updated later