### PR TITLE
[REF] tokenize: rewrite range tokenizer

### DIFF
--- a/src/formulas/composer_tokenizer.ts
+++ b/src/formulas/composer_tokenizer.ts
@@ -1,6 +1,4 @@
-import { Token } from ".";
-import { mergeSymbolsIntoRanges } from "./range_tokenizer";
-import { tokenize } from "./tokenizer";
+import { rangeTokenize, Token } from "./index";
 
 interface FunctionContext {
   parent: string;
@@ -119,7 +117,7 @@ function mapParentFunction(tokens: EnrichedToken[]): EnrichedToken[] {
  * @param formula
  */
 export function composerTokenize(formula: string): EnrichedToken[] {
-  const tokens = tokenize(formula);
+  const tokens = rangeTokenize(formula);
 
-  return mapParentFunction(mapParenthesis(enrichTokens(mergeSymbolsIntoRanges(tokens))));
+  return mapParentFunction(mapParenthesis(enrichTokens(tokens)));
 }

--- a/src/helpers/references.ts
+++ b/src/helpers/references.ts
@@ -1,6 +1,12 @@
 /** Reference of a cell (eg. A1, $B$5) */
 export const cellReference = new RegExp(/\$?([A-Z]{1,3})\$?([0-9]{1,7})/, "i");
 
+// Same as above, but matches the exact string (nothing before or after)
+const singleCellReference = new RegExp(/^\$?([A-Z]{1,3})\$?([0-9]{1,7})$/, "i");
+
+/** Reference of a column header (eg. A, AB) */
+const colHeader = new RegExp(/^([A-Z]{1,3})+$/, "i");
+
 /** Reference of a column (eg. A, $CA, Sheet1!B) */
 const colReference = new RegExp(/^\s*('.+'!|[^']+!)?\$?([A-Z]{1,3})$/, "i");
 
@@ -23,12 +29,28 @@ export const rangeReference = new RegExp(
   "i"
 );
 
-// Return true if the given xc is the reference of a column (eg. A or AC or Sheet1!A)
-export function isColReference(xc: string) {
+/**
+ * Return true if the given xc is the reference of a column (e.g. A or AC or Sheet1!A)
+ */
+export function isColReference(xc: string): boolean {
   return colReference.test(xc);
 }
 
-// Return true if the given xc is the reference of a column (eg. 1 or Sheet1!1)
-export function isRowReference(xc: string) {
+/**
+ * Return true if the given xc is the reference of a column (e.g. 1 or Sheet1!1)
+ */
+export function isRowReference(xc: string): boolean {
   return rowReference.test(xc);
+}
+
+export function isColHeader(str: string): boolean {
+  return colHeader.test(str);
+}
+
+/**
+ * Return true if the given xc is the reference of a single cell,
+ * without any specified sheet (e.g. A1)
+ */
+export function isSingleCellReference(xc: string): boolean {
+  return singleCellReference.test(xc);
 }

--- a/tests/formulas/__snapshots__/composer_tokenizer.test.ts.snap
+++ b/tests/formulas/__snapshots__/composer_tokenizer.test.ts.snap
@@ -43,15 +43,37 @@ Array [
     "value": "(",
   },
   Object {
+    "end": 8,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "SUM",
+    },
+    "length": 1,
+    "start": 7,
+    "type": "SPACE",
+    "value": " ",
+  },
+  Object {
+    "end": 15,
+    "functionContext": Object {
+      "argPosition": 0,
+      "parent": "SUM",
+    },
+    "length": 7,
+    "start": 8,
+    "type": "REFERENCE",
+    "value": "C4 : C5",
+  },
+  Object {
     "end": 16,
     "functionContext": Object {
       "argPosition": 0,
       "parent": "SUM",
     },
-    "length": 9,
-    "start": 7,
-    "type": "REFERENCE",
-    "value": " C4 : C5 ",
+    "length": 1,
+    "start": 15,
+    "type": "SPACE",
+    "value": " ",
   },
   Object {
     "end": 17,

--- a/tests/formulas/composer_tokenizer.test.ts
+++ b/tests/formulas/composer_tokenizer.test.ts
@@ -29,7 +29,9 @@ describe("composerTokenizer", () => {
   test("unbound range with spaces", () => {
     expect(composerTokenize("= A : A ")).toEqual([
       { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
-      { start: 1, end: 8, length: 7, type: "REFERENCE", value: " A : A " },
+      { start: 1, end: 2, length: 1, type: "SPACE", value: " " },
+      { start: 2, end: 7, length: 5, type: "REFERENCE", value: "A : A" },
+      { start: 7, end: 8, length: 1, type: "SPACE", value: " " },
     ]);
   });
 
@@ -38,14 +40,18 @@ describe("composerTokenizer", () => {
       { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
       { start: 1, end: 3, length: 2, type: "REFERENCE", value: "A3" },
       { start: 3, end: 4, length: 1, type: "OPERATOR", value: "+" },
-      { start: 4, end: 16, length: 12, type: "REFERENCE", value: "  A1 : A2   " },
+      { start: 4, end: 6, length: 2, type: "SPACE", value: "  " },
+      { start: 6, end: 13, length: 7, type: "REFERENCE", value: "A1 : A2" },
+      { start: 13, end: 16, length: 3, type: "SPACE", value: "   " },
     ]);
   });
 
   test("range with spaces then operation", () => {
     expect(composerTokenize("=  A1 : A2   +a3")).toEqual([
       { start: 0, end: 1, length: 1, type: "OPERATOR", value: "=" },
-      { start: 1, end: 13, length: 12, type: "REFERENCE", value: "  A1 : A2   " },
+      { start: 1, end: 3, length: 2, type: "SPACE", value: "  " },
+      { start: 3, end: 10, length: 7, type: "REFERENCE", value: "A1 : A2" },
+      { start: 10, end: 13, length: 3, type: "SPACE", value: "   " },
       { start: 13, end: 14, length: 1, type: "OPERATOR", value: "+" },
       { start: 14, end: 16, length: 2, type: "REFERENCE", value: "a3" },
     ]);

--- a/tests/formulas/range_tokenizer.test.ts
+++ b/tests/formulas/range_tokenizer.test.ts
@@ -15,7 +15,7 @@ describe("rangeTokenizer", () => {
       { type: "REFERENCE", value: "A1" },
     ]);
   });
-  test("operation and range", () => {
+  test("operation and range without spaces", () => {
     expect(rangeTokenize("=A3+A1:A2")).toEqual([
       { type: "OPERATOR", value: "=" },
       { type: "REFERENCE", value: "A3" },
@@ -28,14 +28,18 @@ describe("rangeTokenizer", () => {
       { type: "OPERATOR", value: "=" },
       { type: "REFERENCE", value: "A3" },
       { type: "OPERATOR", value: "+" },
-      { type: "REFERENCE", value: "A1:A2" },
+      { type: "SPACE", value: "  " },
+      { type: "REFERENCE", value: "A1 : A2" },
+      { type: "SPACE", value: "   " },
     ]);
   });
 
   test("range with spaces then operation", () => {
     expect(rangeTokenize("=  A1 : A2   +a3")).toEqual([
       { type: "OPERATOR", value: "=" },
-      { type: "REFERENCE", value: "A1:A2" },
+      { type: "SPACE", value: "  " },
+      { type: "REFERENCE", value: "A1 : A2" },
+      { type: "SPACE", value: "   " },
       { type: "OPERATOR", value: "+" },
       { type: "REFERENCE", value: "a3" },
     ]);
@@ -48,7 +52,9 @@ describe("rangeTokenizer", () => {
       { type: "FUNCTION", value: "SUM" },
       { type: "SPACE", value: " " },
       { type: "LEFT_PAREN", value: "(" },
-      { type: "REFERENCE", value: "C4:C5" },
+      { type: "SPACE", value: " " },
+      { type: "REFERENCE", value: "C4 : C5" },
+      { type: "SPACE", value: " " },
       { type: "RIGHT_PAREN", value: ")" },
     ]);
   });
@@ -101,7 +107,7 @@ describe("rangeTokenizer", () => {
   });
 });
 
-describe("knows what's a reference and what's not", () => {
+describe("knows what is a reference and what is not", () => {
   test("lowercase cell reference", () => {
     expect(rangeTokenize("=a1")).toEqual([
       { type: "OPERATOR", value: "=" },
@@ -169,6 +175,15 @@ describe("knows what's a reference and what's not", () => {
     expect(rangeTokenize("=Sheet3!A1:A2")).toEqual([
       { type: "OPERATOR", value: "=" },
       { type: "REFERENCE", value: "Sheet3!A1:A2" },
+    ]);
+  });
+
+  test("double sheet range", () => {
+    expect(rangeTokenize("=Sheet3!A1:Sheet3!A2")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "REFERENCE", value: "Sheet3!A1" },
+      { type: "OPERATOR", value: ":" },
+      { type: "REFERENCE", value: "Sheet3!A2" },
     ]);
   });
 

--- a/tests/formulas/tokenizer.test.ts
+++ b/tests/formulas/tokenizer.test.ts
@@ -176,6 +176,18 @@ describe("tokenizer", () => {
       { type: "OPERATOR", value: "=" },
       { type: "REFERENCE", value: "Sheet1!A1" },
     ]);
+    expect(tokenize("=Sheet1!A1:A2")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "REFERENCE", value: "Sheet1!A1" },
+      { type: "OPERATOR", value: ":" },
+      { type: "REFERENCE", value: "A2" },
+    ]);
+    expect(tokenize("=Sheet1!A:A")).toEqual([
+      { type: "OPERATOR", value: "=" },
+      { type: "SYMBOL", value: "Sheet1!A" },
+      { type: "OPERATOR", value: ":" },
+      { type: "SYMBOL", value: "A" },
+    ]);
     expect(tokenize("='Sheet1'!A1")).toEqual([
       { type: "OPERATOR", value: "=" },
       { type: "REFERENCE", value: "'Sheet1'!A1" },


### PR DESCRIPTION
## Description:

The `rangeTokenize` (`mergeSymbolsIntoRanges`) function is not easy to read and understand, with lots of
nested statements and temporary variables. This has not improved since the
introduction of full row and columns references in https://github.com/odoo/o-spreadsheet/commit/d49de1cdb5f08a758a28ec99a96f2baa8169c23f

This commit rewrites the function using a state machine.
IMHO the business logic of matching tokens is way easier to understand this
way, with a more declarative style.

Odoo task ID : [2900513](https://www.odoo.com/web#id=2900513&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo