### PR TITLE
[REF] prettier: Force common end-of-line char projectwwide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# force LF end-of-line policy
+* eol=lf

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "typescript": "^4.4.3"
   },
   "prettier": {
-    "printWidth": 100,
-    "endOfLine": "auto"
+    "printWidth": 100
   },
   "dependencies": {
     "@odoo/owl": "^1.4.10"


### PR DESCRIPTION
Letting user stick with his system EOL policy leads to some issues when
we generate the bundle `o_spreadsheet.js`.
E.g. With the current setup: rollup@2.64
 on a Linux (Ubuntu 20.04) setup, rollup will preserve the EOL of
the files, which can be a mix of CRLF and LF.
On MacOS X 12.4, every EOL is overriden with LF.

This ultimately means that the files generated by both systems differ
and will introduce an unnecessary diff when pushed on a different
repository (namely https://www.github.com/odoo/enteprise).

Here we take the approach to force a generic EOL policy (LF) and require
users to properly setup their `git` installation to follow that policy.

How to setup
------------

```bash
cd {"o-spreadsheet directory"}
git config core.autocrlf input
```

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

