### PR TITLE
[FIX] range: correctly adapt ranges

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -64,8 +64,19 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
               const toRemove = Math.min(range.zone[end], max) - min + 1;
               changeType = "RESIZE";
               newRange = this.createAdaptedRange(newRange, dimension, changeType, -toRemove);
-            }
-            if (min < range.zone[start]) {
+            } else if (range.zone[start] >= min && range.zone[end] <= max) {
+              changeType = "REMOVE";
+            } else if (range.zone[start] <= max && range.zone[end] >= max) {
+              const toRemove = max - range.zone[start] + 1;
+              changeType = "RESIZE";
+              newRange = this.createAdaptedRange(newRange, dimension, changeType, -toRemove);
+              newRange = this.createAdaptedRange(
+                newRange,
+                dimension,
+                "MOVE",
+                -(range.zone[start] - min)
+              );
+            } else if (min < range.zone[start]) {
               changeType = "MOVE";
               newRange = this.createAdaptedRange(newRange, dimension, changeType, -(max - min + 1));
             }
@@ -163,12 +174,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
   private verifyRangeRemoved(adaptRange: ApplyRangeChange): ApplyRangeChange {
     return (range: Range) => {
       const result: ApplyRangeChangeResult = adaptRange(range);
-      if (
-        result.changeType !== "NONE" &&
-        result.range &&
-        (result.range.zone.right - result.range.zone.left < 0 ||
-          result.range.zone.bottom - result.range.zone.top < 0)
-      ) {
+      if (result.changeType !== "NONE" && !isZoneValid(result.range.zone)) {
         return { range: result.range, changeType: "REMOVE" };
       }
       return result;

--- a/tests/plugins/__snapshots__/grid_manipulation.test.ts.snap
+++ b/tests/plugins/__snapshots__/grid_manipulation.test.ts.snap
@@ -98,7 +98,7 @@ Object {
     "style": undefined,
   },
   "A6": Object {
-    "content": "=SUM(A1:B1)",
+    "content": "=SUM(B1)",
     "format": undefined,
     "style": undefined,
   },
@@ -268,7 +268,7 @@ Object {
     "style": undefined,
   },
   "F1": Object {
-    "content": "=SUM(A1:A2)",
+    "content": "=SUM(A2)",
     "format": undefined,
     "style": undefined,
   },

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -318,6 +318,17 @@ describe("conditional format", () => {
     });
   });
 
+  test("delete cf when range is deleted with previous rows", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
+      target: target("A4"),
+      sheetId,
+    });
+    deleteRows(model, [2, 3]);
+    expect(model.getters.getConditionalFormats(sheetId)).toEqual([]);
+  });
+
   test("is saved/restored", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),


### PR DESCRIPTION


## Description:

- CF on A4
- Delete rows 3 and 4
=> CF is now in A2 instead of being deleted

- In F1, write "=SUM(A3:A4)"
- Delete rows 2 and 3
=> the formula should now be "=SUM(A2)"

Note there were wrong snapshots testing this scenario

Co-authored-by: Adrien Minne <adrm@odoo.com>

Odoo task ID : [2791441](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo