### PR TITLE
[FIX] composer: F4 shortcut shouldn't always select the whole range

### DIFF
--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -285,14 +285,19 @@ export class EditionPlugin extends UIPlugin {
     const start = tokens[0].start;
     const end = tokens[tokens.length - 1].end;
     const newContent = content.slice(0, start) + updatedReferences + content.slice(end);
-
     const lengthDiff = newContent.length - content.length;
+
+    const startOfTokens = refTokens[0].start;
+    const endOfTokens = refTokens[refTokens.length - 1].end + lengthDiff;
+    const selection = { start: startOfTokens, end: endOfTokens };
+    // Put the selection at the end of the token if we cycled on a single token
+    if (refTokens.length === 1 && this.selectionStart === this.selectionEnd) {
+      selection.start = selection.end;
+    }
+
     this.dispatch("SET_CURRENT_CONTENT", {
       content: newContent,
-      selection: {
-        start: refTokens[0].start,
-        end: refTokens[refTokens.length - 1].end + lengthDiff,
-      },
+      selection,
     });
   }
 

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -1220,17 +1220,17 @@ describe("composer", () => {
   });
 
   test("f4 shortcut set composer selection to entire cell symbol on which f4 is applied", async () => {
-    composerEl = await typeInComposerGrid("=A1");
-    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 1, end: 1 });
+    composerEl = await typeInComposerGrid("=AA1");
+    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 1, end: 2 });
     await keyDown("F4");
-    expect(model.getters.getCurrentContent()).toEqual("=$A$1");
-    expect(model.getters.getComposerSelection()).toEqual({ start: 1, end: 5 });
-    expect(cehMock.currentState).toEqual({ cursorStart: 1, cursorEnd: 5 });
+    expect(model.getters.getCurrentContent()).toEqual("=$AA$1");
+    expect(model.getters.getComposerSelection()).toEqual({ start: 1, end: 6 });
+    expect(cehMock.currentState).toEqual({ cursorStart: 1, cursorEnd: 6 });
   });
 
   test("f4 shortcut set composer selection to entire range symbol on which f4 is applied", async () => {
     composerEl = await typeInComposerGrid("=A1:B2");
-    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 1, end: 1 });
+    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 1, end: 2 });
     await keyDown("F4");
     expect(model.getters.getCurrentContent()).toEqual("=$A$1:$B$2");
     expect(model.getters.getComposerSelection()).toEqual({ start: 1, end: 10 });
@@ -1292,6 +1292,18 @@ describe("composer", () => {
     expect(composerEl.textContent).toEqual("=SUM($A$1,$C$2)");
     await keyDown("ArrowDown");
     expect(composerEl.textContent).toEqual("=SUM($A$1,$C$2)");
+  });
+
+  test("f4 put selection at the end of looped token when the original selection was of size 0", async () => {
+    composerEl = await typeInComposerGrid("=A1");
+    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 1, end: 1 });
+    await keyDown("F4");
+    expect(composerEl.textContent).toEqual("=$A$1");
+    expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });
+
+    await keyDown("F4");
+    expect(composerEl.textContent).toEqual("=A$1");
+    expect(model.getters.getComposerSelection()).toEqual({ start: 4, end: 4 });
   });
 });
 


### PR DESCRIPTION
Before, when using F4 to loop ranges through references modes, the whole
range was always selected. This is not always a behaviour we want, for
example we do'nt want it in this use case :

- begin typing "=" in the composer
- select a range with the mouse
- hit F4 to switch to absolute references
- hit 'comma' to declare the second arg
- the 'comma' replaced the range since it was selected after hitting F4

We now align the behaviour with GSheet : we only select the whole range
after hitting F4 if there was a selection of at least one character (thus
not if there was only a writing cursor).

Odoo task 2870853

Odoo task ID : [2870853](https://www.odoo.com/web#id=2870853&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo