### PR TITLE
[FIX] selectionInput: Reset selection anchor when changing sheet

### DIFF
--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -183,9 +183,11 @@ export class EditionPlugin extends UIPlugin {
         this.selectionEnd = this.currentContent.length;
         break;
       case "ACTIVATE_SHEET":
-        const [col, row] = getNextVisibleCellCoords(this.getters.getSheet(cmd.sheetIdTo), 0, 0);
-        const zone = this.getters.expandZone(cmd.sheetIdTo, positionToZone({ col, row }));
-        this.selection.resetAnchor(this, { cell: { col, row }, zone });
+        if (cmd.sheetIdFrom !== cmd.sheetIdTo) {
+          const [col, row] = getNextVisibleCellCoords(this.getters.getSheet(cmd.sheetIdTo), 0, 0);
+          const zone = this.getters.expandZone(cmd.sheetIdTo, positionToZone({ col, row }));
+          this.selection.resetAnchor(this, { cell: { col, row }, zone });
+        }
         break;
       case "DELETE_SHEET":
       case "UNDO":

--- a/src/plugins/ui/selection_input.ts
+++ b/src/plugins/ui/selection_input.ts
@@ -1,4 +1,11 @@
-import { getComposerSheetName, getNextColor, UuidGenerator, zoneToXc } from "../../helpers/index";
+import {
+  getComposerSheetName,
+  getNextColor,
+  getNextVisibleCellCoords,
+  positionToZone,
+  UuidGenerator,
+  zoneToXc,
+} from "../../helpers/index";
 import { Mode, ModelConfig } from "../../model";
 import { StreamCallbacks } from "../../selection_stream/event_stream";
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
@@ -111,6 +118,13 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
           this.willAddNewRange = this.ranges[index].xc.trim() !== "";
         }
         break;
+      }
+      case "ACTIVATE_SHEET": {
+        if (cmd.sheetIdFrom !== cmd.sheetIdTo) {
+          const [col, row] = getNextVisibleCellCoords(this.getters.getSheet(cmd.sheetIdTo), 0, 0);
+          const zone = this.getters.expandZone(cmd.sheetIdTo, positionToZone({ col, row }));
+          this.selection.resetAnchor(this, { cell: { col, row }, zone });
+        }
       }
     }
   }

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -557,6 +557,21 @@ describe("edition", () => {
     expect(model.getters.getCurrentContent()).toBe("=Sheet2!A2+Sheet2!A3");
   });
 
+  test("composer selection is reset only when changing sheet", () => {
+    const model = new Model();
+    createSheet(model, { sheetId: "42", name: "Sheet2" });
+    selectCell(model, "D3");
+    model.dispatch("START_EDITION", { text: "=" });
+    moveAnchorCell(model, "down");
+    expect(model.getters.getCurrentContent()).toBe("=D4");
+    activateSheet(model, "42");
+    moveAnchorCell(model, "down");
+    expect(model.getters.getCurrentContent()).toEqual("=Sheet2!A2");
+    activateSheet(model, "42");
+    moveAnchorCell(model, "down");
+    expect(model.getters.getCurrentContent()).toEqual("=Sheet2!A3");
+  });
+
   test("select an empty cell, start selecting mode at the composer position", () => {
     const model = new Model();
     const [col, row] = toCartesian("A2");

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -7,6 +7,7 @@ import {
   createSheet,
   createSheetWithName,
   merge,
+  moveAnchorCell,
   resizeAnchorZone,
   selectCell,
   setAnchorCorner,
@@ -587,5 +588,18 @@ describe("selection input plugin", () => {
     expect(model.getters.getSelectionInput(id)[0].isFocused).toBe(false);
     activateSheet(model, "42");
     expect(model.getters.getSelectionInput(id)[0].isFocused).toBe(false);
+  });
+
+  test("input selection is reset only when changing sheet", () => {
+    createSheet(model, { sheetId: "42" });
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
+    model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
+    selectCell(model, "B7");
+    activateSheet(model, "42");
+    moveAnchorCell(model, "down");
+    expect(highlightedZones(model)).toEqual(["A2"]);
+    activateSheet(model, "42");
+    moveAnchorCell(model, "down");
+    expect(highlightedZones(model)).toEqual(["A3"]);
   });
 });


### PR DESCRIPTION
This is an issue very similar to cdd61a07. When changing sheet, we have
no guarantee that the structure of the previous and new sheet match and
that a valid on position on the former is valid on the latter.

This issue actually arose when we introduced the `SelectionStreamProcessor`
in c6bfc09a as the `Edition` and `SelectionInput` plugins no longer depend on
`SelectionPlugin`, which handles this situation. It was solved as a
side-effect for `Edition`in 8329240c but the problem also existed for
`SelectionInput`, only it was failing silently.

Task 2860238

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2860238](https://www.odoo.com/web#id=2860238&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo