### PR TITLE
[FIX] spreadhseet: fix link demo data

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -16,7 +16,7 @@ export const demoData = {
       cols: { 1: {}, 3: {} },
       rows: {},
       cells: {
-        A21: { content: "[Sheet2 => B2:](o-spreadsheet://Sheet2)" },
+        A21: { content: "[Sheet2 => B2:](o-spreadsheet://sh2)" },
         B2: { content: "[Owl is awesome](https://github.com/odoo/owl)", style: 1 },
         B4: { content: "Numbers", style: 4 },
         B21: { content: "=Sheet2!B2", style: 7 },


### PR DESCRIPTION
Fix the link in the sheet 1 of the demo data that had the wrong sheet id

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo