### PR TITLE
[REF] popovers : improve popover component

### DIFF
--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -1,4 +1,4 @@
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, useChildSubEnv, useRef, useState } from "@odoo/owl";
 import { positionToZone } from "../../helpers/zones";
 import { clickableCellRegistry } from "../../registries/cell_clickable_registry";
 import {
@@ -59,6 +59,7 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
     this.canvasPosition = useAbsolutePosition(gridRef);
     this.hoveredCell = useState({ col: undefined, row: undefined });
 
+    useChildSubEnv({ getPopoverContainerRect: () => this.getGridRect() });
     useGridDrawing("canvas", this.env.model, () => this.env.model.getters.getSheetViewDimension());
     this.onMouseWheel = useWheelHandler((deltaX, deltaY) => {
       this.moveCanvas(deltaX, deltaY);
@@ -168,6 +169,10 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
       offsetX: offsetScrollbarX + deltaX,
       offsetY: offsetScrollbarY + deltaY,
     });
+  }
+
+  private getGridRect(): Rect {
+    return { ...this.canvasPosition, ...this.env.model.getters.getSheetViewDimensionWithHeaders() };
   }
 }
 

--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -14,8 +14,8 @@
         />
         <canvas t-ref="canvas"/>
         <GridPopover
-          gridPosition="canvasPosition"
           hoveredCell="hoveredCell"
+          gridRect="getGridRect()"
           onMouseWheel.bind="onMouseWheel"
           onClosePopover.bind="onClosePopover"
         />

--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -4,7 +4,7 @@ import { CellPopoverComponent, PopoverBuilders } from "../../types/cell_popovers
 import { CellErrorLevel } from "../../types/errors";
 import { css } from "../helpers/css";
 
-const ERROR_TOOLTIP_HEIGHT = 40;
+const ERROR_TOOLTIP_MAX_HEIGHT = 80;
 const ERROR_TOOLTIP_WIDTH = 180;
 
 css/* scss */ `
@@ -13,6 +13,8 @@ css/* scss */ `
     background-color: white;
     border-left: 3px solid red;
     padding: 10px;
+    width: ${ERROR_TOOLTIP_WIDTH}px;
+    box-sizing: border-box !important;
   }
 `;
 
@@ -22,7 +24,7 @@ interface ErrorToolTipProps {
 }
 
 class ErrorToolTip extends Component<ErrorToolTipProps> {
-  static size = { width: ERROR_TOOLTIP_WIDTH, height: ERROR_TOOLTIP_HEIGHT };
+  static maxSize = { maxHeight: ERROR_TOOLTIP_MAX_HEIGHT };
   static template = "o-spreadsheet-ErrorToolTip";
   static components = {};
 }

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -9,6 +9,7 @@ import { Menu, MenuState } from "../../menu/menu";
 
 interface Props {
   figure: Figure;
+  onFigureDeleted: () => void;
 }
 
 export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
@@ -106,3 +107,8 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
     return this.env.model.getters.getImagePath(this.figureId);
   }
 }
+
+ImageFigure.props = {
+  figure: Object,
+  onFigureDeleted: Function,
+};

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -1,4 +1,12 @@
-import { Component, onMounted, useEffect, useExternalListener, useRef, useState } from "@odoo/owl";
+import {
+  Component,
+  onMounted,
+  useChildSubEnv,
+  useEffect,
+  useExternalListener,
+  useRef,
+  useState,
+} from "@odoo/owl";
 import {
   AUTOFILL_EDGE_LENGTH,
   HEADER_HEIGHT,
@@ -21,6 +29,7 @@ import {
   HeaderIndex,
   Pixel,
   Position,
+  Rect,
   Ref,
   SpreadsheetChildEnv,
 } from "../../types/index";
@@ -109,6 +118,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     this.canvasPosition = useAbsolutePosition(this.gridRef);
     this.hoveredCell = useState({ col: undefined, row: undefined });
 
+    useChildSubEnv({ getPopoverContainerRect: () => this.getGridRect() });
     useExternalListener(document.body, "cut", this.copy.bind(this, true));
     useExternalListener(document.body, "copy", this.copy.bind(this, false));
     useExternalListener(document.body, "paste", this.paste);
@@ -332,6 +342,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
 
   isCellHovered(col: HeaderIndex, row: HeaderIndex): boolean {
     return this.hoveredCell.col === col && this.hoveredCell.row === row;
+  }
+
+  private getGridRect(): Rect {
+    return { ...this.canvasPosition, ...this.env.model.getters.getSheetViewDimensionWithHeaders() };
   }
 
   // ---------------------------------------------------------------------------

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -51,8 +51,8 @@
       </t>
       <GridPopover
         t-if="!menuState.isOpen"
-        gridPosition="canvasPosition"
         hoveredCell="hoveredCell"
+        gridRect="getGridRect()"
         onMouseWheel.bind="onMouseWheel"
         onClosePopover.bind="onClosePopover"
       />

--- a/src/components/grid_popover/grid_popover.ts
+++ b/src/components/grid_popover/grid_popover.ts
@@ -1,11 +1,11 @@
 import { Component } from "@odoo/owl";
-import { DOMCoordinates, Position, SpreadsheetChildEnv } from "../../types";
+import { Position, Rect, SpreadsheetChildEnv } from "../../types";
 import { ClosedCellPopover, PositionedCellPopover } from "../../types/cell_popovers";
 import { Popover } from "../popover/popover";
 
 interface Props {
-  gridPosition: DOMCoordinates;
   hoveredCell: Partial<Position>;
+  gridRect: Rect;
   onClosePopover: () => void;
   onMouseWheel: (ev: WheelEvent) => void;
 }
@@ -18,21 +18,22 @@ export class GridPopover extends Component<Props, SpreadsheetChildEnv> {
     if (!popover.isOpen) {
       return { isOpen: false };
     }
-    const coordinates = popover.coordinates;
+    const anchorRect = popover.anchorRect;
     return {
       ...popover,
       // transform from the "canvas coordinate system" to the "body coordinate system"
-      coordinates: {
-        x: coordinates.x + this.props.gridPosition.x,
-        y: coordinates.y + this.props.gridPosition.y,
+      anchorRect: {
+        ...anchorRect,
+        x: anchorRect.x + this.props.gridRect.x,
+        y: anchorRect.y + this.props.gridRect.y,
       },
     };
   }
 }
 
 GridPopover.props = {
-  gridPosition: Object,
   hoveredCell: Object,
   onClosePopover: Function,
   onMouseWheel: Function,
+  gridRect: Object,
 };

--- a/src/components/grid_popover/grid_popover.xml
+++ b/src/components/grid_popover/grid_popover.xml
@@ -2,11 +2,11 @@
   <t t-name="o-spreadsheet-GridPopover" owl="1">
     <Popover
       t-if="cellPopover.isOpen"
-      position="cellPopover.coordinates"
-      childWidth="cellPopover.Component.size.width"
-      childHeight="cellPopover.Component.size.height"
-      flipHorizontalOffset="cellPopover.cellWidth"
-      flipVerticalOffset="cellPopover.cellHeight"
+      positioning="cellPopover.cellCorner"
+      maxHeight="cellPopover.Component.size and cellPopover.Component.size.maxHeight"
+      maxWidth="cellPopover.Component.size and cellPopover.Component.size.maxHidth"
+      anchorRect="cellPopover.anchorRect"
+      containerRect="env.getPopoverContainerRect()"
       onMouseWheel="props.onMouseWheel">
       <t
         t-component="cellPopover.Component"

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -7,7 +7,7 @@ import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popov
 import { css } from "../../helpers/css";
 import { Menu } from "../../menu/menu";
 
-const LINK_TOOLTIP_HEIGHT = 43;
+const LINK_TOOLTIP_HEIGHT = 32;
 const LINK_TOOLTIP_WIDTH = 220;
 
 css/* scss */ `
@@ -19,6 +19,9 @@ css/* scss */ `
     border-radius: 4px;
     display: flex;
     justify-content: space-between;
+    height: ${LINK_TOOLTIP_HEIGHT}px;
+    width: ${LINK_TOOLTIP_WIDTH}px;
+    box-sizing: border-box !important;
 
     img {
       margin-right: 3px;
@@ -63,7 +66,6 @@ interface LinkDisplayProps {
 export class LinkDisplay extends Component<LinkDisplayProps, SpreadsheetChildEnv> {
   static components = { Menu };
   static template = "o-spreadsheet-LinkDisplay";
-  static size = { width: LINK_TOOLTIP_WIDTH, height: LINK_TOOLTIP_HEIGHT };
 
   get cell(): EvaluatedCell {
     const { col, row } = this.props.cellPosition;

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -12,7 +12,7 @@ const MENU_OFFSET_X = 320;
 const MENU_OFFSET_Y = 100;
 const PADDING = 12;
 const LINK_EDITOR_WIDTH = 340;
-const LINK_EDITOR_HEIGHT = 180;
+const LINK_EDITOR_HEIGHT = 165;
 
 css/* scss */ `
   .o-link-editor {
@@ -23,6 +23,9 @@ css/* scss */ `
     display: flex;
     flex-direction: column;
     border-radius: 4px;
+    height: ${LINK_EDITOR_HEIGHT}px;
+    width: ${LINK_EDITOR_WIDTH}px;
+
     .o-section {
       .o-section-title {
         font-weight: bold;
@@ -99,7 +102,6 @@ interface State {
 
 export class LinkEditor extends Component<LinkEditorProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-LinkEditor";
-  static size = { width: LINK_EDITOR_WIDTH, height: LINK_EDITOR_HEIGHT };
   static components = { Menu };
   menuItems = linkMenuRegistry.getAll();
   private link: State = useState(this.defaultState);

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -2,12 +2,12 @@
   <t t-name="o-spreadsheet-Menu" owl="1">
     <Popover
       t-if="props.menuItems.length"
-      position="props.position"
-      childWidth="MENU_WIDTH"
-      childHeight="menuHeight"
-      flipHorizontalOffset="popover.flipHorizontalOffset"
-      flipVerticalOffset="popover.flipVerticalOffset"
-      marginTop="popover.marginTop">
+      anchorRect="popover.anchorRect"
+      positioning="popover.positioning"
+      verticalOffset="popover.verticalOffset"
+      onPopoverHidden="() => this.closeSubMenu()"
+      onPopoverMoved="() => this.closeSubMenu()"
+      maxHeight="menuHeight">
       <div
         t-ref="menu"
         class="o-menu"

--- a/src/components/popover/popover.xml
+++ b/src/components/popover/popover.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-Popover" owl="1">
     <t t-portal="'.o-spreadsheet'">
-      <div t-att-style="style" class="o-popover" t-on-wheel="props.onMouseWheel">
+      <div class="o-popover" t-ref="popover" t-on-wheel="props.onMouseWheel">
         <t t-slot="default"/>
       </div>
     </t>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -129,6 +129,7 @@ export const FILTER_ICON_EDGE_LENGTH = 17;
 
 // Menus
 export const MENU_WIDTH = 250;
+export const MENU_VERTICAL_PADDING = 8;
 export const MENU_ITEM_HEIGHT = 28;
 export const MENU_SEPARATOR_BORDER_WIDTH = 1;
 export const MENU_SEPARATOR_PADDING = 5;

--- a/src/helpers/rectangle.ts
+++ b/src/helpers/rectangle.ts
@@ -1,0 +1,28 @@
+import { Rect, Zone } from "../types";
+import { intersection } from "./zones";
+
+/**
+ * Compute the intersection of two rectangles. Returns nothing if the two rectangles don't overlap
+ */
+export function rectIntersection(rect1: Rect, rect2: Rect): Rect | undefined {
+  return zoneToRect(intersection(rectToZone(rect1), rectToZone(rect2)));
+}
+
+function rectToZone(rect: Rect): Zone {
+  return {
+    left: rect.x,
+    top: rect.y,
+    right: rect.x + rect.width,
+    bottom: rect.y + rect.height,
+  };
+}
+
+function zoneToRect(zone: Zone | undefined): Rect | undefined {
+  if (!zone) return undefined;
+  return {
+    x: zone.left,
+    y: zone.top,
+    width: zone.right - zone.left,
+    height: zone.bottom - zone.top,
+  };
+}

--- a/src/types/cell_popovers.ts
+++ b/src/types/cell_popovers.ts
@@ -1,12 +1,13 @@
 import { ComponentConstructor } from "@odoo/owl";
 import { Getters } from "./index";
 import { CellPosition, PropsOf } from "./misc";
-import { DOMCoordinates } from "./rendering";
+import { Rect } from "./rendering";
 
 export type CellPopoverType = "ErrorToolTip" | "LinkDisplay" | "FilterMenu" | "LinkEditor";
+export type PopoverPropsPosition = "TopRight" | "BottomLeft";
 
-type SizedComponentConstructor = ComponentConstructor & {
-  size: { width: number; height: number };
+type MaxSizedComponentConstructor = ComponentConstructor & {
+  maxSize?: { maxWidth?: number; maxHeight?: number };
 };
 
 /**
@@ -16,7 +17,7 @@ type SizedComponentConstructor = ComponentConstructor & {
 type CellPopoverBuilder = (
   position: CellPosition,
   getters: Getters
-) => CellPopoverComponent<SizedComponentConstructor>;
+) => CellPopoverComponent<MaxSizedComponentConstructor>;
 
 export interface PopoverBuilders {
   onOpen?: CellPopoverBuilder;
@@ -36,19 +37,19 @@ type OpenCellPopover<C extends ComponentConstructor> = {
   isOpen: true;
   Component: C;
   props: PropsOf<C>;
-  cellCorner: "TopRight" | "BottomLeft";
+  cellCorner: PopoverPropsPosition;
 };
 
-export type CellPopoverComponent<C extends SizedComponentConstructor = SizedComponentConstructor> =
-  | ClosedCellPopover
-  | OpenCellPopover<C>;
+export type CellPopoverComponent<
+  C extends MaxSizedComponentConstructor = MaxSizedComponentConstructor
+> = ClosedCellPopover | OpenCellPopover<C>;
 
-export type PositionedCellPopover<C extends SizedComponentConstructor = SizedComponentConstructor> =
-  {
-    isOpen: true;
-    Component: C;
-    props: PropsOf<C>;
-    coordinates: DOMCoordinates;
-    cellWidth: number;
-    cellHeight: number;
-  };
+export type PositionedCellPopover<
+  C extends MaxSizedComponentConstructor = MaxSizedComponentConstructor
+> = {
+  isOpen: true;
+  Component: C;
+  props: PropsOf<C>;
+  anchorRect: Rect;
+  cellCorner: PopoverPropsPosition;
+};

--- a/tests/components/__snapshots__/context_menu.test.ts.snap
+++ b/tests/components/__snapshots__/context_menu.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Context Menu context menu simple rendering 1`] = `
+exports[`Standalone context menu tests Context Menu context menu simple rendering 1`] = `
 <div
   class="o-menu"
 >

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -120,17 +120,7 @@ height: 1px;
 exports[`error tooltip can display error tooltip 1`] = `
 <div
   class="o-popover"
-  style="
-      position: absolute;
-      z-index: 30;
-      top:187px;
-      left:336px;
-      max-height:960px;
-      width:180px;
-      overflow-y: auto;
-      overflow-x: hidden;
-      box-shadow: 1px 2px 5px 2px rgb(51 51 51 / 15%);
-    "
+  style="visibility: visible; max-height: 824px; max-width: 697px; top: 187px; left: 336px;"
 >
   <div
     class="o-error-tooltip"

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1,7 +1,6 @@
 import { App } from "@odoo/owl";
 import { CommandResult, Model, Spreadsheet } from "../../src";
 import { ChartTerms } from "../../src/components/translations_terms";
-import { BACKGROUND_CHART_COLOR } from "../../src/constants";
 import { toHex, toZone } from "../../src/helpers";
 import { ChartDefinition } from "../../src/types";
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
@@ -12,6 +11,7 @@ import {
   createScorecardChart,
   updateChart,
 } from "../test_helpers/commands_helpers";
+import { TEST_CHART_DATA } from "../test_helpers/constants";
 import {
   setInputValueAndTrigger,
   simulateClick,
@@ -26,50 +26,13 @@ import {
   spyDispatch,
   textContentAll,
 } from "../test_helpers/helpers";
+import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
-export const TEST_CHART_DATA = {
-  basicChart: {
-    type: "bar" as const,
-    dataSets: ["B1:B4"],
-    labelRange: "A2:A4",
-    dataSetsHaveTitle: true,
-    title: "hello",
-    background: BACKGROUND_CHART_COLOR,
-    verticalAxisPosition: "left" as const,
-    stacked: false,
-    legendPosition: "top" as const,
-  },
-  scorecard: {
-    type: "scorecard" as const,
-    keyValue: "B1:B4",
-    baseline: "A2:A4",
-    title: "hello",
-    baselineDescr: "description",
-    baselineMode: "difference" as const,
-  },
-  gauge: {
-    type: "gauge" as const,
-    dataRange: "B1:B4",
-    title: "hello",
-    sectionRule: {
-      rangeMin: "0",
-      rangeMax: "100",
-      colors: {
-        lowerColor: "#6aa84f",
-        middleColor: "#f1c232",
-        upperColor: "#cc0000",
-      },
-      lowerInflectionPoint: {
-        type: "number" as const,
-        value: "33",
-      },
-      upperInflectionPoint: {
-        type: "number" as const,
-        value: "66",
-      },
-    },
-  },
-};
+mockGetBoundingClientRect({
+  "o-popover": () => ({ height: 0, width: 0 }),
+  "o-spreadsheet": () => ({ top: 100, left: 200, height: 1000, width: 1000 }),
+  "o-figure-menu-item": () => ({ top: 500, left: 500 }),
+});
 
 function createTestChart(type: string) {
   switch (type) {
@@ -88,19 +51,6 @@ function createTestChart(type: string) {
 function errorMessages(): string[] {
   return textContentAll(".o-sidepanel-error div");
 }
-
-const originalGetBoundingClientRect = HTMLDivElement.prototype.getBoundingClientRect;
-jest
-  .spyOn(HTMLDivElement.prototype, "getBoundingClientRect")
-  // @ts-ignore the mock should return a complete DOMRect, not only { top, left }
-  .mockImplementation(function (this: HTMLDivElement) {
-    if (this.className.includes("o-spreadsheet")) {
-      return { top: 100, left: 200 };
-    } else if (this.className.includes("o-figure-menu-item")) {
-      return { top: 500, left: 500 };
-    }
-    return originalGetBoundingClientRect.call(this);
-  });
 
 let fixture: HTMLElement;
 let model: Model;

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -1,6 +1,6 @@
 import { App, Component, useSubEnv, xml } from "@odoo/owl";
 import { Menu } from "../../src/components/menu/menu";
-import { MENU_ITEM_HEIGHT, MENU_WIDTH, TOPBAR_HEIGHT } from "../../src/constants";
+import { MENU_ITEM_HEIGHT, MENU_VERTICAL_PADDING, MENU_WIDTH } from "../../src/constants";
 import { toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { createFullMenuItem, FullMenuItem } from "../../src/registries";
@@ -10,56 +10,62 @@ import { setCellContent } from "../test_helpers/commands_helpers";
 import { rightClickCell, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import {
+  getStylePropertyInPx,
   makeTestFixture,
   MockClipboard,
   mountSpreadsheet,
   nextTick,
   Touch,
 } from "../test_helpers/helpers";
+import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
 let fixture: HTMLElement;
 let app: App;
 let model: Model;
 
-beforeEach(async () => {
-  const clipboard = new MockClipboard();
-  Object.defineProperty(navigator, "clipboard", {
-    get() {
-      return clipboard;
-    },
-    configurable: true,
-  });
-  fixture = makeTestFixture();
-  ({ app, model } = await mountSpreadsheet(fixture));
+mockGetBoundingClientRect({
+  "o-menu": (el) => getElPosition(el),
+  "o-popover": (el) => {
+    const childName = (el.firstChild?.firstChild as HTMLElement)?.title;
+    if (childName && childName.includes("subMenu")) {
+      return getSubMenuSize();
+    }
+    return getMenuSize();
+  },
+  "o-spreadsheet": () => ({ top: 0, left: 0, height: 1000, width: 1000 }),
 });
 
-afterEach(() => {
-  app.destroy();
-  fixture.remove();
-});
+function getElPosition(element: string | Element): {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+} {
+  const menu = typeof element === "string" ? fixture.querySelector<HTMLElement>(element)! : element;
 
-function getSelectionAnchorCellXc(model: Model): string {
-  const { col, row } = model.getters.getSelection().anchor.cell;
-  return toXC(col, row);
-}
+  const top = getStylePropertyInPx(menu.parentElement!, "top")!;
+  const left = getStylePropertyInPx(menu.parentElement!, "left")!;
+  const width = getStylePropertyInPx(menu.parentElement!, "width");
+  const height = getStylePropertyInPx(menu.parentElement!, "height");
+  const maxHeight = getStylePropertyInPx(menu.parentElement!, "max-height")!;
+  const maxWidth = getStylePropertyInPx(menu.parentElement!, "max-width")!;
 
-function getPosition(element: string | Element): { top: number; left: number } {
-  const menu = typeof element === "string" ? fixture.querySelector(element)! : element;
-  const { top, left } = window.getComputedStyle(menu.parentElement!);
   return {
-    top: parseInt(top.replace("px", "")),
-    left: parseInt(left.replace("px", "")),
+    top,
+    left,
+    width: width || maxWidth,
+    height: height || maxHeight,
   };
 }
 
 function getMenuPosition() {
-  const { left, top } = getPosition(".o-menu");
-  return { left, top: top - TOPBAR_HEIGHT };
+  const { left, top } = getElPosition(".o-menu");
+  return { left, top: top };
 }
 
 function getSubMenuPosition() {
-  const { left, top } = getPosition(fixture.querySelectorAll(".o-menu")[1]);
-  return { left, top: top - TOPBAR_HEIGHT };
+  const { left, top } = getElPosition(fixture.querySelectorAll(".o-menu")[1]);
+  return { left, top: top };
 }
 
 function getItemSize() {
@@ -69,7 +75,7 @@ function getItemSize() {
 function getSize(menuItemsCount: number): { width: number; height: number } {
   return {
     width: MENU_WIDTH,
-    height: getItemSize() * menuItemsCount,
+    height: getItemSize() * menuItemsCount + 2 * MENU_VERTICAL_PADDING,
   };
 }
 
@@ -85,73 +91,83 @@ function getSubMenuSize() {
   return getSize(menuItems.length);
 }
 
-interface ContextMenuTestConfig {
-  onClose?: () => void;
-  menuItems?: FullMenuItem[];
-}
-
-async function renderContextMenu(
-  x: number,
-  y: number,
-  testConfig: ContextMenuTestConfig = {},
-  width = 1000,
-  height = 1000
-): Promise<[number, number]> {
-  // x, y are relative to the upper left grid corner, but the menu
-  // props must take the top bar into account.
-
-  app = new App(ContextMenuParent, {
-    props: {
-      x,
-      y: y + TOPBAR_HEIGHT,
-      width,
-      height,
-      model: new Model(),
-      config: testConfig,
-    },
+describe("Standalone context menu tests", () => {
+  beforeEach(async () => {
+    const clipboard = new MockClipboard();
+    Object.defineProperty(navigator, "clipboard", {
+      get() {
+        return clipboard;
+      },
+      configurable: true,
+    });
+    fixture = makeTestFixture();
+    ({ app, model } = await mountSpreadsheet(fixture));
   });
-  app.addTemplates(OWL_TEMPLATES);
-  parent = await app.mount(fixture);
 
-  await nextTick();
-  return [x, y];
-}
+  afterEach(() => {
+    app.destroy();
+    fixture.remove();
+  });
 
-const subMenu: FullMenuItem[] = [
-  createFullMenuItem("root", {
-    name: "root",
-    sequence: 1,
-    children: [
-      () => [
-        createFullMenuItem("subMenu1", {
-          name: "subMenu1",
-          sequence: 1,
-          action() {},
-        }),
-        createFullMenuItem("subMenu2", {
-          name: "subMenu2",
-          sequence: 1,
-          action() {},
-        }),
+  function getSelectionAnchorCellXc(model: Model): string {
+    const { col, row } = model.getters.getSelection().anchor.cell;
+    return toXC(col, row);
+  }
+
+  interface ContextMenuTestConfig {
+    onClose?: () => void;
+    menuItems?: FullMenuItem[];
+  }
+
+  async function renderContextMenu(
+    x: number,
+    y: number,
+    testConfig: ContextMenuTestConfig = {},
+    width = 1000,
+    height = 1000
+  ): Promise<[number, number]> {
+    // x, y are relative to the upper left grid corner, but the menu
+    // props must take the top bar into account.
+
+    app = new App(ContextMenuParent, {
+      props: {
+        x,
+        y,
+        width,
+        height,
+        model: new Model(),
+        config: testConfig,
+      },
+    });
+    app.addTemplates(OWL_TEMPLATES);
+    parent = await app.mount(fixture);
+    await nextTick();
+    return [x, y];
+  }
+
+  const subMenu: FullMenuItem[] = [
+    createFullMenuItem("root", {
+      name: "root",
+      sequence: 1,
+      children: [
+        () => [
+          createFullMenuItem("subMenu1", {
+            name: "subMenu1",
+            sequence: 1,
+            action() {},
+          }),
+          createFullMenuItem("subMenu2", {
+            name: "subMenu2",
+            sequence: 1,
+            action() {},
+          }),
+        ],
       ],
-    ],
-  }),
-];
+    }),
+  ];
 
-const originalGetBoundingClientRect = HTMLDivElement.prototype.getBoundingClientRect;
-// @ts-ignore the mock should return a complete DOMRect, not only { top, left }
-jest
-  .spyOn(HTMLDivElement.prototype, "getBoundingClientRect")
-  .mockImplementation(function (this: HTMLDivElement) {
-    const menu = this.className.includes("o-menu");
-    if (menu) {
-      return getPosition(this);
-    }
-    return originalGetBoundingClientRect.call(this);
-  });
-
-class ContextMenuParent extends Component {
-  static template = xml/* xml */ `
+  class ContextMenuParent extends Component {
+    static template = xml/* xml */ `
     <div class="o-spreadsheet">
       <Menu
         onClose="() => this.onClose()"
@@ -160,582 +176,634 @@ class ContextMenuParent extends Component {
       />
     </div>
   `;
-  static components = { Menu };
-  menus!: FullMenuItem[];
-  position!: { x: number; y: number; width: number; height: number };
-  onClose!: () => void;
+    static components = { Menu };
+    menus!: FullMenuItem[];
+    position!: { x: number; y: number; width: number; height: number };
+    onClose!: () => void;
 
-  setup() {
-    useSubEnv({
-      model: this.props.model,
-      isDashboard: () => this.props.model.getters.isDashboard(),
-    });
-  }
-
-  constructor(props, env, node) {
-    super(props, env, node);
-    this.onClose = this.props.config.onClose || (() => {});
-    this.position = {
-      x: this.props.x,
-      y: this.props.y,
-      width: this.props.width,
-      height: this.props.height,
-    };
-    this.menus = this.props.config.menuItems || [
-      createFullMenuItem("Action", {
-        name: "Action",
-        sequence: 1,
-        action() {},
-      }),
-    ];
-    this.props.model.dispatch("RESIZE_SHEETVIEW", {
-      height: this.props.height,
-      width: this.props.width,
-      gridOffsetX: 0,
-      gridOffsetY: 0,
-    });
-  }
-}
-
-describe("Context Menu", () => {
-  test("context menu simple rendering", async () => {
-    await rightClickCell(model, "C8");
-    expect(fixture.querySelector(".o-menu")).toMatchSnapshot();
-  });
-
-  test("right click on a cell opens a context menu", async () => {
-    expect(getSelectionAnchorCellXc(model)).toBe("A1");
-    expect(fixture.querySelector(".o-menu")).toBeFalsy();
-    await rightClickCell(model, "C8");
-    expect(getSelectionAnchorCellXc(model)).toBe("C8");
-    expect(fixture.querySelector(".o-menu")).toBeTruthy();
-  });
-
-  test("right click on a cell, then left click elsewhere closes a context menu", async () => {
-    await rightClickCell(model, "C8");
-    expect(getSelectionAnchorCellXc(model)).toBe("C8");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu")).toBeTruthy();
-
-    await simulateClick(".o-grid-overlay", 50, 50);
-    expect(fixture.querySelector(".o-menu")).toBeFalsy();
-  });
-
-  test("can copy/paste with context menu", async () => {
-    setCellContent(model, "B1", "b1");
-
-    await rightClickCell(model, "B1");
-    expect(getSelectionAnchorCellXc(model)).toBe("B1");
-
-    // click on 'copy' menu item
-    await simulateClick(".o-menu div[data-name='copy']");
-
-    await rightClickCell(model, "B2");
-
-    // click on 'paste' menu item
-    await simulateClick(".o-menu div[data-name='paste']");
-    expect(getCellContent(model, "B1")).toBe("b1");
-    expect(getCellContent(model, "B2")).toBe("b1");
-  });
-
-  test("can cut/paste with context menu", async () => {
-    setCellContent(model, "B1", "b1");
-
-    await rightClickCell(model, "B1");
-
-    // click on 'cut' menu item
-    await simulateClick(".o-menu div[data-name='cut']");
-
-    // right click on B2
-    await rightClickCell(model, "B2");
-    await nextTick();
-    expect(getSelectionAnchorCellXc(model)).toBe("B2");
-
-    // click on 'paste' menu item
-    await simulateClick(".o-menu div[data-name='paste']");
-
-    expect(getCell(model, "B1")).toBeUndefined();
-    expect(getCellContent(model, "B2")).toBe("b1");
-  });
-
-  test("menu does not close when right click elsewhere", async () => {
-    await rightClickCell(model, "B1");
-    expect(fixture.querySelector(".o-menu")).toBeTruthy();
-    await rightClickCell(model, "D5");
-    expect(fixture.querySelector(".o-menu")).toBeTruthy();
-  });
-
-  test("close contextmenu when clicking on menubar", async () => {
-    await rightClickCell(model, "B1");
-    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
-    triggerMouseEvent(".o-topbar-topleft", "click");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu")).toBeFalsy();
-  });
-
-  test("close contextmenu when clicking on menubar item", async () => {
-    await rightClickCell(model, "B1");
-    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
-    triggerMouseEvent(".o-topbar-menu[data-id='insert']", "click");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeFalsy();
-  });
-  test("close contextmenu when clicking on tools bar", async () => {
-    await rightClickCell(model, "B1");
-    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
-    const fontSizeTool = fixture.querySelector('.o-tool[title="Font Size"]')!;
-    triggerMouseEvent(fontSizeTool, "click");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeFalsy();
-  });
-
-  test("menu can be hidden/displayed based on the env", async () => {
-    const menuDefinitions = Object.assign({}, cellMenuRegistry.content);
-    cellMenuRegistry
-      .add("visible_action", {
-        name: "visible_action",
-        sequence: 1,
-        isVisible: (env) => getEvaluatedCell(model, "B1").value === "b1",
-        action() {},
-      })
-      .add("hidden_action", {
-        name: "hidden_action",
-        sequence: 2,
-        isVisible: (env) => getEvaluatedCell(model, "B1").value !== "b1",
-        action() {},
+    setup() {
+      useSubEnv({
+        model: this.props.model,
+        isDashboard: () => this.props.model.getters.isDashboard(),
       });
-    setCellContent(model, "B1", "b1");
-    await rightClickCell(model, "B1");
-    expect(fixture.querySelector(".o-menu div[data-name='visible_action']")).toBeTruthy();
-    expect(fixture.querySelector(".o-menu div[data-name='hidden_action']")).toBeFalsy();
-    cellMenuRegistry.content = menuDefinitions;
-  });
+    }
 
-  test("submenu opens and close when (un)overed", async () => {
-    const menuItems: FullMenuItem[] = [
-      createFullMenuItem("action", {
-        name: "action",
-        sequence: 1,
-        action() {},
-      }),
-      createFullMenuItem("root", {
-        name: "root",
-        sequence: 2,
-        children: [
-          () => [
-            createFullMenuItem("subMenu", {
-              name: "subMenu",
-              sequence: 1,
-              action() {},
-            }),
-          ],
-        ],
-      }),
-    ];
-    await renderContextMenu(300, 300, { menuItems });
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='action']", "mouseover");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
-  });
+    constructor(props, env, node) {
+      super(props, env, node);
+      this.onClose = this.props.config.onClose || (() => {});
+      this.position = {
+        x: this.props.x,
+        y: this.props.y,
+        width: this.props.width,
+        height: this.props.height,
+      };
+      this.menus = this.props.config.menuItems || [
+        createFullMenuItem("Action", {
+          name: "Action",
+          sequence: 1,
+          action() {},
+        }),
+      ];
+      this.props.model.dispatch("RESIZE_SHEETVIEW", {
+        height: this.props.height,
+        width: this.props.width,
+        gridOffsetX: 0,
+        gridOffsetY: 0,
+      });
+    }
+  }
 
-  test("Submenu parent is highlighted", async () => {
-    await renderContextMenu(300, 300, { menuItems: cellMenuRegistry.getAll() });
-    const menuItem = fixture.querySelector(".o-menu div[data-name='paste_special']");
-    expect(menuItem?.classList).not.toContain("o-menu-item-active");
-    triggerMouseEvent(menuItem, "mouseover");
-    await nextTick();
-    expect(menuItem?.classList).toContain("o-menu-item-active");
-    triggerMouseEvent(".o-menu div[data-name='paste_value_only']", "mouseover");
-    await nextTick();
-    expect(menuItem?.classList).toContain("o-menu-item-active");
-  });
-
-  test("submenu does not open when disabled", async () => {
-    const menuItems: FullMenuItem[] = [
-      createFullMenuItem("root", {
-        name: "root",
-        sequence: 1,
-        isEnabled: () => false,
-        children: [
-          () => [
-            createFullMenuItem("subMenu", {
-              name: "subMenu",
-              sequence: 1,
-              action() {},
-            }),
-          ],
-        ],
-      }),
-    ];
-    await renderContextMenu(300, 300, { menuItems });
-    expect(fixture.querySelector(".o-menu div[data-name='root']")!.classList).toContain("disabled");
-    await simulateClick(".o-menu div[data-name='root']");
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
-  });
-
-  test("submenu does not close when sub item overed", async () => {
-    await renderContextMenu(300, 300, { menuItems: subMenu });
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='subMenu1']", "mouseover");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
-  });
-
-  test("menu does not close when root menu is clicked", async () => {
-    await renderContextMenu(300, 300, { menuItems: subMenu });
-    await simulateClick(".o-menu div[data-name='root']");
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
-    expect(fixture.querySelector(".o-menu div[data-name='root']")).toBeTruthy();
-  });
-
-  test("menu closed when sub menu item is clicked", async () => {
-    const mockCallback = jest.fn(() => {});
-    await renderContextMenu(300, 300, {
-      onClose: mockCallback,
-      menuItems: subMenu,
+  describe("Context Menu", () => {
+    test("context menu simple rendering", async () => {
+      await rightClickCell(model, "C8");
+      expect(fixture.querySelector(".o-menu")).toMatchSnapshot();
     });
-    await simulateClick(".o-menu div[data-name='root']");
-    await simulateClick(".o-menu div[data-name='subMenu1']");
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeFalsy();
-    expect(mockCallback).toHaveBeenCalled();
-  });
 
-  test("it renders subsubmenus", async () => {
-    const menuItems: FullMenuItem[] = [
-      createFullMenuItem("root1", {
-        name: "root1",
-        sequence: 1,
-        children: [
-          () => [
-            createFullMenuItem("root2", {
-              name: "root2",
-              sequence: 1,
-              children: [
-                () => [
-                  createFullMenuItem("subMenu", {
-                    name: "subMenu",
-                    sequence: 1,
-                    action() {},
-                  }),
+    test("right click on a cell opens a context menu", async () => {
+      expect(getSelectionAnchorCellXc(model)).toBe("A1");
+      expect(fixture.querySelector(".o-menu")).toBeFalsy();
+      await rightClickCell(model, "C8");
+      expect(getSelectionAnchorCellXc(model)).toBe("C8");
+      expect(fixture.querySelector(".o-menu")).toBeTruthy();
+    });
+
+    test("right click on a cell, then left click elsewhere closes a context menu", async () => {
+      await rightClickCell(model, "C8");
+      expect(getSelectionAnchorCellXc(model)).toBe("C8");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu")).toBeTruthy();
+
+      await simulateClick(".o-grid-overlay", 50, 50);
+      expect(fixture.querySelector(".o-menu")).toBeFalsy();
+    });
+
+    test("can copy/paste with context menu", async () => {
+      setCellContent(model, "B1", "b1");
+
+      await rightClickCell(model, "B1");
+      expect(getSelectionAnchorCellXc(model)).toBe("B1");
+
+      // click on 'copy' menu item
+      await simulateClick(".o-menu div[data-name='copy']");
+
+      await rightClickCell(model, "B2");
+
+      // click on 'paste' menu item
+      await simulateClick(".o-menu div[data-name='paste']");
+      expect(getCellContent(model, "B1")).toBe("b1");
+      expect(getCellContent(model, "B2")).toBe("b1");
+    });
+
+    test("can cut/paste with context menu", async () => {
+      setCellContent(model, "B1", "b1");
+
+      await rightClickCell(model, "B1");
+
+      // click on 'cut' menu item
+      await simulateClick(".o-menu div[data-name='cut']");
+
+      // right click on B2
+      await rightClickCell(model, "B2");
+      await nextTick();
+      expect(getSelectionAnchorCellXc(model)).toBe("B2");
+
+      // click on 'paste' menu item
+      await simulateClick(".o-menu div[data-name='paste']");
+
+      expect(getCell(model, "B1")).toBeUndefined();
+      expect(getCellContent(model, "B2")).toBe("b1");
+    });
+
+    test("menu does not close when right click elsewhere", async () => {
+      await rightClickCell(model, "B1");
+      expect(fixture.querySelector(".o-menu")).toBeTruthy();
+      await rightClickCell(model, "D5");
+      expect(fixture.querySelector(".o-menu")).toBeTruthy();
+    });
+
+    test("close contextmenu when clicking on menubar", async () => {
+      await rightClickCell(model, "B1");
+      expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
+      triggerMouseEvent(".o-topbar-topleft", "click");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu")).toBeFalsy();
+    });
+
+    test("close contextmenu when clicking on menubar item", async () => {
+      await rightClickCell(model, "B1");
+      expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
+      triggerMouseEvent(".o-topbar-menu[data-id='insert']", "click");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeFalsy();
+    });
+    test("close contextmenu when clicking on tools bar", async () => {
+      await rightClickCell(model, "B1");
+      expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
+      const fontSizeTool = fixture.querySelector('.o-tool[title="Font Size"]')!;
+      triggerMouseEvent(fontSizeTool, "click");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeFalsy();
+    });
+
+    test("menu can be hidden/displayed based on the env", async () => {
+      const menuDefinitions = Object.assign({}, cellMenuRegistry.content);
+      cellMenuRegistry
+        .add("visible_action", {
+          name: "visible_action",
+          sequence: 1,
+          isVisible: (env) => getEvaluatedCell(model, "B1").value === "b1",
+          action() {},
+        })
+        .add("hidden_action", {
+          name: "hidden_action",
+          sequence: 2,
+          isVisible: (env) => getEvaluatedCell(model, "B1").value !== "b1",
+          action() {},
+        });
+      setCellContent(model, "B1", "b1");
+      await rightClickCell(model, "B1");
+      expect(fixture.querySelector(".o-menu div[data-name='visible_action']")).toBeTruthy();
+      expect(fixture.querySelector(".o-menu div[data-name='hidden_action']")).toBeFalsy();
+      cellMenuRegistry.content = menuDefinitions;
+    });
+
+    test("submenu opens and close when (un)overed", async () => {
+      const menuItems: FullMenuItem[] = [
+        createFullMenuItem("action", {
+          name: "action",
+          sequence: 1,
+          action() {},
+        }),
+        createFullMenuItem("root", {
+          name: "root",
+          sequence: 2,
+          children: [
+            () => [
+              createFullMenuItem("subMenu", {
+                name: "subMenu",
+                sequence: 1,
+                action() {},
+              }),
+            ],
+          ],
+        }),
+      ];
+      await renderContextMenu(300, 300, { menuItems });
+      triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeTruthy();
+      triggerMouseEvent(".o-menu div[data-name='action']", "mouseover");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
+    });
+
+    test("Submenu parent is highlighted", async () => {
+      await renderContextMenu(300, 300, { menuItems: cellMenuRegistry.getAll() });
+      const menuItem = fixture.querySelector(".o-menu div[data-name='paste_special']");
+      expect(menuItem?.classList).not.toContain("o-menu-item-active");
+      triggerMouseEvent(menuItem, "mouseover");
+      await nextTick();
+      expect(menuItem?.classList).toContain("o-menu-item-active");
+      triggerMouseEvent(".o-menu div[data-name='paste_value_only']", "mouseover");
+      await nextTick();
+      expect(menuItem?.classList).toContain("o-menu-item-active");
+    });
+
+    test("submenu does not open when disabled", async () => {
+      const menuItems: FullMenuItem[] = [
+        createFullMenuItem("root", {
+          name: "root",
+          sequence: 1,
+          isEnabled: () => false,
+          children: [
+            () => [
+              createFullMenuItem("subMenu", {
+                name: "subMenu",
+                sequence: 1,
+                action() {},
+              }),
+            ],
+          ],
+        }),
+      ];
+      await renderContextMenu(300, 300, { menuItems });
+      expect(fixture.querySelector(".o-menu div[data-name='root']")!.classList).toContain(
+        "disabled"
+      );
+      await simulateClick(".o-menu div[data-name='root']");
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
+    });
+
+    test("submenu does not close when sub item overed", async () => {
+      await renderContextMenu(300, 300, { menuItems: subMenu });
+      triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
+      triggerMouseEvent(".o-menu div[data-name='subMenu1']", "mouseover");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
+    });
+
+    test("menu does not close when root menu is clicked", async () => {
+      await renderContextMenu(300, 300, { menuItems: subMenu });
+      await simulateClick(".o-menu div[data-name='root']");
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
+      expect(fixture.querySelector(".o-menu div[data-name='root']")).toBeTruthy();
+    });
+
+    test("menu closed when sub menu item is clicked", async () => {
+      const mockCallback = jest.fn(() => {});
+      await renderContextMenu(300, 300, {
+        onClose: mockCallback,
+        menuItems: subMenu,
+      });
+      await simulateClick(".o-menu div[data-name='root']");
+      await simulateClick(".o-menu div[data-name='subMenu1']");
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeFalsy();
+      expect(mockCallback).toHaveBeenCalled();
+    });
+
+    test("it renders subsubmenus", async () => {
+      const menuItems: FullMenuItem[] = [
+        createFullMenuItem("root1", {
+          name: "root1",
+          sequence: 1,
+          children: [
+            () => [
+              createFullMenuItem("root2", {
+                name: "root2",
+                sequence: 1,
+                children: [
+                  () => [
+                    createFullMenuItem("subMenu", {
+                      name: "subMenu",
+                      sequence: 1,
+                      action() {},
+                    }),
+                  ],
                 ],
-              ],
-            }),
+              }),
+            ],
           ],
-        ],
-      }),
-    ];
-    await renderContextMenu(300, 990, { menuItems });
-    await simulateClick("div[data-name='root1']");
-    await simulateClick("div[data-name='root2']");
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeTruthy();
-  });
+        }),
+      ];
+      await renderContextMenu(300, 990, { menuItems });
+      await simulateClick("div[data-name='root1']");
+      await simulateClick("div[data-name='root2']");
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeTruthy();
+    });
 
-  test("Menu with icon is correctly displayed", async () => {
-    const menuItems: FullMenuItem[] = [
-      createFullMenuItem("root1", {
-        name: "root1",
-        sequence: 1,
-        icon: "not-displayed-class",
-        children: [
-          () => [
-            createFullMenuItem("root2", {
-              name: "root2",
-              sequence: 1,
-              action() {},
-              icon: "my-class",
-            }),
+    test("Menu with icon is correctly displayed", async () => {
+      const menuItems: FullMenuItem[] = [
+        createFullMenuItem("root1", {
+          name: "root1",
+          sequence: 1,
+          icon: "not-displayed-class",
+          children: [
+            () => [
+              createFullMenuItem("root2", {
+                name: "root2",
+                sequence: 1,
+                action() {},
+                icon: "my-class",
+              }),
+            ],
           ],
-        ],
-      }),
-    ];
-    await renderContextMenu(300, 990, { menuItems });
-    expect(fixture.querySelector("div[data-name='root1'] > i")).toBeNull();
-    await simulateClick("div[data-name='root1']");
-    expect(fixture.querySelector("div[data-name='root2'] > i")?.classList).toContain("my-class");
-  });
+        }),
+      ];
+      await renderContextMenu(300, 990, { menuItems });
+      expect(fixture.querySelector("div[data-name='root1'] > i")).toBeNull();
+      await simulateClick("div[data-name='root1']");
+      expect(fixture.querySelector("div[data-name='root2'] > i")?.classList).toContain("my-class");
+    });
 
-  test("Can color menu items", async () => {
-    const menuItems: FullMenuItem[] = [
-      createFullMenuItem("black", {
-        name: "black",
-        sequence: 1,
-        action() {},
-      }),
-      createFullMenuItem("orange", {
-        name: "orange",
-        sequence: 2,
-        action() {},
-        textColor: "orange",
-      }),
-    ];
-    await renderContextMenu(0, 0, { menuItems });
-    expect((fixture.querySelector("div[data-name='black']") as HTMLElement).style.color).toEqual(
-      ""
-    );
-    expect((fixture.querySelector("div[data-name='orange']") as HTMLElement).style.color).toEqual(
-      "orange"
-    );
-  });
+    test("Can color menu items", async () => {
+      const menuItems: FullMenuItem[] = [
+        createFullMenuItem("black", {
+          name: "black",
+          sequence: 1,
+          action() {},
+        }),
+        createFullMenuItem("orange", {
+          name: "orange",
+          sequence: 2,
+          action() {},
+          textColor: "orange",
+        }),
+      ];
+      await renderContextMenu(0, 0, { menuItems });
+      expect((fixture.querySelector("div[data-name='black']") as HTMLElement).style.color).toEqual(
+        ""
+      );
+      expect((fixture.querySelector("div[data-name='orange']") as HTMLElement).style.color).toEqual(
+        "orange"
+      );
+    });
 
-  test("Only submenus of the current parent are visible", async () => {
-    const menuItems: FullMenuItem[] = [
-      createFullMenuItem("root_1", {
-        name: "root_1",
-        sequence: 1,
-        children: [
-          () => [
-            createFullMenuItem("root_1_1", {
-              name: "root_1_1",
-              sequence: 1,
-              children: [
-                () => [
-                  createFullMenuItem("subMenu_1", {
-                    name: "subMenu_1",
-                    sequence: 1,
-                    action() {},
-                  }),
+    test("Only submenus of the current parent are visible", async () => {
+      const menuItems: FullMenuItem[] = [
+        createFullMenuItem("root_1", {
+          name: "root_1",
+          sequence: 1,
+          children: [
+            () => [
+              createFullMenuItem("root_1_1", {
+                name: "root_1_1",
+                sequence: 1,
+                children: [
+                  () => [
+                    createFullMenuItem("subMenu_1", {
+                      name: "subMenu_1",
+                      sequence: 1,
+                      action() {},
+                    }),
+                  ],
                 ],
-              ],
-            }),
+              }),
+            ],
           ],
-        ],
-      }),
-      createFullMenuItem("root_2", {
-        name: "root_2",
-        sequence: 2,
-        children: [
-          () => [
-            createFullMenuItem("root_2_1", {
-              name: "root_2_1",
-              sequence: 1,
-              children: [
-                () => [
-                  createFullMenuItem("subMenu_2", {
-                    name: "subMenu_2",
-                    sequence: 1,
-                    action() {},
-                  }),
+        }),
+        createFullMenuItem("root_2", {
+          name: "root_2",
+          sequence: 2,
+          children: [
+            () => [
+              createFullMenuItem("root_2_1", {
+                name: "root_2_1",
+                sequence: 1,
+                children: [
+                  () => [
+                    createFullMenuItem("subMenu_2", {
+                      name: "subMenu_2",
+                      sequence: 1,
+                      action() {},
+                    }),
+                  ],
                 ],
-              ],
-            }),
+              }),
+            ],
           ],
-        ],
-      }),
-    ];
-    await renderContextMenu(300, 300, { menuItems });
+        }),
+      ];
+      await renderContextMenu(300, 300, { menuItems });
 
-    triggerMouseEvent(".o-menu div[data-name='root_1']", "mouseover");
-    await nextTick();
-    triggerMouseEvent(".o-menu div[data-name='root_1_1']", "mouseover");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu_1']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='root_2']", "mouseover");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu div[data-name='subMenu_1']")).toBeFalsy();
-    expect(fixture.querySelector(".o-menu div[data-name='root_2_1']")).toBeTruthy();
-  });
+      triggerMouseEvent(".o-menu div[data-name='root_1']", "mouseover");
+      await nextTick();
+      triggerMouseEvent(".o-menu div[data-name='root_1_1']", "mouseover");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu_1']")).toBeTruthy();
+      triggerMouseEvent(".o-menu div[data-name='root_2']", "mouseover");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu div[data-name='subMenu_1']")).toBeFalsy();
+      expect(fixture.querySelector(".o-menu div[data-name='root_2_1']")).toBeTruthy();
+    });
 
-  test("Submenu visibility is taken into account", async () => {
-    const menuItems: FullMenuItem[] = [
-      createFullMenuItem("root", {
-        name: "root_1",
-        sequence: 1,
-        children: [
-          () => [
-            createFullMenuItem("menu_1", {
-              name: "root_1_1",
-              sequence: 1,
-              children: [
-                () => [
-                  createFullMenuItem("visible_submenu_1", {
-                    name: "visible_submenu_1",
-                    sequence: 1,
-                    action() {},
-                    isVisible: () => true,
-                  }),
-                  createFullMenuItem("invisible_submenu_1", {
-                    name: "invisible_submenu_1",
-                    sequence: 1,
-                    action() {},
-                    isVisible: () => false,
-                  }),
+    test("Submenu visibility is taken into account", async () => {
+      const menuItems: FullMenuItem[] = [
+        createFullMenuItem("root", {
+          name: "root_1",
+          sequence: 1,
+          children: [
+            () => [
+              createFullMenuItem("menu_1", {
+                name: "root_1_1",
+                sequence: 1,
+                children: [
+                  () => [
+                    createFullMenuItem("visible_submenu_1", {
+                      name: "visible_submenu_1",
+                      sequence: 1,
+                      action() {},
+                      isVisible: () => true,
+                    }),
+                    createFullMenuItem("invisible_submenu_1", {
+                      name: "invisible_submenu_1",
+                      sequence: 1,
+                      action() {},
+                      isVisible: () => false,
+                    }),
+                  ],
                 ],
-              ],
+              }),
+            ],
+          ],
+        }),
+      ];
+      await renderContextMenu(300, 300, { menuItems });
+      triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu div[data-name='menu_1']")).toBeTruthy();
+      triggerMouseEvent(".o-menu div[data-name='menu_1']", "mouseover");
+      await nextTick();
+      expect(fixture.querySelector(".o-menu div[data-name='visible_submenu_1']")).toBeTruthy();
+      expect(fixture.querySelector(".o-menu div[data-name='invisible_submenu_1']")).toBeFalsy();
+    });
+
+    test("scroll through the menu with the wheel / scrollbar prevents the grid from scrolling", async () => {
+      const verticalScrollBar = fixture.querySelector(".o-scrollbar.vertical") as HTMLElement;
+      const horizontalScrollBar = fixture.querySelector(".o-scrollbar.horizontal") as HTMLElement;
+      expect(verticalScrollBar.scrollTop).toBe(0);
+      expect(horizontalScrollBar.scrollLeft).toBe(0);
+
+      await rightClickCell(model, "C8");
+
+      const menu = fixture.querySelector(".o-menu")!;
+      // scroll
+      menu.dispatchEvent(
+        new WheelEvent("wheel", { deltaY: 300, deltaX: 300, deltaMode: 0, bubbles: true })
+      );
+      menu.dispatchEvent(new Event("scroll", { bubbles: true }));
+      await nextTick();
+
+      // grid always at (0, 0) scroll position
+      expect(verticalScrollBar.scrollTop).toBe(0);
+      expect(horizontalScrollBar.scrollLeft).toBe(0);
+    });
+
+    test("scroll through the menu with the touch device prevents the grid from scrolling", async () => {
+      const verticalScrollBar = fixture.querySelector(".o-scrollbar.vertical") as HTMLElement;
+      const horizontalScrollBar = fixture.querySelector(".o-scrollbar.horizontal") as HTMLElement;
+
+      expect(verticalScrollBar.scrollTop).toBe(0);
+      expect(horizontalScrollBar.scrollLeft).toBe(0);
+
+      await rightClickCell(model, "C8");
+
+      const menu = fixture.querySelector(".o-menu")!;
+
+      // start move at (310, 210) touch position
+      menu.dispatchEvent(
+        new TouchEvent("touchstart", {
+          bubbles: true,
+          cancelable: true,
+          touches: [
+            new Touch({
+              clientX: 310,
+              clientY: 210,
+              identifier: 1,
+              target: menu,
             }),
           ],
-        ],
-      }),
-    ];
-    await renderContextMenu(300, 300, { menuItems });
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu div[data-name='menu_1']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='menu_1']", "mouseover");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu div[data-name='visible_submenu_1']")).toBeTruthy();
-    expect(fixture.querySelector(".o-menu div[data-name='invisible_submenu_1']")).toBeFalsy();
+        })
+      );
+      // move down;
+      menu.dispatchEvent(
+        new TouchEvent("touchmove", {
+          bubbles: true,
+          cancelable: true,
+          touches: [
+            new Touch({
+              clientX: 310,
+              clientY: 180,
+              identifier: 2,
+              target: menu,
+            }),
+          ],
+        })
+      );
+
+      await nextTick();
+      // grid always at (0, 0) scroll position
+      expect(verticalScrollBar.scrollTop).toBe(0);
+      expect(horizontalScrollBar.scrollLeft).toBe(0);
+    });
   });
 
-  test("scroll through the menu with the wheel / scrollbar prevents the grid from scrolling", async () => {
-    const verticalScrollBar = fixture.querySelector(".o-scrollbar.vertical") as HTMLElement;
-    const horizontalScrollBar = fixture.querySelector(".o-scrollbar.horizontal") as HTMLElement;
-    expect(verticalScrollBar.scrollTop).toBe(0);
-    expect(horizontalScrollBar.scrollLeft).toBe(0);
+  describe("Context Menu position on large screen 1000px/1000px", () => {
+    test("it renders menu on the bottom right if enough space", async () => {
+      const [clickX, clickY] = await renderContextMenu(300, 300);
+      const { left, top } = getMenuPosition();
+      expect(left).toBe(clickX);
+      expect(top).toBe(clickY);
+    });
 
-    await rightClickCell(model, "C8");
+    test("it renders menu on the top right if not enough space", async () => {
+      const [clickX, clickY] = await renderContextMenu(300, 990);
+      const { left, top } = getMenuPosition();
+      const { height } = getMenuSize();
+      expect(left).toBe(clickX);
+      expect(top).toBe(clickY - height);
+    });
 
-    const menu = fixture.querySelector(".o-menu")!;
-    // scroll
-    menu.dispatchEvent(
-      new WheelEvent("wheel", { deltaY: 300, deltaX: 300, deltaMode: 0, bubbles: true })
-    );
-    menu.dispatchEvent(new Event("scroll", { bubbles: true }));
-    await nextTick();
+    test("it renders menu on the bottom left if not enough space", async () => {
+      const [clickX, clickY] = await renderContextMenu(990, 300);
+      const { left, top } = getMenuPosition();
+      const { width } = getMenuSize();
+      expect(left).toBe(clickX - width);
+      expect(top).toBe(clickY);
+    });
 
-    // grid always at (0, 0) scroll position
-    expect(verticalScrollBar.scrollTop).toBe(0);
-    expect(horizontalScrollBar.scrollLeft).toBe(0);
-  });
+    test("it renders menu on the top left if not enough space", async () => {
+      const [clickX, clickY] = await renderContextMenu(990, 990);
+      const { left, top } = getMenuPosition();
+      const { width, height } = getMenuSize();
+      expect(left).toBe(clickX - width);
+      expect(top).toBe(clickY - height);
+    });
 
-  test("scroll through the menu with the touch device prevents the grid from scrolling", async () => {
-    const verticalScrollBar = fixture.querySelector(".o-scrollbar.vertical") as HTMLElement;
-    const horizontalScrollBar = fixture.querySelector(".o-scrollbar.horizontal") as HTMLElement;
+    test("it renders submenu on the bottom right if enough space", async () => {
+      const [clickX, clickY] = await renderContextMenu(300, 300, { menuItems: subMenu });
+      await simulateClick("div[data-name='root']");
+      const { left, top } = getSubMenuPosition();
+      const { width } = getMenuSize();
+      expect(left).toBe(clickX + width);
+      expect(top).toBe(clickY);
+    });
 
-    expect(verticalScrollBar.scrollTop).toBe(0);
-    expect(horizontalScrollBar.scrollLeft).toBe(0);
+    test("it renders submenu on the bottom left if not enough space", async () => {
+      const [clickX, clickY] = await renderContextMenu(1000 - MENU_WIDTH - 10, 300, {
+        menuItems: subMenu,
+      });
+      await simulateClick("div[data-name='root']");
+      const { left, top } = getSubMenuPosition();
+      const { width } = getMenuSize();
+      const { left: rootLeft } = getMenuPosition();
+      expect(rootLeft).toBe(clickX);
+      expect(left).toBe(clickX - width);
+      expect(top).toBe(clickY);
+    });
 
-    await rightClickCell(model, "C8");
+    test("it renders all menus on the bottom left if not enough space", async () => {
+      const [clickX, clickY] = await renderContextMenu(990, 300, { menuItems: subMenu });
+      await simulateClick("div[data-name='root']");
+      const { left, top } = getSubMenuPosition();
+      const { width } = getMenuSize();
+      const { left: rootLeft } = getMenuPosition();
+      expect(rootLeft).toBe(clickX - width);
+      expect(left).toBe(clickX - 2 * width);
+      expect(top).toBe(clickY);
+    });
 
-    const menu = fixture.querySelector(".o-menu")!;
+    test("it renders submenu on the top right if not enough space", async () => {
+      const [clickX, clickY] = await renderContextMenu(300, 960, { menuItems: subMenu });
+      await simulateClick("div[data-name='root']");
+      const { left, top } = getSubMenuPosition();
+      const { height } = getSubMenuSize();
+      const { width } = getMenuSize();
+      expect(top).toBe(clickY - height + getItemSize());
+      expect(left).toBe(clickX + width);
+    });
 
-    // start move at (310, 210) touch position
-    menu.dispatchEvent(
-      new TouchEvent("touchstart", {
-        bubbles: true,
-        cancelable: true,
-        touches: [
-          new Touch({
-            clientX: 310,
-            clientY: 210,
-            identifier: 1,
-            target: menu,
-          }),
-        ],
-      })
-    );
-    // move down;
-    menu.dispatchEvent(
-      new TouchEvent("touchmove", {
-        bubbles: true,
-        cancelable: true,
-        touches: [
-          new Touch({
-            clientX: 310,
-            clientY: 180,
-            identifier: 2,
-            target: menu,
-          }),
-        ],
-      })
-    );
-
-    await nextTick();
-    // grid always at (0, 0) scroll position
-    expect(verticalScrollBar.scrollTop).toBe(0);
-    expect(horizontalScrollBar.scrollLeft).toBe(0);
+    test("it renders all menus on the top right if not enough space", async () => {
+      const [clickX, clickY] = await renderContextMenu(300, 990, { menuItems: subMenu });
+      await simulateClick("div[data-name='root']");
+      const { left, top } = getSubMenuPosition();
+      const { top: rootTop } = getMenuPosition();
+      const { height, width } = getSubMenuSize();
+      const { height: rootHeight } = getMenuSize();
+      expect(rootTop).toBe(clickY - rootHeight);
+      expect(top).toBe(clickY - height);
+      expect(left).toBe(clickX + width);
+    });
   });
 });
 
-describe("Context Menu position on large screen 1000px/1000px", () => {
-  test("it renders menu on the bottom right if enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(300, 300);
-    const { left, top } = getMenuPosition();
-    expect(left).toBe(clickX);
-    expect(top).toBe(clickY);
+describe("Context menu react to grid size changes", () => {
+  beforeEach(async () => {
+    fixture = makeTestFixture();
+    ({ app, model } = await mountSpreadsheet(fixture));
   });
 
-  test("it renders menu on the top right if not enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(300, 990);
-    const { left, top } = getMenuPosition();
-    const { height } = getMenuSize();
-    expect(left).toBe(clickX);
-    expect(top).toBe(clickY - height);
+  afterEach(() => {
+    fixture.remove();
+    app.destroy();
   });
 
-  test("it renders menu on the bottom left if not enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(990, 300);
-    const { left, top } = getMenuPosition();
-    const { width } = getMenuSize();
-    expect(left).toBe(clickX - width);
-    expect(top).toBe(clickY);
+  test("Submenu is closed when grid size change make the parent menu hidden", async () => {
+    fixture
+      .querySelector(".o-grid-overlay")!
+      .dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, clientX: 800, clientY: 0 }));
+    await nextTick();
+    await simulateClick("div[data-name='paste_special']");
+    let menus = fixture.querySelectorAll(".o-menu");
+    expect(menus[0].parentElement?.style.visibility).toBe("visible");
+    expect(menus[1]).toBeTruthy();
+
+    model.dispatch("RESIZE_SHEETVIEW", { width: 500, height: 500 });
+    await nextTick();
+    await nextTick(); // First render hides the parent menu, second closes the submenu
+
+    menus = fixture.querySelectorAll(".o-menu");
+    expect(menus[0].parentElement?.style.visibility).toBe("hidden");
+    expect(menus[1]).toBeFalsy();
   });
 
-  test("it renders menu on the top left if not enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(990, 990);
-    const { left, top } = getMenuPosition();
-    const { width, height } = getMenuSize();
-    expect(left).toBe(clickX - width);
-    expect(top).toBe(clickY - height);
-  });
+  test("Submenu is closed when grid size change moves the parent menu", async () => {
+    fixture
+      .querySelector(".o-grid-overlay")!
+      .dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, clientX: 500, clientY: 0 }));
+    await nextTick();
+    await simulateClick("div[data-name='paste_special']");
+    let menus = fixture.querySelectorAll(".o-menu");
+    expect(menus[0].parentElement?.style.left).toBe("500px");
+    expect(menus[1]).toBeTruthy();
 
-  test("it renders submenu on the bottom right if enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(300, 300, { menuItems: subMenu });
-    await simulateClick("div[data-name='root']");
-    const { left, top } = getSubMenuPosition();
-    const { width } = getMenuSize();
-    expect(left).toBe(clickX + width);
-    expect(top).toBe(clickY);
-  });
+    model.dispatch("RESIZE_SHEETVIEW", { width: 500 + MENU_WIDTH / 2, height: 1000 });
+    await nextTick();
+    await nextTick(); // First render moves the parent menu, second closes the submenu
 
-  test("it renders submenu on the bottom left if not enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(1000 - MENU_WIDTH - 10, 300, {
-      menuItems: subMenu,
-    });
-    await simulateClick("div[data-name='root']");
-    const { left, top } = getSubMenuPosition();
-    const { width } = getMenuSize();
-    const { left: rootLeft } = getMenuPosition();
-    expect(rootLeft).toBe(clickX);
-    expect(left).toBe(clickX - width);
-    expect(top).toBe(clickY);
-  });
-
-  test("it renders all menus on the bottom left if not enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(990, 300, { menuItems: subMenu });
-    await simulateClick("div[data-name='root']");
-    const { left, top } = getSubMenuPosition();
-    const { width } = getMenuSize();
-    const { left: rootLeft } = getMenuPosition();
-    expect(rootLeft).toBe(clickX - width);
-    expect(left).toBe(clickX - 2 * width);
-    expect(top).toBe(clickY);
-  });
-
-  test("it renders submenu on the top right if not enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(300, 960, { menuItems: subMenu });
-    await simulateClick("div[data-name='root']");
-    const { left, top } = getSubMenuPosition();
-    const { height } = getSubMenuSize();
-    const { width } = getMenuSize();
-    expect(top).toBe(clickY - height + getItemSize());
-    expect(left).toBe(clickX + width);
-  });
-
-  test("it renders all menus on the top right if not enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(300, 990, { menuItems: subMenu });
-    await simulateClick("div[data-name='root']");
-    const { left, top } = getSubMenuPosition();
-    const { top: rootTop } = getMenuPosition();
-    const { height } = getSubMenuSize();
-    const { height: rootHeight } = getMenuSize();
-    const { width } = getSubMenuSize();
-    expect(rootTop).toBe(clickY - rootHeight);
-    expect(top).toBe(clickY - height);
-    expect(left).toBe(clickX + width);
+    menus = fixture.querySelectorAll(".o-menu");
+    expect(menus[0].parentElement?.style.left).toBe(`${500 - MENU_WIDTH}px`);
+    expect(menus[1]).toBeFalsy();
   });
 });

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -1,12 +1,14 @@
 import { App, Component, xml } from "@odoo/owl";
 import { Model } from "../../src";
+import { ChartJsComponent } from "../../src/components/figures/chart/chartJs/chartjs";
+import { ScorecardChart } from "../../src/components/figures/chart/scorecard/chart_scorecard";
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
   MENU_WIDTH,
   MIN_FIG_SIZE,
 } from "../../src/constants";
-import { figureRegistry } from "../../src/registries";
+import { chartComponentRegistry, figureRegistry } from "../../src/registries";
 import { CreateFigureCommand, Figure, SpreadsheetChildEnv, UID } from "../../src/types";
 import {
   activateSheet,
@@ -25,11 +27,13 @@ import {
   getFigureDefinition,
   getFigureIds,
   makeTestFixture,
+  mockChart,
   MockClipboard,
   mountSpreadsheet,
   nextTick,
 } from "../test_helpers/helpers";
-import { TEST_CHART_DATA } from "./charts.test";
+import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
+import { TEST_CHART_DATA } from "./../test_helpers/constants";
 
 let fixture: HTMLElement;
 let model: Model;
@@ -84,8 +88,21 @@ class TextFigure extends Component<Props, SpreadsheetChildEnv> {
   static template = TEMPLATE;
 }
 
+mockChart();
+mockGetBoundingClientRect({
+  "o-popover": () => ({ height: 0, width: 0 }),
+  "o-spreadsheet": () => ({ top: 100, left: 200, height: 1000, width: 1000 }),
+  "o-figure-menu-item": () => ({ top: 500, left: 500 }),
+});
+
 beforeAll(() => {
   figureRegistry.add("text", { Component: TextFigure });
+  // TODO : remove this once #1861 is merged
+  chartComponentRegistry.add("line", ChartJsComponent);
+  chartComponentRegistry.add("bar", ChartJsComponent);
+  chartComponentRegistry.add("pie", ChartJsComponent);
+  chartComponentRegistry.add("gauge", ChartJsComponent);
+  chartComponentRegistry.add("scorecard", ScorecardChart);
 });
 afterAll(() => {
   figureRegistry.remove("text");

--- a/tests/components/link/__snapshots__/link_display.test.ts.snap
+++ b/tests/components/link/__snapshots__/link_display.test.ts.snap
@@ -1,16 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`link display component simple snapshot 1`] = `
-"<div class=\\"o-popover\\" style=\\"
-      position: absolute;
-      z-index: 30;
-      top:49px;
-      left:48px;
-      max-height:960px;
-      width:220px;
-      overflow-y: auto;
-      overflow-x: hidden;
-      box-shadow: 1px 2px 5px 2px rgb(51 51 51 / 15%);
-    \\"><div class=\\"o-link-tool d-flex align-items-center\\"><!-- t-key to prevent owl from re-using the previous img element when the link changes.
+"<div class=\\"o-popover\\" style=\\"visibility: visible; max-height: 962px; max-width: 985px; top: 49px; left: 48px;\\"><div class=\\"o-link-tool d-flex align-items-center\\"><!-- t-key to prevent owl from re-using the previous img element when the link changes.
     The wrong/previous image would be displayed while the new one loads --><img src=\\"https://www.google.com/s2/favicons?sz=16&amp;domain=https://url.com\\"><a class=\\"o-link\\" target=\\"_blank\\" href=\\"https://url.com\\" title=\\"https://url.com\\">https://url.com</a><span class=\\"o-link-icon o-unlink\\" title=\\"Remove link\\"><svg class=\\"o-icon\\" viewBox=\\"0 0 512 512\\"><path fill=\\"currentColor\\" d=\\"M304.083 405.907c4.686 4.686 4.686 12.284 0 16.971l-44.674 44.674c-59.263 59.262-155.693 59.266-214.961 0-59.264-59.265-59.264-155.696 0-214.96l44.675-44.675c4.686-4.686 12.284-4.686 16.971 0l39.598 39.598c4.686 4.686 4.686 12.284 0 16.971l-44.675 44.674c-28.072 28.073-28.072 73.75 0 101.823 28.072 28.072 73.75 28.073 101.824 0l44.674-44.674c4.686-4.686 12.284-4.686 16.971 0l39.597 39.598zm-56.568-260.216c4.686 4.686 12.284 4.686 16.971 0l44.674-44.674c28.072-28.075 73.75-28.073 101.824 0 28.072 28.073 28.072 73.75 0 101.823l-44.675 44.674c-4.686 4.686-4.686 12.284 0 16.971l39.598 39.598c4.686 4.686 12.284 4.686 16.971 0l44.675-44.675c59.265-59.265 59.265-155.695 0-214.96-59.266-59.264-155.695-59.264-214.961 0l-44.674 44.674c-4.686 4.686-4.686 12.284 0 16.971l39.597 39.598zm234.828 359.28l22.627-22.627c9.373-9.373 9.373-24.569 0-33.941L63.598 7.029c-9.373-9.373-24.569-9.373-33.941 0L7.029 29.657c-9.373 9.373-9.373 24.569 0 33.941l441.373 441.373c9.373 9.372 24.569 9.372 33.941 0z\\"></path></svg></span><span class=\\"o-link-icon o-edit-link\\" title=\\"Edit link\\"><svg class=\\"o-icon\\" viewBox=\\"0 0 576 512\\"><path fill=\\"currentColor\\" d=\\"M402.6 83.2l90.2 90.2c3.8 3.8 3.8 10 0 13.8L274.4 405.6l-92.8 10.3c-12.4 1.4-22.9-9.1-21.5-21.5l10.3-92.8L388.8 83.2c3.8-3.8 10-3.8 13.8 0zm162-22.9l-48.8-48.8c-15.2-15.2-39.9-15.2-55.2 0l-35.4 35.4c-3.8 3.8-3.8 10 0 13.8l90.2 90.2c3.8 3.8 10 3.8 13.8 0l35.4-35.4c15.2-15.3 15.2-40 0-55.2zM384 346.2V448H64V128h229.8c3.2 0 6.2-1.3 8.5-3.5l40-40c7.6-7.6 2.2-20.5-8.5-20.5H48C21.5 64 0 85.5 0 112v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V306.2c0-10.7-12.9-16-20.5-8.5l-40 40c-2.2 2.3-3.5 5.3-3.5 8.5z\\"></path></svg></span></div></div>"
 `;

--- a/tests/components/link/link_editor.test.ts
+++ b/tests/components/link/link_editor.test.ts
@@ -15,6 +15,11 @@ import {
 } from "../../test_helpers/dom_helper";
 import { getCell, getEvaluatedCell } from "../../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+import { mockGetBoundingClientRect } from "../../test_helpers/mock_helpers";
+
+mockGetBoundingClientRect({
+  "o-spreadsheet": () => ({ top: 0, left: 0, height: 1000, width: 1000 }),
+});
 
 describe("link editor component", () => {
   let fixture: HTMLElement;

--- a/tests/components/popover.test.ts
+++ b/tests/components/popover.test.ts
@@ -1,0 +1,345 @@
+import { App, Component, useSubEnv, xml } from "@odoo/owl";
+import { Model } from "../../src";
+import { Popover, PopoverProps } from "../../src/components/popover/popover";
+import { Pixel, Rect } from "../../src/types";
+import { OWL_TEMPLATES } from "../setup/jest.setup";
+import { getStylePropertyInPx, makeTestFixture } from "../test_helpers/helpers";
+import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
+
+const POPOVER_HEIGHT = 200;
+const POPOVER_WIDTH = 200;
+
+let fixture: HTMLElement;
+let model: Model;
+let app: App;
+
+interface MountPopoverArgs extends Partial<PopoverProps> {
+  childWidth: Pixel;
+  childHeight: Pixel;
+  containerRect?: Rect;
+}
+
+async function mountTestPopover(args: MountPopoverArgs) {
+  class Parent extends Component<any, any> {
+    static template = xml/* xml */ `
+        <div class="o-spreadsheet">
+          <Popover t-props="popoverProps">
+            <div style="height:${args.childHeight}px;width:${args.childWidth}px;"/>
+          </Popover>
+        </div>
+  `;
+    static components = { Popover };
+
+    setup() {
+      const env: any = {
+        model: this.props.model,
+        isDashboard: () => false,
+      };
+      if (args.containerRect) {
+        env.getPopoverContainerRect = () => args.containerRect;
+      }
+      useSubEnv(env);
+    }
+
+    get popoverProps() {
+      return {
+        anchorRect: args.anchorRect || { x: 0, y: 0, width: 10, height: 10 },
+        positioning: args.positioning || "right",
+        maxWidth: args.maxHeight,
+        maxHeight: args.maxHeight,
+      };
+    }
+  }
+
+  app = new App(Parent, { props: { model } });
+  app.addTemplates(OWL_TEMPLATES);
+  await app.mount(fixture);
+}
+
+mockGetBoundingClientRect({
+  "o-popover": (el: HTMLElement) => {
+    const maxHeight = getStylePropertyInPx(el, "max-height");
+    const maxWidth = getStylePropertyInPx(el, "max-height");
+    const childHeight = getStylePropertyInPx(el.firstChild! as HTMLElement, "height");
+    const childWidth = getStylePropertyInPx(el.firstChild! as HTMLElement, "width");
+    return {
+      height: childHeight || maxHeight,
+      width: childWidth || maxWidth,
+    };
+  },
+  "o-spreadsheet": () => ({ top: 0, left: 0, height: 1000, width: 1000 }),
+});
+
+beforeEach(async () => {
+  fixture = makeTestFixture();
+  model = new Model();
+});
+
+afterEach(() => {
+  app?.destroy();
+  fixture.remove();
+});
+
+describe("Popover sizing", () => {
+  test("Prop maxHeight and maxWidth make popover use CSS maxwidth/height", async () => {
+    await mountTestPopover({
+      anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+      positioning: "TopRight",
+      maxWidth: POPOVER_WIDTH,
+      maxHeight: POPOVER_HEIGHT,
+      childHeight: 100,
+      childWidth: 100,
+    });
+    const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+    expect(popover).toBeTruthy();
+    expect(popover.style["max-width"]).toEqual(`${POPOVER_WIDTH}px`);
+    expect(popover.style["max-height"]).toEqual(`${POPOVER_HEIGHT}px`);
+  });
+
+  test("Popover use the spreadsheet size to compute its max size", async () => {
+    await mountTestPopover({
+      anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+      positioning: "TopRight",
+      childHeight: 100,
+      childWidth: 100,
+    });
+    const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+    expect(popover).toBeTruthy();
+    expect(popover.style["max-width"]).toEqual("1000px");
+    expect(popover.style["max-height"]).toEqual("1000px");
+  });
+});
+
+describe("Popover positioning", () => {
+  describe("Popover positioned TopRight", () => {
+    test("Popover right of point", async () => {
+      await mountTestPopover({
+        anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+        positioning: "TopRight",
+        childHeight: 100,
+        childWidth: 100,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual("0px");
+      expect(popover.style.top).toEqual("0px");
+    });
+
+    test("Popover right of box", async () => {
+      const box = { x: 0, y: 0, width: 100, height: 100 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "TopRight",
+        childWidth: 50,
+        childHeight: 50,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual(`${box.width}px`);
+      expect(popover.style.top).toEqual(`${box.y}px`);
+    });
+
+    test("Popover overflowing right is rendered left of box", async () => {
+      const viewPortDims = model.getters.getSheetViewDimensionWithHeaders();
+      const box = { x: viewPortDims.width - 50, y: 0, width: 50, height: 50 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "TopRight",
+        childWidth: 100,
+        childHeight: 100,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual(`${box.x - 100}px`);
+      expect(popover.style.top).toEqual(`${box.y}px`);
+    });
+
+    test("Popover overflowing down is rendered with its bottom aligned to the bottom of the box", async () => {
+      const viewPortDims = model.getters.getSheetViewDimensionWithHeaders();
+      const box = { x: 0, y: viewPortDims.height - 50, width: 50, height: 50 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "TopRight",
+        childHeight: 100,
+        childWidth: 100,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual(`${box.width}px`);
+      expect(popover.style.top).toEqual(`${box.y + box.height - 100}px`);
+    });
+
+    test("Popover overflowing down and right is rendered to the left of the box with its bottom aligned to the bottom of the box", async () => {
+      const viewPortDims = model.getters.getSheetViewDimensionWithHeaders();
+      const box = {
+        x: viewPortDims.width - 50,
+        y: viewPortDims.height - 50,
+        width: 50,
+        height: 50,
+      };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "TopRight",
+        childHeight: 100,
+        childWidth: 100,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual(`${box.x - 100}px`);
+      expect(popover.style.top).toEqual(`${box.y + box.height - 100}px`);
+    });
+  });
+
+  describe("Popover positioned BottomLeft", () => {
+    test("Popover bottom of point", async () => {
+      await mountTestPopover({
+        anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+        positioning: "BottomLeft",
+        childHeight: 100,
+        childWidth: 100,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual("0px");
+      expect(popover.style.top).toEqual("0px");
+    });
+
+    test("Popover bottom of box", async () => {
+      const box = { x: 0, y: 0, width: 100, height: 100 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "BottomLeft",
+        childHeight: 100,
+        childWidth: 100,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual(`${box.x}px`);
+      expect(popover.style.top).toEqual(`${box.height}px`);
+    });
+
+    test("Popover overflowing right is rendered with its right border matching the box right border", async () => {
+      const viewPortDims = model.getters.getSheetViewDimensionWithHeaders();
+      const box = { x: viewPortDims.width - 50, y: 0, width: 50, height: 50 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "BottomLeft",
+        childWidth: 100,
+        childHeight: 100,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual(`${box.x + box.width - 100}px`);
+      expect(popover.style.top).toEqual(`${box.height}px`);
+    });
+
+    test("Popover overflowing down is rendered above the box", async () => {
+      const viewPortDims = model.getters.getSheetViewDimensionWithHeaders();
+      const box = { x: 0, y: viewPortDims.height - 50, width: 50, height: 50 };
+      await mountTestPopover({
+        anchorRect: box,
+        positioning: "BottomLeft",
+        childHeight: 100,
+        childWidth: 100,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual(`${box.x}px`);
+      expect(popover.style.top).toEqual(`${box.y - 100}px`);
+    });
+
+    test("Popover overflowing down and right is rendered with its right border matching the box right border and above the box", async () => {
+      const viewPortDims = model.getters.getSheetViewDimensionWithHeaders();
+      const box = {
+        x: viewPortDims.width - 50,
+        y: viewPortDims.height - 50,
+        width: 50,
+        height: 50,
+      };
+      await mountTestPopover({
+        anchorRect: box,
+        containerRect: { x: 0, y: 0, ...viewPortDims },
+        positioning: "BottomLeft",
+        childHeight: 100,
+        childWidth: 100,
+      });
+      const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+      expect(popover).toBeTruthy();
+      expect(popover.style.left).toEqual(`${box.x + box.width - 100}px`);
+      expect(popover.style.top).toEqual(`${box.y - 100}px`);
+    });
+  });
+
+  test("If the anchorRect is not fully in the containerRect, the intersection between the two in taken as anchor", async () => {
+    const viewPortDims = model.getters.getSheetViewDimensionWithHeaders();
+    const anchorRect = {
+      x: viewPortDims.width - 75,
+      y: 0,
+      width: 100,
+      height: 100,
+    };
+    await mountTestPopover({
+      anchorRect,
+      positioning: "BottomLeft",
+      childHeight: 100,
+      childWidth: 100,
+    });
+    const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+    expect(popover).toBeTruthy();
+    expect(popover.style.left).toEqual(`${anchorRect.x + 75 - 100}px`);
+    expect(popover.style.top).toEqual(`${anchorRect.y + anchorRect.height}px`);
+  });
+
+  test("If the anchorRect is not at all in the containerRect, the popover is hidden", async () => {
+    const viewPortDims = model.getters.getSheetViewDimensionWithHeaders();
+    const anchorRect = {
+      x: viewPortDims.width + 75,
+      y: 0,
+      width: 100,
+      height: 100,
+    };
+    await mountTestPopover({
+      anchorRect,
+      positioning: "BottomLeft",
+      childHeight: 100,
+      childWidth: 100,
+    });
+    const popover = fixture.querySelector(".o-popover")! as HTMLElement;
+    expect(popover).toBeTruthy();
+    expect(popover.style.visibility).toEqual("hidden");
+  });
+
+  test("The containerRect is the spreadsheet element if it is not explicitly in the popover props", async () => {
+    mockGetBoundingClientRect({
+      "o-spreadsheet": () => ({ x: 200, y: 200, width: 1000, height: 1000 }),
+    });
+    await mountTestPopover({
+      anchorRect: { x: 0, y: 0, width: 0, height: 0 },
+      positioning: "BottomLeft",
+      childHeight: 100,
+      childWidth: 100,
+    });
+    let popover = fixture.querySelector(".o-popover")! as HTMLElement;
+    expect(popover.style.visibility).toEqual("hidden");
+
+    app.destroy();
+    await mountTestPopover({
+      anchorRect: { x: 300, y: 300, width: 0, height: 0 },
+      positioning: "BottomLeft",
+      childHeight: 100,
+      childWidth: 100,
+    });
+    popover = fixture.querySelector(".o-popover")! as HTMLElement;
+    expect(popover.style.visibility).toEqual("visible");
+
+    app.destroy();
+    await mountTestPopover({
+      anchorRect: { x: 1400, y: 1400, width: 0, height: 0 },
+      positioning: "BottomLeft",
+      childHeight: 100,
+      childWidth: 100,
+    });
+    popover = fixture.querySelector(".o-popover")! as HTMLElement;
+    expect(popover.style.visibility).toEqual("hidden");
+  });
+});

--- a/tests/plugins/cell_popovers.test.ts
+++ b/tests/plugins/cell_popovers.test.ts
@@ -3,50 +3,16 @@ import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { merge, setCellContent } from "../test_helpers";
 
 describe("cell popover plugin", () => {
-  test("position is snapped when the viewport is scrolled", () => {
-    const model = new Model();
-    const startColOne = 0;
-    const startColTwo = startColOne + DEFAULT_CELL_WIDTH;
-    setCellContent(model, "A1", "=0/0");
-    expect(model.getters.getCellPopover({ col: 0, row: 0 })).toMatchObject({
-      coordinates: {
-        x: startColTwo,
-        y: 0,
-      },
-    });
-    model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 2, offsetY: 0 });
-    expect(model.getters.getCellPopover({ col: 0, row: 0 })).toMatchObject({
-      coordinates: {
-        x: startColTwo,
-        y: 0,
-      },
-    });
-  });
-
-  test("bottom left position is correct on a merge", () => {
+  test("Anchor rect is correct on a merge", () => {
     const model = new Model();
     merge(model, "A1:B2");
-    model.dispatch("OPEN_CELL_POPOVER", {
-      col: 0,
-      row: 0,
-      popoverType: "LinkEditor",
-    });
+    setCellContent(model, "A1", "=0/0");
     expect(model.getters.getCellPopover({ col: 1, row: 1 })).toMatchObject({
-      coordinates: {
+      anchorRect: {
         x: 0,
-        y: 2 * DEFAULT_CELL_HEIGHT,
-      },
-    });
-  });
-
-  test("top right position is correct on a merge", () => {
-    const model = new Model();
-    merge(model, "A1:B2");
-    setCellContent(model, "A1", "=0/0");
-    expect(model.getters.getCellPopover({ col: 1, row: 1 })).toMatchObject({
-      coordinates: {
-        x: 2 * DEFAULT_CELL_WIDTH,
         y: 0,
+        height: 2 * DEFAULT_CELL_HEIGHT,
+        width: 2 * DEFAULT_CELL_WIDTH,
       },
     });
   });

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -1,0 +1,45 @@
+import { BACKGROUND_CHART_COLOR } from "../../src/constants";
+
+export const TEST_CHART_DATA = {
+  basicChart: {
+    type: "bar" as const,
+    dataSets: ["B1:B4"],
+    labelRange: "A2:A4",
+    dataSetsHaveTitle: true,
+    title: "hello",
+    background: BACKGROUND_CHART_COLOR,
+    verticalAxisPosition: "left" as const,
+    stacked: false,
+    legendPosition: "top" as const,
+  },
+  scorecard: {
+    type: "scorecard" as const,
+    keyValue: "B1:B4",
+    baseline: "A2:A4",
+    title: "hello",
+    baselineDescr: "description",
+    baselineMode: "difference" as const,
+  },
+  gauge: {
+    type: "gauge" as const,
+    dataRange: "B1:B4",
+    title: "hello",
+    sectionRule: {
+      rangeMin: "0",
+      rangeMax: "100",
+      colors: {
+        lowerColor: "#6aa84f",
+        middleColor: "#f1c232",
+        upperColor: "#cc0000",
+      },
+      lowerInflectionPoint: {
+        type: "number" as const,
+        value: "33",
+      },
+      upperInflectionPoint: {
+        type: "number" as const,
+        value: "66",
+      },
+    },
+  },
+};

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -568,3 +568,10 @@ export function getFigureDefinition(
       throw new Error(`Invalide figure type: ${type}`);
   }
 }
+
+/** Extract a property of the style of the given html element and return its size in pixel */
+export function getStylePropertyInPx(el: HTMLElement, property: string): number | undefined {
+  const styleProperty = el.style[property] as string;
+  if (!styleProperty) return undefined;
+  return Number(styleProperty.replace("px", ""));
+}

--- a/tests/test_helpers/mock_helpers.ts
+++ b/tests/test_helpers/mock_helpers.ts
@@ -1,0 +1,35 @@
+const originalGetBoundingClientRect = HTMLDivElement.prototype.getBoundingClientRect;
+
+export function mockGetBoundingClientRect(
+  classesWithMocks: Record<string, (el: HTMLElement) => Partial<DOMRect>>
+) {
+  const mockedClasses = Object.keys(classesWithMocks);
+
+  jest
+    .spyOn(HTMLDivElement.prototype, "getBoundingClientRect")
+    .mockImplementation(function (this: HTMLDivElement) {
+      const mockedClass = mockedClasses.find((className) => this.classList.contains(className));
+      if (mockedClass) {
+        return populateDOMRect(classesWithMocks[mockedClass](this));
+      }
+      return originalGetBoundingClientRect.call(this);
+    });
+}
+
+/**
+ * Try to populate the DOMRect with all the values we can based on what's in the partial DOMRect provided.
+ * For example set the rect.left if the rect.x is provided, or the rect.right if the rect.width
+ * and rec.x are provided.
+ */
+function populateDOMRect(partialRect: Partial<DOMRect>): Partial<DOMRect> {
+  const rect = { ...partialRect };
+
+  if (rect.x && !rect.left) rect.left = rect.x;
+  if (rect.y && !rect.top) rect.top = rect.y;
+  if (rect.width && rect.x && !rect.right) rect.right = rect.x + rect.width;
+  if (rect.height && rect.y && !rect.bottom) rect.bottom = rect.y + rect.height;
+  if (rect.left && rect.right && !rect.width) rect.width = rect.right - rect.left;
+  if (rect.top && rect.bottom && !rect.height) rect.height = rect.bottom - rect.top;
+
+  return rect;
+}


### PR DESCRIPTION
The popover component have currently some problems :

- It's currently not possible to define the height of a popover.
The "childHeight" props is only used for positioning.
- flipHorizontalOffset/flipVerticalOffset props are confusing to use.
They should sometime be positive, sometime negatives, and are computed
by hand to use popovers. Ideally we'd want the logic of it to be
hidden in the component.
- The popovers are linked with the grid (with scrollbar/topbar size
used in computations), but we use them at other places

Refactored the popover component. Now :

- The logic of the popover being displayed in the left/right, depending
on if whether there is space or not, is hidden in the component
- The popovers are now independent of the grid, they can be used anywhere
- Now the popover is positioned based on the actual size of its child,
not around arbitrary childHeight/Width props (that were dropped).

The main props are now :
- positioning: position of the popover (TopLeft/BottomRight)
- anchorRect : rectangle around which the popover is positioned
(the cell rectangle in the grid, a single point for menus)
- containerRec : rectangle inside which the popover is displayed, and
shouldn't overflow out of (ie. the viewport in the grid)
- Dropped props marginTop, it is now implied in containerRec
- added props max height/width

Odoo task ID : [2796248](https://www.odoo.com/web#id=2796248&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo