### PR TITLE
[IMP] composer: changed formula bracket or string highlight color

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -17,10 +17,10 @@ const ASSISTANT_WIDTH = 300;
 
 export const FunctionColor = "#4a4e4d";
 export const OperatorColor = "#3da4ab";
-export const StringColor = "#f6cd61";
+export const StringColor = "#00a82d";
 export const SelectionIndicatorColor = "darkgrey";
 export const NumberColor = "#02c39a";
-export const MatchingParenColor = "pink";
+export const MatchingParenColor = "black";
 
 export const SelectionIndicatorClass = "selector-flag";
 


### PR DESCRIPTION
## Description:

Increased the contrast of formulas brackets/string arguments for better readability. Now,

> String argument highlight color is #00a82d (green) instead of pink.
> Bracket highlight is black instead of pink.

Odoo task ID : [2801483](https://www.odoo.com/web#id=2801483&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo