### PR TITLE
[FIX] format: move SET_DECIMAL out of core

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -1,14 +1,7 @@
-import { DATETIME_FORMAT, FORMULA_REF_IDENTIFIER, NULL_FORMAT } from "../../constants";
+import { FORMULA_REF_IDENTIFIER, NULL_FORMAT } from "../../constants";
 import { cellFactory } from "../../helpers/cells/cell_factory";
 import { FormulaCell } from "../../helpers/cells/index";
-import {
-  isInside,
-  maximumDecimalPlaces,
-  range,
-  stringify,
-  toCartesian,
-  toXC,
-} from "../../helpers/index";
+import { isInside, range, stringify, toCartesian, toXC } from "../../helpers/index";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -103,9 +96,6 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
           this.setFormatter(cmd.sheetId, cmd.target, cmd.format);
         }
         break;
-      case "SET_DECIMAL":
-        this.setDecimal(cmd.sheetId, cmd.target, cmd.step);
-        break;
       case "CLEAR_FORMATTING":
         this.clearStyles(cmd.sheetId, cmd.target);
         break;
@@ -149,150 +139,6 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
         }
       }
     }
-  }
-
-  /**
-   * This function allows to adjust the quantity of decimal places after a decimal
-   * point on cells containing number value. It does this by changing the cells
-   * format. Values aren't modified.
-   *
-   * The change of the decimal quantity is done one by one, the sign of the step
-   * variable indicates whether we are increasing or decreasing.
-   *
-   * If several cells are in the zone, the format resulting from the change of the
-   * first cell (with number type) will be applied to the whole zone.
-   */
-  private setDecimal(sheetId: UID, zones: Zone[], step: number) {
-    // Find the first cell with a number value and get the format
-    const numberFormat = this.searchNumberFormat(sheetId, zones);
-    if (numberFormat !== undefined) {
-      // Depending on the step sign, increase or decrease the decimal representation
-      // of the format
-      const newFormat = this.changeDecimalFormat(numberFormat, step);
-      // Apply the new format on the whole zone
-      this.setFormatter(sheetId, zones, newFormat!);
-    }
-  }
-
-  /**
-   * Take a range of cells and return the format of the first cell containing a
-   * number value. Returns a default format if the cell hasn't format. Returns
-   * undefined if no number value in the range.
-   */
-  private searchNumberFormat(sheetId: UID, zones: Zone[]): string | undefined {
-    for (let zone of zones) {
-      for (let row = zone.top; row <= zone.bottom; row++) {
-        for (let col = zone.left; col <= zone.right; col++) {
-          const cell = this.getters.getCell(sheetId, col, row);
-          if (
-            cell?.evaluated.type === CellValueType.number &&
-            !cell.format?.match(DATETIME_FORMAT) // reject dates
-          ) {
-            return cell.format || this.setDefaultNumberFormat(cell.evaluated.value as any);
-          }
-        }
-      }
-    }
-    return undefined;
-  }
-
-  /**
-   * Function used to give the default format of a cell with a number for value.
-   * It is considered that the default format of a number is 0 followed by as many
-   * 0 as there are decimal places.
-   *
-   * Example:
-   * - 1 --> '0'
-   * - 123 --> '0'
-   * - 12345 --> '0'
-   * - 42.1 --> '0.0'
-   * - 456.0001 --> '0.0000'
-   */
-  private setDefaultNumberFormat(cellValue: number): string {
-    const strValue = cellValue.toString();
-    const parts = strValue.split(".");
-    if (parts.length === 1) {
-      return "0";
-    }
-    return "0." + Array(parts[1].length + 1).join("0");
-  }
-
-  /**
-   * This function take a cell format representation and return a new format representation
-   * with more or less decimal places.
-   *
-   * If the format doesn't look like a digital format (means that not contain '0')
-   * or if this one cannot be increased or decreased, the returned format will be
-   * the same.
-   *
-   * This function aims to work with all possible formats as well as custom formats.
-   *
-   * Examples of format changed by this function:
-   * - "0" (step = 1) --> "0.0"
-   * - "0.000%" (step = 1) --> "0.0000%"
-   * - "0.00" (step = -1) --> "0.0"
-   * - "0%" (step = -1) --> "0%"
-   * - "#,##0.0" (step = -1) --> "#,##0"
-   * - "#,##0;0.0%;0.000" (step = 1) --> "#,##0.0;0.00%;0.0000"
-   */
-  private changeDecimalFormat(format: string, step: number): string {
-    const sign = Math.sign(step);
-    // According to the representation of the cell format. A format can contain
-    // up to 4 sub-formats which can be applied depending on the value of the cell
-    // (among positive / negative / zero / text), each of these sub-format is separated
-    // by ';' in the format. We need to make the change on each sub-format.
-    const subFormats = format.split(";");
-    let newSubFormats: string[] = [];
-
-    for (let subFormat of subFormats) {
-      const decimalPointPosition = subFormat.indexOf(".");
-      const exponentPosition = subFormat.toUpperCase().indexOf("E");
-      let newSubFormat: string;
-
-      // the 1st step is to find the part of the zeros located before the
-      // exponent (when existed)
-      const subPart = exponentPosition > -1 ? subFormat.slice(0, exponentPosition) : subFormat;
-      const zerosAfterDecimal =
-        decimalPointPosition > -1 ? subPart.slice(decimalPointPosition).match(/0/g)!.length : 0;
-
-      // the 2nd step is to add (or remove) zero after the last zeros obtained in
-      // step 1
-      const lastZeroPosition = subPart.lastIndexOf("0");
-      if (lastZeroPosition > -1) {
-        if (sign > 0) {
-          // in this case we want to add decimal information
-          if (zerosAfterDecimal < maximumDecimalPlaces) {
-            newSubFormat =
-              subFormat.slice(0, lastZeroPosition + 1) +
-              (zerosAfterDecimal === 0 ? ".0" : "0") +
-              subFormat.slice(lastZeroPosition + 1);
-          } else {
-            newSubFormat = subFormat;
-          }
-        } else {
-          // in this case we want to remove decimal information
-          if (zerosAfterDecimal > 0) {
-            // remove last zero
-            newSubFormat =
-              subFormat.slice(0, lastZeroPosition) + subFormat.slice(lastZeroPosition + 1);
-            // if a zero always exist after decimal point else remove decimal point
-            if (zerosAfterDecimal === 1) {
-              newSubFormat =
-                newSubFormat.slice(0, decimalPointPosition) +
-                newSubFormat.slice(decimalPointPosition + 1);
-            }
-          } else {
-            // zero after decimal isn't present, we can't remove zero
-            newSubFormat = subFormat;
-          }
-        }
-      } else {
-        // no zeros are present in this format, we do nothing
-        newSubFormat = subFormat;
-      }
-      newSubFormats.push(newSubFormat);
-    }
-    return newSubFormats.join(";");
   }
 
   /**

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -15,6 +15,7 @@ import { EvaluationPlugin } from "./ui/evaluation";
 import { EvaluationChartPlugin } from "./ui/evaluation_chart";
 import { EvaluationConditionalFormatPlugin } from "./ui/evaluation_conditional_format";
 import { FindAndReplacePlugin } from "./ui/find_and_replace";
+import { FormatPlugin } from "./ui/format";
 import { HighlightPlugin } from "./ui/highlight";
 import { RendererPlugin } from "./ui/renderer";
 import { SelectionPlugin } from "./ui/selection";
@@ -52,4 +53,5 @@ export const uiPluginRegistry = new Registry<UIPluginConstructor>()
   .add("find_and_replace", FindAndReplacePlugin)
   .add("sort", SortPlugin)
   .add("automatic_sum", AutomaticSumPlugin)
+  .add("format", FormatPlugin)
   .add("selection_multiuser", SelectionMultiUserPlugin);

--- a/src/plugins/ui/format.ts
+++ b/src/plugins/ui/format.ts
@@ -1,0 +1,168 @@
+import { DATETIME_FORMAT } from "../../constants";
+import { maximumDecimalPlaces } from "../../helpers";
+import { Mode } from "../../model";
+import { CellValueType, Command, UID, Zone } from "../../types/index";
+import { UIPlugin } from "../ui_plugin";
+
+export class FormatPlugin extends UIPlugin {
+  static modes: Mode[] = ["normal"];
+  // ---------------------------------------------------------------------------
+  // Command Handling
+  // ---------------------------------------------------------------------------
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "SET_DECIMAL":
+        this.setDecimal(cmd.sheetId, cmd.target, cmd.step);
+        break;
+    }
+  }
+
+  /**
+   * This function allows to adjust the quantity of decimal places after a decimal
+   * point on cells containing number value. It does this by changing the cells
+   * format. Values aren't modified.
+   *
+   * The change of the decimal quantity is done one by one, the sign of the step
+   * variable indicates whether we are increasing or decreasing.
+   *
+   * If several cells are in the zone, the format resulting from the change of the
+   * first cell (with number type) will be applied to the whole zone.
+   */
+  private setDecimal(sheetId: UID, zones: Zone[], step: number) {
+    // Find the first cell with a number value and get the format
+    const numberFormat = this.searchNumberFormat(sheetId, zones);
+    if (numberFormat !== undefined) {
+      // Depending on the step sign, increase or decrease the decimal representation
+      // of the format
+      const newFormat = this.changeDecimalFormat(numberFormat, step);
+      // Apply the new format on the whole zone
+      this.dispatch("SET_FORMATTING", {
+        sheetId,
+        target: zones,
+        format: newFormat,
+      });
+    }
+  }
+
+  /**
+   * Take a range of cells and return the format of the first cell containing a
+   * number value. Returns a default format if the cell hasn't format. Returns
+   * undefined if no number value in the range.
+   */
+  private searchNumberFormat(sheetId: UID, zones: Zone[]): string | undefined {
+    for (let zone of zones) {
+      for (let row = zone.top; row <= zone.bottom; row++) {
+        for (let col = zone.left; col <= zone.right; col++) {
+          const cell = this.getters.getCell(sheetId, col, row);
+          if (
+            cell?.evaluated.type === CellValueType.number &&
+            !cell.format?.match(DATETIME_FORMAT) // reject dates
+          ) {
+            return cell.format || this.setDefaultNumberFormat(cell.evaluated.value);
+          }
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Function used to give the default format of a cell with a number for value.
+   * It is considered that the default format of a number is 0 followed by as many
+   * 0 as there are decimal places.
+   *
+   * Example:
+   * - 1 --> '0'
+   * - 123 --> '0'
+   * - 12345 --> '0'
+   * - 42.1 --> '0.0'
+   * - 456.0001 --> '0.0000'
+   */
+  private setDefaultNumberFormat(cellValue: number): string {
+    const strValue = cellValue.toString();
+    const parts = strValue.split(".");
+    if (parts.length === 1) {
+      return "0";
+    }
+    return "0." + Array(parts[1].length + 1).join("0");
+  }
+
+  /**
+   * This function take a cell format representation and return a new format representation
+   * with more or less decimal places.
+   *
+   * If the format doesn't look like a digital format (means that not contain '0')
+   * or if this one cannot be increased or decreased, the returned format will be
+   * the same.
+   *
+   * This function aims to work with all possible formats as well as custom formats.
+   *
+   * Examples of format changed by this function:
+   * - "0" (step = 1) --> "0.0"
+   * - "0.000%" (step = 1) --> "0.0000%"
+   * - "0.00" (step = -1) --> "0.0"
+   * - "0%" (step = -1) --> "0%"
+   * - "#,##0.0" (step = -1) --> "#,##0"
+   * - "#,##0;0.0%;0.000" (step = 1) --> "#,##0.0;0.00%;0.0000"
+   */
+  private changeDecimalFormat(format: string, step: number): string {
+    const sign = Math.sign(step);
+    // According to the representation of the cell format. A format can contain
+    // up to 4 sub-formats which can be applied depending on the value of the cell
+    // (among positive / negative / zero / text), each of these sub-format is separated
+    // by ';' in the format. We need to make the change on each sub-format.
+    const subFormats = format.split(";");
+    let newSubFormats: string[] = [];
+
+    for (let subFormat of subFormats) {
+      const decimalPointPosition = subFormat.indexOf(".");
+      const exponentPosition = subFormat.toUpperCase().indexOf("E");
+      let newSubFormat: string;
+
+      // the 1st step is to find the part of the zeros located before the
+      // exponent (when existed)
+      const subPart = exponentPosition > -1 ? subFormat.slice(0, exponentPosition) : subFormat;
+      const zerosAfterDecimal =
+        decimalPointPosition > -1 ? subPart.slice(decimalPointPosition).match(/0/g)!.length : 0;
+
+      // the 2nd step is to add (or remove) zero after the last zeros obtained in
+      // step 1
+      const lastZeroPosition = subPart.lastIndexOf("0");
+      if (lastZeroPosition > -1) {
+        if (sign > 0) {
+          // in this case we want to add decimal information
+          if (zerosAfterDecimal < maximumDecimalPlaces) {
+            newSubFormat =
+              subFormat.slice(0, lastZeroPosition + 1) +
+              (zerosAfterDecimal === 0 ? ".0" : "0") +
+              subFormat.slice(lastZeroPosition + 1);
+          } else {
+            newSubFormat = subFormat;
+          }
+        } else {
+          // in this case we want to remove decimal information
+          if (zerosAfterDecimal > 0) {
+            // remove last zero
+            newSubFormat =
+              subFormat.slice(0, lastZeroPosition) + subFormat.slice(lastZeroPosition + 1);
+            // if a zero always exist after decimal point else remove decimal point
+            if (zerosAfterDecimal === 1) {
+              newSubFormat =
+                newSubFormat.slice(0, decimalPointPosition) +
+                newSubFormat.slice(decimalPointPosition + 1);
+            }
+          } else {
+            // zero after decimal isn't present, we can't remove zero
+            newSubFormat = subFormat;
+          }
+        }
+      } else {
+        // no zeros are present in this format, we do nothing
+        newSubFormat = subFormat;
+      }
+      newSubFormats.push(newSubFormat);
+    }
+    return newSubFormats.join(";");
+  }
+}

--- a/tests/collaborative/inverses.test.ts
+++ b/tests/collaborative/inverses.test.ts
@@ -15,7 +15,6 @@ import {
   RemoveMergeCommand,
   ResizeColumnsRowsCommand,
   SetBorderCommand,
-  SetDecimalCommand,
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
@@ -292,12 +291,6 @@ describe("Inverses commands", () => {
       col: 1,
       row: 1,
     };
-    const setDecimal: SetDecimalCommand = {
-      type: "SET_DECIMAL",
-      sheetId: "1",
-      target: [toZone("A1")],
-      step: 2,
-    };
     const updateChart: UpdateChartCommand = {
       type: "UPDATE_CHART",
       sheetId: "42",
@@ -315,7 +308,6 @@ describe("Inverses commands", () => {
       setFormatting,
       clearFormatting,
       setBorder,
-      setDecimal,
       updateChart,
     ])("The inverse is the identity", (cmd: CoreCommand) => {
       expect(inverseCommand(cmd)).toEqual([cmd]);

--- a/tests/collaborative/ot/ot_columns_added.test.ts
+++ b/tests/collaborative/ot/ot_columns_added.test.ts
@@ -11,7 +11,6 @@ import {
   RemoveMergeCommand,
   ResizeColumnsRowsCommand,
   SetBorderCommand,
-  SetDecimalCommand,
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
@@ -112,19 +111,13 @@ describe("OT with ADD_COLUMNS_ROWS with dimension COL", () => {
     sheetId,
   };
 
-  const setDecimal: Omit<SetDecimalCommand, "target"> = {
-    type: "SET_DECIMAL",
-    sheetId,
-    step: 1,
-  };
-
   const addConditionalFormat: Omit<AddConditionalFormatCommand, "target"> = {
     type: "ADD_CONDITIONAL_FORMAT",
     sheetId,
     cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
   };
 
-  describe.each([deleteContent, setFormatting, clearFormatting, setDecimal, addConditionalFormat])(
+  describe.each([deleteContent, setFormatting, clearFormatting, addConditionalFormat])(
     "target commands",
     (cmd) => {
       test(`add columns  before ${cmd.type}`, () => {

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -11,7 +11,6 @@ import {
   RemoveMergeCommand,
   ResizeColumnsRowsCommand,
   SetBorderCommand,
-  SetDecimalCommand,
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
@@ -103,19 +102,13 @@ describe("OT with REMOVE_COLUMN", () => {
     sheetId,
   };
 
-  const setDecimal: Omit<SetDecimalCommand, "target"> = {
-    type: "SET_DECIMAL",
-    sheetId,
-    step: 1,
-  };
-
   const addConditionalFormat: Omit<AddConditionalFormatCommand, "target"> = {
     type: "ADD_CONDITIONAL_FORMAT",
     sheetId,
     cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
   };
 
-  describe.each([deleteContent, setFormatting, clearFormatting, setDecimal, addConditionalFormat])(
+  describe.each([deleteContent, setFormatting, clearFormatting, addConditionalFormat])(
     "target commands",
     (cmd) => {
       test(`remove columns before ${cmd.type}`, () => {

--- a/tests/collaborative/ot/ot_merged.test.ts
+++ b/tests/collaborative/ot/ot_merged.test.ts
@@ -7,7 +7,6 @@ import {
   DeleteContentCommand,
   RemoveMergeCommand,
   SetBorderCommand,
-  SetDecimalCommand,
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
@@ -85,22 +84,13 @@ describe("OT with ADD_MERGE", () => {
     sheetId,
   };
 
-  const setDecimal: Omit<SetDecimalCommand, "target"> = {
-    type: "SET_DECIMAL",
-    sheetId,
-    step: 1,
-  };
-
-  describe.each([deleteContent, setFormatting, clearFormatting, setDecimal])(
-    "target commands",
-    (cmd) => {
-      test(`${cmd.type} outside merge`, () => {
-        const command = { ...cmd, target: [toZone("E1:F2")] };
-        const result = transform(command, addMerge);
-        expect(result).toEqual(command);
-      });
-    }
-  );
+  describe.each([deleteContent, setFormatting, clearFormatting])("target commands", (cmd) => {
+    test(`${cmd.type} outside merge`, () => {
+      const command = { ...cmd, target: [toZone("E1:F2")] };
+      const result = transform(command, addMerge);
+      expect(result).toEqual(command);
+    });
+  });
 
   const removeMerge: Omit<RemoveMergeCommand, "target"> = {
     type: "REMOVE_MERGE",

--- a/tests/collaborative/ot/ot_rows_added.test.ts
+++ b/tests/collaborative/ot/ot_rows_added.test.ts
@@ -11,7 +11,6 @@ import {
   RemoveMergeCommand,
   ResizeColumnsRowsCommand,
   SetBorderCommand,
-  SetDecimalCommand,
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
@@ -107,19 +106,13 @@ describe("OT with ADD_COLUMNS_ROWS with dimension ROW", () => {
     sheetId,
   };
 
-  const setDecimal: Omit<SetDecimalCommand, "target"> = {
-    type: "SET_DECIMAL",
-    sheetId,
-    step: 1,
-  };
-
   const addConditionalFormat: Omit<AddConditionalFormatCommand, "target"> = {
     type: "ADD_CONDITIONAL_FORMAT",
     sheetId,
     cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
   };
 
-  describe.each([deleteContent, setFormatting, clearFormatting, setDecimal, addConditionalFormat])(
+  describe.each([deleteContent, setFormatting, clearFormatting, addConditionalFormat])(
     "target commands",
     (cmd) => {
       test(`add rows before ${cmd.type}`, () => {

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -11,7 +11,6 @@ import {
   RemoveMergeCommand,
   ResizeColumnsRowsCommand,
   SetBorderCommand,
-  SetDecimalCommand,
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
@@ -103,19 +102,13 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
     sheetId,
   };
 
-  const setDecimal: Omit<SetDecimalCommand, "target"> = {
-    type: "SET_DECIMAL",
-    sheetId,
-    step: 1,
-  };
-
   const addConditionalFormat: Omit<AddConditionalFormatCommand, "target"> = {
     type: "ADD_CONDITIONAL_FORMAT",
     sheetId,
     cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
   };
 
-  describe.each([deleteContent, setFormatting, clearFormatting, setDecimal, addConditionalFormat])(
+  describe.each([deleteContent, setFormatting, clearFormatting, addConditionalFormat])(
     "target commands",
     (cmd) => {
       test(`remove rows before ${cmd.type}`, () => {

--- a/tests/collaborative/ot/ot_sheet_deleted.test.ts
+++ b/tests/collaborative/ot/ot_sheet_deleted.test.ts
@@ -19,7 +19,6 @@ import {
   RenameSheetCommand,
   ResizeColumnsRowsCommand,
   SetBorderCommand,
-  SetDecimalCommand,
   SetFormattingCommand,
   UpdateCellCommand,
   UpdateCellPositionCommand,
@@ -97,11 +96,6 @@ describe("OT with DELETE_SHEET", () => {
     row: 0,
     border: undefined,
   };
-  const setDecimal: Omit<SetDecimalCommand, "sheetId"> = {
-    type: "SET_DECIMAL",
-    target: [toZone("A1")],
-    step: 3,
-  };
   const createChart: Omit<CreateChartCommand, "sheetId"> = {
     type: "CREATE_CHART",
     id: "1",
@@ -145,7 +139,6 @@ describe("OT with DELETE_SHEET", () => {
     setFormatting,
     clearFormatting,
     setBorder,
-    setDecimal,
     createChart,
     resizeColumns,
     resizeRows,


### PR DESCRIPTION
Handling "SET_DECIMAL" command depends on the evaluated value of cells.

The values are not guaranteed to be the same for every users because
they can depends on: asynchronous network calls, user accesss rights.

Handling the same SET_DECIMAL command can therefore lead to different
results for different users which would be de-synchronized.


We have a task planned to completely remove the evaluation from core to
prevent such mistakes in the future. See task [2813749](https://www.odoo.com/web#id=2813749&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo