### PR TITLE
[IMP] spreadsheet: increase cell font resize its row

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -1037,7 +1037,7 @@ export const demoData = {
     },
   ],
   styles: {
-    1: { bold: true, textColor: "#3A3791", fontSize: 12 },
+    1: { bold: true, textColor: "#3A3791", fontSize: 18 },
     2: { italic: true },
     3: { strikethrough: true },
     4: { fillColor: "#e3efd9" },

--- a/demo/main.js
+++ b/demo/main.js
@@ -113,7 +113,7 @@ class Demo extends Component {
     }
     this.model = new Model(
       demoData,
-      // makeLargeDataset(26, 10_000, ["numbers"]);
+      // makeLargeDataset(26, 10_000, ["numbers"]),
       {
         evalContext: { env: this.env },
         transportService: this.transportService,

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -1,15 +1,17 @@
 //------------------------------------------------------------------------------
 // Miscellaneous
 //------------------------------------------------------------------------------
-
 import {
+  DEFAULT_CELL_HEIGHT,
   DEFAULT_FONT,
   DEFAULT_FONT_SIZE,
   DEFAULT_FONT_WEIGHT,
   MIN_CF_ICON_MARGIN,
+  PADDING_AUTORESIZE,
 } from "../constants";
 import { fontSizeMap } from "../fonts";
-import { Cloneable, ConsecutiveIndexes, Lazy, Link, Style, UID } from "../types";
+import { Cell, ConsecutiveIndexes, Lazy, Link, Style, UID } from "../types";
+import { Cloneable, Pixel } from "./../types/misc";
 import { parseDateTime } from "./dates";
 /**
  * Stringify an object, like JSON.stringify, except that the first level of keys
@@ -104,6 +106,22 @@ export function getComposerSheetName(sheetName: string): string {
 
 export function clip(val: number, min: number, max: number): number {
   return val < min ? min : val > max ? max : val;
+}
+
+/** Get the default height of the cell. The height depends on the font size */
+export function getDefaultCellHeight(cell: Cell | undefined): Pixel {
+  if (!cell?.style?.fontSize) {
+    return DEFAULT_CELL_HEIGHT;
+  }
+  return fontSizeInPixels(cell.style) + 2 * PADDING_AUTORESIZE;
+}
+
+export function fontSizeInPixels(style: Style) {
+  const sizeInPt = style.fontSize || DEFAULT_FONT_SIZE;
+  if (!fontSizeMap[sizeInPt]) {
+    throw new Error("Size of the font is not supported");
+  }
+  return fontSizeMap[sizeInPt];
 }
 
 export function computeTextWidth(context: CanvasRenderingContext2D, text: string, style: Style) {

--- a/src/plugins/core/header_size.ts
+++ b/src/plugins/core/header_size.ts
@@ -1,8 +1,10 @@
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../constants";
-import { deepCopy, getAddHeaderStartIndex, range } from "../../helpers";
-import { Command, ExcelWorkbookData, WorkbookData } from "../../types";
+import { deepCopy, getAddHeaderStartIndex, getDefaultCellHeight, range } from "../../helpers";
+import { Cell, Command, ExcelWorkbookData, WorkbookData } from "../../types";
 import { Dimension, HeaderIndex, Pixel, UID } from "../../types/misc";
 import { CorePlugin } from "../core_plugin";
+
+type CellId = UID;
 
 interface HeaderSize {
   manualSize: Pixel | undefined;
@@ -11,12 +13,14 @@ interface HeaderSize {
 
 interface HeaderSizeState {
   sizes: Record<UID, Record<Dimension, Array<HeaderSize>>>;
+  tallestCellInRows: Record<UID, Array<CellId | undefined>>;
 }
 
 export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements HeaderSizeState {
   static getters = ["getRowSize", "getColSize"] as const;
 
   readonly sizes: Record<UID, Record<Dimension, Array<HeaderSize>>> = {};
+  readonly tallestCellInRows: Record<UID, Array<CellId | undefined>> = {};
 
   handle(cmd: Command) {
     switch (cmd.type) {
@@ -33,40 +37,93 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
           })),
         };
         this.history.update("sizes", cmd.sheetId, sizes);
+        this.history.update("tallestCellInRows", cmd.sheetId, []);
         break;
       }
       case "DUPLICATE_SHEET":
         this.history.update("sizes", cmd.sheetIdTo, deepCopy(this.sizes[cmd.sheetId]));
+        this.history.update(
+          "tallestCellInRows",
+          cmd.sheetIdTo,
+          deepCopy(this.tallestCellInRows[cmd.sheetId])
+        );
         break;
       case "DELETE_SHEET":
         const sizes = { ...this.sizes };
         delete sizes[cmd.sheetId];
         this.history.update("sizes", sizes);
+        const tallestCellInRows = { ...this.tallestCellInRows };
+        delete tallestCellInRows[cmd.sheetId];
+        this.history.update("tallestCellInRows", tallestCellInRows);
         break;
       case "REMOVE_COLUMNS_ROWS": {
         const sizes = [...this.sizes[cmd.sheetId][cmd.dimension]];
+        const tallestCellInRows = [...this.tallestCellInRows[cmd.sheetId]];
         for (let headerIndex of [...cmd.elements].sort().reverse()) {
           sizes.splice(headerIndex, 1);
+          if (cmd.dimension === "ROW") {
+            tallestCellInRows.splice(headerIndex, 1);
+          }
         }
         this.history.update("sizes", cmd.sheetId, cmd.dimension, sizes);
+        if (cmd.dimension === "ROW") {
+          this.history.update("tallestCellInRows", cmd.sheetId, tallestCellInRows);
+        }
         break;
       }
       case "ADD_COLUMNS_ROWS": {
         const sizes = [...this.sizes[cmd.sheetId][cmd.dimension]];
         const addIndex = getAddHeaderStartIndex(cmd.position, cmd.base);
+        const tallestCellInRows = [...this.tallestCellInRows[cmd.sheetId]];
         const baseSize = sizes[cmd.base];
         for (let i = 0; i < cmd.quantity; i++) {
           sizes.splice(addIndex, 0, baseSize);
+          if (cmd.dimension === "ROW") {
+            tallestCellInRows.splice(i, 1, undefined);
+          }
         }
         this.history.update("sizes", cmd.sheetId, cmd.dimension, sizes);
+        if (cmd.dimension === "ROW") {
+          this.history.update("tallestCellInRows", cmd.sheetId, tallestCellInRows);
+        }
         break;
       }
       case "RESIZE_COLUMNS_ROWS":
         for (let el of cmd.elements) {
-          this.history.update("sizes", cmd.sheetId, cmd.dimension, el, {
-            computedSize: cmd.size,
-            manualSize: cmd.size,
-          });
+          if (cmd.dimension === "ROW") {
+            const { cell: tallestCell, height } = this.getRowTallestCell(cmd.sheetId, el);
+            const size = height;
+            this.history.update("tallestCellInRows", cmd.sheetId, el, tallestCell?.id);
+            this.history.update("sizes", cmd.sheetId, cmd.dimension, el, {
+              manualSize: cmd.size || undefined,
+              computedSize: size,
+            });
+          } else {
+            this.history.update("sizes", cmd.sheetId, cmd.dimension, el, {
+              manualSize: cmd.size || undefined,
+              computedSize: cmd.size || DEFAULT_CELL_WIDTH,
+            });
+          }
+        }
+        break;
+      case "UPDATE_CELL":
+        if (!this.sizes[cmd.sheetId]?.["ROW"]?.[cmd.row]?.manualSize) {
+          this.adjustRowSizeWithCellFont(cmd.sheetId, cmd.col, cmd.row);
+        }
+        break;
+      case "ADD_MERGE":
+      case "REMOVE_MERGE":
+        for (let target of cmd.target) {
+          for (let row of range(target.top, target.bottom + 1)) {
+            const { height: rowHeight, cell: tallestCell } = this.getRowTallestCell(
+              cmd.sheetId,
+              row
+            );
+            this.history.update("tallestCellInRows", cmd.sheetId, row, tallestCell?.id);
+            if (rowHeight !== this.getRowSize(cmd.sheetId, row)) {
+              this.history.update("sizes", cmd.sheetId, "ROW", row, "computedSize", rowHeight);
+            }
+          }
         }
         break;
     }
@@ -81,6 +138,36 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
     return this.getHeaderSize(sheetId, "ROW", index);
   }
 
+  /**
+   * Change the size of a row to match the cell with the biggest font size.
+   */
+  private adjustRowSizeWithCellFont(sheetId: UID, col: HeaderIndex, row: HeaderIndex) {
+    const currentCell = this.getters.getCell(sheetId, col, row);
+    const currentRowSize = this.getRowSize(sheetId, row);
+    const newCellHeight = this.getCellHeight(sheetId, col, row);
+
+    const tallestCell = this.tallestCellInRows[sheetId]?.[row];
+    let shouldRowBeUpdated =
+      !tallestCell ||
+      !this.getters.getCellById(tallestCell) || // tallest cell was deleted
+      (currentCell?.id === tallestCell && newCellHeight < currentRowSize); // tallest cell is smaller than before;
+
+    let newRowHeight: Pixel | undefined = undefined;
+    if (shouldRowBeUpdated) {
+      const { height: maxHeight, cell: tallestCell } = this.getRowTallestCell(sheetId, row);
+      newRowHeight = maxHeight;
+      this.history.update("tallestCellInRows", sheetId, row, tallestCell?.id);
+    } else if (newCellHeight > currentRowSize) {
+      newRowHeight = newCellHeight;
+      const tallestCell = this.getters.getCell(sheetId, col, row);
+      this.history.update("tallestCellInRows", sheetId, row, tallestCell?.id);
+    }
+
+    if (newRowHeight !== undefined && newRowHeight !== currentRowSize) {
+      this.history.update("sizes", sheetId, "ROW", row, "computedSize", newRowHeight);
+    }
+  }
+
   private getHeaderSize(sheetId: UID, dimension: Dimension, index: HeaderIndex): Pixel {
     return (
       this.sizes[sheetId]?.[dimension][index]?.manualSize ||
@@ -91,11 +178,17 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
 
   private computeSheetSizes(sheetId: UID): Record<Dimension, Array<Pixel>> {
     const sizes: Record<Dimension, Array<Pixel>> = { COL: [], ROW: [] };
-    for (const col of range(0, this.getters.getNumberCols(sheetId))) {
+    for (let col of range(0, this.getters.getNumberCols(sheetId))) {
       sizes.COL.push(this.getHeaderSize(sheetId, "COL", col));
     }
-    for (const row of range(0, this.getters.getNumberRows(sheetId))) {
-      sizes.ROW.push(this.getHeaderSize(sheetId, "ROW", row));
+    for (let row of range(0, this.getters.getNumberRows(sheetId))) {
+      let rowSize = this.sizes[sheetId]?.["ROW"]?.[row].manualSize;
+      if (!rowSize) {
+        const { cell: tallestCell, height } = this.getRowTallestCell(sheetId, row);
+        rowSize = height;
+        this.history.update("tallestCellInRows", sheetId, row, tallestCell?.id);
+      }
+      sizes.ROW.push(rowSize);
     }
     return sizes;
   }
@@ -104,9 +197,49 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
     return dimension === "COL" ? DEFAULT_CELL_WIDTH : DEFAULT_CELL_HEIGHT;
   }
 
+  /**
+   * Return the height the cell should have in the sheet, which is either DEFAULT_CELL_HEIGHT if the cell is in a multi-row
+   * merge, or the height of the cell computed based on its font size.
+   */
+  private getCellHeight(sheetId: UID, col: HeaderIndex, row: HeaderIndex): Pixel {
+    const merge = this.getters.getMerge(sheetId, col, row);
+    if (merge && merge.bottom !== merge.top) {
+      return DEFAULT_CELL_HEIGHT;
+    }
+    const cell = this.getters.getCell(sheetId, col, row);
+    return getDefaultCellHeight(cell);
+  }
+
+  /**
+   * Get the tallest cell of a row and its size.
+   *
+   * The tallest cell of the row correspond to the cell with the biggest font size,
+   * and that is not part of a multi-line merge.
+   */
+  private getRowTallestCell(sheetId: UID, row: HeaderIndex): { cell?: Cell; height: Pixel } {
+    const cellIds = this.getters.getRowCells(sheetId, row);
+    let maxHeight = 0;
+    let tallestCell: Cell | undefined = undefined;
+    for (let i = 0; i < cellIds.length; i++) {
+      const cell = this.getters.getCellById(cellIds[i]);
+      if (!cell) continue;
+      const { col, row } = this.getters.getCellPosition(cell.id);
+      const cellHeight = this.getCellHeight(sheetId, col, row);
+      if (cellHeight > maxHeight && cellHeight > DEFAULT_CELL_HEIGHT) {
+        maxHeight = cellHeight;
+        tallestCell = cell;
+      }
+    }
+
+    if (maxHeight <= DEFAULT_CELL_HEIGHT) {
+      return { height: DEFAULT_CELL_HEIGHT };
+    }
+    return { cell: tallestCell, height: maxHeight };
+  }
+
   import(data: WorkbookData) {
     for (let sheet of data.sheets) {
-      const manualSizes: Record<Dimension, Array<number>> = { COL: [], ROW: [] };
+      const manualSizes: Record<Dimension, Array<HeaderIndex>> = { COL: [], ROW: [] };
       for (let [rowIndex, row] of Object.entries(sheet.rows)) {
         if (row.size) {
           manualSizes["ROW"][rowIndex] = row.size;
@@ -120,13 +253,13 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
       }
       const computedSizes = this.computeSheetSizes(sheet.id);
       this.sizes[sheet.id] = {
-        COL: manualSizes.COL.map((size, i) => ({
-          manualSize: size,
-          computedSize: computedSizes.COL[i],
+        COL: computedSizes.COL.map((size, i) => ({
+          manualSize: manualSizes.COL[i],
+          computedSize: size,
         })),
-        ROW: manualSizes.ROW.map((size, i) => ({
-          manualSize: size,
-          computedSize: computedSizes.ROW[i],
+        ROW: computedSizes.ROW.map((size, i) => ({
+          manualSize: manualSizes.ROW[i],
+          computedSize: size,
         })),
       };
     }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -31,10 +31,10 @@ import { UIPluginConstructor } from "./ui_plugin";
 
 export const corePluginRegistry = new Registry<CorePluginConstructor>()
   .add("sheet", SheetPlugin)
-  .add("headerSize", HeaderSizePlugin)
   .add("header visibility", HeaderVisibilityPlugin)
   .add("cell", CellPlugin)
   .add("merge", MergePlugin)
+  .add("headerSize", HeaderSizePlugin)
   .add("borders", BordersPlugin)
   .add("conditional formatting", ConditionalFormatPlugin)
   .add("figures", FigurePlugin)

--- a/src/plugins/ui/ui_sheet.ts
+++ b/src/plugins/ui/ui_sheet.ts
@@ -1,12 +1,11 @@
-import { DEFAULT_FONT_SIZE, PADDING_AUTORESIZE } from "../../constants";
-import { fontSizeMap } from "../../fonts";
-import { computeIconWidth, computeTextWidth, isDefined } from "../../helpers/index";
+import { PADDING_AUTORESIZE } from "../../constants";
+import { computeIconWidth, computeTextWidth } from "../../helpers/index";
 import { Cell, CellValueType, Command, CommandResult, UID } from "../../types";
 import { HeaderIndex, Pixel } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
 export class SheetUIPlugin extends UIPlugin {
-  static getters = ["getCellWidth", "getCellHeight", "getTextWidth", "getCellText"] as const;
+  static getters = ["getCellWidth", "getTextWidth", "getCellText"] as const;
 
   private ctx = document.createElement("canvas").getContext("2d")!;
 
@@ -45,15 +44,12 @@ export class SheetUIPlugin extends UIPlugin {
         break;
       case "AUTORESIZE_ROWS":
         for (let row of cmd.rows) {
-          const size = this.getRowMaxHeight(cmd.sheetId, row);
-          if (size !== 0) {
-            this.dispatch("RESIZE_COLUMNS_ROWS", {
-              elements: [row],
-              dimension: "ROW",
-              size: size + 2 * PADDING_AUTORESIZE,
-              sheetId: cmd.sheetId,
-            });
-          }
+          this.dispatch("RESIZE_COLUMNS_ROWS", {
+            elements: [row],
+            dimension: "ROW",
+            size: null,
+            sheetId: cmd.sheetId,
+          });
         }
         break;
     }
@@ -78,12 +74,6 @@ export class SheetUIPlugin extends UIPlugin {
     return computeTextWidth(this.ctx, text, this.getters.getCellStyle(cell));
   }
 
-  getCellHeight(cell: Cell): number {
-    const style = this.getters.getCellStyle(cell);
-    const sizeInPt = style.fontSize || DEFAULT_FONT_SIZE;
-    return fontSizeMap[sizeInPt];
-  }
-
   getCellText(cell: Cell, showFormula: boolean = false): string {
     if (showFormula && (cell.isFormula() || cell.evaluated.type === CellValueType.error)) {
       return cell.content;
@@ -99,15 +89,6 @@ export class SheetUIPlugin extends UIPlugin {
   private getColMaxWidth(sheetId: UID, index: HeaderIndex): Pixel {
     const cells = this.getters.getColCells(sheetId, index);
     const sizes = cells.map((cell: Cell) => this.getCellWidth(cell));
-    return Math.max(0, ...sizes);
-  }
-
-  private getRowMaxHeight(sheetId: UID, index: HeaderIndex): Pixel {
-    const sheet = this.getters.getSheet(sheetId);
-    const cells = Object.values(sheet.rows[index].cells)
-      .filter(isDefined)
-      .map((cellId) => this.getters.getCellById(cellId));
-    const sizes = cells.map((cell: Cell) => this.getCellHeight(cell));
     return Math.max(0, ...sizes);
   }
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -218,7 +218,7 @@ export interface MoveColumnsRowsCommand extends GridDependentCommand {
 export interface ResizeColumnsRowsCommand extends GridDependentCommand {
   type: "RESIZE_COLUMNS_ROWS";
   elements: number[];
-  size: number;
+  size: number | null;
 }
 
 export interface HideColumnsRowsCommand extends GridDependentCommand {

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -4,19 +4,17 @@ import { ColResizer, RowResizer } from "../../src/components/headers_overlay/hea
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
-  DEFAULT_FONT_SIZE,
   HEADER_WIDTH,
   MIN_COL_WIDTH,
   MIN_ROW_HEIGHT,
-  PADDING_AUTORESIZE,
 } from "../../src/constants";
-import { fontSizeMap } from "../../src/fonts";
 import { lettersToNumber, scrollDelay, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import {
   hideColumns,
   hideRows,
   redo,
+  resizeRows,
   setCellContent,
   undo,
 } from "../test_helpers/commands_helpers";
@@ -414,22 +412,24 @@ describe("Resizer component", () => {
   });
 
   test("Double click: Modify the size of a row", async () => {
+    resizeRows(model, [1], 30);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(30);
     setCellContent(model, "B2", "b2");
     await dblClickRow(1);
-    const size = fontSizeMap[DEFAULT_FONT_SIZE] + 2 * PADDING_AUTORESIZE;
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(size);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(DEFAULT_CELL_HEIGHT);
   });
 
   test("Double click on rows then undo, then redo", async () => {
     fillData();
+    resizeRows(model, [0, 1, 2, 3, 4], 30);
     setCellContent(model, "C3", "C3");
     setCellContent(model, "C4", "C4");
     await selectRow(2);
     await selectRow(3, { ctrlKey: true });
     await dblClickRow(2);
     const sheet = model.getters.getActiveSheetId();
-    const initialSize = model.getters.getRowSize(sheet, 0);
-    const size = fontSizeMap[DEFAULT_FONT_SIZE] + 2 * PADDING_AUTORESIZE;
+    const initialSize = 30;
+    const size = DEFAULT_CELL_HEIGHT;
     expect(model.getters.getRowSize(sheet, 1)).toBe(initialSize);
     expect(model.getters.getRowSize(sheet, 2)).toBe(size);
     expect(model.getters.getRowSize(sheet, 3)).toBe(size);
@@ -571,31 +571,31 @@ describe("Resizer component", () => {
 
   test("Select 123 5, dblclick 5 then resize all", async () => {
     fillData();
+    resizeRows(model, [0, 1, 2, 3, 4, 5, 6], 30);
     await selectRow(0);
     await selectRow(2, { shiftKey: true });
     await selectRow(4, { ctrlKey: true });
     await dblClickRow(4);
-    const size = fontSizeMap[DEFAULT_FONT_SIZE] + 2 * PADDING_AUTORESIZE;
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 0)).toBe(size);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(size);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 2)).toBe(size);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 3)).toBe(DEFAULT_CELL_HEIGHT);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 4)).toBe(size);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 0)).toBe(DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 2)).toBe(DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 3)).toBe(30);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 4)).toBe(DEFAULT_CELL_HEIGHT);
   });
 
   test("Select 123 5, dblclick 6 then resize only 6", async () => {
     fillData();
+    resizeRows(model, [0, 1, 2, 3, 4, 5, 6], 30);
     await selectRow(0);
     await selectRow(2, { shiftKey: true });
     await selectRow(4, { ctrlKey: true });
     await dblClickRow(5);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 0)).toBe(DEFAULT_CELL_HEIGHT);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(DEFAULT_CELL_HEIGHT);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 2)).toBe(DEFAULT_CELL_HEIGHT);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 3)).toBe(DEFAULT_CELL_HEIGHT);
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 4)).toBe(DEFAULT_CELL_HEIGHT);
-    const size = fontSizeMap[DEFAULT_FONT_SIZE] + 2 * PADDING_AUTORESIZE;
-    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 5)).toBe(size);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 0)).toBe(30);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(30);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 2)).toBe(30);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 3)).toBe(30);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 4)).toBe(30);
+    expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 5)).toBe(DEFAULT_CELL_HEIGHT);
   });
 
   test("Select A, drag to C then ABC selected", async () => {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -496,7 +496,7 @@ describe("clipboard", () => {
 
   test("Dispatch a PASTE command with interactive=true correctly takes pasteOption into account", async () => {
     const model = new Model();
-    const style = { fontSize: 42 };
+    const style = { fontSize: 36 };
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "=42");
     model.dispatch("UPDATE_CELL", { sheetId, col: 0, row: 0, style });

--- a/tests/plugins/formatting.test.ts
+++ b/tests/plugins/formatting.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_FONT_SIZE, PADDING_AUTORESIZE } from "../../src/constants";
+import { DEFAULT_CELL_HEIGHT, PADDING_AUTORESIZE } from "../../src/constants";
 import { fontSizeMap } from "../../src/fonts";
 import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
@@ -6,6 +6,7 @@ import { SheetUIPlugin } from "../../src/plugins/ui/ui_sheet";
 import { Cell, CommandResult, UID } from "../../src/types";
 import {
   createSheet,
+  resizeRows,
   selectCell,
   setAnchorCorner,
   setCellContent,
@@ -370,7 +371,6 @@ describe("Autoresize", () => {
   let sheetId: UID;
   const sizes = [10, 20];
   const padding = 2 * PADDING_AUTORESIZE;
-  const rowSize = fontSizeMap[DEFAULT_FONT_SIZE];
 
   beforeEach(() => {
     model = new Model();
@@ -397,17 +397,19 @@ describe("Autoresize", () => {
   });
 
   test("Can autoresize a row", () => {
+    resizeRows(model, [0], 30);
     setCellContent(model, "A1", "test");
     model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0] });
-    expect(model.getters.getRowSize(sheetId, 0)).toBe(rowSize + padding);
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(DEFAULT_CELL_HEIGHT);
   });
 
   test("Can autoresize two rows", () => {
+    resizeRows(model, [0, 2], 30);
     setCellContent(model, "A1", "test");
     setCellContent(model, "A3", "test");
     model.dispatch("SET_FORMATTING", { sheetId, target: [toZone("A3")], style: { fontSize: 24 } });
     model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0, 2] });
-    expect(model.getters.getRowSize(sheetId, 0)).toBe(rowSize + padding);
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(DEFAULT_CELL_HEIGHT);
     expect(model.getters.getRowSize(sheetId, 2)).toBe(fontSizeMap[24] + padding);
   });
 
@@ -425,9 +427,10 @@ describe("Autoresize", () => {
     const initialSize = model.getters.getRowSize(sheetId, 0);
     const newSheetId = "42";
     createSheet(model, { sheetId: newSheetId });
+    resizeRows(model, [0], 30, "42");
     setCellContent(model, "A1", "test", newSheetId);
     model.dispatch("AUTORESIZE_ROWS", { sheetId: newSheetId, rows: [0] });
     expect(model.getters.getRowSize(sheetId, 0)).toBe(initialSize);
-    expect(model.getters.getRowSize(newSheetId, 0)).toBe(rowSize + padding);
+    expect(model.getters.getRowSize(newSheetId, 0)).toBe(DEFAULT_CELL_HEIGHT);
   });
 });

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -9,6 +9,7 @@ import {
   CreateSheetCommand,
   DispatchResult,
   SortDirection,
+  Style,
   UID,
   UpDown,
 } from "../../src/types";
@@ -686,5 +687,18 @@ export function setViewportOffset(model: Model, offsetX: number, offsetY: number
   return model.dispatch("SET_VIEWPORT_OFFSET", {
     offsetX,
     offsetY,
+  });
+}
+
+export function setStyle(
+  model: Model,
+  targetXc: string,
+  style: Style,
+  sheetId: UID = model.getters.getActiveSheetId()
+) {
+  return model.dispatch("SET_FORMATTING", {
+    sheetId: sheetId,
+    target: target(targetXc),
+    style: style,
   });
 }


### PR DESCRIPTION
## Description:

When the user increase the font size of a cell, the row size should be updated,
except if the row had previously been resized by the user.

I'm basing the size of a row only base on the font size rather than font size + cell content (empty/non-empty) lik pr #1109 . It's waaaaaay easier and give no performance problems. It's the same behaviour as Excel.

Don't export sizes or rows that were automatically computed, but re-compute them at import.

This commit also fix AUTORESIZE_ROW to align its behaviour with GSheet. Now
the minimum size possible for a row auto-resized id the default cell height.

Odoo task ID : [2714374](https://www.odoo.com/web#id=2714374&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo