### PR TITLE
[IMP] topbar_menu_registry: improved formatting for "format" menu

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -24,7 +24,7 @@ import { Popover } from "../popover/popover";
 css/* scss */ `
   .o-menu {
     background-color: white;
-    padding: 8px 0px;
+    padding: 5px 0px;
     .o-menu-item {
       display: flex;
       justify-content: space-between;
@@ -53,7 +53,7 @@ css/* scss */ `
         &:hover {
           background-color: #ebebeb;
         }
-        .o-menu-item-shortcut {
+        .o-menu-item-description {
           color: grey;
         }
       }
@@ -195,8 +195,8 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
   getName(menu: FullMenuItem) {
     return cellMenuRegistry.getName(menu, this.env);
   }
-  getShortCut(menu: FullMenuItem) {
-    return cellMenuRegistry.getShortCut(menu);
+  getDescription(menu: FullMenuItem) {
+    return cellMenuRegistry.getDescription(menu);
   }
 
   isRoot(menu: FullMenuItem) {

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -21,7 +21,11 @@
             t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled}"
             t-att-style="getColor(menuItem)">
             <t t-esc="getName(menuItem)"/>
-            <span class="o-menu-item-shortcut" t-esc="getShortCut(menuItem)"/>
+            <span
+              t-if="getDescription(menuItem)"
+              class="o-menu-item-description"
+              t-esc="getDescription(menuItem)"
+            />
             <t t-if="isMenuRoot">
               <t t-call="o-spreadsheet.Icon.TRIANGLE_RIGHT"/>
             </t>

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -36,23 +36,35 @@ interface State {
 }
 
 const FORMATS = [
-  { name: "general", text: `${NumberFormatTerms.General} (${NumberFormatTerms.NoSpecificFormat})` },
-  { name: "number", text: `${NumberFormatTerms.Number} (1,000.12)`, value: "#,##0.00" },
-  { name: "percent", text: `${NumberFormatTerms.Percent} (10.12%)`, value: "0.00%" },
-  { name: "currency", text: `${NumberFormatTerms.Currency} ($1,000.12)`, value: "[$$]#,##0.00" },
+  { name: "general", text: NumberFormatTerms.General },
+  { name: "number", text: NumberFormatTerms.Number, description: "(1,000.12)", value: "#,##0.00" },
+  { name: "percent", text: NumberFormatTerms.Percent, description: "(10.12%)", value: "0.00%" },
+  {
+    name: "currency",
+    text: NumberFormatTerms.Currency,
+    description: "($1,000.12)",
+    value: "[$$]#,##0.00",
+  },
   {
     name: "currency_rounded",
-    text: `${NumberFormatTerms.CurrencyRounded} ($1,000)`,
+    text: NumberFormatTerms.CurrencyRounded,
+    description: "($1,000)",
     value: "[$$]#,##0",
   },
-  { name: "date", text: `${NumberFormatTerms.Date} (9/26/2008)`, value: "m/d/yyyy" },
-  { name: "time", text: `${NumberFormatTerms.Time} (10:43:00 PM)`, value: "hh:mm:ss a" },
+  { name: "date", text: NumberFormatTerms.Date, description: "(9/26/2008)", value: "m/d/yyyy" },
+  { name: "time", text: NumberFormatTerms.Time, description: "(10:43:00 PM)", value: "hh:mm:ss a" },
   {
     name: "datetime",
-    text: `${NumberFormatTerms.DateTime} (9/26/2008 22:43:00)`,
+    text: NumberFormatTerms.DateTime,
+    description: "(9/26/2008 22:43:00)",
     value: "m/d/yyyy hh:mm:ss",
   },
-  { name: "duration", text: `${NumberFormatTerms.Duration} (27:51:38)`, value: "hhhh:mm:ss" },
+  {
+    name: "duration",
+    text: NumberFormatTerms.Duration,
+    description: "(27:51:38)",
+    value: "hhhh:mm:ss",
+  },
 ];
 
 const CUSTOM_FORMATS = [
@@ -224,16 +236,18 @@ css/* scss */ `
             }
 
             &.o-format-tool {
-              padding: 7px 0;
+              padding: 5px 0;
+              width: 220px;
+              font-size: 12px;
               > div {
-                padding-left: 25px;
+                padding: 0 20px;
                 white-space: nowrap;
 
                 &.active:before {
                   content: "✓";
                   font-weight: bold;
                   position: absolute;
-                  left: 10px;
+                  left: 5px;
                 }
               }
             }

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -97,6 +97,7 @@
                   t-att-data-format="format.name"
                   t-att-class="{active: currentFormat === format.name}">
                   <t t-esc="format.text"/>
+                  <span class="float-right text-muted" t-esc="format.description"/>
                 </div>
               </t>
               <t t-foreach="customFormats" t-as="customFormat" t-key="customFormat.name">

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -58,7 +58,6 @@ export const ChartTerms = {
 
 export const NumberFormatTerms = {
   General: _lt("General"),
-  NoSpecificFormat: _lt("no specific format"),
   Number: _lt("Number"),
   Percent: _lt("Percent"),
   Currency: _lt("Currency"),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ export const MIN_CELL_TEXT_MARGIN = 4;
 export const CF_ICON_EDGE_LENGTH = 15;
 
 // Menus
-export const MENU_WIDTH = 200;
+export const MENU_WIDTH = 220;
 export const MENU_ITEM_HEIGHT = 24;
 export const MENU_SEPARATOR_BORDER_WIDTH = 1;
 export const MENU_SEPARATOR_PADDING = 5;

--- a/src/registries/menu_items_registry.ts
+++ b/src/registries/menu_items_registry.ts
@@ -26,7 +26,7 @@ import { SpreadsheetChildEnv } from "../types/env";
  */
 export interface MenuItem {
   name: string | ((env: SpreadsheetChildEnv) => string);
-  shortCut?: string;
+  description?: string;
   sequence: number;
   id?: string;
   isVisible?: (env: SpreadsheetChildEnv) => boolean;
@@ -47,7 +47,7 @@ const DEFAULT_MENU_ITEM = (key: string) => ({
   isVisible: () => true,
   isEnabled: () => true,
   isReadonlyAllowed: false,
-  shortCut: "",
+  description: "",
   action: false,
   children: [],
   separator: false,
@@ -108,8 +108,8 @@ export class MenuItemRegistry extends Registry<FullMenuItem> {
     }
     return node.name;
   }
-  getShortCut(node: FullMenuItem): string {
-    return node.shortCut ? node.shortCut : "";
+  getDescription(node: FullMenuItem): string {
+    return node.description ? node.description : "";
   }
 
   /**

--- a/src/registries/menus/cell_menu_registry.ts
+++ b/src/registries/menus/cell_menu_registry.ts
@@ -12,20 +12,20 @@ export const cellMenuRegistry = new MenuItemRegistry();
 cellMenuRegistry
   .add("cut", {
     name: _lt("Cut"),
-    shortCut: "Ctrl+X",
+    description: "Ctrl+X",
     sequence: 10,
     action: ACTIONS.CUT_ACTION,
   })
   .add("copy", {
     name: _lt("Copy"),
-    shortCut: "Ctrl+C",
+    description: "Ctrl+C",
     sequence: 20,
     isReadonlyAllowed: true,
     action: ACTIONS.COPY_ACTION,
   })
   .add("paste", {
     name: _lt("Paste"),
-    shortCut: "Ctrl+V",
+    description: "Ctrl+V",
     sequence: 30,
     action: ACTIONS.PASTE_ACTION,
   })

--- a/src/registries/menus/col_menu_registry.ts
+++ b/src/registries/menus/col_menu_registry.ts
@@ -8,20 +8,20 @@ export const colMenuRegistry = new MenuItemRegistry();
 colMenuRegistry
   .add("cut", {
     name: _lt("Cut"),
-    shortCut: "Ctrl+X",
+    description: "Ctrl+X",
     sequence: 10,
     action: ACTIONS.CUT_ACTION,
   })
   .add("copy", {
     name: _lt("Copy"),
-    shortCut: "Ctrl+C",
+    description: "Ctrl+C",
     sequence: 20,
     isReadonlyAllowed: true,
     action: ACTIONS.COPY_ACTION,
   })
   .add("paste", {
     name: _lt("Paste"),
-    shortCut: "Ctrl+V",
+    description: "Ctrl+V",
     sequence: 30,
     action: ACTIONS.PASTE_ACTION,
   })

--- a/src/registries/menus/row_menu_registry.ts
+++ b/src/registries/menus/row_menu_registry.ts
@@ -9,19 +9,19 @@ rowMenuRegistry
   .add("cut", {
     name: _lt("Cut"),
     sequence: 10,
-    shortCut: "Ctrl+X",
+    description: "Ctrl+X",
     action: ACTIONS.CUT_ACTION,
   })
   .add("copy", {
     name: _lt("Copy"),
-    shortCut: "Ctrl+C",
+    description: "Ctrl+C",
     sequence: 20,
     isReadonlyAllowed: true,
     action: ACTIONS.COPY_ACTION,
   })
   .add("paste", {
     name: _lt("Paste"),
-    shortCut: "Ctrl+V",
+    description: "Ctrl+V",
     sequence: 30,
     action: ACTIONS.PASTE_ACTION,
   })

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -16,39 +16,39 @@ topbarMenuRegistry
   .add("data", { name: _lt("Data"), sequence: 60 })
   .addChild("save", ["file"], {
     name: _lt("Save"),
-    shortCut: "Ctrl+S",
+    description: "Ctrl+S",
     sequence: 10,
     action: () => console.log("Not implemented"),
   })
   .addChild("undo", ["edit"], {
     name: _lt("Undo"),
-    shortCut: "Ctrl+Z",
+    description: "Ctrl+Z",
     sequence: 10,
     action: ACTIONS.UNDO_ACTION,
   })
   .addChild("redo", ["edit"], {
     name: _lt("Redo"),
-    shortCut: "Ctrl+Y",
+    description: "Ctrl+Y",
     sequence: 20,
     action: ACTIONS.REDO_ACTION,
     separator: true,
   })
   .addChild("copy", ["edit"], {
     name: _lt("Copy"),
-    shortCut: "Ctrl+C",
+    description: "Ctrl+C",
     sequence: 30,
     isReadonlyAllowed: true,
     action: ACTIONS.COPY_ACTION,
   })
   .addChild("cut", ["edit"], {
     name: _lt("Cut"),
-    shortCut: "Ctrl+X",
+    description: "Ctrl+X",
     sequence: 40,
     action: ACTIONS.CUT_ACTION,
   })
   .addChild("paste", ["edit"], {
     name: _lt("Paste"),
-    shortCut: "Ctrl+V",
+    description: "Ctrl+V",
     sequence: 50,
     action: ACTIONS.PASTE_ACTION,
   })
@@ -86,7 +86,7 @@ topbarMenuRegistry
   })
   .addChild("find_and_replace", ["edit"], {
     name: _lt("Find and replace"),
-    shortCut: "Ctrl+H",
+    description: "Ctrl+H",
     sequence: 65,
     isReadonlyAllowed: true,
     action: ACTIONS.OPEN_FAR_SIDEPANEL_ACTION,
@@ -207,29 +207,33 @@ topbarMenuRegistry
     separator: true,
   })
   .addChild("format_number_general", ["format", "format_number"], {
-    name: `${NumberFormatTerms.General} (${NumberFormatTerms.NoSpecificFormat})`,
+    name: NumberFormatTerms.General,
     sequence: 10,
     separator: true,
     action: ACTIONS.FORMAT_GENERAL_ACTION,
   })
   .addChild("format_number_number", ["format", "format_number"], {
-    name: `${NumberFormatTerms.Number} (1,000.12)`,
+    name: NumberFormatTerms.Number,
+    description: "(1,000.12)",
     sequence: 20,
     action: ACTIONS.FORMAT_NUMBER_ACTION,
   })
   .addChild("format_number_percent", ["format", "format_number"], {
-    name: `${NumberFormatTerms.Percent} (10.12%)`,
+    name: NumberFormatTerms.Percent,
+    description: "(10.12%)",
     sequence: 30,
     separator: true,
     action: ACTIONS.FORMAT_PERCENT_ACTION,
   })
   .addChild("format_number_currency", ["format", "format_number"], {
-    name: `${NumberFormatTerms.Currency} ($1,000.12)`,
+    name: NumberFormatTerms.Currency,
+    description: "($1,000.12)",
     sequence: 37,
     action: ACTIONS.FORMAT_CURRENCY_ACTION,
   })
   .addChild("format_number_currency_rounded", ["format", "format_number"], {
-    name: `${NumberFormatTerms.CurrencyRounded} ($1,000)`,
+    name: NumberFormatTerms.CurrencyRounded,
+    description: "($1,000)",
     sequence: 38,
     action: ACTIONS.FORMAT_CURRENCY_ROUNDED_ACTION,
   })
@@ -240,22 +244,26 @@ topbarMenuRegistry
     action: ACTIONS.OPEN_CUSTOM_CURRENCY_SIDEPANEL_ACTION,
   })
   .addChild("format_number_date", ["format", "format_number"], {
-    name: `${NumberFormatTerms.Date} (9/26/2008)`,
+    name: NumberFormatTerms.Date,
+    description: "(9/26/2008)",
     sequence: 40,
     action: ACTIONS.FORMAT_DATE_ACTION,
   })
   .addChild("format_number_time", ["format", "format_number"], {
-    name: `${NumberFormatTerms.Time} (10:43:00 PM)`,
+    name: NumberFormatTerms.Time,
+    description: "(10:43:00 PM)",
     sequence: 50,
     action: ACTIONS.FORMAT_TIME_ACTION,
   })
   .addChild("format_number_date_time", ["format", "format_number"], {
-    name: `${NumberFormatTerms.DateTime} (9/26/2008 22:43:00)`,
+    name: NumberFormatTerms.DateTime,
+    description: "(9/26/2008 22:43:00)",
     sequence: 60,
     action: ACTIONS.FORMAT_DATE_TIME_ACTION,
   })
   .addChild("format_number_duration", ["format", "format_number"], {
-    name: `${NumberFormatTerms.Duration} (27:51:38)`,
+    name: NumberFormatTerms.Duration,
+    description: "(27:51:38)",
     sequence: 70,
     separator: true,
     action: ACTIONS.FORMAT_DURATION_ACTION,
@@ -263,18 +271,18 @@ topbarMenuRegistry
   .addChild("format_bold", ["format"], {
     name: _lt("Bold"),
     sequence: 20,
-    shortCut: "Ctrl+B",
+    description: "Ctrl+B",
     action: ACTIONS.FORMAT_BOLD_ACTION,
   })
   .addChild("format_italic", ["format"], {
     name: _lt("Italic"),
     sequence: 30,
-    shortCut: "Ctrl+I",
+    description: "Ctrl+I",
     action: ACTIONS.FORMAT_ITALIC_ACTION,
   })
   .addChild("format_underline", ["format"], {
     name: _lt("Underline"),
-    shortCut: "Ctrl+U",
+    description: "Ctrl+U",
     sequence: 40,
     action: ACTIONS.FORMAT_UNDERLINE_ACTION,
   })

--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -10,11 +10,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     title="Sum: 24"
   >
     Sum: 24
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -25,11 +21,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     title="Avg: 24"
   >
     Avg: 24
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -40,11 +32,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     title="Min: 24"
   >
     Min: 24
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -55,11 +43,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     title="Max: 24"
   >
     Max: 24
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -70,11 +54,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     title="Count: 1"
   >
     Count: 1
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -85,11 +65,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     title="Count Numbers: 1"
   >
     Count Numbers: 1
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>

--- a/tests/components/__snapshots__/context_menu.test.ts.snap
+++ b/tests/components/__snapshots__/context_menu.test.ts.snap
@@ -11,10 +11,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
   >
     Cut
     <span
-      class="o-menu-item-shortcut"
+      class="o-menu-item-description"
     >
       Ctrl+X
     </span>
+    
     
     
   </div>
@@ -26,10 +27,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
   >
     Copy
     <span
-      class="o-menu-item-shortcut"
+      class="o-menu-item-description"
     >
       Ctrl+C
     </span>
+    
     
     
   </div>
@@ -41,10 +43,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
   >
     Paste
     <span
-      class="o-menu-item-shortcut"
+      class="o-menu-item-description"
     >
       Ctrl+V
     </span>
+    
     
     
   </div>
@@ -55,11 +58,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Paste special"
   >
     Paste special
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     <svg
       class="o-icon"
     >
@@ -81,11 +80,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Sort range"
   >
     Sort range
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     <svg
       class="o-icon"
     >
@@ -107,11 +102,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Insert row"
   >
     Insert row
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -122,11 +113,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Insert column"
   >
     Insert column
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -137,11 +124,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Insert cells"
   >
     Insert cells
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     <svg
       class="o-icon"
     >
@@ -163,11 +146,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Delete row 8"
   >
     Delete row 8
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -178,11 +157,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Delete column C"
   >
     Delete column C
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -193,11 +168,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Delete cells"
   >
     Delete cells
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     <svg
       class="o-icon"
     >
@@ -217,11 +188,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Clear cells"
   >
     Clear cells
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -234,11 +201,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Insert link"
   >
     Insert link
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>
@@ -251,11 +214,7 @@ exports[`Context Menu context menu simple rendering 1`] = `
     title="Conditional formatting"
   >
     Conditional formatting
-    <span
-      class="o-menu-item-shortcut"
-    >
-      
-    </span>
+    
     
     
   </div>

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -168,47 +168,92 @@ exports[`TopBar component can set cell format 1`] = `
                 class="active"
                 data-format="general"
               >
-                General (no specific format)
+                General
+                <span
+                  class="float-right text-muted"
+                >
+                  
+                </span>
               </div>
               <div
                 data-format="number"
               >
-                Number (1,000.12)
+                Number
+                <span
+                  class="float-right text-muted"
+                >
+                  (1,000.12)
+                </span>
               </div>
               <div
                 data-format="percent"
               >
-                Percent (10.12%)
+                Percent
+                <span
+                  class="float-right text-muted"
+                >
+                  (10.12%)
+                </span>
               </div>
               <div
                 data-format="currency"
               >
-                Currency ($1,000.12)
+                Currency
+                <span
+                  class="float-right text-muted"
+                >
+                  ($1,000.12)
+                </span>
               </div>
               <div
                 data-format="currency_rounded"
               >
-                Currency rounded ($1,000)
+                Currency rounded
+                <span
+                  class="float-right text-muted"
+                >
+                  ($1,000)
+                </span>
               </div>
               <div
                 data-format="date"
               >
-                Date (9/26/2008)
+                Date
+                <span
+                  class="float-right text-muted"
+                >
+                  (9/26/2008)
+                </span>
               </div>
               <div
                 data-format="time"
               >
-                Time (10:43:00 PM)
+                Time
+                <span
+                  class="float-right text-muted"
+                >
+                  (10:43:00 PM)
+                </span>
               </div>
               <div
                 data-format="datetime"
               >
-                Date time (9/26/2008 22:43:00)
+                Date time
+                <span
+                  class="float-right text-muted"
+                >
+                  (9/26/2008 22:43:00)
+                </span>
               </div>
               <div
                 data-format="duration"
               >
-                Duration (27:51:38)
+                Duration
+                <span
+                  class="float-right text-muted"
+                >
+                  (27:51:38)
+                </span>
               </div>
               
               

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -2,7 +2,13 @@ import { App, Component, useSubEnv, xml } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import { Grid } from "../../src/components/grid/grid";
 import { Menu } from "../../src/components/menu/menu";
-import { HEADER_HEIGHT, HEADER_WIDTH, MENU_ITEM_HEIGHT, TOPBAR_HEIGHT } from "../../src/constants";
+import {
+  HEADER_HEIGHT,
+  HEADER_WIDTH,
+  MENU_ITEM_HEIGHT,
+  MENU_WIDTH,
+  TOPBAR_HEIGHT,
+} from "../../src/constants";
 import { toXC, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { createFullMenuItem, FullMenuItem } from "../../src/registries";
@@ -77,7 +83,7 @@ function getItemSize() {
 
 function getSize(menuItemsCount: number): { width: number; height: number } {
   return {
-    width: 200,
+    width: MENU_WIDTH,
     height: getItemSize() * menuItemsCount,
   };
 }
@@ -631,7 +637,7 @@ describe("Context Menu position on large screen 1000px/1000px", () => {
   });
 
   test("it renders submenu on the bottom left if not enough space", async () => {
-    const [clickX, clickY] = await renderContextMenu(780, 300, { menuItems: subMenu });
+    const [clickX, clickY] = await renderContextMenu(770, 300, { menuItems: subMenu });
     await simulateClick("div[data-name='root']");
     const { left, top } = getSubMenuPosition();
     const { width } = getMenuSize();
@@ -721,7 +727,7 @@ describe("Context Menu position on small screen 1000px/300px", () => {
   });
 
   test("it renders submenu at the top of the screen on the left, if not enough space above, below and on the right", async () => {
-    const [clickX] = await renderContextMenu(780, 150, { menuItems: longMenuItems }, 1000, 300);
+    const [clickX] = await renderContextMenu(770, 150, { menuItems: longMenuItems }, 1000, 300);
     await simulateClick("div[data-name='root_4']");
     const { left, top } = getSubMenuPosition();
     const { width } = getMenuSize();

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -80,7 +80,7 @@ describe("Menu Item Registry", () => {
     topbarMenuRegistry.addChild("child2", ["root", "child1"], {
       name: "Child2",
       sequence: 1,
-      shortCut: "coucou",
+      description: "coucou",
     });
     const item = topbarMenuRegistry.get("root");
     expect(item.children).toHaveLength(1);
@@ -88,7 +88,7 @@ describe("Menu Item Registry", () => {
     expect(item.children[0].id).toBe("child1");
     expect(item.children[0].children).toHaveLength(1);
     expect(item.children[0].children[0].name).toBe("Child2");
-    expect(item.children[0].children[0].shortCut).toBe("coucou");
+    expect(item.children[0].children[0].description).toBe("coucou");
     expect(item.children[0].children[0].id).toBe("child2");
   });
 


### PR DESCRIPTION
## Description:
This commit modfies,
- Alignment of example text in Format > Numbers menu.
- Lowered Menu padding to fix alignment of menu items.
- Menu width increased by 20 px.
- Removed an unwanted text in format menu.
- Removed "shortCut" field from menu registry format
- Added a new "description" field in menu registry format.
- Changed width value to MENU_WIDTH in test case.
- Updated snapshots in context_menu, bottom_bar.
- Modified format of quickFormat menu

Odoo task ID : [2790095](https://www.odoo.com/web#id=2790095&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo