### PR TITLE
[FIX] clipboard: resolve the cut and paste of merges

### DIFF
--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -484,7 +484,6 @@ export class ClipboardPlugin extends UIPlugin {
       col: selection.left,
       row: selection.top,
     });
-    this.dispatch("REMOVE_MERGE", { sheetId: state.sheetId, target: state.merges });
     this.state = undefined;
   }
 
@@ -570,7 +569,12 @@ export class ClipboardPlugin extends UIPlugin {
         const origin = rowCells[c];
         const position = { col: col + c, row: row + r, sheetId: sheet.id };
         this.removeMergeIfTopLeft(position);
-        this.pasteMergeIfExist(origin.position, position);
+        // TODO: refactor this part. the "Paste merge" action is also executed with
+        // MOVE_RANGES in pasteFromCut. Adding a condition on the operation type here
+        // is not appropriate
+        if (state.operation !== "CUT") {
+          this.pasteMergeIfExist(origin.position, position);
+        }
         this.pasteCell(origin, position, state.operation, pasteOption);
         if (shouldPasteCF) {
           this.dispatch("PASTE_CONDITIONAL_FORMAT", {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -335,16 +335,16 @@ describe("clipboard", () => {
         },
       ],
     });
-    cut(model, "B1");
+    cut(model, "B1:C2");
     paste(model, "B4");
     expect(model.getters.isInMerge("s2", ...toCartesianArray("B1"))).toBe(false);
     expect(model.getters.isInMerge("s2", ...toCartesianArray("B2"))).toBe(false);
     expect(model.getters.isInMerge("s2", ...toCartesianArray("C1"))).toBe(false);
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("B2"))).toBe(false);
+    expect(model.getters.isInMerge("s2", ...toCartesianArray("C2"))).toBe(false);
     expect(model.getters.isInMerge("s2", ...toCartesianArray("B4"))).toBe(true);
     expect(model.getters.isInMerge("s2", ...toCartesianArray("B5"))).toBe(true);
     expect(model.getters.isInMerge("s2", ...toCartesianArray("C4"))).toBe(true);
-    expect(model.getters.isInMerge("s2", ...toCartesianArray("B5"))).toBe(true);
+    expect(model.getters.isInMerge("s2", ...toCartesianArray("C5"))).toBe(true);
   });
 
   test("paste merge on existing merge removes existing merge", () => {


### PR DESCRIPTION
## Description:

This commit fixes a bug not allowing cut and paste merge.
This commit resolves the "false negative" test associated
with this behavior.

Odoo task ID : [2921827](https://www.odoo.com/web#id=2921827&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo