### PR TITLE
[IMP] line_chart: add transparent fill to linechart

### DIFF
--- a/src/helpers/charts/chart_ui_common.ts
+++ b/src/helpers/charts/chart_ui_common.ts
@@ -78,7 +78,7 @@ export function getDefaultChartJsRuntime(
       },
       elements: {
         line: {
-          fill: false, // do not fill the area under line charts
+          fill: true,
         },
         point: {
           hitRadius: 15, // increased hit radius to display point tooltip when hovering nearby

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -339,7 +339,6 @@ function createLineChartRuntime(chart: LineChart, getters: Getters): LineChartRu
   }
 
   const colors = new ChartColors();
-
   for (let { label, data } of dataSetsValues) {
     if (["linear", "time"].includes(axisType)) {
       // Replace empty string labels by undefined to make sure chartJS doesn't decide that "" is the same as 0
@@ -352,7 +351,7 @@ function createLineChartRuntime(chart: LineChart, getters: Getters): LineChartRu
       data,
       lineTension: 0, // 0 -> render straight lines, which is much faster
       borderColor: color,
-      backgroundColor: color,
+      backgroundColor: color.replace(/\)/i, ",0.4)"),
     };
     config.data!.datasets!.push(dataset);
   }

--- a/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
@@ -7,7 +7,7 @@ Object {
     "data": Object {
       "datasets": Array [
         Object {
-          "backgroundColor": "rgb(31,119,180)",
+          "backgroundColor": "rgb(31,119,180,0.4)",
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             Object {
@@ -44,7 +44,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -115,7 +115,7 @@ Object {
     "data": Object {
       "datasets": Array [
         Object {
-          "backgroundColor": "rgb(31,119,180)",
+          "backgroundColor": "rgb(31,119,180,0.4)",
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             Object {
@@ -152,7 +152,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -230,7 +230,7 @@ Object {
     "data": Object {
       "datasets": Array [
         Object {
-          "backgroundColor": "rgb(31,119,180)",
+          "backgroundColor": "rgb(31,119,180,0.4)",
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             Object {
@@ -267,7 +267,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -356,7 +356,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -427,7 +427,7 @@ Object {
     "data": Object {
       "datasets": Array [
         Object {
-          "backgroundColor": "rgb(31,119,180)",
+          "backgroundColor": "rgb(31,119,180,0.4)",
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             30,
@@ -446,7 +446,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -515,7 +515,7 @@ Object {
     "data": Object {
       "datasets": Array [
         Object {
-          "backgroundColor": "rgb(31,119,180)",
+          "backgroundColor": "rgb(31,119,180,0.4)",
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             10,
@@ -526,7 +526,7 @@ Object {
           "lineTension": 0,
         },
         Object {
-          "backgroundColor": "rgb(255,127,14)",
+          "backgroundColor": "rgb(255,127,14,0.4)",
           "borderColor": "rgb(255,127,14)",
           "data": Array [
             20,
@@ -549,7 +549,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -618,7 +618,7 @@ Object {
     "data": Object {
       "datasets": Array [
         Object {
-          "backgroundColor": "rgb(31,119,180)",
+          "backgroundColor": "rgb(31,119,180,0.4)",
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             10,
@@ -629,7 +629,7 @@ Object {
           "lineTension": 0,
         },
         Object {
-          "backgroundColor": "rgb(255,127,14)",
+          "backgroundColor": "rgb(255,127,14,0.4)",
           "borderColor": "rgb(255,127,14)",
           "data": Array [
             20,
@@ -652,7 +652,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -732,7 +732,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -801,7 +801,7 @@ Object {
     "data": Object {
       "datasets": Array [
         Object {
-          "backgroundColor": "rgb(31,119,180)",
+          "backgroundColor": "rgb(31,119,180,0.4)",
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             10,
@@ -812,7 +812,7 @@ Object {
           "lineTension": 0,
         },
         Object {
-          "backgroundColor": "rgb(255,127,14)",
+          "backgroundColor": "rgb(255,127,14,0.4)",
           "borderColor": "rgb(255,127,14)",
           "data": Array [
             20,
@@ -835,7 +835,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -904,7 +904,7 @@ Object {
     "data": Object {
       "datasets": Array [
         Object {
-          "backgroundColor": "rgb(31,119,180)",
+          "backgroundColor": "rgb(31,119,180,0.4)",
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             30,
@@ -915,7 +915,7 @@ Object {
           "lineTension": 0,
         },
         Object {
-          "backgroundColor": "rgb(255,127,14)",
+          "backgroundColor": "rgb(255,127,14,0.4)",
           "borderColor": "rgb(255,127,14)",
           "data": Array [
             40,
@@ -938,7 +938,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -1007,7 +1007,7 @@ Object {
     "data": Object {
       "datasets": Array [
         Object {
-          "backgroundColor": "rgb(31,119,180)",
+          "backgroundColor": "rgb(31,119,180,0.4)",
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             30,
@@ -1018,7 +1018,7 @@ Object {
           "lineTension": 0,
         },
         Object {
-          "backgroundColor": "rgb(255,127,14)",
+          "backgroundColor": "rgb(255,127,14,0.4)",
           "borderColor": "rgb(255,127,14)",
           "data": Array [
             40,
@@ -1041,7 +1041,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,

--- a/tests/plugins/chart/__snapshots__/gauge_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/gauge_chart.test.ts.snap
@@ -29,7 +29,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,
@@ -114,7 +114,7 @@ Object {
       },
       "elements": Object {
         "line": Object {
-          "fill": false,
+          "fill": true,
         },
         "point": Object {
           "hitRadius": 15,


### PR DESCRIPTION

## Description:

PURPOSE

Add the same transparent blue fill on linechart that the one we have in backend.

SPECIFICATION

Added the blue fill on o-spreadsheet linecharts.

Odoo task ID : [2888350](https://www.odoo.com/web#id=2888350&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo