### PR TITLE
[FIX] dependencies: update owl to beta-15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@odoo/owl": "2.0.0-beta-6",
+        "@odoo/owl": "2.0.0-beta-15",
         "bootstrap": "^4.6.0"
       },
       "devDependencies": {
@@ -1297,9 +1297,9 @@
       }
     },
     "node_modules/@odoo/owl": {
-      "version": "2.0.0-beta-6",
-      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-2.0.0-beta-6.tgz",
-      "integrity": "sha512-MSwTajx7oMXSfDT50wwTM1aipv4H7bI9JCVRzb68BNKfWTOVODu0BOHUJuIq+9cVDoY9f8u4YWmVS8GOCg7EBg==",
+      "version": "2.0.0-beta-15",
+      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-2.0.0-beta-15.tgz",
+      "integrity": "sha512-WjSvy7oSCMGih2vnPm6WYp5Kz45MHgGkxrUst9kbpVHqbnygu62ZbHJGGCFoI4xNWs19LGHVsIuc93t47pCzVA==",
       "engines": {
         "node": ">=12.18.3"
       }
@@ -11756,9 +11756,9 @@
       }
     },
     "@odoo/owl": {
-      "version": "2.0.0-beta-6",
-      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-2.0.0-beta-6.tgz",
-      "integrity": "sha512-MSwTajx7oMXSfDT50wwTM1aipv4H7bI9JCVRzb68BNKfWTOVODu0BOHUJuIq+9cVDoY9f8u4YWmVS8GOCg7EBg=="
+      "version": "2.0.0-beta-15",
+      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-2.0.0-beta-15.tgz",
+      "integrity": "sha512-WjSvy7oSCMGih2vnPm6WYp5Kz45MHgGkxrUst9kbpVHqbnygu62ZbHJGGCFoI4xNWs19LGHVsIuc93t47pCzVA=="
     },
     "@rollup/plugin-node-resolve": {
       "version": "11.2.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "printWidth": 100
   },
   "dependencies": {
-    "@odoo/owl": "2.0.0-beta-6",
+    "@odoo/owl": "2.0.0-beta-15",
     "bootstrap": "^4.6.0"
   },
   "jest": {

--- a/src/components/composer/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown.ts
@@ -83,7 +83,7 @@ export interface TextValueProviderApi {
   getValueToFill: () => string | undefined;
 }
 
-export abstract class TextValueProvider extends Component<Props> implements TextValueProviderApi {
+export class TextValueProvider extends Component<Props> implements TextValueProviderApi {
   static template = TEMPLATE;
 
   state = useState({

--- a/src/components/side_panel/custom_currency.ts
+++ b/src/components/side_panel/custom_currency.ts
@@ -142,25 +142,29 @@ export class CustomCurrencyPanel extends Component<any, SpreadsheetChildEnv> {
     this.availableCurrencies = [emptyCurrency, ...currenciesRegistry.getAll()];
   }
 
-  updateSelectCurrency(ev) {
-    this.state.selectedCurrencyIndex = ev.target.value;
+  updateSelectCurrency(ev: InputEvent) {
+    const target = ev.target as HTMLInputElement;
+    this.state.selectedCurrencyIndex = parseInt(target.value, 10);
     const currency = this.availableCurrencies[this.state.selectedCurrencyIndex];
     this.state.currencyCode = currency.code;
     this.state.currencySymbol = currency.symbol;
   }
 
-  updateCode(ev) {
-    this.state.currencyCode = ev.target.value;
+  updateCode(ev: InputEvent) {
+    const target = ev.target as HTMLInputElement;
+    this.state.currencyCode = target.value;
     this.initAvailableCurrencies();
   }
 
-  updateSymbol(ev) {
-    this.state.currencySymbol = ev.target.value;
+  updateSymbol(ev: InputEvent) {
+    const target = ev.target as HTMLInputElement;
+    this.state.currencySymbol = target.value;
     this.initAvailableCurrencies();
   }
 
-  updateSelectFormat(ev) {
-    this.state.selectedFormatIndex = ev.target.value;
+  updateSelectFormat(ev: InputEvent) {
+    const target = ev.target as HTMLInputElement;
+    this.state.selectedFormatIndex = parseInt(target.value, 10);
   }
 
   apply() {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -6,6 +6,7 @@ import { functionRegistry } from "../../src/functions/index";
 import { toCartesian, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { MergePlugin } from "../../src/plugins/core/merge";
+import { _t } from "../../src/translation";
 import {
   ColorScaleMidPointThreshold,
   ColorScaleThreshold,
@@ -71,8 +72,17 @@ export function makeTestFixture() {
   return fixture;
 }
 
-export class MockClipboard {
+export class MockClipboard implements Clipboard {
   private content: string = "Some random clipboard content";
+
+  async read() {
+    throw new Error("Clipboard mock read function not implemented");
+    return [];
+  }
+
+  async write() {
+    throw new Error("Clipboard mock write function not implemented");
+  }
 
   readText(): Promise<string> {
     return Promise.resolve(this.content);
@@ -100,18 +110,27 @@ export function testUndoRedo(model: Model, expect: jest.Expect, command: Command
   expect(model).toExport(after);
 }
 
-let templates: any = {};
-
 // Requires to be called wit jest realTimers
 export async function mountSpreadsheet(
   fixture: HTMLElement,
   props: SpreadsheetProps = { model: new Model() },
   env: Partial<SpreadsheetChildEnv> = {}
 ): Promise<{ app: App; parent: Spreadsheet }> {
-  const app = new App(Spreadsheet, { props, env, test: true });
-  app.templates = templates;
+  const mockEnv: SpreadsheetChildEnv = {
+    model: props.model,
+    _t: _t,
+    clipboard: new MockClipboard(),
+    openSidePanel: () => {},
+    openLinkEditor: () => {},
+    toggleSidePanel: () => {},
+    loadCurrencies: async () => [],
+    editText: () => {},
+    notifyUser: () => {},
+    askConfirmation: () => {},
+    ...env,
+  };
+  const app = new App(Spreadsheet, { props, env: mockEnv, test: true });
   const parent = (await app.mount(fixture)) as Spreadsheet;
-  templates = app.templates;
   return { app, parent };
 }
 


### PR DESCRIPTION
Note the optimisation to re-use compiled templates in tests
can no longer be used since odoo/owl@0e60594 because templates are
now binded to the current app[1]

[1] https://github.com/odoo/owl/blob/588b655c1117136cb4517d1f05fed02e08f06f69/src/runtime/template_set.ts#L116

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo