### PR TITLE
[FIX] top_bar: bugged top_bar menu item hitbox

### DIFF
--- a/src/components/top_bar.ts
+++ b/src/components/top_bar.ts
@@ -130,17 +130,17 @@ export class TopBar extends Component<any, SpreadsheetEnv> {
           <div class="o-tool" title="${Terms.Bold}" t-att-class="{active:style.bold}" t-on-click="toogleStyle('bold')">${icons.BOLD_ICON}</div>
           <div class="o-tool" title="${Terms.Italic}" t-att-class="{active:style.italic}" t-on-click="toogleStyle('italic')">${icons.ITALIC_ICON}</div>
           <div class="o-tool" title="${Terms.Strikethrough}"  t-att-class="{active:style.strikethrough}" t-on-click="toogleStyle('strikethrough')">${icons.STRIKE_ICON}</div>
-          <div class="o-tool o-dropdown o-with-color">
-            <span t-attf-style="border-color:{{textColor}}" title="${Terms.TextColor}" t-on-click="toggleDropdownTool('textColorTool')">${icons.TEXT_COLOR_ICON}</span>
+          <div class="o-tool o-dropdown o-with-color" title="${Terms.TextColor}" t-on-click="toggleDropdownTool('textColorTool')" >
+            <span t-attf-style="border-color:{{textColor}}">${icons.TEXT_COLOR_ICON}</span>
             <ColorPicker t-if="state.activeTool === 'textColorTool'" t-on-color-picked="setColor('textColor')" t-key="textColor"/>
           </div>
           <div class="o-divider"/>
-          <div class="o-tool  o-dropdown o-with-color">
-            <span t-attf-style="border-color:{{fillColor}}" title="${Terms.FillColor}" t-on-click="toggleDropdownTool('fillColorTool')">${icons.FILL_COLOR_ICON}</span>
+          <div class="o-tool  o-dropdown o-with-color" title="${Terms.FillColor}" t-on-click="toggleDropdownTool('fillColorTool')">
+            <span t-attf-style="border-color:{{fillColor}}">${icons.FILL_COLOR_ICON}</span>
             <ColorPicker t-if="state.activeTool === 'fillColorTool'" t-on-color-picked="setColor('fillColor')" t-key="fillColor"/>
           </div>
-          <div class="o-tool o-dropdown">
-            <span title="${Terms.Borders}" t-on-click="toggleDropdownTool('borderTool')">${icons.BORDERS_ICON}</span>
+          <div class="o-tool o-dropdown" t-on-click="toggleDropdownTool('borderTool')" title="${Terms.Borders}">
+            <span>${icons.BORDERS_ICON}</span>
             <div class="o-dropdown-content o-border" t-if="state.activeTool === 'borderTool'">
               <div class="o-dropdown-line">
                 <span class="o-line-item" t-on-click="setBorder('all')">${icons.BORDERS_ICON}</span>

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -227,10 +227,10 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
         </div>
         <div
           class="o-tool o-dropdown o-with-color"
+          title="Text Color"
         >
           <span
             style="border-color:black"
-            title="Text Color"
           >
             <svg
               class="o-icon"
@@ -248,10 +248,10 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
         />
         <div
           class="o-tool o-dropdown o-with-color"
+          title="Fill Color"
         >
           <span
             style="border-color:white"
-            title="Fill Color"
           >
             <svg
               class="o-icon"
@@ -265,10 +265,9 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
         </div>
         <div
           class="o-tool o-dropdown"
+          title="Borders"
         >
-          <span
-            title="Borders"
-          >
+          <span>
             <svg
               class="o-icon"
             >

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -264,10 +264,10 @@ exports[`TopBar component can set cell format 1`] = `
       </div>
       <div
         class="o-tool o-dropdown o-with-color"
+        title="Text Color"
       >
         <span
           style="border-color:black"
-          title="Text Color"
         >
           <svg
             class="o-icon"
@@ -285,10 +285,10 @@ exports[`TopBar component can set cell format 1`] = `
       />
       <div
         class="o-tool o-dropdown o-with-color"
+        title="Fill Color"
       >
         <span
           style="border-color:white"
-          title="Fill Color"
         >
           <svg
             class="o-icon"
@@ -302,10 +302,9 @@ exports[`TopBar component can set cell format 1`] = `
       </div>
       <div
         class="o-tool o-dropdown"
+        title="Borders"
       >
-        <span
-          title="Borders"
-        >
+        <span>
           <svg
             class="o-icon"
           >
@@ -605,10 +604,10 @@ exports[`TopBar component simple rendering 1`] = `
       </div>
       <div
         class="o-tool o-dropdown o-with-color"
+        title="Text Color"
       >
         <span
           style="border-color:black"
-          title="Text Color"
         >
           <svg
             class="o-icon"
@@ -626,10 +625,10 @@ exports[`TopBar component simple rendering 1`] = `
       />
       <div
         class="o-tool o-dropdown o-with-color"
+        title="Fill Color"
       >
         <span
           style="border-color:white"
-          title="Fill Color"
         >
           <svg
             class="o-icon"
@@ -643,10 +642,9 @@ exports[`TopBar component simple rendering 1`] = `
       </div>
       <div
         class="o-tool o-dropdown"
+        title="Borders"
       >
-        <span
-          title="Borders"
-        >
+        <span>
           <svg
             class="o-icon"
           >

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -87,7 +87,7 @@ describe("TopBar component", () => {
     await parent.mount(fixture);
 
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
-    fixture.querySelector('span[title="Borders"]')!.dispatchEvent(new Event("click"));
+    fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
     await nextTick();
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
     expect(fixture.querySelectorAll(".o-line-item").length).not.toBe(0);
@@ -247,10 +247,10 @@ describe("TopBar component", () => {
     await parent.mount(fixture);
 
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
-    fixture.querySelector('span[title="Borders"]')!.dispatchEvent(new Event("click"));
+    fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
     await nextTick();
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
-    fixture.querySelector('span[title="Borders"]')!.dispatchEvent(new Event("click"));
+    fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
     await nextTick();
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
   });


### PR DESCRIPTION
## Description:

This commit modifies few attributes on xml level to fix the issue of
misleading hitbox for three top bar (toolbar) menu items. Due to click being
programmed in span a marginal boundary of that button was inactive,
which is resolved by moving the click event to parent attribute.

Odoo task ID : [2901921](https://www.odoo.com/web#id=2901921&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo