### PR TITLE
[FIX] Error tooltip Popover fix15.0

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -22,7 +22,7 @@ import { Model } from "../model";
 import { cellMenuRegistry } from "../registries/menus/cell_menu_registry";
 import { colMenuRegistry } from "../registries/menus/col_menu_registry";
 import { rowMenuRegistry } from "../registries/menus/row_menu_registry";
-import { CellValueType, Client, Position, SpreadsheetEnv, Viewport } from "../types/index";
+import { BoxDims, CellValueType, Client, Position, SpreadsheetEnv, Viewport } from "../types/index";
 import { Autofill } from "./autofill";
 import { ClientTag } from "./collaborative_client_tag";
 import { GridComposer } from "./composer/grid_composer";
@@ -59,7 +59,7 @@ const registries = {
 };
 
 const LINK_EDITOR_WIDTH = 340;
-const LINK_EDITOR_HEIGHT = 180;
+const LINK_EDITOR_HEIGHT = 197;
 
 const ERROR_TOOLTIP_HEIGHT = 80;
 const ERROR_TOOLTIP_WIDTH = 180;
@@ -199,27 +199,27 @@ const TEMPLATE = xml/* xml */ `
     </t>
     <Popover
       t-if="errorTooltip.isOpen"
-      position="errorTooltip.position"
-      childWidth="${ERROR_TOOLTIP_WIDTH}"
-      childHeight="${ERROR_TOOLTIP_HEIGHT}">
+      anchorRect="errorTooltip.anchorRect"
+      positioning="'right'"
+      dynamicHeight="true"
+      childMaxWidth="${ERROR_TOOLTIP_WIDTH}"
+      childMaxHeight="${ERROR_TOOLTIP_HEIGHT}">
       <ErrorToolTip text="errorTooltip.text"/>
     </Popover>
     <Popover
       t-if="shouldDisplayLink"
-      position="popoverPosition.position"
-      flipHorizontalOffset="-popoverPosition.cellWidth"
-      flipVerticalOffset="-popoverPosition.cellHeight"
-      childWidth="${LINK_TOOLTIP_WIDTH}"
-      childHeight="${LINK_TOOLTIP_HEIGHT}">
+      anchorRect="popoverAnchorRect"
+      positioning="'bottom'"
+      childMaxWidth="${LINK_TOOLTIP_WIDTH}"
+      childMaxHeight="${LINK_TOOLTIP_HEIGHT}">
       <LinkDisplay cellPosition="activeCellPosition"/>
     </Popover>
     <Popover
       t-if="props.linkEditorIsOpen"
-      position="popoverPosition.position"
-      flipHorizontalOffset="-popoverPosition.cellWidth"
-      flipVerticalOffset="-popoverPosition.cellHeight"
-      childWidth="${LINK_EDITOR_WIDTH}"
-      childHeight="${LINK_EDITOR_HEIGHT}">
+      anchorRect="popoverAnchorRect"
+      positioning="'bottom'"
+      childMaxWidth="${LINK_EDITOR_WIDTH}"
+      childMaxHeight="${LINK_EDITOR_HEIGHT}">
       <LinkEditor cellPosition="activeCellPosition"/>
     </Popover>
     <t t-if="getters.getEditionMode() === 'inactive'">
@@ -343,13 +343,13 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
 
     if (cell && cell.evaluated.type === CellValueType.error) {
       const viewport = this.getters.getActiveSnappedViewport();
-      const [x, y, width] = this.getters.getRect(
+      const [x, y, width, height] = this.getters.getRect(
         { left: col, top: row, right: col, bottom: row },
         viewport
       );
       return {
         isOpen: true,
-        position: { x: x + width, y: y + TOPBAR_HEIGHT },
+        anchorRect: { x: x, y: y + TOPBAR_HEIGHT, height, width },
         text: cell.evaluated.error,
       };
     }
@@ -383,7 +383,7 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
    * Get a reasonable position to display the popover, under the active cell.
    * Used by link popover components.
    */
-  get popoverPosition() {
+  get popoverAnchorRect(): BoxDims {
     const [col, row] = this.getters.getBottomLeftCell(
       this.getters.getActiveSheetId(),
       ...this.getters.getPosition()
@@ -393,11 +393,7 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
       { left: col, top: row, right: col, bottom: row },
       viewport
     );
-    return {
-      position: { x, y: y + height + TOPBAR_HEIGHT },
-      cellWidth: width,
-      cellHeight: height,
-    };
+    return { x, y: y + TOPBAR_HEIGHT, height, width };
   }
 
   // this map will handle most of the actions that should happen on key down. The arrow keys are managed in the key

--- a/src/components/popover.ts
+++ b/src/components/popover.ts
@@ -1,62 +1,81 @@
 import * as owl from "@odoo/owl";
 import { BOTTOMBAR_HEIGHT, SCROLLBAR_WIDTH, TOPBAR_HEIGHT } from "../constants";
-import { DOMCoordinates, GridDimension, SpreadsheetEnv } from "../types";
+import { BoxDims, GridDimension, SpreadsheetEnv } from "../types";
 const { Component, tags } = owl;
 const { Portal } = owl.misc;
 const { xml } = tags;
 
 const TEMPLATE = xml/* xml */ `
   <Portal target="'.o-spreadsheet'">
-    <div t-att-style="style">
+    <div class="o-spreadsheet-popover" t-att-style="style">
       <t t-slot="default"/>
     </div>
   </Portal>
 `;
 
+interface Position {
+  border: "top" | "bottom" | "left" | "right";
+  coord: number;
+}
+
 interface Props {
   /**
+   * Rectangle beside which the popover is displayed.
    * Coordinates are expressed relative to the ".o-spreadsheet" element.
    */
-  position: DOMCoordinates;
+  anchorRect: BoxDims;
+
+  /** The popover can be positioned below the anchor Rectangle, or to the right of the rectangle */
+  positioning: "bottom" | "right";
+
+  /** Minimum margin between the top of the screen and the popover */
   marginTop: number;
-  childWidth: number;
-  childHeight: number;
-  /**
-   * The component is moved by this amount to the left when
-   * it is rendered on the left.
+
+  childMaxWidth: number;
+  childMaxHeight: number;
+
+  /** If false, the popover have a fixed width = childMaxWidth. Else it has a dynamic width that can go up to childMaxWidth */
+  dynamicWidth: boolean;
+  /** If false, the popover have a fixed height = childMaxHeight. Else it has a dynamic height that can go up to childMaxHeight */
+  dynamicHeight: boolean;
+
+  /** Offset to apply to the vertical position of the popover. Useful to not take padding into account when positioning
+   * the Component for example.
    */
-  flipHorizontalOffset: number;
-  /**
-   * The component is moved by this amount to the top when
-   * it is rendered on the top.
-   */
-  flipVerticalOffset: number;
+  verticalOffset: number;
 }
 
 export class Popover extends Component<Props, SpreadsheetEnv> {
   static template = TEMPLATE;
   static components = { Portal };
   static defaultProps = {
-    flipHorizontalOffset: 0,
-    flipVerticalOffset: 0,
+    positioning: "bottom",
+    dynamicHeight: false,
+    dynamicWidth: false,
     verticalOffset: 0,
     marginTop: 0,
   };
   private getters = this.env.getters;
 
   get style() {
-    const horizontalPosition = `left:${this.horizontalPosition()}`;
-    const verticalPosition = `top:${this.verticalPosition()}`;
-    const height = `max-height:${
-      this.viewportDimension.height - BOTTOMBAR_HEIGHT - SCROLLBAR_WIDTH
-    }`;
+    const horizontalPosition = this.horizontalPosition();
+    const verticalPosition = this.verticalPosition();
+
+    const height = `${this.props.dynamicHeight ? "max-height" : "height"}:${Math.min(
+      this.viewportDimension.height - BOTTOMBAR_HEIGHT - SCROLLBAR_WIDTH,
+      this.props.childMaxHeight
+    )}px`;
+    const width = `${this.props.dynamicWidth ? "max-width" : "width"}:${
+      this.props.childMaxWidth
+    }px`;
+
     return `
       position: absolute;
       z-index: 5;
-      ${verticalPosition}px;
-      ${horizontalPosition}px;
-      ${height}px;
-      width:${this.props.childWidth}px;
+      ${verticalPosition.border}:${verticalPosition.coord}px;
+      ${horizontalPosition.border}:${horizontalPosition.coord}px;
+      ${height};
+      ${width};
       overflow-y: auto;
       overflow-x: hidden;
       box-shadow: 1px 2px 5px 2px rgb(51 51 51 / 15%);
@@ -68,31 +87,69 @@ export class Popover extends Component<Props, SpreadsheetEnv> {
   }
 
   private get shouldRenderRight(): boolean {
-    const { x } = this.props.position;
-    return x + this.props.childWidth < this.viewportDimension.width;
+    const { x } = this.props.anchorRect;
+    return this.props.positioning === "bottom"
+      ? x + this.props.childMaxWidth < this.viewportDimension.width
+      : x + this.props.childMaxWidth + this.props.anchorRect.width < this.viewportDimension.width;
   }
 
   private get shouldRenderBottom(): boolean {
-    const { y } = this.props.position;
-    return y + this.props.childHeight < this.viewportDimension.height + TOPBAR_HEIGHT;
+    const { y } = this.props.anchorRect;
+    const maxY = this.viewportDimension.height + TOPBAR_HEIGHT;
+    return this.props.positioning === "bottom"
+      ? y + this.props.childMaxHeight + this.props.anchorRect.height < maxY
+      : y + this.props.childMaxHeight < maxY;
   }
 
-  private horizontalPosition(): number {
-    const { x } = this.props.position;
-    if (this.shouldRenderRight) {
-      return x;
+  private horizontalPosition(): Position {
+    const { x, width } = this.props.anchorRect;
+
+    if (this.props.positioning === "right") {
+      if (this.shouldRenderRight) {
+        return { coord: x + width, border: "left" }; // left border at right of anchorRect
+      } else {
+        // in CSS, right is the distance between right of the page and right of element, not coordinate of right
+        return { coord: window.innerWidth - x, border: "right" }; // right border at left of anchorRect
+      }
+    } else {
+      if (this.shouldRenderRight) {
+        return { coord: x, border: "left" }; // left border at left anchorRect
+      } else {
+        return { coord: window.innerWidth - x - width, border: "right" }; // right border at right of anchorRect
+      }
     }
-    return x - this.props.childWidth - this.props.flipHorizontalOffset;
   }
 
-  private verticalPosition(): number {
-    const { y } = this.props.position;
-    if (this.shouldRenderBottom) {
-      return y;
+  private verticalPosition(): Position {
+    let verticalPosition: Position;
+    const { y, height } = this.props.anchorRect;
+
+    if (this.props.positioning === "right") {
+      if (this.shouldRenderBottom) {
+        verticalPosition = { coord: y, border: "top" }; // top border at top of anchorRect
+      } else {
+        // in CSS, bottom is the distance between bottom of the page and bottom of element, not coordinate of bottom
+        verticalPosition = { coord: window.innerHeight - y - height, border: "bottom" }; // bottom border at bottom of anchorRect
+      }
+    } else {
+      if (this.shouldRenderBottom) {
+        verticalPosition = { coord: y + height, border: "top" }; // top border at bottom of anchorRect
+      } else {
+        verticalPosition = { coord: window.innerHeight - y, border: "bottom" }; // bottom border at top of anchorRect
+      }
     }
-    return Math.max(
-      y - this.props.childHeight + this.props.flipVerticalOffset,
-      this.props.marginTop
-    );
+
+    verticalPosition.coord -= this.props.verticalOffset;
+
+    if (this.props.marginTop && verticalPosition.border === "bottom") {
+      const topCoordinate =
+        window.innerHeight - (verticalPosition.coord + this.props.childMaxHeight);
+      const overflowInTopMargin = this.props.marginTop - topCoordinate;
+      if (overflowInTopMargin > 0) {
+        verticalPosition.coord -= overflowInTopMargin;
+      }
+    }
+
+    return verticalPosition;
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,11 +34,12 @@ export const MIN_CF_ICON_MARGIN = 4;
 export const MIN_CELL_TEXT_MARGIN = 4;
 export const CF_ICON_EDGE_LENGTH = 15;
 
-export const LINK_TOOLTIP_HEIGHT = 43;
+export const LINK_TOOLTIP_HEIGHT = 43.5;
 export const LINK_TOOLTIP_WIDTH = 220;
 
 // Menus
 export const MENU_WIDTH = 200;
+export const MENU_VERTICAL_PADDING = 8;
 export const MENU_ITEM_HEIGHT = 24;
 export const MENU_SEPARATOR_BORDER_WIDTH = 1;
 export const MENU_SEPARATOR_PADDING = 5;

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -10,11 +10,17 @@ export interface DOMCoordinates {
   y: number;
 }
 
-export interface Box {
+/**
+ * Coordinate and sizes in pixels
+ */
+export interface BoxDims {
   x: number;
   y: number;
   width: number;
   height: number;
+}
+
+export interface Box extends BoxDims {
   text: string;
   textWidth: number;
   style: Style | null;

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -52,12 +52,13 @@ exports[`Grid component simple rendering snapshot 1`] = `
 
 exports[`error tooltip can display error tooltip 1`] = `
 <div
+  class="o-spreadsheet-popover"
   style="
       position: absolute;
       z-index: 5;
       top:250px;
       left:336px;
-      max-height:934px;
+      max-height:80px;
       width:180px;
       overflow-y: auto;
       overflow-x: hidden;

--- a/tests/components/popover.test.ts
+++ b/tests/components/popover.test.ts
@@ -1,0 +1,215 @@
+import { Model, Spreadsheet } from "../../src";
+import { Popover } from "../../src/components/popover";
+import { BoxDims } from "../../src/types";
+import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+
+const POPOVER_HEIGHT = 200;
+const POPOVER_WIDTH = 200;
+
+let fixture: HTMLElement;
+let model: Model;
+let parent: Spreadsheet;
+
+async function mountTestPopover(args: {
+  anchorRect: BoxDims;
+  positioning?: "bottom" | "right";
+  dynamicHeight?: boolean;
+  dynamicWidth?: boolean;
+}) {
+  const popover = new Popover(parent, {
+    anchorRect: args.anchorRect,
+    positioning: args.positioning || "right",
+    childMaxWidth: POPOVER_WIDTH,
+    childMaxHeight: POPOVER_HEIGHT,
+    marginTop: 0,
+    dynamicHeight: !!args.dynamicHeight,
+    dynamicWidth: !!args.dynamicWidth,
+    verticalOffset: 0,
+  });
+  await popover.mount(fixture);
+  await nextTick();
+}
+
+beforeEach(async () => {
+  fixture = makeTestFixture();
+  const data = {
+    sheets: [
+      {
+        colNumber: 10,
+        rowNumber: 10,
+      },
+    ],
+  };
+  parent = await mountSpreadsheet(fixture, { data });
+  model = parent.model;
+});
+
+afterEach(() => {
+  parent.destroy();
+  fixture.remove();
+});
+
+describe("Popover sizing", () => {
+  test("Base sizing", async () => {
+    await mountTestPopover({
+      anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+      positioning: "right",
+    });
+    const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+    expect(popover).toBeTruthy();
+    expect(popover.style["width"]).toEqual(`${POPOVER_WIDTH}px`);
+    expect(popover.style["height"]).toEqual(`${POPOVER_HEIGHT}px`);
+  });
+
+  test("Prop dynamicHeight makes popover use max-height instead of height", async () => {
+    await mountTestPopover({
+      anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+      positioning: "right",
+      dynamicHeight: true,
+    });
+    const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+    expect(popover).toBeTruthy();
+    expect(popover.style["height"]).toBeFalsy();
+    expect(popover.style["max-height"]).toEqual(`${POPOVER_HEIGHT}px`);
+  });
+
+  test("Prop dynamicWidth makes popover use max-width instead of width", async () => {
+    await mountTestPopover({
+      anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+      positioning: "right",
+      dynamicWidth: true,
+    });
+    const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+    expect(popover).toBeTruthy();
+    expect(popover.style["width"]).toBeFalsy();
+    expect(popover.style["max-width"]).toEqual(`${POPOVER_WIDTH}px`);
+  });
+});
+
+describe("Popover positioning", () => {
+  describe("Popover positioned right", () => {
+    test("Popover right of point", async () => {
+      await mountTestPopover({
+        anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+        positioning: "right",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["left"]).toEqual("0px");
+      expect(popover.style["top"]).toEqual("0px");
+    });
+
+    test("Popover right of box", async () => {
+      await mountTestPopover({
+        anchorRect: { x: 0, y: 0, width: 100, height: 100 },
+        positioning: "right",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["left"]).toEqual("100px");
+      expect(popover.style["top"]).toEqual("0px");
+    });
+
+    test("Popover overflowing right is rendered left of box", async () => {
+      const viewPortDims = model.getters.getViewportDimension();
+      const box = { x: viewPortDims.width, y: 0, width: 100, height: 100 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "right",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["right"]).toEqual(`${window.innerWidth - box.x}px`);
+      expect(popover.style["top"]).toEqual("0px");
+    });
+
+    test("Popover overflowing down is rendered with its bottom aligned to the bottom of the box", async () => {
+      const viewPortDims = model.getters.getViewportDimension();
+      const box = { x: 0, y: viewPortDims.height, width: 100, height: 100 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "right",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["left"]).toEqual("100px");
+      expect(popover.style["bottom"]).toEqual(`${window.innerHeight - box.y - box.height}px`);
+    });
+
+    test("Popover overflowing down and right is rendered to the left of the box with its bottom aligned to the bottom of the box", async () => {
+      const viewPortDims = model.getters.getViewportDimension();
+      const box = { x: viewPortDims.width, y: viewPortDims.height, width: 100, height: 100 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "right",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["right"]).toEqual(`${window.innerWidth - box.x}px`);
+      expect(popover.style["bottom"]).toEqual(`${window.innerHeight - box.y - box.height}px`);
+    });
+  });
+
+  describe("Popover positioned bottom", () => {
+    test("Popover bottom of point", async () => {
+      await mountTestPopover({
+        anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+        positioning: "bottom",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["left"]).toEqual("0px");
+      expect(popover.style["top"]).toEqual("0px");
+    });
+
+    test("Popover bottom of box", async () => {
+      await mountTestPopover({
+        anchorRect: { x: 0, y: 0, width: 100, height: 100 },
+        positioning: "bottom",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["left"]).toEqual("0px");
+      expect(popover.style["top"]).toEqual("100px");
+    });
+
+    test("Popover overflowing right is rendered with its right border matching the box right border", async () => {
+      const viewPortDims = model.getters.getViewportDimension();
+      const box = { x: viewPortDims.width, y: 0, width: 100, height: 100 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "bottom",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["right"]).toEqual(`${window.innerWidth - box.x - box.width}px`);
+      expect(popover.style["top"]).toEqual("100px");
+    });
+
+    test("Popover overflowing down is rendered above the box", async () => {
+      const viewPortDims = model.getters.getViewportDimension();
+      const box = { x: 0, y: viewPortDims.height, width: 100, height: 100 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "bottom",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["left"]).toEqual("0px");
+      expect(popover.style["bottom"]).toEqual(`${window.innerHeight - box.y}px`);
+    });
+
+    test("Popover overflowing down and right is rendered with its right border matching the box right border and above the box", async () => {
+      const viewPortDims = model.getters.getViewportDimension();
+      const box = { x: viewPortDims.width, y: viewPortDims.height, width: 100, height: 100 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "bottom",
+      });
+      const popover = fixture.querySelector(".o-spreadsheet-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style["right"]).toEqual(`${window.innerWidth - box.x - box.width}px`);
+      expect(popover.style["bottom"]).toEqual(`${window.innerHeight - box.y}px`);
+    });
+  });
+});


### PR DESCRIPTION
## Description:

The popovers components have some problems : 

- It's currently not possible to define the height of a popover. The "childHeight" props is only used for positioning.
- flipHorizontalOffset/flipVerticalOffset props are confusing to use. They should sometime be positive, sometime negatives, and computed by hand to use popovers. Ideally we'd want the logic of it to be hidden in the component.  

Refactored the popover component to now take as a props a Rectangle, and where it should be displayed relative to this rectangle (at the right/bottom). The positioning logic is now inside the component, which make it easier to use. Also allow the popover to either have a fixed size, or a dynamic size (with height or max-height).

Odoo task ID : [2796248](https://www.odoo.com/web#id=2796248&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo