### PR TITLE
[FIX] import: can import sheets with more than 125k cells

### DIFF
--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -1404,8 +1404,8 @@ export class CorePlugin extends BasePlugin {
 function getSheetSize(data: SheetData): { rowNumber: number; colNumber: number } {
   const positions = Object.keys(data.cells).map(toCartesian);
   return {
-    rowNumber: Math.max(data.rowNumber, ...positions.map(([col, row]) => row + 1)),
-    colNumber: Math.max(data.colNumber, ...positions.map(([col, row]) => col + 1)),
+    rowNumber: Math.max(data.rowNumber, ...new Set(positions.map(([col, row]) => row + 1))),
+    colNumber: Math.max(data.colNumber, ...new Set(positions.map(([col, row]) => col + 1))),
   };
 }
 


### PR DESCRIPTION
Bug introduced by d6c4c4

There's a limit to the number of function arguments. In Chrome, it's a bit more
than 125k.

Since the mentioned commit, loading a spreadsheet with more than 125k cells
crashes with `RangeError: Maximum call stack size exceeded`

This commit mitigate the issue. Now the limit before a crash is
125k columns or 125k rows instead of 125k cells.
