### PR TITLE
[IMP] spreadsheet: change zones to XC into commands

### DIFF
--- a/src/collaborative/ot/ot.ts
+++ b/src/collaborative/ot/ot.ts
@@ -1,4 +1,4 @@
-import { isDefined, isInside } from "../../helpers/index";
+import { isDefined, isInside, toZone, zoneToXc } from "../../helpers/index";
 import { otRegistry } from "../../registries/ot_registry";
 import {
   AddColumnsRowsCommand,
@@ -112,8 +112,8 @@ function transformTarget(
   executed: CoreCommand
 ): Extract<CoreCommand, TargetDependentCommand> | TransformResult {
   const target: Zone[] = [];
-  for (const zone of cmd.target) {
-    const newZone = transformZone(zone, executed);
+  for (const xc of cmd.target) {
+    const newZone = transformZone(toZone(xc), executed);
     if (newZone) {
       target.push(newZone);
     }
@@ -121,7 +121,7 @@ function transformTarget(
   if (!target.length) {
     return "IGNORE_COMMAND";
   }
-  return { ...cmd, target };
+  return { ...cmd, target: target.map(zoneToXc) };
 }
 
 function transformDimension(
@@ -217,7 +217,8 @@ function transformPositionWithMerge(
   cmd: Extract<CoreCommand, PositionDependentCommand>,
   executed: AddMergeCommand
 ): Extract<CoreCommand, PositionDependentCommand> | TransformResult {
-  for (const zone of executed.target) {
+  for (const zoneXc of executed.target) {
+    const zone = toZone(zoneXc);
     const sameTopLeft = cmd.col === zone.left && cmd.row === zone.top;
     if (!sameTopLeft && isInside(cmd.col, cmd.row, zone)) {
       return "IGNORE_COMMAND";

--- a/src/collaborative/ot/ot_specific.ts
+++ b/src/collaborative/ot/ot_specific.ts
@@ -94,15 +94,17 @@ function mergeTransformation(
     return cmd;
   }
   const target: Zone[] = [];
-  for (const zone1 of cmd.target) {
-    for (const zone2 of executed.target) {
+  for (const zone1Xc of cmd.target) {
+    const zone1 = toZone(zone1Xc);
+    for (const zone2Xc of executed.target) {
+      const zone2 = toZone(zone2Xc);
       if (!overlap(zone1, zone2)) {
         target.push({ ...zone1 });
       }
     }
   }
   if (target.length) {
-    return { ...cmd, target };
+    return { ...cmd, target: target.map(zoneToXc) };
   }
   return undefined;
 }

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -22,6 +22,7 @@ import {
   isInside,
   MAX_DELAY,
   range,
+  zoneToXc,
 } from "../../helpers/index";
 import { interactivePaste } from "../../helpers/ui/paste";
 import { ComposerSelection } from "../../plugins/ui/edition";
@@ -431,7 +432,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     DELETE: () => {
       this.env.model.dispatch("DELETE_CONTENT", {
         sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
+        target: this.env.model.getters.getSelectedZones().map(zoneToXc),
       });
     },
     "CTRL+A": () => this.env.model.selection.selectAll(),
@@ -443,19 +444,19 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     "CTRL+B": () =>
       this.env.model.dispatch("SET_FORMATTING", {
         sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
+        target: this.env.model.getters.getSelectedZones().map(zoneToXc),
         style: { bold: !this.env.model.getters.getCurrentStyle().bold },
       }),
     "CTRL+I": () =>
       this.env.model.dispatch("SET_FORMATTING", {
         sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
+        target: this.env.model.getters.getSelectedZones().map(zoneToXc),
         style: { italic: !this.env.model.getters.getCurrentStyle().italic },
       }),
     "CTRL+U": () =>
       this.env.model.dispatch("SET_FORMATTING", {
         sheetId: this.env.model.getters.getActiveSheetId(),
-        target: this.env.model.getters.getSelectedZones(),
+        target: this.env.model.getters.getSelectedZones().map(zoneToXc),
         style: { underline: !this.env.model.getters.getCurrentStyle().underline },
       }),
     "ALT+=": () => {
@@ -766,7 +767,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       this.gridOverlay.el!.removeEventListener("mousemove", onMouseMove);
       if (this.env.model.getters.isPaintingFormat()) {
         this.env.model.dispatch("PASTE", {
-          target: this.env.model.getters.getSelectedZones(),
+          target: this.env.model.getters.getSelectedZones().map(zoneToXc),
         });
       }
     };
@@ -826,7 +827,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
 
     if (this.env.model.getters.isPaintingFormat()) {
       this.env.model.dispatch("PASTE", {
-        target: this.env.model.getters.getSelectedZones(),
+        target: this.env.model.getters.getSelectedZones().map(zoneToXc),
       });
     }
   }
@@ -908,7 +909,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       return;
     }
     const type = cut ? "CUT" : "COPY";
-    const target = this.env.model.getters.getSelectedZones();
+    const target = this.env.model.getters.getSelectedZones().map(zoneToXc);
     this.env.model.dispatch(type, { target });
     const content = this.env.model.getters.getClipboardContent();
     this.clipBoardString = content;
@@ -923,7 +924,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     const clipboardData = ev.clipboardData!;
     if (clipboardData.types.indexOf("text/plain") > -1) {
       const content = clipboardData.getData("text/plain");
-      const target = this.env.model.getters.getSelectedZones();
+      const target = this.env.model.getters.getSelectedZones().map(zoneToXc);
       if (this.clipBoardString === content) {
         // the paste actually comes from o-spreadsheet itself
         interactivePaste(this.env, target);

--- a/src/components/highlight/highlight/highlight.ts
+++ b/src/components/highlight/highlight/highlight.ts
@@ -1,6 +1,6 @@
 import { Component, useRef, useState } from "@odoo/owl";
 import { HEADER_HEIGHT, HEADER_WIDTH } from "../../../constants";
-import { clip, isEqual } from "../../../helpers";
+import { clip, isEqual, zoneToXc } from "../../../helpers";
 import { SpreadsheetChildEnv, Zone } from "../../../types";
 import { dragAndDropBeyondTheViewport } from "../../helpers/drag_and_drop";
 import { Border } from "../border/border";
@@ -37,7 +37,7 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
     let lastRow = isTop ? z.top : z.bottom;
     let currentZone = z;
 
-    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
+    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: zoneToXc(currentZone) });
 
     const mouseMove = (col, row) => {
       if (lastCol !== col || lastRow !== row) {
@@ -55,7 +55,7 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
         newZone = this.env.model.getters.expandZone(activeSheet.id, newZone);
 
         if (!isEqual(newZone, currentZone)) {
-          this.env.model.dispatch("CHANGE_HIGHLIGHT", { zone: newZone });
+          this.env.model.dispatch("CHANGE_HIGHLIGHT", { zone: zoneToXc(newZone) });
           currentZone = newZone;
         }
       }
@@ -103,7 +103,7 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
     const deltaRowMax = activeSheet.rows.length - z.bottom - 1;
 
     let currentZone = z;
-    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: currentZone });
+    this.env.model.dispatch("START_CHANGE_HIGHLIGHT", { zone: zoneToXc(currentZone) });
 
     let lastCol = initCol;
     let lastRow = initRow;
@@ -125,7 +125,7 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
         newZone = this.env.model.getters.expandZone(activeSheet.id, newZone);
 
         if (!isEqual(newZone, currentZone)) {
-          this.env.model.dispatch("CHANGE_HIGHLIGHT", { zone: newZone });
+          this.env.model.dispatch("CHANGE_HIGHLIGHT", { zone: zoneToXc(newZone) });
           currentZone = newZone;
         }
       }

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -1,6 +1,6 @@
 import { Component, onWillUpdateProps, useExternalListener, useState } from "@odoo/owl";
 import { DEFAULT_COLOR_SCALE_MIDPOINT_COLOR } from "../../../constants";
-import { colorNumberString, rangeReference, toZone } from "../../../helpers/index";
+import { colorNumberString, rangeReference } from "../../../helpers/index";
 import {
   CancelledReason,
   CellIsRule,
@@ -517,7 +517,7 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
               ? this.state.currentCF.id
               : this.env.model.uuidGenerator.uuidv4(),
         },
-        target: this.state.currentCF.ranges.map(toZone),
+        target: this.state.currentCF.ranges,
         sheetId: this.env.model.getters.getActiveSheetId(),
       });
       if (!result.isSuccessful) {

--- a/src/components/side_panel/custom_currency/custom_currency.ts
+++ b/src/components/side_panel/custom_currency/custom_currency.ts
@@ -1,4 +1,5 @@
 import { Component, onWillStart, useState } from "@odoo/owl";
+import { zoneToXc } from "../../../helpers";
 import { currenciesRegistry } from "../../../registries/currencies_registry";
 import { Currency, Format, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
@@ -105,7 +106,7 @@ export class CustomCurrencyPanel extends Component<any, SpreadsheetChildEnv> {
     const selectedFormat = this.formatProposals[this.state.selectedFormatIndex];
     this.env.model.dispatch("SET_FORMATTING", {
       sheetId: this.env.model.getters.getActiveSheetId(),
-      target: this.env.model.getters.getSelectedZones(),
+      target: this.env.model.getters.getSelectedZones().map(zoneToXc),
       format: selectedFormat.format,
     });
   }

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -7,7 +7,7 @@ import {
 } from "@odoo/owl";
 import { BACKGROUND_HEADER_COLOR, DEFAULT_FONT_SIZE } from "../../constants";
 import { fontSizes } from "../../fonts";
-import { isEqual } from "../../helpers/index";
+import { isEqual, zoneToXc } from "../../helpers/index";
 import { setFormatter, setStyle, topbarComponentRegistry } from "../../registries/index";
 import { topbarMenuRegistry } from "../../registries/menus/topbar_menu_registry";
 import { FullMenuItem } from "../../registries/menu_items_registry";
@@ -392,7 +392,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
 
   toggleMerge() {
     const zones = this.env.model.getters.getSelectedZones();
-    const target = [zones[zones.length - 1]];
+    const target = [zones[zones.length - 1]].map(zoneToXc);
     const sheetId = this.env.model.getters.getActiveSheetId();
     if (this.inMerge) {
       this.env.model.dispatch("REMOVE_MERGE", { sheetId, target });
@@ -418,7 +418,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   setBorder(command: BorderCommand) {
     this.env.model.dispatch("SET_FORMATTING", {
       sheetId: this.env.model.getters.getActiveSheetId(),
-      target: this.env.model.getters.getSelectedZones(),
+      target: this.env.model.getters.getSelectedZones().map(zoneToXc),
       border: command,
     });
   }
@@ -444,21 +444,21 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   setDecimal(step: number) {
     this.env.model.dispatch("SET_DECIMAL", {
       sheetId: this.env.model.getters.getActiveSheetId(),
-      target: this.env.model.getters.getSelectedZones(),
+      target: this.env.model.getters.getSelectedZones().map(zoneToXc),
       step: step,
     });
   }
 
   paintFormat() {
     this.env.model.dispatch("ACTIVATE_PAINT_FORMAT", {
-      target: this.env.model.getters.getSelectedZones(),
+      target: this.env.model.getters.getSelectedZones().map(zoneToXc),
     });
   }
 
   clearFormatting() {
     this.env.model.dispatch("CLEAR_FORMATTING", {
       sheetId: this.env.model.getters.getActiveSheetId(),
-      target: this.env.model.getters.getSelectedZones(),
+      target: this.env.model.getters.getSelectedZones().map(zoneToXc),
     });
   }
 

--- a/src/helpers/sort.ts
+++ b/src/helpers/sort.ts
@@ -10,7 +10,7 @@ import {
   UID,
   Zone,
 } from "../types";
-import { isEqual } from "./zones";
+import { isEqual, zoneToXc } from "./zones";
 
 type CellWithIndex = { index: number; type: CellValueType; value: any };
 
@@ -85,7 +85,13 @@ export function interactiveSortSelection(
 
   const { col, row } = anchor;
   if (multiColumns) {
-    result = env.model.dispatch("SORT_CELLS", { sheetId, col, row, zone, sortDirection });
+    result = env.model.dispatch("SORT_CELLS", {
+      sheetId,
+      col,
+      row,
+      zone: zoneToXc(zone),
+      sortDirection,
+    });
   } else {
     // check contiguity
     const contiguousZone = env.model.getters.getContiguousZone(sheetId, zone);
@@ -95,7 +101,7 @@ export function interactiveSortSelection(
         sheetId,
         col,
         row,
-        zone,
+        zone: zoneToXc(zone),
         sortDirection,
       });
     } else {
@@ -109,7 +115,7 @@ export function interactiveSortSelection(
             sheetId,
             col,
             row,
-            zone,
+            zone: zoneToXc(zone),
             sortDirection,
           });
         },
@@ -118,7 +124,7 @@ export function interactiveSortSelection(
             sheetId,
             col,
             row,
-            zone,
+            zone: zoneToXc(zone),
             sortDirection,
           });
         }

--- a/src/helpers/ui/paste.ts
+++ b/src/helpers/ui/paste.ts
@@ -1,6 +1,6 @@
 import { CommandResult, DispatchResult } from "../..";
 import { _lt } from "../../translation";
-import { ClipboardOptions, SpreadsheetChildEnv, Zone } from "../../types";
+import { ClipboardOptions, SpreadsheetChildEnv } from "../../types";
 
 export function handlePasteResult(env: SpreadsheetChildEnv, result: DispatchResult) {
   if (!result.isSuccessful) {
@@ -19,7 +19,7 @@ export function handlePasteResult(env: SpreadsheetChildEnv, result: DispatchResu
 
 export function interactivePaste(
   env: SpreadsheetChildEnv,
-  target: Zone[],
+  target: string[],
   pasteOption?: ClipboardOptions
 ) {
   const result = env.model.dispatch("PASTE", { target, pasteOption });

--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -35,8 +35,8 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   handle(cmd: Command) {
     switch (cmd.type) {
       case "ADD_MERGE":
-        for (const zone of cmd.target) {
-          this.addBordersToMerge(cmd.sheetId, zone);
+        for (const xc of cmd.target) {
+          this.addBordersToMerge(cmd.sheetId, toZone(xc));
         }
         break;
       case "DUPLICATE_SHEET":
@@ -61,12 +61,14 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
       case "SET_FORMATTING":
         if (cmd.border) {
           const sheet = this.getters.getSheet(cmd.sheetId);
-          const target = cmd.target.map((zone) => this.getters.expandZone(cmd.sheetId, zone));
+          const target = cmd.target.map((zone) =>
+            this.getters.expandZone(cmd.sheetId, toZone(zone))
+          );
           this.setBorders(sheet, target, cmd.border);
         }
         break;
       case "CLEAR_FORMATTING":
-        this.clearBorders(cmd.sheetId, cmd.target);
+        this.clearBorders(cmd.sheetId, cmd.target.map(toZone));
         break;
       case "REMOVE_COLUMNS_ROWS":
         for (let el of cmd.elements) {

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -9,6 +9,7 @@ import {
   range,
   toCartesian,
   toXC,
+  toZone,
 } from "../../helpers/index";
 import {
   AddColumnsRowsCommand,
@@ -101,17 +102,17 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     switch (cmd.type) {
       case "SET_FORMATTING":
         if ("style" in cmd) {
-          this.setStyle(cmd.sheetId, cmd.target, cmd.style);
+          this.setStyle(cmd.sheetId, cmd.target.map(toZone), cmd.style);
         }
         if ("format" in cmd && cmd.format !== undefined) {
-          this.setFormatter(cmd.sheetId, cmd.target, cmd.format);
+          this.setFormatter(cmd.sheetId, cmd.target.map(toZone), cmd.format);
         }
         break;
       case "SET_DECIMAL":
-        this.setDecimal(cmd.sheetId, cmd.target, cmd.step);
+        this.setDecimal(cmd.sheetId, cmd.target.map(toZone), cmd.step);
         break;
       case "CLEAR_FORMATTING":
-        this.clearStyles(cmd.sheetId, cmd.target);
+        this.clearStyles(cmd.sheetId, cmd.target.map(toZone));
         break;
       case "ADD_COLUMNS_ROWS":
         if (cmd.dimension === "COL") {

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -1,5 +1,5 @@
 import { compile } from "../../formulas/index";
-import { isInside, zoneToXc } from "../../helpers/index";
+import { isInside } from "../../helpers/index";
 import {
   AddConditionalFormatCommand,
   ApplyRangeChange,
@@ -133,7 +133,7 @@ export class ConditionalFormatPlugin
       case "ADD_CONDITIONAL_FORMAT":
         const cf = {
           ...cmd.cf,
-          ranges: cmd.target.map(zoneToXc),
+          ranges: cmd.target,
         };
         this.addConditionalFormatting(cf, cmd.sheetId);
         break;

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -96,13 +96,13 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
         }
         break;
       case "ADD_MERGE":
-        for (const zone of cmd.target) {
-          this.addMerge(this.getters.getSheet(cmd.sheetId)!, zone);
+        for (const xc of cmd.target) {
+          this.addMerge(this.getters.getSheet(cmd.sheetId)!, toZone(xc));
         }
         break;
       case "REMOVE_MERGE":
-        for (const zone of cmd.target) {
-          this.removeMerge(cmd.sheetId, zone);
+        for (const xc of cmd.target) {
+          this.removeMerge(cmd.sheetId, toZone(xc));
         }
         break;
     }
@@ -278,14 +278,16 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     return range !== undefined ? rangeToMerge(mergeId, range) : undefined;
   }
 
-  private checkDestructiveMerge({ sheetId, target }: AddMergeCommand): CommandResult {
+  private checkDestructiveMerge({ sheetId, target: targetXc }: AddMergeCommand): CommandResult {
+    const target = targetXc.map(toZone);
     const sheet = this.getters.tryGetSheet(sheetId);
     if (!sheet) return CommandResult.Success;
     const isDestructive = target.some((zone) => this.isMergeDestructive(sheet, zone));
     return isDestructive ? CommandResult.MergeIsDestructive : CommandResult.Success;
   }
 
-  private checkOverlap({ target }: AddMergeCommand): CommandResult {
+  private checkOverlap({ target: targetXc }: AddMergeCommand): CommandResult {
+    const target = targetXc.map(toZone);
     for (const zone of target) {
       for (const zone2 of target) {
         if (zone !== zone2 && overlap(zone, zone2)) {

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -14,6 +14,7 @@ import {
   numberToLetters,
   positions,
   toCartesian,
+  toZone,
 } from "../../helpers/index";
 import { _lt, _t } from "../../translation";
 import {
@@ -128,7 +129,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
         this.setGridLinesVisibility(cmd.sheetId, cmd.areGridLinesVisible);
         break;
       case "DELETE_CONTENT":
-        this.clearZones(cmd.sheetId, cmd.target);
+        this.clearZones(cmd.sheetId, cmd.target.map(toZone));
         break;
       case "CREATE_SHEET":
         const sheet = this.createSheet(
@@ -1040,10 +1041,10 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   private checkZones(cmd: Command): CommandResult {
     const zones: Zone[] = [];
     if ("zone" in cmd) {
-      zones.push(cmd.zone);
+      zones.push(toZone(cmd.zone));
     }
     if ("target" in cmd && Array.isArray(cmd.target)) {
-      zones.push(...cmd.target);
+      zones.push(...cmd.target.map(toZone));
     }
     if (!zones.every(isZoneValid)) {
       return CommandResult.InvalidRange;

--- a/src/plugins/ui/autofill.ts
+++ b/src/plugins/ui/autofill.ts
@@ -1,4 +1,4 @@
-import { clip, isInside, toCartesian, toXC, union } from "../../helpers/index";
+import { clip, isInside, toCartesian, toXC, union, zoneToXc } from "../../helpers/index";
 import { Mode } from "../../model";
 import { autofillModifiersRegistry, autofillRulesRegistry } from "../../registries/index";
 import {
@@ -400,7 +400,7 @@ export class AutofillPlugin extends UIPlugin {
       if (zone) {
         this.dispatch("REMOVE_MERGE", {
           sheetId: activeSheet.id,
-          target: [zone],
+          target: [zoneToXc(zone)],
         });
       }
     }
@@ -409,12 +409,12 @@ export class AutofillPlugin extends UIPlugin {
       this.dispatch("ADD_MERGE", {
         sheetId: activeSheet.id,
         target: [
-          {
+          zoneToXc({
             top: row,
             bottom: row + originMerge.bottom - originMerge.top,
             left: col,
             right: col + originMerge.right - originMerge.left,
-          },
+          }),
         ],
       });
     }

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -161,7 +161,7 @@ export class EditionPlugin extends UIPlugin {
             const sheetName = sheet || this.getters.getSheetName(this.sheetId);
             const activeSheetId = this.getters.getActiveSheetId();
             return (
-              isEqual(this.getters.expandZone(activeSheetId, toZone(xc)), cmd.zone) &&
+              isEqual(this.getters.expandZone(activeSheetId, toZone(xc)), toZone(cmd.zone)) &&
               this.getters.getSheetName(activeSheetId) === sheetName
             );
           });
@@ -173,7 +173,7 @@ export class EditionPlugin extends UIPlugin {
         this.selectionInitialStart = previousRefToken!.start;
         break;
       case "CHANGE_HIGHLIGHT":
-        const newRef = this.getZoneReference(cmd.zone, this.previousRange!.parts);
+        const newRef = this.getZoneReference(toZone(cmd.zone), this.previousRange!.parts);
         this.selectionStart = this.selectionInitialStart;
         this.selectionEnd = this.selectionInitialStart + this.previousRef.length;
         this.replaceSelection(newRef);

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -466,7 +466,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
         rule: cf.rule,
         stopIfTrue: cf.stopIfTrue,
       },
-      target: newRange.map(toZone),
+      target: newRange,
       sheetId,
     });
   }

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -11,6 +11,7 @@ import {
   uniqueZones,
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
+  zoneToXc,
 } from "../../helpers/index";
 import { Mode, ModelConfig } from "../../model";
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
@@ -610,23 +611,23 @@ export class GridSelectionPlugin extends UIPlugin {
 
     this.dispatch("CUT", {
       target: [
-        {
+        zoneToXc({
           left: isCol ? start + deltaCol : 0,
           right: isCol ? end + deltaCol : sheet.cols.length - 1,
           top: !isCol ? start + deltaRow : 0,
           bottom: !isCol ? end + deltaRow : sheet.rows.length - 1,
-        },
+        }),
       ],
     });
 
     this.dispatch("PASTE", {
       target: [
-        {
+        zoneToXc({
           left: isCol ? cmd.base : 0,
           right: isCol ? cmd.base + thickness - 1 : sheet.cols.length - 1,
           top: !isCol ? cmd.base : 0,
           bottom: !isCol ? cmd.base + thickness - 1 : sheet.rows.length - 1,
-        },
+        }),
       ],
     });
 

--- a/src/plugins/ui/sort.ts
+++ b/src/plugins/ui/sort.ts
@@ -1,4 +1,4 @@
-import { isInside, overlap, range, zoneToDimension } from "../../helpers/index";
+import { isInside, overlap, range, toZone, zoneToDimension } from "../../helpers/index";
 import { sortCells } from "../../helpers/sort";
 import { _lt } from "../../translation";
 import {
@@ -21,7 +21,7 @@ export class SortPlugin extends UIPlugin {
   allowDispatch(cmd: Command) {
     switch (cmd.type) {
       case "SORT_CELLS":
-        if (!isInside(cmd.col, cmd.row, cmd.zone)) {
+        if (!isInside(cmd.col, cmd.row, toZone(cmd.zone))) {
           throw new Error(_lt("The anchor must be part of the provided zone"));
         }
         return this.checkValidations(cmd, this.checkMerge, this.checkMergeSizes);
@@ -32,12 +32,13 @@ export class SortPlugin extends UIPlugin {
   handle(cmd: Command) {
     switch (cmd.type) {
       case "SORT_CELLS":
-        this.sortZone(cmd.sheetId, cmd, cmd.zone, cmd.sortDirection);
+        this.sortZone(cmd.sheetId, cmd, toZone(cmd.zone), cmd.sortDirection);
         break;
     }
   }
 
-  private checkMerge({ sheetId, zone }: SortCommand): CommandResult {
+  private checkMerge({ sheetId, zone: zoneXC }: SortCommand): CommandResult {
+    const zone = toZone(zoneXC);
     if (!this.getters.doesIntersectMerge(sheetId, zone)) {
       return CommandResult.Success;
     }
@@ -52,7 +53,8 @@ export class SortPlugin extends UIPlugin {
     return CommandResult.Success;
   }
 
-  private checkMergeSizes({ sheetId, zone }: SortCommand): CommandResult {
+  private checkMergeSizes({ sheetId, zone: zoneXC }: SortCommand): CommandResult {
+    const zone = toZone(zoneXC);
     if (!this.getters.doesIntersectMerge(sheetId, zone)) {
       return CommandResult.Success;
     }

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -32,7 +32,7 @@ function getRowsNumber(env: SpreadsheetChildEnv): number {
 export function setFormatter(env: SpreadsheetChildEnv, format: Format) {
   env.model.dispatch("SET_FORMATTING", {
     sheetId: env.model.getters.getActiveSheetId(),
-    target: env.model.getters.getSelectedZones(),
+    target: env.model.getters.getSelectedZones().map(zoneToXc),
     format,
   });
 }
@@ -40,7 +40,7 @@ export function setFormatter(env: SpreadsheetChildEnv, format: Format) {
 export function setStyle(env: SpreadsheetChildEnv, style: Style) {
   env.model.dispatch("SET_FORMATTING", {
     sheetId: env.model.getters.getActiveSheetId(),
-    target: env.model.getters.getSelectedZones(),
+    target: env.model.getters.getSelectedZones().map(zoneToXc),
     style,
   });
 }
@@ -54,12 +54,12 @@ export const UNDO_ACTION = (env: SpreadsheetChildEnv) => env.model.dispatch("REQ
 export const REDO_ACTION = (env: SpreadsheetChildEnv) => env.model.dispatch("REQUEST_REDO");
 
 export const COPY_ACTION = async (env: SpreadsheetChildEnv) => {
-  env.model.dispatch("COPY", { target: env.model.getters.getSelectedZones() });
+  env.model.dispatch("COPY", { target: env.model.getters.getSelectedZones().map(zoneToXc) });
   await env.clipboard.writeText(env.model.getters.getClipboardContent());
 };
 
 export const CUT_ACTION = async (env: SpreadsheetChildEnv) => {
-  env.model.dispatch("CUT", { target: env.model.getters.getSelectedZones() });
+  env.model.dispatch("CUT", { target: env.model.getters.getSelectedZones().map(zoneToXc) });
   await env.clipboard.writeText(env.model.getters.getClipboardContent());
 };
 
@@ -73,7 +73,7 @@ export const PASTE_ACTION = async (env: SpreadsheetChildEnv) => {
     console.warn("The OS clipboard could not be read.");
     console.error(e);
   }
-  const target = env.model.getters.getSelectedZones();
+  const target = env.model.getters.getSelectedZones().map(zoneToXc);
   if (osClipboard && osClipboard !== spreadsheetClipboard) {
     env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
       target,
@@ -86,20 +86,20 @@ export const PASTE_ACTION = async (env: SpreadsheetChildEnv) => {
 
 export const PASTE_VALUE_ACTION = (env: SpreadsheetChildEnv) =>
   env.model.dispatch("PASTE", {
-    target: env.model.getters.getSelectedZones(),
+    target: env.model.getters.getSelectedZones().map(zoneToXc),
     pasteOption: "onlyValue",
   });
 
 export const PASTE_FORMAT_ACTION = (env: SpreadsheetChildEnv) =>
   env.model.dispatch("PASTE", {
-    target: env.model.getters.getSelectedZones(),
+    target: env.model.getters.getSelectedZones().map(zoneToXc),
     pasteOption: "onlyFormat",
   });
 
 export const DELETE_CONTENT_ACTION = (env: SpreadsheetChildEnv) =>
   env.model.dispatch("DELETE_CONTENT", {
     sheetId: env.model.getters.getActiveSheetId(),
-    target: env.model.getters.getSelectedZones(),
+    target: env.model.getters.getSelectedZones().map(zoneToXc),
   });
 
 export const SET_FORMULA_VISIBILITY_ACTION = (env: SpreadsheetChildEnv) =>
@@ -140,9 +140,9 @@ export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetChildEnv) => {
 
 export const DELETE_CONTENT_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
   const sheetId = env.model.getters.getActiveSheetId();
-  const target = [...env.model.getters.getActiveRows()].map((index) =>
-    env.model.getters.getRowsZone(sheetId, index, index)
-  );
+  const target = [...env.model.getters.getActiveRows()]
+    .map((index) => env.model.getters.getRowsZone(sheetId, index, index))
+    .map(zoneToXc);
   env.model.dispatch("DELETE_CONTENT", {
     target,
     sheetId: env.model.getters.getActiveSheetId(),
@@ -172,9 +172,9 @@ export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
 
 export const DELETE_CONTENT_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
   const sheetId = env.model.getters.getActiveSheetId();
-  const target = [...env.model.getters.getActiveCols()].map((index) =>
-    env.model.getters.getColsZone(sheetId, index, index)
-  );
+  const target = [...env.model.getters.getActiveCols()]
+    .map((index) => env.model.getters.getColsZone(sheetId, index, index))
+    .map(zoneToXc);
   env.model.dispatch("DELETE_CONTENT", {
     target,
     sheetId: env.model.getters.getActiveSheetId(),
@@ -255,25 +255,25 @@ export const REMOVE_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
 
 export const INSERT_CELL_SHIFT_DOWN = (env: SpreadsheetChildEnv) => {
   const zone = env.model.getters.getSelectedZone();
-  const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "ROW" });
+  const result = env.model.dispatch("INSERT_CELL", { zone: zoneToXc(zone), shiftDimension: "ROW" });
   handlePasteResult(env, result);
 };
 
 export const INSERT_CELL_SHIFT_RIGHT = (env: SpreadsheetChildEnv) => {
   const zone = env.model.getters.getSelectedZone();
-  const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "COL" });
+  const result = env.model.dispatch("INSERT_CELL", { zone: zoneToXc(zone), shiftDimension: "COL" });
   handlePasteResult(env, result);
 };
 
 export const DELETE_CELL_SHIFT_UP = (env: SpreadsheetChildEnv) => {
   const zone = env.model.getters.getSelectedZone();
-  const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "ROW" });
+  const result = env.model.dispatch("DELETE_CELL", { zone: zoneToXc(zone), shiftDimension: "ROW" });
   handlePasteResult(env, result);
 };
 
 export const DELETE_CELL_SHIFT_LEFT = (env: SpreadsheetChildEnv) => {
   const zone = env.model.getters.getSelectedZone();
-  const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "COL" });
+  const result = env.model.dispatch("DELETE_CELL", { zone: zoneToXc(zone), shiftDimension: "COL" });
   handlePasteResult(env, result);
 };
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -9,7 +9,6 @@ import {
   Figure,
   Format,
   Style,
-  Zone,
 } from "./index";
 import { Border, CellPosition, ClipboardOptions, Dimension, UID } from "./misc";
 
@@ -55,7 +54,7 @@ export function isGridDependent(cmd: CoreCommand): boolean {
 }
 
 export interface TargetDependentCommand {
-  target: Zone[];
+  target: string[];
 }
 
 export function isTargetDependent(cmd: CoreCommand): boolean {
@@ -360,25 +359,25 @@ export interface SetDecimalCommand extends SheetDependentCommand, TargetDependen
 // ------------------------------------------------
 export interface CopyCommand {
   type: "COPY";
-  target: Zone[];
+  target: string[];
 }
 
 export interface CutCommand {
   type: "CUT";
-  target: Zone[];
+  target: string[];
 }
 
 export interface PasteCommand {
   type: "PASTE";
-  target: Zone[];
+  target: string[];
   pasteOption?: ClipboardOptions;
   force?: boolean;
 }
 
 export interface CutAndPasteCommand {
   type: "CUT_AND_PASTE";
-  source: Zone;
-  target: Zone;
+  source: string;
+  target: string;
 }
 
 export interface AutoFillCellCommand {
@@ -395,12 +394,12 @@ export interface AutoFillCellCommand {
 
 export interface ActivatePaintFormatCommand {
   type: "ACTIVATE_PAINT_FORMAT";
-  target: Zone[];
+  target: string[];
 }
 
 export interface PasteFromOSClipboardCommand {
   type: "PASTE_FROM_OS_CLIPBOARD";
-  target: Zone[];
+  target: string[];
   text: string;
 }
 
@@ -457,12 +456,12 @@ export interface EvaluateCellsCommand {
 
 export interface StartChangeHighlightCommand {
   type: "START_CHANGE_HIGHLIGHT";
-  zone: Zone;
+  zone: string;
 }
 
 export interface ChangeHighlightCommand {
   type: "CHANGE_HIGHLIGHT";
-  zone: Zone;
+  zone: string;
 }
 
 export interface StopComposerSelectionCommand {
@@ -509,7 +508,7 @@ export interface ShowFormulaCommand {
 export interface DeleteContentCommand {
   type: "DELETE_CONTENT";
   sheetId: UID;
-  target: Zone[];
+  target: string[];
 }
 
 export interface ClearCellCommand {
@@ -680,7 +679,7 @@ export interface SortCommand {
   sheetId: UID;
   col: number;
   row: number;
-  zone: Zone;
+  zone: string;
   sortDirection: SortDirection;
 }
 
@@ -723,13 +722,13 @@ export interface SumSelectionCommand {
 export interface DeleteCellCommand {
   type: "DELETE_CELL";
   shiftDimension: Dimension;
-  zone: Zone;
+  zone: string;
 }
 
 export interface InsertCellCommand {
   type: "INSERT_CELL";
   shiftDimension: Dimension;
-  zone: Zone;
+  zone: string;
 }
 
 export interface PasteCFCommand {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -218,8 +218,8 @@ describe("Multi users synchronisation", () => {
       row: 0,
       style: { fillColor: "#fefefe" },
     });
-    alice.dispatch("COPY", { target: [toZone("A1")] });
-    alice.dispatch("PASTE", { target: [toZone("A2")] });
+    alice.dispatch("COPY", { target: ["A1"] });
+    alice.dispatch("PASTE", { target: ["A2"] });
     expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "A1")!.style, {
       fillColor: "#fefefe",
     });
@@ -236,8 +236,8 @@ describe("Multi users synchronisation", () => {
       row: 1,
       style: { fillColor: "#fefefe" },
     });
-    alice.dispatch("COPY", { target: [toZone("A1")] });
-    alice.dispatch("PASTE", { target: [toZone("B2")] });
+    alice.dispatch("COPY", { target: ["A1"] });
+    alice.dispatch("PASTE", { target: ["B2"] });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => getCell(user, "B2")!.style,
       undefined
@@ -300,7 +300,7 @@ describe("Multi users synchronisation", () => {
       });
       bob.dispatch("DELETE_CONTENT", {
         sheetId,
-        target: [toZone("A1:B2")],
+        target: ["A1:B2"],
       });
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCellContent(user, "B2"), "");
@@ -316,7 +316,7 @@ describe("Multi users synchronisation", () => {
       });
       bob.dispatch("SET_FORMATTING", {
         sheetId,
-        target: [toZone("B2:C3")],
+        target: ["B2:C3"],
         border: "external",
       });
     });
@@ -747,17 +747,17 @@ describe("Multi users synchronisation", () => {
     setCellContent(alice, "A1", "1");
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#0000FF" }, "2"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#00FF00" }, "3"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     network.concurrent(() => {
@@ -788,12 +788,12 @@ describe("Multi users synchronisation", () => {
     setCellContent(alice, "A1", "1");
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     alice.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#0000FF" }, "2"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     network.concurrent(() => {

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -138,7 +138,7 @@ describe("Collaborative local history", () => {
     undo(alice);
     bob.dispatch("SET_FORMATTING", {
       sheetId: bob.getters.getActiveSheetId(),
-      target: [toZone("H2:J6")],
+      target: ["H2:J6"],
       style: { fillColor: "#121212" },
     });
     expect([alice, bob, charlie]).toHaveSynchronizedExportedData();

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -465,7 +465,7 @@ describe("Collaborative Sheet manipulation", () => {
         bob.dispatch("ADD_CONDITIONAL_FORMAT", {
           sheetId,
           cf,
-          target: [toZone("A1:A3"), toZone("C1:D3"), toZone("F1:F3")],
+          target: ["A1:A3", "C1:D3", "F1:F3"],
         });
       });
       expect([alice, bob, charlie]).toHaveSynchronizedValue(
@@ -488,7 +488,7 @@ describe("Collaborative Sheet manipulation", () => {
         bob.dispatch("ADD_CONDITIONAL_FORMAT", {
           sheetId,
           cf,
-          target: [toZone("A1:A3"), toZone("C1:D3"), toZone("F1:G3")],
+          target: ["A1:A3", "C1:D3", "F1:G3"],
         });
       });
       expect([alice, bob, charlie]).toHaveSynchronizedValue(
@@ -511,7 +511,7 @@ describe("Collaborative Sheet manipulation", () => {
         bob.dispatch("ADD_CONDITIONAL_FORMAT", {
           sheetId,
           cf,
-          target: [toZone("A1:A3"), toZone("A4:A10"), toZone("A11:A12")],
+          target: ["A1:A3", "A4:A10", "A11:A12"],
         });
       });
       expect([alice, bob, charlie]).toHaveSynchronizedValue(
@@ -534,7 +534,7 @@ describe("Collaborative Sheet manipulation", () => {
         bob.dispatch("ADD_CONDITIONAL_FORMAT", {
           sheetId,
           cf,
-          target: [toZone("A1:A3"), toZone("A4:A5"), toZone("A11:A12")],
+          target: ["A1:A3", "A4:A5", "A11:A12"],
         });
       });
       expect([alice, bob, charlie]).toHaveSynchronizedValue(

--- a/tests/collaborative/inverses.test.ts
+++ b/tests/collaborative/inverses.test.ts
@@ -1,4 +1,3 @@
-import { toZone } from "../../src/helpers";
 import { inverseCommand } from "../../src/helpers/inverse_commands";
 import {
   AddColumnsRowsCommand,
@@ -253,7 +252,7 @@ describe("Inverses commands", () => {
     const deleteContent: DeleteContentCommand = {
       type: "DELETE_CONTENT",
       sheetId: "1",
-      target: [toZone("A1")],
+      target: ["A1"],
     };
     const resizeColumns: ResizeColumnsRowsCommand = {
       type: "RESIZE_COLUMNS_ROWS",
@@ -278,12 +277,12 @@ describe("Inverses commands", () => {
       type: "SET_FORMATTING",
       sheetId: "1",
       border: "all",
-      target: [toZone("A1")],
+      target: ["A1"],
     };
     const clearFormatting: ClearFormattingCommand = {
       type: "CLEAR_FORMATTING",
       sheetId: "1",
-      target: [toZone("A1")],
+      target: ["A1"],
     };
     const setBorder: SetBorderCommand = {
       type: "SET_BORDER",
@@ -295,7 +294,7 @@ describe("Inverses commands", () => {
     const setDecimal: SetDecimalCommand = {
       type: "SET_DECIMAL",
       sheetId: "1",
-      target: [toZone("A1")],
+      target: ["A1"],
       step: 2,
     };
     const updateChart: UpdateChartCommand = {

--- a/tests/collaborative/ot/ot_columns_added.test.ts
+++ b/tests/collaborative/ot/ot_columns_added.test.ts
@@ -1,5 +1,4 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers/zones";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
@@ -128,29 +127,29 @@ describe("OT with ADD_COLUMNS_ROWS with dimension COL", () => {
     "target commands",
     (cmd) => {
       test(`add columns  before ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A1:A3")] };
+        const command = { ...cmd, target: ["A1:A3"] };
         const result = transform(command, addColumnsAfter);
         expect(result).toEqual(command);
       });
       test(`add columns after ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("M1:O2")] };
+        const command = { ...cmd, target: ["M1:O2"] };
         const result = transform(command, addColumnsAfter);
-        expect(result).toEqual({ ...command, target: [toZone("O1:Q2")] });
+        expect(result).toEqual({ ...command, target: ["O1:Q2"] });
       });
       test(`add columns in ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("F1:G2")] };
+        const command = { ...cmd, target: ["F1:G2"] };
         const result = transform(command, addColumnsAfter);
-        expect(result).toEqual({ ...command, target: [toZone("F1:I2")] });
+        expect(result).toEqual({ ...command, target: ["F1:I2"] });
       });
       test(`${cmd.type} and columns added in different sheets`, () => {
-        const command = { ...cmd, target: [toZone("A1:F3")], sheetId: "42" };
+        const command = { ...cmd, target: ["A1:F3"], sheetId: "42" };
         const result = transform(command, addColumnsAfter);
         expect(result).toEqual(command);
       });
       test(`${cmd.type} with two targets, one before and one after`, () => {
-        const command = { ...cmd, target: [toZone("A1:A3"), toZone("M1:O2")] };
+        const command = { ...cmd, target: ["A1:A3", "M1:O2"] };
         const result = transform(command, addColumnsAfter);
-        expect(result).toEqual({ ...command, target: [toZone("A1:A3"), toZone("O1:Q2")] });
+        expect(result).toEqual({ ...command, target: ["A1:A3", "O1:Q2"] });
       });
     }
   );

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -1,5 +1,4 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
@@ -119,39 +118,39 @@ describe("OT with REMOVE_COLUMN", () => {
     "target commands",
     (cmd) => {
       test(`remove columns before ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A1:A3")] };
+        const command = { ...cmd, target: ["A1:A3"] };
         const result = transform(command, removeColumns);
         expect(result).toEqual(command);
       });
       test(`remove columns after ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("M1:O2")] };
+        const command = { ...cmd, target: ["M1:O2"] };
         const result = transform(command, removeColumns);
-        expect(result).toEqual({ ...command, target: [toZone("J1:L2")] });
+        expect(result).toEqual({ ...command, target: ["J1:L2"] });
       });
       test(`remove columns before and after ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("E1:E2")] };
+        const command = { ...cmd, target: ["E1:E2"] };
         const result = transform(command, removeColumns);
-        expect(result).toEqual({ ...command, target: [toZone("C1:C2")] });
+        expect(result).toEqual({ ...command, target: ["C1:C2"] });
       });
       test(`${cmd.type} in removed columns`, () => {
-        const command = { ...cmd, target: [toZone("F1:G2")] };
+        const command = { ...cmd, target: ["F1:G2"] };
         const result = transform(command, removeColumns);
-        expect(result).toEqual({ ...command, target: [toZone("D1:D2")] });
+        expect(result).toEqual({ ...command, target: ["D1:D2"] });
       });
       test(`${cmd.type} and columns removed in different sheets`, () => {
-        const command = { ...cmd, target: [toZone("A1:F3")], sheetId: "42" };
+        const command = { ...cmd, target: ["A1:F3"], sheetId: "42" };
         const result = transform(command, removeColumns);
         expect(result).toEqual(command);
       });
       test(`${cmd.type} with a target removed`, () => {
-        const command = { ...cmd, target: [toZone("C1:D2")] };
+        const command = { ...cmd, target: ["C1:D2"] };
         const result = transform(command, removeColumns);
         expect(result).toBeUndefined();
       });
       test(`${cmd.type} with a target removed, but another valid`, () => {
-        const command = { ...cmd, target: [toZone("C1:D2"), toZone("A1")] };
+        const command = { ...cmd, target: ["C1:D2", "A1"] };
         const result = transform(command, removeColumns);
-        expect(result).toEqual({ ...command, target: [toZone("A1")] });
+        expect(result).toEqual({ ...command, target: ["A1"] });
       });
     }
   );

--- a/tests/collaborative/ot/ot_merged.test.ts
+++ b/tests/collaborative/ot/ot_merged.test.ts
@@ -1,5 +1,4 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers";
 import {
   AddMergeCommand,
   ClearCellCommand,
@@ -95,7 +94,7 @@ describe("OT with ADD_MERGE", () => {
     "target commands",
     (cmd) => {
       test(`${cmd.type} outside merge`, () => {
-        const command = { ...cmd, target: [toZone("E1:F2")] };
+        const command = { ...cmd, target: ["E1:F2"] };
         const result = transform(command, addMerge);
         expect(result).toEqual(command);
       });

--- a/tests/collaborative/ot/ot_rows_added.test.ts
+++ b/tests/collaborative/ot/ot_rows_added.test.ts
@@ -1,5 +1,4 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
@@ -123,34 +122,34 @@ describe("OT with ADD_COLUMNS_ROWS with dimension ROW", () => {
     "target commands",
     (cmd) => {
       test(`add rows before ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A1:C1")] };
+        const command = { ...cmd, target: ["A1:C1"] };
         const result = transform(command, addRowsAfter);
         expect(result).toEqual(command);
       });
       test(`add rows after ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A10:B11")] };
+        const command = { ...cmd, target: ["A10:B11"] };
         const result = transform(command, addRowsAfter);
-        expect(result).toEqual({ ...command, target: [toZone("A12:B13")] });
+        expect(result).toEqual({ ...command, target: ["A12:B13"] });
       });
       test(`add rows after in ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A5:B6")] };
+        const command = { ...cmd, target: ["A5:B6"] };
         const result = transform(command, addRowsAfter);
-        expect(result).toEqual({ ...command, target: [toZone("A5:B8")] });
+        expect(result).toEqual({ ...command, target: ["A5:B8"] });
       });
       test(`add rows before in ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A5:B6")] };
+        const command = { ...cmd, target: ["A5:B6"] };
         const result = transform(command, addRowsBefore);
-        expect(result).toEqual({ ...command, target: [toZone("A5:B6")] });
+        expect(result).toEqual({ ...command, target: ["A5:B6"] });
       });
       test(`${cmd.type} and rows added in different sheets`, () => {
-        const command = { ...cmd, target: [toZone("A1:F3")], sheetId: "42" };
+        const command = { ...cmd, target: ["A1:F3"], sheetId: "42" };
         const result = transform(command, addRowsAfter);
         expect(result).toEqual(command);
       });
       test(`${cmd.type} with two targets, one before and one after`, () => {
-        const command = { ...cmd, target: [toZone("A1:C1"), toZone("A10:B11")] };
+        const command = { ...cmd, target: ["A1:C1", "A10:B11"] };
         const result = transform(command, addRowsAfter);
-        expect(result).toEqual({ ...command, target: [toZone("A1:C1"), toZone("A12:B13")] });
+        expect(result).toEqual({ ...command, target: ["A1:C1", "A12:B13"] });
       });
     }
   );

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -1,5 +1,4 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
@@ -119,39 +118,39 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
     "target commands",
     (cmd) => {
       test(`remove rows before ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A1:C1")] };
+        const command = { ...cmd, target: ["A1:C1"] };
         const result = transform(command, removeRows);
         expect(result).toEqual(command);
       });
       test(`remove rows after ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A12:B14")] };
+        const command = { ...cmd, target: ["A12:B14"] };
         const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, target: [toZone("A9:B11")] });
+        expect(result).toEqual({ ...command, target: ["A9:B11"] });
       });
       test(`remove rows before and after ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A5:B5")] };
+        const command = { ...cmd, target: ["A5:B5"] };
         const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, target: [toZone("A3:B3")] });
+        expect(result).toEqual({ ...command, target: ["A3:B3"] });
       });
       test(`${cmd.type} in removed rows`, () => {
-        const command = { ...cmd, target: [toZone("A6:B7")] };
+        const command = { ...cmd, target: ["A6:B7"] };
         const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, target: [toZone("A4:B4")] });
+        expect(result).toEqual({ ...command, target: ["A4:B4"] });
       });
       test(`${cmd.type} and rows removed in different sheets`, () => {
-        const command = { ...cmd, target: [toZone("A1:C6")], sheetId: "42" };
+        const command = { ...cmd, target: ["A1:C6"], sheetId: "42" };
         const result = transform(command, removeRows);
         expect(result).toEqual(command);
       });
       test(`${cmd.type} with a target removed`, () => {
-        const command = { ...cmd, target: [toZone("A3:B4")] };
+        const command = { ...cmd, target: ["A3:B4"] };
         const result = transform(command, removeRows);
         expect(result).toBeUndefined();
       });
       test(`${cmd.type} with a target removed, but another valid`, () => {
-        const command = { ...cmd, target: [toZone("A3:B4"), toZone("A1")] };
+        const command = { ...cmd, target: ["A3:B4", "A1"] };
         const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, target: [toZone("A1")] });
+        expect(result).toEqual({ ...command, target: ["A1"] });
       });
     }
   );

--- a/tests/collaborative/ot/ot_sheet_deleted.test.ts
+++ b/tests/collaborative/ot/ot_sheet_deleted.test.ts
@@ -1,5 +1,4 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import { toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
@@ -41,7 +40,7 @@ describe("OT with DELETE_SHEET", () => {
   const clearCell: Omit<ClearCellCommand, "sheetId"> = { type: "CLEAR_CELL", col: 0, row: 0 };
   const deleteContent: Omit<DeleteContentCommand, "sheetId"> = {
     type: "DELETE_CONTENT",
-    target: [toZone("A1")],
+    target: ["A1"],
   };
   const addColumns: Omit<AddColumnsRowsCommand, "sheetId"> = {
     type: "ADD_COLUMNS_ROWS",
@@ -77,7 +76,7 @@ describe("OT with DELETE_SHEET", () => {
   const addCF: Omit<AddConditionalFormatCommand, "sheetId"> = {
     type: "ADD_CONDITIONAL_FORMAT",
     cf: createEqualCF("test", { fillColor: "orange" }, "id"),
-    target: [toZone("A1:B1")],
+    target: ["A1:B1"],
   };
   const createFigure: Omit<CreateFigureCommand, "sheetId"> = {
     type: "CREATE_FIGURE",
@@ -85,11 +84,11 @@ describe("OT with DELETE_SHEET", () => {
   };
   const setFormatting: Omit<SetFormattingCommand, "sheetId"> = {
     type: "SET_FORMATTING",
-    target: [toZone("A1")],
+    target: ["A1"],
   };
   const clearFormatting: Omit<ClearFormattingCommand, "sheetId"> = {
     type: "CLEAR_FORMATTING",
-    target: [toZone("A1")],
+    target: ["A1"],
   };
   const setBorder: Omit<SetBorderCommand, "sheetId"> = {
     type: "SET_BORDER",
@@ -99,7 +98,7 @@ describe("OT with DELETE_SHEET", () => {
   };
   const setDecimal: Omit<SetDecimalCommand, "sheetId"> = {
     type: "SET_DECIMAL",
-    target: [toZone("A1")],
+    target: ["A1"],
     step: 3,
   };
   const createChart: Omit<CreateChartCommand, "sheetId"> = {

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -6,7 +6,7 @@ import {
   tokenColor,
 } from "../../src/components/composer/composer/composer";
 import { fontSizes } from "../../src/fonts";
-import { colors, toCartesian, toZone } from "../../src/helpers/index";
+import { colors, toCartesian } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { LinkCell } from "../../src/types";
 import {
@@ -238,33 +238,33 @@ describe("ranges and highlights", () => {
   describe("change highlight position in the grid", () => {
     test("change the associated range in the composer ", async () => {
       composerEl = await typeInComposerGrid("=SUM(B2)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C3") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B2" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "C3" });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(C3)");
     });
 
     test("change the first associated range in the composer when ranges are the same", async () => {
       composerEl = await typeInComposerGrid("=SUM(B2, B2)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C3") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B2" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "C3" });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(C3, B2)");
     });
 
     test("the first range doesn't change if other highlight transit by the first range state ", async () => {
       composerEl = await typeInComposerGrid("=SUM(B2, B1)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B3") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "B2" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "B3" });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(B2, B3)");
     });
 
     test("can change references of different length", async () => {
       composerEl = await typeInComposerGrid("=SUM(B1)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "B1:B2" });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(B1:B2)");
     });
@@ -272,8 +272,8 @@ describe("ranges and highlights", () => {
     test("can change references with sheetname", async () => {
       composerEl = await typeInComposerGrid("=Sheet42!B1");
       createSheetWithName(model, { sheetId: "42", activate: true }, "Sheet42");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "B2" });
       await nextTick();
       expect(composerEl.textContent).toBe("=Sheet42!B2");
     });
@@ -281,8 +281,8 @@ describe("ranges and highlights", () => {
     test("change references of the current sheet", async () => {
       composerEl = await typeInComposerGrid("=SUM(B1,Sheet42!B1)");
       createSheetWithName(model, { sheetId: "42", activate: true }, "Sheet42");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "B2" });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM(B1,Sheet42!B2)");
     });
@@ -292,8 +292,8 @@ describe("ranges and highlights", () => {
       ["=$b1", "=$C1"],
     ])("can change cells reference with index fixed", async (ref, resultRef) => {
       composerEl = await typeInComposerGrid(ref);
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "C1" });
       await nextTick();
       expect(composerEl.textContent).toBe(resultRef);
     });
@@ -310,8 +310,8 @@ describe("ranges and highlights", () => {
       ["=$B$1:$B$2", "=$C$1:$C$2"],
     ])("can change ranges reference with index fixed", async (ref, resultRef) => {
       composerEl = await typeInComposerGrid(ref);
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1:C2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1:B2" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "C1:C2" });
       await nextTick();
       expect(composerEl.textContent).toBe(resultRef);
     });
@@ -319,14 +319,14 @@ describe("ranges and highlights", () => {
     test("can change cells merged reference", async () => {
       merge(model, "B1:B2");
       composerEl = await typeInComposerGrid("=B1");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1:B2" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "C1" });
       await nextTick();
       expect(composerEl.textContent).toBe("=C1");
 
       composerEl = await typeInComposerGrid("+B2");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1:B2" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "C2" });
       await nextTick();
       expect(composerEl.textContent).toBe("=C1+C2");
     });
@@ -334,16 +334,16 @@ describe("ranges and highlights", () => {
     test("can change cells merged reference with index fixed", async () => {
       merge(model, "B1:B2");
       composerEl = await typeInComposerGrid("=B$2");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("C1:C2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1:B2" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "C1:C2" });
       await nextTick();
       expect(composerEl.textContent).toBe("=C$1:C$2");
     });
 
     test("can change references of different length with index fixed", async () => {
       composerEl = await typeInComposerGrid("=SUM($B$1)");
-      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: toZone("B1") });
-      model.dispatch("CHANGE_HIGHLIGHT", { zone: toZone("B1:B2") });
+      model.dispatch("START_CHANGE_HIGHLIGHT", { zone: "B1" });
+      model.dispatch("CHANGE_HIGHLIGHT", { zone: "B1:B2" });
       await nextTick();
       expect(composerEl.textContent).toBe("=SUM($B$1:$B$2)");
     });
@@ -850,7 +850,7 @@ describe("composer", () => {
     test("with text color", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { textColor: "#123456" },
       });
       await typeInComposerGrid("Hello");
@@ -865,7 +865,7 @@ describe("composer", () => {
     test("with background color", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { fillColor: "#123456" },
       });
       await typeInComposerGrid("Hello");
@@ -877,7 +877,7 @@ describe("composer", () => {
       const fontSize = fontSizes[0];
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { fontSize: fontSize.pt },
       });
       await typeInComposerGrid("Hello");
@@ -888,7 +888,7 @@ describe("composer", () => {
     test("with font weight", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { bold: true },
       });
       await typeInComposerGrid("Hello");
@@ -899,7 +899,7 @@ describe("composer", () => {
     test("with font style", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { italic: true },
       });
       await typeInComposerGrid("Hello");
@@ -910,7 +910,7 @@ describe("composer", () => {
     test("with text decoration strikethrough", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { strikethrough: true },
       });
       await typeInComposerGrid("Hello");
@@ -921,7 +921,7 @@ describe("composer", () => {
     test("with text decoration underline", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { underline: true },
       });
       await typeInComposerGrid("Hello");
@@ -932,7 +932,7 @@ describe("composer", () => {
     test("with text decoration strikethrough and underline", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { strikethrough: true, underline: true },
       });
       await typeInComposerGrid("Hello");
@@ -943,7 +943,7 @@ describe("composer", () => {
     test("with text align", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { align: "right" },
       });
       await typeInComposerGrid("Hello");
@@ -956,7 +956,7 @@ describe("composer", () => {
     test("with text color", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { textColor: "#123456" },
       });
       await typeInComposerGrid("=");
@@ -967,7 +967,7 @@ describe("composer", () => {
     test("with background color", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { textColor: "#123456" },
       });
       await typeInComposerGrid("=");
@@ -979,7 +979,7 @@ describe("composer", () => {
       const fontSize = fontSizes[0];
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { fontSize: fontSize.pt },
       });
       await typeInComposerGrid("=");
@@ -990,7 +990,7 @@ describe("composer", () => {
     test("with font weight", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { bold: true },
       });
       await typeInComposerGrid("=");
@@ -1001,7 +1001,7 @@ describe("composer", () => {
     test("with font style", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { italic: true },
       });
       await typeInComposerGrid("=");
@@ -1012,7 +1012,7 @@ describe("composer", () => {
     test("with text decoration", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { strikethrough: true },
       });
       await typeInComposerGrid("=");
@@ -1023,7 +1023,7 @@ describe("composer", () => {
     test("with text align", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: { align: "right" },
       });
       await typeInComposerGrid("=");

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -110,7 +110,7 @@ describe("UI of conditional formats", () => {
       model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1:A2")],
+        target: ["A1:A2"],
       });
       model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: createColorScale(
@@ -118,7 +118,7 @@ describe("UI of conditional formats", () => {
           { type: "value", color: 0xff00ff, value: "" },
           { type: "value", color: 0x123456, value: "" }
         ),
-        target: [toZone("B1:B5")],
+        target: ["B1:B5"],
         sheetId: model.getters.getActiveSheetId(),
       });
       await nextTick();
@@ -184,7 +184,7 @@ describe("UI of conditional formats", () => {
             values: ["3"],
           },
         },
-        target: [toZone("A1:A3")],
+        target: ["A1:A3"],
         sheetId: model.getters.getActiveSheetId(),
       });
     });
@@ -192,7 +192,7 @@ describe("UI of conditional formats", () => {
     test("the preview should be bold when the rule is bold", async () => {
       model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: createEqualCF("2", { bold: true, fillColor: "#ff0000" }, "99"),
-        target: [toZone("C1:C5")],
+        target: ["C1:C5"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -239,7 +239,7 @@ describe("UI of conditional formats", () => {
             type: "ColorScaleRule",
           },
         },
-        target: [toZone("B2:B5")],
+        target: ["B2:B5"],
         sheetId: model.getters.getActiveSheetId(),
       });
     });
@@ -309,7 +309,7 @@ describe("UI of conditional formats", () => {
             values: ["3"],
           },
         },
-        target: [toZone("A1:A3")],
+        target: ["A1:A3"],
         sheetId: model.getters.getActiveSheetId(),
       });
     });
@@ -332,8 +332,8 @@ describe("UI of conditional formats", () => {
     test("displayed range is updated if range changes", async () => {
       const previews = document.querySelectorAll(selectors.listPreview);
       expect(previews[0].querySelector(selectors.description.range)!.textContent).toBe("A1:A2");
-      model.dispatch("COPY", { target: [toZone("A1:A2")] });
-      model.dispatch("PASTE", { target: [toZone("C1")] });
+      model.dispatch("COPY", { target: ["A1:A2"] });
+      model.dispatch("PASTE", { target: ["C1"] });
       await nextTick();
       expect(previews[0].querySelector(selectors.description.range)!.textContent).toBe(
         "A1:A2,C1:C2"
@@ -432,7 +432,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      target: ["B2:B5"],
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -483,7 +483,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      target: ["B2:B5"],
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -534,7 +534,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      target: ["B2:B5"],
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -585,7 +585,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      target: ["B2:B5"],
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -649,7 +649,7 @@ describe("UI of conditional formats", () => {
           type: "ColorScaleRule",
         },
       },
-      target: [toZone("B2:B5")],
+      target: ["B2:B5"],
       sheetId: model.getters.getActiveSheetId(),
     });
   });
@@ -683,7 +683,7 @@ describe("UI of conditional formats", () => {
     triggerMouseEvent(selectors.closePanel, "click");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { bold: true, fillColor: "#ff0000" }, "99"),
-      target: [toZone("A1:A2")],
+      target: ["A1:A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
     createSheet(model, { sheetId: "42" });
@@ -1185,7 +1185,7 @@ describe("UI of conditional formats", () => {
             },
           },
         },
-        target: [toZone("B2:B5")],
+        target: ["B2:B5"],
         sheetId: model.getters.getActiveSheetId(),
       });
     });
@@ -1246,7 +1246,7 @@ describe("UI of conditional formats", () => {
             },
           },
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
     });
@@ -1296,7 +1296,7 @@ describe("UI of conditional formats", () => {
           },
         },
       },
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
   });

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -3,7 +3,7 @@ import { Spreadsheet } from "../../src";
 import { Grid } from "../../src/components/grid/grid";
 import { Menu } from "../../src/components/menu/menu";
 import { HEADER_HEIGHT, HEADER_WIDTH, MENU_ITEM_HEIGHT, TOPBAR_HEIGHT } from "../../src/constants";
-import { toXC, toZone } from "../../src/helpers";
+import { toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { createFullMenuItem, FullMenuItem } from "../../src/registries";
 import { cellMenuRegistry } from "../../src/registries/menus/cell_menu_registry";
@@ -732,7 +732,7 @@ describe("Context Menu - CF", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule,
       sheetId: model.getters.getActiveSheetId(),
-      target: cfRule.ranges.map(toZone),
+      target: cfRule.ranges,
     });
     setSelection(model, ["A1:K11"]);
     await rightClickCell(model, "C5");
@@ -769,12 +769,12 @@ describe("Context Menu - CF", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule1,
       sheetId: model.getters.getActiveSheetId(),
-      target: cfRule1.ranges.map(toZone),
+      target: cfRule1.ranges,
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule2,
       sheetId: model.getters.getActiveSheetId(),
-      target: cfRule2.ranges.map(toZone),
+      target: cfRule2.ranges,
     });
     setSelection(model, ["A1:K11"]);
     await rightClickCell(model, "C5");
@@ -801,7 +801,7 @@ describe("Context Menu - CF", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule1,
       sheetId: model.getters.getActiveSheetId(),
-      target: cfRule1.ranges.map(toZone),
+      target: cfRule1.ranges,
     });
     setSelection(model, ["A1:A11"]);
     await rightClickCell(model, "A2");

--- a/tests/components/custom_currency_side_panel.test.ts
+++ b/tests/components/custom_currency_side_panel.test.ts
@@ -1,5 +1,6 @@
 import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
+import { zoneToXc } from "../../src/helpers";
 import { currenciesRegistry } from "../../src/registries/currencies_registry";
 import { Currency } from "../../src/types/currency";
 import { setSelection } from "../test_helpers/commands_helpers";
@@ -361,7 +362,7 @@ describe("custom currency sidePanel component", () => {
       await nextTick();
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: parent.env.model.getters.getActiveSheetId(),
-        target: parent.env.model.getters.getSelectedZones(),
+        target: parent.env.model.getters.getSelectedZones().map(zoneToXc),
         format: formatResult,
       });
     });
@@ -394,7 +395,7 @@ describe("custom currency sidePanel component", () => {
           await nextTick();
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: parent.env.model.getters.getActiveSheetId(),
-            target: parent.env.model.getters.getSelectedZones(),
+            target: parent.env.model.getters.getSelectedZones().map(zoneToXc),
             format: expect.stringMatching(decimalPlacesRegexp),
           });
         }
@@ -429,7 +430,7 @@ describe("custom currency sidePanel component", () => {
           await nextTick();
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: parent.env.model.getters.getActiveSheetId(),
-            target: parent.env.model.getters.getSelectedZones(),
+            target: parent.env.model.getters.getSelectedZones().map(zoneToXc),
             format: expect.stringMatching(positionExpressionRegexp),
           });
         }
@@ -452,7 +453,7 @@ describe("custom currency sidePanel component", () => {
           await nextTick();
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: parent.env.model.getters.getActiveSheetId(),
-            target: parent.env.model.getters.getSelectedZones(),
+            target: parent.env.model.getters.getSelectedZones().map(zoneToXc),
             format: expect.stringMatching(twoDecimalPlacesRegex),
           });
         }
@@ -482,7 +483,7 @@ describe("custom currency sidePanel component", () => {
           await nextTick();
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: parent.env.model.getters.getActiveSheetId(),
-            target: parent.env.model.getters.getSelectedZones(),
+            target: parent.env.model.getters.getSelectedZones().map(zoneToXc),
             format: expect.stringMatching(positionExpressionRegexp),
           });
         }

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -2,7 +2,7 @@ import { App } from "@odoo/owl";
 import { Spreadsheet, TransportService } from "../../src";
 import { Grid } from "../../src/components/grid/grid";
 import { HEADER_WIDTH, MESSAGE_VERSION, SCROLLBAR_WIDTH } from "../../src/constants";
-import { scrollDelay, toZone } from "../../src/helpers";
+import { scrollDelay, toZone, zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import {
   createSheet,
@@ -297,7 +297,7 @@ describe("Grid component", () => {
     test("can undo/redo with keyboard", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
+        target: [zoneToXc({ left: 0, right: 0, top: 0, bottom: 0 })],
         style: { fillColor: "red" },
       });
       expect(getCell(model, "A1")!.style).toBeDefined();
@@ -315,7 +315,7 @@ describe("Grid component", () => {
     test("can undo/redo with keyboard (uppercase version)", async () => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
+        target: [zoneToXc({ left: 0, right: 0, top: 0, bottom: 0 })],
         style: { fillColor: "red" },
       });
       expect(getCell(model, "A1")!.style).toBeDefined();
@@ -581,10 +581,10 @@ describe("Grid component", () => {
       selectCell(model, "B2");
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+        target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
         style: { bold: true },
       });
-      const target = [{ left: 1, top: 1, bottom: 1, right: 1 }];
+      const target = [zoneToXc({ left: 1, top: 1, bottom: 1, right: 1 })];
       model.dispatch("ACTIVATE_PAINT_FORMAT", { target });
       gridMouseEvent(model, "mousedown", "C8");
       expect(getCell(model, "C8")).toBeUndefined();
@@ -597,10 +597,10 @@ describe("Grid component", () => {
       selectCell(model, "B2");
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+        target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
         style: { bold: true },
       });
-      const target = [{ left: 1, top: 1, bottom: 1, right: 1 }];
+      const target = [zoneToXc({ left: 1, top: 1, bottom: 1, right: 1 })];
       model.dispatch("ACTIVATE_PAINT_FORMAT", { target });
       expect(getCell(model, "C2")).toBeUndefined();
       document.activeElement!.dispatchEvent(

--- a/tests/components/grid_manipulation.test.ts
+++ b/tests/components/grid_manipulation.test.ts
@@ -1,6 +1,7 @@
 import { App } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
+import { zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { selectColumn, selectRow } from "../test_helpers/commands_helpers";
 import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
@@ -65,12 +66,12 @@ describe("Context Menu add/remove row/col", () => {
     simulateClick(".o-menu div[data-name='clear_column']");
     expect(dispatch).toHaveBeenCalledWith("DELETE_CONTENT", {
       target: [
-        {
+        zoneToXc({
           top: 0,
           bottom: model.getters.getActiveSheet().rows.length - 1,
           left: 3,
           right: 3,
-        },
+        }),
       ],
       sheetId: model.getters.getActiveSheetId(),
     });
@@ -83,12 +84,12 @@ describe("Context Menu add/remove row/col", () => {
     simulateClick(".o-menu div[data-name='clear_row']");
     expect(dispatch).toHaveBeenCalledWith("DELETE_CONTENT", {
       target: [
-        {
+        zoneToXc({
           top: 4,
           bottom: 4,
           left: 0,
           right: model.getters.getActiveSheet().cols.length - 1,
-        },
+        }),
       ],
       sheetId: model.getters.getActiveSheetId(),
     });

--- a/tests/components/highlight.test.ts
+++ b/tests/components/highlight.test.ts
@@ -132,12 +132,12 @@ describe("Corner component", () => {
       // select B2 nw corner
       selectNWCellCorner(cornerEl, "B2");
       expect(model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        zone: "B2",
       });
       // move to A1
       moveToCell(cornerEl, "A1");
       expect(model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("A1:B2"),
+        zone: "A1:B2",
       });
     });
 
@@ -148,13 +148,13 @@ describe("Corner component", () => {
       // select B2 ne corner
       selectNECellCorner(cornerEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        zone: "B2",
       });
 
       // move to C1
       moveToCell(cornerEl, "C1");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("B1:C2"),
+        zone: "B1:C2",
       });
     });
 
@@ -165,13 +165,13 @@ describe("Corner component", () => {
       // select B2 sw corner
       selectSWCellCorner(cornerEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        zone: "B2",
       });
 
       // move to A3
       moveToCell(cornerEl, "A3");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("A2:B3"),
+        zone: "A2:B3",
       });
     });
 
@@ -182,13 +182,13 @@ describe("Corner component", () => {
       // select B2 se corner
       selectSECellCorner(cornerEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        zone: "B2",
       });
 
       // move to C3
       moveToCell(cornerEl, "C3");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("B2:C3"),
+        zone: "B2:C3",
       });
     });
   });
@@ -200,7 +200,7 @@ describe("Corner component", () => {
     // select A1 nw corner
     selectNWCellCorner(cornerEl, "A1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1"),
+      zone: "A1",
     });
 
     // move outside the grid
@@ -222,13 +222,13 @@ describe("Corner component", () => {
     // select B2 se corner
     selectNWCellCorner(cornerEl, "B2");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("B2"),
+      zone: "B2",
     });
 
     // move to B1
     moveToCell(cornerEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C2"),
+      zone: "B1:C2",
     });
   });
 
@@ -246,7 +246,7 @@ describe("Corner component", () => {
     // select B1 nw corner
     selectNWCellCorner(cornerEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("B1"),
+      zone: "B1",
     });
 
     // move to C1
@@ -271,7 +271,7 @@ describe("Corner component", () => {
     // select A2 nw corner
     selectTopCellBorder(cornerEl, "A2");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A2"),
+      zone: "A2",
     });
 
     // move to A3
@@ -292,13 +292,13 @@ describe("Border component", () => {
       // select B2 top border
       selectTopCellBorder(borderEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        zone: "B2",
       });
 
       // move to C2
       moveToCell(borderEl, "C2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("C2"),
+        zone: "C2",
       });
     });
 
@@ -309,13 +309,13 @@ describe("Border component", () => {
       // select B2 left border
       selectLeftCellBorder(borderEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        zone: "B2",
       });
 
       // move to C2
       moveToCell(borderEl, "C2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("C2"),
+        zone: "C2",
       });
     });
 
@@ -326,13 +326,13 @@ describe("Border component", () => {
       // select B2 right border
       selectRightCellBorder(borderEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        zone: "B2",
       });
 
       // move to C2
       moveToCell(borderEl, "C2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("C2"),
+        zone: "C2",
       });
     });
 
@@ -343,13 +343,13 @@ describe("Border component", () => {
       // select B2 bottom border
       selectBottomCellBorder(borderEl, "B2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-        zone: toZone("B2"),
+        zone: "B2",
       });
 
       // move to C2
       moveToCell(borderEl, "C2");
       expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-        zone: toZone("C2"),
+        zone: "C2",
       });
     });
   });
@@ -361,19 +361,19 @@ describe("Border component", () => {
     // select A1 top border
     selectTopCellBorder(borderEl, "A1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1:B2"),
+      zone: "A1:B2",
     });
 
     // move to B1
     moveToCell(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C2"),
+      zone: "B1:C2",
     });
 
     // move to C1
     moveToCell(borderEl, "C1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("C1:D2"),
+      zone: "C1:D2",
     });
   });
 
@@ -384,13 +384,13 @@ describe("Border component", () => {
     // select B1 top border
     selectTopCellBorder(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1:B2"),
+      zone: "A1:B2",
     });
 
     // move to C1
     moveToCell(borderEl, "C1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C2"),
+      zone: "B1:C2",
     });
   });
 
@@ -401,7 +401,7 @@ describe("Border component", () => {
     // select B2 bottom border
     selectBottomCellBorder(borderEl, "B2");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1:B2"),
+      zone: "A1:B2",
     });
 
     // move to A2
@@ -417,13 +417,13 @@ describe("Border component", () => {
     // select A1 top border
     selectTopCellBorder(borderEl, "A1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1"),
+      zone: "A1",
     });
 
     // move to B1
     moveToCell(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C1"),
+      zone: "B1:C1",
     });
   });
 
@@ -435,13 +435,13 @@ describe("Border component", () => {
     // select A1 top border
     selectTopCellBorder(borderEl, "A1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A1"),
+      zone: "A1",
     });
 
     // move to B1
     moveToCell(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("CHANGE_HIGHLIGHT", {
-      zone: toZone("B1:C1"),
+      zone: "B1:C1",
     });
   });
 
@@ -459,7 +459,7 @@ describe("Border component", () => {
     // select B1 top border
     selectTopCellBorder(borderEl, "B1");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("B1"),
+      zone: "B1",
     });
 
     // move to C1
@@ -484,7 +484,7 @@ describe("Border component", () => {
     // select A2 top border
     selectTopCellBorder(borderEl, "A2");
     expect(parent.model.dispatch).toHaveBeenCalledWith("START_CHANGE_HIGHLIGHT", {
-      zone: toZone("A2"),
+      zone: "A2",
     });
 
     // move to A3

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -1,7 +1,7 @@
 import { App, Component, onMounted, onWillUnmount, useState, useSubEnv, xml } from "@odoo/owl";
 import { TopBar } from "../../src/components/top_bar/top_bar";
 import { DEFAULT_FONT_SIZE } from "../../src/constants";
-import { toZone } from "../../src/helpers";
+import { zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { topbarComponentRegistry } from "../../src/registries";
 import { topbarMenuRegistry } from "../../src/registries/menus/topbar_menu_registry";
@@ -159,7 +159,7 @@ describe("TopBar component", () => {
 
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, right: 0, top: 0, bottom: 0 })],
       style: { bold: true },
     });
     await nextTick();
@@ -197,7 +197,7 @@ describe("TopBar component", () => {
     selectCell(model, "B1");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       border: "all",
     });
     expect(getBorder(model, "B1")).toBeDefined();
@@ -278,7 +278,7 @@ describe("TopBar component", () => {
       setCellContent(model, "A1", content);
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         style: style as Style,
       });
       const { app } = await mountParent(model);
@@ -512,7 +512,7 @@ describe("TopBar - CF", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule,
       sheetId: model.getters.getActiveSheetId(),
-      target: cfRule.ranges.map(toZone),
+      target: cfRule.ranges,
     });
     setSelection(model, ["A1:K11"]);
 
@@ -556,12 +556,12 @@ describe("TopBar - CF", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule1,
       sheetId: model.getters.getActiveSheetId(),
-      target: cfRule1.ranges.map(toZone),
+      target: cfRule1.ranges,
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: cfRule2,
       sheetId: model.getters.getActiveSheetId(),
-      target: cfRule2.ranges.map(toZone),
+      target: cfRule2.ranges,
     });
     setSelection(model, ["A1:K11"]);
 

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -1,6 +1,7 @@
 import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../src";
 import { fontSizes } from "../src/fonts";
+import { zoneToXc } from "../src/helpers";
 import { interactivePaste } from "../src/helpers/ui/paste";
 import {
   colMenuRegistry,
@@ -150,7 +151,7 @@ describe("Menu Item actions", () => {
     env.clipboard.writeText = jest.fn(() => Promise.resolve());
     doAction(["edit", "copy"], env);
     expect(dispatch).toHaveBeenCalledWith("COPY", {
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(env.clipboard.writeText).toHaveBeenCalledWith(env.model.getters.getClipboardContent());
   });
@@ -159,7 +160,7 @@ describe("Menu Item actions", () => {
     env.clipboard.writeText = jest.fn(() => Promise.resolve());
     doAction(["edit", "cut"], env);
     expect(dispatch).toHaveBeenCalledWith("CUT", {
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(env.clipboard.writeText).toHaveBeenCalledWith(env.model.getters.getClipboardContent());
   });
@@ -171,7 +172,7 @@ describe("Menu Item actions", () => {
     await nextTick();
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
       text: await env.clipboard.readText(),
-      target: [{ bottom: 0, left: 0, right: 0, top: 0 }],
+      target: [zoneToXc({ bottom: 0, left: 0, right: 0, top: 0 })],
     });
   });
 
@@ -187,7 +188,7 @@ describe("Menu Item actions", () => {
   test("Edit -> paste_special -> paste_special_value", () => {
     doAction(["edit", "paste_special", "paste_special_value"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE", {
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
       pasteOption: "onlyValue",
     });
   });
@@ -195,7 +196,7 @@ describe("Menu Item actions", () => {
   test("Edit -> paste_special -> paste_special_format", () => {
     doAction(["edit", "paste_special", "paste_special_format"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE", {
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
       pasteOption: "onlyFormat",
     });
   });
@@ -204,7 +205,7 @@ describe("Menu Item actions", () => {
     doAction(["edit", "edit_delete_cell_values"], env);
     expect(dispatch).toHaveBeenCalledWith("DELETE_CONTENT", {
       sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
     });
   });
 
@@ -544,7 +545,7 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_general"], env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        target: env.model.getters.getSelectedZones().map(zoneToXc),
         format: "",
       });
     });
@@ -553,7 +554,7 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_number"], env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        target: env.model.getters.getSelectedZones().map(zoneToXc),
         format: "#,##0.00",
       });
     });
@@ -562,7 +563,7 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_percent"], env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        target: env.model.getters.getSelectedZones().map(zoneToXc),
         format: "0.00%",
       });
     });
@@ -571,7 +572,7 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_currency"], env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        target: env.model.getters.getSelectedZones().map(zoneToXc),
         format: "[$$]#,##0.00",
       });
     });
@@ -580,7 +581,7 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_currency_rounded"], env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        target: env.model.getters.getSelectedZones().map(zoneToXc),
         format: "[$$]#,##0",
       });
     });
@@ -589,7 +590,7 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_date"], env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        target: env.model.getters.getSelectedZones().map(zoneToXc),
         format: "m/d/yyyy",
       });
     });
@@ -598,7 +599,7 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_time"], env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        target: env.model.getters.getSelectedZones().map(zoneToXc),
         format: "hh:mm:ss a",
       });
     });
@@ -607,7 +608,7 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_date_time"], env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        target: env.model.getters.getSelectedZones().map(zoneToXc),
         format: "m/d/yyyy hh:mm:ss",
       });
     });
@@ -616,7 +617,7 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_duration"], env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
-        target: env.model.getters.getSelectedZones(),
+        target: env.model.getters.getSelectedZones().map(zoneToXc),
         format: "hhhh:mm:ss",
       });
     });
@@ -635,7 +636,7 @@ describe("Menu Item actions", () => {
     doAction(["format", "format_bold"], env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
       sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
       style: { bold: true },
     });
   });
@@ -644,7 +645,7 @@ describe("Menu Item actions", () => {
     doAction(["format", "format_italic"], env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
       sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
       style: { italic: true },
     });
   });
@@ -653,7 +654,7 @@ describe("Menu Item actions", () => {
     doAction(["format", "format_underline"], env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
       sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
       style: { underline: true },
     });
   });
@@ -662,7 +663,7 @@ describe("Menu Item actions", () => {
     doAction(["format", "format_strikethrough"], env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
       sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
       style: { strikethrough: true },
     });
   });
@@ -672,7 +673,7 @@ describe("Menu Item actions", () => {
     doAction(["format", "format_font_size", `format_font_size_${fontSize.pt}`], env);
     expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
       sheetId: env.model.getters.getActiveSheetId(),
-      target: env.model.getters.getSelectedZones(),
+      target: env.model.getters.getSelectedZones().map(zoneToXc),
       style: { fontSize: fontSize.pt },
     });
   });
@@ -683,7 +684,7 @@ describe("Menu Item actions", () => {
     expect(dispatch).toHaveBeenCalledWith("SORT_CELLS", {
       sheetId: env.model.getters.getActiveSheetId(),
       ...anchor.cell,
-      zone: zones[0],
+      zone: zoneToXc(zones[0]),
       sortDirection: "ascending",
     });
   });
@@ -694,7 +695,7 @@ describe("Menu Item actions", () => {
     expect(dispatch).toHaveBeenCalledWith("SORT_CELLS", {
       sheetId: env.model.getters.getActiveSheetId(),
       ...anchor.cell,
-      zone: zones[0],
+      zone: zoneToXc(zones[0]),
       sortDirection: "descending",
     });
   });

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1,5 +1,4 @@
 import { CommandResult, CorePlugin } from "../src";
-import { toZone } from "../src/helpers";
 import { LocalHistory } from "../src/history/local_history";
 import { Mode, Model, ModelConfig } from "../src/model";
 import { BordersPlugin } from "../src/plugins/core/borders";
@@ -116,7 +115,7 @@ describe("Model", () => {
     uiPluginRegistry.add("myUIPlugin", MyUIPlugin);
     corePluginRegistry.add("myCorePlugin", MyCorePlugin);
     const model = new Model();
-    model.dispatch("COPY", { target: [toZone("A1")] });
+    model.dispatch("COPY", { target: ["A1"] });
     expect(result).toBeCancelledBecause(CommandResult.CancelledForUnknownReason);
     uiPluginRegistry.remove("myUIPlugin");
     corePluginRegistry.remove("myCorePlugin");
@@ -162,7 +161,7 @@ describe("Model", () => {
       handle(cmd: Command) {
         if (cmd.type === "COPY") {
           result = this.dispatch("PASTE", {
-            target: [toZone("A2")],
+            target: ["A2"],
           });
         }
       }
@@ -170,7 +169,7 @@ describe("Model", () => {
     uiPluginRegistry.add("myUIPlugin", MyUIPlugin);
     const model = new Model();
     setCellContent(model, "A1", "copy&paste me");
-    model.dispatch("COPY", { target: [toZone("A1")] });
+    model.dispatch("COPY", { target: ["A1"] });
     expect(result).toBeSuccessfullyDispatched();
     expect(getCellText(model, "A2")).toBe("copy&paste me");
     corePluginRegistry.remove("myUIPlugin");

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -144,7 +144,7 @@ describe("Autofill", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf,
       sheetId: model.getters.getActiveSheetId(),
-      target: cf.ranges.map(toZone),
+      target: cf.ranges,
     });
     let col: number, row: number;
     ({ col, row } = toCartesian("A1"));

--- a/tests/plugins/borders.test.ts
+++ b/tests/plugins/borders.test.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_BORDER_DESC as b, DEFAULT_BORDER_DESC } from "../../src/constants";
-import { toZone } from "../../src/helpers";
+import { zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { BorderDescr } from "../../src/types/index";
 import {
@@ -240,7 +240,7 @@ describe("borders", () => {
     expect(getBorder(model, "B2")).toBeDefined();
     model.dispatch("DELETE_CONTENT", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(getBorder(model, "B2")).toBeDefined();
   });
@@ -267,7 +267,7 @@ describe("borders", () => {
     expect(getBorder(model, "B1")).toBeDefined();
     model.dispatch("CLEAR_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(getBorder(model, "B1")).toBeNull();
   });
@@ -307,8 +307,8 @@ describe("borders", () => {
     setBorder(model, "external", "B2");
     const s = DEFAULT_BORDER_DESC;
     expect(getBorder(model, "B2")).toEqual({ top: s, bottom: s, right: s, left: s });
-    model.dispatch("CUT", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C4")] });
+    model.dispatch("CUT", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C4"] });
     expect(getBorder(model, "C4")).toEqual({ top: s, bottom: s, right: s, left: s });
     expect(getBorder(model, "B2")).toBeNull();
   });

--- a/tests/plugins/cell.test.ts
+++ b/tests/plugins/cell.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../src";
-import { buildSheetLink, toZone } from "../../src/helpers";
+import { buildSheetLink } from "../../src/helpers";
 import { CellValueType, CommandResult, LinkCell } from "../../src/types";
 import {
   createSheet,
@@ -213,8 +213,8 @@ describe("link cell", () => {
     const model = new Model();
     setCellContent(model, "B2", `[my label](odoo.com)`);
     const B2 = getCell(model, "B2") as LinkCell;
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("D2")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["D2"] });
     const B2After = getCell(model, "B2") as LinkCell;
     const D2 = getCell(model, "D2") as LinkCell;
     expect(B2After.link).toEqual(B2.link);
@@ -228,8 +228,8 @@ describe("link cell", () => {
     const sheetLink = buildSheetLink(sheetId);
     setCellContent(model, "B2", `[my label](${sheetLink})`);
     const B2 = getCell(model, "B2") as LinkCell;
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("D2")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["D2"] });
     const B2After = getCell(model, "B2") as LinkCell;
     const D2 = getCell(model, "D2") as LinkCell;
     expect(B2After.link).toEqual(B2.link);
@@ -247,8 +247,8 @@ describe("link cell", () => {
       content: "[my label](odoo.com)",
       style: { fillColor: "#555", bold: true, textColor: "#111" },
     });
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("D2")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["D2"] });
     expect(getCell(model, "D2")?.style).toEqual({
       fillColor: "#555",
       bold: true,

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -1,4 +1,4 @@
-import { toZone } from "../../src/helpers";
+import { toZone, zoneToXc } from "../../src/helpers";
 import { interactivePaste } from "../../src/helpers/ui/paste";
 import { Model } from "../../src/model";
 import { ClipboardPlugin } from "../../src/plugins/ui/clipboard";
@@ -51,8 +51,8 @@ describe("clipboard", () => {
       },
     });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("D2")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["D2"] });
     expect(getCell(model, "B2")).toMatchObject({
       content: "b2",
       evaluated: {
@@ -81,7 +81,7 @@ describe("clipboard", () => {
       },
     });
 
-    model.dispatch("CUT", { target: [toZone("B2")] });
+    model.dispatch("CUT", { target: ["B2"] });
     expect(getCell(model, "B2")).toMatchObject({
       content: "b2",
       evaluated: {
@@ -89,7 +89,7 @@ describe("clipboard", () => {
         value: "b2",
       },
     });
-    model.dispatch("PASTE", { target: [toZone("D2")] });
+    model.dispatch("PASTE", { target: ["D2"] });
 
     expect(getCell(model, "B2")).toBeUndefined();
     expect(getCell(model, "D2")).toMatchObject({
@@ -103,14 +103,14 @@ describe("clipboard", () => {
     expect(getClipboardVisibleZones(model).length).toBe(0);
 
     // select D3 and paste. it should do nothing
-    model.dispatch("PASTE", { target: [toZone("D3:D3")] });
+    model.dispatch("PASTE", { target: ["D3:D3"] });
 
     expect(getCell(model, "D3")).toBeUndefined();
   });
 
   test("paste without copied value", () => {
     const model = new Model();
-    const result = model.dispatch("PASTE", { target: [toZone("D2")] });
+    const result = model.dispatch("PASTE", { target: ["D2"] });
     expect(result).toBeCancelledBecause(CommandResult.EmptyClipboard);
   });
 
@@ -132,11 +132,11 @@ describe("clipboard", () => {
   test("can cut and paste a cell in different sheets", () => {
     const model = new Model();
     setCellContent(model, "A1", "a1");
-    model.dispatch("CUT", { target: [toZone("A1")] });
+    model.dispatch("CUT", { target: ["A1"] });
     const to = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42", activate: true });
     setCellContent(model, "A1", "a1Sheet2");
-    model.dispatch("PASTE", { target: [toZone("B2")] });
+    model.dispatch("PASTE", { target: ["B2"] });
     expect(getCell(model, "A1")).toMatchObject({
       content: "a1Sheet2",
       evaluated: {
@@ -157,7 +157,7 @@ describe("clipboard", () => {
     expect(getClipboardVisibleZones(model).length).toBe(0);
 
     // select D3 and paste. it should do nothing
-    model.dispatch("PASTE", { target: [toZone("D3:D3")] });
+    model.dispatch("PASTE", { target: ["D3:D3"] });
 
     expect(getCell(model, "D3")).toBeUndefined();
   });
@@ -167,10 +167,10 @@ describe("clipboard", () => {
     setCellContent(model, "A1", "a1");
     setCellContent(model, "A2", "a2");
 
-    model.dispatch("CUT", { target: [toZone("A1:A2")] });
+    model.dispatch("CUT", { target: ["A1:A2"] });
     expect(getGrid(model)).toEqual({ A1: "a1", A2: "a2" });
 
-    model.dispatch("PASTE", { target: [toZone("A2")] });
+    model.dispatch("PASTE", { target: ["A2"] });
     expect(getGrid(model)).toEqual({ A2: "a1", A3: "a2" });
   });
 
@@ -181,13 +181,13 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: sheet1,
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"] });
 
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
     expect(getCell(model, "C2")!.style).toEqual({ bold: true });
@@ -200,7 +200,7 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
@@ -208,10 +208,10 @@ describe("clipboard", () => {
     // set value in A1, select and copy it
     setCellContent(model, "A1", "a1");
     selectCell(model, "A1");
-    model.dispatch("COPY", { target: [toZone("A1")] });
+    model.dispatch("COPY", { target: ["A1"] });
 
     // select B2 again and paste
-    model.dispatch("PASTE", { target: [toZone("B2")] });
+    model.dispatch("PASTE", { target: ["B2"] });
 
     expect(getCell(model, "B2")!.evaluated.value).toBe("a1");
     expect(getCell(model, "B2")!.style).not.toBeDefined();
@@ -225,16 +225,16 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: sheet1,
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
     // set value in A1, select and copy it
     selectCell(model, "A1");
-    model.dispatch("COPY", { target: [toZone("A1")] });
+    model.dispatch("COPY", { target: ["A1"] });
 
-    model.dispatch("PASTE", { target: [toZone("B2")] });
+    model.dispatch("PASTE", { target: ["B2"] });
 
     expect(getCell(model, "B2")).toBeUndefined();
   });
@@ -244,13 +244,13 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       border: "bottom",
     });
     expect(getBorder(model, "B2")).toEqual({ bottom: ["thin", "#000"] });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"] });
 
     expect(getBorder(model, "B2")).toEqual({ bottom: ["thin", "#000"] });
     expect(getBorder(model, "C2")).toEqual({ bottom: ["thin", "#000"] });
@@ -281,13 +281,13 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       format: "0.00%",
     });
     expect(getCellContent(model, "B2")).toBe("45.10%");
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"] });
 
     expect(getCellContent(model, "C2")).toBe("45.10%");
   });
@@ -426,7 +426,7 @@ describe("clipboard", () => {
       ],
     });
     const sheet2 = "s2";
-    model.dispatch("COPY", { target: [toZone("B2")] });
+    model.dispatch("COPY", { target: ["B2"] });
     activateSheet(model, sheet2);
     model.dispatch("PASTE", { target: target("A1") });
     expect(model.getters.isInMerge(sheet2, ...toCartesianArray("A1"))).toBe(true);
@@ -454,9 +454,9 @@ describe("clipboard", () => {
 
     expect(getCellText(model, "A1", "s1")).toBe("=A2");
 
-    model.dispatch("COPY", { target: [toZone("A1")] });
+    model.dispatch("COPY", { target: ["A1"] });
     activateSheet(model, "s2");
-    model.dispatch("PASTE", { target: [toZone("A1")] });
+    model.dispatch("PASTE", { target: ["A1"] });
 
     expect(getCellText(model, "A1", "s1")).toBe("=A2");
     expect(getCellText(model, "A1", "s2")).toBe("=A2");
@@ -480,11 +480,11 @@ describe("clipboard", () => {
 
     selectCell(model, "B2");
     const selection = model.getters.getSelection().zones;
-    model.dispatch("COPY", { target: selection });
+    model.dispatch("COPY", { target: selection.map(zoneToXc) });
 
     selectCell(model, "A1");
     const env = makeInteractiveTestEnv(model, { notifyUser });
-    interactivePaste(env, model.getters.getSelectedZones());
+    interactivePaste(env, model.getters.getSelectedZones().map(zoneToXc));
     expect(notifyUser).toHaveBeenCalled();
   });
 
@@ -530,8 +530,8 @@ describe("clipboard", () => {
 
     selectCell(model, "B2");
     const selection = model.getters.getSelection().zones;
-    model.dispatch("COPY", { target: selection });
-    const result = model.dispatch("PASTE", { target: [toZone("A1")] });
+    model.dispatch("COPY", { target: selection.map(zoneToXc) });
+    const result = model.dispatch("PASTE", { target: ["A1"] });
     expect(result).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
     expect(model.getters.isInMerge("s1", ...toCartesianArray("A1"))).toBe(false);
     expect(model.getters.isInMerge("s1", ...toCartesianArray("A2"))).toBe(false);
@@ -555,7 +555,7 @@ describe("clipboard", () => {
     });
     selectCell(model, "B2");
     const selection = model.getters.getSelection().zones;
-    model.dispatch("COPY", { target: selection });
+    model.dispatch("COPY", { target: selection.map(zoneToXc) });
     model.dispatch("PASTE", { target: target("A1"), force: true });
     expect(model.getters.isInMerge("s1", ...toCartesianArray("A1"))).toBe(true);
     expect(model.getters.isInMerge("s1", ...toCartesianArray("A2"))).toBe(true);
@@ -572,12 +572,12 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
 
-    model.dispatch("CUT", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")] });
+    model.dispatch("CUT", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"] });
 
     expect(getCell(model, "C2")).toMatchObject({
       style: { bold: true },
@@ -594,12 +594,12 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "B2", "abc");
     selectCell(model, "B2");
-    model.dispatch("COPY", { target: [toZone("B2")] });
+    model.dispatch("COPY", { target: ["B2"] });
     expect(model.getters.getClipboardContent()).toBe("abc");
 
     setCellContent(model, "B2", "= 1 + 2");
     selectCell(model, "B2");
-    model.dispatch("COPY", { target: [toZone("B2")] });
+    model.dispatch("COPY", { target: ["B2"] });
     expect(model.getters.getClipboardContent()).toBe("3");
   });
 
@@ -610,14 +610,14 @@ describe("clipboard", () => {
     setCellContent(model, "C2", "c2");
     setCellContent(model, "C3", "c3");
 
-    model.dispatch("COPY", { target: [toZone("B2:C3")] });
+    model.dispatch("COPY", { target: ["B2:C3"] });
 
     expect(getCell(model, "D1")).toBeUndefined();
     expect(getCell(model, "D2")).toBeUndefined();
     expect(getCell(model, "E1")).toBeUndefined();
     expect(getCell(model, "E2")).toBeUndefined();
 
-    model.dispatch("PASTE", { target: [toZone("D1:D1")] });
+    model.dispatch("PASTE", { target: ["D1:D1"] });
 
     expect(getCellContent(model, "D1")).toBe("b2");
     expect(getCellContent(model, "D2")).toBe("b3");
@@ -636,13 +636,13 @@ describe("clipboard", () => {
     setCellContent(model, "B3", "b3");
     setCellContent(model, "C2", "c2");
     setCellContent(model, "C3", "c3");
-    model.dispatch("COPY", { target: [toZone("B2:C3")] });
+    model.dispatch("COPY", { target: ["B2:C3"] });
     expect(model.getters.getClipboardContent()).toBe("b2\tc2\nb3\tc3");
   });
 
   test("can paste multiple cells from os clipboard", () => {
     const model = new Model();
-    model.dispatch("PASTE_FROM_OS_CLIPBOARD", { text: "a\t1\nb\t2", target: [toZone("C1")] });
+    model.dispatch("PASTE_FROM_OS_CLIPBOARD", { text: "a\t1\nb\t2", target: ["C1"] });
 
     expect(getCellContent(model, "C1")).toBe("a");
     expect(getCellContent(model, "C2")).toBe("b");
@@ -652,7 +652,7 @@ describe("clipboard", () => {
 
   test("pasting numbers from windows clipboard => interpreted as number", () => {
     const model = new Model();
-    model.dispatch("PASTE_FROM_OS_CLIPBOARD", { text: "1\r\n2\r\n3", target: [toZone("C1")] });
+    model.dispatch("PASTE_FROM_OS_CLIPBOARD", { text: "1\r\n2\r\n3", target: ["C1"] });
 
     expect(getCellContent(model, "C1")).toBe("1");
     expect(getCell(model, "C1")?.evaluated.value).toBe(1);
@@ -665,9 +665,9 @@ describe("clipboard", () => {
   test("pasting a value in a larger selection", () => {
     const model = new Model();
     setCellContent(model, "A1", "1");
-    model.dispatch("COPY", { target: [toZone("A1:A1")] });
+    model.dispatch("COPY", { target: ["A1:A1"] });
 
-    model.dispatch("PASTE", { target: [toZone("C2:E3")] });
+    model.dispatch("PASTE", { target: ["C2:E3"] });
     expect(getCellContent(model, "C2")).toBe("1");
     expect(getCellContent(model, "C3")).toBe("1");
     expect(getCellContent(model, "D2")).toBe("1");
@@ -680,14 +680,14 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
-    model.dispatch("COPY", { target: [toZone("A1:A2")] });
+    model.dispatch("COPY", { target: ["A1:A2"] });
 
     // select C1:C3
     selectCell(model, "C1");
     setAnchorCorner(model, "C3");
 
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, left: 2, bottom: 2, right: 2 });
-    model.dispatch("PASTE", { target: [toZone("C1:C3")] });
+    model.dispatch("PASTE", { target: ["C1:C3"] });
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, left: 2, bottom: 1, right: 2 });
     expect(getCellContent(model, "C1")).toBe("1");
     expect(getCellContent(model, "C2")).toBe("2");
@@ -697,12 +697,12 @@ describe("clipboard", () => {
   test("selection is not changed if pasting a single value into two zones", () => {
     const model = new Model();
     setCellContent(model, "A1", "1");
-    model.dispatch("COPY", { target: [toZone("A1:A1")] });
+    model.dispatch("COPY", { target: ["A1:A1"] });
 
     selectCell(model, "C1");
     addCellToSelection(model, "E1");
 
-    model.dispatch("PASTE", { target: [toZone("C1"), toZone("E1")] });
+    model.dispatch("PASTE", { target: ["C1", "E1"] });
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, left: 2, bottom: 0, right: 2 });
     expect(model.getters.getSelectedZones()[1]).toEqual({ top: 0, left: 4, bottom: 0, right: 4 });
   });
@@ -710,9 +710,9 @@ describe("clipboard", () => {
   test("pasting a value in multiple zones", () => {
     const model = new Model();
     setCellContent(model, "A1", "33");
-    model.dispatch("COPY", { target: [toZone("A1:A1")] });
+    model.dispatch("COPY", { target: ["A1:A1"] });
 
-    model.dispatch("PASTE", { target: [toZone("C1"), toZone("E1")] });
+    model.dispatch("PASTE", { target: ["C1", "E1"] });
 
     expect(getCellContent(model, "C1")).toBe("33");
     expect(getCellContent(model, "E1")).toBe("33");
@@ -722,8 +722,8 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
-    model.dispatch("COPY", { target: [toZone("A1:A2")] });
-    const result = model.dispatch("PASTE", { target: [toZone("C1"), toZone("E1")] });
+    model.dispatch("COPY", { target: ["A1:A2"] });
+    const result = model.dispatch("PASTE", { target: ["C1", "E1"] });
 
     expect(result).toBeCancelledBecause(CommandResult.WrongPasteSelection);
   });
@@ -733,12 +733,12 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
-    model.dispatch("COPY", { target: [toZone("A1:A2")] });
+    model.dispatch("COPY", { target: ["A1:A2"] });
 
     selectCell(model, "C4");
     addCellToSelection(model, "F6");
     const env = makeInteractiveTestEnv(model, { notifyUser });
-    interactivePaste(env, model.getters.getSelectedZones());
+    interactivePaste(env, model.getters.getSelectedZones().map(zoneToXc));
     expect(notifyUser).toHaveBeenCalled();
   });
 
@@ -906,8 +906,8 @@ describe("clipboard", () => {
     expect(getCellText(model, "B2")).toEqual('="test"');
     expect(getCell(model, "B2")!.evaluated.value).toEqual("test");
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("D2")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["D2"] });
     expect(getCellText(model, "B2")).toEqual('="test"');
     expect(getCell(model, "B2")!.evaluated.value).toEqual("test");
     expect(getCellText(model, "D2")).toEqual('="test"');
@@ -919,8 +919,8 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("D2")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["D2"] });
     expect(getCell(model, "D2")).toBeDefined();
     undo(model);
     expect(getCell(model, "D2")).toBeUndefined();
@@ -932,13 +932,13 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")], pasteOption: "onlyFormat" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"], pasteOption: "onlyFormat" });
     expect(getCellContent(model, "C2")).toBe("");
     expect(getCell(model, "C2")!.style).toEqual({ bold: true });
   });
@@ -949,13 +949,13 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")], pasteOption: "onlyFormat" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"], pasteOption: "onlyFormat" });
     expect(getCellContent(model, "C2")).toBe("");
     expect(getCell(model, "C2")!.style).toEqual({ bold: true });
   });
@@ -967,13 +967,13 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")], pasteOption: "onlyFormat" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"], pasteOption: "onlyFormat" });
 
     expect(getCellContent(model, "C2")).toBe("c2");
     expect(getCell(model, "C2")!.style).toEqual({ bold: true });
@@ -985,11 +985,11 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
-    model.dispatch("COPY", { target: [toZone("B2:B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")], pasteOption: "onlyFormat" });
+    model.dispatch("COPY", { target: ["B2:B2"] });
+    model.dispatch("PASTE", { target: ["C2"], pasteOption: "onlyFormat" });
 
     expect(getCellContent(model, "C2")).toBe("");
     expect(getCell(model, "C2")!.style).toEqual({ bold: true });
@@ -1002,8 +1002,8 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
     selectCell(model, "B2");
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")], pasteOption: "onlyValue" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"], pasteOption: "onlyValue" });
     expect(getCellContent(model, "C2")).toBe("b2");
   });
 
@@ -1013,13 +1013,13 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")], pasteOption: "onlyValue" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"], pasteOption: "onlyValue" });
 
     expect(getCell(model, "C2")!.evaluated.value).toBe("b2");
     expect(getCell(model, "C2")!.style).not.toBeDefined();
@@ -1031,13 +1031,13 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       border: "bottom",
     });
     expect(getBorder(model, "B2")).toEqual({ bottom: ["thin", "#000"] });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")], pasteOption: "onlyValue" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"], pasteOption: "onlyValue" });
 
     expect(getCell(model, "C2")!.evaluated.value).toBe("b2");
     expect(getBorder(model, "C2")).toBeNull();
@@ -1049,13 +1049,13 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       format: "0.00%",
     });
     expect(getCellContent(model, "B2")).toBe("45.10%");
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")], pasteOption: "onlyValue" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C2"], pasteOption: "onlyValue" });
 
     expect(getCellContent(model, "C2")).toBe("0.451");
   });
@@ -1075,7 +1075,7 @@ describe("clipboard", () => {
     setCellContent(model, "C2", "2");
     let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
+      target: ["A1", "A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
 
@@ -1099,13 +1099,13 @@ describe("clipboard", () => {
     selectCell(model, "C3");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 2, right: 2, top: 2, bottom: 2 }],
+      target: [zoneToXc({ left: 2, right: 2, top: 2, bottom: 2 })],
       style: { bold: true },
     });
     expect(getCell(model, "C3")!.style).toEqual({ bold: true });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C3")], pasteOption: "onlyValue" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C3"], pasteOption: "onlyValue" });
 
     expect(getCellContent(model, "C3")).toBe("b2");
     expect(getCell(model, "C3")!.style).toEqual({ bold: true });
@@ -1118,14 +1118,14 @@ describe("clipboard", () => {
     selectCell(model, "C3");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       border: "bottom",
     });
     expect(getBorder(model, "C3")).toEqual({ bottom: ["thin", "#000"] });
     expect(getBorder(model, "C4")).toEqual({ top: ["thin", "#000"] });
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C3")], pasteOption: "onlyValue" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C3"], pasteOption: "onlyValue" });
 
     expect(getCellContent(model, "C3")).toBe("b2");
     expect(getBorder(model, "C3")).toEqual({ bottom: ["thin", "#000"] });
@@ -1138,13 +1138,13 @@ describe("clipboard", () => {
     selectCell(model, "C3");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       format: "0.00%",
     });
     expect(getCellContent(model, "C3")).toBe("45.10%");
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("C3")], pasteOption: "onlyValue" });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["C3"], pasteOption: "onlyValue" });
 
     expect(getCellContent(model, "C3")).toBe("4200.00%");
   });
@@ -1154,8 +1154,8 @@ describe("clipboard", () => {
     setCellContent(model, "A1", "=SUM(1+2)");
     setCellContent(model, "A2", "=EQ(42,42)");
     setCellContent(model, "A3", '=CONCAT("Ki","kou")');
-    model.dispatch("COPY", { target: [toZone("A1:A3")] });
-    model.dispatch("PASTE", { target: [toZone("B1")], pasteOption: "onlyValue" });
+    model.dispatch("COPY", { target: ["A1:A3"] });
+    model.dispatch("PASTE", { target: ["B1"], pasteOption: "onlyValue" });
     expect(getCellContent(model, "B1")).toBe("3");
     expect(getCellContent(model, "B2")).toBe("TRUE");
     expect(getCellContent(model, "B3")).toBe("Kikou");
@@ -1167,11 +1167,11 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
-    model.dispatch("COPY", { target: [toZone("B2:B2")] });
-    model.dispatch("PASTE", { target: [toZone("C2")], pasteOption: "onlyValue" });
+    model.dispatch("COPY", { target: ["B2:B2"] });
+    model.dispatch("PASTE", { target: ["C2"], pasteOption: "onlyValue" });
 
     expect(getCellContent(model, "C2")).toBe("b2");
     expect(getCell(model, "C2")!.style).not.toBeDefined();
@@ -1183,8 +1183,8 @@ describe("clipboard", () => {
   test("can copy and paste a formula and update the refs", () => {
     const model = new Model();
     setCellContent(model, "A1", "=SUM(C1:C2)");
-    model.dispatch("COPY", { target: [toZone("A1")] });
-    model.dispatch("PASTE", { target: [toZone("B2")] });
+    model.dispatch("COPY", { target: ["A1"] });
+    model.dispatch("PASTE", { target: ["B2"] });
     expect(getCellText(model, "B2")).toBe("=SUM(D2:D3)");
   });
 
@@ -1207,8 +1207,8 @@ describe("clipboard", () => {
   ])("can copy and paste formula with $refs", (value, expected) => {
     const model = new Model();
     setCellContent(model, "A1", value);
-    model.dispatch("COPY", { target: [toZone("A1")] });
-    model.dispatch("PASTE", { target: [toZone("B2")] });
+    model.dispatch("COPY", { target: ["A1"] });
+    model.dispatch("PASTE", { target: ["B2"] });
     expect(getCellText(model, "B2")).toBe(expected);
   });
 
@@ -1220,16 +1220,16 @@ describe("clipboard", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 1, right: 1, top: 1, bottom: 1 }],
+      target: [zoneToXc({ left: 1, right: 1, top: 1, bottom: 1 })],
       style: { bold: true },
     });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
     // select A1 and copy format
-    model.dispatch("COPY", { target: [toZone("A1")] });
+    model.dispatch("COPY", { target: ["A1"] });
 
     // select B2 and paste format
-    model.dispatch("PASTE", { target: [toZone("B2")], pasteOption: "onlyFormat" });
+    model.dispatch("PASTE", { target: ["B2"], pasteOption: "onlyFormat" });
 
     expect(getCellContent(model, "B2")).toBe("b2");
     expect(getCell(model, "B2")!.style).not.toBeDefined();
@@ -1251,7 +1251,7 @@ describe("clipboard", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
       sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1"), toZone("A2")],
+      target: ["A1", "A2"],
     });
     model.dispatch("COPY", { target: target("A1") });
     model.dispatch("PASTE", { target: target("C1") });
@@ -1281,7 +1281,7 @@ describe("clipboard", () => {
     setCellContent(model, "C2", "2");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
+      target: ["A1", "A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
     model.dispatch("CUT", { target: target("A1") });
@@ -1309,7 +1309,7 @@ describe("clipboard", () => {
     setCellContent(model, "A2", "2");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
+      target: ["A1", "A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
     model.dispatch("COPY", { target: target("A1:A2") });
@@ -1348,7 +1348,7 @@ describe("clipboard", () => {
     setCellContent(model, "A2", "2");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
+      target: ["A1", "A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
     model.dispatch("CUT", { target: target("A1:A2") });
@@ -1386,10 +1386,10 @@ describe("clipboard", () => {
     setCellContent(model, "A2", "2");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
+      target: ["A1", "A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
-    model.dispatch("COPY", { target: [toZone("A1:A2")] });
+    model.dispatch("COPY", { target: ["A1:A2"] });
     activateSheet(model, "s2");
     model.dispatch("PASTE", { target: target("A1") });
     expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
@@ -1423,10 +1423,10 @@ describe("clipboard", () => {
     setCellContent(model, "A2", "2");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
+      target: ["A1", "A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
-    model.dispatch("CUT", { target: [toZone("A1:A2")] });
+    model.dispatch("CUT", { target: ["A1:A2"] });
     activateSheet(model, sheet2);
     model.dispatch("PASTE", { target: target("A1") });
     expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
@@ -1449,8 +1449,8 @@ describe("clipboard", () => {
     createSheet(model, { sheetId: "42" });
     setCellContent(model, "B2", "=Sheet2!B2");
 
-    model.dispatch("COPY", { target: [toZone("B2")] });
-    model.dispatch("PASTE", { target: [toZone("B3")] });
+    model.dispatch("COPY", { target: ["B2"] });
+    model.dispatch("PASTE", { target: ["B3"] });
     expect(getCellText(model, "B3")).toBe("=Sheet2!B3");
   });
 
@@ -1469,8 +1469,8 @@ describe("clipboard", () => {
     createSheet(model, { sheetId: "42", rows: 2, cols: 2 });
     setCellContent(model, "A1", "=Sheet2!A1:A2");
 
-    model.dispatch("COPY", { target: [toZone("A1")] });
-    model.dispatch("PASTE", { target: [toZone("A2")] });
+    model.dispatch("COPY", { target: ["A1"] });
+    model.dispatch("PASTE", { target: ["A2"] });
     expect(getCellText(model, "A2")).toBe("=Sheet2!A2:A3");
   });
 
@@ -1479,8 +1479,8 @@ describe("clipboard", () => {
     createSheet(model, { sheetId: "42" });
     setCellContent(model, "A1", "=SUM(Sheet2!A2:A5)");
 
-    model.dispatch("COPY", { target: [toZone("A1")] });
-    model.dispatch("PASTE", { target: [toZone("B1")] });
+    model.dispatch("COPY", { target: ["A1"] });
+    model.dispatch("PASTE", { target: ["B1"] });
     expect(getCellText(model, "B1")).toBe("=SUM(Sheet2!B2:B5)");
   });
 
@@ -1493,8 +1493,8 @@ describe("clipboard", () => {
     deleteRows(model, [0]);
     expect(getCell(model, "A2")!.content).toBe(expectedInvalidFormula);
 
-    model.dispatch("COPY", { target: [toZone("A2")] });
-    model.dispatch("PASTE", { target: [toZone("C5")] });
+    model.dispatch("COPY", { target: ["A2"] });
+    model.dispatch("PASTE", { target: ["C5"] });
     expect(getCell(model, "C5")!.content).toBe(expectedInvalidFormula);
   });
 
@@ -1507,8 +1507,8 @@ describe("clipboard", () => {
     deleteColumns(model, ["A"]);
     expect(getCell(model, "B1")!.content).toBe(expectedInvalidFormula);
 
-    model.dispatch("COPY", { target: [toZone("B1")] });
-    model.dispatch("PASTE", { target: [toZone("C3")] });
+    model.dispatch("COPY", { target: ["B1"] });
+    model.dispatch("PASTE", { target: ["C3"] });
     expect(getCell(model, "C3")!.content).toBe(expectedInvalidFormula);
   });
 
@@ -1521,8 +1521,8 @@ describe("clipboard", () => {
     deleteRows(model, [0]);
     expect(getCell(model, "A2")!.content).toBe(expectedInvalidFormula);
 
-    model.dispatch("CUT", { target: [toZone("A2")] });
-    model.dispatch("PASTE", { target: [toZone("C5")] });
+    model.dispatch("CUT", { target: ["A2"] });
+    model.dispatch("PASTE", { target: ["C5"] });
     expect(getCell(model, "C5")!.content).toBe(expectedInvalidFormula);
   });
 
@@ -1535,8 +1535,8 @@ describe("clipboard", () => {
     deleteColumns(model, ["A"]);
     expect(getCell(model, "B1")!.content).toBe(expectedInvalidFormula);
 
-    model.dispatch("CUT", { target: [toZone("B1")] });
-    model.dispatch("PASTE", { target: [toZone("C3")] });
+    model.dispatch("CUT", { target: ["B1"] });
+    model.dispatch("PASTE", { target: ["C3"] });
     expect(getCell(model, "C3")!.content).toBe(expectedInvalidFormula);
   });
 });
@@ -1548,8 +1548,10 @@ describe("clipboard: pasting outside of sheet", () => {
     const activeSheet = model.getters.getActiveSheet();
     const currentRowNumber = activeSheet.rows.length;
 
-    model.dispatch("COPY", { target: [model.getters.getColsZone(activeSheet.id, 0, 0)] });
-    model.dispatch("PASTE", { target: [toZone("B2")] });
+    model.dispatch("COPY", {
+      target: [model.getters.getColsZone(activeSheet.id, 0, 0)].map(zoneToXc),
+    });
+    model.dispatch("PASTE", { target: ["B2"] });
     expect(activeSheet.rows.length).toBe(currentRowNumber + 1);
     expect(getCellContent(model, "B2")).toBe("txt");
     expect(model.getters.getSelectedZones()).toEqual([toZone("B2:B101")]);
@@ -1562,8 +1564,10 @@ describe("clipboard: pasting outside of sheet", () => {
     const activeSheet = model.getters.getActiveSheet();
     const currentColNumber = activeSheet.cols.length;
 
-    model.dispatch("COPY", { target: [model.getters.getRowsZone(activeSheet.id, 0, 0)] });
-    model.dispatch("PASTE", { target: [toZone("B2")] });
+    model.dispatch("COPY", {
+      target: [model.getters.getRowsZone(activeSheet.id, 0, 0)].map(zoneToXc),
+    });
+    model.dispatch("PASTE", { target: ["B2"] });
     expect(activeSheet.cols.length).toBe(currentColNumber + 1);
     expect(getCellContent(model, "B2")).toBe("txt");
     expect(model.getters.getSelectedZones()).toEqual([toZone("B2:AA2")]);
@@ -1603,7 +1607,7 @@ describe("clipboard: pasting outside of sheet", () => {
     createSheet(model, { activate: true, sheetId: "2", rows: 2, cols: 2 });
     model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
       text: "A\nque\tcoucou\nBOB",
-      target: [toZone("B2")],
+      target: ["B2"],
     });
     expect(getCellContent(model, "B2")).toBe("A");
     expect(getCellContent(model, "B3")).toBe("que");
@@ -1618,7 +1622,7 @@ describe("clipboard: pasting outside of sheet", () => {
     });
     model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
       text: "A\nque\tcoucou\tPatrick",
-      target: [toZone("B2")],
+      target: ["B2"],
     });
     expect(getCellContent(model, "B2")).toBe("A");
     expect(getCellContent(model, "B3")).toBe("que");
@@ -1633,7 +1637,7 @@ describe("clipboard: pasting outside of sheet", () => {
 
     model.dispatch("CUT", { target: target("A1:B1") });
     addColumns(model, "after", "A", 1);
-    model.dispatch("PASTE", { target: [toZone("A2")] });
+    model.dispatch("PASTE", { target: ["A2"] });
     expect(getCellContent(model, "A1")).toBe("1");
     expect(getCellContent(model, "C1")).toBe("2");
     expect(getCellContent(model, "A2")).toBe("");
@@ -1647,7 +1651,7 @@ describe("clipboard: pasting outside of sheet", () => {
 
     model.dispatch("CUT", { target: target("A1:B1") });
     addColumns(model, "after", "A", 5);
-    model.dispatch("PASTE", { target: [toZone("A2")] });
+    model.dispatch("PASTE", { target: ["A2"] });
     expect(getCellContent(model, "A1")).toBe("1");
     expect(getCellContent(model, "G1")).toBe("2");
     expect(getCellContent(model, "A2")).toBe("");
@@ -1661,7 +1665,7 @@ describe("clipboard: pasting outside of sheet", () => {
 
     model.dispatch("CUT", { target: target("A1:A2") });
     addRows(model, "after", 0, 1);
-    model.dispatch("PASTE", { target: [toZone("C1")] });
+    model.dispatch("PASTE", { target: ["C1"] });
     expect(getCellContent(model, "A1")).toBe("1");
     expect(getCellContent(model, "A3")).toBe("2");
     expect(getCellContent(model, "C1")).toBe("");
@@ -1675,7 +1679,7 @@ describe("clipboard: pasting outside of sheet", () => {
 
     model.dispatch("CUT", { target: target("A1:A2") });
     addRows(model, "after", 0, 5);
-    model.dispatch("PASTE", { target: [toZone("C1")] });
+    model.dispatch("PASTE", { target: ["C1"] });
     expect(getCellContent(model, "A1")).toBe("1");
     expect(getCellContent(model, "A7")).toBe("2");
     expect(getCellContent(model, "C1")).toBe("");

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -1,4 +1,3 @@
-import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult, ConditionalFormattingOperatorValues } from "../../src/types";
 import {
@@ -31,12 +30,12 @@ describe("conditional format", () => {
     setCellContent(model, "A4", "4");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1:A4")],
+      target: ["A1:A4"],
       sheetId: model.getters.getActiveSheetId(),
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("4", { fillColor: "#0000FF" }, "2"),
-      target: [toZone("A1:A4")],
+      target: ["A1:A4"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toEqual([
@@ -82,7 +81,7 @@ describe("conditional format", () => {
     expect(sheetId).not.toBe(model.getters.getActiveSheetId());
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("4", { fillColor: "#0000FF" }, "2"),
-      target: [toZone("A1:A4")],
+      target: ["A1:A4"],
       sheetId: sheetId,
     });
     activateSheet(model, "42");
@@ -124,7 +123,7 @@ describe("conditional format", () => {
     expect(
       model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: createEqualCF("4", { fillColor: "#0000FF" }, "2"),
-        target: [toZone("A1:A4000")],
+        target: ["A1:A4000"],
         sheetId: sheetId,
       })
     ).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
@@ -138,12 +137,12 @@ describe("conditional format", () => {
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1:A4")],
+      target: ["A1:A4"],
       sheetId,
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("4", { fillColor: "#0000FF" }, "2"),
-      target: [toZone("A1:A4")],
+      target: ["A1:A4"],
       sheetId,
     });
     expect(model.getters.getConditionalFormats(sheetId)).toEqual([
@@ -197,7 +196,7 @@ describe("conditional format", () => {
     setCellContent(model, "A2", "1");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
+      target: ["A1", "A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
@@ -213,7 +212,7 @@ describe("conditional format", () => {
     setCellContent(model, "A2", "1");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
+      target: ["A1", "A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
@@ -255,7 +254,7 @@ describe("conditional format", () => {
     setCellContent(model, "B2", "1");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("B1"), toZone("B2")],
+      target: ["B1", "B2"],
       sheetId,
     });
     expect(model.getters.getConditionalStyle(...toCartesianArray("B1"))).toEqual({
@@ -333,7 +332,7 @@ describe("conditional format", () => {
   test("is saved/restored", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1:A4")],
+      target: ["A1:A4"],
       sheetId: model.getters.getActiveSheetId(),
     });
     const workbookData = model.exportData();
@@ -349,7 +348,7 @@ describe("conditional format", () => {
     setCellContent(model, "A2", "2");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
@@ -369,7 +368,7 @@ describe("conditional format", () => {
     setCellContent(model, "A1", "2");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     setCellContent(model, "A1", "=BLA");
@@ -380,12 +379,12 @@ describe("conditional format", () => {
     setCellContent(model, "A1", "2");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { textColor: "#445566" }, "2"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
@@ -398,12 +397,12 @@ describe("conditional format", () => {
     setCellContent(model, "A1", "2");
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#FF0000" }, "2"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
@@ -425,12 +424,12 @@ describe("conditional format", () => {
         id: "1",
         stopIfTrue: true,
       },
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { fillColor: "#445566" }, "2"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
@@ -441,7 +440,7 @@ describe("conditional format", () => {
   test("Set conditionalFormat on empty cell", () => {
     let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(result).toBeSuccessfullyDispatched();
@@ -607,12 +606,12 @@ describe("conditional format", () => {
     const idRule2 = "2";
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, idRule1),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#0000FF" }, idRule2),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
 
@@ -628,12 +627,12 @@ describe("conditional format", () => {
     const idRule2 = "2";
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, idRule1),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#0000FF" }, idRule2),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     let formats = model.getters.getConditionalFormats(sheetId);
@@ -657,12 +656,12 @@ describe("conditional format", () => {
     const idRule2 = "2";
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, idRule1),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#0000FF" }, idRule2),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     let formats = model.getters.getConditionalFormats(sheetId);
@@ -689,12 +688,12 @@ describe("conditional format", () => {
     const idRule2 = "2";
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, idRule1),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#0000FF" }, idRule2),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
@@ -772,7 +771,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -870,7 +869,7 @@ describe("conditional formats types", () => {
             },
             id: "11",
           },
-          target: [toZone("A1")],
+          target: ["A1"],
           sheetId: model.getters.getActiveSheetId(),
         });
         setCellContent(model, "A1", cellContent);
@@ -894,7 +893,7 @@ describe("conditional formats types", () => {
             },
             id: "11",
           },
-          target: [toZone("A1")],
+          target: ["A1"],
           sheetId: model.getters.getActiveSheetId(),
         });
         setCellContent(model, "A1", cellContent);
@@ -914,7 +913,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
       setCellContent(model, "A1", "5");
@@ -940,7 +939,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -969,7 +968,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -996,7 +995,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -1025,7 +1024,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -1062,7 +1061,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
@@ -1293,7 +1292,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
       setCellContent(model, "A1", "");
@@ -1335,7 +1334,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
       setCellContent(model, "A1", "");
@@ -1388,7 +1387,7 @@ describe("conditional formats types", () => {
             },
             id: "11",
           },
-          target: [toZone("A1")],
+          target: ["A1"],
           sheetId: model.getters.getActiveSheetId(),
         });
         expect(result).toBeSuccessfullyDispatched();
@@ -1428,7 +1427,7 @@ describe("conditional formats types", () => {
             },
             id: "11",
           },
-          target: [toZone("A1")],
+          target: ["A1"],
           sheetId: model.getters.getActiveSheetId(),
         });
         expect(result).toBeCancelledBecause(CommandResult.FirstArgMissing);
@@ -1453,7 +1452,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
       expect(result).toBeCancelledBecause(CommandResult.SecondArgMissing);
@@ -1475,7 +1474,7 @@ describe("conditional formats types", () => {
           },
           id: "11",
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
       expect(result).toBeCancelledBecause(
@@ -1492,7 +1491,7 @@ describe("conditional formats types", () => {
         test("lower inflection point is NaN", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
-            target: [toZone("A1")],
+            target: ["A1"],
             cf: {
               id: "1",
               rule: {
@@ -1512,7 +1511,7 @@ describe("conditional formats types", () => {
         test("upper inflection point is NaN", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
-            target: [toZone("A1")],
+            target: ["A1"],
             cf: {
               id: "1",
               rule: {
@@ -1535,7 +1534,7 @@ describe("conditional formats types", () => {
     test("refuse invalid and async formulas %s", () => {
       const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
+        target: ["A1"],
         cf: {
           id: "1",
           rule: {
@@ -1569,7 +1568,7 @@ describe("conditional formats types", () => {
         test("upper bigger than lower", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
-            target: [toZone("A1")],
+            target: ["A1"],
             cf: {
               id: "1",
               rule: {
@@ -1604,7 +1603,7 @@ describe("conditional formats types", () => {
             },
           },
         },
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual(undefined);
@@ -1629,7 +1628,7 @@ describe("conditional formats types", () => {
               },
             },
           },
-          target: [toZone("A1")],
+          target: ["A1"],
           sheetId: model.getters.getActiveSheetId(),
         });
         expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
@@ -1658,7 +1657,7 @@ describe("conditional formats types", () => {
             },
           },
         },
-        target: [toZone("A1:A5")],
+        target: ["A1:A5"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -1690,7 +1689,7 @@ describe("conditional formats types", () => {
             },
           },
         },
-        target: [toZone("A1:A5")],
+        target: ["A1:A5"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -1722,7 +1721,7 @@ describe("conditional formats types", () => {
             },
           },
         },
-        target: [toZone("A1:A5")],
+        target: ["A1:A5"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -1740,7 +1739,7 @@ describe("conditional formats types", () => {
         test("minimum is NaN", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
-            target: [toZone("A1")],
+            target: ["A1"],
             cf: {
               id: "1",
               rule: {
@@ -1755,7 +1754,7 @@ describe("conditional formats types", () => {
         test("midpoint is NaN", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
-            target: [toZone("A1")],
+            target: ["A1"],
             cf: {
               id: "1",
               rule: {
@@ -1771,7 +1770,7 @@ describe("conditional formats types", () => {
         test("maximum is NaN", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
-            target: [toZone("A1")],
+            target: ["A1"],
             cf: {
               id: "1",
               rule: {
@@ -1800,7 +1799,7 @@ describe("conditional formats types", () => {
         test("min bigger than max", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
-            target: [toZone("A1")],
+            target: ["A1"],
             cf: {
               id: "1",
               rule: {
@@ -1815,7 +1814,7 @@ describe("conditional formats types", () => {
         test("mid bigger than max", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
-            target: [toZone("A1")],
+            target: ["A1"],
             cf: {
               id: "1",
               rule: {
@@ -1831,7 +1830,7 @@ describe("conditional formats types", () => {
         test("min bigger than mid", () => {
           const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
             sheetId: model.getters.getActiveSheetId(),
-            target: [toZone("A1")],
+            target: ["A1"],
             cf: {
               id: "1",
               rule: {
@@ -1854,7 +1853,7 @@ describe("conditional formats types", () => {
           { type: "value", color: 0xff00ff },
           { type: "value", color: 0x123456 }
         ),
-        target: [toZone("A1")],
+        target: ["A1"],
         sheetId: model.getters.getActiveSheetId(),
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual(undefined);
@@ -1873,7 +1872,7 @@ describe("conditional formats types", () => {
           { type: "value", color: 0xff00ff },
           { type: "value", color: 0x123456 }
         ),
-        target: [toZone("A1:A5")],
+        target: ["A1:A5"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -1907,7 +1906,7 @@ describe("conditional formats types", () => {
           { type: "value", color: 0xff00ff },
           { type: "value", color: 0x123456 }
         ),
-        target: [toZone("A1:A5")],
+        target: ["A1:A5"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -1941,7 +1940,7 @@ describe("conditional formats types", () => {
           { type: "value", color: 0xff00ff },
           { type: "value", color: 0x123456 }
         ),
-        target: [toZone("A1:A5")],
+        target: ["A1:A5"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -1973,7 +1972,7 @@ describe("conditional formats types", () => {
           { type: "value", color: 0xff0000 },
           { type: "value", color: 0x00ff00 }
         ),
-        target: [toZone("A1:A5")],
+        target: ["A1:A5"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -1997,7 +1996,7 @@ describe("conditional formats types", () => {
           { type: "value", color: 0xff00ff },
           { type: "value", color: 0x123456 }
         ),
-        target: [toZone("A1:A2")],
+        target: ["A1:A2"],
         sheetId: model.getters.getActiveSheetId(),
       });
 
@@ -2013,7 +2012,7 @@ describe("conditional formats types", () => {
           { type: "value", color: 0xff00ff },
           { type: "value", color: 0x123456 }
         ),
-        target: [toZone("A1:A10")],
+        target: ["A1:A10"],
         sheetId,
       });
       deleteCells(model, "A2:A3", "up");

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -1,4 +1,5 @@
 import { functionRegistry } from "../../src/functions";
+import { zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
@@ -184,7 +185,7 @@ describe("core", () => {
       selectCell(model, "B2");
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: model.getters.getSelectedZones(),
+        target: model.getters.getSelectedZones().map(zoneToXc),
         border: "bottom",
       });
       expect(getCellContent(model, "B2")).toBe("");
@@ -196,7 +197,7 @@ describe("core", () => {
       selectCell(model, "A1");
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: model.getters.getSelectedZones(),
+        target: model.getters.getSelectedZones().map(zoneToXc),
         format: "0.00000",
       });
       expect(getCellContent(model, "A1")).toBe("0.00000");
@@ -204,7 +205,7 @@ describe("core", () => {
       selectCell(model, "A2");
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: model.getters.getSelectedZones(),
+        target: model.getters.getSelectedZones().map(zoneToXc),
         format: "0.00%",
       });
       expect(getCellContent(model, "A2")).toBe("0.00%");
@@ -215,7 +216,7 @@ describe("core", () => {
       setCellContent(model, "A1", "=sum(A2) + 1");
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
+        target: [zoneToXc({ left: 0, top: 0, right: 0, bottom: 0 })],
         style: { bold: true },
       });
       expect(getCellContent(model, "A1")).toEqual("1");
@@ -521,7 +522,7 @@ describe("history", () => {
     selectCell(model, "A2");
     model.dispatch("DELETE_CONTENT", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(getCell(model, "A2")).toBeUndefined();
 
@@ -537,7 +538,7 @@ describe("history", () => {
     setCellContent(model, "A1", "3");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, top: 0, right: 0, bottom: 0 })],
       style: { bold: true },
     });
 
@@ -545,7 +546,7 @@ describe("history", () => {
 
     model.dispatch("DELETE_CONTENT", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, top: 0, right: 0, bottom: 0 })],
     });
     expect(getCellContent(model, "A1")).toBe("");
   });
@@ -555,7 +556,7 @@ describe("history", () => {
     setCellContent(model, "A1", "3");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, top: 0, right: 0, bottom: 0 })],
       border: "bottom",
     });
 
@@ -563,7 +564,7 @@ describe("history", () => {
 
     model.dispatch("DELETE_CONTENT", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, top: 0, right: 0, bottom: 0 })],
     });
     expect(getCellContent(model, "A1")).toBe("");
   });
@@ -573,7 +574,7 @@ describe("history", () => {
     setCellContent(model, "A1", "3");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, top: 0, right: 0, bottom: 0 })],
       format: "#,##0.00",
     });
 
@@ -581,7 +582,7 @@ describe("history", () => {
 
     model.dispatch("DELETE_CONTENT", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, top: 0, right: 0, bottom: 0 })],
     });
     expect(getCellContent(model, "A1")).toBe("");
   });

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -1,4 +1,4 @@
-import { toCartesian, toZone } from "../../src/helpers";
+import { toCartesian, toZone, zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
@@ -55,7 +55,7 @@ describe("edition", () => {
     selectCell(model, "A2");
     model.dispatch("DELETE_CONTENT", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(getCell(model, "A2")).toBeTruthy();
     expect(getCellContent(model, "A2")).toBe("");

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -1,4 +1,5 @@
 import { args, functionRegistry } from "../../src/functions";
+import { zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { ArgRange, CellValueType, InvalidEvaluation } from "../../src/types";
 import {
@@ -208,7 +209,7 @@ describe("evaluateCells", () => {
     const value = evaluation.value;
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, top: 0, right: 0, bottom: 0 })],
       format: "#,##0",
     });
     evaluation = getCell(model, "A1")?.evaluated as InvalidEvaluation;

--- a/tests/plugins/formatting.test.ts
+++ b/tests/plugins/formatting.test.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_FONT_SIZE, PADDING_AUTORESIZE } from "../../src/constants";
 import { fontSizeMap } from "../../src/fonts";
-import { toZone } from "../../src/helpers";
+import { zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { SheetUIPlugin } from "../../src/plugins/ui/ui_sheet";
 import { Cell, CommandResult, UID } from "../../src/types";
@@ -16,7 +16,7 @@ import { getPlugin } from "../test_helpers/helpers";
 function setFormat(model: Model, format: string) {
   model.dispatch("SET_FORMATTING", {
     sheetId: model.getters.getActiveSheetId(),
-    target: model.getters.getSelectedZones(),
+    target: model.getters.getSelectedZones().map(zoneToXc),
     format,
   });
 }
@@ -24,7 +24,7 @@ function setFormat(model: Model, format: string) {
 function setDecimal(model: Model, step: number) {
   model.dispatch("SET_DECIMAL", {
     sheetId: model.getters.getActiveSheetId(),
-    target: model.getters.getSelectedZones(),
+    target: model.getters.getSelectedZones().map(zoneToXc),
     step: step,
   });
 }
@@ -148,7 +148,7 @@ describe("formatting values (with formatters)", () => {
     expect(
       model.dispatch("SET_FORMATTING", {
         sheetId: "invalid sheet Id",
-        target: [toZone("A1")],
+        target: ["A1"],
       })
     ).toBeCancelledBecause(CommandResult.InvalidSheetId);
   });
@@ -171,7 +171,7 @@ describe("formatting values (when change decimal)", () => {
     selectCell(model, "A1");
     model.dispatch("DELETE_CONTENT", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(getCell(model, "A1")!.format).toBe("0%");
     setDecimal(model, 1);
@@ -405,7 +405,7 @@ describe("Autoresize", () => {
   test("Can autoresize two rows", () => {
     setCellContent(model, "A1", "test");
     setCellContent(model, "A3", "test");
-    model.dispatch("SET_FORMATTING", { sheetId, target: [toZone("A3")], style: { fontSize: 24 } });
+    model.dispatch("SET_FORMATTING", { sheetId, target: ["A3"], style: { fontSize: 24 } });
     model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0, 2] });
     expect(model.getters.getRow(sheetId, 0)?.size).toBe(rowSize + padding);
     expect(model.getters.getRow(sheetId, 2)?.size).toBe(fontSizeMap[24] + padding);

--- a/tests/plugins/grid_manipulation.test.ts
+++ b/tests/plugins/grid_manipulation.test.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_CELL_WIDTH,
   INCORRECT_RANGE_STRING,
 } from "../../src/constants";
-import { lettersToNumber, toCartesian, toXC, toZone } from "../../src/helpers";
+import { lettersToNumber, toCartesian, toXC, toZone, zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { Border, CommandResult, UID } from "../../src/types";
 import {
@@ -51,7 +51,7 @@ function clearColumns(indexes: string[]) {
       return model.getters.getColsZone(sheetId, index, index);
     });
   model.dispatch("DELETE_CONTENT", {
-    target,
+    target: target.map(zoneToXc),
     sheetId: model.getters.getActiveSheetId(),
   });
 }
@@ -62,7 +62,7 @@ function clearRows(indexes: number[]) {
     return model.getters.getRowsZone(sheetId, index, index);
   });
   model.dispatch("DELETE_CONTENT", {
-    target,
+    target: target.map(zoneToXc),
     sheetId: model.getters.getActiveSheetId(),
   });
 }
@@ -510,7 +510,7 @@ describe("Columns", () => {
       const s = ["thin", "#000"];
       model.dispatch("SET_FORMATTING", {
         sheetId,
-        target: [toZone("B2")],
+        target: ["B2"],
         border: "external",
       });
       addColumns(model, "after", "B", 1);
@@ -524,7 +524,7 @@ describe("Columns", () => {
       const s = ["thin", "#000"];
       model.dispatch("SET_FORMATTING", {
         sheetId,
-        target: [toZone("B2")],
+        target: ["B2"],
         border: "external",
       });
       addColumns(model, "before", "B", 1);
@@ -538,7 +538,7 @@ describe("Columns", () => {
       const s = ["thin", "#000"];
       model.dispatch("SET_FORMATTING", {
         sheetId,
-        target: [toZone("B2")],
+        target: ["B2"],
         border: "external",
       });
       deleteColumns(model, ["C"]);
@@ -1383,7 +1383,7 @@ describe("Rows", () => {
       const s = ["thin", "#000"];
       model.dispatch("SET_FORMATTING", {
         sheetId,
-        target: [toZone("B2")],
+        target: ["B2"],
         border: "external",
       });
       addRows(model, "after", 1, 1);
@@ -1397,7 +1397,7 @@ describe("Rows", () => {
       const s = ["thin", "#000"];
       model.dispatch("SET_FORMATTING", {
         sheetId,
-        target: [toZone("B2")],
+        target: ["B2"],
         border: "external",
       });
       addRows(model, "before", 1, 1);
@@ -1411,7 +1411,7 @@ describe("Rows", () => {
       const s = ["thin", "#000"];
       model.dispatch("SET_FORMATTING", {
         sheetId,
-        target: [toZone("B2")],
+        target: ["B2"],
         border: "external",
       });
       deleteRows(model, [2]);
@@ -1925,7 +1925,7 @@ describe("Delete cell", () => {
       target: target("A3"),
       style: { fillColor: "orange" },
     });
-    testUndoRedo(model, expect, "DELETE_CELL", { zone: toZone("A1"), dimension: "ROW" });
+    testUndoRedo(model, expect, "DELETE_CELL", { zone: "A1", dimension: "ROW" });
   });
 });
 
@@ -2012,7 +2012,7 @@ describe("Insert cell", () => {
       target: target("A3"),
       style: { fillColor: "orange" },
     });
-    testUndoRedo(model, expect, "INSERT_CELL", { zone: toZone("A1"), dimension: "ROW" });
+    testUndoRedo(model, expect, "INSERT_CELL", { zone: "A1", dimension: "ROW" });
   });
 });
 

--- a/tests/plugins/history.test.ts
+++ b/tests/plugins/history.test.ts
@@ -1,5 +1,6 @@
 import { UIPlugin } from "../../src";
 import { MAX_HISTORY_STEPS } from "../../src/constants";
+import { zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { uiPluginRegistry } from "../../src/plugins";
 import { StateObserver } from "../../src/state_observer";
@@ -211,12 +212,12 @@ describe("Model history", () => {
     selectCell(model, "B2");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       border: "all",
     });
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       border: "all",
     });
 

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -1,6 +1,6 @@
 import { App, Component, useSubEnv, xml } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
-import { toCartesian, toXC, toZone } from "../../src/helpers/index";
+import { toCartesian, toXC, toZone, zoneToXc } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { CommandResult, Style } from "../../src/types/index";
 import { OWL_TEMPLATES } from "../setup/jest.setup";
@@ -183,7 +183,7 @@ describe("merges", () => {
 
     model.dispatch("SET_FORMATTING", {
       sheetId: sheet1,
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       style: { fillColor: "#333" },
     });
 
@@ -256,7 +256,7 @@ describe("merges", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
     expect(
-      model.dispatch("ADD_MERGE", { sheetId, target: [toZone("A1:B2"), toZone("A2:B3")] })
+      model.dispatch("ADD_MERGE", { sheetId, target: ["A1:B2", "A2:B3"] })
     ).toBeCancelledBecause(CommandResult.MergeOverlap);
   });
 
@@ -390,7 +390,7 @@ describe("merges", () => {
     merge(model, "A1:B1");
     model.dispatch("SET_FORMATTING", {
       sheetId: sheet1,
-      target: [{ left: 0, right: 1, top: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, right: 1, top: 0, bottom: 0 })],
       style: { fillColor: "red" },
     });
 
@@ -408,7 +408,7 @@ describe("merges", () => {
     setAnchorCorner(model, "B1");
     model.dispatch("SET_FORMATTING", {
       sheetId: sheet1,
-      target: [{ left: 0, right: 1, top: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, right: 1, top: 0, bottom: 0 })],
       style: { fillColor: "red" },
     });
 
@@ -429,7 +429,7 @@ describe("merges", () => {
     const sheet1 = model.getters.getSheetIds()[0];
     model.dispatch("SET_FORMATTING", {
       sheetId: sheet1,
-      target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
+      target: [zoneToXc({ left: 0, right: 0, top: 0, bottom: 0 })],
       style: { fillColor: "red" },
     });
     setAnchorCorner(model, "B1");
@@ -451,7 +451,7 @@ describe("merges", () => {
     merge(model, "A1:B1");
     model.dispatch("SET_FORMATTING", {
       sheetId,
-      target: [toZone("A1")],
+      target: ["A1"],
       border: "external",
     });
     const line = ["thin", "#000"];
@@ -470,7 +470,7 @@ describe("merges", () => {
 
     model.dispatch("SET_FORMATTING", {
       sheetId: sheet1,
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       border: "external",
     });
     const line = ["thin", "#000"];
@@ -487,7 +487,7 @@ describe("merges", () => {
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("SET_FORMATTING", {
       sheetId,
-      target: [toZone("A1")],
+      target: ["A1"],
       border: "external",
     });
     const line = ["thin", "#000"];
@@ -504,7 +504,7 @@ describe("merges", () => {
     const sheet1 = model.getters.getSheetIds()[0];
     model.dispatch("SET_FORMATTING", {
       sheetId: sheet1,
-      target: [toZone("A1")],
+      target: ["A1"],
       border: "external",
       style: { fillColor: "red" },
     });

--- a/tests/plugins/navigation.test.ts
+++ b/tests/plugins/navigation.test.ts
@@ -1,4 +1,4 @@
-import { toCartesian, toXC } from "../../src/helpers";
+import { toCartesian, toXC, zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult, Viewport } from "../../src/types";
 import { SelectionDirection } from "../../src/types/selection";
@@ -75,7 +75,7 @@ describe("navigation", () => {
     const rowNumber = activeSheet.rows.length;
     model.dispatch("ADD_MERGE", {
       sheetId: activeSheet.id,
-      target: [{ top: rowNumber - 2, bottom: rowNumber - 1, left: 0, right: 0 }],
+      target: [zoneToXc({ top: rowNumber - 2, bottom: rowNumber - 1, left: 0, right: 0 })],
     });
     const xc = toXC(0, rowNumber - 2);
     selectCell(model, xc);
@@ -90,7 +90,7 @@ describe("navigation", () => {
     const rowNumber = activeSheet.rows.length;
     model.dispatch("ADD_MERGE", {
       sheetId: activeSheet.id,
-      target: [{ top: rowNumber - 3, bottom: rowNumber - 2, left: 0, right: 0 }],
+      target: [zoneToXc({ top: rowNumber - 3, bottom: rowNumber - 2, left: 0, right: 0 })],
     });
     model.dispatch("HIDE_COLUMNS_ROWS", {
       sheetId: activeSheet.id,
@@ -110,7 +110,7 @@ describe("navigation", () => {
     const colNumber = activeSheet.cols.length;
     model.dispatch("ADD_MERGE", {
       sheetId: activeSheet.id,
-      target: [{ top: 0, bottom: 0, left: colNumber - 2, right: colNumber - 1 }],
+      target: [zoneToXc({ top: 0, bottom: 0, left: colNumber - 2, right: colNumber - 1 })],
     });
     const xc = toXC(colNumber - 2, 0);
     selectCell(model, xc);

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -212,7 +212,7 @@ describe("renderer", () => {
     });
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1")],
+      target: ["A1"],
       style: { fillColor: "#DC6CDF" },
     });
 
@@ -250,7 +250,7 @@ describe("renderer", () => {
     fillStyle = [];
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1")],
+      target: ["A1"],
       style: { fillColor: "#DC6CDE" },
     });
     model.drawGrid(ctx);
@@ -269,7 +269,7 @@ describe("renderer", () => {
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("SET_FORMATTING", {
       sheetId,
-      target: [toZone("A1")],
+      target: ["A1"],
       style: { fillColor: "#DC6CDF" },
     });
     merge(model, "A1:A3");
@@ -308,7 +308,7 @@ describe("renderer", () => {
     fillStyle = [];
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1")],
+      target: ["A1"],
       style: { fillColor: "#DC6CDE" },
     });
     model.drawGrid(ctx);
@@ -327,7 +327,7 @@ describe("renderer", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#DC6CDF" }, "1"),
       sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1")],
+      target: ["A1"],
     });
 
     let fillStyle: any[] = [];
@@ -367,7 +367,7 @@ describe("renderer", () => {
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#DC6CDF" }, "1"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId,
     });
     merge(model, "A1:A3");
@@ -647,7 +647,7 @@ describe("renderer", () => {
     fillStyle = [];
     let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("", { fillColor: "#DC6CDF" }, "1"),
-      target: [toZone("A1")],
+      target: ["A1"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(result).toBeSuccessfullyDispatched();
@@ -969,11 +969,11 @@ describe("renderer", () => {
       model.dispatch("COPY", { target: copiedTarget });
       const { ctx, isDotOutlined, reset } = watchClipboardOutline(model);
       model.drawGrid(ctx);
-      expect(isDotOutlined(copiedTarget)).toBeTruthy();
+      expect(isDotOutlined(copiedTarget.map(toZone))).toBeTruthy();
       model.dispatch("PASTE", { target: target("A10") });
       reset();
       model.drawGrid(ctx);
-      expect(isDotOutlined(copiedTarget)).toBeFalsy();
+      expect(isDotOutlined(copiedTarget.map(toZone))).toBeFalsy();
     }
   );
 
@@ -986,11 +986,11 @@ describe("renderer", () => {
       const { ctx, isDotOutlined, reset } = watchClipboardOutline(model);
       model.drawGrid(ctx);
       const expectedOutlinedZone = copiedTarget.slice(-1);
-      expect(isDotOutlined(expectedOutlinedZone)).toBeTruthy();
+      expect(isDotOutlined(expectedOutlinedZone.map(toZone))).toBeTruthy();
       model.dispatch("PASTE", { target: target("A10") });
       reset();
       model.drawGrid(ctx);
-      expect(isDotOutlined(expectedOutlinedZone)).toBeFalsy();
+      expect(isDotOutlined(expectedOutlinedZone.map(toZone))).toBeFalsy();
     }
   );
 
@@ -1004,10 +1004,10 @@ describe("renderer", () => {
     model.dispatch("COPY", { target: copiedTarget });
     const { ctx, isDotOutlined, reset } = watchClipboardOutline(model);
     model.drawGrid(ctx);
-    expect(isDotOutlined(copiedTarget)).toBeTruthy();
+    expect(isDotOutlined(copiedTarget.map(toZone))).toBeTruthy();
     coreOperation(model);
     reset();
     model.drawGrid(ctx);
-    expect(isDotOutlined(copiedTarget)).toBeFalsy();
+    expect(isDotOutlined(copiedTarget.map(toZone))).toBeFalsy();
   });
 });

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -583,7 +583,7 @@ describe("sheets", () => {
     expect(model.getters.getConditionalFormats(newSheetId)).toHaveLength(1);
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("42", { fillColor: "blue" }, "1"),
-      target: [toZone("A1:A2")],
+      target: ["A1:A2"],
       sheetId: model.getters.getActiveSheetId(),
     });
     expect(model.getters.getConditionalStyle(col, row)).toEqual({ fillColor: "blue" });

--- a/tests/plugins/style.test.ts
+++ b/tests/plugins/style.test.ts
@@ -1,4 +1,4 @@
-import { toZone } from "../../src/helpers";
+import { zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { createSheet, selectCell, setCellContent, undo } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent } from "../test_helpers/getters_helpers";
@@ -9,7 +9,7 @@ describe("styles", () => {
     selectCell(model, "B1");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       style: { fillColor: "red" },
     });
 
@@ -25,7 +25,7 @@ describe("styles", () => {
     selectCell(model, "B1");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       style: { fillColor: "red" },
     });
     expect(getCellContent(model, "B1")).toBe("some content");
@@ -42,13 +42,13 @@ describe("styles", () => {
     selectCell(model, "B1");
     model.dispatch("SET_FORMATTING", {
       sheetId: sheet1,
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       style: { fillColor: "red" },
     });
     expect(getCell(model, "B1")!.style).toBeDefined();
     model.dispatch("CLEAR_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(getCellContent(model, "B1")).toBe("b1");
     expect(getCell(model, "B1")!.style).not.toBeDefined();
@@ -59,13 +59,13 @@ describe("styles", () => {
     selectCell(model, "B1");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       style: { fillColor: "red" },
     });
     expect(getCell(model, "B1")!.style).toBeDefined();
     model.dispatch("CLEAR_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(getCell(model, "B1")).toBeUndefined();
   });
@@ -76,13 +76,13 @@ describe("styles", () => {
     selectCell(model, "B1");
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
       style: { fillColor: "red" },
     });
     expect(getCell(model, "B1")!.style).toBeDefined();
     model.dispatch("CLEAR_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
+      target: model.getters.getSelectedZones().map(zoneToXc),
     });
     expect(getCell(model, "B1")!.style).not.toBeDefined();
     undo(model);
@@ -94,7 +94,7 @@ describe("styles", () => {
     createSheet(model, { sheetId: "42" });
     model.dispatch("SET_FORMATTING", {
       sheetId: "42",
-      target: [toZone("A1")],
+      target: ["A1"],
       style: { fillColor: "red" },
     });
     expect(getCell(model, "A1")).toBeUndefined();

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -1,5 +1,5 @@
 import { BACKGROUND_CHART_COLOR } from "../../src/constants";
-import { isInside, lettersToNumber, toCartesian, toZone } from "../../src/helpers/index";
+import { isInside, lettersToNumber, toCartesian, toZone, zoneToXc } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import {
   AnchorZone,
@@ -290,14 +290,14 @@ export function unhideRows(
 
 export function deleteCells(model: Model, range: string, shift: "left" | "up"): DispatchResult {
   return model.dispatch("DELETE_CELL", {
-    zone: toZone(range),
+    zone: range,
     shiftDimension: shift === "left" ? "COL" : "ROW",
   });
 }
 
 export function insertCells(model: Model, range: string, shift: "right" | "down"): DispatchResult {
   return model.dispatch("INSERT_CELL", {
-    zone: toZone(range),
+    zone: range,
     shiftDimension: shift === "right" ? "COL" : "ROW",
   });
 }
@@ -309,7 +309,7 @@ export function setBorder(model: Model, border: BorderCommand, xc?: string) {
   const target = xc ? [toZone(xc)] : model.getters.getSelectedZones();
   model.dispatch("SET_FORMATTING", {
     sheetId: model.getters.getActiveSheetId(),
-    target,
+    target: target.map(zoneToXc),
     border,
   });
 }
@@ -482,7 +482,7 @@ export function sort(
   const { col, row } = toCartesian(anchor);
   return model.dispatch("SORT_CELLS", {
     sheetId: sheetId || model.getters.getActiveSheetId(),
-    zone: toZone(zone),
+    zone: zone,
     col,
     row,
     sortDirection: direction,

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -230,8 +230,8 @@ export function zone(str: string): Zone {
   return toZone(str);
 }
 
-export function target(str: string): Zone[] {
-  return str.split(",").map(zone);
+export function target(str: string): string[] {
+  return str.split(",");
 }
 
 export function createEqualCF(


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo