### PR TITLE
[IMP] viewport: merge viewport and snapped viewport

### DIFF
--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -87,7 +87,7 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
   onMouseDown(ev: MouseEvent) {
     this.state.handler = true;
     this.state.position = { left: 0, top: 0 };
-    const { offsetY, offsetX } = this.env.model.getters.getActiveSnappedViewport();
+    const { offsetY, offsetX } = this.env.model.getters.getActiveViewport();
     const start = {
       left: ev.clientX + offsetX,
       top: ev.clientY + offsetY,
@@ -102,7 +102,7 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
 
     const onMouseMove = (ev: MouseEvent) => {
       const position = this.props.getGridBoundingClientRect();
-      const { offsetY, offsetX } = this.env.model.getters.getActiveSnappedViewport();
+      const { offsetY, offsetX } = this.env.model.getters.getActiveViewport();
       this.state.position = {
         left: ev.clientX - start.left + offsetX,
         top: ev.clientY - start.top + offsetY,

--- a/src/components/collaborative_client_tag/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.ts
@@ -27,7 +27,7 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ClientTag";
   get tagStyle(): string {
     const { col, row, color } = this.props;
-    const viewport = this.env.model.getters.getActiveSnappedViewport();
+    const viewport = this.env.model.getters.getActiveViewport();
     const { height } = this.env.model.getters.getViewportDimensionWithHeaders();
     const [x, y, ,] = this.env.model.getters.getRect(
       { left: col, top: row, right: col, bottom: row },

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -65,7 +65,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     });
     this.rect = this.env.model.getters.getRect(
       this.zone,
-      this.env.model.getters.getActiveSnappedViewport()
+      this.env.model.getters.getActiveViewport()
     );
     onMounted(() => {
       const el = this.gridComposerRef.el!;

--- a/src/components/figures/container/container.ts
+++ b/src/components/figures/container/container.ts
@@ -144,7 +144,7 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
 
   getStyle(info: FigureInfo) {
     const { figure, isSelected } = info;
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
     const target = figure.id === (isSelected && this.dnd.figureId) ? this.dnd : figure;
     const { width, height } = target;
     let x = target.x - offsetX - 1;

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -209,7 +209,7 @@ css/* scss */ `
       &.horizontal {
         bottom: 0;
         height: ${SCROLLBAR_WIDTH}px;
-        right: ${SCROLLBAR_WIDTH + 1}px;
+        right: ${SCROLLBAR_WIDTH}px;
         overflow-y: hidden;
       }
     }
@@ -353,7 +353,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       cell.evaluated.type === CellValueType.error &&
       cell.evaluated.error.logLevel > CellErrorLevel.silent
     ) {
-      const viewport = this.env.model.getters.getActiveSnappedViewport();
+      const viewport = this.env.model.getters.getActiveViewport();
       const [x, y, width] = this.env.model.getters.getRect(
         { left: col, top: row, right: col, bottom: row },
         viewport
@@ -383,7 +383,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   get shouldDisplayLink(): boolean {
     const sheetId = this.env.model.getters.getActiveSheetId();
     const { col, row } = this.activeCellPosition;
-    const viewport = this.env.model.getters.getActiveSnappedViewport();
+    const viewport = this.env.model.getters.getActiveViewport();
     const cell = this.env.model.getters.getCell(sheetId, col, row);
     return (
       this.env.model.getters.isVisibleInViewport(col, row, viewport) &&
@@ -406,7 +406,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       position.col,
       position.row
     );
-    const viewport = this.env.model.getters.getActiveSnappedViewport();
+    const viewport = this.env.model.getters.getActiveViewport();
     const [x, y, width, height] = this.env.model.getters.getRect(
       { left: col, top: row, right: col, bottom: row },
       viewport
@@ -569,8 +569,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onScroll() {
-    const { offsetScrollbarX, offsetScrollbarY } =
-      this.env.model.getters.getActiveSnappedViewport();
+    const { offsetScrollbarX, offsetScrollbarY } = this.env.model.getters.getActiveViewport();
     if (
       offsetScrollbarX !== this.hScrollbar.scroll ||
       offsetScrollbarY !== this.vScrollbar.scroll
@@ -596,7 +595,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   getAutofillPosition() {
     const zone = this.env.model.getters.getSelectedZone();
     const sheetId = this.env.model.getters.getActiveSheetId();
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
     const col = this.env.model.getters.getColDimensions(sheetId, zone.right);
     const row = this.env.model.getters.getRowDimensions(sheetId, zone.bottom);
     return {
@@ -607,8 +606,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
 
   drawGrid() {
     //reposition scrollbar
-    const { offsetScrollbarX, offsetScrollbarY } =
-      this.env.model.getters.getActiveSnappedViewport();
+    const { offsetScrollbarX, offsetScrollbarY } = this.env.model.getters.getActiveViewport();
     this.hScrollbar.scroll = offsetScrollbarX;
     this.vScrollbar.scroll = offsetScrollbarY;
     // check for position changes
@@ -620,7 +618,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     const thinLineWidth = 0.4 * dpr;
     const renderingContext = {
       ctx,
-      viewport: this.env.model.getters.getActiveSnappedViewport(),
+      viewport: this.env.model.getters.getActiveViewport(),
       dpr,
       thinLineWidth,
     };
@@ -742,7 +740,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       const colEdgeScroll = this.env.model.getters.getEdgeScrollCol(x);
       const rowEdgeScroll = this.env.model.getters.getEdgeScrollRow(y);
 
-      const { left, right, top, bottom } = this.env.model.getters.getActiveSnappedViewport();
+      const { left, right, top, bottom } = this.env.model.getters.getActiveViewport();
       let col: number, row: number;
       if (colEdgeScroll.canEdgeScroll) {
         col = colEdgeScroll.direction > 0 ? right : left - 1;
@@ -834,7 +832,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       const oldZone = this.env.model.getters.getSelectedZone();
       this.env.model.selection.resizeAnchorZone(direction, ev.ctrlKey ? "end" : "one");
       const newZone = this.env.model.getters.getSelectedZone();
-      const viewport = this.env.model.getters.getActiveSnappedViewport();
+      const viewport = this.env.model.getters.getActiveViewport();
       const sheetId = this.env.model.getters.getActiveSheetId();
       let { col, row } = findCellInNewZone(oldZone, newZone);
       col = Math.min(col, this.env.model.getters.getNumberCols(sheetId) - 1);

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -411,7 +411,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getViewportOffset(): number {
-    return this.env.model.getters.getActiveSnappedViewport().left;
+    return this.env.model.getters.getActiveViewport().left;
   }
 
   _getClientPosition(ev: MouseEvent): number {
@@ -435,7 +435,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   _getBoundaries(): { first: number; last: number } {
-    const { left, right } = this.env.model.getters.getActiveSnappedViewport();
+    const { left, right } = this.env.model.getters.getActiveViewport();
     return { first: left, last: right };
   }
 
@@ -495,7 +495,7 @@ export class ColResizer extends AbstractResizer {
   }
 
   _adjustViewport(direction: number): void {
-    const { left, offsetY } = this.env.model.getters.getActiveSnappedViewport();
+    const { left, offsetY } = this.env.model.getters.getActiveViewport();
     const sheetId = this.env.model.getters.getActiveSheetId();
     const offsetX = this.env.model.getters.getColDimensions(sheetId, left + direction).start;
     this.env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
@@ -622,7 +622,7 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getViewportOffset(): number {
-    return this.env.model.getters.getActiveSnappedViewport().top;
+    return this.env.model.getters.getActiveViewport().top;
   }
 
   _getClientPosition(ev: MouseEvent): number {
@@ -646,7 +646,7 @@ export class RowResizer extends AbstractResizer {
   }
 
   _getBoundaries(): { first: number; last: number } {
-    const { top, bottom } = this.env.model.getters.getActiveSnappedViewport();
+    const { top, bottom } = this.env.model.getters.getActiveViewport();
     return { first: top, last: bottom };
   }
 
@@ -706,7 +706,7 @@ export class RowResizer extends AbstractResizer {
   }
 
   _adjustViewport(direction: number): void {
-    const { top, offsetX } = this.env.model.getters.getActiveSnappedViewport();
+    const { top, offsetX } = this.env.model.getters.getActiveViewport();
     const sheetId = this.env.model.getters.getActiveSheetId();
     const offsetY = this.env.model.getters.getRowDimensions(sheetId, top + direction).start;
     this.env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });

--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -48,7 +48,7 @@ export function dragAndDropBeyondTheViewport(
     const offsetY = currentEv.clientY - position.top;
     const edgeScrollInfoX = env.model.getters.getEdgeScrollCol(offsetX - HEADER_WIDTH);
     const edgeScrollInfoY = env.model.getters.getEdgeScrollRow(offsetY - HEADER_HEIGHT);
-    const { top, left, bottom, right } = env.model.getters.getActiveSnappedViewport();
+    const { top, left, bottom, right } = env.model.getters.getActiveViewport();
 
     let colIndex: number;
     if (edgeScrollInfoX.canEdgeScroll) {
@@ -68,7 +68,7 @@ export function dragAndDropBeyondTheViewport(
 
     const sheetId = env.model.getters.getActiveSheetId();
     if (edgeScrollInfoX.canEdgeScroll) {
-      const { left, offsetY } = env.model.getters.getActiveSnappedViewport();
+      const { left, offsetY } = env.model.getters.getActiveViewport();
       const offsetX = env.model.getters.getColDimensions(
         sheetId,
         left + edgeScrollInfoX.direction
@@ -81,7 +81,7 @@ export function dragAndDropBeyondTheViewport(
     }
 
     if (edgeScrollInfoY.canEdgeScroll) {
-      const { top, offsetX } = env.model.getters.getActiveSnappedViewport();
+      const { top, offsetX } = env.model.getters.getActiveViewport();
       const offsetY = env.model.getters.getRowDimensions(
         sheetId,
         top + edgeScrollInfoY.direction

--- a/src/components/highlight/border/border.ts
+++ b/src/components/highlight/border/border.ts
@@ -48,7 +48,7 @@ export class Border extends Component<Props, SpreadsheetChildEnv> {
     const widthValue = isHorizontal ? right - left : lineWidth;
     const heightValue = isVertical ? bottom - top : lineWidth;
 
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
     return `
         left:${leftValue + HEADER_WIDTH - offsetX}px;
         top:${topValue + HEADER_HEIGHT - offsetY}px;

--- a/src/components/highlight/corner/corner.ts
+++ b/src/components/highlight/corner/corner.ts
@@ -43,7 +43,7 @@ export class Corner extends Component<Props, SpreadsheetChildEnv> {
   private isLeft = this.props.orientation[1] === "w";
 
   get style() {
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
     const sheetId = this.env.model.getters.getActiveSheetId();
     const z = this.props.zone;
     const leftValue = this.isLeft

--- a/src/model.ts
+++ b/src/model.ts
@@ -429,7 +429,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   drawGrid(context: GridRenderingContext) {
     // we make sure here that the viewport is properly positioned: the offsets
     // correspond exactly to a cell
-    context.viewport = this.getters.getActiveSnappedViewport(); //snaped one
+    context.viewport = this.getters.getActiveViewport(); //snaped one
     for (let [renderer, layer] of this.renderers) {
       context.ctx.save();
       renderer.drawGrid(context, layer);

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -85,7 +85,7 @@ export class RendererPlugin extends UIPlugin {
    * column of the current viewport
    */
   getColDimensionsInViewport(sheetId: UID, col: number): HeaderDimensions {
-    const { left } = this.getters.getActiveSnappedViewport();
+    const { left } = this.getters.getActiveViewport();
     const start = this.getColRowOffset("COL", left, col, sheetId);
     const size = this.getters.getColSize(sheetId, col);
     const isColHidden = this.getters.isColHidden(sheetId, col);
@@ -115,7 +115,7 @@ export class RendererPlugin extends UIPlugin {
    * of the current viewport
    */
   getRowDimensionsInViewport(sheetId: UID, row: number): HeaderDimensions {
-    const { top } = this.getters.getActiveSnappedViewport();
+    const { top } = this.getters.getActiveViewport();
     const start = this.getColRowOffset("ROW", top, row, sheetId);
     const size = this.getters.getRowSize(sheetId, row);
     const isRowHidden = this.getters.isRowHidden(sheetId, row);
@@ -210,7 +210,7 @@ export class RendererPlugin extends UIPlugin {
     let delay = 0;
     const { width } = this.getters.getViewportDimension();
     const { width: gridWidth } = this.getters.getMaxViewportSize(this.getters.getActiveSheet());
-    const { left, offsetX } = this.getters.getActiveSnappedViewport();
+    const { left, offsetX } = this.getters.getActiveViewport();
     if (x < 0 && left > 0) {
       canEdgeScroll = true;
       direction = -1;
@@ -230,7 +230,7 @@ export class RendererPlugin extends UIPlugin {
     let delay = 0;
     const { height } = this.getters.getViewportDimension();
     const { height: gridHeight } = this.getters.getMaxViewportSize(this.getters.getActiveSheet());
-    const { top, offsetY } = this.getters.getActiveSnappedViewport();
+    const { top, offsetY } = this.getters.getActiveViewport();
     if (y < 0 && top > 0) {
       canEdgeScroll = true;
       direction = -1;

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -466,7 +466,7 @@ export class GridSelectionPlugin extends UIPlugin {
     const sheetId = this.getters.getActiveSheetId();
     const result: Figure[] = [];
     const figures = this.getters.getFigures(sheetId);
-    const { offsetX, offsetY } = this.getters.getActiveSnappedViewport();
+    const { offsetX, offsetY } = this.getters.getActiveViewport();
     const { width, height } = this.getters.getViewportDimensionWithHeaders();
     for (let figure of figures) {
       if (figure.x >= offsetX + width || figure.x + figure.width <= offsetX) {

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -52,14 +52,19 @@ export interface Viewport extends Zone {
    */
   offsetX: number;
   /**
+   * The scrollBar offset in the X coordinate, which can differ from offsetX as
+   * the former is "smooth" and the latter will "snap" from one cell coordinate to the other
+   */
+  offsetScrollbarX: number;
+  /**
    * The offset in the Y coordinate between the viewport top side and
    * the grid top side (top of row "1").
    */
   offsetY: number;
-}
-
-export interface SnappedViewport extends Viewport {
-  offsetScrollbarX: number;
+  /**
+   * The scrollBar offset in the Y coordinate, which can differ from offsetX as
+   * the former is "smooth" and the latter will "snap" from one cell coordinate to the other
+   */
   offsetScrollbarY: number;
 }
 

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -806,7 +806,7 @@ describe("Events on Grid update viewport correctly", () => {
   test("Vertical scroll", async () => {
     fixture.querySelector(".o-grid")!.dispatchEvent(new WheelEvent("wheel", { deltaY: 1200 }));
     await nextTick();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 52,
       bottom: 93,
       left: 0,
@@ -822,7 +822,7 @@ describe("Events on Grid update viewport correctly", () => {
       .querySelector(".o-grid")!
       .dispatchEvent(new WheelEvent("wheel", { deltaY: 200, shiftKey: true }));
     await nextTick();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 41,
       left: 2,
@@ -836,17 +836,17 @@ describe("Events on Grid update viewport correctly", () => {
   test("Move selection with keyboard", async () => {
     await clickCell(model, "H1");
     expect(getActiveXc(model)).toBe("H1");
-    const viewport = model.getters.getActiveSnappedViewport();
+    const viewport = model.getters.getActiveViewport();
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
     );
     expect(getActiveXc(model)).toBe("I1");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
     );
     expect(getActiveXc(model)).toBe("J1");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       ...viewport,
       offsetX: 96,
       offsetScrollbarX: 96,
@@ -858,17 +858,17 @@ describe("Events on Grid update viewport correctly", () => {
   test("Alter selection with keyboard", async () => {
     await clickCell(model, "H1");
     expect(getActiveXc(model)).toBe("H1");
-    const viewport = model.getters.getActiveSnappedViewport();
+    const viewport = model.getters.getActiveViewport();
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", shiftKey: true, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("H1:I1"));
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", shiftKey: true, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("H1:J1"));
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       ...viewport,
       offsetX: 96,
       offsetScrollbarX: 96,
@@ -891,15 +891,15 @@ describe("Events on Grid update viewport correctly", () => {
         bubbles: true,
       })
     );
-    const viewport = model.getters.getActiveSnappedViewport();
+    const viewport = model.getters.getActiveViewport();
     selectCell(model, "Y1");
     await nextTick();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", shiftKey: true, bubbles: true })
     );
     await nextTick();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
   });
 
   test("A resize of the grid DOM element impacts the viewport", async () => {
@@ -934,10 +934,10 @@ describe("Events on Grid update viewport correctly", () => {
         bubbles: true,
       })
     );
-    const viewport = model.getters.getActiveSnappedViewport();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    const viewport = model.getters.getActiveViewport();
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
     await clickCell(model, "Y1", { shiftKey: true });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
   });
 
   test("resize event handler is removed", () => {
@@ -968,7 +968,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-grid-overlay", "mouseup", 1.5 * width, y);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 6,
       right: 15,
       top: 0,
@@ -981,7 +981,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-grid-overlay", "mouseup", -0.5 * width, y);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 3,
       right: 12,
       top: 0,
@@ -998,7 +998,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-grid-overlay", "mouseup", x, 1.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 6,
@@ -1011,7 +1011,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-grid-overlay", "mouseup", x, -0.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 3,

--- a/tests/components/highlight.test.ts
+++ b/tests/components/highlight.test.ts
@@ -544,7 +544,7 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     const advanceTimer = scrollDelay(0.5 * width) * 6 - 1;
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-border-n", "mouseup", 1.5 * width, y);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 6,
       right: 15,
       top: 0,
@@ -560,7 +560,7 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-border-n", "mouseup", -0.5 * width, y);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 3,
       right: 12,
       top: 0,
@@ -577,7 +577,7 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-border-n", "mouseup", x, 1.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 6,
@@ -593,7 +593,7 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-border-n", "mouseup", x, -0.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 3,
@@ -610,7 +610,7 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     const advanceTimer = scrollDelay(0.5 * width) * 6 - 1;
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-corner-nw", "mouseup", 1.5 * width, y);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 6,
       right: 15,
       top: 0,
@@ -626,7 +626,7 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-corner-nw", "mouseup", -0.5 * width, y);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 3,
       right: 12,
       top: 0,
@@ -643,7 +643,7 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-corner-nw", "mouseup", x, 1.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 6,
@@ -659,7 +659,7 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-corner-nw", "mouseup", x, -0.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 3,

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -771,7 +771,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-col-resizer", "mouseup", 1.5 * width, y);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 6,
       right: 15,
       top: 0,
@@ -785,7 +785,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-col-resizer", "mouseup", -0.5 * width, y);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 3,
       right: 12,
       top: 0,
@@ -802,7 +802,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer);
     triggerMouseEvent(".o-row-resizer", "mouseup", x, 1.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 6,
@@ -815,7 +815,7 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     jest.advanceTimersByTime(advanceTimer2);
     triggerMouseEvent(".o-row-resizer", "mouseup", x, -0.5 * height);
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 9,
       top: 3,

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -393,23 +393,24 @@ describe("Composer / selectionInput interactions", () => {
 
   test("Selecting a range should not scroll the viewport to the current Grid selection", async () => {
     const model = parent.model;
-    const startViewport = model.getters.getActiveSnappedViewport();
+    const { top, bottom, left, right } = model.getters.getActiveViewport();
     await typeInComposerTopBar("=");
     // scroll
     fixture
       .querySelector(".o-grid")!
       .dispatchEvent(new WheelEvent("wheel", { deltaY: 3 * DEFAULT_CELL_HEIGHT }));
     await nextTick();
-    const scrolledViewport = model.getters.getActiveSnappedViewport();
+    const scrolledViewport = model.getters.getActiveViewport();
     expect(scrolledViewport).toMatchObject({
-      ...startViewport,
-      top: startViewport.top + 3,
-      bottom: startViewport.bottom + 3,
+      left,
+      right,
+      top: top + 3,
+      bottom: bottom + 3,
       offsetY: 3 * DEFAULT_CELL_HEIGHT,
       offsetScrollbarY: 3 * DEFAULT_CELL_HEIGHT,
     });
     await clickCell(model, "E5");
     expect(model.getters.getSelectedZones()).toEqual([toZone("A1")]);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(scrolledViewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(scrolledViewport);
   });
 });

--- a/tests/plugins/navigation.test.ts
+++ b/tests/plugins/navigation.test.ts
@@ -20,7 +20,7 @@ function getViewport(
 ): Viewport {
   model.dispatch("RESIZE_VIEWPORT", { width, height });
   model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
-  return model.getters.getActiveSnappedViewport();
+  return model.getters.getActiveViewport();
 }
 
 describe("navigation", () => {
@@ -180,12 +180,12 @@ describe("navigation", () => {
     expect(viewport.right).toBe(6);
 
     selectCell(model, "E1");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.left).toBe(0);
     expect(viewport.right).toBe(6);
 
     selectCell(model, "G1");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.left).toBe(1);
     expect(viewport.right).toBe(7);
   });
@@ -197,12 +197,12 @@ describe("navigation", () => {
     expect(viewport.right).toBe(7);
 
     selectCell(model, "B1");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.left).toBe(1);
     expect(viewport.right).toBe(7);
 
     selectCell(model, "A1");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.left).toBe(0);
     expect(viewport.right).toBe(6);
   });
@@ -214,12 +214,12 @@ describe("navigation", () => {
     expect(viewport.bottom).toBe(13);
 
     selectCell(model, "A13");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(0);
     expect(viewport.bottom).toBe(13);
 
     selectCell(model, "A14");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(1);
     expect(viewport.bottom).toBe(14);
   });
@@ -231,12 +231,12 @@ describe("navigation", () => {
     expect(viewport.bottom).toBe(15);
 
     selectCell(model, "A3");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(2);
     expect(viewport.bottom).toBe(15);
 
     selectCell(model, "A2");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(1);
     expect(viewport.bottom).toBe(14);
   });
@@ -250,12 +250,12 @@ describe("navigation", () => {
     merge(model, "A1:A2");
 
     selectCell(model, "A3");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(2);
     expect(viewport.bottom).toBe(15);
 
     selectCell(model, "A2");
-    viewport = model.getters.getActiveSnappedViewport();
+    viewport = model.getters.getActiveViewport();
     expect(viewport.top).toBe(0);
     expect(viewport.bottom).toBe(13);
   });

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -53,7 +53,7 @@ class MockGridRenderingContext implements GridRenderingContext {
       width: width - HEADER_WIDTH,
       height: height - HEADER_HEIGHT,
     });
-    this.viewport = model.getters.getActiveSnappedViewport();
+    this.viewport = model.getters.getActiveViewport();
 
     const handler = {
       get: (target, val) => {
@@ -1036,7 +1036,7 @@ describe("renderer", () => {
     ["normal" as Mode, [HEADER_WIDTH, HEADER_HEIGHT, DEFAULT_CELL_WIDTH, DEFAULT_CELL_HEIGHT]],
   ])("A1 starts at the upper left corner with mode %s", (mode, expectedRect) => {
     const model = new Model({}, { mode });
-    const viewport = model.getters.getActiveSnappedViewport();
+    const viewport = model.getters.getActiveViewport();
     const rect = model.getters.getRect(toZone("A1"), viewport);
     expect(rect).toEqual(expectedRect);
   });

--- a/tests/plugins/viewport.test.ts
+++ b/tests/plugins/viewport.test.ts
@@ -38,7 +38,7 @@ describe("Viewport of Simple sheet", () => {
   test("Select cell correctly affects offset", () => {
     // Since we rely on the adjustViewportPosition function here, the offsets will be linear combinations of the cells width and height
     selectCell(model, "P1");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 6,
@@ -48,7 +48,7 @@ describe("Viewport of Simple sheet", () => {
     });
 
     selectCell(model, "A79");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 36,
       bottom: 79,
       left: 0,
@@ -59,7 +59,7 @@ describe("Viewport of Simple sheet", () => {
 
     // back to topleft
     selectCell(model, "A1");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 0,
@@ -69,7 +69,7 @@ describe("Viewport of Simple sheet", () => {
     });
 
     selectCell(model, "U51");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 8,
       bottom: 51,
       left: 11,
@@ -79,10 +79,10 @@ describe("Viewport of Simple sheet", () => {
     });
   });
   test("Can Undo/Redo action that alters viewport structure (add/delete rows or cols)", () => {
-    model.getters.getActiveSnappedViewport();
+    model.getters.getActiveViewport();
     addRows(model, "before", 0, 70);
     selectCell(model, "B170");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 10,
       top: 127,
@@ -91,7 +91,7 @@ describe("Viewport of Simple sheet", () => {
       offsetY: DEFAULT_CELL_HEIGHT * 127,
     });
     undo(model);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 10,
       top: 57,
@@ -100,7 +100,7 @@ describe("Viewport of Simple sheet", () => {
       offsetY: DEFAULT_CELL_HEIGHT * 57,
     });
     redo(model); // should not alter offset
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       left: 0,
       right: 10,
       top: 57,
@@ -112,23 +112,23 @@ describe("Viewport of Simple sheet", () => {
 
   test("Add columns doesn't affect offset", () => {
     selectCell(model, "P1");
-    const currentViewport = model.getters.getActiveSnappedViewport();
+    const currentViewport = model.getters.getActiveViewport();
     addColumns(model, "after", "P", 30);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(currentViewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
     undo(model);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(currentViewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
     addColumns(model, "before", "P", 30);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(currentViewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
   });
   test("Add rows doesn't affect offset", () => {
     selectCell(model, "A51");
-    const currentViewport = model.getters.getActiveSnappedViewport();
+    const currentViewport = model.getters.getActiveViewport();
     addRows(model, "after", 50, 30);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(currentViewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
     undo(model);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(currentViewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
     addRows(model, "before", 50, 30);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(currentViewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(currentViewport);
   });
 
   test("Horizontal scroll correctly affects offset", () => {
@@ -136,7 +136,7 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH * 2,
       offsetY: 0,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 2,
@@ -149,7 +149,7 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH * 16,
       offsetY: 0,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 16,
@@ -162,7 +162,7 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH * 12.6,
       offsetY: 0,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 12,
@@ -182,7 +182,7 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH * 2,
       offsetY: 0,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 1,
       left: 2,
@@ -197,7 +197,7 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 2,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 2,
       bottom: 45,
       left: 0,
@@ -210,7 +210,7 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 57,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 57,
       bottom: 99,
       left: 0,
@@ -223,7 +223,7 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 12.6,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 12,
       bottom: 55,
       left: 0,
@@ -243,7 +243,7 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 2,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 2,
       bottom: 45,
       left: 0,
@@ -278,13 +278,13 @@ describe("Viewport of Simple sheet", () => {
       offsetX: DEFAULT_CELL_WIDTH * 2,
       offsetY: 0,
     });
-    const { offsetX } = model.getters.getActiveSnappedViewport();
+    const { offsetX } = model.getters.getActiveViewport();
     resizeColumns(
       model,
       range(0, model.getters.getNumberCols(sheetId)).map(numberToLetters),
       DEFAULT_CELL_WIDTH * 2
     );
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 1,
@@ -305,13 +305,13 @@ describe("Viewport of Simple sheet", () => {
       [...Array(model.getters.getNumberCols(sheetId)).keys()].map(numberToLetters),
       DEFAULT_CELL_WIDTH / 2
     );
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 7,
       right: 25,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 7,
@@ -327,9 +327,9 @@ describe("Viewport of Simple sheet", () => {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 2,
     });
-    const { offsetY } = model.getters.getActiveSnappedViewport();
+    const { offsetY } = model.getters.getActiveViewport();
     resizeRows(model, [...Array(numberRows).keys()], DEFAULT_CELL_HEIGHT * 2);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 1,
       bottom: 22,
       left: 0,
@@ -344,20 +344,20 @@ describe("Viewport of Simple sheet", () => {
     //scroll max
     selectCell(model, "A100");
     model.selection.selectAll();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 57,
       bottom: 99,
       left: 0,
       right: 10,
     });
     resizeRows(model, [...Array(numberRows).keys()], DEFAULT_CELL_HEIGHT / 2);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 15,
       bottom: 99,
       left: 0,
       right: 10,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 15,
       bottom: 99,
       left: 0,
@@ -369,7 +369,7 @@ describe("Viewport of Simple sheet", () => {
 
   test("Hide/unhide Columns from leftest column", () => {
     hideColumns(model, [0, 1, 2, 4, 5].map(numberToLetters)); // keep 3
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 3,
@@ -381,10 +381,10 @@ describe("Viewport of Simple sheet", () => {
 
   test("Hide/unhide Columns from rightest column", () => {
     selectCell(model, "Z1");
-    const viewport = model.getters.getActiveSnappedViewport();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    const viewport = model.getters.getActiveViewport();
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
     hideColumns(model, range(13, 26).map(numberToLetters));
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: viewport.top,
       bottom: viewport.bottom,
       left: 3,
@@ -395,7 +395,7 @@ describe("Viewport of Simple sheet", () => {
   });
   test("Hide/unhide Row from top row", () => {
     hideRows(model, [0, 1, 2, 4, 5]); // keep 3
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 3,
       bottom: 48,
       left: 0,
@@ -406,10 +406,10 @@ describe("Viewport of Simple sheet", () => {
   });
   test("Hide/unhide Rows from bottom row", () => {
     selectCell(model, "A100");
-    const viewport = model.getters.getActiveSnappedViewport();
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    const viewport = model.getters.getActiveViewport();
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
     hideRows(model, range(60, 100));
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 17,
       bottom: 99,
       left: viewport.left,
@@ -419,10 +419,10 @@ describe("Viewport of Simple sheet", () => {
     });
   });
   test("Horizontally move position to top right then back to top left correctly affects offset", () => {
-    const { right } = model.getters.getActiveSnappedViewport();
+    const { right } = model.getters.getActiveViewport();
     selectCell(model, toXC(right - 1, 0));
     moveAnchorCell(model, "right");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 1,
@@ -433,7 +433,7 @@ describe("Viewport of Simple sheet", () => {
 
     moveAnchorCell(model, "right");
     moveAnchorCell(model, "right");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 3,
@@ -442,11 +442,11 @@ describe("Viewport of Simple sheet", () => {
       offsetY: 0,
     });
 
-    const { left } = model.getters.getActiveSnappedViewport();
+    const { left } = model.getters.getActiveViewport();
     selectCell(model, toXC(left, 0));
     moveAnchorCell(model, "left");
     moveAnchorCell(model, "left");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 1,
@@ -457,10 +457,10 @@ describe("Viewport of Simple sheet", () => {
   });
 
   test("Vertically move position to bottom left then back to top left correctly affects offset", () => {
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     selectCell(model, toXC(0, bottom - 1));
     moveAnchorCell(model, "down");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 1,
       bottom: 44,
       left: 0,
@@ -471,7 +471,7 @@ describe("Viewport of Simple sheet", () => {
 
     moveAnchorCell(model, "down");
     moveAnchorCell(model, "down");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 3,
       bottom: 46,
       left: 0,
@@ -480,11 +480,11 @@ describe("Viewport of Simple sheet", () => {
       offsetY: DEFAULT_CELL_HEIGHT * 3,
     });
 
-    const { top } = model.getters.getActiveSnappedViewport();
+    const { top } = model.getters.getActiveViewport();
     selectCell(model, toXC(0, top));
     moveAnchorCell(model, "up");
     moveAnchorCell(model, "up");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 1,
       bottom: 44,
       left: 0,
@@ -497,7 +497,7 @@ describe("Viewport of Simple sheet", () => {
   test("Move position on cells that are taller than the client's height", () => {
     const { height } = model.getters.getViewportDimensionWithHeaders();
     resizeRows(model, [0], height + 50);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 0,
       left: 0,
@@ -506,7 +506,7 @@ describe("Viewport of Simple sheet", () => {
       offsetY: 0,
     });
     moveAnchorCell(model, "down");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 1,
       bottom: 44,
       left: 0,
@@ -519,7 +519,7 @@ describe("Viewport of Simple sheet", () => {
   test("Move position on cells wider than the client's width", () => {
     const { width } = model.getters.getViewportDimensionWithHeaders();
     resizeColumns(model, ["A"], width + 50);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 0,
@@ -528,7 +528,7 @@ describe("Viewport of Simple sheet", () => {
       offsetY: 0,
     });
     moveAnchorCell(model, "right");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 43,
       left: 1,
@@ -539,25 +539,25 @@ describe("Viewport of Simple sheet", () => {
   });
   test("Select Column while updating range does not update viewport", () => {
     selectCell(model, "C51");
-    const viewport = model.getters.getActiveSnappedViewport();
+    const viewport = model.getters.getActiveViewport();
     selectColumn(model, 3, "overrideSelection");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
   });
   test("Select Row does not update viewport", () => {
     selectCell(model, "U5");
-    const viewport = model.getters.getActiveSnappedViewport();
+    const viewport = model.getters.getActiveViewport();
     selectRow(model, 3, "overrideSelection");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject(viewport);
+    expect(model.getters.getActiveViewport()).toMatchObject(viewport);
   });
   test("Resize Viewport is correctly computed and does not adjust position", () => {
     selectCell(model, "K71");
     model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 100, offsetY: 112 });
-    const viewport = model.getters.getActiveSnappedViewport();
+    const viewport = model.getters.getActiveViewport();
     model.dispatch("RESIZE_VIEWPORT", {
       width: 500,
       height: 500,
     });
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       ...viewport,
       bottom: viewport.top + Math.ceil(500 / DEFAULT_CELL_HEIGHT) - 1,
       right: viewport.left + Math.ceil(500 / DEFAULT_CELL_WIDTH) - 1,
@@ -588,7 +588,7 @@ describe("Viewport of Simple sheet", () => {
       model.getters.getActiveSheet()
     ));
 
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       offsetScrollbarX: gridWidth - width + HEADER_WIDTH,
       offsetScrollbarY: gridHeight - height + HEADER_HEIGHT,
     });
@@ -619,7 +619,7 @@ describe("multi sheet with different sizes", () => {
 
   test("viewports of multiple sheets of different size are correctly computed", () => {
     activateSheet(model, "small");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 1,
       left: 0,
@@ -628,7 +628,7 @@ describe("multi sheet with different sizes", () => {
       offsetY: 0,
     });
     activateSheet(model, "big");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 4,
       left: 0,
@@ -642,7 +642,7 @@ describe("multi sheet with different sizes", () => {
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("small");
     selectCell(model, "B2");
     deleteColumns(model, ["B"]);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 1,
       left: 0,
@@ -655,7 +655,7 @@ describe("multi sheet with different sizes", () => {
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("small");
     selectCell(model, "B2");
     deleteRows(model, [1]);
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 0,
       left: 0,
@@ -670,14 +670,14 @@ describe("multi sheet with different sizes", () => {
       height: 3.5 * DEFAULT_CELL_HEIGHT, // concretely 3.5 cells visible
     });
     activateSheet(model, "small");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 1,
       left: 0,
       right: 1,
     });
     activateSheet(model, "big");
-    expect(model.getters.getActiveSnappedViewport()).toMatchObject({
+    expect(model.getters.getActiveViewport()).toMatchObject({
       top: 0,
       bottom: 3,
       left: 0,
@@ -699,11 +699,11 @@ describe("shift viewport up/down", () => {
   });
 
   test("basic move viewport", () => {
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom);
+    expect(model.getters.getActiveViewport().top).toBe(bottom);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(0);
+    expect(model.getters.getActiveViewport().top).toBe(0);
   });
 
   test("move viewport with non-default size", () => {
@@ -711,70 +711,70 @@ describe("shift viewport up/down", () => {
       height: 100,
       width: 100,
     });
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom);
+    expect(model.getters.getActiveViewport().top).toBe(bottom);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(0);
+    expect(model.getters.getActiveViewport().top).toBe(0);
   });
 
   test("RENAME move viewport not starting from the top", () => {
     selectCell(model, "A4");
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 3,
     });
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom + 3);
+    expect(model.getters.getActiveViewport().top).toBe(bottom + 3);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(3);
+    expect(model.getters.getActiveViewport().top).toBe(3);
   });
 
   test("RENAME move viewport not starting from the top", () => {
     selectCell(model, "A4");
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 3 + 1,
     });
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom + 3);
+    expect(model.getters.getActiveViewport().top).toBe(bottom + 3);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(3);
+    expect(model.getters.getActiveViewport().top).toBe(3);
   });
 
   test("RENAME move viewport not starting from the top", () => {
     selectCell(model, "A4");
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 0,
       offsetY: DEFAULT_CELL_HEIGHT * 3 - 1,
     });
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom + 2);
+    expect(model.getters.getActiveViewport().top).toBe(bottom + 2);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(2);
+    expect(model.getters.getActiveViewport().top).toBe(2);
   });
 
   test("move all the way down and up again", () => {
     const sheetId = model.getters.getActiveSheetId();
     const numberOfRows = model.getters.getNumberRows(sheetId);
-    let { bottom } = model.getters.getActiveSnappedViewport();
+    let { bottom } = model.getters.getActiveViewport();
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom);
+    expect(model.getters.getActiveViewport().top).toBe(bottom);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().bottom).toBe(numberOfRows - 1);
+    expect(model.getters.getActiveViewport().bottom).toBe(numberOfRows - 1);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().bottom).toBe(numberOfRows - 1);
+    expect(model.getters.getActiveViewport().bottom).toBe(numberOfRows - 1);
 
-    let { top } = model.getters.getActiveSnappedViewport();
+    let { top } = model.getters.getActiveViewport();
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().bottom).toBe(top);
+    expect(model.getters.getActiveViewport().bottom).toBe(top);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(0);
+    expect(model.getters.getActiveViewport().top).toBe(0);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(0);
+    expect(model.getters.getActiveViewport().top).toBe(0);
   });
 
   test("move viewport does not changes its dimension", () => {
@@ -792,13 +792,13 @@ describe("shift viewport up/down", () => {
       offsetY: 0,
     });
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
+    expect(model.getters.getActiveViewport().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
+    expect(model.getters.getActiveViewport().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
   });
 
   test("anchor cell at the viewport top is shifted", () => {
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     selectCell(model, "A1");
     model.dispatch("SHIFT_VIEWPORT_DOWN");
     expect(model.getters.getSelectedZones()).toHaveLength(1);
@@ -809,7 +809,7 @@ describe("shift viewport up/down", () => {
   });
 
   test("anchor cell not at the viewport top is shifted", () => {
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     selectCell(model, "B4");
     model.dispatch("SHIFT_VIEWPORT_DOWN");
     expect(model.getters.getSelectedZone()).toEqual({
@@ -826,7 +826,7 @@ describe("shift viewport up/down", () => {
     setSelection(model, ["A1:A2", "B5", "D1:D2"], {
       anchor: "D1",
     });
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     model.dispatch("SHIFT_VIEWPORT_DOWN");
     expect(model.getters.getSelectedZones()).toHaveLength(1);
     expect(model.getters.getSelectedZone()).toEqual({
@@ -838,22 +838,22 @@ describe("shift viewport up/down", () => {
   });
 
   test("hidden rows are skipped", () => {
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     model.dispatch("HIDE_COLUMNS_ROWS", {
       dimension: "ROW",
       elements: [2, 3, 4],
       sheetId: model.getters.getActiveSheetId(),
     });
-    const { bottom: bottomWithHiddenRows } = model.getters.getActiveSnappedViewport();
+    const { bottom: bottomWithHiddenRows } = model.getters.getActiveViewport();
     expect(bottomWithHiddenRows).toBe(bottom + 3);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(bottomWithHiddenRows);
+    expect(model.getters.getActiveViewport().top).toBe(bottomWithHiddenRows);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().bottom).toBe(bottomWithHiddenRows);
+    expect(model.getters.getActiveViewport().bottom).toBe(bottomWithHiddenRows);
   });
 
   test("bottom cell is in a merge and new anchor in the merge", () => {
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     const mergeTop = bottom - 1;
     const mergeBottom = bottom + 1;
     merge(
@@ -866,13 +866,13 @@ describe("shift viewport up/down", () => {
       })
     );
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(mergeTop);
+    expect(model.getters.getActiveViewport().top).toBe(mergeTop);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSnappedViewport().bottom).toBe(bottom);
+    expect(model.getters.getActiveViewport().bottom).toBe(bottom);
   });
 
   test("bottom cell is in a merge and new anchor *not* in the merge", () => {
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     const mergeTop = bottom - 1;
     const mergeBottom = bottom + 1;
     merge(
@@ -886,11 +886,11 @@ describe("shift viewport up/down", () => {
     );
     selectCell(model, "B1");
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSnappedViewport().top).toBe(bottom);
+    expect(model.getters.getActiveViewport().top).toBe(bottom);
   });
 
   test("anchor ends up at the last row", () => {
-    const { bottom } = model.getters.getActiveSnappedViewport();
+    const { bottom } = model.getters.getActiveViewport();
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("RESIZE_VIEWPORT", {
       width: 1000,
@@ -898,7 +898,7 @@ describe("shift viewport up/down", () => {
     });
     deleteRows(model, range(bottom + 1, model.getters.getNumberRows(sheetId)));
     selectCell(model, toXC(0, bottom));
-    expect(model.getters.getActiveSnappedViewport().bottom).toBe(bottom);
+    expect(model.getters.getActiveViewport().bottom).toBe(bottom);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
     expect(model.getters.getSelectedZone()).toEqual({
       top: bottom,
@@ -916,10 +916,10 @@ describe("shift viewport up/down", () => {
       deleteRows(model, range(2, model.getters.getNumberRows(sheetId)));
       selectCell(model, selectedCell);
       model.dispatch("SHIFT_VIEWPORT_DOWN");
-      expect(model.getters.getActiveSnappedViewport().top).toBe(0);
+      expect(model.getters.getActiveViewport().top).toBe(0);
       expect(model.getters.getSelectedZone()).toEqual(toZone(selectedCell));
       model.dispatch("SHIFT_VIEWPORT_UP");
-      expect(model.getters.getActiveSnappedViewport().top).toBe(0);
+      expect(model.getters.getActiveViewport().top).toBe(0);
       expect(model.getters.getSelectedZone()).toEqual(toZone(selectedCell));
     }
   );
@@ -927,7 +927,7 @@ describe("shift viewport up/down", () => {
   test.each(["A1", "A2", "A15"])(
     "anchor %s is shifted by the correct amount when the sheet end is reached",
     (selectedCell) => {
-      const { bottom } = model.getters.getActiveSnappedViewport();
+      const { bottom } = model.getters.getActiveViewport();
       const sheetId = model.getters.getActiveSheetId();
       // delete all rows after the viewport except three
       deleteRows(model, range(bottom + 3, model.getters.getNumberRows(sheetId)));

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -34,7 +34,7 @@ export async function clickCell(
   extra: MouseEventInit = { bubbles: true }
 ) {
   const zone = toZone(xc);
-  const viewport = model.getters.getActiveSnappedViewport();
+  const viewport = model.getters.getActiveViewport();
   let [x, y, ,] = model.getters.getRect(zone, viewport);
   if (model.getters.isDashboard()) {
     x += HEADER_WIDTH;
@@ -50,7 +50,7 @@ export async function gridMouseEvent(
   extra: MouseEventInit = { bubbles: true }
 ) {
   const zone = toZone(xc);
-  const viewport = model.getters.getActiveSnappedViewport();
+  const viewport = model.getters.getActiveViewport();
   let [x, y, ,] = model.getters.getRect(zone, viewport);
   if (!model.getters.isDashboard()) {
     x -= HEADER_WIDTH;

--- a/tests/test_helpers/renderer_helpers.ts
+++ b/tests/test_helpers/renderer_helpers.ts
@@ -21,7 +21,7 @@ export class MockGridRenderingContext implements GridRenderingContext {
 
   constructor(model: Model, width: number, height: number, observer: ContextObserver) {
     model.dispatch("RESIZE_VIEWPORT", { width, height });
-    this.viewport = model.getters.getActiveSnappedViewport();
+    this.viewport = model.getters.getActiveViewport();
 
     const handler = {
       get: (target, val) => {
@@ -59,10 +59,12 @@ export function watchClipboardOutline(model: Model) {
   const viewport: Viewport = {
     bottom: viewportSize,
     left: 0,
-    offsetX: 0,
-    offsetY: 0,
     right: viewportSize,
     top: 0,
+    offsetX: 0,
+    offsetY: 0,
+    offsetScrollbarX: 0,
+    offsetScrollbarY: 0,
   };
   let lineDash = false;
   let outlinedRects: any[][] = [];


### PR DESCRIPTION
Since c60ebd2e, the scrollbar offset has been duplicated on the snapped
viewport. As it was the only reason to keep both types of viewport
simultaneously, we can merge them to gether in order to simplify the
plugin internal structure.

Part of task 2696839

Co-authored-by: Anthony Hendrickx <anhe@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2696839](https://www.odoo.com/web#id=2696839&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo