### PR TITLE
[FIX] config: Avoid compiling test files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "allowJs": true,
     "sourceMap": true
   },
-  "include": ["src", "tests"]
+  "include": ["src"]
 }


### PR DESCRIPTION
Currently, when running a `build:*` script, we compile both src and
test files from TS to JS.
There is no need to compile the test files as the step is only useful to
utlimately rollup the `src` files.
Furthermore, the test files (and src) are recompiled by jest when
running the tests.

Benchmark
---------

before : `rm -r dist && time mpm run build:js`
real    0m8.321s
user    0m15.928s
sys     0m0.290s

after : `rm -r  dist && time npm run build:js`
real    0m5.563s
user    0m11.454s
sys     0m0.176s

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo