### PR TITLE
[FIX] highlights: Handle merges correctly

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -2,7 +2,7 @@ import * as owl from "@odoo/owl";
 import { SELECTION_BORDER_COLOR } from "../../constants";
 import { EnrichedToken } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { DEBUG, isEqual, rangeReference, toZone } from "../../helpers/index";
+import { DEBUG, isEqual, rangeReference, toZone, zoneToDimension } from "../../helpers/index";
 import { ComposerSelection, SelectionIndicator } from "../../plugins/ui/edition";
 import { FunctionDescription, Rect, SpreadsheetEnv } from "../../types/index";
 import { TextValueProvider } from "./autocomplete_dropdown";
@@ -521,11 +521,13 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     const refSheet = sheetName
       ? this.getters.getSheetIdByName(sheetName)
       : this.getters.getEditionSheet();
-    const highlight = highlights.find(
-      (highlight) =>
-        highlight.sheet === refSheet &&
-        isEqual(this.getters.expandZone(refSheet, toZone(xc)), highlight.zone)
-    );
+    const highlight = highlights.find((highlight) => {
+      if (highlight.sheet !== refSheet) return false;
+      let zone = toZone(xc);
+      const { height, width } = zoneToDimension(zone);
+      zone = height * width === 1 ? this.getters.expandZone(refSheet, toZone(xc)) : zone;
+      return highlight.sheet === refSheet && isEqual(zone, highlight.zone);
+    });
     return highlight && highlight.color ? highlight.color : undefined;
   }
 

--- a/src/plugins/ui/highlight.ts
+++ b/src/plugins/ui/highlight.ts
@@ -1,6 +1,6 @@
-import { isEqual, toZone } from "../../helpers/index";
+import { isEqual, toZone, zoneToDimension } from "../../helpers/index";
 import { Mode } from "../../model";
-import { GridRenderingContext, Highlight, LAYERS, Zone } from "../../types/index";
+import { GridRenderingContext, Highlight, LAYERS } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
 /**
@@ -35,7 +35,9 @@ export class HighlightPlugin extends UIPlugin {
       const [xc, sheet] = r1c1.split("!").reverse();
       const sheetId = sheet ? this.getters.getSheetIdByName(sheet) : activeSheetId;
       if (sheetId) {
-        const zone: Zone = this.getters.expandZone(activeSheetId, toZone(xc));
+        let zone = toZone(xc);
+        const { height, width } = zoneToDimension(zone);
+        zone = height * width === 1 ? this.getters.expandZone(activeSheetId, toZone(xc)) : zone;
         preparedHighlights.push({ zone, color, sheet: sheetId });
       }
     }

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -236,14 +236,25 @@ describe("ranges and highlights", () => {
     await keydown("ArrowDown");
     expect(composerEl.textContent).toBe("=B2");
     expect(getHighlights(model)).toHaveLength(1);
-    expect(getHighlights(model)[0].zone).toMatchObject({
-      top: 1,
-      bottom: 2,
-      left: 1,
-      right: 2,
-    });
+    expect(getHighlights(model)[0].zone).toMatchObject(toZone("B2:C3"));
     await keydown("ArrowDown");
     expect(composerEl.textContent).toBe("=C4");
+  });
+
+  test("Create a ref overlapping merges by typing -> the merge is ignored if the range covers several cells", async () => {
+    selectCell(model, "B2");
+    model.dispatch("ALTER_SELECTION", { delta: [1, 1] });
+    merge(model, "B2:C3");
+    selectCell(model, "C1");
+    await typeInComposer("=B2:B10");
+    expect(composerEl.textContent).toBe("=B2:B10");
+    expect(getHighlights(model)).toHaveLength(1);
+    expect(getHighlights(model)[0].zone).toMatchObject(toZone("B2:B10"));
+    model.dispatch("STOP_EDITION", { cancel: true });
+    await typeInComposer("=B2:B3");
+    expect(composerEl.textContent).toBe("=B2:B3");
+    expect(getHighlights(model)).toHaveLength(1);
+    expect(getHighlights(model)[0].zone).toMatchObject(toZone("B2:B3"));
   });
 
   describe("change highlight position in the grid", () => {


### PR DESCRIPTION
Steps to reproduce:
- type =SUM(A1:A10), look at the highlight
- merge A2:B2
- click on the SUM, the highlight is wrong, it covers A2:B10 instead of
  A1:A10.

After investigation on other tools (GSheet & Excel) the rules seems to
be the following:
When the range to highlight covers a single cell and that it is part of
a range, then we highlight the whole merge. The rest of the time, we
only highlight the cells covered by the range.

E.g.

Consider a merge in A1:C3,

A1     -> highlight A1:C3
C3     -> highlight A1:C3
A1:A10 -> highlight A1:A10
A1:A2  -> highlight A1:A2

task 2833434

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo