### PR TITLE
[IMP] topbar: one-liner number formats in dropdown

### DIFF
--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -226,10 +226,10 @@ css/* scss */ `
             }
 
             &.o-format-tool {
-              width: 180px;
               padding: 7px 0;
               > div {
                 padding-left: 25px;
+                white-space: nowrap;
 
                 &.active:before {
                   content: "✓";


### PR DESCRIPTION
Commit 1a4f185b was lost during the conversion to owl 2 (see 604a3f5a)
Original commit message:
"
The imposed width of the dropdown forced several elements of the
dropdown to span over two lines without any seemingly good reason.

task 2749310
"

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo