### PR TITLE
[IMP] clipboard: paste value from OS clipboard

### DIFF
--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -202,11 +202,24 @@ describe("Menu Item actions", () => {
     expect(getNode(["edit", "paste_special"]).isVisible(env)).toBeTruthy();
   });
 
-  test("Edit -> paste_special -> paste_special_value", () => {
+  test("Edit -> paste_special -> paste_special_value", async () => {
+    doAction(["edit", "copy"], env);
     doAction(["edit", "paste_special", "paste_special_value"], env);
+    await nextTick();
     expect(dispatch).toHaveBeenCalledWith("PASTE", {
       target: env.model.getters.getSelectedZones(),
       pasteOption: "onlyValue",
+    });
+  });
+
+  test("Edit -> paste_special -> paste_special_value from OS clipboard", async () => {
+    const text = "in OS clipboard";
+    await env.clipboard.writeText(text);
+    doAction(["edit", "paste_special", "paste_special_value"], env);
+    await nextTick();
+    expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
+      target: target("A1"),
+      text,
     });
   });
 


### PR DESCRIPTION
Copy something outside the spreadsheet
Edit > Paste special > Paste value only
=> nothing happens

Note: pasting from the OS clipboard isn't currently
interactive. Maybe it should ?

Task 2870923

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2870923](https://www.odoo.com/web#id=2870923&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo