### PR TITLE
[IMP] topbar_menu_registry: adding clearformat option in format menu

### DIFF
--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -624,6 +624,13 @@ export const FORMAT_STRIKETHROUGH_ACTION = (env: SpreadsheetChildEnv) =>
 export const FORMAT_UNDERLINE_ACTION = (env: SpreadsheetChildEnv) =>
   setStyle(env, { underline: !env.model.getters.getCurrentStyle().underline });
 
+export const FORMAT_CLEARFORMAT_ACTION = (env: SpreadsheetChildEnv) => {
+  env.model.dispatch("CLEAR_FORMATTING", {
+    sheetId: env.model.getters.getActiveSheetId(),
+    target: env.model.getters.getSelectedZones(),
+  });
+};
+
 //------------------------------------------------------------------------------
 // Side panel
 //------------------------------------------------------------------------------

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -294,6 +294,12 @@ topbarMenuRegistry
     sequence: 70,
     action: ACTIONS.OPEN_CF_SIDEPANEL_ACTION,
     separator: true,
+  })
+  .addChild("format_clearFormat", ["format"], {
+    name: _lt("Clear formatting"),
+    sequence: 80,
+    action: ACTIONS.FORMAT_CLEARFORMAT_ACTION,
+    separator: true,
   });
 
 // Font-sizes

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -8,6 +8,7 @@ import { topbarMenuRegistry } from "../../src/registries/menus/topbar_menu_regis
 import { ConditionalFormat, Style } from "../../src/types";
 import { OWL_TEMPLATES } from "../setup/jest.setup";
 import {
+  addCellToSelection,
   selectCell,
   setAnchorCorner,
   setCellContent,
@@ -19,6 +20,7 @@ import {
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
+  target,
   typeInComposerTopBar,
 } from "../test_helpers/helpers";
 
@@ -476,6 +478,33 @@ describe("TopBar - Custom currency", () => {
     triggerMouseEvent(".o-format-tool div[data-custom='custom_currency']", "click");
     await nextTick();
     expect(fixture.querySelector(".o-custom-currency")).toBeTruthy();
+    app.destroy();
+  });
+});
+
+describe("Format", () => {
+  test("can clear format", async () => {
+    const { app, parent } = await mountSpreadsheet(fixture);
+    const model = parent.model;
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: target("A1, B2:B3"),
+      style: { fillColor: "#000000" },
+    });
+    selectCell(model, "A1");
+    addCellToSelection(model, "B2");
+    setAnchorCorner(model, "B3");
+    expect(getCell(model, "A1")?.style).toEqual({ fillColor: "#000000" });
+    expect(getCell(model, "B2")?.style).toEqual({ fillColor: "#000000" });
+    expect(getCell(model, "B3")?.style).toEqual({ fillColor: "#000000" });
+    triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
+    await nextTick();
+    triggerMouseEvent(".o-menu-item[data-name='format_clearFormat']", "click");
+    await nextTick();
+    expect(getCell(model, "A1")?.style).toBeUndefined();
+    expect(getCell(model, "B2")?.style).toBeUndefined();
+    expect(getCell(model, "B3")?.style).toBeUndefined();
     app.destroy();
   });
 });

--- a/tests/plugins/style.test.ts
+++ b/tests/plugins/style.test.ts
@@ -2,6 +2,7 @@ import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { createSheet, selectCell, setCellContent, undo } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent } from "../test_helpers/getters_helpers";
+import { target } from "../test_helpers/helpers";
 
 describe("styles", () => {
   test("can undo and redo a setStyle operation on an empty cell", () => {
@@ -87,6 +88,21 @@ describe("styles", () => {
     expect(getCell(model, "B1")!.style).not.toBeDefined();
     undo(model);
     expect(getCell(model, "B1")!.style).toBeDefined();
+  });
+
+  test("clear formatting does not remove format", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    model.dispatch("SET_FORMATTING", {
+      sheetId: sheetId,
+      target: target("A1"),
+      format: "#,##0.0",
+    });
+    model.dispatch("CLEAR_FORMATTING", {
+      sheetId,
+      target: target("A1"),
+    });
+    expect(getCell(model, "A1")?.format).toBe("#,##0.0");
   });
 
   test("Can set a format in another than the active one", () => {


### PR DESCRIPTION
## Description:

Adds "Clear formatting" button in topbar > format menu

Odoo task ID : [2842052](https://www.odoo.com/web#id=2842052&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo