### PR TITLE
[REF] headers: use ranges inside headers plugins

### DIFF
--- a/src/plugins/base_plugin.ts
+++ b/src/plugins/base_plugin.ts
@@ -28,7 +28,7 @@ export class BasePlugin<State = any, C = any> implements CommandHandler<C>, Vali
   protected dispatch: CommandDispatcher["dispatch"];
 
   constructor(
-    stateObserver: StateObserver,
+    protected readonly stateObserver: StateObserver,
     dispatch: CommandDispatcher["dispatch"],
     config: ModelConfig
   ) {

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -13,6 +13,7 @@ import {
 import { CoreGetters } from "../types/getters";
 import { BasePlugin } from "./base_plugin";
 import { RangeAdapter } from "./core/range";
+import { HeaderMap, HeaderMapManager } from "./header_map";
 
 export interface CorePluginConstructor {
   new (
@@ -50,9 +51,14 @@ export class CorePlugin<State = any, C = CoreCommand>
   ) {
     super(stateObserver, dispatch, config);
     this.range = range;
+
     range.addRangeProvider(this.adaptRanges.bind(this));
     this.getters = getters;
     this.uuidGenerator = uuidGenerator;
+  }
+
+  protected newHeaderMap<T>(): HeaderMap<T> {
+    return new HeaderMapManager<T>(this.stateObserver, this.range);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/header_map.ts
+++ b/src/plugins/header_map.ts
@@ -1,0 +1,110 @@
+// interface ObjectWithId {
+//   id : string;
+// }
+import { deepCopy, toXC } from "../helpers";
+import { StateObserver } from "../state_observer";
+import { ApplyRangeChange, Range, RangeProvider, UID, WorkbookHistory } from "../types";
+import { Dimension, RangePart } from "./../types/misc";
+import { RangeAdapter } from "./core/range";
+
+export interface HeaderMap<T> {
+  set(sheetId: UID, dimension: Dimension, index: number, id: T): void;
+  get(sheetId: UID, dimension: Dimension, index: number): T | undefined;
+  delete(sheetId: UID, dimension: Dimension, index: number): void;
+  deleteSheet(sheetId: UID): void;
+  duplicateSheet(sheetId: UID, sheetIdTo: UID): void;
+}
+
+interface RangeValue<T> {
+  range: Range;
+  value: T;
+}
+type HeaderIndex = string;
+
+interface HeaderMapManagerState<T> {
+  values: Record<UID, Record<Dimension, Record<HeaderIndex, RangeValue<T> | undefined>>>;
+}
+
+export class HeaderMapManager<T> implements RangeProvider, HeaderMap<T>, HeaderMapManagerState<T> {
+  static nextHistoryId = 0;
+  private history: WorkbookHistory<HeaderMapManagerState<T>>;
+
+  readonly values: Record<UID, Record<Dimension, Record<HeaderIndex, RangeValue<T>>>> = {};
+
+  constructor(stateObserver: StateObserver, private range: RangeAdapter) {
+    range.addRangeProvider(this.adaptRanges.bind(this));
+    this.history = Object.assign(Object.create(stateObserver), {
+      update: stateObserver.addChange.bind(stateObserver, this),
+    });
+  }
+
+  adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID) {
+    const sheetIds = sheetId ? [sheetId] : Object.keys(this.values);
+    for (const sheetId of sheetIds) {
+      for (const dimension of ["COL", "ROW"] as Dimension[]) {
+        // aggregate updates while iterating and apply them later
+        const toModify: RangeValue<T>[] = [];
+        for (const index of Object.keys(this.values?.[sheetId]?.[dimension] || [])) {
+          const valueRange = this.values[sheetId][dimension][index];
+          if (!valueRange || (sheetId && valueRange.range.sheetId !== sheetId)) {
+            continue;
+          }
+          const range = valueRange.range;
+
+          const change = applyChange(range);
+          if (change.changeType !== "NONE" && !change.isGlobalGridChange) {
+            continue;
+          }
+          switch (change.changeType) {
+            case "REMOVE":
+              this.history.update("values", sheetId, dimension, index, undefined);
+              break;
+            case "RESIZE":
+              throw new Error("Cannot resize a header range");
+            case "MOVE":
+            case "CHANGE":
+              const range = change.range;
+              toModify.push({ range, value: valueRange.value });
+              this.history.update("values", sheetId, dimension, index, undefined); // delete previous entry
+              break;
+          }
+        }
+        for (const rangeValue of toModify) {
+          const index =
+            dimension === "COL" ? rangeValue.range.zone.left : rangeValue.range.zone.top;
+          this.history.update("values", sheetId, dimension, String(index), rangeValue);
+        }
+      }
+    }
+  }
+
+  set(sheetId: UID, dimension: Dimension, index: number, value: T) {
+    const col = dimension === "COL" ? index : 0;
+    const row = dimension === "ROW" ? index : 0;
+    // TODO when it's merged, replace this by full col/row ranges.
+    const rangePart: RangePart = { colFixed: dimension === "ROW", rowFixed: dimension === "COL" };
+    const range = this.range.getRangeFromSheetXC(sheetId, toXC(col, row, rangePart));
+    this.history.update("values", sheetId, dimension, String(index), { range, value });
+  }
+
+  get(sheetId: UID, dimension: Dimension, index: number): T | undefined {
+    return this.values[sheetId]?.[dimension]?.[index]?.value;
+  }
+
+  delete(sheetId: UID, dimension: Dimension, index: number) {
+    const value = this.get(sheetId, dimension, index);
+    if (value) {
+      this.history.update("values", sheetId, dimension, String(index), undefined); // remove previous entry
+    }
+  }
+
+  deleteSheet(sheetId: string): void {
+    const values = { ...this.values };
+    delete values[sheetId];
+    this.history.update("values", values);
+  }
+
+  duplicateSheet(sheetId: UID, sheetIdTo: string): void {
+    this.history.update("values", sheetIdTo, deepCopy(this.values[sheetId]));
+  }
+}

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -652,6 +652,14 @@ export class GridSelectionPlugin extends UIPlugin {
         size,
         elements: [currentIndex],
       });
+      const isHidden = this.getters.isHeaderHidden(cmd.sheetId, cmd.dimension, element);
+      if (isHidden) {
+        this.dispatch("HIDE_COLUMNS_ROWS", {
+          dimension: cmd.dimension,
+          sheetId: cmd.sheetId,
+          elements: [currentIndex],
+        });
+      }
       currentIndex += 1;
     }
 

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -202,7 +202,12 @@ export const enum DIRECTION {
 
 export type ChangeType = "REMOVE" | "RESIZE" | "MOVE" | "CHANGE" | "NONE";
 export type ApplyRangeChangeResult =
-  | { changeType: Exclude<ChangeType, "NONE">; range: Range }
+  | {
+      changeType: Exclude<ChangeType, "NONE">;
+      range: Range;
+      /** True if the change is applied globally on the grid, false if its a local change */
+      isGlobalGridChange: boolean;
+    }
   | { changeType: "NONE" };
 export type ApplyRangeChange = (range: Range) => ApplyRangeChangeResult;
 

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -958,6 +958,14 @@ describe("move elements(s)", () => {
     expect(model.getters.getColSize(sheetId, 2)).toEqual(10);
   });
 
+  test("Move a hidden col keep it hidden", () => {
+    const model = new Model();
+    hideColumns(model, ["A"]);
+    moveColumns(model, "D", ["A"]);
+    const sheetId = model.getters.getActiveSheetId();
+    expect(model.getters.isColHidden(sheetId, 2)).toBeTruthy();
+  });
+
   test("Move a resized row preserve the size", () => {
     const model = new Model();
     resizeRows(model, [0], 10);
@@ -967,5 +975,13 @@ describe("move elements(s)", () => {
     expect(model.getters.getRowSize(sheetId, 0)).toEqual(DEFAULT_CELL_HEIGHT);
     expect(model.getters.getRowSize(sheetId, 1)).toEqual(20);
     expect(model.getters.getRowSize(sheetId, 2)).toEqual(10);
+  });
+
+  test("Move a hidden row keep it hidden", () => {
+    const model = new Model();
+    hideRows(model, [0]);
+    moveRows(model, 3, [0]);
+    const sheetId = model.getters.getActiveSheetId();
+    expect(model.getters.isRowHidden(sheetId, 2)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Before, the plugins `header_sizes` and `header_visibility` were updating
their data "by hand" when handling commands such as `ADD_COLUMNS_ROWS`.

This commit introduce a `HeaderMap` object that handle all the grid changes
automatically using ranges.

There a problem with the command `MOVE_RANGES`:
 - when inserting/deleting cell, we handle this with a CUT that will dispatch
    a `MOVE_RANGES`. This made the ranges of our `HeaderMap` move when we
    didn't wanted them to.

Solve this problem by returning the command that resulted in the changes in
`adaptRanges`, and ignoring changes that were coming from a `MOVE_RANGES`.

## Notes : 
Not sure we really wan adaptRanges to return the command as well as the changed range.
I'm not sure how else to fix the problem. Maybe there is 2 different concept that I bundle in `Range`, but I'm not too sure what's really different about them. We should brainstorm sometimes.

Odoo task ID : [2889911](https://www.odoo.com/web#id=2889911&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo