### PR TITLE
[FIX] config: fix pre-commit structure

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# ativate user inputs
-exec < /dev/tty
 
 if [ "$HUSKY_PRE_COMMIT" != 0 ]; then
     npx lint-staged
+    # ativate user inputs
+    exec < /dev/tty
 
     consoleregexp='console\.|debugger'
 


### PR DESCRIPTION
The new pre-commit step added in cb1076b7 was executing bash
instructions regardless of the ENV variable `HUSKY_PRE_COMMIT` which
allows users to bypass the pre-commit altogether.
This prevents Windows Platform users from commiting altogether as the
instructions are not recognized.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo