### PR TITLE
[FIX] config: Feed dedicated tsconfig.json file to jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,12 @@
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/tests/setup/jest.setup.ts"
-    ]
+    ],
+    "globals": {
+      "ts-jest": {
+        "tsconfig": "tsconfig.jest.json"
+      }
+    }
   },
   "lint-staged": {
     "{src/*.ts,src/**/*.ts,tests/*.ts,tests/**/*.ts,doc/*.md,demo/*.js}": "prettier --write"

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "preserveConstEnums": true,
+    "noImplicitThis": true,
+    "moduleResolution": "node",
+    "removeComments": false,
+    "target": "es2019",
+    "outDir": "dist",
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictPropertyInitialization": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "sourceMap": true
+  },
+  "include": ["src", "tests"],
+  "typedocOptions": {
+    "entryPoints": ["src/index.ts"],
+    "out": "doc/tsdoc",
+    "name": "o-spreadsheet API",
+    "readme": "none",
+    "excludePrivate": true,
+    "hideGenerator": true,
+    "disableSources": true,
+    "excludeExternals": true
+  }
+}


### PR DESCRIPTION
Since 457fe704, we changed stopped compiling the `.ts` files in the
`tests` folders to save compilation time. Unfortunately, jest was using
the very same file to compile (via `ts-jest`) and it actually needs to
compile `tests/setup/jest.setup.ts` to work properly.

This commit introduces a new dedicated `tsconfig` file for ts-jest in
order to retain the improvements of 457fe704.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo