### PR TITLE
[FIX] evaluation: slow evaluation of gargantuan ranges

### DIFF
--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -186,6 +186,21 @@ export function union(z1: Zone, z2: Zone): Zone {
 }
 
 /**
+ * Compute the intersection of two zones. Returns nothing if the two zones don't overlap
+ */
+export function intersection(z1: Zone, z2: Zone): Zone | undefined {
+  if (!overlap(z1, z2)) {
+    return undefined;
+  }
+  return {
+    top: Math.max(z1.top, z2.top),
+    left: Math.max(z1.left, z2.left),
+    bottom: Math.min(z1.bottom, z2.bottom),
+    right: Math.min(z1.right, z2.right),
+  };
+}
+
+/**
  * Two zones are equal if they represent the same area, so we clearly cannot use
  * reference equality.
  */


### PR DESCRIPTION
When fetching the actual cell values of a range, we were exploring all
the references covered by the range even those outside of the sheet.

In some edge cases, this drastically slows the evaluation as we iterate
on lots of references for nothing.

Furthermore, the mapping between the references and the cells was slower
than a simple nested `for` loop.

BenchMark:
==========

1. Evaluating 30k cells

Performances stay unchanged :

Before this commit : 351.3 ms (78 ms std)
After this commit  : 349.6 ms (73 ms std)

In 15.0
-------

10 cells with ref A1:ZZZ999 in a 26x100 sheet
before: 3.86 s
after: 4.3 ms

10 cells with ref A1:ZZZ999 in  a 104x400 sheet
before: 5.32 s
after: 67.9 ms

In saas-15.1+
-------------

10 cells with ref A1:ZZZ999 in a 26x100 sheet
before: 10.81 s
after:  4.56 ms

10 cells with ref A1:ZZZ999 in a 104x400 sheet
before: 15.75 s
after: 64.74 ms

Task 2824909

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo