### PR TITLE
[IMP] link chart to odoo menu

### DIFF
--- a/src/components/figures/chart/chart.ts
+++ b/src/components/figures/chart/chart.ts
@@ -22,10 +22,14 @@ css/* scss */ `
       display: none;
       position: absolute;
       padding: 5px;
+    }
+
+    .o-chart-menu-item {
       cursor: pointer;
     }
   }
-  .o-figure.active:focus {
+  .o-figure.active:focus,
+  .o-figure:hover {
     .o-chart-container {
       .o-chart-menu {
         display: flex;
@@ -51,6 +55,8 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
 
   canvas = useRef("graphContainer");
   private chartContainerRef = useRef("chartContainer");
+  private menuButtonRef = useRef("menuButton");
+  private menuButtonPosition = useAbsolutePosition(this.menuButtonRef);
   private chart?: Chart;
   private state: State = { background: BACKGROUND_CHART_COLOR };
   private position = useAbsolutePosition(this.chartContainerRef);
@@ -152,11 +158,11 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
     this.openContextMenu(position);
   }
 
-  showMenu(ev: MouseEvent) {
-    const target = ev.currentTarget as HTMLElement;
-    const x = target.offsetLeft;
-    const y = target.offsetTop;
-    const position = { x: this.position.x + x - MENU_WIDTH, y: this.position.y + y };
+  showMenu() {
+    const position = {
+      x: this.menuButtonPosition.x - MENU_WIDTH,
+      y: this.menuButtonPosition.y,
+    };
     this.openContextMenu(position);
   }
 

--- a/src/components/figures/chart/chart.xml
+++ b/src/components/figures/chart/chart.xml
@@ -1,8 +1,14 @@
 <templates>
   <t t-name="o-spreadsheet.ChartFigure" owl="1">
     <div class="o-chart-container" t-ref="chartContainer" t-on-contextmenu="onContextMenu">
-      <div class="o-chart-menu" t-on-click="showMenu" t-on-contextmenu.prevent.stop="showMenu">
-        <t t-call="o-spreadsheet.Icon.LIST"/>
+      <div class="o-chart-menu">
+        <div
+          class="o-chart-menu-item"
+          t-on-click="showMenu"
+          t-ref="menuButton"
+          t-on-contextmenu.prevent.stop="showMenu">
+          <t t-call="o-spreadsheet.Icon.LIST"/>
+        </div>
       </div>
       <canvas t-att-style="canvasStyle" t-ref="graphContainer"/>
       <Menu

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { ChartFigure } from "./components/figures/chart/chart";
+import { ChartPanel } from "./components/side_panel/chart_panel/chart_panel";
 import {
   BOTTOMBAR_HEIGHT,
   DEFAULT_CELL_HEIGHT,
@@ -124,4 +126,8 @@ export const helpers = {
   parseMarkdownLink,
   markdownLink,
   createEmptyWorkbookData,
+};
+export const components = {
+  ChartFigure,
+  ChartPanel,
 };

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -106,15 +106,15 @@ describe("figures", () => {
   });
   test("charts have a menu button", () => {
     expect(fixture.querySelector(".o-figure")).not.toBeNull();
-    expect(fixture.querySelector(".o-chart-menu")).not.toBeNull();
+    expect(fixture.querySelector(".o-chart-menu-item")).not.toBeNull();
   });
 
   test("Click on Menu button open context menu", async () => {
     expect(fixture.querySelector(".o-figure")).not.toBeNull();
     await simulateClick(".o-figure");
     expect(document.activeElement).toBe(fixture.querySelector(".o-figure"));
-    expect(fixture.querySelector(".o-chart-menu")).not.toBeNull();
-    await simulateClick(".o-chart-menu");
+    expect(fixture.querySelector(".o-chart-menu-item")).not.toBeNull();
+    await simulateClick(".o-chart-menu-item");
     expect(fixture.querySelector(".o-menu")).not.toBeNull();
   });
 
@@ -126,14 +126,14 @@ describe("figures", () => {
       .mockImplementation(function (this: HTMLDivElement) {
         if (this.className.includes("o-spreadsheet")) {
           return { top: 100, left: 200 };
-        } else if (this.className.includes("o-chart-container")) {
+        } else if (this.className.includes("o-chart-menu-item")) {
           return { top: 500, left: 500 };
         }
         return originalGetBoundingClientRect.call(this);
       });
 
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     const menuPopover = fixture.querySelector(".o-menu")?.parentElement;
     expect(menuPopover?.style.top).toBe(`${500 - 100}px`);
     expect(menuPopover?.style.left).toBe(`${500 - 200 - MENU_WIDTH}px`);
@@ -178,8 +178,8 @@ describe("figures", () => {
     expect(fixture.querySelector(".o-figure")).not.toBeNull();
     await simulateClick(".o-figure");
     expect(document.activeElement).toBe(fixture.querySelector(".o-figure"));
-    expect(fixture.querySelector(".o-chart-menu")).not.toBeNull();
-    await simulateClick(".o-chart-menu");
+    expect(fixture.querySelector(".o-chart-menu-item")).not.toBeNull();
+    await simulateClick(".o-chart-menu-item");
     expect(fixture.querySelector(".o-menu")).not.toBeNull();
     const deleteButton = fixture.querySelectorAll(".o-menu-item")[1];
     expect(deleteButton.textContent).toBe("Delete");
@@ -189,7 +189,7 @@ describe("figures", () => {
 
   test("Click on Edit button will prefill sidepanel", async () => {
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     const editButton = fixture.querySelectorAll(".o-menu-item")[0];
     expect(editButton.textContent).toBe("Edit");
     await simulateClick(".o-menu div[data-name='edit']");
@@ -212,7 +212,7 @@ describe("figures", () => {
     const chartId = "someuuid";
     const sheetId = model.getters.getActiveSheetId();
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     const editButton = fixture.querySelectorAll(".o-menu-item")[0];
     expect(editButton.textContent).toBe("Edit");
     await simulateClick(".o-menu div[data-name='edit']");
@@ -296,7 +296,7 @@ describe("figures", () => {
 
   test("drawing of chart will receive new data after update", async () => {
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     const editButton = fixture.querySelectorAll(".o-menu-item")[0];
     expect(editButton.textContent).toBe("Edit");
     await simulateClick(".o-menu div[data-name='edit']");
@@ -321,12 +321,12 @@ describe("figures", () => {
   test("deleting chart will close sidePanel", async () => {
     expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     await simulateClick(".o-menu div[data-name='edit']");
     await nextTick();
     expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeTruthy();
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     await simulateClick(".o-menu div[data-name='delete']");
     expect(model.getters.getChartRuntime("someuuid")).toBeUndefined();
     await nextTick();
@@ -336,12 +336,12 @@ describe("figures", () => {
   test("can refresh a chart", async () => {
     expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     await simulateClick(".o-menu div[data-name='edit']");
     await nextTick();
     expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeTruthy();
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     const dispatch = spyDispatch(parent);
     await simulateClick(".o-menu div[data-name='refresh']");
     expect(dispatch).toHaveBeenCalledWith("REFRESH_CHART", {
@@ -354,7 +354,7 @@ describe("figures", () => {
     await nextTick();
     const figures = fixture.querySelectorAll(".o-figure");
     await simulateClick(figures[0] as HTMLElement);
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     await simulateClick(".o-menu div[data-name='edit']");
     await nextTick();
     expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeTruthy();
@@ -394,7 +394,7 @@ describe("figures", () => {
 
   test("update chart with empty dataset and empty labels", async () => {
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     await simulateClick(".o-menu div[data-name='edit']");
 
     await simulateClick(".o-data-series input");
@@ -414,7 +414,7 @@ describe("figures", () => {
 
   test("update chart with invalid dataset and empty labels", async () => {
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     await simulateClick(".o-menu div[data-name='edit']");
     await simulateClick(".o-data-series input");
     setInputValueAndTrigger(".o-data-series input", "This is not valid", "change");
@@ -425,7 +425,7 @@ describe("figures", () => {
 
   test("update chart with invalid labels", async () => {
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     await simulateClick(".o-menu div[data-name='edit']");
     await simulateClick(".o-data-labels input");
     setInputValueAndTrigger(".o-data-labels input", "this is not valid", "change");
@@ -436,7 +436,7 @@ describe("figures", () => {
 
   test("Can remove the last data series", async () => {
     await simulateClick(".o-figure");
-    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-chart-menu-item");
     await simulateClick(".o-menu div[data-name='edit']");
     await simulateClick(".o-data-series .o-add-selection");
     const element = document.querySelectorAll(".o-data-series input")[1];


### PR DESCRIPTION
## Description:

Some tweaks to allow to link charts to odoo menus in Odoo.

Odoo task ID : [2799630](https://www.odoo.com/web#id=2799630&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo