### PR TITLE
[FIX] chart: open chart menu only

### DIFF
--- a/src/components/figures/chart/chart.ts
+++ b/src/components/figures/chart/chart.ts
@@ -150,7 +150,6 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onContextMenu(ev: MouseEvent) {
-    ev.preventDefault();
     const position = {
       x: this.position.x + ev.offsetX,
       y: this.position.y + ev.offsetY,

--- a/src/components/figures/chart/chart.xml
+++ b/src/components/figures/chart/chart.xml
@@ -1,6 +1,9 @@
 <templates>
   <t t-name="o-spreadsheet.ChartFigure" owl="1">
-    <div class="o-chart-container" t-ref="chartContainer" t-on-contextmenu="onContextMenu">
+    <div
+      class="o-chart-container"
+      t-ref="chartContainer"
+      t-on-contextmenu.prevent.stop="onContextMenu">
       <div class="o-chart-menu">
         <div
           class="o-chart-menu-item"

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -115,7 +115,7 @@ describe("figures", () => {
     expect(document.activeElement).toBe(fixture.querySelector(".o-figure"));
     expect(fixture.querySelector(".o-chart-menu-item")).not.toBeNull();
     await simulateClick(".o-chart-menu-item");
-    expect(fixture.querySelector(".o-menu")).not.toBeNull();
+    expect(fixture.querySelectorAll(".o-menu").length).toBe(1);
   });
 
   test("Context menu is positioned according to the spreadsheet position", async () => {
@@ -456,7 +456,7 @@ describe("figures", () => {
   test("Can open context menu on right click", async () => {
     triggerMouseEvent(".o-chart-container", "contextmenu");
     await nextTick();
-    expect(document.querySelector(".o-menu")).not.toBeNull();
+    expect(document.querySelectorAll(".o-menu").length).toBe(1);
   });
 });
 describe("charts with multiple sheets", () => {


### PR DESCRIPTION
Right click on a chart figure open the chart menu and the
grid menu. It should only open the chart menu.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo