### PR TITLE
[FIX] chart: render chart with new background

### DIFF
--- a/src/components/figures/chart.ts
+++ b/src/components/figures/chart.ts
@@ -51,10 +51,6 @@ interface Props {
   onFigureDeleted: () => void;
 }
 
-interface State {
-  background: string;
-}
-
 export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   static template = TEMPLATE;
   static components = { Menu };
@@ -63,11 +59,11 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   canvas = useRef("graphContainer");
   private chartContainerRef = useRef("chartContainer");
   private chart?: Chart;
-  private state: State = { background: BACKGROUND_CHART_COLOR };
   private position = useAbsolutePosition(this.chartContainerRef);
 
   get canvasStyle() {
-    return `background-color: ${this.state.background}`;
+    const chart = this.env.model.getters.getChartDefinition(this.props.figure.id);
+    return `background-color: ${chart ? chart.background : BACKGROUND_CHART_COLOR}`;
   }
 
   setup() {
@@ -104,10 +100,6 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
       } else {
         this.chart && this.chart.destroy();
       }
-      const def = this.env.model.getters.getChartDefinition(figure.id);
-      if (def) {
-        this.state.background = def.background;
-      }
     });
   }
 
@@ -115,10 +107,6 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
     const canvas = this.canvas.el as HTMLCanvasElement;
     const ctx = canvas.getContext("2d")!;
     this.chart = new window.Chart(ctx, chartData);
-    const def = this.env.model.getters.getChartDefinition(this.props.figure.id);
-    if (def) {
-      this.state.background = def.background;
-    }
   }
 
   showMenu(ev: MouseEvent) {

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -318,6 +318,21 @@ describe("figures", () => {
     expect((mockChartData.options!.title as any).text).toBe("hello");
   });
 
+  test("can change a chart background color from the side panel", async () => {
+    await simulateClick(".o-figure");
+    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-menu div[data-name='edit']");
+    await nextTick();
+    const designPanel = fixture.querySelectorAll(".o-panel-element")[1];
+    triggerMouseEvent(designPanel, "click");
+    const canvas = fixture.querySelector(".o-chart-container canvas") as HTMLElement;
+    await nextTick();
+    expect(canvas.style.backgroundColor).toBe("rgb(255, 255, 255)");
+    await simulateClick(".o-with-color-picker span");
+    await simulateClick(".o-color-picker-line-item");
+    expect(canvas.style.backgroundColor).toBe("rgb(0, 0, 0)");
+  });
+
   test("deleting chart will close sidePanel", async () => {
     expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
     await simulateClick(".o-figure");


### PR DESCRIPTION
- Create a chart
- open the side panel and change its background color
=> the new color is not reflected directly. You need to
move your mouse over the grid to trigger a new rendering.

Not sure why it used to work. Probably some subtle change from
owl 2.

Note: it does not happen in Odoo. Probably an extra rendering
triggered by something, somewhere

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [x] exportable in excel
- [x] translations (\_lt("qmsdf %s", abc))
- [x] unit tested
- [x] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo