### PR TITLE
[IMP] config: Add leftover debugger/console check in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,25 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+# ativate user inputs
+exec < /dev/tty
+
 if [ "$HUSKY_PRE_COMMIT" != 0 ]; then
     npx lint-staged
+
+    consoleregexp='console\.|debugger'
+
+    # CHECK
+    if test $(git diff --cached | grep -nE $consoleregexp | wc -l) != 0
+    then 
+        exec git diff --cached --color | grep -nE $consoleregexp -A 2 -B 2
+        read -p "There are some occurrences of forbidden patterns at your modification. Are you sure want to continue? (y/n)" yn
+        echo $yn | grep ^[Yy]$
+        if [ $? -eq 0 ] 
+        then
+            exit 0; #THE USER WANTS TO CONTINUE
+        else
+            exit 1; # THE USER DONT WANT TO CONTINUE SO ROLLBACK
+        fi
+    fi
 fi


### PR DESCRIPTION
This will prevent people from pushing debug statements by mistake.
The hook includes an override as debug statements are sometimes required
(e.g. inside the compiler and its related tests).

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo