### PR TITLE
[IMP] config: purge dist files when switching branches

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -3,6 +3,7 @@
 
 if [ "$HUSKY_POST_CHECKOUT" != 0 ]; then
     if [ "$1" != "$2" ]; then
+        rm -rf dist >/dev/null 2>&1
         npm install >/dev/null 2>&1
     fi
 fi


### PR DESCRIPTION
We can sometimes forget to purge our dist folder when switching branches
which can be deceiving when running human tests (i.e. testing a demo
sheet).
This can sometimes lead to awkward bugs or behaviour that we
believe to detect which are just residuals of another branch/build.

Just as we have to reset our npm packages it seems fair to do the same
thing with the dist folder.

Task 2837807

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo