### PR TITLE
[FIX] sheet: undeterministic sheet id

### DIFF
--- a/src/collaborative/ot/ot.ts
+++ b/src/collaborative/ot/ot.ts
@@ -114,8 +114,9 @@ function transformSheetId(
   const deleteSheet = executed.type === "DELETE_SHEET" && executed.sheetId;
   if (cmd.sheetId === deleteSheet) {
     return "IGNORE_COMMAND";
-  }
-  if ("sheetId" in executed && cmd.sheetId !== executed.sheetId) {
+  } else if (cmd.type === "CREATE_SHEET" || executed.type === "CREATE_SHEET") {
+    return cmd;
+  } else if ("sheetId" in executed && cmd.sheetId !== executed.sheetId) {
     return "TRANSFORMATION_NOT_NEEDED";
   }
   return cmd;

--- a/src/collaborative/ot/ot_specific.ts
+++ b/src/collaborative/ot/ot_specific.ts
@@ -5,6 +5,7 @@ import {
   AddMergeCommand,
   ChartUIDefinition,
   CreateChartCommand,
+  CreateSheetCommand,
   DeleteFigureCommand,
   RemoveColumnsRowsCommand,
   RemoveMergeCommand,
@@ -30,6 +31,7 @@ otRegistry.addTransformation(
   updateChartRangesTransformation
 );
 otRegistry.addTransformation("DELETE_FIGURE", ["UPDATE_FIGURE", "UPDATE_CHART"], updateChartFigure);
+otRegistry.addTransformation("CREATE_SHEET", ["CREATE_SHEET"], createSheetTransformation);
 otRegistry.addTransformation("ADD_MERGE", ["ADD_MERGE", "REMOVE_MERGE"], mergeTransformation);
 otRegistry.addTransformation("ADD_MERGE", ["SORT_CELLS"], sortMergedTransformation);
 otRegistry.addTransformation("REMOVE_MERGE", ["SORT_CELLS"], sortUnMergedTransformation);
@@ -69,6 +71,22 @@ function updateChartRangesTransformation(
       labelRange: labelZone ? zoneToXc(labelZone) : undefined,
     } as ChartUIDefinition,
   };
+}
+
+function createSheetTransformation(
+  cmd: CreateSheetCommand,
+  executed: CreateSheetCommand
+): CreateSheetCommand {
+  if (cmd.name === executed.name) {
+    return {
+      ...cmd,
+      name: cmd.name?.match(/\d+/)
+        ? cmd.name.replace(/\d+/, (n) => (parseInt(n) + 1).toString())
+        : `${cmd.name}~`,
+      position: cmd.position + 1,
+    };
+  }
+  return cmd;
 }
 
 function mergeTransformation(

--- a/src/components/bottom_bar.ts
+++ b/src/components/bottom_bar.ts
@@ -149,7 +149,8 @@ export class BottomBar extends Component<{}, SpreadsheetEnv> {
     const position =
       this.env.getters.getVisibleSheets().findIndex((sheetId) => sheetId === activeSheetId) + 1;
     const sheetId = this.env.uuidGenerator.uuidv4();
-    this.env.dispatch("CREATE_SHEET", { sheetId, position });
+    const name = this.getters.getNextSheetName(this.env._t("Sheet"));
+    this.env.dispatch("CREATE_SHEET", { sheetId, position, name });
     this.env.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
   toZone,
   UuidGenerator,
 } from "./helpers/index";
+import { createEmptyWorkbookData } from "./migrations/data";
 import { corePluginRegistry, uiPluginRegistry } from "./plugins/index";
 import {
   autofillModifiersRegistry,
@@ -124,4 +125,5 @@ export const helpers = {
   isMarkdownLink,
   parseMarkdownLink,
   markdownLink,
+  createEmptyWorkbookData,
 };

--- a/src/model.ts
+++ b/src/model.ts
@@ -6,7 +6,12 @@ import { DataSourceRegistry } from "./data_source";
 import { DEBUG, UuidGenerator } from "./helpers/index";
 import { buildRevisionLog } from "./history/factory";
 import { LocalHistory } from "./history/local_history";
-import { createEmptyExcelWorkbookData, createEmptyWorkbookData, load } from "./migrations/data";
+import {
+  createEmptyExcelWorkbookData,
+  createEmptyWorkbookData,
+  load,
+  repairInitialMessages,
+} from "./migrations/data";
 import { RangeAdapter } from "./plugins/core/range";
 import { CorePlugin, CorePluginConstructor } from "./plugins/core_plugin";
 import { corePluginRegistry, uiPluginRegistry } from "./plugins/index";
@@ -135,6 +140,8 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
   ) {
     super();
     DEBUG.model = this;
+
+    stateUpdateMessages = repairInitialMessages(data, stateUpdateMessages);
 
     const workbookData = load(data);
 

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -24,6 +24,7 @@ import {
   CommandResult,
   ConsecutiveIndexes,
   CoreCommand,
+  CreateSheetCommand,
   ExcelWorkbookData,
   RenameSheetCommand,
   Row,
@@ -65,6 +66,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "getHiddenColsGroups",
     "getHiddenRowsGroups",
     "getGridLinesVisibility",
+    "getNextSheetName",
     "isEmpty",
   ];
 
@@ -84,11 +86,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     }
     switch (cmd.type) {
       case "CREATE_SHEET": {
-        const { visibleSheets } = this;
-        if (cmd.position > visibleSheets.length || cmd.position < 0) {
-          return CommandResult.WrongSheetPosition;
-        }
-        return CommandResult.Success;
+        return this.checkValidations(cmd, this.checkSheetName, this.checkSheetPosition);
       }
       case "MOVE_SHEET":
         const currentIndex = this.visibleSheets.findIndex((id) => id === cmd.sheetId);
@@ -133,7 +131,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
       case "CREATE_SHEET":
         const sheet = this.createSheet(
           cmd.sheetId,
-          this.generateSheetName(),
+          cmd.name || this.getNextSheetName(),
           cmd.cols || 26,
           cmd.rows || 100,
           cmd.position
@@ -380,6 +378,17 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     return this.getSheet(sheetId).rows.length;
   }
 
+  getNextSheetName(baseName = "Sheet"): string {
+    let i = 1;
+    const names = this.getSheets().map((s) => s.name);
+    let name = `${baseName}${i}`;
+    while (names.includes(name)) {
+      name = `${baseName}${i}`;
+      i++;
+    }
+    return name;
+  }
+
   // ---------------------------------------------------------------------------
   // Row/Col manipulation
   // ---------------------------------------------------------------------------
@@ -461,18 +470,6 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     }
   }
 
-  private generateSheetName(): string {
-    let i = 1;
-    const names = this.getSheets().map((s) => s.name);
-    const baseName = _lt("Sheet");
-    let name = `${baseName}${i}`;
-    while (names.includes(name)) {
-      name = `${baseName}${i}`;
-      i++;
-    }
-    return name;
-  }
-
   private createSheet(
     id: UID,
     name: string,
@@ -505,7 +502,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     this.history.update("visibleSheets", visibleSheets);
   }
 
-  private checkSheetName(cmd: RenameSheetCommand): CommandResult {
+  private checkSheetName(cmd: RenameSheetCommand | CreateSheetCommand): CommandResult {
     const { visibleSheets, sheets } = this;
     const name = cmd.name && cmd.name.trim().toLowerCase();
 
@@ -514,6 +511,14 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     }
     if (FORBIDDEN_IN_EXCEL_REGEX.test(name!)) {
       return CommandResult.ForbiddenCharactersInSheetName;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkSheetPosition(cmd: CreateSheetCommand) {
+    const { visibleSheets } = this;
+    if (cmd.position > visibleSheets.length || cmd.position < 0) {
+      return CommandResult.WrongSheetPosition;
     }
     return CommandResult.Success;
   }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -299,6 +299,7 @@ export interface RemoveMergeCommand
 export interface CreateSheetCommand extends BaseCommand, SheetDependentCommand {
   type: "CREATE_SHEET";
   position: number;
+  name?: string; // should be required in master
   cols?: number;
   rows?: number;
 }

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -55,6 +55,7 @@ export interface CoreGetters {
   getGridLinesVisibility: SheetPlugin["getGridLinesVisibility"];
   getNumberRows: SheetPlugin["getNumberRows"];
   getNumberCols: SheetPlugin["getNumberCols"];
+  getNextSheetName: SheetPlugin["getNextSheetName"];
   isEmpty: SheetPlugin["isEmpty"];
 
   zoneToXC: CellPlugin["zoneToXC"];

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -59,10 +59,34 @@ describe("Collaborative Sheet manipulation", () => {
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getVisibleSheets(),
-      [sheet1, "3", "2"]
+      [sheet1, "2", "3"]
     );
     expect(alice.getters.getSheetName("2")).not.toEqual(alice.getters.getSheetName("3"));
     expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
+  });
+
+  test("concurrently create three numbered sheets with the same name", () => {
+    network.concurrent(() => {
+      createSheet(alice, { sheetId: "alice42", name: "Sheet2" });
+      createSheet(bob, { sheetId: "bob42", name: "Sheet2" });
+      createSheet(charlie, { sheetId: "charlie42", name: "Sheet2" });
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => user.getters.getSheets().map(({ name }) => name),
+      ["Sheet1", "Sheet2", "Sheet3", "Sheet4"]
+    );
+  });
+
+  test("concurrently create three sheets with the same name", () => {
+    network.concurrent(() => {
+      createSheet(alice, { sheetId: "alice42", name: "Sheet" });
+      createSheet(bob, { sheetId: "bob42", name: "Sheet" });
+      createSheet(charlie, { sheetId: "charlie42", name: "Sheet" });
+    });
+    expect([alice, bob, charlie]).toHaveSynchronizedValue(
+      (user) => user.getters.getSheets().map(({ name }) => name),
+      ["Sheet1", "Sheet", "Sheet~", "Sheet~~"]
+    );
   });
 
   test("create sheet and move sheet concurrently", () => {

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -67,12 +67,27 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-add-sheet", "click");
     const activeSheetId = parent.env.getters.getActiveSheetId();
     expect(parent.env.dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
+      name: "Sheet2",
       sheetId: "42",
       position: 1,
     });
     expect(parent.env.dispatch).toHaveBeenNthCalledWith(2, "ACTIVATE_SHEET", {
       sheetIdTo: "42",
       sheetIdFrom: activeSheetId,
+    });
+    parent.destroy();
+  });
+
+  test("create a second sheet while the first one is called Sheet2", async () => {
+    const model = new Model({ sheets: [{ name: "Sheet2" }] });
+    const parent = new Parent(model);
+    await parent.mount(fixture);
+    expect(model.getters.getSheets().map((sheet) => sheet.name)).toEqual(["Sheet2"]);
+    triggerMouseEvent(".o-add-sheet", "click");
+    expect(parent.env.dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
+      sheetId: expect.any(String),
+      name: "Sheet1",
+      position: 1,
     });
     parent.destroy();
   });

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -132,6 +132,13 @@ describe("sheets", () => {
     ).toBeCancelledBecause(CommandResult.ForbiddenCharactersInSheetName);
   });
 
+  test("Cannot create a sheet with a duplicate name", () => {
+    const model = new Model({ sheets: [{ name: "My first sheet" }] });
+    expect(createSheet(model, { sheetId: "42", name: "My first sheet" })).toBeCancelledBecause(
+      CommandResult.DuplicatedSheetName
+    );
+  });
+
   test("Cannot create a sheet with a position > length of sheets", () => {
     const model = new Model();
     expect(model.dispatch("CREATE_SHEET", { sheetId: "42", position: 54 })).toBeCancelledBecause(

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -48,6 +48,7 @@ export function createSheet(
     sheetId,
     cols: data.cols,
     rows: data.rows,
+    name: data.name,
   });
   if (data.activate) {
     activateSheet(model, sheetId);


### PR DESCRIPTION
Steps to reproduce:
- Create a spreadsheet with a user using language A
- write a formula referencing this sheet: `=Sheet1!A1`
- open the spreadsheet with another language
=> boom

In a collaborative context when a sheet is created, the name is currently
generated on the fly by each client.
The name looks like "Sheet1", "Sheet2", etc.
and "Sheet" is translated to the user's language which leads to divergent
states between users!

This also happens with a brand new spreadsheet: the first sheet is generated
on the fly by each client.

For existing spreadsheet
------------------------
This commit removes the translation to fix the issue and ensure all clients
have the same state. Initial commands that might have the previous wrong
translated sheetId are repaired the best we can.

For future spreadsheet
----------------------
Translate the sheet name upfront and sent it with the sheet creation command.
The `name` property in the command is optional because we know we have
some existing initial commands without this property.
Will become required in master (with a proper command migration script)

opw 2793588

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo