### PR TITLE
[IMP] components: remove useless combobox in search and replace pannel

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -47,9 +47,6 @@ interface FindAndReplaceState {
     exactMatch: boolean;
     searchFormulas: boolean;
   };
-  replaceOptions: {
-    modifyFormulas: boolean;
-  };
 }
 
 export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
@@ -90,9 +87,6 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
 
   onFocusSidePanel() {
     this.state.searchOptions.searchFormulas = this.env.model.getters.shouldShowFormulas();
-    this.state.replaceOptions.modifyFormulas = this.state.searchOptions.searchFormulas
-      ? this.state.searchOptions.searchFormulas
-      : this.state.replaceOptions.modifyFormulas;
     this.env.model.dispatch("REFRESH_SEARCH");
   }
 
@@ -100,7 +94,6 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     this.env.model.dispatch("SET_FORMULA_VISIBILITY", {
       show: this.state.searchOptions.searchFormulas,
     });
-    this.state.replaceOptions.modifyFormulas = this.state.searchOptions.searchFormulas;
     this.updateSearch();
   }
 
@@ -126,14 +119,12 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
   replace() {
     this.env.model.dispatch("REPLACE_SEARCH", {
       replaceWith: this.state.replaceWith,
-      replaceOptions: this.state.replaceOptions,
     });
   }
 
   replaceAll() {
     this.env.model.dispatch("REPLACE_ALL_SEARCH", {
       replaceWith: this.state.replaceWith,
-      replaceOptions: this.state.replaceOptions,
     });
   }
 
@@ -156,9 +147,6 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
         matchCase: false,
         exactMatch: false,
         searchFormulas: false,
-      },
-      replaceOptions: {
-        modifyFormulas: false,
       },
     };
   }

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -80,18 +80,6 @@
             t-on-keydown="onKeydownReplace"
           />
         </div>
-
-        <div class="o-far-item">
-          <label class="o-far-checkbox">
-            <input
-              class="o-far-input"
-              t-att-disabled="state.searchOptions.searchFormulas"
-              type="checkbox"
-              t-model="state.replaceOptions.modifyFormulas"
-            />
-            <span class="o-far-label">Also modify formulas</span>
-          </label>
-        </div>
       </div>
 
       <div class="o-sidePanelButtons" t-if="!env.model.getters.isReadonly()">

--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -10,10 +10,6 @@ export interface SearchOptions {
   searchFormulas: boolean;
 }
 
-export interface ReplaceOptions {
-  modifyFormulas: boolean;
-}
-
 export enum Direction {
   previous = -1,
   current = 0,
@@ -47,9 +43,6 @@ export class FindAndReplacePlugin extends UIPlugin {
     exactMatch: false,
     searchFormulas: false,
   };
-  private replaceOptions: ReplaceOptions = {
-    modifyFormulas: false,
-  };
   private toSearch: string = "";
 
   // ---------------------------------------------------------------------------
@@ -71,10 +64,10 @@ export class FindAndReplacePlugin extends UIPlugin {
         this.selectNextCell(Direction.next);
         break;
       case "REPLACE_SEARCH":
-        this.replace(cmd.replaceWith, cmd.replaceOptions);
+        this.replace(cmd.replaceWith);
         break;
       case "REPLACE_ALL_SEARCH":
-        this.replaceAll(cmd.replaceWith, cmd.replaceOptions);
+        this.replaceAll(cmd.replaceWith);
         break;
       case "UNDO":
       case "REDO":
@@ -214,20 +207,15 @@ export class FindAndReplacePlugin extends UIPlugin {
       exactMatch: false,
       searchFormulas: false,
     };
-    this.replaceOptions = {
-      modifyFormulas: false,
-    };
   }
 
   // ---------------------------------------------------------------------------
   // Replace
   // ---------------------------------------------------------------------------
   /**
-   * Replace the value of the currently selected match if the replaceOptions
-   * allow it
+   * Replace the value of the currently selected match
    */
-  private replace(replaceWith: string, replaceOptions: ReplaceOptions) {
-    this.replaceOptions = replaceOptions;
+  private replace(replaceWith: string) {
     if (this.selectedMatchIndex === null || !this.currentSearchRegex) {
       return;
     }
@@ -257,10 +245,10 @@ export class FindAndReplacePlugin extends UIPlugin {
   /**
    * Apply the replace function to all the matches one time.
    */
-  private replaceAll(replaceWith: string, replaceOptions: ReplaceOptions) {
+  private replaceAll(replaceWith: string) {
     const matchCount = this.searchMatches.length;
     for (let i = 0; i < matchCount; i++) {
-      this.replace(replaceWith, replaceOptions);
+      this.replace(replaceWith);
     }
   }
 
@@ -272,7 +260,7 @@ export class FindAndReplacePlugin extends UIPlugin {
     if (cell) {
       if (this.searchOptions.searchFormulas && cell.isFormula()) {
         return cell.content;
-      } else if (this.replaceOptions.modifyFormulas || !cell.isFormula()) {
+      } else if (this.searchOptions.searchFormulas || !cell.isFormula()) {
         return (cell.evaluated.value as any).toString();
       }
     }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,5 +1,5 @@
 import { ComposerSelection } from "../plugins/ui/edition";
-import { ReplaceOptions, SearchOptions } from "../plugins/ui/find_and_replace";
+import { SearchOptions } from "../plugins/ui/find_and_replace";
 import { ChartDefinition } from "./chart/chart";
 import { UpDown } from "./conditional_formatting";
 import { BorderCommand, ConditionalFormat, Figure, Format, Style, Zone } from "./index";
@@ -683,12 +683,10 @@ export interface SelectSearchNextCommand {
 export interface ReplaceSearchCommand {
   type: "REPLACE_SEARCH";
   replaceWith: string;
-  replaceOptions: ReplaceOptions;
 }
 export interface ReplaceAllSearchCommand {
   type: "REPLACE_ALL_SEARCH";
   replaceWith: string;
-  replaceOptions: ReplaceOptions;
 }
 
 export interface SortCommand {

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -192,10 +192,7 @@ describe("find and replace sidePanel component", () => {
       const dispatch = spyDispatch(parent);
       triggerMouseEvent(document.querySelector(selectors.replaceButton), "click");
       await nextTick();
-      expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", {
-        replaceOptions: { modifyFormulas: false },
-        replaceWith: "kikou",
-      });
+      expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "kikou" });
     });
 
     test("Can replace a value in a formula", async () => {
@@ -205,23 +202,7 @@ describe("find and replace sidePanel component", () => {
       const dispatch = spyDispatch(parent);
       triggerMouseEvent(document.querySelector(selectors.replaceButton), "click");
       await nextTick();
-      expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", {
-        replaceOptions: { modifyFormulas: true },
-        replaceWith: "4",
-      });
-    });
-
-    test("formulas will be overwritten if modify formula is checked", async () => {
-      setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "4", "input");
-      setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "2", "input");
-      triggerMouseEvent(document.querySelector(selectors.checkBoxReplaceFormulas), "click");
-      const dispatch = spyDispatch(parent);
-      triggerMouseEvent(document.querySelector(selectors.replaceButton), "click");
-      await nextTick();
-      expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", {
-        replaceOptions: { modifyFormulas: true },
-        replaceWith: "2",
-      });
+      expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "4" });
     });
 
     test("formulas wont be modified if not looking in formulas or not modifying formulas", async () => {
@@ -230,10 +211,7 @@ describe("find and replace sidePanel component", () => {
       const dispatch = spyDispatch(parent);
       triggerMouseEvent(document.querySelector(selectors.replaceButton), "click");
       await nextTick();
-      expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", {
-        replaceOptions: { modifyFormulas: false },
-        replaceWith: "2",
-      });
+      expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "2" });
     });
 
     test("can replace all", async () => {
@@ -242,10 +220,7 @@ describe("find and replace sidePanel component", () => {
       const dispatch = spyDispatch(parent);
       triggerMouseEvent(document.querySelector(selectors.replaceAllButton), "click");
       await nextTick();
-      expect(dispatch).toHaveBeenCalledWith("REPLACE_ALL_SEARCH", {
-        replaceOptions: { modifyFormulas: false },
-        replaceWith: "kikou",
-      });
+      expect(dispatch).toHaveBeenCalledWith("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
     });
 
     test("Can replace with Enter key", async () => {
@@ -256,10 +231,7 @@ describe("find and replace sidePanel component", () => {
         .querySelector(selectors.inputReplace)!
         .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
       await nextTick();
-      expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", {
-        replaceOptions: { modifyFormulas: false },
-        replaceWith: "kikou",
-      });
+      expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "kikou" });
     });
   });
 });

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -1,11 +1,10 @@
 import { Model } from "../../src";
-import { ReplaceOptions, SearchOptions } from "../../src/plugins/ui/find_and_replace";
+import { SearchOptions } from "../../src/plugins/ui/find_and_replace";
 import { activateSheet, createSheet, setCellContent } from "../test_helpers/commands_helpers";
 import { getCellContent, getCellText } from "../test_helpers/getters_helpers";
 
 let model: Model;
 let searchOptions: SearchOptions;
-let replaceOptions: ReplaceOptions;
 
 describe("basic search", () => {
   beforeEach(() => {
@@ -399,12 +398,11 @@ describe("replace", () => {
       exactMatch: false,
       searchFormulas: false,
     };
-    replaceOptions = { modifyFormulas: false };
   });
 
   test("Can replace a simple text value", () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "hello", searchOptions });
-    model.dispatch("REPLACE_SEARCH", { replaceWith: "kikou", replaceOptions });
+    model.dispatch("REPLACE_SEARCH", { replaceWith: "kikou" });
     const matches = model.getters.getSearchMatches();
     const matchIndex = model.getters.getCurrentSelectedMatchIndex();
     expect(matches).toHaveLength(0);
@@ -415,8 +413,7 @@ describe("replace", () => {
   test("Can replace a value in a formula", () => {
     searchOptions.searchFormulas = true;
     model.dispatch("UPDATE_SEARCH", { toSearch: "2", searchOptions });
-    replaceOptions.modifyFormulas = true;
-    model.dispatch("REPLACE_SEARCH", { replaceWith: "4", replaceOptions });
+    model.dispatch("REPLACE_SEARCH", { replaceWith: "4" });
     const matches = model.getters.getSearchMatches();
     const matchIndex = model.getters.getCurrentSelectedMatchIndex();
     expect(matches).toHaveLength(0);
@@ -424,20 +421,9 @@ describe("replace", () => {
     expect(getCellText(model, "A2")).toBe("=SUM(4,4)");
   });
 
-  test("formulas will be overwritten if modify formula is checked", () => {
-    model.dispatch("UPDATE_SEARCH", { toSearch: "4", searchOptions });
-    replaceOptions.modifyFormulas = true;
-    model.dispatch("REPLACE_SEARCH", { replaceWith: "2", replaceOptions });
-    const matches = model.getters.getSearchMatches();
-    const matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(matches).toHaveLength(0);
-    expect(matchIndex).toStrictEqual(null);
-    expect(getCellContent(model, "A2")).toBe("2");
-  });
-
   test("formulas wont be modified if not looking in formulas or not modifying formulas", () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "4", searchOptions });
-    model.dispatch("REPLACE_SEARCH", { replaceWith: "2", replaceOptions });
+    model.dispatch("REPLACE_SEARCH", { replaceWith: "2" });
     const matches = model.getters.getSearchMatches();
     const matchIndex = model.getters.getCurrentSelectedMatchIndex();
     expect(matches).toHaveLength(1);
@@ -447,7 +433,7 @@ describe("replace", () => {
 
   test("can replace all", () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "hell", searchOptions });
-    model.dispatch("REPLACE_ALL_SEARCH", { replaceWith: "kikou", replaceOptions });
+    model.dispatch("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
     const matches = model.getters.getSearchMatches();
     const matchIndex = model.getters.getCurrentSelectedMatchIndex();
     expect(matches).toHaveLength(0);


### PR DESCRIPTION
## TASK DESCRIPTION

When opening the Search and Replace pannel, we have two checkboxes that have the same use : to see, search and replace in the formulas instead of the values of the cells. As using the replace checkbox without the search checkbox is
senseless and triggering the search checkbox automatically adapt the replace checkbox to match, we decided to remove the replace checkbox.

## COMMIT INFORMATION

After removing the checkbox from the pannel, we also removed the dict property replaceOptions, as it only contained the checkbox value, which don't have to be stored anymore. The replace and search_and_replace functions' argument has then be changed from a dictionnary to a simple boolean, where the value of this bool is now read from the search checkbox.

## RELATED TASK
Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## REVIEW CHECKLIST

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo