### PR TITLE
[FIX] overlay: persisting handle after header resizing

### DIFF
--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -154,9 +154,11 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
     this.state.waitingForMove = false;
   }
 
-  onDblClick() {
+  onDblClick(ev: MouseEvent) {
     this._fitElementSize(this.state.activeElement);
     this.state.isResizing = false;
+    this._computeHandleDisplay(ev);
+    this._computeGrabDisplay(ev);
   }
 
   onMouseDown(ev: MouseEvent) {

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -382,8 +382,10 @@ describe("Resizer component", () => {
   test("Double click: Modify the size of a column", async () => {
     setCellContent(model, "B2", "b2");
     await dblClickColumn("B");
+    await nextTick();
     const expectedSize = 2 * 13 + 2 * PADDING_AUTORESIZE_HORIZONTAL; // 2 * letter size + 2 * padding
     expect(model.getters.getColSize(model.getters.getActiveSheetId(), 1)).toBe(expectedSize);
+    expect(fixture.querySelector(".o-handle")).toBeFalsy();
   });
 
   test("Double click on column then undo, then redo", async () => {
@@ -419,7 +421,9 @@ describe("Resizer component", () => {
     expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(30);
     setCellContent(model, "B2", "b2");
     await dblClickRow(1);
+    await nextTick();
     expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(DEFAULT_CELL_HEIGHT);
+    expect(fixture.querySelector(".o-handle")).toBeFalsy();
   });
 
   test("Double click on rows then undo, then redo", async () => {


### PR DESCRIPTION
When resizing an header, an handle appears and the cursor change to a
double arrow. There was a problem that after a double click (which
cause an auto-resize), the handle persisted in the middle of nowhere.

Now update the state of the handle after a double click even in the
overlay.

Odoo task ID : [2928598](https://www.odoo.com/web#id=2928598&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo