### PR TITLE
[IMP] error_handling: remove recursive expression in evaluationError

### DIFF
--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -200,17 +200,11 @@ export class EvaluationPlugin extends UIPlugin {
 
     function getCellValue(cell: Cell, sheetId: UID): CellValue {
       if (cell.isFormula() && cell.evaluated.type === CellValueType.error) {
-        throw new EvaluationError(
-          cell.evaluated.value,
-          _lt("This formula depends on invalid values: %s", cell.evaluated.error)
-        );
+        throw new EvaluationError(cell.evaluated.value, cell.evaluated.error);
       }
       computeValue(cell, sheetId);
       if (cell.evaluated.type === CellValueType.error) {
-        throw new EvaluationError(
-          cell.evaluated.value,
-          _lt("This formula depends on invalid values: %s", cell.evaluated.error)
-        );
+        throw new EvaluationError(cell.evaluated.value, cell.evaluated.error);
       }
       return cell.evaluated.value;
     }

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -991,6 +991,19 @@ describe("evaluateCells", () => {
     expect(getCellError(model, "A1")).toBe("Invalid reference");
   });
 
+  test("Coherent handling of error when referencing errored cell", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=+(");
+    setCellContent(model, "B1", "=A1");
+    setCellContent(model, "C1", "=B1");
+    expect(getCell(model, "A1")!.evaluated.value).toBe("#BAD_EXPR");
+    expect(getCell(model, "B1")!.evaluated.value).toBe("#BAD_EXPR");
+    expect(getCell(model, "C1")!.evaluated.value).toBe("#BAD_EXPR");
+    expect(getCellError(model, "A1")).toBe("Invalid expression");
+    expect(getCellError(model, "B1")).toBe("Invalid expression");
+    expect(getCellError(model, "C1")).toBe("Invalid expression");
+  });
+
   // TO DO: add tests for exp format (ex: 4E10)
   // RO DO: add tests for DATE string format (ex match: "28 02 2020")
 });


### PR DESCRIPTION
When referencing an errored cell in another cell, we use the following
pattern for the referencing cell's error :
"This formula depends on invalid value: " + referenced cell's message

After some investigation, Google Spreadsheet 'simply' propagate error
message when a cell is referencing an errored message. We then simply
apply the same behaviour here, removing then the "This formula depends
on invalid value: " prefix

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo