### PR TITLE
[FIX] chart: context-menu on top-right of chart

### DIFF
--- a/src/components/figures/chart/chart.xml
+++ b/src/components/figures/chart/chart.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet.ChartFigure" owl="1">
     <div class="o-chart-container" t-ref="chartContainer" t-on-contextmenu="onContextMenu">
-      <div class="o-chart-menu" t-on-click="showMenu">
+      <div class="o-chart-menu" t-on-click="showMenu" t-on-contextmenu.prevent.stop="showMenu">
         <t t-call="o-spreadsheet.Icon.LIST"/>
       </div>
       <canvas t-att-style="canvasStyle" t-ref="graphContainer"/>


### PR DESCRIPTION
Since 759d1cff30552e95829c17e8a5eafa94cb3daf51, right click on the "list"
button of a chart trigger the chart menu on the top left of the chart.

This fix ensure that left click and right click on the "list" button
have the same behavior.

