### PR TITLE
[FIX] charts: keeps multiple ranges in dataset when changing chart type

### DIFF
--- a/src/helpers/charts/bar_chart.ts
+++ b/src/helpers/charts/bar_chart.ts
@@ -100,7 +100,7 @@ export class BarChart extends AbstractChart {
   static getDefinitionFromContextCreation(context: ChartCreationContext): BarChartDefinition {
     return {
       background: context.background || BACKGROUND_CHART_COLOR,
-      dataSets: context.range ? [context.range] : [],
+      dataSets: context.range ? context.range : [],
       dataSetsHaveTitle: false,
       stackedBar: false,
       legendPosition: "top",
@@ -115,10 +115,9 @@ export class BarChart extends AbstractChart {
     return {
       background: this.background,
       title: this.title,
-      range:
-        this.dataSets.length > 0
-          ? this.getters.getRangeString(this.dataSets[0].dataRange, this.sheetId)
-          : undefined,
+      range: this.dataSets.map((ds: DataSet) =>
+        this.getters.getRangeString(ds.dataRange, this.sheetId)
+      ),
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,

--- a/src/helpers/charts/gauge_chart.ts
+++ b/src/helpers/charts/gauge_chart.ts
@@ -195,7 +195,7 @@ export class GaugeChart extends AbstractChart {
       background: context.background || BACKGROUND_CHART_COLOR,
       title: context.title || "",
       type: "gauge",
-      dataRange: context.range,
+      dataRange: context.range ? context.range[0] : undefined,
       sectionRule: {
         colors: {
           lowerColor: DEFAULT_GAUGE_LOWER_COLOR,
@@ -249,7 +249,9 @@ export class GaugeChart extends AbstractChart {
     return {
       background: this.background,
       title: this.title,
-      range: this.dataRange ? this.getters.getRangeString(this.dataRange, this.sheetId) : undefined,
+      range: this.dataRange
+        ? [this.getters.getRangeString(this.dataRange, this.sheetId)]
+        : undefined,
     };
   }
 

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -105,7 +105,7 @@ export class LineChart extends AbstractChart {
   static getDefinitionFromContextCreation(context: ChartCreationContext): LineChartDefinition {
     return {
       background: context.background || BACKGROUND_CHART_COLOR,
-      dataSets: context.range ? [context.range] : [],
+      dataSets: context.range ? context.range : [],
       dataSetsHaveTitle: false,
       labelsAsText: false,
       legendPosition: "top",
@@ -143,10 +143,9 @@ export class LineChart extends AbstractChart {
     return {
       background: this.background,
       title: this.title,
-      range:
-        this.dataSets.length > 0
-          ? this.getters.getRangeString(this.dataSets[0].dataRange, this.sheetId)
-          : undefined,
+      range: this.dataSets.map((ds: DataSet) =>
+        this.getters.getRangeString(ds.dataRange, this.sheetId)
+      ),
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,

--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -102,7 +102,7 @@ export class PieChart extends AbstractChart {
   static getDefinitionFromContextCreation(context: ChartCreationContext): PieChartDefinition {
     return {
       background: context.background || BACKGROUND_CHART_COLOR,
-      dataSets: context.range ? [context.range] : [],
+      dataSets: context.range ? context.range : [],
       dataSetsHaveTitle: false,
       legendPosition: "top",
       title: context.title || "",
@@ -119,10 +119,9 @@ export class PieChart extends AbstractChart {
     return {
       background: this.background,
       title: this.title,
-      range:
-        this.dataSets.length > 0
-          ? this.getters.getRangeString(this.dataSets[0].dataRange, this.sheetId)
-          : undefined,
+      range: this.dataSets.map((ds: DataSet) =>
+        this.getters.getRangeString(ds.dataRange, this.sheetId)
+      ),
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,

--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -90,7 +90,7 @@ export class ScorecardChart extends AbstractChart {
     return {
       background: context.background || BACKGROUND_CHART_COLOR,
       type: "scorecard",
-      keyValue: context.range,
+      keyValue: context.range ? context.range[0] : undefined,
       title: context.title || "",
       baselineMode: "absolute",
       baselineColorUp: "#00A04A",
@@ -134,7 +134,7 @@ export class ScorecardChart extends AbstractChart {
     return {
       background: this.background,
       title: this.title,
-      range: this.keyValue ? this.getters.getRangeString(this.keyValue, this.sheetId) : undefined,
+      range: this.keyValue ? [this.getters.getRangeString(this.keyValue, this.sheetId)] : undefined,
       auxiliaryRange: this.baseline
         ? this.getters.getRangeString(this.baseline, this.sheetId)
         : undefined,

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -57,7 +57,7 @@ export interface ExcelChartDefinition {
 }
 
 export interface ChartCreationContext {
-  readonly range?: string;
+  readonly range?: string[];
   readonly title?: string;
   readonly background?: string;
   readonly auxiliaryRange?: string;


### PR DESCRIPTION
## Task Description

When switching from one kind of chart to another, we only keep the first range of the selected dataset. While this make sense for gauge and score charts, we should keep the multiple datasets for line, bar and pie charts.

The proposed fix then switch the type of the `range` property of the `ChartCreationContext` to use a `string[]` instead of the previous `string` type, making us able to pass more than one range when changing the chart type.

## Related Task
Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo