### PR TITLE
[IMP] renderer: Hide gridlines over color formatted cells in dashboard

### DIFF
--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -47,6 +47,8 @@ import { UIPlugin } from "../ui_plugin";
 // Constants, types, helpers, ...
 // -----------------------------------------------------------------------------
 
+export const CELL_BACKGROUND_GRIDLINE_STROKE_STYLE = "#111";
+
 export class RendererPlugin extends UIPlugin {
   static layers = [LAYERS.Background, LAYERS.Headers];
   static getters = [
@@ -317,24 +319,31 @@ export class RendererPlugin extends UIPlugin {
 
   private drawCellBackground(renderingContext: GridRenderingContext) {
     const { ctx, thinLineWidth } = renderingContext;
-    ctx.lineWidth = 0.3 * thinLineWidth;
-    const inset = 0.1 * thinLineWidth;
+    const areGridLinesVisible =
+      !this.getters.isDashboard() &&
+      this.getters.getGridLinesVisibility(this.getters.getActiveSheetId());
+    ctx.lineWidth = areGridLinesVisible ? 0.3 * thinLineWidth : thinLineWidth;
+    const inset = areGridLinesVisible ? 0.1 * thinLineWidth : 0;
     ctx.strokeStyle = "#111";
-    const areGridLinesVisible = this.getters.getGridLinesVisibility(
-      this.getters.getActiveSheetId()
-    );
     for (let box of this.boxes) {
       // fill color
       let style = box.style;
       if ((style.fillColor && style.fillColor !== "#ffffff") || box.isMerge) {
         ctx.fillStyle = style.fillColor || "#ffffff";
-        ctx.fillRect(box.x, box.y, box.width, box.height);
         if (areGridLinesVisible) {
+          ctx.fillRect(box.x, box.y, box.width, box.height);
           ctx.strokeRect(
             box.x + inset,
             box.y + inset,
             box.width - 2 * inset,
             box.height - 2 * inset
+          );
+        } else {
+          ctx.fillRect(
+            box.x - thinLineWidth,
+            box.y - thinLineWidth,
+            box.width + 2 * thinLineWidth,
+            box.height + 2 * thinLineWidth
           );
         }
       }


### PR DESCRIPTION
Currently, we draw gridline over cells that have a colored background.
This should only happen under 2 conditions - the grid lines are visibles
(per user choice) and we are not in dashboard mode.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2883210](https://www.odoo.com/web#id=2883210&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo