### PR TITLE
[FIX] edition: do not reset selection when range selecting on differe…

### DIFF
--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -326,10 +326,12 @@ export class EditionPlugin extends UIPlugin {
    */
   private startComposerRangeSelection() {
     this.mode = "resettingPosition";
-    this.dispatch("SELECT_CELL", {
-      col: this.col,
-      row: this.row,
-    });
+    if (this.sheet === this.getters.getActiveSheetId()) {
+      this.dispatch("SELECT_CELL", {
+        col: this.col,
+        row: this.row,
+      });
+    }
     this.mode = "waitingForRangeSelection";
     // We set this variable to store the start of the multiple range
     // selection. This is useful for example when we select multiple

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -519,7 +519,7 @@ describe("edition", () => {
     expect(model.getters.getCurrentContent()).toBe("=D4");
   });
 
-  test("enable selection mode reset to initial position", () => {
+  test("enable selection mode reset to initial position only wehn selecting on the edition sheet", () => {
     const model = new Model();
     selectCell(model, "D3");
     model.dispatch("START_EDITION", { text: "=" });
@@ -529,6 +529,18 @@ describe("edition", () => {
     model.dispatch("SET_CURRENT_CONTENT", { content: "=D4+" });
     model.dispatch("MOVE_POSITION", { deltaX: 0, deltaY: 1 });
     expect(model.getters.getCurrentContent()).toBe("=D4+D4");
+    model.dispatch("STOP_EDITION");
+    selectCell(model, "D3");
+    createSheet(model, { sheetId: "sheet2" });
+    model.dispatch("START_EDITION", { text: "=" });
+    activateSheet(model, "sheet2");
+    expect(model.getters.getSelectedZone()).toStrictEqual(toZone("A1"));
+    model.dispatch("MOVE_POSITION", { deltaX: 0, deltaY: 1 });
+    expect(model.getters.getCurrentContent()).toBe("=Sheet2!A2");
+    model.dispatch("STOP_COMPOSER_RANGE_SELECTION");
+    model.dispatch("SET_CURRENT_CONTENT", { content: "=Sheet2!A2+" });
+    model.dispatch("MOVE_POSITION", { deltaX: 0, deltaY: 1 });
+    expect(model.getters.getCurrentContent()).toBe("=Sheet2!A2+Sheet2!A3");
   });
 
   test("select an empty cell, start selecting mode at the composer position", () => {


### PR DESCRIPTION
…nt sheet

When starting a ranger selection in the composer, we would
systematically reset the selection anchor to the cell that we were
editing in the first place. This behaviour is required when a user edits
a formula and wants to select some ranges by moving the position with
their keyboard.

e.g. User wants to sum several range together -
they start editing  cell A1
select a first cell anywhere on the grid,
input a comma to add another zone,
hit ArrowDown,
it should select A2.

Unfortunately, when selecting a range on another sheet, this behaviour
does not make sense anymore since there is no guarantee that the anchor
coordinates of the edited cell existes on another sheet.

e.g. Edit on A1000  sheet 1 with 1000 rows, then move to sheet 2 with 10
rows, When selecting several ranges for a formula, you cannot be 'moved'
to A1000 since it doesn't exist.

To solve this, we choose to prevent the reset of the anchor when the
current sheet differs from the sheet of the edited cell.

task 2859417

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo