### PR TITLE
[FIX] CF: open sidepanel

### DIFF
--- a/src/components/side_panel/conditional_formatting/color_scale_rule_editor.ts
+++ b/src/components/side_panel/conditional_formatting/color_scale_rule_editor.ts
@@ -39,7 +39,7 @@ const THRESHOLD_TEMPLATE = xml/* xml */ `
       />
       <div class="o-tools">
         <div class="o-tool  o-dropdown o-with-color" t-att-disabled="threshold === undefined" >
-          <span title="Fill Color"  t-attf-style="border-color:#{{getThresholdColor(threshold)}}"
+          <span title="Fill Color"  t-attf-style="border-color:{{getThresholdColor(threshold)}}"
                 t-on-click.stop="(ev) => this.toggleMenu('colorScale-'+thresholdType+'Color', ev)">${icons.FILL_COLOR_ICON}</span>
           <ColorPicker t-if="state.openedMenu === 'colorScale-'+thresholdType+'Color'" dropdownDirection="'left'" onColorPicked="(color) => this.setColorScaleColor(thresholdType, color)"/>
         </div>


### PR DESCRIPTION
Opening the CF side panel crashes with the newer owl version.

since https://github.com/odoo/owl/commit/385e118e583815bc8191391b5280894cdc4d9feb
`t-attf` supports only `{{}}` or `#{}`

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo