### PR TITLE
[IMP] errors_handling: add a log level to display errors

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -30,6 +30,7 @@ import { cellMenuRegistry } from "../../registries/menus/cell_menu_registry";
 import { colMenuRegistry } from "../../registries/menus/col_menu_registry";
 import { dashboardMenuRegistry } from "../../registries/menus/dashboard_menu_registry";
 import { rowMenuRegistry } from "../../registries/menus/row_menu_registry";
+import { CellErrorLevel } from "../../types/errors";
 import {
   CellValueType,
   Client,
@@ -354,7 +355,11 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     );
     const cell = this.env.model.getters.getCell(sheetId, mainCol, mainRow);
 
-    if (cell && cell.evaluated.type === CellValueType.error) {
+    if (
+      cell &&
+      cell.evaluated.type === CellValueType.error &&
+      cell.evaluated.error.logLevel > CellErrorLevel.silent
+    ) {
       const viewport = this.env.model.getters.getActiveSnappedViewport();
       const [x, y, width] = this.env.model.getters.getRect(
         { left: col, top: row, right: col, bottom: row },
@@ -366,7 +371,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
           x: x + width + this.canvasPosition.x,
           y: y + this.canvasPosition.y,
         },
-        text: cell.evaluated.error,
+        text: cell.evaluated.error.message,
         cellWidth: width,
       };
     }

--- a/src/helpers/cells/cell_factory.ts
+++ b/src/helpers/cells/cell_factory.ts
@@ -3,6 +3,7 @@ import { DEFAULT_ERROR_MESSAGE } from "../../constants";
 import { compile } from "../../formulas";
 import { cellRegistry } from "../../registries/cell_types";
 import { Cell, CellDisplayProperties, CoreGetters, UID } from "../../types";
+import { BadExpressionError } from "../../types/errors";
 import { parseDateTime } from "../dates";
 import {
   isBoolean,
@@ -136,7 +137,12 @@ export function cellFactory(getters: CoreGetters) {
     try {
       return builder.createCell(id, content, properties, sheetId, getters);
     } catch (error) {
-      return new BadExpressionCell(id, content, error.message || DEFAULT_ERROR_MESSAGE, properties);
+      return new BadExpressionCell(
+        id,
+        content,
+        new BadExpressionError(error.message || DEFAULT_ERROR_MESSAGE),
+        properties
+      );
     }
   };
 }

--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -21,7 +21,7 @@ import {
   TextEvaluation,
   UID,
 } from "../../types";
-import { CellErrorType } from "../../types/errors";
+import { CellErrorType, EvaluationError } from "../../types/errors";
 import { formatValue } from "../format";
 import { markdownLink, parseMarkdownLink, parseSheetLink } from "../misc";
 
@@ -300,10 +300,10 @@ export class FormulaCell extends AbstractCell implements IFormulaCell {
     }
   }
 
-  assignError(value: string, errorMessage: string) {
+  assignError(value: string, error: EvaluationError) {
     this.evaluated = {
       value,
-      error: errorMessage,
+      error,
       type: CellValueType.error,
     };
   }
@@ -320,7 +320,20 @@ export class BadExpressionCell extends AbstractCell<InvalidEvaluation> {
    * @param error Compilation or parsing error
    * @param properties
    */
-  constructor(id: UID, readonly content: string, error: string, properties: CellDisplayProperties) {
-    super(id, { value: CellErrorType.BadExpression, type: CellValueType.error, error }, properties);
+  constructor(
+    id: UID,
+    readonly content: string,
+    error: EvaluationError,
+    properties: CellDisplayProperties
+  ) {
+    super(
+      id,
+      {
+        value: CellErrorType.BadExpression,
+        type: CellValueType.error,
+        error,
+      },
+      properties
+    );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ export {
   TransportService,
 } from "./types/collaborative/transport_service";
 export { coreTypes, invalidateEvaluationCommands, readonlyAllowedCommands } from "./types/commands";
+export { EvaluationError } from "./types/errors";
 export const SPREADSHEET_DIMENSIONS = {
   MIN_ROW_HEIGHT,
   MIN_COL_WIDTH,

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -24,6 +24,7 @@ import {
   searchHeaderIndex,
   union,
 } from "../../helpers/index";
+import { CellErrorLevel } from "../../types/errors";
 import {
   Align,
   Box,
@@ -641,8 +642,11 @@ export class RendererPlugin extends UIPlugin {
     };
 
     /** Error */
-    if (cell.evaluated.type === CellValueType.error) {
-      box.error = cell.evaluated.error;
+    if (
+      cell.evaluated.type === CellValueType.error &&
+      cell.evaluated.error.logLevel > CellErrorLevel.silent
+    ) {
+      box.error = cell.evaluated.error.message;
     }
 
     /** ClipRect */

--- a/src/types/cells.ts
+++ b/src/types/cells.ts
@@ -1,4 +1,5 @@
 import { SpreadsheetChildEnv } from "./env";
+import { EvaluationError } from "./errors";
 import { Format, FormattedValue } from "./format";
 import { CompiledFormula, Link, Range, Style, UID } from "./misc";
 
@@ -45,7 +46,7 @@ export interface ICell {
 
 export interface FormulaCell extends ICell {
   assignValue: (value: CellValue) => void;
-  assignError: (value: string, errorMessage: string) => void;
+  assignError: (value: string, error: EvaluationError) => void;
   startEvaluation: () => void;
   readonly normalizedText: string;
   readonly compiledFormula: CompiledFormula;
@@ -102,7 +103,7 @@ export type EmptyEvaluation = {
 export type InvalidEvaluation = {
   readonly type: CellValueType.error;
   readonly value: string;
-  readonly error: string;
+  readonly error: EvaluationError;
 };
 
 export type CellEvaluation =

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -8,12 +8,30 @@ export enum CellErrorType {
   GenericError = "#ERROR",
 }
 
-export class EvaluationError extends Error {
-  errorType: string;
+export enum CellErrorLevel {
+  silent = 0,
+  error = 1,
+}
 
-  constructor(cellErrorType: string, message: string) {
+export class EvaluationError extends Error {
+  constructor(
+    readonly errorType: string,
+    message: string,
+    readonly logLevel: number = CellErrorLevel.error
+  ) {
     super(message);
-    this.errorType = cellErrorType;
+  }
+}
+
+export class BadExpressionError extends EvaluationError {
+  constructor(errorMessage: string) {
+    super(CellErrorType.BadExpression, errorMessage);
+  }
+}
+
+export class CircularDependencyError extends EvaluationError {
+  constructor() {
+    super(CellErrorType.CircularDependency, _lt("Circular reference"));
   }
 }
 
@@ -25,6 +43,6 @@ export class InvalidReferenceError extends EvaluationError {
 
 export class NotAvailableError extends EvaluationError {
   constructor() {
-    super(CellErrorType.NotAvailable, _lt("Data not available"));
+    super(CellErrorType.NotAvailable, _lt("Data not available"), CellErrorLevel.silent);
   }
 }

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -735,6 +735,17 @@ describe("error tooltip", () => {
     expect(document.querySelector(".o-error-tooltip")).not.toBeNull();
   });
 
+  test("don't display error on #N/A", async () => {
+    Date.now = jest.fn(() => 0);
+    setCellContent(model, "A1", "=NA()");
+    await nextTick();
+    gridMouseEvent(model, "mousemove", "A1");
+    Date.now = jest.fn(() => 500);
+    jest.advanceTimersByTime(300);
+    await nextTick();
+    expect(document.querySelector(".o-error-tooltip")).toBeNull();
+  });
+
   test("can display error tooltip", async () => {
     Date.now = jest.fn(() => 0);
     setCellContent(model, "C8", "=1/0");

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -206,7 +206,7 @@ describe("evaluateCells", () => {
     const model = new Model();
     setCellContent(model, "A1", formula);
     let evaluation = getCell(model, "A1")?.evaluated as InvalidEvaluation;
-    const error = evaluation.error;
+    const error = evaluation.error.message;
     const value = evaluation.value;
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
@@ -215,7 +215,7 @@ describe("evaluateCells", () => {
     });
     evaluation = getCell(model, "A1")?.evaluated as InvalidEvaluation;
     expect(evaluation.type).toBe(CellValueType.error);
-    expect(evaluation.error).toBe(error);
+    expect(evaluation.error.message).toBe(error);
     expect(evaluation.value).toBe(value);
   });
 

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -38,7 +38,9 @@ export function getCellError(
   sheetId: UID = model.getters.getActiveSheetId()
 ): string | undefined {
   const cell = getCell(model, xc, sheetId);
-  return cell && cell.evaluated.type === CellValueType.error ? cell.evaluated.error : undefined;
+  return cell && cell.evaluated.type === CellValueType.error
+    ? cell.evaluated.error.message
+    : undefined;
 }
 
 /**


### PR DESCRIPTION
## TASK DESCRIPTION

The aim of this task is to hide the ERROR symbole (red triangle in the upper right corner of the cell) for some kind of error.
This is done by adding an ErrorLevel to the error classes so that the errors having 'silent' as level are not displayed.

Currently, only the NotAvailable error is silent, as this error is defined by the user.

## RELATED TASK
Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo