### PR TITLE
[FIX]  popover fix 15.0

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -61,7 +61,7 @@ const registries = {
 const LINK_EDITOR_WIDTH = 340;
 const LINK_EDITOR_HEIGHT = 180;
 
-const ERROR_TOOLTIP_HEIGHT = 80;
+const ERROR_TOOLTIP_HEIGHT = 40;
 const ERROR_TOOLTIP_WIDTH = 180;
 // copy and paste are specific events that should not be managed by the keydown event,
 // but they shouldn't be preventDefault and stopped (else copy and paste events will not trigger)
@@ -200,6 +200,7 @@ const TEMPLATE = xml/* xml */ `
     <Popover
       t-if="errorTooltip.isOpen"
       position="errorTooltip.position"
+      flipHorizontalOffset="errorTooltip.cellWidth"
       childWidth="${ERROR_TOOLTIP_WIDTH}"
       childHeight="${ERROR_TOOLTIP_HEIGHT}">
       <ErrorToolTip text="errorTooltip.text"/>
@@ -351,6 +352,7 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
         isOpen: true,
         position: { x: x + width, y: y + TOPBAR_HEIGHT },
         text: cell.evaluated.error,
+        cellWidth: width,
       };
     }
     return { isOpen: false };


### PR DESCRIPTION
## Description:

Errors popovers at the bottom or right of the screen have the wrong position.

Odoo task ID : [2797193](https://www.odoo.com/web#id=2797193&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo