### PR TITLE
[FIX] format: display time format in composer

### DIFF
--- a/src/helpers/cells/cell_factory.ts
+++ b/src/helpers/cells/cell_factory.ts
@@ -1,3 +1,4 @@
+import { isDateTimeFormat } from "..";
 import { DEFAULT_ERROR_MESSAGE } from "../../constants";
 import { compile } from "../../formulas";
 import { cellRegistry } from "../../registries/cell_types";
@@ -51,6 +52,14 @@ cellRegistry
     sequence: 20,
     match: (content) => content === "",
     createCell: (id, content, properties) => new EmptyCell(id, properties),
+  })
+  .add("NumberWithDateTimeFormat", {
+    sequence: 25,
+    match: (content, format) => !!format && isNumber(content) && isDateTimeFormat(format),
+    createCell: (id, content, properties) => {
+      const format = properties.format!;
+      return new DateTimeCell(id, parseNumber(content), { ...properties, format });
+    },
   })
   .add("Number", {
     sequence: 30,
@@ -120,7 +129,7 @@ export function cellFactory(getters: CoreGetters) {
     properties: CellDisplayProperties,
     sheetId: UID
   ): Cell {
-    const builder = builders.find((factory) => factory.match(content));
+    const builder = builders.find((factory) => factory.match(content, properties.format));
     if (!builder) {
       return new TextCell(id, content, properties);
     }

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -208,6 +208,18 @@ function splitNumber(
   return { integerDigits, decimalDigits };
 }
 
+/**
+ * Check if the given format is a time, date or date time format.
+ */
+export function isDateTimeFormat(format: Format) {
+  try {
+    applyDateTimeFormat(1, format);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 export function applyDateTimeFormat(value: number, format: string): FormattedValue {
   // TODO: unify the format functions for date and datetime
   // This requires some code to 'parse' or 'tokenize' the format, keep it in a

--- a/src/registries/cell_types.ts
+++ b/src/registries/cell_types.ts
@@ -1,5 +1,5 @@
 import { Registry } from "../registry";
-import { Cell, CellDisplayProperties, CoreGetters, UID } from "../types";
+import { Cell, CellDisplayProperties, CoreGetters, Format, UID } from "../types";
 
 //------------------------------------------------------------------------------
 // Cell Registry
@@ -13,7 +13,7 @@ interface CellBuilder {
   /**
    * Check if this factory should be used
    */
-  match: (content: string) => boolean;
+  match: (content: string, format: Format | undefined) => boolean;
   createCell: (
     id: UID,
     content: string,

--- a/tests/helpers/format.test.ts
+++ b/tests/helpers/format.test.ts
@@ -1,5 +1,5 @@
 import { parseDateTime } from "../../src/helpers";
-import { formatValue } from "../../src/helpers/format";
+import { formatValue, isDateTimeFormat } from "../../src/helpers/format";
 
 describe("formatValue on number", () => {
   test("apply default format ", () => {
@@ -221,6 +221,42 @@ describe("formatValue on number", () => {
 });
 
 describe("formatValue on date and time", () => {
+  test.each([
+    "hh:mm",
+    "hh:mm:ss",
+    "hh:mm a",
+    "hh:mm:ss a",
+    "hhhh:mm:ss",
+    "m/d/yyyy hh:mm:ss",
+    "m/d/yyyy hh:mm:ss a",
+    "yyyy mm dd",
+    "yyyy-mm-dd",
+    "yyyy/mm/dd",
+    "yyyy m d",
+    "yyyy-m-d",
+    "yyyy/m/d",
+    "m d yyyy",
+    "m-d-yyyy",
+    "m/d/yyyy",
+    "mm dd yyyy",
+    "mm-dd-yyyy",
+    "mm/dd/yyyy",
+    "mm dd",
+    "mm-dd",
+    "mm/dd",
+    "m d",
+    "m-d",
+    "m/d",
+  ])("detect date time format %s", (format) => {
+    expect(isDateTimeFormat(format)).toBe(true);
+  });
+
+  test.each(["", "a", "[$€]#,##0.0", "[$m-d-yyyy]#,##0.0", "#,##0.0"])(
+    "dont detect wrong date time format %s",
+    (format) => {
+      expect(isDateTimeFormat(format)).toBe(false);
+    }
+  );
   describe("apply default format", () => {
     test.each([
       ["0:0", "00:00"],

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -126,6 +126,12 @@ describe("Autofill", () => {
     expect(cell.format).toBe("m/d/yyyy");
   });
 
+  test("Autofill a date displays a date in the composer", () => {
+    setCellContent(model, "A1", "1/1/2017");
+    autofill("A1", "A2");
+    expect(getCell(model, "A2")?.composerContent).toBe("1/2/2017");
+  });
+
   test("Autofill add CF to target cell if present in origin cell", () => {
     setCellContent(model, "A1", "1");
     autofill("A1", "A4");

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -706,4 +706,43 @@ describe("edition", () => {
     });
     expect(getCell(model, "A1")?.composerContent).toBe("44124");
   });
+
+  test("set a date format on a number displays the date", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "42736");
+    expect(getCell(model, "A1")?.composerContent).toBe("42736");
+    model.dispatch("UPDATE_CELL", {
+      sheetId: model.getters.getActiveSheetId(),
+      col: 0,
+      row: 0,
+      format: "mm/dd/yyyy",
+    });
+    expect(getCell(model, "A1")?.composerContent).toBe("01/01/2017");
+  });
+
+  test("set a number format on a time displays the number", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "12:00:00 AM");
+    expect(getCell(model, "A1")?.composerContent).toBe("12:00:00 AM");
+    model.dispatch("UPDATE_CELL", {
+      sheetId: model.getters.getActiveSheetId(),
+      col: 0,
+      row: 0,
+      format: "#,##0.00",
+    });
+    expect(getCell(model, "A1")?.composerContent).toBe("0");
+  });
+
+  test("set a time format on a number displays the time", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    expect(getCell(model, "A1")?.composerContent).toBe("1");
+    model.dispatch("UPDATE_CELL", {
+      sheetId: model.getters.getActiveSheetId(),
+      col: 0,
+      row: 0,
+      format: "hh:mm:ss a",
+    });
+    expect(getCell(model, "A1")?.composerContent).toBe("12:00:00 AM");
+  });
 });


### PR DESCRIPTION
- write a number in a cell
- set a time format on this cell (or date or datetime)
=> the composer displays the raw number in the composer

- write a date
- autofill the cell
=> the autofilled cell has the same problem.

Task 2821636

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2821636](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo