### PR TITLE
Master imp default chart title aath

### DIFF
--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -965,6 +965,36 @@ describe("Menu Item actions", () => {
             B3: { content: "11" },
             B4: { content: "12" },
             B5: { content: "13" },
+
+            C1: { content: "" },
+            C2: { content: "2" },
+            C3: { content: "4" },
+            C4: { content: "6" },
+
+            D1: { content: "=sum()" },
+            D2: { content: "3" },
+            D3: { content: "2" },
+            D4: { content: "5" },
+
+            E1: { content: "Title1" },
+            E2: { content: "10" },
+            E3: { content: "11" },
+            E4: { content: "12" },
+
+            F1: { content: "=sum(1,2)" },
+            F2: { content: "7" },
+            F3: { content: "8" },
+            F4: { content: "9" },
+
+            G1: { content: "" },
+            G2: { content: "7" },
+            G3: { content: "8" },
+            G4: { content: "9" },
+
+            H1: { content: "Title2" },
+            H2: { content: "7" },
+            H3: { content: "8" },
+            H4: { content: "9" },
           },
         },
       ],
@@ -991,7 +1021,7 @@ describe("Menu Item actions", () => {
           labelRange: undefined,
           legendPosition: "none",
           stackedBar: false,
-          title: "",
+          title: expect.any(String),
           type: "bar",
           verticalAxisPosition: "left",
         },
@@ -1056,7 +1086,6 @@ describe("Menu Item actions", () => {
       const payload = { ...defaultPayload };
       payload.definition.dataSets = ["B2:B5"];
       payload.definition.labelRange = undefined;
-      payload.definition.dataSetsHaveTitle = false;
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1076,7 +1105,6 @@ describe("Menu Item actions", () => {
       const payload = { ...defaultPayload };
       payload.definition.dataSets = ["B2:B5"];
       payload.definition.labelRange = "A2:A5";
-      payload.definition.dataSetsHaveTitle = false;
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
 
@@ -1087,6 +1115,41 @@ describe("Menu Item actions", () => {
       payload.definition.dataSets = ["B1:B5"];
       payload.definition.labelRange = "A2:A5";
       payload.definition.dataSetsHaveTitle = true;
+      expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
+    });
+
+    test("Chart title should be set by default if dataset have any", () => {
+      setSelection(model, ["B1:C4"]);
+      doAction(["insert", "insert_chart"], env);
+      const payload = { ...defaultPayload };
+      payload.definition.dataSets = ["C1:C4"];
+      payload.definition.legendPosition = "none";
+      payload.definition.title = "";
+      payload.definition.dataSetsHaveTitle = false;
+      payload.definition.labelRange = "B1:B4";
+      expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
+    });
+    test("Chart title should only generate string and numerical values", async () => {
+      setSelection(model, ["C1:G4"]);
+      doAction(["insert", "insert_chart"], env);
+      const payload = { ...defaultPayload };
+      payload.definition.dataSets = ["D1:G4"];
+      payload.definition.legendPosition = "top";
+      payload.definition.title = "Title1 and 3";
+      payload.definition.dataSetsHaveTitle = true;
+      payload.definition.labelRange = "C2:C4";
+      await nextTick();
+      expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
+    });
+    test("Chart title should only append and prefix to last title", () => {
+      setSelection(model, ["C1:H4"]);
+      doAction(["insert", "insert_chart"], env);
+      const payload = { ...defaultPayload };
+      payload.definition.dataSets = ["D1:H4"];
+      payload.definition.legendPosition = "top";
+      payload.definition.title = "Title1, 3 and Title2";
+      payload.definition.dataSetsHaveTitle = true;
+      payload.definition.labelRange = "C2:C4";
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });
     test("[Case 1] Chart is inserted with proper legend position", () => {
@@ -1104,7 +1167,8 @@ describe("Menu Item actions", () => {
       doAction(["insert", "insert_chart"], env);
       const payload = { ...defaultPayload };
       payload.definition.dataSets = ["G1:I5"];
-      payload.definition.labelRange = "F1:F5";
+      payload.definition.dataSetsHaveTitle = true;
+      payload.definition.labelRange = "F2:F5";
       payload.definition.legendPosition = "top";
       expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     });


### PR DESCRIPTION
## Description:
PURPOSE

Set a default title on newly created charts.

SPECIFICATION

At creation, set the chart title to a concatenation of all the data series
titles, separated by commas and 'and'.

Odoo task ID : [2866952](https://www.odoo.com/web#id=2866952&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo