### PR TITLE
[FIX] spreadsheet: xml bundle not generated on run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "serve-static": "live-server --open=demo --watch=dist/o_spreadsheet.js,dist/o_spreadsheet.xml,demo",
-    "dev": "npm-run-all --parallel server serve-static watch:*",
+    "dev": "npm-run-all build --parallel server serve-static watch:*",
     "server": "node tools/server/main.js",
     "build:js": "tsc --module es6 --outDir dist/js --incremental",
     "bundle:js": "rollup -c -m",

--- a/tools/bundle_xml/bundle_xml_templates.js
+++ b/tools/bundle_xml/bundle_xml_templates.js
@@ -75,6 +75,9 @@ function prettify(xmlString) {
 }
 
 function writeToFile(filepath, data) {
+  if (!fs.existsSync(path.dirname(filepath))) {
+    fs.mkdirSync(path.dirname(filepath), { recursive: true });
+  }
   fs.writeFile(filepath, data, (err) => {
     if (err) {
       process.stdout.write(`Error while writing file ${filepath}: ${err}`);


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo