### PR TITLE
[FIX] conditional_formatting.xml: fixed missing space

### DIFF
--- a/src/components/side_panel/conditional_formatting/conditional_formatting.xml
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.xml
@@ -140,7 +140,7 @@
             <t t-if="cf.rule.values">
               <t t-esc="' ' + cf.rule.values[0]"/>
               <t t-if="cf.rule.values[1]">
-                <span style="white-space: pre;">and</span>
+                <span style="white-space: pre;padding:5px">and</span>
                 <t t-esc="cf.rule.values[1]"/>
               </t>
             </t>


### PR DESCRIPTION
## Description:

Fixed missing space for conditional formatting description.

Odoo task ID : [2892116](https://www.odoo.com/web#id=2892116&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo