### PR TITLE
[FIX] Selection: Use correct sheet properties for default selection

### DIFF
--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -241,7 +241,7 @@ export class SelectionPlugin extends UIPlugin<SelectionPluginState> {
         if (cmd.sheetIdTo in this.sheetsData) {
           Object.assign(this, this.sheetsData[cmd.sheetIdTo]);
         } else {
-          this.selectCell(...getNextVisibleCellCoords(this.getters.getSheets()[0], 0, 0));
+          this.selectCell(...getNextVisibleCellCoords(this.getters.getSheet(cmd.sheetIdTo), 0, 0));
         }
         break;
       case "SET_SELECTION":

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -502,6 +502,27 @@ describe("multiple sheets", () => {
     expect(model.getters.getSelectedZone()).toEqual(toZone("A1"));
     expect(model.getters.getActiveSheetId()).toBe("42");
   });
+
+  test("Activating an unvisited sheet selects its first visible cell", () => {
+    const model = new Model({
+      sheets: [
+        {
+          sheetId: "Sheet1",
+        },
+        {
+          sheetId: "Sheet2",
+          colNumber: 5,
+          rowNumber: 5,
+          cols: { 0: { isHidden: true }, 1: { isHidden: true } },
+          rows: { 0: { isHidden: true } },
+          merges: ["C2:C3"],
+        },
+      ],
+    });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1"));
+    activateSheet(model, "Sheet2");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("C2:C3"));
+  });
 });
 
 describe("Alter selection starting from hidden cells", () => {


### PR DESCRIPTION
How to reproduce:
-----------------

1. Create a Spreadsheet with 2 sheets
2. On the first sheet, hide the first two columns
3. Activate the second sheet

=> Your default selection is in `C1` instead of `A1`.

Issue
-----
When activating a new sheet (new = non previously visited at runtime)
we always define its default selection based on the first sheet
properties, not its own.

Task 2859722

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2859722](https://www.odoo.com/web#id=2859722&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo