### PR TITLE
[FIX] drag&drop: Use the correct delay to edgeScroll

### DIFF
--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -48,7 +48,6 @@ export function dragAndDropBeyondTheViewport(
     const edgeScrollInfoX = env.getters.getEdgeScrollCol(offsetX);
     const edgeScrollInfoY = env.getters.getEdgeScrollRow(offsetY);
     const { top, left, bottom, right } = env.getters.getActiveSnappedViewport();
-
     let colIndex: number;
     if (edgeScrollInfoX.canEdgeScroll) {
       colIndex = edgeScrollInfoX.direction > 0 ? right : left - 1;
@@ -84,7 +83,7 @@ export function dragAndDropBeyondTheViewport(
       timeOutId = setTimeout(() => {
         timeOutId = null;
         onMouseMove(currentEv);
-      }, Math.round(edgeScrollInfoX.delay));
+      }, Math.round(edgeScrollInfoY.delay));
     }
   };
 

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -907,7 +907,7 @@ describe("Events on Grid update viewport correctly", () => {
       });
     });
 
-    test("Can edge-scroll vertically", () => {
+    test("Can edge-scroll vertically", async () => {
       const { width, height } = model.getters.getViewportDimension();
       const x = width / 2;
       triggerMouseEvent("canvas", "mousedown", x, height / 2);

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -812,7 +812,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     });
   });
 
-  test("Can edge-scroll vertically", () => {
+  test("Can edge-scroll vertically", async () => {
     const { height } = model.getters.getViewportDimension();
     const x = DEFAULT_CELL_WIDTH / 2;
     triggerMouseEvent(".o-row-resizer", "mousedown", x, height / 2);


### PR DESCRIPTION
in the `dragAndDropBeyondTheViewport` helper, we would use the time delay
computed for a horizontal edgescroll when scrolling vertically. This
meant that when scrolling vertically, we would call the
`onMouseMove`callback with a timeout delay of 0ms, thus scrolling way
too fast.

Writing a test for this particular case highlighted the complexity of
the necessary setup to test such a feature as well as the fact that we
need to test it on EVERY component that can edgeScroll, and the list of
seuch components can only grow over time.

A work targetting the master branch will try to address this issue by
testing the actual helper in a more generic context, which should in
turn hopefully allow to make simpler tests upon the components themselves.

task 2850618

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo