### PR TITLE
[FIX] templates: replace 'module' name spacing

### DIFF
--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -55,7 +55,7 @@ interface State {
 }
 
 export class Autofill extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.Autofill";
+  static template = "o-spreadsheet-Autofill";
   state: State = useState({
     position: { left: 0, top: 0 },
     handler: false,

--- a/src/components/autofill/autofill.xml
+++ b/src/components/autofill/autofill.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Autofill" owl="1">
+  <t t-name="o-spreadsheet-Autofill" owl="1">
     <div
       class="o-autofill"
       t-on-mousedown="onMouseDown"

--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -107,7 +107,7 @@ interface Props {
 }
 
 export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.BottomBar";
+  static template = "o-spreadsheet-BottomBar";
   static components = { Menu };
 
   private bottomBarRef = useRef("bottomBar");

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.BottomBar" owl="1">
+  <t t-name="o-spreadsheet-BottomBar" owl="1">
     <div
       class="o-spreadsheet-bottom-bar o-two-columns"
       t-on-click="props.onClick"
@@ -8,10 +8,10 @@
         class="o-sheet-item o-add-sheet"
         t-att-class="{'disabled': env.model.getters.isReadonly()}"
         t-on-click="addSheet">
-        <t t-call="o-spreadsheet.Icon.PLUS"/>
+        <t t-call="o-spreadsheet-Icon.PLUS"/>
       </div>
       <div class="o-sheet-item o-list-sheets" t-on-click="listSheets">
-        <t t-call="o-spreadsheet.Icon.LIST"/>
+        <t t-call="o-spreadsheet-Icon.LIST"/>
       </div>
       <div class="o-all-sheets">
         <t t-foreach="getVisibleSheets()" t-as="sheet" t-key="sheet.id">
@@ -28,7 +28,7 @@
               t-on-dblclick="(ev) => this.onDblClick(sheet.id, ev)"
             />
             <span class="o-sheet-icon" t-on-click.stop="(ev) => this.onIconClick(sheet.id, ev)">
-              <t t-call="o-spreadsheet.Icon.TRIANGLE_DOWN"/>
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
             </span>
           </div>
         </t>
@@ -41,7 +41,7 @@
         t-on-click="listSelectionStatistics">
         <t t-esc="selectedStatistic"/>
         <span>
-          <t t-call="o-spreadsheet.Icon.TRIANGLE_DOWN"/>
+          <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
         </span>
       </div>
 

--- a/src/components/collaborative_client_tag/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.ts
@@ -24,7 +24,7 @@ css/* scss */ `
   }
 `;
 export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.ClientTag";
+  static template = "o-spreadsheet-ClientTag";
   get tagStyle(): string {
     const { col, row, color } = this.props;
     const viewport = this.env.model.getters.getActiveSnappedViewport();

--- a/src/components/collaborative_client_tag/collaborative_client_tag.xml
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.ClientTag" owl="1">
+  <t t-name="o-spreadsheet-ClientTag" owl="1">
     <div>
       <div class="o-client-tag" t-att-style="tagStyle" t-esc="props.name"/>
     </div>

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -159,7 +159,7 @@ interface Props {
 }
 
 export class ColorPicker extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.ColorPicker";
+  static template = "o-spreadsheet-ColorPicker";
   COLORS = COLORS;
 
   onColorClick(ev: MouseEvent) {

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.ColorPicker" owl="1">
+  <t t-name="o-spreadsheet-ColorPicker" owl="1">
     <div
       class="o-color-picker"
       t-att-class="props.dropdownDirection || 'right'"

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
@@ -72,7 +72,7 @@ export interface TextValueProviderApi {
 }
 
 export abstract class TextValueProvider extends Component<Props> implements TextValueProviderApi {
-  static template = "o-spreadsheet.TextValueProvider";
+  static template = "o-spreadsheet-TextValueProvider";
   state = useState({
     values: <AutocompleteValue[]>[],
     selectedIndex: 0,

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.TextValueProvider" owl="1">
+  <t t-name="o-spreadsheet-TextValueProvider" owl="1">
     <div
       t-att-class="{'o-autocomplete-dropdown':state.values.length}"
       t-att-style="state.values.length > 0 ? props.borderStyle : null">

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -119,7 +119,7 @@ interface FunctionDescriptionState {
 }
 
 export class Composer extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.Composer";
+  static template = "o-spreadsheet-Composer";
   static components = { TextValueProvider, FunctionDescriptionProvider };
   static defaultProps = {
     inputStyle: "",

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Composer" owl="1">
+  <t t-name="o-spreadsheet-Composer" owl="1">
     <div class="o-composer-container">
       <div
         t-att-class="{ 'o-composer': true, 'text-muted': env.model.getters.isReadonly(), 'unfocusable': env.model.getters.isReadonly() }"

--- a/src/components/composer/formula_assistant/formula_assistant.ts
+++ b/src/components/composer/formula_assistant/formula_assistant.ts
@@ -67,7 +67,7 @@ interface AssistantState {
 }
 
 export class FunctionDescriptionProvider extends Component<Props> {
-  static template = "o-spreadsheet.FunctionDescriptionProvider";
+  static template = "o-spreadsheet-FunctionDescriptionProvider";
   assistantState: AssistantState = useState({
     allowCellSelectionBehind: false,
   });

--- a/src/components/composer/formula_assistant/formula_assistant.xml
+++ b/src/components/composer/formula_assistant/formula_assistant.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.FunctionDescriptionProvider" owl="1">
+  <t t-name="o-spreadsheet-FunctionDescriptionProvider" owl="1">
     <div
       class="o-formula-assistant-container"
       t-att-style="props.borderStyle"

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -40,7 +40,7 @@ interface Props {
  * It also applies the style of the cell to the composer input.
  */
 export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.GridComposer";
+  static template = "o-spreadsheet-GridComposer";
   static components = { Composer };
 
   private gridComposerRef!: Ref<HTMLElement>;

--- a/src/components/composer/grid_composer/grid_composer.xml
+++ b/src/components/composer/grid_composer/grid_composer.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.GridComposer" owl="1">
+  <t t-name="o-spreadsheet-GridComposer" owl="1">
     <div class="o-grid-composer" t-att-style="containerStyle" t-ref="gridComposer">
       <Composer
         focus="props.focus"

--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -16,5 +16,5 @@ export interface ErrorToolTipProps {
 }
 
 export class ErrorToolTip extends Component<ErrorToolTipProps, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.ErrorToolTip";
+  static template = "o-spreadsheet-ErrorToolTip";
 }

--- a/src/components/error_tooltip/error_tooltip.xml
+++ b/src/components/error_tooltip/error_tooltip.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.ErrorToolTip" owl="1">
+  <t t-name="o-spreadsheet-ErrorToolTip" owl="1">
     <div class="o-error-tooltip">
       <t t-esc="props.text"/>
     </div>

--- a/src/components/figures/chart/chart.ts
+++ b/src/components/figures/chart/chart.ts
@@ -45,7 +45,7 @@ interface Props {
 }
 
 export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.ChartFigure";
+  static template = "o-spreadsheet-ChartFigure";
   static components = { Menu };
   private menuState: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
 

--- a/src/components/figures/chart/chart.xml
+++ b/src/components/figures/chart/chart.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.ChartFigure" owl="1">
+  <t t-name="o-spreadsheet-ChartFigure" owl="1">
     <div
       class="o-chart-container"
       t-ref="chartContainer"
@@ -10,7 +10,7 @@
           t-on-click="showMenu"
           t-ref="menuButton"
           t-on-contextmenu.prevent.stop="showMenu">
-          <t t-call="o-spreadsheet.Icon.LIST"/>
+          <t t-call="o-spreadsheet-Icon.LIST"/>
         </div>
       </div>
       <canvas t-att-style="canvasStyle" t-ref="graphContainer"/>

--- a/src/components/figures/container/container.ts
+++ b/src/components/figures/container/container.ts
@@ -101,7 +101,7 @@ interface Props {
 }
 
 export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.FiguresContainer";
+  static template = "o-spreadsheet-FiguresContainer";
   static components = {};
   figureRegistry = figureRegistry;
 

--- a/src/components/figures/container/container.xml
+++ b/src/components/figures/container/container.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.FiguresContainer" owl="1">
+  <t t-name="o-spreadsheet-FiguresContainer" owl="1">
     <div>
       <t t-foreach="getVisibleFigures()" t-as="info" t-key="info.id">
         <div

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -241,7 +241,7 @@ interface Props {
 // JS
 // -----------------------------------------------------------------------------
 export class Grid extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.Grid";
+  static template = "o-spreadsheet-Grid";
   static components = {
     GridComposer,
     HeadersOverlay,

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Grid" owl="1">
+  <t t-name="o-spreadsheet-Grid" owl="1">
     <div
       class="o-grid"
       t-att-class="{'o-two-columns': !props.sidePanelIsOpen}"

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -394,7 +394,7 @@ css/* scss */ `
 `;
 
 export class ColResizer extends AbstractResizer {
-  static template = "o-spreadsheet.ColResizer";
+  static template = "o-spreadsheet-ColResizer";
 
   private colResizerRef!: Ref<HTMLElement>;
 
@@ -600,7 +600,7 @@ css/* scss */ `
 `;
 
 export class RowResizer extends AbstractResizer {
-  static template = "o-spreadsheet.RowResizer";
+  static template = "o-spreadsheet-RowResizer";
 
   setup() {
     super.setup();
@@ -756,7 +756,7 @@ css/* scss */ `
 `;
 
 export class HeadersOverlay extends Component<any, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.HeadersOverlay";
+  static template = "o-spreadsheet-HeadersOverlay";
   static components = { ColResizer, RowResizer };
 
   selectAll() {

--- a/src/components/headers_overlay/headers_overlay.xml
+++ b/src/components/headers_overlay/headers_overlay.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.HeadersOverlay" owl="1">
+  <t t-name="o-spreadsheet-HeadersOverlay" owl="1">
     <div class="o-overlay">
       <ColResizer onOpenContextMenu="props.onOpenContextMenu"/>
       <RowResizer onOpenContextMenu="props.onOpenContextMenu"/>
@@ -7,7 +7,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet.RowResizer" owl="1">
+  <t t-name="o-spreadsheet-RowResizer" owl="1">
     <div
       class="o-row-resizer"
       t-on-mousemove.self="onMouseMove"
@@ -47,7 +47,7 @@
             t-att-data-index="hiddenItem_index"
             t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) - 17}}px;"
             t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet.Icon.TRIANGLE_UP"/>
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>
           </div>
         </t>
         <t t-if="!hiddenItem.includes(env.model.getters.getActiveSheet().rows.length-1)">
@@ -56,14 +56,14 @@
             t-att-data-index="hiddenItem_index"
             t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
             t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet.Icon.TRIANGLE_DOWN"/>
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
           </div>
         </t>
       </t>
     </div>
   </t>
 
-  <t t-name="o-spreadsheet.ColResizer" owl="1">
+  <t t-name="o-spreadsheet-ColResizer" owl="1">
     <div
       class="o-col-resizer"
       t-on-mousemove.self="onMouseMove"
@@ -103,7 +103,7 @@
             t-att-data-index="hiddenItem_index"
             t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) - 17}}px; margin-right:6px;"
             t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet.Icon.TRIANGLE_LEFT"/>
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_LEFT"/>
           </div>
         </t>
         <t t-if="!hiddenItem.includes(env.model.getters.getActiveSheet().cols.length-1)">
@@ -112,7 +112,7 @@
             t-att-data-index="hiddenItem_index"
             t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
             t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet.Icon.TRIANGLE_RIGHT"/>
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
           </div>
         </t>
       </t>

--- a/src/components/highlight/border/border.ts
+++ b/src/components/highlight/border/border.ts
@@ -25,7 +25,7 @@ interface Props {
 }
 
 export class Border extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.Border";
+  static template = "o-spreadsheet-Border";
   get style() {
     const isTop = ["n", "w", "e"].includes(this.props.orientation);
     const isLeft = ["n", "w", "s"].includes(this.props.orientation);

--- a/src/components/highlight/border/border.xml
+++ b/src/components/highlight/border/border.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Border" owl="1">
+  <t t-name="o-spreadsheet-Border" owl="1">
     <div
       class="o-border"
       t-on-mousedown="onMouseDown"

--- a/src/components/highlight/corner/corner.ts
+++ b/src/components/highlight/corner/corner.ts
@@ -38,7 +38,7 @@ interface Props {
 }
 
 export class Corner extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.Corner";
+  static template = "o-spreadsheet-Corner";
   private isTop = this.props.orientation[0] === "n";
   private isLeft = this.props.orientation[1] === "w";
 

--- a/src/components/highlight/corner/corner.xml
+++ b/src/components/highlight/corner/corner.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Corner" owl="1">
+  <t t-name="o-spreadsheet-Corner" owl="1">
     <div
       class="o-corner"
       t-on-mousedown="onMouseDown"

--- a/src/components/highlight/highlight/highlight.ts
+++ b/src/components/highlight/highlight/highlight.ts
@@ -15,7 +15,7 @@ interface HighlightState {
   shiftingMode: "isMoving" | "isResizing" | "none";
 }
 export class Highlight extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.Highlight";
+  static template = "o-spreadsheet-Highlight";
   static components = {
     Corner,
     Border,

--- a/src/components/highlight/highlight/highlight.xml
+++ b/src/components/highlight/highlight/highlight.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Highlight" owl="1">
+  <t t-name="o-spreadsheet-Highlight" owl="1">
     <div class="o-highlight" t-ref="highlight">
       <t t-foreach="['nw', 'ne', 'sw', 'se']" t-as="orientation" t-key="orientation">
         <Corner

--- a/src/components/icon_picker/icon_picker.ts
+++ b/src/components/icon_picker/icon_picker.ts
@@ -29,7 +29,7 @@ css/* scss */ `
 `;
 
 export class IconPicker extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.IconPicker";
+  static template = "o-spreadsheet-IconPicker";
   icons = ICONS;
   iconSets = ICON_SETS;
 

--- a/src/components/icon_picker/icon_picker.xml
+++ b/src/components/icon_picker/icon_picker.xml
@@ -1,22 +1,22 @@
 <templates>
-  <t t-name="o-spreadsheet.IconPicker" owl="1">
+  <t t-name="o-spreadsheet-IconPicker" owl="1">
     <div class="o-icon-picker">
       <t t-foreach="iconSets" t-as="iconSet" t-key="iconSet">
         <div class="o-cf-icon-line">
           <div
             class="o-icon-picker-item"
             t-on-click="() => this.onIconClick(iconSets[iconSet].good)">
-            <t t-call="o-spreadsheet.Icon.{{icons[iconSets[iconSet].good].template}}"/>
+            <t t-call="o-spreadsheet-Icon.{{icons[iconSets[iconSet].good].template}}"/>
           </div>
           <div
             class="o-icon-picker-item"
             t-on-click="() => this.onIconClick(iconSets[iconSet].neutral)">
-            <t t-call="o-spreadsheet.Icon.{{icons[iconSets[iconSet].neutral].template}}"/>
+            <t t-call="o-spreadsheet-Icon.{{icons[iconSets[iconSet].neutral].template}}"/>
           </div>
           <div
             class="o-icon-picker-item"
             t-on-click="() => this.onIconClick(iconSets[iconSet].bad)">
-            <t t-call="o-spreadsheet.Icon.{{icons[iconSets[iconSet].bad].template}}"/>
+            <t t-call="o-spreadsheet-Icon.{{icons[iconSets[iconSet].bad].template}}"/>
           </div>
         </div>
       </t>

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Icon.UNDO" owl="1">
+  <t t-name="o-spreadsheet-Icon.UNDO" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -8,7 +8,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.REDO" owl="1">
+  <t t-name="o-spreadsheet-Icon.REDO" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -17,7 +17,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.PAINT_FORMAT" owl="1">
+  <t t-name="o-spreadsheet-Icon.PAINT_FORMAT" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -26,7 +26,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.CLEAR_FORMAT" owl="1">
+  <t t-name="o-spreadsheet-Icon.CLEAR_FORMAT" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -35,27 +35,27 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.TRIANGLE_DOWN" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_DOWN" owl="1">
     <svg class="o-icon">
       <polygon fill="#000000" points="0 0 4 4 8 0" transform="translate(5 7)"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.TRIANGLE_UP" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_UP" owl="1">
     <svg class="o-icon">
       <polygon fill="#000000" points="4 0 0 4 8 4" transform="translate(5 7)"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.TRIANGLE_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_RIGHT" owl="1">
     <svg class="o-icon">
       <polygon fill="#000000" points="0 0 4 4 0 8" transform="translate(5 5)"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.TRIANGLE_LEFT" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_LEFT" owl="1">
     <svg class="o-icon">
       <polygon fill="#000000" points="4 0 0 4 4 8" transform="translate(5 5)"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BOLD" owl="1">
+  <t t-name="o-spreadsheet-Icon.BOLD" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -65,7 +65,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.ITALIC" owl="1">
+  <t t-name="o-spreadsheet-Icon.ITALIC" owl="1">
     <svg class="o-icon">
       <polygon
         fill="#000000"
@@ -75,7 +75,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.UNDERLINE" owl="1">
+  <t t-name="o-spreadsheet-Icon.UNDERLINE" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -84,7 +84,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.STRIKE" owl="1">
+  <t t-name="o-spreadsheet-Icon.STRIKE" owl="1">
     <svg class="o-icon">
       <path
         fill="#010101"
@@ -95,7 +95,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet.Icon.TEXT_COLOR" owl="1">
+  <t t-name="o-spreadsheet-Icon.TEXT_COLOR" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -104,7 +104,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.FILL_COLOR" owl="1">
+  <t t-name="o-spreadsheet-Icon.FILL_COLOR" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -112,7 +112,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.MERGE_CELL" owl="1">
+  <t t-name="o-spreadsheet-Icon.MERGE_CELL" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -120,7 +120,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.ALIGN_LEFT" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_LEFT" owl="1">
     <svg class="o-icon align-left">
       <path
         fill="#000000"
@@ -129,7 +129,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.ALIGN_CENTER" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_CENTER" owl="1">
     <svg class="o-icon align-center">
       <path
         fill="#000000"
@@ -138,7 +138,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.ALIGN_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_RIGHT" owl="1">
     <svg class="o-icon align-right">
       <path
         fill="#000000"
@@ -147,7 +147,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.ALIGN_MIDDLE" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_MIDDLE" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -156,7 +156,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.TEXT_WRAPPING" owl="1">
+  <t t-name="o-spreadsheet-Icon.TEXT_WRAPPING" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -165,7 +165,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDERS" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDERS" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -174,7 +174,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDER_HV" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_HV" owl="1">
     <svg class="o-icon">
       <g fill="#000000">
         <path
@@ -185,7 +185,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDER_H" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_H" owl="1">
     <svg class="o-icon">
       <g fill="#000000">
         <path
@@ -196,7 +196,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDER_V" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_V" owl="1">
     <svg class="o-icon">
       <g fill="#000000">
         <path
@@ -207,7 +207,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDER_EXTERNAL" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_EXTERNAL" owl="1">
     <svg class="o-icon">
       <g fill="#000000">
         <path
@@ -218,7 +218,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDER_LEFT" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_LEFT" owl="1">
     <svg class="o-icon">
       <g fill="#000000">
         <path
@@ -229,7 +229,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDER_TOP" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_TOP" owl="1">
     <svg class="o-icon">
       <g fill="#000000">
         <path
@@ -240,7 +240,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDER_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_RIGHT" owl="1">
     <svg class="o-icon">
       <g fill="#000000">
         <path
@@ -251,7 +251,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDER_BOTTOM" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_BOTTOM" owl="1">
     <svg class="o-icon">
       <g fill="#000000">
         <path
@@ -262,7 +262,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.BORDER_CLEAR" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_CLEAR" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -274,7 +274,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet.Icon.PLUS" owl="1">
+  <t t-name="o-spreadsheet-Icon.PLUS" owl="1">
     <svg class="o-icon">
       <path
         fill="#000000"
@@ -282,7 +282,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.LIST" owl="1">
+  <t t-name="o-spreadsheet-Icon.LIST" owl="1">
     <svg class="o-icon" viewBox="0 0 384 384">
       <rect x="0" y="277.333" width="384" height="42.667"/>
       <rect x="0" y="170.667" width="384" height="42.667"/>
@@ -290,7 +290,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet.Icon.EDIT" owl="1">
+  <t t-name="o-spreadsheet-Icon.EDIT" owl="1">
     <svg class="o-icon" viewBox="0 0 576 512">
       <path
         fill="currentColor"
@@ -298,7 +298,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.UNLINK" owl="1">
+  <t t-name="o-spreadsheet-Icon.UNLINK" owl="1">
     <svg class="o-icon" viewBox="0 0 512 512">
       <path
         fill="currentColor"
@@ -310,7 +310,7 @@
  *  http://fontawesome.io/
  *  https://fontawesome.com/license
  */
-  <t t-name="o-spreadsheet.Icon.CARET_UP" owl="1">
+  <t t-name="o-spreadsheet-Icon.CARET_UP" owl="1">
     <svg class="caret-up" viewBox="0 0 320 512">
       <path
         fill="currentColor"
@@ -318,7 +318,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.CARET_DOWN" owl="1">
+  <t t-name="o-spreadsheet-Icon.CARET_DOWN" owl="1">
     <svg class="caret-down" viewBox="0 0 320 512">
       <path
         fill="currentColor"
@@ -327,7 +327,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet.Icon.TRASH" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRASH" owl="1">
     <svg class="o-cf-icon trash" viewBox="0 0 448 512">
       <path
         fill="currentColor"
@@ -335,7 +335,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.REFRESH" owl="1">
+  <t t-name="o-spreadsheet-Icon.REFRESH" owl="1">
     <svg class="o-cf-icon refresh" viewBox="0 0 512 512">
       <path
         fill="currentColor"
@@ -344,7 +344,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet.Icon.ARROW_DOWN" owl="1">
+  <t t-name="o-spreadsheet-Icon.ARROW_DOWN" owl="1">
     <svg
       class="o-cf-icon arrow-down"
       width="10"
@@ -357,7 +357,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.ARROW_UP" owl="1">
+  <t t-name="o-spreadsheet-Icon.ARROW_UP" owl="1">
     <svg class="o-cf-icon arrow-up" width="10" height="10" focusable="false" viewBox="0 0 448 512">
       <path
         fill="#00A04A"
@@ -365,7 +365,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.ARROW_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.ARROW_RIGHT" owl="1">
     <svg
       class="o-cf-icon arrow-right"
       width="10"
@@ -379,7 +379,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet.Icon.SMILE" owl="1">
+  <t t-name="o-spreadsheet-Icon.SMILE" owl="1">
     <svg class="o-cf-icon smile" width="10" height="10" focusable="false" viewBox="0 0 496 512">
       <path
         fill="#00A04A"
@@ -387,7 +387,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.MEH" owl="1">
+  <t t-name="o-spreadsheet-Icon.MEH" owl="1">
     <svg class="o-cf-icon meh" width="10" height="10" focusable="false" viewBox="0 0 496 512">
       <path
         fill="#F0AD4E"
@@ -395,7 +395,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.FROWN" owl="1">
+  <t t-name="o-spreadsheet-Icon.FROWN" owl="1">
     <svg class="o-cf-icon frown" width="10" height="10" focusable="false" viewBox="0 0 496 512">
       <path
         fill="#DC6965"
@@ -404,7 +404,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet.Icon.GREEN_DOT" owl="1">
+  <t t-name="o-spreadsheet-Icon.GREEN_DOT" owl="1">
     <svg class="o-cf-icon green-dot" width="10" height="10" focusable="false" viewBox="0 0 512 512">
       <path
         fill="#00A04A"
@@ -412,7 +412,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.YELLOW_DOT" owl="1">
+  <t t-name="o-spreadsheet-Icon.YELLOW_DOT" owl="1">
     <svg
       class="o-cf-icon yellow-dot"
       width="10"
@@ -425,7 +425,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet.Icon.RED_DOT" owl="1">
+  <t t-name="o-spreadsheet-Icon.RED_DOT" owl="1">
     <svg class="o-cf-icon red-dot" width="10" height="10" focusable="false" viewBox="0 0 512 512">
       <path
         fill="#DC6965"

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -51,7 +51,7 @@ export class LinkDisplay extends Component<
   SpreadsheetChildEnv
 > {
   static components = { Menu };
-  static template = "o-spreadsheet.LinkDisplay";
+  static template = "o-spreadsheet-LinkDisplay";
 
   get cell(): LinkCell {
     const { col, row } = this.props.cellPosition;

--- a/src/components/link/link_display/link_display.xml
+++ b/src/components/link/link_display/link_display.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.LinkDisplay" owl="1">
+  <t t-name="o-spreadsheet-LinkDisplay" owl="1">
     <div class="o-link-tool">
       <t t-set="link" t-value="cell.link"/>
       <a
@@ -19,10 +19,10 @@
         <t t-esc="cell.urlRepresentation"/>
       </a>
       <span class="o-link-icon o-unlink" t-on-click="unlink" title="Remove link">
-        <t t-call="o-spreadsheet.Icon.UNLINK"/>
+        <t t-call="o-spreadsheet-Icon.UNLINK"/>
       </span>
       <span class="o-link-icon o-edit-link" t-on-click="edit" title="Edit link">
-        <t t-call="o-spreadsheet.Icon.EDIT"/>
+        <t t-call="o-spreadsheet-Icon.EDIT"/>
       </span>
     </div>
   </t>

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -94,7 +94,7 @@ interface State {
 }
 
 export class LinkEditor extends Component<LinkEditorProps, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.LinkEditor";
+  static template = "o-spreadsheet-LinkEditor";
   static components = { Menu };
   menuItems = linkMenuRegistry.getAll();
   private state: State = useState(this.defaultState);

--- a/src/components/link/link_editor/link_editor.xml
+++ b/src/components/link/link_editor/link_editor.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.LinkEditor" owl="1">
+  <t t-name="o-spreadsheet-LinkEditor" owl="1">
     <div
       class="o-link-editor"
       t-on-click.stop="() => this.menu.isOpen=false"
@@ -21,7 +21,7 @@
           </t>
           <button t-if="state.link.url" t-on-click="removeLink" class="o-remove-url">✖</button>
           <button t-if="!state.link.url" t-on-click.stop="openMenu" class="o-special-link">
-            <t t-call="o-spreadsheet.Icon.LIST"/>
+            <t t-call="o-spreadsheet-Icon.LIST"/>
           </button>
         </div>
       </div>

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -89,7 +89,7 @@ export interface MenuState {
   menuItems: FullMenuItem[];
 }
 export class Menu extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.Menu";
+  static template = "o-spreadsheet-Menu";
   MENU_WIDTH = MENU_WIDTH;
 
   static components = { Menu, Popover };

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Menu" owl="1">
+  <t t-name="o-spreadsheet-Menu" owl="1">
     <Popover
       t-if="props.menuItems.length"
       position="props.position"
@@ -29,7 +29,7 @@
             <span class="o-menu-item-name" t-esc="getName(menuItem)"/>
             <span class="o-menu-item-shortcut" t-esc="getShortCut(menuItem)"/>
             <t t-if="isMenuRoot">
-              <span t-call="o-spreadsheet.Icon.TRIANGLE_RIGHT"/>
+              <span t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
             </t>
             <t t-elif="menuItem.icon">
               <i t-att-class="menuItem.icon" class="o-menu-item-icon"/>

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -24,7 +24,7 @@ interface Props {
 }
 
 export class Popover extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.Popover";
+  static template = "o-spreadsheet-Popover";
   static defaultProps = {
     flipHorizontalOffset: 0,
     flipVerticalOffset: 0,

--- a/src/components/popover/popover.xml
+++ b/src/components/popover/popover.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Popover" owl="1">
+  <t t-name="o-spreadsheet-Popover" owl="1">
     <t t-portal="'.o-spreadsheet'">
       <div t-att-style="style">
         <t t-slot="default"/>

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -77,7 +77,7 @@ interface SelectionRange extends Omit<RangeInputValue, "color"> {
  * changes.
  */
 export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.SelectionInput";
+  static template = "o-spreadsheet-SelectionInput";
   private id = uuidGenerator.uuidv4();
   private previousRanges: string[] = this.props.ranges || [];
   private originSheet = this.env.model.getters.getActiveSheetId();

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.SelectionInput" owl="1">
+  <t t-name="o-spreadsheet-SelectionInput" owl="1">
     <div class="o-selection">
       <div
         t-foreach="ranges"

--- a/src/components/side_panel/chart_panel/chart_panel.ts
+++ b/src/components/side_panel/chart_panel/chart_panel.ts
@@ -59,7 +59,7 @@ interface ChartPanelState {
 }
 
 export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.ChartPanel";
+  static template = "o-spreadsheet-ChartPanel";
   static components = { SelectionInput, ColorPicker };
 
   private state: ChartPanelState = useState(this.initialState(this.props.figure));

--- a/src/components/side_panel/chart_panel/chart_panel.xml
+++ b/src/components/side_panel/chart_panel/chart_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.ChartPanel" owl="1">
+  <t t-name="o-spreadsheet-ChartPanel" owl="1">
     <div class="o-chart">
       <div class="o-panel">
         <div
@@ -18,15 +18,15 @@
         </div>
       </div>
       <t t-if="state.panel === 'configuration'">
-        <t t-call="o-spreadsheet.ChartConfigurationPanel"/>
+        <t t-call="o-spreadsheet-ChartConfigurationPanel"/>
       </t>
       <t t-else="">
-        <t t-call="o-spreadsheet.ChartDesignPanel"/>
+        <t t-call="o-spreadsheet-ChartDesignPanel"/>
       </t>
     </div>
   </t>
 
-  <t t-name="o-spreadsheet.ChartConfigurationPanel" owl="1">
+  <t t-name="o-spreadsheet-ChartConfigurationPanel" owl="1">
     <div>
       <div class="o-section">
         <div class="o-section-title">Chart type</div>
@@ -95,7 +95,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet.ChartDesignPanel" owl="1">
+  <t t-name="o-spreadsheet-ChartDesignPanel" owl="1">
     <div>
       <div class="o-section o-chart-title">
         <div class="o-section-title">Background color</div>
@@ -104,7 +104,7 @@
           <span
             t-attf-style="border-color:{{state.chart.background}}"
             t-on-click.stop="toggleColorPicker">
-            <t t-call="o-spreadsheet.Icon.FILL_COLOR"/>
+            <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
           </span>
           <ColorPicker
             t-if="state.fillColorTool"

--- a/src/components/side_panel/conditional_formatting/cell_is_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cell_is_rule_editor.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.CellIsRuleEditorPreview" owl="1">
+  <t t-name="o-spreadsheet-CellIsRuleEditorPreview" owl="1">
     <div
       class="o-cf-preview-line"
       t-attf-style="font-weight:{{currentStyle.bold ?'bold':'normal'}};
@@ -13,7 +13,7 @@
     <t t-else="">Preview text</t>
   </t>
 
-  <t t-name="o-spreadsheet.CellIsRuleEditor" owl="1">
+  <t t-name="o-spreadsheet-CellIsRuleEditor" owl="1">
     <div class="o-cf-cell-is-rule">
       <div class="o-section-subtitle">Format cells if...</div>
       <select t-model="rule.operator" class="o-input o-cell-is-operator">
@@ -41,7 +41,7 @@
       </t>
       <div class="o-section-subtitle">Formatting style</div>
 
-      <t t-call="o-spreadsheet.CellIsRuleEditorPreview">
+      <t t-call="o-spreadsheet-CellIsRuleEditorPreview">
         <t t-set="currentStyle" t-value="rule.style"/>
       </t>
       <div class="o-tools">
@@ -50,35 +50,35 @@
           title="Bold"
           t-att-class="{active:rule.style.bold}"
           t-on-click="() => this.toggleStyle('bold')">
-          <t t-call="o-spreadsheet.Icon.BOLD"/>
+          <t t-call="o-spreadsheet-Icon.BOLD"/>
         </div>
         <div
           class="o-tool"
           title="Italic"
           t-att-class="{active:rule.style.italic}"
           t-on-click="() => this.toggleStyle('italic')">
-          <t t-call="o-spreadsheet.Icon.ITALIC"/>
+          <t t-call="o-spreadsheet-Icon.ITALIC"/>
         </div>
         <div
           class="o-tool"
           title="Underline"
           t-att-class="{active:rule.style.underline}"
           t-on-click="(ev) => this.toggleStyle('underline', ev)">
-          <t t-call="o-spreadsheet.Icon.UNDERLINE"/>
+          <t t-call="o-spreadsheet-Icon.UNDERLINE"/>
         </div>
         <div
           class="o-tool"
           title="Strikethrough"
           t-att-class="{active:rule.style.strikethrough}"
           t-on-click="(ev) => this.toggleStyle('strikethrough', ev)">
-          <t t-call="o-spreadsheet.Icon.STRIKE"/>
+          <t t-call="o-spreadsheet-Icon.STRIKE"/>
         </div>
         <div class="o-tool o-dropdown o-with-color">
           <span
             title="TextColor"
             t-attf-style="border-color:{{rule.style.textColor}}"
             t-on-click.stop="(ev) => this.toggleMenu('cellIsRule-textColor', ev)">
-            <t t-call="o-spreadsheet.Icon.TEXT_COLOR"/>
+            <t t-call="o-spreadsheet-Icon.TEXT_COLOR"/>
           </span>
           <ColorPicker
             t-if="state.openedMenu === 'cellIsRule-textColor'"
@@ -93,7 +93,7 @@
             title="FillColor"
             t-attf-style="border-color:{{rule.style.fillColor}}"
             t-on-click.stop="(ev) => this.toggleMenu('cellIsRule-fillColor', ev)">
-            <t t-call="o-spreadsheet.Icon.FILL_COLOR"/>
+            <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
           </span>
           <ColorPicker
             t-if="state.openedMenu === 'cellIsRule-fillColor'"

--- a/src/components/side_panel/conditional_formatting/color_scale_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/color_scale_rule_editor.xml
@@ -1,9 +1,9 @@
 <templates>
-  <t t-name="o-spreadsheet.ColorScaleRuleEditorPreview" owl="1">
+  <t t-name="o-spreadsheet-ColorScaleRuleEditorPreview" owl="1">
     <div class="o-cf-preview-gradient" t-attf-style="{{getPreviewGradient()}}">Preview text</div>
   </t>
 
-  <t t-name="o-spreadsheet.ColorScaleRuleEditorThreshold" owl="1">
+  <t t-name="o-spreadsheet-ColorScaleRuleEditorThreshold" owl="1">
     <div t-attf-class="o-threshold o-threshold-{{thresholdType}}">
       <t t-if="thresholdType === 'midpoint'">
         <t t-set="type" t-value="threshold and threshold.type"/>
@@ -42,7 +42,7 @@
             title="Fill Color"
             t-attf-style="border-color:#{{getThresholdColor(threshold)}}"
             t-on-click.stop="(ev) => this.toggleMenu('colorScale-'+thresholdType+'Color', ev)">
-            <t t-call="o-spreadsheet.Icon.FILL_COLOR"/>
+            <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
           </span>
           <ColorPicker
             t-if="state.openedMenu === 'colorScale-'+thresholdType+'Color'"
@@ -54,22 +54,22 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet.ColorScaleRuleEditor" owl="1">
+  <t t-name="o-spreadsheet-ColorScaleRuleEditor" owl="1">
     <div class="o-cf-color-scale-editor">
       <div class="o-section-subtitle">Preview</div>
-      <t t-call="o-spreadsheet.ColorScaleRuleEditorPreview"/>
+      <t t-call="o-spreadsheet-ColorScaleRuleEditorPreview"/>
       <div class="o-section-subtitle">Minpoint</div>
-      <t t-call="o-spreadsheet.ColorScaleRuleEditorThreshold">
+      <t t-call="o-spreadsheet-ColorScaleRuleEditorThreshold">
         <t t-set="threshold" t-value="rule.minimum"/>
         <t t-set="thresholdType" t-value="'minimum'"/>
       </t>
       <div class="o-section-subtitle">MidPoint</div>
-      <t t-call="o-spreadsheet.ColorScaleRuleEditorThreshold">
+      <t t-call="o-spreadsheet-ColorScaleRuleEditorThreshold">
         <t t-set="threshold" t-value="rule.midpoint"/>
         <t t-set="thresholdType" t-value="'midpoint'"/>
       </t>
       <div class="o-section-subtitle">MaxPoint</div>
-      <t t-call="o-spreadsheet.ColorScaleRuleEditorThreshold">
+      <t t-call="o-spreadsheet-ColorScaleRuleEditorThreshold">
         <t t-set="threshold" t-value="rule.maximum"/>
         <t t-set="thresholdType" t-value="'maximum'"/>
       </t>

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -394,7 +394,7 @@ interface State {
 }
 
 export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.ConditionalFormattingPanel";
+  static template = "o-spreadsheet-ConditionalFormattingPanel";
   static components = { SelectionInput, IconPicker, ColorPicker };
 
   icons = ICONS;

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.xml
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.ConditionalFormattingPanel" owl="1">
+  <t t-name="o-spreadsheet-ConditionalFormattingPanel" owl="1">
     <div class="o-cf">
       <t t-if="state.mode === 'list' || state.mode === 'reorder'">
         <div class="o-cf-preview-list">
@@ -8,7 +8,7 @@
             t-foreach="conditionalFormats"
             t-as="cf"
             t-key="cf.id">
-            <t t-call="o-spreadsheet.ConditionalFormattingPanelPreview"/>
+            <t t-call="o-spreadsheet-ConditionalFormattingPanelPreview"/>
           </div>
         </div>
         <t t-if="state.mode === 'list'">
@@ -91,15 +91,15 @@
             </div>
           </div>
           <div class="o-section o-cf-editor">
-            <t t-if="state.currentCFType === 'CellIsRule'" t-call="o-spreadsheet.CellIsRuleEditor">
+            <t t-if="state.currentCFType === 'CellIsRule'" t-call="o-spreadsheet-CellIsRuleEditor">
               <t t-set="rule" t-value="state.rules.cellIs"/>
             </t>
             <t
               t-if="state.currentCFType === 'ColorScaleRule'"
-              t-call="o-spreadsheet.ColorScaleRuleEditor">
+              t-call="o-spreadsheet-ColorScaleRuleEditor">
               <t t-set="rule" t-value="state.rules.colorScale"/>
             </t>
-            <t t-if="state.currentCFType === 'IconSetRule'" t-call="o-spreadsheet.IconSetEditor">
+            <t t-if="state.currentCFType === 'IconSetRule'" t-call="o-spreadsheet-IconSetEditor">
               <t t-set="rule" t-value="state.rules.iconSet"/>
             </t>
             <div class="o-sidePanelButtons">
@@ -121,13 +121,13 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet.ConditionalFormattingPanelPreview" owl="1">
+  <t t-name="o-spreadsheet-ConditionalFormattingPanelPreview" owl="1">
     <div class="o-cf-preview" t-att-class="{ 'o-cf-cursor-ptr': state.mode !== 'reorder' }">
       <t t-if="cf.rule.type==='IconSetRule'">
         <div class="o-cf-preview-icon">
-          <t t-call="o-spreadsheet.Icon.{{icons[cf.rule.icons.upper].template}}"/>
-          <t t-call="o-spreadsheet.Icon.{{icons[cf.rule.icons.middle].template}}"/>
-          <t t-call="o-spreadsheet.Icon.{{icons[cf.rule.icons.lower].template}}"/>
+          <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.upper].template}}"/>
+          <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.middle].template}}"/>
+          <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.lower].template}}"/>
         </div>
       </t>
       <t t-else="">
@@ -154,14 +154,14 @@
             <div
               class="o-cf-reorder-button-up o-cf-reorder-button"
               t-on-click="(ev) => this.reorderRule(cf, 'up', ev)">
-              <t t-call="o-spreadsheet.Icon.CARET_UP"/>
+              <t t-call="o-spreadsheet-Icon.CARET_UP"/>
             </div>
           </t>
           <t t-if="!cf_last">
             <div
               class="o-cf-reorder-button-down o-cf-reorder-button"
               t-on-click="(ev) => this.reorderRule(cf, 'down', ev)">
-              <t t-call="o-spreadsheet.Icon.CARET_DOWN"/>
+              <t t-call="o-spreadsheet-Icon.CARET_DOWN"/>
             </div>
           </t>
         </div>
@@ -172,7 +172,7 @@
             class="o-cf-delete-button"
             t-on-click.stop="(ev) => this.deleteConditionalFormat(cf, ev)"
             aria-label="Remove rule">
-            <t t-call="o-spreadsheet.Icon.TRASH"/>
+            <t t-call="o-spreadsheet-Icon.TRASH"/>
           </div>
         </div>
       </t>

--- a/src/components/side_panel/conditional_formatting/icon_set_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/icon_set_rule_editor.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.IconSets" owl="1">
+  <t t-name="o-spreadsheet-IconSets" owl="1">
     <div>
       <div class="o-section-subtitle">Icons</div>
       <div class="o-cf-iconsets">
@@ -10,25 +10,25 @@
           t-key="iconSet"
           t-on-click="(ev) => this.setIconSet(iconSet, ev)">
           <div class="o-cf-icon">
-            <t t-call="o-spreadsheet.Icon.{{icons[iconSets[iconSet].good].template}}"/>
+            <t t-call="o-spreadsheet-Icon.{{icons[iconSets[iconSet].good].template}}"/>
           </div>
           <div class="o-cf-icon">
-            <t t-call="o-spreadsheet.Icon.{{icons[iconSets[iconSet].neutral].template}}"/>
+            <t t-call="o-spreadsheet-Icon.{{icons[iconSets[iconSet].neutral].template}}"/>
           </div>
           <div class="o-cf-icon">
-            <t t-call="o-spreadsheet.Icon.{{icons[iconSets[iconSet].bad].template}}"/>
+            <t t-call="o-spreadsheet-Icon.{{icons[iconSets[iconSet].bad].template}}"/>
           </div>
         </div>
       </div>
     </div>
   </t>
 
-  <t t-name="o-spreadsheet.IconSetInflexionPointRow" owl="1">
+  <t t-name="o-spreadsheet-IconSetInflexionPointRow" owl="1">
     <tr>
       <td>
         <div t-on-click.stop="(ev) => this.toggleMenu('iconSet-'+icon+'Icon', ev)">
           <div class="o-cf-icon-button">
-            <t t-call="o-spreadsheet.Icon.{{icons[iconValue].template}}"/>
+            <t t-call="o-spreadsheet-Icon.{{icons[iconValue].template}}"/>
           </div>
         </div>
         <IconPicker
@@ -66,7 +66,7 @@
     </tr>
   </t>
 
-  <t t-name="o-spreadsheet.IconSetInflexionPoints" owl="1">
+  <t t-name="o-spreadsheet-IconSetInflexionPoints" owl="1">
     <div class="o-inflection">
       <table>
         <tr>
@@ -76,13 +76,13 @@
           <th class="o-cf-iconset-value">Value</th>
           <th class="o-cf-iconset-type">Type</th>
         </tr>
-        <t t-call="o-spreadsheet.IconSetInflexionPointRow">
+        <t t-call="o-spreadsheet-IconSetInflexionPointRow">
           <t t-set="iconValue" t-value="rule.icons.upper"/>
           <t t-set="icon" t-value="'upper'"/>
           <t t-set="inflectionPointValue" t-value="rule.upperInflectionPoint"/>
           <t t-set="inflectionPoint" t-value="'upperInflectionPoint'"/>
         </t>
-        <t t-call="o-spreadsheet.IconSetInflexionPointRow">
+        <t t-call="o-spreadsheet-IconSetInflexionPointRow">
           <t t-set="iconValue" t-value="rule.icons.middle"/>
           <t t-set="icon" t-value="'middle'"/>
           <t t-set="inflectionPointValue" t-value="rule.lowerInflectionPoint"/>
@@ -92,7 +92,7 @@
           <td>
             <div t-on-click.stop="(ev) => this.toggleMenu('iconSet-lowerIcon', ev)">
               <div class="o-cf-icon-button">
-                <t t-call="o-spreadsheet.Icon.{{icons[rule.icons.lower].template}}"/>
+                <t t-call="o-spreadsheet-Icon.{{icons[rule.icons.lower].template}}"/>
               </div>
             </div>
             <IconPicker
@@ -108,13 +108,13 @@
       </table>
     </div>
   </t>
-  <t t-name="o-spreadsheet.IconSetEditor" owl="1">
+  <t t-name="o-spreadsheet-IconSetEditor" owl="1">
     <div class="o-cf-iconset-rule">
-      <t t-call="o-spreadsheet.IconSets"/>
-      <t t-call="o-spreadsheet.IconSetInflexionPoints"/>
+      <t t-call="o-spreadsheet-IconSets"/>
+      <t t-call="o-spreadsheet-IconSetInflexionPoints"/>
       <div class="btn btn-link o_refresh_measures o-cf-iconset-reverse" t-on-click="reverseIcons">
         <div class="mr-1 d-inline-block">
-          <t t-call="o-spreadsheet.Icon.REFRESH"/>
+          <t t-call="o-spreadsheet-Icon.REFRESH"/>
         </div>
         Reverse icons
       </div>

--- a/src/components/side_panel/custom_currency/custom_currency.ts
+++ b/src/components/side_panel/custom_currency/custom_currency.ts
@@ -25,7 +25,7 @@ interface State {
 }
 
 export class CustomCurrencyPanel extends Component<any, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.CustomCurrencyPanel";
+  static template = "o-spreadsheet-CustomCurrencyPanel";
   private availableCurrencies!: Currency[];
   private state!: State;
 

--- a/src/components/side_panel/custom_currency/custom_currency.xml
+++ b/src/components/side_panel/custom_currency/custom_currency.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.CustomCurrencyPanel" owl="1">
+  <t t-name="o-spreadsheet-CustomCurrencyPanel" owl="1">
     <div class="o-custom-currency">
       <div class="o-section" t-if="availableCurrencies.length > 1">
         <div class="o-section-title">Currency</div>

--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -53,7 +53,7 @@ interface FindAndReplaceState {
 }
 
 export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.FindAndReplacePanel";
+  static template = "o-spreadsheet-FindAndReplacePanel";
   private state: FindAndReplaceState = useState(this.initialState());
   private inDebounce;
 

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.FindAndReplacePanel" owl="1">
+  <t t-name="o-spreadsheet-FindAndReplacePanel" owl="1">
     <div
       class="o-find-and-replace"
       tabindex="0"

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -137,7 +137,7 @@ interface State {
 }
 
 export class SidePanel extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.SidePanel";
+  static template = "o-spreadsheet-SidePanel";
   state!: State;
 
   setup() {

--- a/src/components/side_panel/side_panel/side_panel.xml
+++ b/src/components/side_panel/side_panel/side_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.SidePanel" owl="1">
+  <t t-name="o-spreadsheet-SidePanel" owl="1">
     <div class="o-sidePanel">
       <div class="o-sidePanelHeader">
         <div class="o-sidePanelTitle" t-esc="getTitle()"/>

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -88,7 +88,7 @@ interface ComposerState {
 }
 
 export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.Spreadsheet";
+  static template = "o-spreadsheet-Spreadsheet";
   static components = { TopBar, Grid, BottomBar, SidePanel, LinkEditor };
   static _t = t;
 

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.Spreadsheet" owl="1">
+  <t t-name="o-spreadsheet-Spreadsheet" owl="1">
     <div class="o-spreadsheet" t-on-keydown="onKeydown" t-att-style="getStyle()">
       <TopBar
         t-if="!env.isDashboard()"

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -255,7 +255,7 @@ css/* scss */ `
   }
 `;
 export class TopBar extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet.TopBar";
+  static template = "o-spreadsheet-TopBar";
   DEFAULT_FONT_SIZE = DEFAULT_FONT_SIZE;
 
   static components = { ColorPicker, Menu, Composer };

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet.TopBar" owl="1">
+  <t t-name="o-spreadsheet-TopBar" owl="1">
     <div class="o-spreadsheet-topbar o-two-columns" t-on-click="props.onClick">
       <div class="o-topbar-top">
         <!-- Menus -->
@@ -42,24 +42,24 @@
             title="Undo"
             t-att-class="{'o-disabled': !undoTool}"
             t-on-click="undo">
-            <t t-call="o-spreadsheet.Icon.UNDO"/>
+            <t t-call="o-spreadsheet-Icon.UNDO"/>
           </div>
           <div
             class="o-tool"
             t-att-class="{'o-disabled': !redoTool}"
             title="Redo"
             t-on-click="redo">
-            <t t-call="o-spreadsheet.Icon.REDO"/>
+            <t t-call="o-spreadsheet-Icon.REDO"/>
           </div>
           <div
             class="o-tool"
             title="Paint Format"
             t-att-class="{active:paintFormatTool}"
             t-on-click="paintFormat">
-            <t t-call="o-spreadsheet.Icon.PAINT_FORMAT"/>
+            <t t-call="o-spreadsheet-Icon.PAINT_FORMAT"/>
           </div>
           <div class="o-tool" title="Clear Format" t-on-click="clearFormatting">
-            <t t-call="o-spreadsheet.Icon.CLEAR_FORMAT"/>
+            <t t-call="o-spreadsheet-Icon.CLEAR_FORMAT"/>
           </div>
           <div class="o-divider"/>
           <div
@@ -86,7 +86,7 @@
             t-on-click="(ev) => this.toggleDropdownTool('formatTool', ev)">
             <div class="o-text-icon">
               123
-              <t t-call="o-spreadsheet.Icon.TRIANGLE_DOWN"/>
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
             </div>
             <div
               class="o-dropdown-content o-text-options  o-format-tool "
@@ -113,7 +113,7 @@
             t-on-click="(ev) => this.toggleDropdownTool('fontSizeTool', ev)">
             <div class="o-text-icon">
               <t t-esc="style.fontSize || DEFAULT_FONT_SIZE"/>
-              <t t-call="o-spreadsheet.Icon.TRIANGLE_DOWN"/>
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
             </div>
             <div
               class="o-dropdown-content o-text-options "
@@ -130,28 +130,28 @@
             title="Bold"
             t-att-class="{active:style.bold}"
             t-on-click="(ev) => this.toogleStyle('bold', ev)">
-            <t t-call="o-spreadsheet.Icon.BOLD"/>
+            <t t-call="o-spreadsheet-Icon.BOLD"/>
           </div>
           <div
             class="o-tool"
             title="Italic"
             t-att-class="{active:style.italic}"
             t-on-click="(ev) => this.toogleStyle('italic', ev)">
-            <t t-call="o-spreadsheet.Icon.ITALIC"/>
+            <t t-call="o-spreadsheet-Icon.ITALIC"/>
           </div>
           <div
             class="o-tool"
             title="Strikethrough"
             t-att-class="{active:style.strikethrough}"
             t-on-click="(ev) => this.toogleStyle('strikethrough', ev)">
-            <t t-call="o-spreadsheet.Icon.STRIKE"/>
+            <t t-call="o-spreadsheet-Icon.STRIKE"/>
           </div>
           <div class="o-tool o-dropdown o-with-color">
             <span
               t-attf-style="border-color:{{textColor}}"
               title="Text Color"
               t-on-click="(ev) => this.toggleDropdownTool('textColorTool', ev)">
-              <t t-call="o-spreadsheet.Icon.TEXT_COLOR"/>
+              <t t-call="o-spreadsheet-Icon.TEXT_COLOR"/>
             </span>
             <ColorPicker
               t-if="state.activeTool === 'textColorTool'"
@@ -165,7 +165,7 @@
               t-attf-style="border-color:{{fillColor}}"
               title="Fill Color"
               t-on-click="(ev) => this.toggleDropdownTool('fillColorTool', ev)">
-              <t t-call="o-spreadsheet.Icon.FILL_COLOR"/>
+              <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
             </span>
             <ColorPicker
               t-if="state.activeTool === 'fillColorTool'"
@@ -175,43 +175,43 @@
           </div>
           <div class="o-tool o-dropdown">
             <span title="Borders" t-on-click="(ev) => this.toggleDropdownTool('borderTool', ev)">
-              <t t-call="o-spreadsheet.Icon.BORDERS"/>
+              <t t-call="o-spreadsheet-Icon.BORDERS"/>
             </span>
             <div
               class="o-dropdown-content o-border-dropdown"
               t-if="state.activeTool === 'borderTool'">
               <div class="o-dropdown-line">
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('all', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDERS"/>
+                  <t t-call="o-spreadsheet-Icon.BORDERS"/>
                 </span>
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('hv', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDER_HV"/>
+                  <t t-call="o-spreadsheet-Icon.BORDER_HV"/>
                 </span>
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('h', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDER_H"/>
+                  <t t-call="o-spreadsheet-Icon.BORDER_H"/>
                 </span>
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('v', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDER_V"/>
+                  <t t-call="o-spreadsheet-Icon.BORDER_V"/>
                 </span>
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('external', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDER_EXTERNAL"/>
+                  <t t-call="o-spreadsheet-Icon.BORDER_EXTERNAL"/>
                 </span>
               </div>
               <div class="o-dropdown-line">
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('left', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDER_LEFT"/>
+                  <t t-call="o-spreadsheet-Icon.BORDER_LEFT"/>
                 </span>
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('top', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDER_TOP"/>
+                  <t t-call="o-spreadsheet-Icon.BORDER_TOP"/>
                 </span>
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('right', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDER_RIGHT"/>
+                  <t t-call="o-spreadsheet-Icon.BORDER_RIGHT"/>
                 </span>
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('bottom', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDER_BOTTOM"/>
+                  <t t-call="o-spreadsheet-Icon.BORDER_BOTTOM"/>
                 </span>
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('clear', ev)">
-                  <t t-call="o-spreadsheet.Icon.BORDER_CLEAR"/>
+                  <t t-call="o-spreadsheet-Icon.BORDER_CLEAR"/>
                 </span>
               </div>
             </div>
@@ -221,7 +221,7 @@
             title="Merge Cells"
             t-att-class="{active:inMerge, 'o-disabled': cannotMerge}"
             t-on-click="toggleMerge">
-            <t t-call="o-spreadsheet.Icon.MERGE_CELL"/>
+            <t t-call="o-spreadsheet-Icon.MERGE_CELL"/>
           </div>
           <div class="o-divider"/>
           <div
@@ -230,25 +230,25 @@
             t-on-click="(ev) => this.toggleDropdownTool('alignTool', ev)">
             <span>
               <t t-if="style.align === 'right'">
-                <t t-call="o-spreadsheet.Icon.ALIGN_RIGHT"/>
+                <t t-call="o-spreadsheet-Icon.ALIGN_RIGHT"/>
               </t>
               <t t-elif="style.align === 'center'">
-                <t t-call="o-spreadsheet.Icon.ALIGN_CENTER"/>
+                <t t-call="o-spreadsheet-Icon.ALIGN_CENTER"/>
               </t>
               <t t-else="">
-                <t t-call="o-spreadsheet.Icon.ALIGN_LEFT"/>
+                <t t-call="o-spreadsheet-Icon.ALIGN_LEFT"/>
               </t>
-              <t t-call="o-spreadsheet.Icon.TRIANGLE_DOWN"/>
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
             </span>
             <div t-if="state.activeTool === 'alignTool'" class="o-dropdown-content">
               <div class="o-dropdown-item" t-on-click="(ev) => this.toggleAlign('left', ev)">
-                <t t-call="o-spreadsheet.Icon.ALIGN_LEFT"/>
+                <t t-call="o-spreadsheet-Icon.ALIGN_LEFT"/>
               </div>
               <div class="o-dropdown-item" t-on-click="(ev) => this.toggleAlign('center', ev)">
-                <t t-call="o-spreadsheet.Icon.ALIGN_CENTER"/>
+                <t t-call="o-spreadsheet-Icon.ALIGN_CENTER"/>
               </div>
               <div class="o-dropdown-item" t-on-click="(ev) => this.toggleAlign('right', ev)">
-                <t t-call="o-spreadsheet.Icon.ALIGN_RIGHT"/>
+                <t t-call="o-spreadsheet-Icon.ALIGN_RIGHT"/>
               </div>
             </div>
           </div>


### PR DESCRIPTION
When We refactored the component in 10e1a0ca in order to make the
templates extensible in Odoo, we chose to prefix the template names with
a fake module name `o-spreadsheet`. The purpose was to set a unique name
spacing to avoid collision with other templates.

Unfortunately, the implementation of the template engine in Odoo is such
that the strategy only works when templates and their extensions are
declared inside the very same module, all because the module
`o-spreadsheet`does not actually exist.

To solve this, we drop the fake module name altogether and add a simple
prefix `o-spreadsheet-*` to the templates. the former will allow the
template engine to automatically link the template to the module in
which it was declared and the latter will avoid collisions with other
module templates, which cas the very goal.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo