### PR TITLE
[FIX] autoresize: left padding different than right padding

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,13 +28,14 @@ export const BOTTOMBAR_HEIGHT = 36;
 export const DEFAULT_CELL_WIDTH = 96;
 export const DEFAULT_CELL_HEIGHT = 23;
 export const SCROLLBAR_WIDTH = 15;
-export const PADDING_AUTORESIZE = 3;
 export const AUTOFILL_EDGE_LENGTH = 8;
 export const ICON_EDGE_LENGTH = 18;
 export const UNHIDE_ICON_EDGE_LENGTH = 14;
 export const MIN_CF_ICON_MARGIN = 4;
 export const MIN_CELL_TEXT_MARGIN = 4;
 export const CF_ICON_EDGE_LENGTH = 15;
+export const PADDING_AUTORESIZE_VERTICAL = 3;
+export const PADDING_AUTORESIZE_HORIZONTAL = MIN_CELL_TEXT_MARGIN;
 
 // Menus
 export const MENU_WIDTH = 250;

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_FONT_SIZE,
   DEFAULT_FONT_WEIGHT,
   MIN_CF_ICON_MARGIN,
-  PADDING_AUTORESIZE,
+  PADDING_AUTORESIZE_VERTICAL,
 } from "../constants";
 import { fontSizeMap } from "../fonts";
 import { Cell, ConsecutiveIndexes, Lazy, Link, Style, UID } from "../types";
@@ -113,7 +113,7 @@ export function getDefaultCellHeight(cell: Cell | undefined): Pixel {
   if (!cell?.style?.fontSize) {
     return DEFAULT_CELL_HEIGHT;
   }
-  return fontSizeInPixels(cell.style) + 2 * PADDING_AUTORESIZE;
+  return fontSizeInPixels(cell.style) + 2 * PADDING_AUTORESIZE_VERTICAL;
 }
 
 export function fontSizeInPixels(style: Style) {

--- a/src/plugins/ui/ui_sheet.ts
+++ b/src/plugins/ui/ui_sheet.ts
@@ -1,8 +1,8 @@
-import { PADDING_AUTORESIZE } from "../../constants";
 import { computeIconWidth, computeTextWidth } from "../../helpers/index";
 import { Cell, CellValueType, Command, CommandResult, UID } from "../../types";
 import { HeaderIndex, Pixel } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
+import { PADDING_AUTORESIZE_HORIZONTAL } from "./../../constants";
 
 export class SheetUIPlugin extends UIPlugin {
   static getters = ["getCellWidth", "getTextWidth", "getCellText"] as const;
@@ -36,7 +36,7 @@ export class SheetUIPlugin extends UIPlugin {
             this.dispatch("RESIZE_COLUMNS_ROWS", {
               elements: [col],
               dimension: "COL",
-              size: size + 2 * PADDING_AUTORESIZE,
+              size: size + 2 * PADDING_AUTORESIZE_HORIZONTAL,
               sheetId: cmd.sheetId,
             });
           }

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -7,6 +7,7 @@ import {
   HEADER_WIDTH,
   MIN_COL_WIDTH,
   MIN_ROW_HEIGHT,
+  PADDING_AUTORESIZE_HORIZONTAL,
 } from "../../src/constants";
 import { lettersToNumber, scrollDelay, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
@@ -381,7 +382,8 @@ describe("Resizer component", () => {
   test("Double click: Modify the size of a column", async () => {
     setCellContent(model, "B2", "b2");
     await dblClickColumn("B");
-    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 1)).toBe(32);
+    const expectedSize = 2 * 13 + 2 * PADDING_AUTORESIZE_HORIZONTAL; // 2 * letter size + 2 * padding
+    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 1)).toBe(expectedSize);
   });
 
   test("Double click on column then undo, then redo", async () => {
@@ -392,11 +394,12 @@ describe("Resizer component", () => {
     await dblClickColumn("D");
     const sheet = model.getters.getActiveSheetId();
     const initialSize = model.getters.getColSize(sheet, 0);
+    const resizedSize = 2 * 13 + 2 * PADDING_AUTORESIZE_HORIZONTAL; // 2 letter fontSize 13 + 2*3px padding
     expect(model.getters.getColSize(sheet, 1)).toBe(initialSize);
-    expect(model.getters.getColSize(sheet, 2)).toBe(32); // 32 = 2 letters fontSize 13 + 2*3px padding
-    expect(model.getters.getColSize(sheet, 3)).toBe(32);
+    expect(model.getters.getColSize(sheet, 2)).toBe(resizedSize);
+    expect(model.getters.getColSize(sheet, 3)).toBe(resizedSize);
     expect(model.getters.getColSize(sheet, 4)).toBe(initialSize);
-    expect(model.getters.getColDimensions(sheet, 4)!.start).toBe(initialSize * 2 + 64);
+    expect(model.getters.getColDimensions(sheet, 4)!.start).toBe(initialSize * 2 + resizedSize * 2);
     undo(model);
     expect(model.getters.getColSize(sheet, 1)).toBe(initialSize);
     expect(model.getters.getColSize(sheet, 2)).toBe(initialSize);
@@ -405,10 +408,10 @@ describe("Resizer component", () => {
     expect(model.getters.getColDimensions(sheet, 4)!.start).toBe(initialSize * 4);
     redo(model);
     expect(model.getters.getColSize(sheet, 1)).toBe(initialSize);
-    expect(model.getters.getColSize(sheet, 2)).toBe(32);
-    expect(model.getters.getColSize(sheet, 3)).toBe(32);
+    expect(model.getters.getColSize(sheet, 2)).toBe(resizedSize);
+    expect(model.getters.getColSize(sheet, 3)).toBe(resizedSize);
     expect(model.getters.getColSize(sheet, 4)).toBe(initialSize);
-    expect(model.getters.getColDimensions(sheet, 4)!.start).toBe(initialSize * 2 + 64);
+    expect(model.getters.getColDimensions(sheet, 4)!.start).toBe(initialSize * 2 + resizedSize * 2);
   });
 
   test("Double click: Modify the size of a row", async () => {
@@ -548,11 +551,12 @@ describe("Resizer component", () => {
     await selectColumn("C", { shiftKey: true });
     await selectColumn("E", { ctrlKey: true });
     await dblClickColumn("E");
-    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 0)).toBe(19); // 19 = 1 letter fontSize 13 + 2*3px padding
-    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 1)).toBe(19);
-    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 2)).toBe(19);
+    const resizedSize = 13 + 2 * PADDING_AUTORESIZE_HORIZONTAL; // 1 letter fontSize 13 + 2 * padding
+    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 0)).toBe(resizedSize);
+    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 1)).toBe(resizedSize);
+    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 2)).toBe(resizedSize);
     expect(model.getters.getColSize(model.getters.getActiveSheetId(), 3)).toBe(DEFAULT_CELL_WIDTH);
-    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 4)).toBe(19);
+    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 4)).toBe(resizedSize);
   });
 
   test("Select ABC E, dblclick F then resize only F", async () => {
@@ -561,12 +565,13 @@ describe("Resizer component", () => {
     await selectColumn("C", { shiftKey: true });
     await selectColumn("E", { ctrlKey: true });
     await dblClickColumn("F");
+    const resizedSize = 13 + 2 * PADDING_AUTORESIZE_HORIZONTAL; // 1 letter fontSize 13 + 2 * padding
     expect(model.getters.getColSize(model.getters.getActiveSheetId(), 0)).toBe(DEFAULT_CELL_WIDTH);
     expect(model.getters.getColSize(model.getters.getActiveSheetId(), 1)).toBe(DEFAULT_CELL_WIDTH);
     expect(model.getters.getColSize(model.getters.getActiveSheetId(), 2)).toBe(DEFAULT_CELL_WIDTH);
     expect(model.getters.getColSize(model.getters.getActiveSheetId(), 3)).toBe(DEFAULT_CELL_WIDTH);
     expect(model.getters.getColSize(model.getters.getActiveSheetId(), 4)).toBe(DEFAULT_CELL_WIDTH);
-    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 5)).toBe(19); // 19 = 1 letter fontSize 13 + 2*3px padding
+    expect(model.getters.getColSize(model.getters.getActiveSheetId(), 5)).toBe(resizedSize);
   });
 
   test("Select 123 5, dblclick 5 then resize all", async () => {

--- a/tests/plugins/formatting.test.ts
+++ b/tests/plugins/formatting.test.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_CELL_HEIGHT, PADDING_AUTORESIZE } from "../../src/constants";
+import {
+  DEFAULT_CELL_HEIGHT,
+  PADDING_AUTORESIZE_HORIZONTAL,
+  PADDING_AUTORESIZE_VERTICAL,
+} from "../../src/constants";
 import { fontSizeMap } from "../../src/fonts";
 import { args, functionRegistry } from "../../src/functions";
 import { toString } from "../../src/functions/helpers";
@@ -407,7 +411,8 @@ describe("Autoresize", () => {
   let model: Model;
   let sheetId: UID;
   const sizes = [10, 20];
-  const padding = 2 * PADDING_AUTORESIZE;
+  const hPadding = 2 * PADDING_AUTORESIZE_HORIZONTAL;
+  const vPadding = 2 * PADDING_AUTORESIZE_VERTICAL;
 
   beforeEach(() => {
     model = new Model();
@@ -422,15 +427,15 @@ describe("Autoresize", () => {
   test("Can autoresize a column", () => {
     setCellContent(model, "A1", "size0");
     model.dispatch("AUTORESIZE_COLUMNS", { sheetId, cols: [0] });
-    expect(model.getters.getColSize(sheetId, 0)).toBe(sizes[0] + padding);
+    expect(model.getters.getColSize(sheetId, 0)).toBe(sizes[0] + hPadding);
   });
 
   test("Can autoresize two columns", () => {
     setCellContent(model, "A1", "size0");
     setCellContent(model, "C1", "size1");
     model.dispatch("AUTORESIZE_COLUMNS", { sheetId, cols: [0, 2] });
-    expect(model.getters.getColSize(sheetId, 0)).toBe(sizes[0] + padding);
-    expect(model.getters.getColSize(sheetId, 2)).toBe(sizes[1] + padding);
+    expect(model.getters.getColSize(sheetId, 0)).toBe(sizes[0] + hPadding);
+    expect(model.getters.getColSize(sheetId, 2)).toBe(sizes[1] + hPadding);
   });
 
   test("Can autoresize a row", () => {
@@ -447,7 +452,7 @@ describe("Autoresize", () => {
     model.dispatch("SET_FORMATTING", { sheetId, target: [toZone("A3")], style: { fontSize: 24 } });
     model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0, 2] });
     expect(model.getters.getRowSize(sheetId, 0)).toBe(DEFAULT_CELL_HEIGHT);
-    expect(model.getters.getRowSize(sheetId, 2)).toBe(fontSizeMap[24] + padding);
+    expect(model.getters.getRowSize(sheetId, 2)).toBe(fontSizeMap[24] + vPadding);
   });
 
   test("Can autoresize a column in another sheet", () => {
@@ -457,7 +462,7 @@ describe("Autoresize", () => {
     setCellContent(model, "A1", "size0", newSheetId);
     model.dispatch("AUTORESIZE_COLUMNS", { sheetId: newSheetId, cols: [0] });
     expect(model.getters.getColSize(sheetId, 0)).toBe(initialSize);
-    expect(model.getters.getColSize(newSheetId, 0)).toBe(sizes[0] + padding);
+    expect(model.getters.getColSize(newSheetId, 0)).toBe(sizes[0] + hPadding);
   });
 
   test("Can autoresize a row in another sheet", () => {


### PR DESCRIPTION
When auto-resizing a column, the left padding was different from the
right padding in the cell.

This was because auto-resize used an arbitrary constant `PADDING_AUTORESIZE`
to compute the size of the cell, but the renderer used the constant
`MIN_CELL_TEXT_MARGIN` to set the left padding of the cell.

Create the constant `PADDING_AUTORESIZE_HORIZONTAL` that is equal to
`MIN_CELL_TEXT_MARGIN` and add it to  the computation of the column size
fixes the problem.

Before: https://www.odoo.com/web/image/33620956
After: https://www.odoo.com/web/image/33620957

Odoo task 2918857

Odoo task ID : [2918857](https://www.odoo.com/web#id=2918857&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo