### PR TITLE
[FIX] import: can import sheets with more than 125k cells

### DIFF
--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -945,8 +945,8 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   private getImportedSheetSize(data: SheetData): { rowNumber: number; colNumber: number } {
     const positions = Object.keys(data.cells).map(toCartesian);
     return {
-      rowNumber: Math.max(data.rowNumber, ...positions.map(([col, row]) => row + 1)),
-      colNumber: Math.max(data.colNumber, ...positions.map(([col, row]) => col + 1)),
+      rowNumber: Math.max(data.rowNumber, ...new Set(positions.map(([col, row]) => row + 1))),
+      colNumber: Math.max(data.colNumber, ...new Set(positions.map(([col, row]) => col + 1))),
     };
   }
 


### PR DESCRIPTION
Bug introduced by 39f6743

There's a limit to the number of function arguments. In Chrome, it's a bit more
than 125k.

Since the mentioned commit, loading a spreadsheet with more than 125k cells
crashes with `RangeError: Maximum call stack size exceeded`

This commit mitigate the issue. Now the limit before a crash is
125k columns or 125k rows instead of 125k cells.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo