### PR TITLE
[FIX] chart: point [0;0] not displayed for linear charts

### DIFF
--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -393,7 +393,7 @@ export class EvaluationChartPlugin extends UIPlugin {
         labels.formattedValues = this.getters.getRangeFormattedValues(definition.labelRange);
         labels.values = this.getters
           .getRangeValues(definition.labelRange)
-          .map((val) => (val ? String(val) : ""));
+          .map((val) => (val !== undefined && val !== null ? String(val) : ""));
       }
     } else if (definition.dataSets.length === 1) {
       for (let i = 0; i < this.getData(definition.dataSets[0], definition.sheetId).length; i++) {

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -1650,6 +1650,30 @@ describe("Linear/Time charts", () => {
     expect(chart.data!.datasets![0].data![1]).toEqual({ y: undefined, x: "1/17/1900" });
   });
 
+  test("linear chart: label 0 isn't set to undefined", () => {
+    setCellContent(model, "B2", "0");
+    setCellContent(model, "B3", "1");
+    setCellContent(model, "C2", "0");
+    setCellContent(model, "C3", "1");
+    createChart(
+      model,
+      {
+        type: "line",
+        dataSets: ["B2:B3"],
+        labelRange: "C2:C3",
+        labelsAsText: false,
+        dataSetsHaveTitle: false,
+      },
+      chartId
+    );
+    const chart = model.getters.getChartRuntime(chartId)!;
+    expect(chart.data!.labels).toEqual(["0", "1"]);
+    expect(chart.data!.datasets![0].data).toEqual([
+      { y: 0, x: "0" },
+      { y: 1, x: "1" },
+    ]);
+  });
+
   test("linear chart: empty label with a value is set to undefined instead of empty string", () => {
     createChart(
       model,


### PR DESCRIPTION
## Description:

Odoo task ID : [2866964](https://www.odoo.com/web#id=2866964&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo