### PR TITLE
[FIX] chart: wrong dimension used at create_chart

### DIFF
--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -550,7 +550,7 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
   const sheetId = env.model.getters.getActiveSheetId();
   const position = {
     x: env.model.getters.getColDimensions(sheetId, zone.right + 1).start,
-    y: env.model.getters.getColDimensions(sheetId, zone.top).start,
+    y: env.model.getters.getRowDimensions(sheetId, zone.top).start,
   };
   let dataSetsHaveTitle = false;
   for (let x = dataSetZone.left; x <= dataSetZone.right; x++) {

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -10,6 +10,7 @@ import {
   topbarMenuRegistry,
 } from "../src/registries/index";
 import { SpreadsheetChildEnv } from "../src/types";
+import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "./../src/constants";
 import {
   hideColumns,
   hideRows,
@@ -958,6 +959,19 @@ describe("Menu Item actions", () => {
     afterEach(() => {
       app.destroy();
     });
+
+    test("Chart is inserted at correct position", () => {
+      setSelection(model, ["B2"]);
+      doAction(["insert", "insert_chart"], env);
+      const payload = { ...defaultPayload };
+      payload.definition.dataSets = ["B2"];
+      payload.position = {
+        x: 2 * DEFAULT_CELL_WIDTH, // x is position of dataset cell + 1
+        y: DEFAULT_CELL_HEIGHT,
+      };
+      expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
+    });
+
     test("Chart of single column without title", () => {
       setSelection(model, ["B2:B5"]);
       doAction(["insert", "insert_chart"], env);


### PR DESCRIPTION
The menu action CREATE_CHART used the col dimension as Y
position instead of the row dimension

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo