### PR TITLE
[IMP] charts: Insert new chart in viewport

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,6 +73,10 @@ export const MAX_HISTORY_STEPS = 99;
 // Id of the first revision
 export const DEFAULT_REVISION_ID = "START_REVISION";
 
+// Figure
+export const DEFAULT_FIGURE_HEIGHT = 335;
+export const DEFAULT_FIGURE_WIDTH = 536;
+
 // Chart
 export const MAX_CHAR_LABEL = 20;
 

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../../constants";
 import { AbstractChart } from "../../helpers/charts/abstract_chart";
 import { chartFactory, validateChartDefinition } from "../../helpers/charts/chart_factory";
 import {
@@ -71,7 +72,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   handle(cmd: CoreCommand) {
     switch (cmd.type) {
       case "CREATE_CHART":
-        this.addFigure(cmd.id, cmd.sheetId, cmd.position);
+        this.addFigure(cmd.id, cmd.sheetId, cmd.position, cmd.size);
         this.addChart(cmd.id, cmd.sheetId, cmd.definition);
         break;
       case "UPDATE_CHART": {
@@ -208,13 +209,24 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   /**
    * Add a figure with tag chart with the given id at the given position
    */
-  private addFigure(id: UID, sheetId: UID, position: { x: number; y: number } = { x: 0, y: 0 }) {
+  private addFigure(
+    id: UID,
+    sheetId: UID,
+    position: { x: number; y: number } = { x: 0, y: 0 },
+    size: { width: number; height: number } = {
+      width: DEFAULT_FIGURE_WIDTH,
+      height: DEFAULT_FIGURE_HEIGHT,
+    }
+  ) {
+    if (this.getters.getFigure(sheetId, id)) {
+      return;
+    }
     const figure: Figure = {
       id,
       x: position.x,
       y: position.y,
-      height: 335,
-      width: 536,
+      width: size.width,
+      height: size.height,
       tag: "chart",
     };
     this.dispatch("CREATE_FIGURE", { sheetId, figure });

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -1,4 +1,8 @@
-import { BACKGROUND_CHART_COLOR } from "../../constants";
+import {
+  BACKGROUND_CHART_COLOR,
+  DEFAULT_FIGURE_HEIGHT,
+  DEFAULT_FIGURE_WIDTH,
+} from "../../constants";
 import { numberToLetters, zoneToXc } from "../../helpers/index";
 import { interactiveSortSelection } from "../../helpers/sort";
 import { interactiveCut } from "../../helpers/ui/cut";
@@ -548,10 +552,15 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
   }
   const dataSets = [zoneToXc(dataSetZone)];
   const sheetId = env.model.getters.getActiveSheetId();
+  const viewport = env.model.getters.getActiveViewport();
+  const left = env.model.getters.getColDimensions(sheetId, viewport.left).start;
+  const top = env.model.getters.getRowDimensions(sheetId, viewport.top).start;
+  const { width, height } = env.model.getters.getViewportDimension();
+  const size = { width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
   const position = {
-    x: env.model.getters.getColDimensions(sheetId, zone.right + 1).start,
-    y: env.model.getters.getRowDimensions(sheetId, zone.top).start,
-  };
+    x: left + Math.max(0, (width - DEFAULT_FIGURE_WIDTH) / 2),
+    y: top + Math.max(0, (height - DEFAULT_FIGURE_HEIGHT) / 2),
+  }; // Position at the center of the viewport
   let dataSetsHaveTitle = false;
   for (let x = dataSetZone.left; x <= dataSetZone.right; x++) {
     const cell = env.model.getters.getCell(sheetId, x, zone.top);
@@ -571,6 +580,7 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
     sheetId,
     id,
     position,
+    size,
     definition: {
       title: "",
       dataSets,

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -342,6 +342,7 @@ export interface CreateChartCommand extends SheetDependentCommand {
   type: "CREATE_CHART";
   id: UID;
   position?: { x: number; y: number };
+  size?: { width: number; height: number };
   definition: ChartDefinition;
 }
 


### PR DESCRIPTION
Currently, when inserting a chart, it is added at the top of the current
sheet. Problem is, when the user is dozens of rows below, he won't see
the chart appearing.

The purpose of this task is to make sure a chart will always be added
in the middle (more of less) of the viewport. This way, the user will
always get feedback.

Task 2884548

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2884548](https://www.odoo.com/web#id=2884548&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo