### PR TITLE
[IMP] charts: remove chart id from abstract chart

### DIFF
--- a/src/helpers/charts/abstract_chart.ts
+++ b/src/helpers/charts/abstract_chart.ts
@@ -19,14 +19,12 @@ import { Validator } from "../../types/validator";
  * The role of this class is to maintain the state of each chart.
  */
 export abstract class AbstractChart {
-  readonly id: UID;
   readonly sheetId: UID;
   readonly title: string;
   abstract readonly type: ChartType;
   protected readonly getters: CoreGetters;
 
-  constructor(id: UID, definition: ChartDefinition, sheetId: UID, getters: CoreGetters) {
-    this.id = id;
+  constructor(definition: ChartDefinition, sheetId: UID, getters: CoreGetters) {
     this.title = definition.title;
     this.sheetId = sheetId;
     this.getters = getters;

--- a/src/helpers/charts/bar_chart.ts
+++ b/src/helpers/charts/bar_chart.ts
@@ -46,8 +46,8 @@ import {
 
 chartRegistry.add("bar", {
   match: (type) => type === "bar",
-  createChart: (id, definition, sheetId, getters) =>
-    new BarChart(id, definition as BarChartDefinition, sheetId, getters),
+  createChart: (definition, sheetId, getters) =>
+    new BarChart(definition as BarChartDefinition, sheetId, getters),
   getChartRuntime: createBarChartRuntime,
   validateChartDefinition: (validator, definition: BarChartDefinition) =>
     BarChart.validateChartDefinition(validator, definition),
@@ -69,8 +69,8 @@ export class BarChart extends AbstractChart {
   readonly stackedBar: boolean;
   readonly type = "bar";
 
-  constructor(id: UID, definition: BarChartDefinition, sheetId: UID, getters: CoreGetters) {
-    super(id, definition, sheetId, getters);
+  constructor(definition: BarChartDefinition, sheetId: UID, getters: CoreGetters) {
+    super(definition, sheetId, getters);
     this.dataSets = createDataSets(
       getters,
       definition.dataSets,
@@ -131,7 +131,7 @@ export class BarChart extends AbstractChart {
     const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
     const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
     const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange);
-    return new BarChart(this.id, definition, sheetId, this.getters);
+    return new BarChart(definition, sheetId, this.getters);
   }
 
   getDefinition(): BarChartDefinition {
@@ -198,7 +198,7 @@ export class BarChart extends AbstractChart {
       return this;
     }
     const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange);
-    return new BarChart(this.id, definition, this.sheetId, this.getters);
+    return new BarChart(definition, this.sheetId, this.getters);
   }
 }
 

--- a/src/helpers/charts/chart_factory.ts
+++ b/src/helpers/charts/chart_factory.ts
@@ -20,7 +20,7 @@ export function chartFactory(getters: CoreGetters) {
     if (!builder) {
       throw new Error(`No builder for this chart: ${definition.type}`);
     }
-    return builder.createChart(id, definition, sheetId, getters);
+    return builder.createChart(definition, sheetId, getters);
   }
 
   return createChart;

--- a/src/helpers/charts/gauge_chart.ts
+++ b/src/helpers/charts/gauge_chart.ts
@@ -37,8 +37,8 @@ import { getDefaultChartJsRuntime } from "./chart_ui_common";
 
 chartRegistry.add("gauge", {
   match: (type) => type === "gauge",
-  createChart: (id, definition, sheetId, getters) =>
-    new GaugeChart(id, definition as GaugeChartDefinition, sheetId, getters),
+  createChart: (definition, sheetId, getters) =>
+    new GaugeChart(definition as GaugeChartDefinition, sheetId, getters),
   getChartRuntime: createGaugeChartRuntime,
   validateChartDefinition: (validator, definition) =>
     GaugeChart.validateChartDefinition(validator, definition as GaugeChartDefinition),
@@ -156,8 +156,8 @@ export class GaugeChart extends AbstractChart {
   readonly background: string;
   readonly type = "gauge";
 
-  constructor(id: UID, definition: GaugeChartDefinition, sheetId: UID, getters: CoreGetters) {
-    super(id, definition, sheetId, getters);
+  constructor(definition: GaugeChartDefinition, sheetId: UID, getters: CoreGetters) {
+    super(definition, sheetId, getters);
     this.dataRange = createRange(this.getters, this.sheetId, definition.dataRange);
     this.sectionRule = definition.sectionRule;
     this.background = definition.background;
@@ -223,7 +223,7 @@ export class GaugeChart extends AbstractChart {
   copyForSheetId(sheetId: string): GaugeChart {
     const dataRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.dataRange);
     const definition = this.getDefinitionWithSpecificRanges(dataRange);
-    return new GaugeChart(this.id, definition, sheetId, this.getters);
+    return new GaugeChart(definition, sheetId, this.getters);
   }
 
   getSheetIdsUsedInChartRanges(): UID[] {
@@ -263,7 +263,7 @@ export class GaugeChart extends AbstractChart {
       return this;
     }
     const definition = this.getDefinitionWithSpecificRanges(range);
-    return new GaugeChart(this.id, definition, this.sheetId, this.getters);
+    return new GaugeChart(definition, this.sheetId, this.getters);
   }
 }
 

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -51,8 +51,8 @@ import {
 
 chartRegistry.add("line", {
   match: (type) => type === "line",
-  createChart: (id, definition, sheetId, getters) =>
-    new LineChart(id, definition as LineChartDefinition, sheetId, getters),
+  createChart: (definition, sheetId, getters) =>
+    new LineChart(definition as LineChartDefinition, sheetId, getters),
   getChartRuntime: createLineChartRuntime,
   validateChartDefinition: (validator, definition) =>
     LineChart.validateChartDefinition(validator, definition as LineChartDefinition),
@@ -74,8 +74,8 @@ export class LineChart extends AbstractChart {
   readonly labelsAsText: boolean;
   readonly type = "line";
 
-  constructor(id: UID, definition: LineChartDefinition, sheetId: UID, getters: CoreGetters) {
-    super(id, definition, sheetId, getters);
+  constructor(definition: LineChartDefinition, sheetId: UID, getters: CoreGetters) {
+    super(definition, sheetId, getters);
     this.dataSets = createDataSets(
       this.getters,
       definition.dataSets,
@@ -166,7 +166,7 @@ export class LineChart extends AbstractChart {
       return this;
     }
     const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange);
-    return new LineChart(this.id, definition, this.sheetId, this.getters);
+    return new LineChart(definition, this.sheetId, this.getters);
   }
 
   getDefinitionForExcel(): ExcelChartDefinition {
@@ -185,7 +185,7 @@ export class LineChart extends AbstractChart {
     const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
     const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
     const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange);
-    return new LineChart(this.id, definition, sheetId, this.getters);
+    return new LineChart(definition, sheetId, this.getters);
   }
 
   getSheetIdsUsedInChartRanges(): UID[] {

--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -53,8 +53,8 @@ import {
 
 chartRegistry.add("pie", {
   match: (type) => type === "pie",
-  createChart: (id, definition, sheetId, getters) =>
-    new PieChart(id, definition as PieChartDefinition, sheetId, getters),
+  createChart: (definition, sheetId, getters) =>
+    new PieChart(definition as PieChartDefinition, sheetId, getters),
   getChartRuntime: createPieChartRuntime,
   validateChartDefinition: (validator, definition: PieChartDefinition) =>
     PieChart.validateChartDefinition(validator, definition),
@@ -74,8 +74,8 @@ export class PieChart extends AbstractChart {
   readonly legendPosition: LegendPosition;
   readonly type = "pie";
 
-  constructor(id: UID, definition: PieChartDefinition, sheetId: UID, getters: CoreGetters) {
-    super(id, definition, sheetId, getters);
+  constructor(definition: PieChartDefinition, sheetId: UID, getters: CoreGetters) {
+    super(definition, sheetId, getters);
     this.dataSets = createDataSets(
       getters,
       definition.dataSets,
@@ -153,7 +153,7 @@ export class PieChart extends AbstractChart {
     const dataSets = copyDataSetsWithNewSheetId(this.sheetId, sheetId, this.dataSets);
     const labelRange = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.labelRange);
     const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange);
-    return new PieChart(this.id, definition, sheetId, this.getters);
+    return new PieChart(definition, sheetId, this.getters);
   }
 
   getDefinitionForExcel(): ExcelChartDefinition {
@@ -197,7 +197,7 @@ export class PieChart extends AbstractChart {
       return this;
     }
     const definition = this.getDefinitionWithSpecificDataSets(dataSets, labelRange);
-    return new PieChart(this.id, definition, this.sheetId, this.getters);
+    return new PieChart(definition, this.sheetId, this.getters);
   }
 }
 

--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -30,8 +30,8 @@ import {
 
 chartRegistry.add("scorecard", {
   match: (type) => type === "scorecard",
-  createChart: (id, definition, sheetId, getters) =>
-    new ScorecardChart(id, definition as ScorecardChartDefinition, sheetId, getters),
+  createChart: (definition, sheetId, getters) =>
+    new ScorecardChart(definition as ScorecardChartDefinition, sheetId, getters),
   getChartRuntime: createScorecardChartRuntime,
   validateChartDefinition: (validator, definition) =>
     ScorecardChart.validateChartDefinition(validator, definition as ScorecardChartDefinition),
@@ -71,8 +71,8 @@ export class ScorecardChart extends AbstractChart {
   readonly fontColor?: string;
   readonly type = "scorecard";
 
-  constructor(id: UID, definition: ScorecardChartDefinition, sheetId: UID, getters: CoreGetters) {
-    super(id, definition, sheetId, getters);
+  constructor(definition: ScorecardChartDefinition, sheetId: UID, getters: CoreGetters) {
+    super(definition, sheetId, getters);
     this.keyValue = createRange(getters, sheetId, definition.keyValue);
     this.baseline = createRange(getters, sheetId, definition.baseline);
     this.baselineMode = definition.baselineMode;
@@ -130,7 +130,7 @@ export class ScorecardChart extends AbstractChart {
     const baseline = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.baseline);
     const keyValue = copyLabelRangeWithNewSheetId(this.sheetId, sheetId, this.keyValue);
     const definition = this.getDefinitionWithSpecificRanges(baseline, keyValue);
-    return new ScorecardChart(this.id, definition, sheetId, this.getters);
+    return new ScorecardChart(definition, sheetId, this.getters);
   }
 
   getDefinition(): ScorecardChartDefinition {
@@ -186,7 +186,7 @@ export class ScorecardChart extends AbstractChart {
       return this;
     }
     const definition = this.getDefinitionWithSpecificRanges(baseline, keyValue);
-    return new ScorecardChart(this.id, definition, this.sheetId, this.getters);
+    return new ScorecardChart(definition, this.sheetId, this.getters);
   }
 }
 

--- a/src/registries/chart_types.ts
+++ b/src/registries/chart_types.ts
@@ -29,12 +29,7 @@ interface ChartBuilder {
    * Check if this factory should be used
    */
   match: (type: ChartType) => boolean;
-  createChart: (
-    id: UID,
-    definition: ChartDefinition,
-    sheetId: UID,
-    getters: CoreGetters
-  ) => AbstractChart;
+  createChart: (definition: ChartDefinition, sheetId: UID, getters: CoreGetters) => AbstractChart;
   getChartRuntime: (chart: AbstractChart, getters: Getters) => ChartRuntime;
   validateChartDefinition(
     validator: Validator,


### PR DESCRIPTION
The `AbstractChart` interface contained a chartId, but this id was :
1) Never used
2) Was wrong after the chart plugin copied the chart using the method
`copyForSheetId`. The method  copied the id of the old chart while the
chart plugin created a new id for the chart.

This commit remove the ids from `AbstractChart`.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo