### PR TITLE
[IMP] charts: keep labels when changing chart type

### DIFF
--- a/src/helpers/charts/bar_chart.ts
+++ b/src/helpers/charts/bar_chart.ts
@@ -107,7 +107,7 @@ export class BarChart extends AbstractChart {
       title: context.title || "",
       type: "bar",
       verticalAxisPosition: "left",
-      labelRange: undefined,
+      labelRange: context.auxiliaryRange || undefined,
     };
   }
 
@@ -119,6 +119,9 @@ export class BarChart extends AbstractChart {
         this.dataSets.length > 0
           ? this.getters.getRangeString(this.dataSets[0].dataRange, this.sheetId)
           : undefined,
+      auxiliaryRange: this.labelRange
+        ? this.getters.getRangeString(this.labelRange, this.sheetId)
+        : undefined,
     };
   }
 

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -112,7 +112,7 @@ export class LineChart extends AbstractChart {
       title: context.title || "",
       type: "line",
       verticalAxisPosition: "left",
-      labelRange: undefined,
+      labelRange: context.auxiliaryRange || undefined,
     };
   }
 
@@ -147,6 +147,9 @@ export class LineChart extends AbstractChart {
         this.dataSets.length > 0
           ? this.getters.getRangeString(this.dataSets[0].dataRange, this.sheetId)
           : undefined,
+      auxiliaryRange: this.labelRange
+        ? this.getters.getRangeString(this.labelRange, this.sheetId)
+        : undefined,
     };
   }
 

--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -108,7 +108,7 @@ export class PieChart extends AbstractChart {
       legendPosition: "top",
       title: context.title || "",
       type: "pie",
-      labelRange: undefined,
+      labelRange: context.auxiliaryRange || undefined,
     };
   }
 
@@ -124,6 +124,9 @@ export class PieChart extends AbstractChart {
         this.dataSets.length > 0
           ? this.getters.getRangeString(this.dataSets[0].dataRange, this.sheetId)
           : undefined,
+      auxiliaryRange: this.labelRange
+        ? this.getters.getRangeString(this.labelRange, this.sheetId)
+        : undefined,
     };
   }
 

--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -95,6 +95,7 @@ export class ScorecardChart extends AbstractChart {
       baselineMode: "absolute",
       baselineColorUp: "#00A04A",
       baselineColorDown: "#DC6965",
+      baseline: context.auxiliaryRange || "",
     };
   }
 
@@ -134,6 +135,9 @@ export class ScorecardChart extends AbstractChart {
       background: this.background,
       title: this.title,
       range: this.keyValue ? this.getters.getRangeString(this.keyValue, this.sheetId) : undefined,
+      auxiliaryRange: this.baseline
+        ? this.getters.getRangeString(this.baseline, this.sheetId)
+        : undefined,
     };
   }
 

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -60,4 +60,5 @@ export interface ChartCreationContext {
   readonly range?: string;
   readonly title?: string;
   readonly background?: string;
+  readonly auxiliaryRange?: string;
 }


### PR DESCRIPTION
## Task Description:

When switching a chart from one type to another (eg line to bar), the labels are not kept. This task aims to fix it by adding a key
labelRange in the chartCreationContext, being now able to pass the labelRange from one kind of chart to another

## Related Task:
Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo