### PR TITLE
[FIX] align: formula referencing empty cell alignment

### DIFF
--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -61,12 +61,12 @@ abstract class AbstractCell<T extends CellEvaluation = CellEvaluation> implement
   get defaultAlign() {
     switch (this.evaluated.type) {
       case CellValueType.number:
+      case CellValueType.empty:
         return "right";
       case CellValueType.boolean:
       case CellValueType.error:
         return "center";
       case CellValueType.text:
-      case CellValueType.empty:
         return "left";
     }
   }

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -128,6 +128,24 @@ describe("renderer", () => {
     expect(textAligns).toEqual(["left", "left", "center"]); // center for headers
   });
 
+  test("formulas referencing an empty cell are properly aligned", () => {
+    const model = new Model();
+
+    setCellContent(model, "A1", "=A2");
+
+    let textAligns: string[] = [];
+    let ctx = new MockGridRenderingContext(model, 1000, 1000, {
+      onSet: (key, value) => {
+        if (key === "textAlign") {
+          textAligns.push(value);
+        }
+      },
+    });
+
+    model.drawGrid(ctx);
+    expect(textAligns).toEqual(["right", "center"]); // center for headers
+  });
+
   test("numbers are aligned right when overflowing vertically", () => {
     const model = new Model();
 


### PR DESCRIPTION
Before the formulas that referenced an empty cells were aligned left, even though their display value was 0 (a number, thus aligned right).

Odoo task 2867136

Odoo task ID : [2867136](https://www.odoo.com/web#id=2867136&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo