### PR TITLE
[IMP] spreadsheet: export chart stuff

### DIFF
--- a/src/components/side_panel/chart/index.ts
+++ b/src/components/side_panel/chart/index.ts
@@ -19,6 +19,7 @@ export { LineBarPieConfigPanel } from "./line_bar_pie_panel/config_panel";
 export { LineBarPieDesignPanel } from "./line_bar_pie_panel/design_panel";
 export { LineConfigPanel } from "./line_chart/line_chart_config_panel";
 export { LineChartDesignPanel } from "./line_chart/line_chart_design_panel";
+export { ChartPanel } from "./main_chart_panel/main_chart_panel";
 export { ScorecardChartConfigPanel } from "./scorecard_chart_panel/scorecard_chart_config_panel";
 export { ScorecardChartDesignPanel } from "./scorecard_chart_panel/scorecard_chart_design_panel";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { ScorecardChart } from "./components/figures/chart/scorecard/chart_score
 import { ChartFigure } from "./components/figures/figure_chart/figure_chart";
 import {
   BarConfigPanel,
+  ChartPanel,
   chartSidePanelComponentRegistry,
   GaugeChartConfigPanel,
   GaugeChartDesignPanel,
@@ -26,6 +27,7 @@ import {
 import { toBoolean, toJsDate, toNumber, toString } from "./functions/helpers";
 import { args, functionRegistry } from "./functions/index";
 import { LinkCell } from "./helpers/cells/index";
+import { ChartColors, chartFontColor, getDefaultChartJsRuntime } from "./helpers/charts";
 import {
   computeTextWidth,
   formatValue,
@@ -59,7 +61,7 @@ import {
   topbarComponentRegistry,
   topbarMenuRegistry,
 } from "./registries/index";
-import { EvaluationError } from "./types/errors";
+import { CellErrorLevel, EvaluationError } from "./types/errors";
 
 /**
  * We export here all entities that needs to be accessed publicly by Odoo.
@@ -151,9 +153,14 @@ export const helpers = {
   parseMarkdownLink,
   markdownLink,
   createEmptyWorkbookData,
+  getDefaultChartJsRuntime,
+  chartFontColor,
+  ChartColors,
   EvaluationError,
+  CellErrorLevel,
 };
 export const components = {
+  ChartPanel,
   ChartFigure,
   ChartJsComponent,
   ScorecardChart,


### PR DESCRIPTION
In order to integrate Odoo chart, we have to export some components and
helpers.

Task-id 2822603

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo