### PR TITLE
[FIX] SelectionInput: Use correct sheetId for highlights

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -10,6 +10,7 @@ export const demoData = {
   sheets: [
     {
       name: "Sheet1",
+      id: "sh1",
       colNumber: 26,
       rowNumber: 120,
       cols: { 1: {}, 3: {} },
@@ -166,6 +167,7 @@ export const demoData = {
     },
     {
       name: "Sheet2",
+      id: "sh2",
       cells: {
         B2: { content: "42" },
       },
@@ -219,6 +221,7 @@ export const demoData = {
     },
     {
       name: "Sheet3",
+      id: "sh3",
       colNumber: 26,
       rowNumber: 180,
       conditionalFormats: [

--- a/src/plugins/ui/highlight.ts
+++ b/src/plugins/ui/highlight.ts
@@ -62,13 +62,12 @@ export class HighlightPlugin extends UIPlugin {
      * In order to avoid superposing the same color layer and modifying the final
      * opacity, we filter highlights to remove duplicates.
      */
-
-    for (let h of this.getHighlights().filter(
+    const highlights = this.getHighlights();
+    for (let h of highlights.filter(
       (highlight, index) =>
         // For every highlight in the sheet, deduplicated by zone
-        this.getHighlights().findIndex(
-          (h) => isEqual(h.zone, highlight.zone) && h.sheetId === sheetId
-        ) === index
+        highlights.findIndex((h) => isEqual(h.zone, highlight.zone) && h.sheetId === sheetId) ===
+        index
     )) {
       const [x, y, width, height] = this.getters.getRect(h.zone, viewport);
       if (width > 0 && height > 0) {

--- a/src/plugins/ui/selection_input.ts
+++ b/src/plugins/ui/selection_input.ts
@@ -247,11 +247,14 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
     const XCs = this.cleanInputs([xc])
       .filter((range) => this.getters.isRangeValid(range))
       .filter((reference) => this.shouldBeHighlighted(this.activeSheet, reference));
-    return XCs.map((xc) => ({
-      zone: toZone(xc),
-      sheetId: this.activeSheet,
-      color,
-    }));
+    return XCs.map((xc) => {
+      const [zoneXc, sheetName] = xc.split("!").reverse();
+      return {
+        zone: toZone(zoneXc),
+        sheetId: (sheetName && this.getters.getSheetIdByName(sheetName)) || this.activeSheet,
+        color,
+      };
+    });
   }
 
   private cleanInputs(ranges: string[]): string[] {

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../src";
-import { zoneToXc } from "../../src/helpers";
+import { toZone, zoneToXc } from "../../src/helpers";
 import { CommandResult } from "../../src/types";
 import {
   activateSheet,
@@ -19,9 +19,12 @@ function select(model: Model, xc: string) {
   model.dispatch("STOP_SELECTION_INPUT");
 }
 
+/** returns the highlighted zone in the current sheet */
 function highlightedZones(model: Model) {
+  const sheetId = model.getters.getActiveSheetId();
   return model.getters
     .getHighlights()
+    .filter((h) => h.sheetId === sheetId)
     .map((h) => h.zone)
     .map(zoneToXc);
 }
@@ -479,6 +482,21 @@ describe("selection input plugin", () => {
     expect(model.getters.getSelectionInput(id)[0].color).toBe(null);
     model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
     expect(model.getters.getSelectionInput(id)[0].color).toBe(color);
+  });
+
+  test("Pre-existing ranges from other sheets are selected", () => {
+    createSheet(model, { sheetId: "42", name: "Sheet2", activate: false });
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, initialRanges: ["Sheet2!A2"] });
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("Sheet2!A2");
+    model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
+    expect(highlightedZones(model)).toEqual([]);
+    const firstSheetId = model.getters.getActiveSheetId();
+    activateSheet(model, "42", firstSheetId);
+    expect(highlightedZones(model)).toEqual(["A2"]);
+    expect(model.getters.getHighlights()[0]).toMatchObject({
+      sheetId: "42",
+      zone: toZone("A2"),
+    });
   });
 
   test("can select multiple ranges in another sheet", () => {


### PR DESCRIPTION
Since the refactoring of highlights in d8d14870, we were creating
highlights based on the sheet where the selectionInput was initiated
rather than using the sheet specified in the xc. This was not detected
in the tests because we were only testing the highlights zones.

Plus: adapted the migration "sanity check" that would partially hide the
issue when live testing by using the same string for a sheet id and name.
With such data, one would not realise if they were to confuse both keys.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo