### PR TITLE
[FIX] charts: time charts with empty labels

### DIFF
--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -506,6 +506,11 @@ export class EvaluationChartPlugin extends UIPlugin {
     if (!definition.labelRange || !definition.dataSets || definition.type !== "line") {
       return false;
     }
+
+    if (!this.canBeLinearChart(definition)) {
+      return false;
+    }
+
     const labelFormat = this.getLabelFormat(definition);
     return Boolean(labelFormat && timeFormatMomentCompatible.test(labelFormat));
   }
@@ -521,6 +526,9 @@ export class EvaluationChartPlugin extends UIPlugin {
 
     const labels = this.getters.getRangeValues(definition.labelRange);
     if (labels.some((label) => isNaN(Number(label)) && label)) {
+      return false;
+    }
+    if (labels.every((label) => !label)) {
       return false;
     }
 

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -518,6 +518,27 @@ describe("figures", () => {
       await simulateClick("input[name='labelsAsText']");
       expect(model.getters.getChartDefinitionUI(sheetId, chartId).labelsAsText).toBeTruthy();
     });
+
+    test("labelAsText checkbox not displayed for text labels with date format", async () => {
+      model.dispatch("SET_FORMATTING", {
+        sheetId: model.getters.getActiveSheetId(),
+        target: [toZone("A2:A4")],
+        format: "m/d/yyyy",
+      });
+      updateChart(model, chartId, { type: "line", labelRange: "A2:A4", dataSets: ["B2:B4"] });
+      await simulateClick(".o-figure");
+      await simulateClick(".o-chart-menu-item");
+      await simulateClick(".o-menu div[data-name='edit']");
+      expect(document.querySelector("input[name='labelsAsText']")).toBeFalsy();
+    });
+
+    test("labelAsText checkbox not displayed for charts with empty labels", async () => {
+      updateChart(model, chartId, { type: "line", labelRange: "F2:F4", dataSets: ["B2:B4"] });
+      await simulateClick(".o-figure");
+      await simulateClick(".o-chart-menu-item");
+      await simulateClick(".o-menu div[data-name='edit']");
+      expect(document.querySelector("input[name='labelsAsText']")).toBeFalsy();
+    });
   });
 });
 


### PR DESCRIPTION
Time charts with empty labels were bugged and displayed random values.
It was also possible to have a time chart when the labels were strings
with a date format.


Odoo task ID : [285700](https://www.odoo.com/web#id=285700&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo