### PR TITLE
[REF] evaluation: simplify reference evaluation functions

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -43,8 +43,8 @@ function splitCodeLines(codeBlocks: string[]): string[] {
  * Used as intermediate compilation.
  * Formula `=SUM(|0|, |1|)` gives the following code.
  * ```js
- * let _2 = range(0, deps, sheetId)
- * let _3 = range(1, deps, sheetId)
+ * let _2 = range(deps[0])
+ * let _3 = range(deps[1])
  * ctx.__lastFnCalled = 'SUM'
  * let _1 = ctx['SUM'](_2,_3)
  * ```
@@ -104,7 +104,6 @@ export function compile(formula: string): CompiledFormula {
     ]).join("\n");
     let baseFunction = new Function(
       "deps", // the dependencies in the current formula
-      "sheetId", // the sheet the formula is currently evaluating
       "ref", // a function to access a certain dependency at a given index
       "range", // same as above, but guarantee that the result is in the form of a range
       "ctx",
@@ -282,9 +281,9 @@ export function compile(formula: string): CompiledFormula {
           const referenceIndex = dependencies.indexOf(ast.value);
           id = nextId++;
           if (hasRange) {
-            statement = `range(${referenceIndex}, deps, sheetId)`;
+            statement = `range(deps[${referenceIndex}])`;
           } else {
-            statement = `ref(${referenceIndex}, deps, sheetId, ${isMeta ? "true" : "false"}, "${
+            statement = `ref(deps[${referenceIndex}], ${isMeta ? "true" : "false"}, "${
               referenceVerification.functionName || OPERATOR_MAP["="]
             }",  ${referenceVerification.paramIndex})`;
           }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -120,21 +120,18 @@ export type Range = {
   prefixSheet: boolean; // true if the user provided the range with the sheet name, so it has to be recomputed with the sheet name too
 };
 export type ReferenceDenormalizer = (
-  position: number,
-  references: Range[],
-  sheetId: UID,
+  range: Range,
   isMeta: boolean,
   functionName: string,
   paramNumber: number
 ) => any | any[][];
 
-export type EnsureRange = (position: number, references: Range[], sheetId: UID) => any[][];
+export type EnsureRange = (range: Range) => any[][];
 
 export type NumberParser = (str: string) => number;
 
 export type _CompiledFormula = (
   deps: Range[],
-  sheetId: UID,
   refFn: ReferenceDenormalizer,
   range: EnsureRange,
   ctx: {}

--- a/tests/formulas/__snapshots__/compiler.test.ts.snap
+++ b/tests/formulas/__snapshots__/compiler.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compile functions with lazy arguments functions call requesting lazy parameters 1`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =USELAZYARG(|N0|)
 const _2 = () => {
@@ -14,7 +14,7 @@ return _1;
 `;
 
 exports[`compile functions with lazy arguments functions call requesting lazy parameters 2`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =USELAZYARG(|N0|/|N1|)
 const _2 = () => {
@@ -30,7 +30,7 @@ return _1;
 `;
 
 exports[`compile functions with lazy arguments functions call requesting lazy parameters 3`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =USELAZYARG(|N0|/|N0|/|N1|)
 const _2 = () => {
@@ -49,7 +49,7 @@ return _1;
 `;
 
 exports[`compile functions with lazy arguments functions call requesting lazy parameters 4`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =USELAZYARG(USELAZYARG(|N0|))
 const _2 = () => {
@@ -66,10 +66,10 @@ return _1;
 `;
 
 exports[`compile functions with meta arguments function call requesting meta parameter 1`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =USEMETAARG(|0|)
-let _2 = ref(0, deps, sheetId, true, \\"USEMETAARG\\",  1);
+let _2 = ref(deps[0], true, \\"USEMETAARG\\",  1);
 ctx.__lastFnCalled = 'USEMETAARG';
 let _1 = ctx['USEMETAARG'](_2);
 return _1;
@@ -77,10 +77,10 @@ return _1;
 `;
 
 exports[`compile functions with meta arguments function call requesting meta parameter 2`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =USEMETAARG(|0|)
-let _2 = ref(0, deps, sheetId, true, \\"USEMETAARG\\",  1);
+let _2 = ref(deps[0], true, \\"USEMETAARG\\",  1);
 ctx.__lastFnCalled = 'USEMETAARG';
 let _1 = ctx['USEMETAARG'](_2);
 return _1;
@@ -88,10 +88,10 @@ return _1;
 `;
 
 exports[`expression compiler cells are converted to ranges if function require a range 1`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|0|)
-let _2 = range(0, deps, sheetId);
+let _2 = range(deps[0]);
 ctx.__lastFnCalled = 'SUM';
 let _1 = ctx['SUM'](_2);
 return _1;
@@ -99,14 +99,14 @@ return _1;
 `;
 
 exports[`expression compiler expression with $ref 1`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|0|+|1|+|2|
-let _3 = ref(0, deps, sheetId, false, \\"ADD\\",  undefined);
-let _4 = ref(1, deps, sheetId, false, \\"ADD\\",  undefined);
+let _3 = ref(deps[0], false, \\"ADD\\",  undefined);
+let _4 = ref(deps[1], false, \\"ADD\\",  undefined);
 ctx.__lastFnCalled = 'ADD';
 let _2 = ctx['ADD'](_3, _4);
-let _5 = ref(2, deps, sheetId, false, \\"ADD\\",  undefined);
+let _5 = ref(deps[2], false, \\"ADD\\",  undefined);
 ctx.__lastFnCalled = 'ADD';
 let _1 = ctx['ADD'](_2, _5);
 return _1;
@@ -114,20 +114,20 @@ return _1;
 `;
 
 exports[`expression compiler expression with references with a sheet 1`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|0|
-let _1 = ref(0, deps, sheetId, false, \\"EQ\\",  undefined);
+let _1 = ref(deps[0], false, \\"EQ\\",  undefined);
 return _1;
 }"
 `;
 
 exports[`expression compiler expressions with a debugger 1`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =? |0| / |N0|
 debugger;
-let _2 = ref(0, deps, sheetId, false, \\"DIVIDE\\",  undefined);
+let _2 = ref(deps[0], false, \\"DIVIDE\\",  undefined);
 let _3 = this.constantValues.numbers[0];
 ctx.__lastFnCalled = 'DIVIDE';
 let _1 = ctx['DIVIDE'](_2, _3);
@@ -136,11 +136,11 @@ return _1;
 `;
 
 exports[`expression compiler read some values and functions 1`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|0| + sum(|1|)
-let _2 = ref(0, deps, sheetId, false, \\"ADD\\",  undefined);
-let _4 = range(1, deps, sheetId);
+let _2 = ref(deps[0], false, \\"ADD\\",  undefined);
+let _4 = range(deps[1]);
 ctx.__lastFnCalled = 'SUM';
 let _3 = ctx['SUM'](_4);
 ctx.__lastFnCalled = 'ADD';
@@ -150,7 +150,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 1`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|
 let _1 = this.constantValues.numbers[0];
@@ -159,7 +159,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 2`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =true
 return true;
@@ -167,7 +167,7 @@ return true;
 `;
 
 exports[`expression compiler some arithmetic expressions 3`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|S0|
 let _1 = this.constantValues.strings[0];
@@ -176,7 +176,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 4`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|N0| + |N1|
 let _2 = this.constantValues.numbers[0];
@@ -188,7 +188,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 5`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|N0| * |N1|
 let _2 = this.constantValues.numbers[0];
@@ -200,7 +200,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 6`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|N0| - |N1|
 let _2 = this.constantValues.numbers[0];
@@ -212,7 +212,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 7`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|N0| / |N1|
 let _2 = this.constantValues.numbers[0];
@@ -224,7 +224,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 8`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =-|N0|
 let _2 = this.constantValues.numbers[0];
@@ -235,7 +235,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 9`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =(|N0| + |N1|) * (-|N1| + |N2|)
 let _3 = this.constantValues.numbers[0];
@@ -255,7 +255,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 10`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|N0|,|N1|)
 let _2 = this.constantValues.numbers[0];
@@ -267,7 +267,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 11`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =sum(true, |S0|)
 let _2 = this.constantValues.strings[0];
@@ -278,7 +278,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 12`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|N0|,,|N1|)
 let _2 = this.constantValues.numbers[0];
@@ -290,7 +290,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 13`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|%
 let _2 = this.constantValues.numbers[0];
@@ -301,7 +301,7 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 14`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =(|N0|+|N1|)%
 let _3 = this.constantValues.numbers[0];
@@ -315,10 +315,10 @@ return _1;
 `;
 
 exports[`expression compiler some arithmetic expressions 15`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =|0|%
-let _2 = ref(0, deps, sheetId, false, \\"UNARY.PERCENT\\",  undefined);
+let _2 = ref(deps[0], false, \\"UNARY.PERCENT\\",  undefined);
 ctx.__lastFnCalled = 'UNARY.PERCENT';
 let _1 = ctx['UNARY.PERCENT']( _2);
 return _1;
@@ -326,12 +326,12 @@ return _1;
 `;
 
 exports[`expression compiler with the same reference multiple times 1`] = `
-"function anonymous(deps,sheetId,ref,range,ctx
+"function anonymous(deps,ref,range,ctx
 ) {
 // =SUM(|0|, |0|, |2|)
-let _2 = range(0, deps, sheetId);
-let _3 = range(0, deps, sheetId);
-let _4 = range(2, deps, sheetId);
+let _2 = range(deps[0]);
+let _3 = range(deps[0]);
+let _4 = range(deps[2]);
 ctx.__lastFnCalled = 'SUM';
 let _1 = ctx['SUM'](_2,_3,_4);
 return _1;

--- a/tests/formulas/compiler.test.ts
+++ b/tests/formulas/compiler.test.ts
@@ -460,23 +460,23 @@ describe("compile functions", () => {
       const rangeA1 = [{ zone: toZone("A1"), sheetId: "ABC" }] as Range[];
       const rangeA1ToB2 = [{ zone: toZone("A1:B2"), sheetId: "ABC" }] as Range[];
 
-      compiledFormula1.execute(rangeA1, "ABC", refFn, ensureRange, ctx);
-      expect(refFn).toHaveBeenCalledWith(0, rangeA1, "ABC", true, "USEMETAARG", 1);
+      compiledFormula1.execute(rangeA1, refFn, ensureRange, ctx);
+      expect(refFn).toHaveBeenCalledWith(rangeA1[0], true, "USEMETAARG", 1);
       expect(ensureRange).toHaveBeenCalledTimes(0);
       refFn.mockReset();
 
-      compiledFormula2.execute(rangeA1ToB2, "ABC", refFn, ensureRange, ctx);
-      expect(refFn).toHaveBeenCalledWith(0, rangeA1ToB2, "ABC", true, "USEMETAARG", 1);
+      compiledFormula2.execute(rangeA1ToB2, refFn, ensureRange, ctx);
+      expect(refFn).toHaveBeenCalledWith(rangeA1ToB2[0], true, "USEMETAARG", 1);
       expect(ensureRange).toHaveBeenCalledTimes(0);
       refFn.mockReset();
 
-      compiledFormula3.execute(rangeA1, "ABC", refFn, ensureRange, ctx);
-      expect(refFn).toHaveBeenCalledWith(0, rangeA1, "ABC", false, "NOTUSEMETAARG", 1);
+      compiledFormula3.execute(rangeA1, refFn, ensureRange, ctx);
+      expect(refFn).toHaveBeenCalledWith(rangeA1[0], false, "NOTUSEMETAARG", 1);
       expect(ensureRange).toHaveBeenCalledTimes(0);
       refFn.mockReset();
 
-      compiledFormula4.execute(rangeA1ToB2, "ABC", refFn, ensureRange, ctx);
-      expect(refFn).toHaveBeenCalledWith(0, rangeA1ToB2, "ABC", false, "NOTUSEMETAARG", 1);
+      compiledFormula4.execute(rangeA1ToB2, refFn, ensureRange, ctx);
+      expect(refFn).toHaveBeenCalledWith(rangeA1ToB2[0], false, "NOTUSEMETAARG", 1);
       expect(ensureRange).toHaveBeenCalledTimes(0);
       refFn.mockReset();
     });


### PR DESCRIPTION
## Description:

No need to pass the array of ranges and the index, the compiler can index the array for us.
Also, `sheetId` is useless since it's already in the range

Odoo task ID : [2877573](https://www.odoo.com/web#id=2877573&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo