### PR TITLE
[FIX] spreadsheet: black border between grid and scrollbar

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -581,7 +581,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       dpr,
       thinLineWidth,
     };
-    const { width, height } = this.env.model.getters.getViewportDimensionWithHeaders();
+    let { width, height } = this.env.model.getters.getViewportDimensionWithHeaders();
+    // TODO : find the root cause that make us need this
+    width = width - 1;
+    height = height - 1;
     canvas.style.width = `${width}px`;
     canvas.style.height = `${height}px`;
     canvas.width = width * dpr;

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -49,9 +49,9 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   
   <canvas
-    height="985"
-    style="width:985px;height:985px;"
-    width="985"
+    height="984"
+    style="width:984px;height:984px;"
+    width="984"
   />
   
   

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -411,9 +411,9 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
     
     
     <canvas
-      height="985"
-      style="width:985px;height:985px;"
-      width="985"
+      height="984"
+      style="width:984px;height:984px;"
+      width="984"
     />
     
     


### PR DESCRIPTION
There is a black border between the grid and the scrollbar
The border seems to comes from an error somewhere in the measurement of
the canvas/grid/viewport.

Do a simple `-1` to fix the issue while waiting for a more in-depth
research on the root of the problem and a real fix.

Should be fixed in [2929584](https://www.odoo.com/web#menu_id=4720&cids=1&action=333&active_id=2328&model=project.task&view_type=form&id=2929584)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo