### PR TITLE
[FIX] evaluation: assign correct error for a cell with two consecutiv…

### DIFF
--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -140,7 +140,7 @@ export class EvaluationPlugin extends UIPlugin {
       if (!(e instanceof Error)) {
         e = new Error(e);
       }
-      if (cell.evaluated.type !== CellValueType.error) {
+      if (cell.evaluated.value !== "#CYCLE") {
         cell.assignValue("#ERROR");
 
         // apply function name

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -1111,4 +1111,24 @@ describe("evaluate formula getter", () => {
     activateSheet(model, firstSheetId);
     expect(getCell(model, "A3", firstSheetId)!.evaluated.value).toBe(5);
   });
+
+  test("cells with two consecutive error are correctly evaluated", () => {
+    let value: number = 1;
+    functionRegistry.add("GETVALUE", {
+      description: "Get value",
+      compute: () => {
+        throw new Error(`Error${value}`);
+      },
+      args: args(``),
+      returns: ["ANY"],
+    });
+    setCellContent(model, "A1", "=GETVALUE()");
+    expect(getCell(model, "A1")!.evaluated.type).toBe(CellValueType.error);
+    expect((getCell(model, "A1")!.evaluated as InvalidEvaluation).error).toBe("Error1");
+    value = 2;
+    model.dispatch("EVALUATE_ALL_SHEETS");
+    expect(getCell(model, "A1")!.evaluated.type).toBe(CellValueType.error);
+    expect((getCell(model, "A1")!.evaluated as InvalidEvaluation).error).toBe("Error2");
+    functionRegistry.remove("GETVALUE");
+  });
 });


### PR DESCRIPTION
…e errors

Before this revision, a cell with two consecutive errors was not correctly
evaluated: the error assigned was the first one instead of the last one.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo