### PR TITLE
[REF] model: copy dispatched commands

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -403,6 +403,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
    * It will call `beforeHandle` and `handle`
    */
   private dispatchToHandlers(handlers: CommandHandler<Command>[], command: Command) {
+    command = JSON.parse(JSON.stringify(command));
     for (const handler of handlers) {
       handler.beforeHandle(command);
     }

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -345,7 +345,7 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
             col,
             row,
             style: topLeft ? topLeft.style : undefined,
-            content: undefined,
+            content: "",
           });
         }
         const merge = this.getMerge(sheet.id, col, row);


### PR DESCRIPTION
With this commit, dispatched commands are copied therefore cannot
be mutated afterward.
Mutating a command is dangerous and would break both the history and the
collaborative editing. See task [2662680](https://www.odoo.com/web#id=2662680&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

There's no perceptible perf difference. With 3000 initial commands, loading
takes ~4.4s with and without this commit.

This commit was originally merged here https://github.com/odoo/o-spreadsheet/commit/b429cff1ccf834633d5fe5d1e3ad26714fa153df, then reverted there https://github.com/odoo/o-spreadsheet/commit/dd5d607e6f021cb9ffb7d5e5edb961c147c059fd
It should be good now ^^'

Odoo task ID : [2667116](https://www.odoo.com/web#id=2667116&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo