### PR TITLE
[FIX] charts: fix label range at chart insertion

### DIFF
--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -516,7 +516,6 @@ export const CREATE_CHART = (env: SpreadsheetEnv) => {
   const id = env.uuidGenerator.uuidv4();
   let labelRange: string | undefined;
   if (zone.left !== zone.right) {
-    labelRange = zoneToXc({ ...zone, right: zone.left, top: zone.top + 1 });
     dataSetZone = { ...zone, left: zone.left + 1 };
   }
   const dataSets = [zoneToXc(dataSetZone)];
@@ -530,7 +529,15 @@ export const CREATE_CHART = (env: SpreadsheetEnv) => {
     const cell = env.getters.getCell(sheetId, x, zone.top);
     if (cell && cell.evaluated.type !== CellValueType.number) {
       dataSetsHaveTitle = true;
+      break;
     }
+  }
+  if (zone.left !== zone.right) {
+    labelRange = zoneToXc({
+      ...zone,
+      right: zone.left,
+      top: dataSetsHaveTitle ? zone.top + 1 : zone.top,
+    });
   }
   env.dispatch("CREATE_CHART", {
     sheetId,

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1,4 +1,3 @@
-import { ChartConfiguration } from "chart.js";
 import { Model, Spreadsheet } from "../../src";
 import { BACKGROUND_CHART_COLOR, MENU_WIDTH } from "../../src/constants";
 import { DispatchResult } from "../../src/types";
@@ -10,38 +9,11 @@ import {
 } from "../test_helpers/dom_helper";
 import {
   makeTestFixture,
+  mockChart,
   mountSpreadsheet,
   nextTick,
   textContentAll,
 } from "../test_helpers/helpers";
-
-const mockChart = () => {
-  const mockChartData: ChartConfiguration = {
-    data: undefined,
-    options: {
-      title: undefined,
-    },
-    type: undefined,
-  };
-  class ChartMock {
-    constructor(ctx: unknown, chartData: ChartConfiguration) {
-      Object.assign(mockChartData, chartData);
-    }
-    set data(value) {
-      mockChartData.data = value;
-    }
-    get data() {
-      return mockChartData.data;
-    }
-    destroy = () => {};
-    update = () => {};
-    options = mockChartData.options;
-    config = mockChartData;
-  }
-  //@ts-ignore
-  window.Chart = ChartMock;
-  return mockChartData;
-};
 
 function errorMessages(): string[] {
   return textContentAll(".o-sidepanel-error div");

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -11,6 +11,7 @@ import { DispatchResult, SpreadsheetEnv } from "../src/types";
 import { hideColumns, hideRows, selectCell, setSelection } from "./test_helpers/commands_helpers";
 import {
   makeTestFixture,
+  mockChart,
   MockClipboard,
   mockUuidV4To,
   mountSpreadsheet,
@@ -824,6 +825,98 @@ describe("Menu Item actions", () => {
     expect(env.dispatch).toHaveBeenCalledWith("SET_GRID_LINES_VISIBILITY", {
       sheetId,
       areGridLinesVisible: false,
+    });
+  });
+
+  describe("Insert > Chart", () => {
+    const data = {
+      sheets: [
+        {
+          name: "Sheet1",
+          colNumber: 10,
+          rowNumber: 10,
+          rows: {},
+          cells: {
+            A2: { content: "P1" },
+            A3: { content: "P2" },
+            A4: { content: "P3" },
+            A5: { content: "P4" },
+
+            B1: { content: "first column dataset" },
+            B2: { content: "10" },
+            B3: { content: "11" },
+            B4: { content: "12" },
+            B5: { content: "13" },
+          },
+        },
+      ],
+    };
+    let dispatchSpy: jest.SpyInstance;
+    let defaultPayload: any;
+
+    beforeEach(async () => {
+      fixture = makeTestFixture();
+      parent = await mountSpreadsheet(fixture, { data });
+      model = parent.model;
+      env = parent.env;
+      mockChart();
+      dispatchSpy = jest.spyOn(env, "dispatch");
+      defaultPayload = {
+        position: expect.any(Object),
+        id: expect.any(String),
+        sheetId: model.getters.getActiveSheetId(),
+        definition: {
+          background: "#FFFFFF",
+          dataSets: ["A1"],
+          dataSetsHaveTitle: false,
+          labelRange: undefined,
+          legendPosition: "top",
+          stackedBar: false,
+          title: "",
+          type: "bar",
+          verticalAxisPosition: "left",
+        },
+      };
+    });
+
+    test("Chart of single column without title", () => {
+      setSelection(model, ["B2:B5"]);
+      doAction(["insert", "insert_chart"], env);
+      const payload = { ...defaultPayload };
+      payload.definition.dataSets = ["B2:B5"];
+      payload.definition.labelRange = undefined;
+      payload.definition.dataSetsHaveTitle = false;
+      expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
+    });
+
+    test("Chart of single column with title", () => {
+      setSelection(model, ["B1:B5"]);
+      doAction(["insert", "insert_chart"], env);
+      const payload = { ...defaultPayload };
+      payload.definition.dataSets = ["B1:B5"];
+      payload.definition.labelRange = undefined;
+      payload.definition.dataSetsHaveTitle = true;
+      expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
+    });
+
+    test("Chart of several columns (ie labels) without title", () => {
+      setSelection(model, ["A2:B5"]);
+      doAction(["insert", "insert_chart"], env);
+      const payload = { ...defaultPayload };
+      payload.definition.dataSets = ["B2:B5"];
+      payload.definition.labelRange = "A2:A5";
+      payload.definition.dataSetsHaveTitle = false;
+      expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
+    });
+
+    test("Chart of several columns (ie labels) with title", () => {
+      setSelection(model, ["A1:B5"]);
+      doAction(["insert", "insert_chart"], env);
+      const payload = { ...defaultPayload };
+      payload.definition.dataSets = ["B1:B5"];
+      payload.definition.labelRange = "A2:A5";
+      payload.definition.dataSetsHaveTitle = true;
+      expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
   });
 });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -1,4 +1,5 @@
 import { Component } from "@odoo/owl";
+import { ChartConfiguration } from "chart.js";
 import format from "xml-formatter";
 import { Spreadsheet } from "../../src/components/spreadsheet";
 import { functionRegistry } from "../../src/functions/index";
@@ -332,3 +333,31 @@ export function mockUuidV4To(model: Model, value: number | string) {
   //@ts-ignore
   return model.uuidGenerator.setNextId(value);
 }
+
+export const mockChart = () => {
+  const mockChartData: ChartConfiguration = {
+    data: undefined,
+    options: {
+      title: undefined,
+    },
+    type: undefined,
+  };
+  class ChartMock {
+    constructor(ctx: unknown, chartData: ChartConfiguration) {
+      Object.assign(mockChartData, chartData);
+    }
+    set data(value) {
+      mockChartData.data = value;
+    }
+    get data() {
+      return mockChartData.data;
+    }
+    destroy = () => {};
+    update = () => {};
+    options = mockChartData.options;
+    config = mockChartData;
+  }
+  //@ts-ignore
+  window.Chart = ChartMock;
+  return mockChartData;
+};


### PR DESCRIPTION
Up until now, the command payload of the action "Insert Chart" was
created under the assumption that the datasets always contained a title.

This would lead to:
- shift between the labels and their dataset value (data from line N
linked to label from line N+1)
- the first label would be skipped
- the data of the last row are missing in the graph.

Task 2806656

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2806656](https://www.odoo.com/web#id=2806656&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo