### PR TITLE
[FIX] figure: figure is unselected when scrolling

### DIFF
--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -189,23 +189,20 @@ export class GridSelectionPlugin extends UIPlugin {
 
   handle(cmd: Command) {
     switch (cmd.type) {
-      // some commands should not remove the current selection
-      case "CREATE_SHEET":
-      case "DELETE_SHEET":
-      case "CREATE_FIGURE":
-      case "CREATE_CHART":
-      case "UPDATE_FIGURE":
-      case "EVALUATE_CELLS":
-      case "DISABLE_SELECTION_INPUT":
-      case "ENABLE_NEW_SELECTION_INPUT":
+      case "START_EDITION":
+      case "ACTIVATE_SHEET":
+        this.selectedFigureId = null;
         break;
       case "DELETE_FIGURE":
         if (this.selectedFigureId === cmd.id) {
           this.selectedFigureId = null;
         }
         break;
-      default:
-        this.selectedFigureId = null;
+      case "DELETE_SHEET":
+        if (this.selectedFigureId && this.getters.getFigure(cmd.sheetId, this.selectedFigureId)) {
+          this.selectedFigureId = null;
+        }
+        break;
     }
     switch (cmd.type) {
       case "START":

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -224,4 +224,12 @@ describe("figures", () => {
     expect(window.getComputedStyle(figure).width).toBe("18px"); // width + borders - 2 * DEFAULT_CELL_WIDTH
     expect(window.getComputedStyle(figure).height).toBe("161px"); // height + offset - 2 * DEFAULT_CELL_WIDTH
   });
+
+  test("Selected figure isn't removed by scroll", async () => {
+    createFigure(model);
+    model.dispatch("SELECT_FIGURE", { id: "someuuid" });
+    fixture.querySelector(".o-grid")!.dispatchEvent(new WheelEvent("wheel", { deltaX: 1500 }));
+    fixture.querySelector(".o-scrollbar.vertical")!.dispatchEvent(new Event("scroll"));
+    expect(model.getters.getSelectedFigureId()).toEqual("someuuid");
+  });
 });


### PR DESCRIPTION
The selected figure was unselected when scrolling. This was caused by
the `handle` of selection that unselected the figure for *any* command
except a few selected one.

In fact for the vast majority of commands we probably don't want to remove
the selected figure. Change the behavious to only unselect figures for
the few commands where it's relevant.

Odoo task 2919819

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo