### PR TITLE
[REF] helpers: rewrite helper to remove zones from zones

### DIFF
--- a/tests/helpers/zones.test.ts
+++ b/tests/helpers/zones.test.ts
@@ -1,6 +1,8 @@
 import {
   createAdaptedZone,
   isZoneValid,
+  mergeAlignedColumns,
+  mergePositionsIntoColumns,
   overlap,
   positions,
   recomputeZones,
@@ -8,7 +10,8 @@ import {
   toUnboundedZone,
   toZone,
 } from "../../src/helpers/index";
-import { Zone } from "../../src/types";
+import { Position, Zone } from "../../src/types";
+import { target } from "../test_helpers/helpers";
 
 describe("overlap", () => {
   test("one zone above the other", () => {
@@ -40,6 +43,149 @@ describe("isZoneValid", () => {
     expect(isZoneValid({ bottom: 1, top: 1, right: 1, left: -1 })).toBe(false);
   });
 });
+
+describe("mergePositionsIntoColumns", () => {
+  function p(xc: string): Position {
+    const zone = toZone(xc);
+    return { col: zone.left, row: zone.top };
+  }
+  const A1 = p("A1");
+  const A2 = p("A2");
+  const A3 = p("A3");
+  const B1 = p("B1");
+  const B2 = p("B2");
+  const C1 = p("C1");
+  const C2 = p("C2");
+  test("no zone", () => {
+    expect(mergePositionsIntoColumns([])).toEqual([]);
+  });
+
+  test("a single zone", () => {
+    expect(mergePositionsIntoColumns([A1])).toEqual(target("A1"));
+  });
+
+  test("a duplicated zone", () => {
+    expect(mergePositionsIntoColumns([A1, A1])).toEqual(target("A1"));
+  });
+
+  test("two non-adjacent positions on the same column", () => {
+    expect(mergePositionsIntoColumns([A1, A3])).toEqual(target("A1, A3"));
+  });
+
+  test("two non-adjacent positions on the same row", () => {
+    expect(mergePositionsIntoColumns([A1, C1])).toEqual(target("A1, C1"));
+  });
+
+  test("two adjacent positions on the same column", () => {
+    expect(mergePositionsIntoColumns([A1, A2])).toEqual(target("A1:A2"));
+  });
+
+  test("two adjacent positions on the same row", () => {
+    expect(mergePositionsIntoColumns([A1, B1])).toEqual(target("A1, B1"));
+  });
+
+  test("four adjacent positions on different columns", () => {
+    expect(mergePositionsIntoColumns([C2, C1, A1, A2])).toEqual(target("A1:A2, C1:C2"));
+  });
+
+  test("four adjacent positions on adjacent columns", () => {
+    expect(mergePositionsIntoColumns([C2, C1, B2, B1])).toEqual(target("B1:B2, C1:C2"));
+  });
+});
+
+describe("mergeAlignedColumns", () => {
+  test("no column", () => {
+    expect(mergeAlignedColumns([])).toEqual([]);
+  });
+  test("a row", () => {
+    expect(() => mergeAlignedColumns(target("A1:B1"))).toThrow();
+    expect(() => mergeAlignedColumns(target("A1:A2, A1:B1"))).toThrow();
+  });
+  test("a single column", () => {
+    expect(mergeAlignedColumns(target("A1:A2"))).toEqual(target("A1:A2"));
+  });
+
+  test("two zones on the same column", () => {
+    expect(mergeAlignedColumns(target("A1:A2, A3:A4"))).toEqual(target("A1:A2, A3:A4"));
+  });
+
+  test("duplicated columns", () => {
+    expect(mergeAlignedColumns(target("A1:A2, A1:A2"))).toEqual(target("A1:A2"));
+  });
+
+  test("two adjacent zones on the same column", () => {
+    expect(mergeAlignedColumns(target("A1:A2, A2:A4"))).toEqual(target("A1:A2, A2:A4"));
+  });
+  test("two aligned zones on non-adjacent columns", () => {
+    expect(mergeAlignedColumns(target("A1:A2, C1:C2"))).toEqual(target("A1:A2, C1:C2"));
+  });
+
+  test("two non-aligned zones on adjacent columns", () => {
+    expect(mergeAlignedColumns(target("A1:A2, B1:B3"))).toEqual(target("A1:A2, B1:B3"));
+  });
+
+  test("two aligned zones on adjacent columns", () => {
+    expect(mergeAlignedColumns(target("A1:A2, B1:B2"))).toEqual(target("A1:B2"));
+  });
+
+  test("three aligned zones on adjacent columns", () => {
+    expect(mergeAlignedColumns(target("A1:A2, B1:B2, C1:C2"))).toEqual(target("A1:C2"));
+  });
+
+  test("three aligned zones on adjacent columns", () => {
+    expect(mergeAlignedColumns(target("A1:A2, B1:B2, C1:C2"))).toEqual(target("A1:C2"));
+  });
+
+  test("two aligned zones on adjacent and one on non-adjacent columns", () => {
+    expect(mergeAlignedColumns(target("A1:A2, B1:B2, D1:D2"))).toEqual(target("A1:B2, D1:D2"));
+    expect(mergeAlignedColumns(target("A1:A2, D1:D2, B1:B2"))).toEqual(target("A1:B2, D1:D2"));
+    expect(mergeAlignedColumns(target("A1:A2, A3:A4, B3:B4"))).toEqual(target("A1:A2, A3:B4"));
+    expect(mergeAlignedColumns(target("A3:A4, A1:A2, B3:B4"))).toEqual(target("A1:A2, A3:B4"));
+  });
+  test("two overlapping columns with one aligned column", () => {
+    expect(mergeAlignedColumns(target("A1:A2, A2:A3, B2:B3"))).toEqual(target("A1:A2, A2:B3"));
+    expect(mergeAlignedColumns(target("A2:A3, A1:A2, B2:B3"))).toEqual(target("A1:A2, A2:B3"));
+
+    expect(mergeAlignedColumns(target("A1:A2, A2:A3, B1:B2"))).toEqual(target("A1:B2, A2:A3"));
+    expect(mergeAlignedColumns(target("A2:A3, A1:A2, B1:B2"))).toEqual(target("A1:B2, A2:A3"));
+  });
+  test("two overlapping columns with two aligned column", () => {
+    expect(mergeAlignedColumns(target("A1:A2, A2:A3, B2:B3, C2:C3"))).toEqual(
+      target("A1:A2, A2:C3")
+    );
+    expect(mergeAlignedColumns(target("B2:B3, C2:C3, A1:A2, A2:A3"))).toEqual(
+      target("A1:A2, A2:C3")
+    );
+
+    expect(mergeAlignedColumns(target("A1:A2, A2:A3, B1:B2, C1:C2"))).toEqual(
+      target("A1:C2, A2:A3")
+    );
+    expect(mergeAlignedColumns(target("C1:C2, A1:A2, A2:A3, B1:B2"))).toEqual(
+      target("A1:C2, A2:A3")
+    );
+  });
+  test("one column inside another with zones on the right", () => {
+    expect(mergeAlignedColumns(target("A1:A4, A2:A3"))).toEqual(target("A1:A4"));
+    expect(mergeAlignedColumns(target("A1:A4, A2:A3, B1:B4"))).toEqual(target("A1:B4"));
+    expect(mergeAlignedColumns(target("A2:A3, A1:A4, B1:B4"))).toEqual(target("A1:B4"));
+
+    expect(mergeAlignedColumns(target("A1:A4, A2:A3, B2:B3"))).toEqual(target("A1:A4, B2:B3"));
+    expect(mergeAlignedColumns(target("A2:A3, A1:A4, B2:B3"))).toEqual(target("A1:A4, B2:B3"));
+
+    expect(mergeAlignedColumns(target("A1:A4, A1:A3, B1:B3"))).toEqual(target("A1:A4, B1:B3"));
+    expect(mergeAlignedColumns(target("A1:A3, A1:A4, B1:B3"))).toEqual(target("A1:A4, B1:B3"));
+  });
+  test("one column inside another with zones on the left", () => {
+    expect(mergeAlignedColumns(target("B1:B3, B1:B4, A1:A3"))).toEqual(target("A1:A3, B1:B4"));
+    expect(mergeAlignedColumns(target("B1:B3, B1:B4, A1:A4"))).toEqual(target("A1:B4"));
+  });
+  test("two aligned respectively with one other", () => {
+    expect(mergeAlignedColumns(target("A1:A2, A3:A4, B1:B2, B3:B4"))).toEqual(
+      target("A1:B2, A3:B4")
+    );
+  });
+});
+
 describe("recomputeZones", () => {
   test("add a cell to zone(1)", () => {
     const toKeep = ["A1:C3", "A4"];


### PR DESCRIPTION
The helper function `recomputeZones` is really hard to read and to understand
with lots of nested for loops, if statement, temporary structures and
variables.

This commit rewrites the helper in a (hopefully) more readable form,
with a more step-by-step approach and smaller functions

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2898467](https://www.odoo.com/web#id=2898467&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo