### PR TITLE
[FIX] tests: fix FakeTimers warning in grid tests

### DIFF
--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -907,73 +907,82 @@ describe("Events on Grid update viewport correctly", () => {
     expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
   });
 
-  describe("Edge-Scrolling on mouseMove in selection", () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
-    test("Can edge-scroll horizontally", async () => {
-      const { width, height } = model.getters.getViewportDimensionWithHeaders();
-      const y = height / 2;
-      triggerMouseEvent("canvas", "mousedown", width / 2, y);
-      triggerMouseEvent("canvas", "mousemove", 1.5 * width, y);
-      const advanceTimer = scrollDelay(0.5 * width) * 6 - 1;
-      jest.advanceTimersByTime(advanceTimer);
-      triggerMouseEvent("canvas", "mouseup", 1.5 * width, y);
-
-      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
-        left: 6,
-        right: 15,
-        top: 0,
-        bottom: 41,
-      });
-
-      triggerMouseEvent("canvas", "mousedown", width / 2, y);
-      triggerMouseEvent("canvas", "mousemove", -0.5 * width, y);
-      const advanceTimer2 = scrollDelay(0.5 * width) * 3 - 1;
-      jest.advanceTimersByTime(advanceTimer2);
-      triggerMouseEvent("canvas", "mouseup", -0.5 * width, y);
-
-      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
-        left: 3,
-        right: 12,
-        top: 0,
-        bottom: 41,
-      });
-    });
-
-    test("Can edge-scroll vertically", () => {
-      const { width, height } = model.getters.getViewportDimensionWithHeaders();
-      const x = width / 2;
-      triggerMouseEvent("canvas", "mousedown", x, height / 2);
-      triggerMouseEvent("canvas", "mousemove", x, 1.5 * height);
-      const advanceTimer = scrollDelay(0.5 * height) * 6 - 1;
-      jest.advanceTimersByTime(advanceTimer);
-      triggerMouseEvent("canvas", "mouseup", x, 1.5 * height);
-
-      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
-        left: 0,
-        right: 9,
-        top: 6,
-        bottom: 47,
-      });
-
-      triggerMouseEvent("canvas", "mousedown", x, height / 2);
-      triggerMouseEvent("canvas", "mousemove", x, -0.5 * height);
-      const advanceTimer2 = scrollDelay(0.5 * height) * 3 - 1;
-      jest.advanceTimersByTime(advanceTimer2);
-      triggerMouseEvent("canvas", "mouseup", x, -0.5 * height);
-
-      expect(model.getters.getActiveSnappedViewport()).toMatchObject({
-        left: 0,
-        right: 9,
-        top: 3,
-        bottom: 44,
-      });
-    });
-  });
-
   test("resize event handler is removed", () => {
     app.destroy();
     window.dispatchEvent(new Event("resize"));
+  });
+});
+
+describe("Edge-Scrolling Grid on mouseMove in selection", () => {
+  // This describe need its own setup to avoid mixing native timers with fake jest timers
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    fixture = makeTestFixture();
+    ({ app, parent } = await mountSpreadsheet(fixture));
+    model = parent.model;
+  });
+
+  afterEach(() => {
+    app.destroy();
+    fixture.remove();
+  });
+  test("Can edge-scroll horizontally", async () => {
+    const { width, height } = model.getters.getViewportDimensionWithHeaders();
+    const y = height / 2;
+    triggerMouseEvent("canvas", "mousedown", width / 2, y);
+    triggerMouseEvent("canvas", "mousemove", 1.5 * width, y);
+    const advanceTimer = scrollDelay(0.5 * width) * 6 - 1;
+    jest.advanceTimersByTime(advanceTimer);
+    triggerMouseEvent("canvas", "mouseup", 1.5 * width, y);
+
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      left: 6,
+      right: 15,
+      top: 0,
+      bottom: 41,
+    });
+
+    triggerMouseEvent("canvas", "mousedown", width / 2, y);
+    triggerMouseEvent("canvas", "mousemove", -0.5 * width, y);
+    const advanceTimer2 = scrollDelay(0.5 * width) * 3 - 1;
+    jest.advanceTimersByTime(advanceTimer2);
+    triggerMouseEvent("canvas", "mouseup", -0.5 * width, y);
+
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      left: 3,
+      right: 12,
+      top: 0,
+      bottom: 41,
+    });
+  });
+
+  test("Can edge-scroll vertically", () => {
+    const { width, height } = model.getters.getViewportDimensionWithHeaders();
+    const x = width / 2;
+    triggerMouseEvent("canvas", "mousedown", x, height / 2);
+    triggerMouseEvent("canvas", "mousemove", x, 1.5 * height);
+    const advanceTimer = scrollDelay(0.5 * height) * 6 - 1;
+    jest.advanceTimersByTime(advanceTimer);
+    triggerMouseEvent("canvas", "mouseup", x, 1.5 * height);
+
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      left: 0,
+      right: 9,
+      top: 6,
+      bottom: 47,
+    });
+
+    triggerMouseEvent("canvas", "mousedown", x, height / 2);
+    triggerMouseEvent("canvas", "mousemove", x, -0.5 * height);
+    const advanceTimer2 = scrollDelay(0.5 * height) * 3 - 1;
+    jest.advanceTimersByTime(advanceTimer2);
+    triggerMouseEvent("canvas", "mouseup", x, -0.5 * height);
+
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+      left: 0,
+      right: 9,
+      top: 3,
+      bottom: 44,
+    });
   });
 });


### PR DESCRIPTION
There was a warning when running grid tests :
> FakeTimers: clearTimeout was invoked to clear a native timer instead of
   one created by this library.
   To automatically clean-up native timers, use `shouldClearNativeTimers`.

The warning was triggered because we were simultaneously using native
and fake timers in a specific test - `Grid > Edge-Scrolling on mouseMove in
selection`.
In this test/describe we first start a model, which create an instance of class
`Session` which itself contains a function built with `debounce`. At
this point, the function `debouncedMove` is linked to a native timer.
Afterwards, we swtiched to faketimers, which ended up triggering the
warning when the `debouncedMove`was called.

This issue appeared with the transition to owl2, which dropped the
internal timer of the library.

The proposed solution is to change the order of setup and first use jest
faketimers before instantiating anything.
Note that we have a similar test in `overlay.test.ts` that does not trigger the
warning and it is already properly starting the faketimers first

Co-authored-by: Rémi Rahir <rar@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo