### PR TITLE
[FIX] package: align rollup version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8546,9 +8546,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.56.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
-      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+      "integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -16778,9 +16778,9 @@
       }
     },
     "rollup": {
-      "version": "2.56.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
-      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+      "integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"


### PR DESCRIPTION
The package-lock.json was updated in 15.0 during a painful forwardport
and we apparently update the version of rollup. This difference brnigs
subtle differencies in the bundle generated.

This commit updates the package-lock of version 14.0 to match those of
versions 15.0+
