### PR TITLE
[FIX] figures: prevent user to manipulate figures in Readonly mode

### DIFF
--- a/src/components/figures/container.ts
+++ b/src/components/figures/container.ts
@@ -246,7 +246,10 @@ export class FiguresContainer extends Component<{ sidePanelIsOpen: Boolean }, Sp
       // not main button, probably a context menu
       return;
     }
-    this.dispatch("SELECT_FIGURE", { id: figure.id });
+    const selectResult = this.dispatch("SELECT_FIGURE", { id: figure.id });
+    if (!selectResult.isSuccessful) {
+      return;
+    }
     if (this.props.sidePanelIsOpen) {
       this.env.openSidePanel("ChartPanel", { figure });
     }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -107,7 +107,6 @@ export const readonlyAllowedCommands = new Set<CommandTypes>([
   "SELECT_CELL",
   "SELECT_COLUMN",
   "SELECT_ROW",
-  "SELECT_FIGURE",
 
   "MOVE_POSITION",
 

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -5,7 +5,7 @@ import { CorePlugin } from "../../src/plugins/core_plugin";
 import { figureRegistry } from "../../src/registries/figure_registry";
 import { BaseCommand, Command, Figure, SpreadsheetEnv, UID } from "../../src/types";
 import { activateSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
-import { simulateClick } from "../test_helpers/dom_helper";
+import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
@@ -218,5 +218,23 @@ describe("figures", () => {
     await nextTick();
     const anchors = fixture.querySelectorAll(".o-anchor");
     expect(anchors).toHaveLength(8);
+  });
+
+  test("Cannot select/move figure in readonly mode", async () => {
+    model.dispatch("CREATE_TEXT_FIGURE", {
+      sheetId: model.getters.getActiveSheetId(),
+      id: "someuuid",
+      text: "Hello",
+    });
+    model.updateReadOnly(true);
+    await nextTick();
+    const figure = fixture.querySelector(".o-figure")!;
+    await simulateClick(".o-figure");
+    expect(document.activeElement).not.toBe(figure);
+    expect(fixture.querySelector(".o-anchor")).toBeNull();
+
+    triggerMouseEvent(figure, "mousedown", 300, 200);
+    await nextTick();
+    expect(figure.classList).not.toContain("o-dragging");
   });
 });


### PR DESCRIPTION
task 2820454

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2820454](https://www.odoo.com/web#id=2820454&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo