### PR TITLE
[FIX] menu: bad CSS for text overflow

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -31,11 +31,14 @@ css/* scss */ `
       box-sizing: border-box;
       height: ${MENU_ITEM_HEIGHT}px;
       padding: 4px 16px;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
       cursor: pointer;
       user-select: none;
+
+      .o-menu-item-name {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
 
       &.o-menu-root {
         display: flex;

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -26,10 +26,10 @@
             class="o-menu-item"
             t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled}"
             t-att-style="getColor(menuItem)">
-            <t t-esc="getName(menuItem)"/>
+            <span class="o-menu-item-name" t-esc="getName(menuItem)"/>
             <span class="o-menu-item-shortcut" t-esc="getShortCut(menuItem)"/>
             <t t-if="isMenuRoot">
-              <t t-call="o-spreadsheet.Icon.TRIANGLE_RIGHT"/>
+              <span t-call="o-spreadsheet.Icon.TRIANGLE_RIGHT"/>
             </t>
             <t t-elif="menuItem.icon">
               <i t-att-class="menuItem.icon" class="o-menu-item-icon"/>

--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -9,7 +9,11 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     data-name="Sum"
     title="Sum: 24"
   >
-    Sum: 24
+    <span
+      class="o-menu-item-name"
+    >
+      Sum: 24
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -24,7 +28,11 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     data-name="Avg"
     title="Avg: 24"
   >
-    Avg: 24
+    <span
+      class="o-menu-item-name"
+    >
+      Avg: 24
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -39,7 +47,11 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     data-name="Min"
     title="Min: 24"
   >
-    Min: 24
+    <span
+      class="o-menu-item-name"
+    >
+      Min: 24
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -54,7 +66,11 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     data-name="Max"
     title="Max: 24"
   >
-    Max: 24
+    <span
+      class="o-menu-item-name"
+    >
+      Max: 24
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -69,7 +85,11 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     data-name="Count"
     title="Count: 1"
   >
-    Count: 1
+    <span
+      class="o-menu-item-name"
+    >
+      Count: 1
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -84,7 +104,11 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     data-name="Count Numbers"
     title="Count Numbers: 1"
   >
-    Count Numbers: 1
+    <span
+      class="o-menu-item-name"
+    >
+      Count Numbers: 1
+    </span>
     <span
       class="o-menu-item-shortcut"
     >

--- a/tests/components/__snapshots__/context_menu.test.ts.snap
+++ b/tests/components/__snapshots__/context_menu.test.ts.snap
@@ -9,7 +9,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="cut"
     title="Cut"
   >
-    Cut
+    <span
+      class="o-menu-item-name"
+    >
+      Cut
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -24,7 +28,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="copy"
     title="Copy"
   >
-    Copy
+    <span
+      class="o-menu-item-name"
+    >
+      Copy
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -39,7 +47,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="paste"
     title="Paste"
   >
-    Paste
+    <span
+      class="o-menu-item-name"
+    >
+      Paste
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -54,21 +66,27 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="paste_special"
     title="Paste special"
   >
-    Paste special
+    <span
+      class="o-menu-item-name"
+    >
+      Paste special
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
       
     </span>
-    <svg
-      class="o-icon"
-    >
-      <polygon
-        fill="#000000"
-        points="0 0 4 4 0 8"
-        transform="translate(5 5)"
-      />
-    </svg>
+    <span>
+      <svg
+        class="o-icon"
+      >
+        <polygon
+          fill="#000000"
+          points="0 0 4 4 0 8"
+          transform="translate(5 5)"
+        />
+      </svg>
+    </span>
     
     
   </div>
@@ -80,21 +98,27 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="sort_range"
     title="Sort range"
   >
-    Sort range
+    <span
+      class="o-menu-item-name"
+    >
+      Sort range
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
       
     </span>
-    <svg
-      class="o-icon"
-    >
-      <polygon
-        fill="#000000"
-        points="0 0 4 4 0 8"
-        transform="translate(5 5)"
-      />
-    </svg>
+    <span>
+      <svg
+        class="o-icon"
+      >
+        <polygon
+          fill="#000000"
+          points="0 0 4 4 0 8"
+          transform="translate(5 5)"
+        />
+      </svg>
+    </span>
     
     
   </div>
@@ -106,7 +130,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="add_row_before"
     title="Insert row"
   >
-    Insert row
+    <span
+      class="o-menu-item-name"
+    >
+      Insert row
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -121,7 +149,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="add_column_before"
     title="Insert column"
   >
-    Insert column
+    <span
+      class="o-menu-item-name"
+    >
+      Insert column
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -136,21 +168,27 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="insert_cell"
     title="Insert cells"
   >
-    Insert cells
+    <span
+      class="o-menu-item-name"
+    >
+      Insert cells
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
       
     </span>
-    <svg
-      class="o-icon"
-    >
-      <polygon
-        fill="#000000"
-        points="0 0 4 4 0 8"
-        transform="translate(5 5)"
-      />
-    </svg>
+    <span>
+      <svg
+        class="o-icon"
+      >
+        <polygon
+          fill="#000000"
+          points="0 0 4 4 0 8"
+          transform="translate(5 5)"
+        />
+      </svg>
+    </span>
     
     
   </div>
@@ -162,7 +200,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="delete_row"
     title="Delete row 8"
   >
-    Delete row 8
+    <span
+      class="o-menu-item-name"
+    >
+      Delete row 8
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -177,7 +219,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="delete_column"
     title="Delete column C"
   >
-    Delete column C
+    <span
+      class="o-menu-item-name"
+    >
+      Delete column C
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -192,21 +238,27 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="delete_cell"
     title="Delete cells"
   >
-    Delete cells
+    <span
+      class="o-menu-item-name"
+    >
+      Delete cells
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
       
     </span>
-    <svg
-      class="o-icon"
-    >
-      <polygon
-        fill="#000000"
-        points="0 0 4 4 0 8"
-        transform="translate(5 5)"
-      />
-    </svg>
+    <span>
+      <svg
+        class="o-icon"
+      >
+        <polygon
+          fill="#000000"
+          points="0 0 4 4 0 8"
+          transform="translate(5 5)"
+        />
+      </svg>
+    </span>
     
     
   </div>
@@ -216,7 +268,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="clear_cell"
     title="Clear cells"
   >
-    Clear cells
+    <span
+      class="o-menu-item-name"
+    >
+      Clear cells
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -233,7 +289,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="insert_link"
     title="Insert link"
   >
-    Insert link
+    <span
+      class="o-menu-item-name"
+    >
+      Insert link
+    </span>
     <span
       class="o-menu-item-shortcut"
     >
@@ -250,7 +310,11 @@ exports[`Context Menu context menu simple rendering 1`] = `
     data-name="conditional_formatting"
     title="Conditional formatting"
   >
-    Conditional formatting
+    <span
+      class="o-menu-item-name"
+    >
+      Conditional formatting
+    </span>
     <span
       class="o-menu-item-shortcut"
     >


### PR DESCRIPTION
The CSS to transform text overflow in menus to ellipsis wasn't working.

The sub-menu arrow was also not displayed if the name of the menu was too long

Odoo task 2877337


Odoo task ID : [2877337](https://www.odoo.com/web#id=2877337&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo