### PR TITLE
[FIX] viewport: Don't adjust viewport on Grid selection for all events

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -854,8 +854,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       const newZone = this.env.model.getters.getSelectedZone();
       const viewport = this.env.model.getters.getActiveSnappedViewport();
       const sheet = this.env.model.getters.getActiveSheet();
-      const [col, row] = findCellInNewZone(oldZone, newZone, viewport);
-
+      let [col, row] = findCellInNewZone(oldZone, newZone);
+      col = Math.min(col, sheet.cols.length - 1);
+      row = Math.min(row, sheet.rows.length - 1);
       const { left, right, top, bottom, offsetX, offsetY } = viewport;
       const newOffsetX =
         col < left || col > right - 1 ? sheet.cols[left + delta[0]].start : offsetX;

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -1,4 +1,4 @@
-import { Position, Viewport, Zone, ZoneDimension } from "../types";
+import { Position, Zone, ZoneDimension } from "../types";
 import { toCartesian, toXC } from "./coordinates";
 import { range } from "./misc";
 
@@ -484,11 +484,7 @@ export function mergeOverlappingZones(zones: Zone[]) {
  * This function will compare the modifications of selection to determine
  * a cell that is part of the new zone and not the previous one.
  */
-export function findCellInNewZone(
-  oldZone: Zone,
-  currentZone: Zone,
-  viewport: Viewport
-): [number, number] {
+export function findCellInNewZone(oldZone: Zone, currentZone: Zone): [number, number] {
   let col: number, row: number;
   const { left: oldLeft, right: oldRight, top: oldTop, bottom: oldBottom } = oldZone!;
   const { left, right, top, bottom } = currentZone;
@@ -497,14 +493,14 @@ export function findCellInNewZone(
   } else if (right != oldRight) {
     col = right;
   } else {
-    col = viewport.left;
+    col = left;
   }
   if (top != oldTop) {
     row = top;
   } else if (bottom != oldBottom) {
     row = bottom;
   } else {
-    row = viewport.top;
+    row = top;
   }
   return [col, row];
 }

--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -80,17 +80,12 @@ export class ViewportPlugin extends UIPlugin {
       case "AlterZoneCorner":
         break;
       case "ZonesSelected":
-        if (event.mode === "updateAnchor") {
-          // altering a zone should not move the viewport
-          const [col, row] = findCellInNewZone(
-            event.previousAnchor.zone,
-            event.anchor.zone,
-            this.getActiveSnappedViewport()
-          );
-          this.refreshViewport(this.getters.getActiveSheetId(), { col, row });
-        } else {
-          this.refreshViewport(this.getters.getActiveSheetId());
-        }
+        // altering a zone should not move the viewport
+        const sheet = this.getters.getActiveSheet();
+        let [col, row] = findCellInNewZone(event.previousAnchor.zone, event.anchor.zone);
+        col = Math.min(col, sheet.cols.length - 1);
+        row = Math.min(row, sheet.rows.length - 1);
+        this.refreshViewport(this.getters.getActiveSheetId(), { col, row });
         break;
     }
   }

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -1,6 +1,7 @@
 import { App } from "@odoo/owl";
 import { Model } from "../../src";
 import { Spreadsheet } from "../../src/components";
+import { DEFAULT_CELL_HEIGHT } from "../../src/constants";
 import { args, functionRegistry } from "../../src/functions";
 import { toZone } from "../../src/helpers";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/registries";
@@ -388,5 +389,26 @@ describe("Composer / selectionInput interactions", () => {
     await simulateClick(".o-figure");
     await clickCell(model, "D1");
     expect(model.getters.getSelectedZones()).toEqual([toZone("D1")]);
+  });
+
+  test("Selecting a range should not scroll the viewport to the current Grid selection", async () => {
+    const model = parent.model;
+    const startViewport = model.getters.getActiveSnappedViewport();
+    await typeInComposerTopBar("=");
+    // scroll
+    fixture
+      .querySelector(".o-grid")!
+      .dispatchEvent(new WheelEvent("wheel", { deltaY: 3 * DEFAULT_CELL_HEIGHT }));
+    await nextTick();
+    const scrolledViewport = model.getters.getActiveSnappedViewport();
+    expect(scrolledViewport).toMatchObject({
+      ...startViewport,
+      top: startViewport.top + 3,
+      bottom: startViewport.bottom + 3,
+      offsetY: 3 * DEFAULT_CELL_HEIGHT,
+    });
+    await clickCell(model, "E5");
+    expect(model.getters.getSelectedZones()).toEqual([toZone("A1")]);
+    expect(model.getters.getActiveSnappedViewport()).toMatchObject(scrolledViewport);
   });
 });


### PR DESCRIPTION
When handling `ZoneSelected` commands, we would refresh the viewport
based on the grid selection (depending on the mode) which is incorrect.
We should always refresh based on the selection of the plugin currently
registered to the `SelectionStreamProcessor`.

task 2849733

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo