### PR TITLE
[FIX] charts: traceback on SelectionInput with empty range

### DIFF
--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.xml
@@ -4,7 +4,7 @@
       <div class="o-section o-data-series">
         <div class="o-section-title">Data range</div>
         <SelectionInput
-          ranges="[props.definition.dataRange]"
+          ranges="[props.definition.dataRange || '']"
           isInvalid="isDataRangeInvalid"
           hasSingleRange="true"
           required="true"

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
@@ -4,7 +4,7 @@
       <div class="o-section o-data-series">
         <div class="o-section-title">Key value</div>
         <SelectionInput
-          ranges="[props.definition.keyValue]"
+          ranges="[props.definition.keyValue || '']"
           isInvalid="isKeyValueInvalid"
           hasSingleRange="true"
           required="true"

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -846,6 +846,24 @@ describe("figures", () => {
     }
   );
 
+  test.each(["basicChart", "scorecard", "gauge"])(
+    "Can edit a chart with empty main range without traceback",
+    async (chartType: string) => {
+      createTestChart(chartType);
+      updateChart(model, chartId, { keyValue: undefined, dataRange: undefined, dataSets: [] });
+      await nextTick();
+      await simulateClick(".o-figure");
+      await simulateClick(".o-chart-menu-item");
+      await simulateClick(".o-menu div[data-name='edit']");
+      await nextTick();
+
+      const input = fixture.querySelector("input.o-required");
+      await simulateClick(input);
+      await nextTick();
+      expect(fixture.querySelector(".o-figure")).toBeTruthy();
+    }
+  );
+
   describe("Scorecard specific tests", () => {
     test("can edit chart baseline colors", async () => {
       createTestChart("scorecard");


### PR DESCRIPTION
There was a problem in the scorecard and gauge side panel. When the chart
had an empty key value/empty range, the user got a traceback when trying
to edit the content of the SelectionInput.

This happened because the side panel gave the SelectionInput an array with
an undefined value as prop, where the SelectionInput expected an array of
strings

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo