### PR TITLE
[IMP] composer: arrow always moves the cursor when editing a formula

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -221,12 +221,17 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
       ev.preventDefault();
       return;
     }
-    // only for arrow up and down
-    if (this.props.focus === "cellFocus" && !this.autoCompleteState.showProvider) {
+    const content = this.env.model.getters.getCurrentContent();
+    if (
+      this.props.focus === "cellFocus" &&
+      !this.autoCompleteState.showProvider &&
+      !content.startsWith("=")
+    ) {
       this.env.model.dispatch("STOP_EDITION");
       return;
     }
     ev.stopPropagation();
+    // only for arrow up and down
     if (
       ["ArrowUp", "ArrowDown"].includes(ev.key) &&
       this.autoCompleteState.showProvider &&

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -392,6 +392,15 @@ describe("composer", () => {
     expect(getCellText(model, "A1")).toBe("c");
   });
 
+  test("Arrow keys will not move to neighbor cell when a formula", async () => {
+    composerEl = await startComposition("=");
+    await typeInComposerGrid(`"`);
+    await typeInComposerGrid(`"`);
+    expect(composerEl.textContent).toBe(`=""`);
+    await keyDown("ArrowLeft");
+    expect(model.getters.getEditionMode()).not.toBe("inactive");
+  });
+
   test("ArrowKeys will move to neighbour cell, if not in contentFocus mode (up/down)", async () => {
     composerEl = await startComposition("a");
     expect(composerEl.textContent).toBe("a");

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -220,17 +220,6 @@ describe("formula assistant", () => {
       expect(model.getters.getEditionMode()).toBe("editing");
     });
 
-    test("leaving 'editing' mode with arrows should hide formula assistant", async () => {
-      await typeInComposerGrid("=FUNC1(1");
-      composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
-      await nextTick();
-      composerEl.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowLeft", bubbles: true }));
-      await nextTick();
-      expect(model.getters.getEditionMode()).toBe("inactive");
-      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
-      expect(model.getters.getCurrentContent()).toBe("=FUNC1(1)");
-    });
-
     describe("function definition", () => {
       test("function without argument", async () => {
         await typeInComposerGrid("=FUNC0(");


### PR DESCRIPTION
Purpose
=======

Let's say I want to type the formula =(5+6)/10
Want I do is:
- type "=" it opens the composer
- type "(" then directly ")"
- now I want to move back between the parenthesis
=> it closes the composer 😬😤

It's the same thing when I want to type a string (enclosed with double quotes):
I always first type both double quotes, then want to move my cursor back
between them.

Specification
=============
Never close the composer with arrows when editing a formula. G Sheet has this
behavior.


Odoo task ID : [2824327](https://www.odoo.com/web#id=2824327&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo