### PR TITLE
[FIX] Tests: Clean *Registry after tests

### DIFF
--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -6,10 +6,11 @@ import { selectCell } from "../test_helpers/commands_helpers";
 import { clickCell } from "../test_helpers/dom_helper";
 import { getCellText } from "../test_helpers/getters_helpers";
 import {
+  clearFunctions,
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
-  resetFunctions,
+  restoreDefaultFunctions,
   typeInComposerGrid as typeInComposerGridHelper,
 } from "../test_helpers/helpers";
 import { ContentEditableHelper } from "./__mocks__/content_editable_helper";
@@ -50,7 +51,7 @@ afterEach(() => {
 
 describe("Functions autocomplete", () => {
   beforeEach(() => {
-    resetFunctions();
+    clearFunctions();
     functionRegistry.add("IF", {
       description: "do if",
       args: args(``),
@@ -69,6 +70,10 @@ describe("Functions autocomplete", () => {
       compute: () => 1,
       returns: ["ANY"],
     });
+  });
+
+  afterAll(() => {
+    restoreDefaultFunctions();
   });
 
   describe("autocomplete", () => {
@@ -244,7 +249,7 @@ describe("Functions autocomplete", () => {
 
 describe("Autocomplete parenthesis", () => {
   beforeAll(() => {
-    resetFunctions();
+    clearFunctions();
     functionRegistry.add("IF", {
       description: "do if",
       args: args(``),
@@ -263,6 +268,10 @@ describe("Autocomplete parenthesis", () => {
       compute: () => 1,
       returns: ["ANY"],
     });
+  });
+
+  afterAll(() => {
+    restoreDefaultFunctions();
   });
 
   test("=sum(1,2 + enter adds closing parenthesis", async () => {

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -55,7 +55,12 @@ class TextFigure extends Component<Props, SpreadsheetChildEnv> {
   static template = TEMPLATE;
 }
 
-figureRegistry.add("text", { Component: TextFigure });
+beforeAll(() => {
+  figureRegistry.add("text", { Component: TextFigure });
+});
+afterAll(() => {
+  figureRegistry.remove("text");
+});
 
 describe("figures", () => {
   beforeEach(async () => {

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -3,10 +3,11 @@ import { Spreadsheet } from "../../src";
 import { args, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import {
+  clearFunctions,
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
-  resetFunctions,
+  restoreDefaultFunctions,
   typeInComposerGrid,
 } from "../test_helpers/helpers";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
@@ -36,8 +37,8 @@ afterEach(() => {
 });
 
 describe("formula assistant", () => {
-  beforeEach(() => {
-    resetFunctions();
+  beforeAll(() => {
+    clearFunctions();
     functionRegistry.add("FUNC0", {
       description: "func without args",
       args: args(``),
@@ -81,6 +82,10 @@ describe("formula assistant", () => {
       compute: () => 1,
       returns: ["ANY"],
     });
+  });
+
+  afterAll(() => {
+    restoreDefaultFunctions();
   });
 
   describe("appearance", () => {

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -638,6 +638,7 @@ describe("Grid component", () => {
       await rightClickCell(model, "B2");
       expect(fixture.querySelectorAll(".o-menu div")).toHaveLength(1);
       expect(fixture.querySelector(".o-menu div[data-name='A']")).not.toBeNull();
+      dashboardMenuRegistry.remove("A");
     });
 
     test("Cannot select a cell in dashboard mode", async () => {

--- a/tests/formulas/compiler.test.ts
+++ b/tests/formulas/compiler.test.ts
@@ -4,7 +4,7 @@ import { compile } from "../../src/formulas/index";
 import { functionRegistry } from "../../src/functions";
 import { createRange } from "../../src/helpers";
 import { ArgType, CompiledFormula } from "../../src/types";
-import { evaluateCell, evaluateCellFormat } from "../test_helpers/helpers";
+import { evaluateCell, evaluateCellFormat, restoreDefaultFunctions } from "../test_helpers/helpers";
 
 function compiledBaseFunction(formula: string): CompiledFormula {
   for (let f in functionCache) {
@@ -85,6 +85,10 @@ describe("expression compiler", () => {
 
 describe("compile functions", () => {
   describe("check number of arguments", () => {
+    afterAll(() => {
+      restoreDefaultFunctions();
+    });
+
     test("with basic arguments", () => {
       functionRegistry.add("ANYFUNCTION", {
         description: "any function",
@@ -101,6 +105,7 @@ describe("compile functions", () => {
       expect(() => compiledBaseFunction("=ANYFUNCTION(1)")).toThrow();
       expect(() => compiledBaseFunction("=ANYFUNCTION(1,2)")).not.toThrow();
       expect(() => compiledBaseFunction("=ANYFUNCTION(1,2,3)")).toThrow();
+      restoreDefaultFunctions();
     });
 
     test("with optional argument", () => {
@@ -118,6 +123,7 @@ describe("compile functions", () => {
       expect(() => compiledBaseFunction("=OPTIONAL(1)")).not.toThrow();
       expect(() => compiledBaseFunction("=OPTIONAL(1,2)")).not.toThrow();
       expect(() => compiledBaseFunction("=OPTIONAL(1,2,3)")).toThrow();
+      restoreDefaultFunctions();
     });
 
     test("with default argument", () => {
@@ -135,6 +141,7 @@ describe("compile functions", () => {
       expect(() => compiledBaseFunction("=USEDEFAULTARG(1)")).not.toThrow();
       expect(() => compiledBaseFunction("=USEDEFAULTARG(1,2)")).not.toThrow();
       expect(() => compiledBaseFunction("=USEDEFAULTARG(1,2,3)")).toThrow();
+      restoreDefaultFunctions();
     });
 
     test("with repeatable argument", () => {
@@ -152,6 +159,7 @@ describe("compile functions", () => {
       expect(() => compiledBaseFunction("=REPEATABLE(1)")).not.toThrow();
       expect(() => compiledBaseFunction("=REPEATABLE(1,2)")).not.toThrow();
       expect(() => compiledBaseFunction("=REPEATABLE(1,2,3,4,5,6)")).not.toThrow();
+      restoreDefaultFunctions();
     });
 
     test("with more than one repeatable argument", () => {
@@ -171,6 +179,7 @@ describe("compile functions", () => {
       expect(() => compiledBaseFunction("=REPEATABLES(1, 2, 3)")).not.toThrow();
       expect(() => compiledBaseFunction("=REPEATABLES(1, 2, 3, 4)")).toThrow();
       expect(() => compiledBaseFunction("=REPEATABLES(1, 2, 3, 4, 5)")).not.toThrow();
+      restoreDefaultFunctions();
     });
   });
 
@@ -211,7 +220,9 @@ describe("compile functions", () => {
         returns: ["ANY"],
       });
     });
-
+    afterAll(() => {
+      restoreDefaultFunctions();
+    });
     test("empty value interpreted as undefined", () => {
       expect(evaluateCell("A1", { A1: "=ISSECONDARGUNDEFINED(1,)" })).toBe(true);
       expect(evaluateCellFormat("A1", { A1: "=ISSECONDARGUNDEFINED(1,)" })).toBe("TRUE");
@@ -229,6 +240,9 @@ describe("compile functions", () => {
   });
 
   describe("check type of arguments", () => {
+    afterAll(() => {
+      restoreDefaultFunctions();
+    });
     test("reject non-range argument when expecting only range argument", () => {
       functionRegistry.add("RANGEEXPECTED", {
         description: "function expect number in 1st arg",
@@ -351,6 +365,10 @@ describe("compile functions", () => {
         },
         returns: ["ANY"],
       });
+    });
+
+    afterAll(() => {
+      restoreDefaultFunctions();
     });
 
     test("with function as argument --> change the order in which functions are evaluated ", () => {

--- a/tests/functions/functions.test.ts
+++ b/tests/functions/functions.test.ts
@@ -12,9 +12,12 @@ import {
 } from "../../src/types";
 import { setCellContent, setCellFormat } from "../test_helpers/commands_helpers";
 import { getCell } from "../test_helpers/getters_helpers";
-import { evaluateCell } from "../test_helpers/helpers";
+import { evaluateCell, restoreDefaultFunctions } from "../test_helpers/helpers";
 
 describe("functions", () => {
+  afterAll(() => {
+    restoreDefaultFunctions();
+  });
   test("can add a function", () => {
     const val = evaluateCell("A1", { A1: "=DOUBLEDOUBLE(3)" });
     expect(val).toBe("#BAD_EXPR");

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -169,6 +169,7 @@ describe("core", () => {
       expect(getCellError(model, "A1")).toBe(
         `Invalid number of arguments for the TWOARGSNEEDED function. Expected 2 minimum, but got 1 instead.`
       );
+      functionRegistry.remove("TWOARGSNEEDED");
     });
   });
 

--- a/tests/plugins/formatting.test.ts
+++ b/tests/plugins/formatting.test.ts
@@ -169,7 +169,7 @@ describe("formatting values (with formatters)", () => {
   });
 
   test("SET_DECIMAL considers the evaluated format to infer the decimal position", () => {
-    functionRegistry.add("SET.FORMAT", {
+    functionRegistry.add("SET.DYN.FORMAT", {
       description: "Returns the value set to the provided format",
       args: args(`
           value (any) "value to format",
@@ -184,10 +184,11 @@ describe("formatting values (with formatters)", () => {
       returns: ["ANY"],
     });
     const model = new Model();
-    setCellContent(model, "A1", '=SET.FORMAT(5, "0.00")');
+    setCellContent(model, "A1", '=SET.DYN.FORMAT(5, "0.00")');
     selectCell(model, "A1");
     setDecimal(model, 1);
     expect(getCell(model, "A1")?.format).toBe("0.000");
+    functionRegistry.remove("SET.DYN.FORMAT");
   });
 });
 

--- a/tests/plugins/import_export.test.ts
+++ b/tests/plugins/import_export.test.ts
@@ -679,4 +679,5 @@ test("Imported data are not mutated", () => {
     e1: { text: "base" },
     e2: { text: "imported" },
   });
+  corePluginRegistry.remove("mutate-plugin");
 });

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -76,7 +76,12 @@ class PluginTestRange extends CorePlugin {
   }
 }
 
-corePluginRegistry.add("testRange", PluginTestRange);
+beforeAll(() => {
+  corePluginRegistry.add("testRange", PluginTestRange);
+});
+afterAll(() => {
+  corePluginRegistry.remove("testRange");
+});
 
 describe("range plugin", () => {
   beforeEach(() => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -22,8 +22,11 @@ import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { redo, setCellContent, undo } from "./commands_helpers";
 import { getCell, getCellContent } from "./getters_helpers";
 
-const functions = functionRegistry.content;
+const functionsContent = functionRegistry.content;
 const functionMap = functionRegistry.mapping;
+
+const functionsContentRestore = { ...functionsContent };
+const functionMapRestore = { ...functionMap };
 
 export function spyDispatch(parent: Spreadsheet): jest.SpyInstance {
   return jest.spyOn(parent.model, "dispatch");
@@ -211,13 +214,23 @@ export function evaluateCellFormat(xc: string, grid: GridDescr): string {
 /*
  * Remove all functions from the internal function list.
  */
-export function resetFunctions() {
+export function clearFunctions() {
   Object.keys(functionMap).forEach((k) => {
     delete functionMap[k];
   });
 
-  Object.keys(functions).forEach((k) => {
-    delete functions[k];
+  Object.keys(functionsContent).forEach((k) => {
+    delete functionsContent[k];
+  });
+}
+
+export function restoreDefaultFunctions() {
+  clearFunctions();
+  Object.keys(functionMapRestore).forEach((k) => {
+    functionMap[k] = functionMapRestore[k];
+  });
+  Object.keys(functionsContentRestore).forEach((k) => {
+    functionsContent[k] = functionsContentRestore[k];
   });
 }
 


### PR DESCRIPTION
Some registries  was never cleared from the different elements
added in the test. This was not an issue and still isn't because jest
seems to start every file in a dedicated process .Still, its good
practice to restore registry afterwards.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo