### PR TITLE
[FIX] spreadsheet.ts: fixed show formula bug

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -53,6 +53,7 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FindAndReplacePanel";
   private state: FindAndReplaceState = useState(this.initialState());
   private inDebounce;
+  private showFormulaState: boolean = false;
 
   private findAndReplaceRef = useRef("findAndReplace");
 
@@ -61,9 +62,14 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   setup() {
+    this.showFormulaState = this.env.model.getters.shouldShowFormulas();
+
     onMounted(() => this.focusInput());
 
-    onWillUnmount(() => this.env.model.dispatch("CLEAR_SEARCH"));
+    onWillUnmount(() => {
+      this.env.model.dispatch("CLEAR_SEARCH");
+      this.env.model.dispatch("SET_FORMULA_VISIBILITY", { show: this.showFormulaState });
+    });
   }
 
   onInput(ev) {

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -184,6 +184,14 @@ describe("find and replace sidePanel component", () => {
       await nextTick();
       expect(model.getters.shouldShowFormulas()).toBe(true);
     });
+
+    test("search in formulas should not show formula after closing the sidepanel", async () => {
+      triggerMouseEvent(document.querySelector(selectors.checkBoxSearchFormulas), "click");
+      await nextTick();
+      triggerMouseEvent(document.querySelector(selectors.closeSidepanel), "click");
+      await nextTick();
+      expect(model.getters.shouldShowFormulas()).toBe(false);
+    });
   });
   describe("replace options", () => {
     test("Can replace a simple text value", async () => {

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -611,3 +611,33 @@ describe("TopBar - CF", () => {
     app.destroy();
   });
 });
+describe("Topbar - View", () => {
+  test("Setting show formula from topbar should retain its state even it's changed via f&r side panel upon closing", async () => {
+    const { app, parent } = await mountSpreadsheet(fixture);
+    const model = parent.model;
+    triggerMouseEvent(".o-topbar-menu[data-id='view']", "click");
+    await nextTick();
+    triggerMouseEvent(".o-menu-item[data-name='view_formulas']", "click");
+    await nextTick();
+    expect(model.getters.shouldShowFormulas()).toBe(true);
+    parent.env.openSidePanel("FindAndReplace");
+    await nextTick();
+    expect(model.getters.shouldShowFormulas()).toBe(true);
+    await nextTick();
+    triggerMouseEvent(
+      document.querySelector(
+        ".o-sidePanel .o-sidePanelBody .o-find-and-replace .o-section:nth-child(1) .o-far-item:nth-child(3) input"
+      ),
+      "click"
+    );
+    await nextTick();
+    expect(model.getters.shouldShowFormulas()).toBe(false);
+    triggerMouseEvent(
+      document.querySelector(".o-sidePanel .o-sidePanelHeader .o-sidePanelClose"),
+      "click"
+    );
+    await nextTick();
+    expect(model.getters.shouldShowFormulas()).toBe(true);
+    app.destroy();
+  });
+});


### PR DESCRIPTION
## Description:

Earlier there was a bug with 'search and replace' side panel, that
upon clicking show formula button and closing the side panel directly
would not change the state of formula visibility, resulting with
formula being displayed on cells instead of value.

To fix this issue, an event is dispatched while closing the side panel
which will set the formula visibility as per settings done via view menu.

Odoo task ID : [2882964](https://www.odoo.com/web#id=2882964&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo