### PR TITLE
[FIX] tests: use not.toBeNull instead of toBeDefined for components

### DIFF
--- a/tests/components/autofill.test.ts
+++ b/tests/components/autofill.test.ts
@@ -184,7 +184,7 @@ describe("Autofill component", () => {
         10
     );
     await nextTick();
-    expect(fixture.querySelector(".o-autofill-nextvalue")).toBeDefined();
+    expect(fixture.querySelector(".o-autofill-nextvalue")).not.toBeNull();
     expect(fixture.querySelector(".o-autofill-nextvalue")!.textContent).toBe("test");
   });
 
@@ -206,7 +206,7 @@ describe("Autofill component", () => {
         10
     );
     await nextTick();
-    expect(fixture.querySelector(".o-autofill-nextvalue")).toBeDefined();
+    expect(fixture.querySelector(".o-autofill-nextvalue")).not.toBeNull();
     triggerMouseEvent(
       autofill,
       "mousemove",
@@ -252,8 +252,8 @@ describe("Autofill component", () => {
         10
     );
     await nextTick();
-    expect(fixture.querySelector(".o-autofill-nextvalue")).toBeDefined();
-    expect(fixture.querySelector(".custom_tooltip")).toBeDefined();
+    expect(fixture.querySelector(".o-autofill-nextvalue")).not.toBeNull();
+    expect(fixture.querySelector(".custom_tooltip")).not.toBeNull();
     expect(fixture.querySelector(".custom_tooltip")!.textContent).toBe("blabla");
   });
 

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -105,17 +105,17 @@ describe("figures", () => {
     ]);
   });
   test("charts have a menu button", () => {
-    expect(fixture.querySelector(".o-figure")).toBeDefined();
-    expect(fixture.querySelector(".o-chart-menu")).toBeDefined();
+    expect(fixture.querySelector(".o-figure")).not.toBeNull();
+    expect(fixture.querySelector(".o-chart-menu")).not.toBeNull();
   });
 
   test("Click on Menu button open context menu", async () => {
-    expect(fixture.querySelector(".o-figure")).toBeDefined();
+    expect(fixture.querySelector(".o-figure")).not.toBeNull();
     await simulateClick(".o-figure");
     expect(document.activeElement).toBe(fixture.querySelector(".o-figure"));
-    expect(fixture.querySelector(".o-chart-menu")).toBeDefined();
+    expect(fixture.querySelector(".o-chart-menu")).not.toBeNull();
     await simulateClick(".o-chart-menu");
-    expect(fixture.querySelector(".o-menu")).toBeDefined();
+    expect(fixture.querySelector(".o-menu")).not.toBeNull();
   });
 
   test("Context menu is positioned according to the spreadsheet position", async () => {
@@ -175,12 +175,12 @@ describe("figures", () => {
       title: "hello",
       type: "bar",
     });
-    expect(fixture.querySelector(".o-figure")).toBeDefined();
+    expect(fixture.querySelector(".o-figure")).not.toBeNull();
     await simulateClick(".o-figure");
     expect(document.activeElement).toBe(fixture.querySelector(".o-figure"));
-    expect(fixture.querySelector(".o-chart-menu")).toBeDefined();
+    expect(fixture.querySelector(".o-chart-menu")).not.toBeNull();
     await simulateClick(".o-chart-menu");
-    expect(fixture.querySelector(".o-menu")).toBeDefined();
+    expect(fixture.querySelector(".o-menu")).not.toBeNull();
     const deleteButton = fixture.querySelectorAll(".o-menu-item")[1];
     expect(deleteButton.textContent).toBe("Delete");
     await simulateClick(".o-menu div[data-name='delete']");
@@ -507,6 +507,6 @@ describe("charts with multiple sheets", () => {
     const runtimeChart = model.getters.getChartRuntime("1");
     expect(runtimeChart).toBeDefined();
     await nextTick();
-    expect(fixture.querySelector(".o-chart-container")).toBeDefined();
+    expect(fixture.querySelector(".o-chart-container")).not.toBeNull();
   });
 });

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -76,7 +76,7 @@ describe("figures", () => {
   test("focus a figure", async () => {
     createFigure(model);
     await nextTick();
-    expect(fixture.querySelector(".o-figure")).toBeDefined();
+    expect(fixture.querySelector(".o-figure")).not.toBeNull();
     await simulateClick(".o-figure");
     expect(document.activeElement).toBe(fixture.querySelector(".o-figure"));
   });

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -78,7 +78,7 @@ describe("Grid component", () => {
   test("can render a sheet with a merge", async () => {
     const sheet1 = model.getters.getVisibleSheets()[0];
     merge(model, "B2:B3", sheet1);
-    expect(fixture.querySelector("canvas")).toBeDefined();
+    expect(fixture.querySelector("canvas")).not.toBeNull();
   });
 
   test("can click on a cell to select it", async () => {

--- a/tests/components/side_panel.test.ts
+++ b/tests/components/side_panel.test.ts
@@ -105,7 +105,7 @@ describe("Side Panel", () => {
     expect(document.querySelectorAll(".o-sidePanel")).toHaveLength(1);
     expect(document.querySelector(".o-sidePanelTitle")!.textContent).toBe("Computed Title");
     expect(document.querySelector(".main_body")!.textContent).toBe("test");
-    expect(document.querySelector(".props_body")).toBeDefined();
+    expect(document.querySelector(".props_body")).not.toBeNull();
     expect(document.querySelector(".props_body")!.textContent).toBe("context");
   });
 
@@ -124,9 +124,9 @@ describe("Side Panel", () => {
     await nextTick();
     expect(document.querySelectorAll(".o-sidePanel")).toHaveLength(1);
     expect(document.querySelector(".o-sidePanelTitle")!.textContent).toBe("PANEL_2");
-    expect(document.querySelector(".main_body_2")).toBeDefined();
+    expect(document.querySelector(".main_body_2")).not.toBeNull();
     expect(document.querySelector(".main_body_2")!.textContent).toBe("Hello");
-    expect(document.querySelector(".props_body_2")).toBeDefined();
+    expect(document.querySelector(".props_body_2")).not.toBeNull();
     expect(document.querySelector(".props_body_2")!.textContent).toBe("field");
   });
 

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -190,9 +190,9 @@ describe("Composer interactions", () => {
     await nextTick();
     const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer");
     const gridComposer = document.querySelector(".o-grid .o-composer");
-    expect(topBarComposer).toBeDefined();
+    expect(topBarComposer).not.toBeNull();
     expect(document.activeElement).toBe(topBarComposer);
-    expect(gridComposer).toBeDefined();
+    expect(gridComposer).not.toBeNull();
     await typeInComposerTopBar("text");
     await nextTick();
     expect(topBarComposer!.textContent).toBe("text");
@@ -237,14 +237,15 @@ describe("Composer interactions", () => {
     expect(topBarComposer!.textContent).toBe("10/10/2021");
   });
 
-  test("autocomplete disapear when grid composer is blured", async () => {
+  test("autocomplete disappear when grid composer is blurred", async () => {
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
     );
     await nextTick();
     const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer")!;
     await typeInComposerGrid("=SU");
-    expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).toBeDefined();
+    await nextTick();
+    expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).not.toBeNull();
     topBarComposer.dispatchEvent(new Event("click"));
     await nextTick();
     expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).toBeNull();


### PR DESCRIPTION
querySelector returns an HTMLElement or null. However, assertion
`expect(null).toBeDefined()` is ok, so our tests were not correct.
