### PR TITLE
[FIX] spreadsheet: figure displayed above scrollbar placeholder

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -210,6 +210,8 @@ css/* scss */ `
       position: absolute;
       overflow: auto;
       z-index: ${ComponentsImportance.ScrollBar};
+      background-color: ${BACKGROUND_GRAY_COLOR};
+
       &.vertical {
         right: 0;
         bottom: ${SCROLLBAR_WIDTH}px;
@@ -221,6 +223,14 @@ css/* scss */ `
         height: ${SCROLLBAR_WIDTH}px;
         right: ${SCROLLBAR_WIDTH}px;
         overflow-y: hidden;
+      }
+      &.corner {
+        right: 0px;
+        bottom: 0px;
+        height: ${SCROLLBAR_WIDTH}px;
+        width: ${SCROLLBAR_WIDTH}px;
+        border-top: 1px solid #e2e3e3;
+        border-left: 1px solid #e2e3e3;
       }
     }
 

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -98,6 +98,7 @@
         t-att-style="hScrollbarStyle">
         <div t-attf-style="height:1px;width:{{gridSize.width}}px"/>
       </div>
+      <div class="o-scrollbar corner"/>
     </div>
   </t>
 </templates>

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -88,6 +88,9 @@ exports[`Grid component simple rendering snapshot 1`] = `
       style="height:1px;width:2592px"
     />
   </div>
+  <div
+    class="o-scrollbar corner"
+  />
 </div>
 `;
 

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -455,6 +455,9 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
         style="height:1px;width:2592px"
       />
     </div>
+    <div
+      class="o-scrollbar corner"
+    />
   </div>
   
   

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -1,8 +1,13 @@
 import { App } from "@odoo/owl";
 import { Spreadsheet, TransportService } from "../../src";
 import { Grid } from "../../src/components/grid/grid";
-import { HEADER_WIDTH, MESSAGE_VERSION, SCROLLBAR_WIDTH } from "../../src/constants";
-import { scrollDelay, toZone, zoneToXc } from "../../src/helpers";
+import {
+  BACKGROUND_GRAY_COLOR,
+  HEADER_WIDTH,
+  MESSAGE_VERSION,
+  SCROLLBAR_WIDTH,
+} from "../../src/constants";
+import { scrollDelay, toHex, toZone, zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import {
   createSheet,
@@ -15,6 +20,7 @@ import {
 } from "../test_helpers/commands_helpers";
 import {
   clickCell,
+  getElComputedStyle,
   gridMouseEvent,
   hoverCell,
   rightClickCell,
@@ -975,5 +981,14 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
       top: 3,
       bottom: 44,
     });
+  });
+
+  test("Scroll bars have background color", () => {
+    // Without background color, elements could be displayed above the scrollbars placeholders
+    const getColor = (selector: string) => toHex(getElComputedStyle(selector, "background"));
+
+    expect(getColor(".o-scrollbar.corner")).toEqual(toHex(BACKGROUND_GRAY_COLOR));
+    expect(getColor(".o-scrollbar.horizontal")).toEqual(toHex(BACKGROUND_GRAY_COLOR));
+    expect(getColor(".o-scrollbar.vertical")).toEqual(toHex(BACKGROUND_GRAY_COLOR));
   });
 });

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -145,3 +145,9 @@ export async function keyUp(key: string, options: any = {}): Promise<void> {
   );
   return await nextTick();
 }
+
+export function getElComputedStyle(selector: string, style: string): string {
+  const element = document.querySelector(selector);
+  if (!element) throw new Error(`No element matching selector "${selector}"`);
+  return window.getComputedStyle(element)[style];
+}


### PR DESCRIPTION
The div that contained the scrollbars didn't have any background, so
despite having a greater z-index than the figures, the figures were
displayed above them when there was no scrollbar displayed.

There was also nothing in the bottom-right corner between the scrollbars,
so the figures were displayed there too.

Added a background color to the scrollbars, and a div at the bottom right
between the scrollbars.

Odoo task ID : [2929373](https://www.odoo.com/web#id=2929373&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo