### PR TITLE
[IMP] errors: add of NA error and corresponding excel functions

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -890,6 +890,18 @@ export const demoData = {
         B161: { content: "=DELTA(1,1)" },
         C161: { content: "1" },
         D161: { content: "=IF(B161=C161,1, 0)" },
+        A162: { content: "NA" },
+        B162: { content: "=NA()" },
+        C162: { content: "#N/A" },
+        D162: { content: "=IF(ISNA(B162),1, 0)" },
+        A163: { content: "ISNA" },
+        B163: { content: "=ISNA(NA())" },
+        C163: { content: "TRUE" },
+        D163: { content: "=IF(B163=C163,1, 0)" },
+        A164: { content: "ISERR" },
+        B164: { content: "=ISERR(NA())" },
+        C164: { content: "FALSE" },
+        D164: { content: "=IF(B164=C164,1, 0)" },
 
         // DATA
         G1: { content: "Name", style: 8 },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import { _lt } from "./translation";
 import { BorderDescr, Style } from "./types";
+import { CellErrorType } from "./types/errors";
 
 // Scheduler
 export const MAXIMUM_EVALUATION_CHECK_DELAY_MS = 15;
@@ -64,7 +65,7 @@ export const LINK_COLOR = "#00f";
 export const DATETIME_FORMAT = /[ymd:]/;
 
 // Ranges
-export const INCORRECT_RANGE_STRING = "#REF";
+export const INCORRECT_RANGE_STRING = CellErrorType.InvalidReference;
 
 // Max Number of history steps kept in memory
 export const MAX_HISTORY_STEPS = 99;

--- a/src/functions/module_info.ts
+++ b/src/functions/module_info.ts
@@ -1,6 +1,25 @@
 import { _lt } from "../translation";
 import { AddFunctionDescription, ArgValue } from "../types";
+import { CellErrorType, NotAvailableError } from "../types/errors";
 import { args } from "./arguments";
+
+// -----------------------------------------------------------------------------
+// ISERR
+// -----------------------------------------------------------------------------
+export const ISERR: AddFunctionDescription = {
+  description: _lt("Whether a value is an error other than #N/A."),
+  args: args(`value (any, lazy) ${_lt("The value to be verified as an error type.")}`),
+  returns: ["BOOLEAN"],
+  compute: function (value: () => ArgValue): boolean {
+    try {
+      value();
+      return false;
+    } catch (e) {
+      return e?.errorType != CellErrorType.NotAvailable;
+    }
+  },
+  isExported: true,
+};
 
 // -----------------------------------------------------------------------------
 // ISERROR
@@ -29,6 +48,24 @@ export const ISLOGICAL: AddFunctionDescription = {
   returns: ["BOOLEAN"],
   compute: function (value: ArgValue): boolean {
     return typeof value === "boolean";
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// ISNA
+// -----------------------------------------------------------------------------
+export const ISNA: AddFunctionDescription = {
+  description: _lt("Whether a value is the error #N/A."),
+  args: args(`value (any, lazy) ${_lt("The value to be verified as an error type.")}`),
+  returns: ["BOOLEAN"],
+  compute: function (value: () => ArgValue): boolean {
+    try {
+      value();
+      return false;
+    } catch (e) {
+      return e?.errorType == CellErrorType.NotAvailable;
+    }
   },
   isExported: true,
 };
@@ -69,6 +106,19 @@ export const ISTEXT: AddFunctionDescription = {
   returns: ["BOOLEAN"],
   compute: function (value: ArgValue): boolean {
     return typeof value === "string";
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// NA
+// -----------------------------------------------------------------------------
+export const NA: AddFunctionDescription = {
+  description: _lt("Returns the error value #N/A."),
+  args: args(``),
+  returns: ["BOOLEAN"],
+  compute: function (value: ArgValue): boolean {
+    throw new NotAvailableError();
   },
   isExported: true,
 };

--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -21,6 +21,7 @@ import {
   TextEvaluation,
   UID,
 } from "../../types";
+import { CellErrorType } from "../../types/errors";
 import { formatValue } from "../format";
 import { markdownLink, parseMarkdownLink, parseSheetLink } from "../misc";
 
@@ -320,6 +321,6 @@ export class BadExpressionCell extends AbstractCell<InvalidEvaluation> {
    * @param properties
    */
   constructor(id: UID, readonly content: string, error: string, properties: CellDisplayProperties) {
-    super(id, { value: "#BAD_EXPR", type: CellValueType.error, error }, properties);
+    super(id, { value: CellErrorType.BadExpression, type: CellValueType.error, error }, properties);
   }
 }

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,7 +1,30 @@
 import { _lt } from "../translation";
 
-export class InvalidReferenceError extends Error {
+export enum CellErrorType {
+  NotAvailable = "#N/A",
+  InvalidReference = "#REF",
+  BadExpression = "#BAD_EXPR",
+  CircularDependency = "#CYCLE",
+  GenericError = "#ERROR",
+}
+
+export class EvaluationError extends Error {
+  errorType: string;
+
+  constructor(cellErrorType: string, message: string) {
+    super(message);
+    this.errorType = cellErrorType;
+  }
+}
+
+export class InvalidReferenceError extends EvaluationError {
   constructor() {
-    super(_lt("Invalid reference"));
+    super(CellErrorType.InvalidReference, _lt("Invalid reference"));
+  }
+}
+
+export class NotAvailableError extends EvaluationError {
+  constructor() {
+    super(CellErrorType.NotAvailable, _lt("Data not available"));
   }
 }

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -11,6 +11,7 @@ import { functionRegistry } from "../../functions";
 import { formatValue, isNumber } from "../../helpers";
 import { mdyDateRegexp, parseDateTime, timeRegexp, ymdDateRegexp } from "../../helpers/dates";
 import { ExcelCellData, Format } from "../../types";
+import { CellErrorType } from "../../types/errors";
 import { XMLAttributes, XMLString } from "../../types/xlsx";
 import { FORCE_DEFAULT_ARGS_FUNCTIONS, NON_RETROCOMPATIBLE_FUNCTIONS } from "../constants";
 import { getCellType, pushElement } from "../helpers/content_helpers";
@@ -36,7 +37,7 @@ export function addFormula(cell: ExcelCellData): {
     const XlsxFormula = adaptFormulaToExcel(formula);
     // hack for cycles : if we don't set a value (be it 0 or #VALUE!), it will appear as invisible on excel,
     // Making it very hard for the client to find where the recursion is.
-    if (cell.value === "#CYCLE") {
+    if (cell.value === CellErrorType.CircularDependency) {
       attrs.push(["t", "str"]);
       cycle = escapeXml/*xml*/ `<v>${cell.value}</v>`;
     }

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -10852,6 +10852,27 @@ Object {
                 </f>
             </c>
         </row>
+        <row r=\\"162\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A162\\" s=\\"1\\">
+                <f>
+                    NA()
+                </f>
+            </c>
+        </row>
+        <row r=\\"163\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A163\\" s=\\"1\\">
+                <f>
+                    ISNA(A162)
+                </f>
+            </c>
+        </row>
+        <row r=\\"164\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A164\\" s=\\"1\\">
+                <f>
+                    ISERR(A162)
+                </f>
+            </c>
+        </row>
     </sheetData>
 </worksheet>",
       "contentType": "sheet",
@@ -13202,6 +13223,27 @@ Object {
             <c r=\\"A161\\" s=\\"1\\">
                 <f>
                     DELTA(1,1)
+                </f>
+            </c>
+        </row>
+        <row r=\\"162\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A162\\" s=\\"1\\">
+                <f>
+                    NA()
+                </f>
+            </c>
+        </row>
+        <row r=\\"163\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A163\\" s=\\"1\\">
+                <f>
+                    ISNA(A162)
+                </f>
+            </c>
+        </row>
+        <row r=\\"164\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A164\\" s=\\"1\\">
+                <f>
+                    ISERR(A162)
                 </f>
             </c>
         </row>

--- a/tests/functions/module_info.test.ts
+++ b/tests/functions/module_info.test.ts
@@ -1,5 +1,48 @@
 import { evaluateCell } from "../test_helpers/helpers";
 
+describe("ISERR formula", () => {
+  test("functional tests on cell arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ISERR()" })).toBe("#BAD_EXPR");
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "TEST" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "=IF()" })).toBe(true);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "=NA()" })).toBe(false);
+  });
+});
+
+describe("ISERR formula", () => {
+  test("functional tests on simple arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ISERR()" })).toBe("#BAD_EXPR");
+    expect(evaluateCell("A1", { A1: '=ISERR("")' })).toBe(false);
+    expect(evaluateCell("A1", { A1: '=ISERR("test")' })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(TRUE)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(FALSE)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(1)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(3%)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(NA())" })).toBe(false);
+
+    expect(evaluateCell("A1", { A1: "=ISERR(1/0)" })).toBe(true); // corresponds to #ERROR error
+  });
+
+  test("functional tests on cell arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "TEST" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "TRUE" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "1" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: '"test"' })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: '"123"' })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: '="TRUE"' })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "=true" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "=false" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "=123" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "=NA()" })).toBe(false);
+
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "=A2" })).toBe(true); // corresponds to #CYCLE error
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "=(+" })).toBe(true); // corresponds to #BAD_EXPR error
+    expect(evaluateCell("A1", { A1: "=ISERR(A2)", A2: "=SQRT(-1)" })).toBe(true); // corresponds to #ERROR error
+  });
+});
+
 describe("ISERROR formula", () => {
   test("functional tests on simple arguments", () => {
     expect(evaluateCell("A1", { A1: "=ISERROR()" })).toBe("#BAD_EXPR");
@@ -10,7 +53,8 @@ describe("ISERROR formula", () => {
     expect(evaluateCell("A1", { A1: "=ISERROR(1)" })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISERROR(3%)" })).toBe(false);
 
-    expect(evaluateCell("A1", { A1: "=ISERROR(1/0)" })).toBe(true); // corespond to #ERROR error
+    expect(evaluateCell("A1", { A1: "=ISERROR(1/0)" })).toBe(true); // corresponds to #ERROR error
+    expect(evaluateCell("A1", { A1: "=ISERROR(NA())" })).toBe(true); // corresponds to #N/A error
   });
 
   test("functional tests on cell arguments", () => {
@@ -25,9 +69,10 @@ describe("ISERROR formula", () => {
     expect(evaluateCell("A1", { A1: "=ISERROR(A2)", A2: "=false" })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISERROR(A2)", A2: "=123" })).toBe(false);
 
-    expect(evaluateCell("A1", { A1: "=ISERROR(A2)", A2: "=A2" })).toBe(true); // corespond to #CYCLE error
-    expect(evaluateCell("A1", { A1: "=ISERROR(A2)", A2: "=(+" })).toBe(true); // corespond to #BAD_EXPR error
-    expect(evaluateCell("A1", { A1: "=ISERROR(A2)", A2: "=SQRT(-1)" })).toBe(true); // corespond to #ERROR error
+    expect(evaluateCell("A1", { A1: "=ISERROR(A2)", A2: "=A2" })).toBe(true); // corresponds to #CYCLE error
+    expect(evaluateCell("A1", { A1: "=ISERROR(A2)", A2: "=(+" })).toBe(true); // corresponds to #BAD_EXPR error
+    expect(evaluateCell("A1", { A1: "=ISERROR(A2)", A2: "=SQRT(-1)" })).toBe(true); // corresponds to #ERROR error
+    expect(evaluateCell("A1", { A1: "=ISERROR(A2)", A2: "=NA()" })).toBe(true); // corresponds to #N/A error
   });
 });
 
@@ -57,6 +102,39 @@ describe("ISLOGICAL formula", () => {
     expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=true" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=false" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=123" })).toBe(false);
+  });
+});
+
+describe("ISNA formula", () => {
+  test("functional tests on simple arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ISNA()" })).toBe("#BAD_EXPR");
+    expect(evaluateCell("A1", { A1: '=ISNA("")' })).toBe(false);
+    expect(evaluateCell("A1", { A1: '=ISNA("test")' })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(TRUE)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(FALSE)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(1)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(3%)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(1/0)" })).toBe(false); // corresponds to #ERROR error
+
+    expect(evaluateCell("A1", { A1: "=ISNA(NA())" })).toBe(true);
+  });
+
+  test("functional tests on cell arguments", () => {
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "TEST" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "TRUE" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "1" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: '"test"' })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: '"123"' })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: '="TRUE"' })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "=true" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "=false" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "=123" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "=A2" })).toBe(false); // corresponds to #CYCLE error
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "=(+" })).toBe(false); // corresponds to #BAD_EXPR error
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "=SQRT(-1)" })).toBe(false); // corresponds to #ERROR error
+
+    expect(evaluateCell("A1", { A1: "=ISNA(A2)", A2: "=NA()" })).toBe(true);
   });
 });
 
@@ -133,5 +211,12 @@ describe("ISTEXT formula", () => {
     expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: '="TRUE"' })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: "=true" })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: "=123" })).toBe(false);
+  });
+});
+
+describe("NA formula", () => {
+  test("functional tests on simple arguments", () => {
+    expect(evaluateCell("A1", { A1: "=NA(0)" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
+    expect(evaluateCell("A1", { A1: "=NA()" })).toBe("#N/A");
   });
 });

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -106,9 +106,9 @@ describe("evaluateCells", () => {
     const grid = { A1: "=A1", A2: "=A1", A3: "=+", A4: "=1 + A3", A5: "=sum('asdf')" };
     const result = evaluateGrid(grid);
     expect(result.A1).toBe("#CYCLE");
-    expect(result.A2).toBe("#ERROR");
+    expect(result.A2).toBe("#CYCLE");
     expect(result.A3).toBe("#BAD_EXPR");
-    expect(result.A4).toBe("#ERROR");
+    expect(result.A4).toBe("#BAD_EXPR");
     expect(result.A5).toBe("#BAD_EXPR");
   });
 

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -261,6 +261,9 @@ const allExportableFormulasData = {
         A159: { content: "=XOR(false, true, false, false)" },
         A160: { content: '=YEAR("3/12/2012")' },
         A161: { content: "=DELTA(1, 1)" },
+        A162: { content: "=NA()" },
+        A163: { content: "=ISNA(A162)" },
+        A164: { content: "=ISERR(A162)" },
 
         // DATA
         G1: { content: "Name", style: 8 },


### PR DESCRIPTION
## Purpose

The aim of this task is to support the simple NA() function that returns #N/A,
which let the user to define some cell as unavailble (often used in combination
with an iferror() of if() function).

The main reason why we want to support this is to avoid breaking XLSX dashboard
that happen to use it on import.

## Specifications

This commit implement the NA(), ISNA() and ISERR functions:
https://support.microsoft.com/en-us/office/na-function-5469c2d1-a90c-4fb5-9bbc-64bd9bb6b47c
https://support.microsoft.com/en-us/office/is-functions-0f2d7971-6019-40a0-a171-f2d869135665

To be able to easily define new custom errors, we added a new class EvaluationError (for
cells that have been evaluated as en error (REF and NA for the moment), used like :
error = new EvaluationError(cellErrorType: string, message: string)

where cellErrorType should be a value from the new enum type CellErrorType, but counldn't
be restricted to this type as we call EvaluationError with cell.evaluated.value as the
cellErrorType.

Thanks to this new error type, every errored evaluation wil throw a new EvaluationError
with the cellErrorType (and a corresponding message), letting us to use this information
to handle the error type, as it has been done in ISNA and ISERR functions.

## BEHAVIOUR CHANGES !

Due to the propagation of the error message, some behaviours has been changed (as well as
the related tests). For exemple, if we have the following configuration :

A1 = A1
A2 = A1

A1 will have a #CYCLE error, while, before this commit, A2 has an #ERROR error. Now, due
to the propagation of the error type, A2 and A1 will have the same error type (#CYCLE).

## Related Task

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo