### PR TITLE
[IMP] topbar: removed brackets from format example

### DIFF
--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -38,32 +38,32 @@ interface State {
 
 const FORMATS = [
   { name: "general", text: NumberFormatTerms.General },
-  { name: "number", text: NumberFormatTerms.Number, description: "(1,000.12)", value: "#,##0.00" },
-  { name: "percent", text: NumberFormatTerms.Percent, description: "(10.12%)", value: "0.00%" },
+  { name: "number", text: NumberFormatTerms.Number, description: "1,000.12", value: "#,##0.00" },
+  { name: "percent", text: NumberFormatTerms.Percent, description: "10.12%", value: "0.00%" },
   {
     name: "currency",
     text: NumberFormatTerms.Currency,
-    description: "($1,000.12)",
+    description: "$1,000.12",
     value: "[$$]#,##0.00",
   },
   {
     name: "currency_rounded",
     text: NumberFormatTerms.CurrencyRounded,
-    description: "($1,000)",
+    description: "$1,000",
     value: "[$$]#,##0",
   },
-  { name: "date", text: NumberFormatTerms.Date, description: "(9/26/2008)", value: "m/d/yyyy" },
-  { name: "time", text: NumberFormatTerms.Time, description: "(10:43:00 PM)", value: "hh:mm:ss a" },
+  { name: "date", text: NumberFormatTerms.Date, description: "9/26/2008", value: "m/d/yyyy" },
+  { name: "time", text: NumberFormatTerms.Time, description: "10:43:00 PM", value: "hh:mm:ss a" },
   {
     name: "datetime",
     text: NumberFormatTerms.DateTime,
-    description: "(9/26/2008 22:43:00)",
+    description: "9/26/2008 22:43:00",
     value: "m/d/yyyy hh:mm:ss",
   },
   {
     name: "duration",
     text: NumberFormatTerms.Duration,
-    description: "(27:51:38)",
+    description: "27:51:38",
     value: "hhhh:mm:ss",
   },
 ];

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -214,26 +214,26 @@ topbarMenuRegistry
   })
   .addChild("format_number_number", ["format", "format_number"], {
     name: NumberFormatTerms.Number,
-    description: "(1,000.12)",
+    description: "1,000.12",
     sequence: 20,
     action: ACTIONS.FORMAT_NUMBER_ACTION,
   })
   .addChild("format_number_percent", ["format", "format_number"], {
     name: NumberFormatTerms.Percent,
-    description: "(10.12%)",
+    description: "10.12%",
     sequence: 30,
     separator: true,
     action: ACTIONS.FORMAT_PERCENT_ACTION,
   })
   .addChild("format_number_currency", ["format", "format_number"], {
     name: NumberFormatTerms.Currency,
-    description: "($1,000.12)",
+    description: "$1,000.12",
     sequence: 37,
     action: ACTIONS.FORMAT_CURRENCY_ACTION,
   })
   .addChild("format_number_currency_rounded", ["format", "format_number"], {
     name: NumberFormatTerms.CurrencyRounded,
-    description: "($1,000)",
+    description: "$1,000",
     sequence: 38,
     action: ACTIONS.FORMAT_CURRENCY_ROUNDED_ACTION,
   })
@@ -245,25 +245,25 @@ topbarMenuRegistry
   })
   .addChild("format_number_date", ["format", "format_number"], {
     name: NumberFormatTerms.Date,
-    description: "(9/26/2008)",
+    description: "9/26/2008",
     sequence: 40,
     action: ACTIONS.FORMAT_DATE_ACTION,
   })
   .addChild("format_number_time", ["format", "format_number"], {
     name: NumberFormatTerms.Time,
-    description: "(10:43:00 PM)",
+    description: "10:43:00 PM",
     sequence: 50,
     action: ACTIONS.FORMAT_TIME_ACTION,
   })
   .addChild("format_number_date_time", ["format", "format_number"], {
     name: NumberFormatTerms.DateTime,
-    description: "(9/26/2008 22:43:00)",
+    description: "9/26/2008 22:43:00",
     sequence: 60,
     action: ACTIONS.FORMAT_DATE_TIME_ACTION,
   })
   .addChild("format_number_duration", ["format", "format_number"], {
     name: NumberFormatTerms.Duration,
-    description: "(27:51:38)",
+    description: "27:51:38",
     sequence: 70,
     separator: true,
     action: ACTIONS.FORMAT_DURATION_ACTION,

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -182,7 +182,7 @@ exports[`TopBar component can set cell format 1`] = `
                 <span
                   class="float-end text-muted"
                 >
-                  (1,000.12)
+                  1,000.12
                 </span>
               </div>
               <div
@@ -192,7 +192,7 @@ exports[`TopBar component can set cell format 1`] = `
                 <span
                   class="float-end text-muted"
                 >
-                  (10.12%)
+                  10.12%
                 </span>
               </div>
               <div
@@ -202,7 +202,7 @@ exports[`TopBar component can set cell format 1`] = `
                 <span
                   class="float-end text-muted"
                 >
-                  ($1,000.12)
+                  $1,000.12
                 </span>
               </div>
               <div
@@ -212,7 +212,7 @@ exports[`TopBar component can set cell format 1`] = `
                 <span
                   class="float-end text-muted"
                 >
-                  ($1,000)
+                  $1,000
                 </span>
               </div>
               <div
@@ -222,7 +222,7 @@ exports[`TopBar component can set cell format 1`] = `
                 <span
                   class="float-end text-muted"
                 >
-                  (9/26/2008)
+                  9/26/2008
                 </span>
               </div>
               <div
@@ -232,7 +232,7 @@ exports[`TopBar component can set cell format 1`] = `
                 <span
                   class="float-end text-muted"
                 >
-                  (10:43:00 PM)
+                  10:43:00 PM
                 </span>
               </div>
               <div
@@ -242,7 +242,7 @@ exports[`TopBar component can set cell format 1`] = `
                 <span
                   class="float-end text-muted"
                 >
-                  (9/26/2008 22:43:00)
+                  9/26/2008 22:43:00
                 </span>
               </div>
               <div
@@ -252,7 +252,7 @@ exports[`TopBar component can set cell format 1`] = `
                 <span
                   class="float-end text-muted"
                 >
-                  (27:51:38)
+                  27:51:38
                 </span>
               </div>
               


### PR DESCRIPTION
## Description:

Those brackets can be confusing as some accounting format actually include
brackets to display negative amounts.

Removed the brackets from the examples in the Format>Numbers dropdown menu

Odoo task ID : [2900459](https://www.odoo.com/web#id=2900459&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo