### PR TITLE
FIX] evaluation_chart: mark charts as outdated for all commands which…

### DIFF
--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -9,13 +9,13 @@ import {
 import { chartTerms } from "../../components/side_panel/translations_terms";
 import { MAX_CHAR_LABEL } from "../../constants";
 import { ChartColors } from "../../helpers/chart";
-import { isDefined, isInside, overlap, recomputeZones, zoneToXc } from "../../helpers/index";
+import { recomputeZones, zoneToXc } from "../../helpers/index";
 import { range } from "../../helpers/misc";
 import { Mode } from "../../model";
 import { Cell } from "../../types";
 import { ChartDefinition, DataSet } from "../../types/chart";
-import { Command } from "../../types/commands";
-import { UID, Zone } from "../../types/misc";
+import { Command, invalidateEvaluationCommands } from "../../types/commands";
+import { UID } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
 export class EvaluationChartPlugin extends UIPlugin {
@@ -26,27 +26,16 @@ export class EvaluationChartPlugin extends UIPlugin {
   readonly chartRuntime: { [figureId: string]: ChartConfiguration } = {};
   private outOfDate: Set<UID> = new Set<UID>();
 
-  beforeHandle(cmd: Command) {
-    switch (cmd.type) {
-      case "REMOVE_COLUMNS_ROWS":
-        const sheet = this.getters.getSheet(cmd.sheetId);
-        const length = cmd.dimension === "ROW" ? sheet.cols.length : sheet.rows.length;
-        const zones: Zone[] = cmd.elements.map((el) => ({
-          top: cmd.dimension === "ROW" ? el : 0,
-          bottom: cmd.dimension === "ROW" ? el : length - 1,
-          left: cmd.dimension === "ROW" ? 0 : el,
-          right: cmd.dimension === "ROW" ? length - 1 : el,
-        }));
-        for (const chartId of Object.keys(this.chartRuntime)) {
-          if (this.areZonesUsedInChart(cmd.sheetId, zones, chartId)) {
-            this.outOfDate.add(chartId);
-          }
-        }
-        break;
-    }
-  }
-
   handle(cmd: Command) {
+    if (
+      invalidateEvaluationCommands.has(cmd.type) ||
+      cmd.type === "EVALUATE_CELLS" ||
+      (cmd.type === "UPDATE_CELL" && "content" in cmd)
+    ) {
+      for (let chartId of Object.keys(this.chartRuntime)) {
+        this.outOfDate.add(chartId);
+      }
+    }
     switch (cmd.type) {
       case "UPDATE_CHART":
       case "CREATE_CHART":
@@ -64,47 +53,11 @@ export class EvaluationChartPlugin extends UIPlugin {
         const chartsIds = this.getters.getChartsIdBySheet(cmd.sheetIdTo);
         this.evaluateUsedSheets(chartsIds);
         break;
-      case "UPDATE_CELL":
-        for (let chartId of Object.keys(this.chartRuntime)) {
-          if (this.isCellUsedInChart(cmd.sheetId, chartId, cmd.col, cmd.row)) {
-            this.outOfDate.add(chartId);
-          }
-        }
-        break;
       case "DELETE_SHEET":
         for (let chartId of Object.keys(this.chartRuntime)) {
           if (!this.getters.getChartDefinition(chartId)) {
             delete this.chartRuntime[chartId];
           }
-        }
-        break;
-      case "ADD_COLUMNS_ROWS":
-        const sheet = this.getters.getSheet(cmd.sheetId);
-        const numberOfElem = cmd.dimension === "ROW" ? sheet.cols.length : sheet.rows.length;
-        const offset = cmd.position === "before" ? 0 : 1;
-        const zone: Zone = {
-          top: cmd.dimension === "ROW" ? cmd.base + offset : 0,
-          bottom: cmd.dimension === "ROW" ? cmd.base + cmd.quantity + offset : numberOfElem - 1,
-          left: cmd.dimension === "ROW" ? 0 : cmd.base + offset,
-          right: cmd.dimension === "ROW" ? numberOfElem - 1 : cmd.base + cmd.quantity + offset,
-        };
-        for (const chartId of Object.keys(this.chartRuntime)) {
-          if (this.areZonesUsedInChart(cmd.sheetId, [zone], chartId)) {
-            this.outOfDate.add(chartId);
-          }
-        }
-        break;
-      case "UNDO":
-      case "REDO":
-        for (let chartId of Object.keys(this.chartRuntime)) {
-          this.outOfDate.add(chartId);
-        }
-        break;
-      case "EVALUATE_CELLS":
-        // if there was an async evaluation of cell, there is no way to know which was updated so all charts must be updated
-        //TODO Need to check that someday
-        for (let id in this.chartRuntime) {
-          this.outOfDate.add(id);
         }
         break;
     }
@@ -219,43 +172,6 @@ export class EvaluationChartPlugin extends UIPlugin {
       };
     }
     return config;
-  }
-
-  private areZonesUsedInChart(sheetId: UID, zones: Zone[], chartId: UID): boolean {
-    const chartDefinition = this.getters.getChartDefinition(chartId);
-    if (!chartDefinition || sheetId !== chartDefinition?.sheetId) {
-      return false;
-    }
-    const ranges = [
-      ...chartDefinition.dataSets.map((ds) => ds.dataRange),
-      chartDefinition.labelRange,
-    ].filter(isDefined);
-    for (let zone of zones) {
-      for (let range of ranges) {
-        if (range.sheetId === sheetId && overlap(range.zone, zone)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private isCellUsedInChart(sheetId: UID, chartId: UID, col: number, row: number): boolean {
-    const chartDefinition = this.getters.getChartDefinition(chartId);
-    if (chartDefinition === undefined) {
-      return false;
-    }
-    const ranges = [
-      ...chartDefinition.dataSets.map((ds) => ds.dataRange),
-      chartDefinition.labelRange,
-    ].filter(isDefined);
-
-    for (let range of ranges) {
-      if (range.sheetId === sheetId && isInside(col, row, range.zone)) {
-        return true;
-      }
-    }
-    return false;
   }
 
   private getSheetIdsUsedInChart(chartDefinition: ChartDefinition): Set<UID> {

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -1467,3 +1467,26 @@ describe("Chart design configuration", () => {
     expect(model.getters.getChartRuntime("42")?.options?.scales?.yAxes![0].position).toBe("right");
   });
 });
+
+describe("Chart evaluation", () => {
+  test("Chart runtime is correctly updated when a value is changed", () => {
+    const model = new Model();
+    setCellContent(model, "A2", "group");
+    setCellContent(model, "B1", "title");
+    setCellContent(model, "B2", "=C3");
+    createChart(
+      model,
+      {
+        dataSets: ["B1:B2"],
+        dataSetsHaveTitle: true,
+        labelRange: "A2",
+      },
+      "1"
+    );
+    expect(model.getters.getChartRuntime("1")!.data!.datasets![0]!.data![0]).toBeNull();
+    setCellContent(model, "C3", "1");
+    expect(model.getters.getChartRuntime("1")!.data!.datasets![0]!.data![0]).toBe(1);
+    deleteColumns(model, ["C"]);
+    expect(model.getters.getChartRuntime("1")!.data!.datasets![0]!.data![0]).toBe("#ERROR");
+  });
+});


### PR DESCRIPTION
… invalidate evaluation

When a command which leads to invalidate the evaluation is dispatched,
all the charts should be marked as outdated.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo