### PR TITLE
[FIX] composer: ctrl clears topbar composer selection

### DIFF
--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -26,6 +26,7 @@ import {
   keyUp,
   rightClickCell,
   simulateClick,
+  triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
@@ -33,6 +34,7 @@ import {
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
+  spyDispatch,
   startGridComposition,
   toRangesData,
   typeInComposerGrid as typeInComposerGridHelper,
@@ -444,6 +446,24 @@ describe("composer", () => {
     expect(model.getters.getEditionMode()).toBe("editing");
     expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer")!);
+  });
+
+  test("Composer take focus on mouse down", async () => {
+    triggerMouseEvent("div.o-composer", "mousedown");
+    await nextTick();
+    expect(model.getters.getEditionMode()).toBe("editing");
+    expect(document.activeElement).toBe(fixture.querySelector("div.o-composer"));
+  });
+
+  test("Composer update its selection when mouseup isn't in the composer", async () => {
+    triggerMouseEvent("div.o-composer", "click");
+    await nextTick();
+
+    const dispatch = spyDispatch(parent);
+    triggerMouseEvent("div.o-composer", "mousedown");
+    triggerMouseEvent("div.o-spreadsheet-topbar", "mouseup");
+    triggerMouseEvent("div.o-spreadsheet-topbar", "click");
+    expect(dispatch).toHaveBeenCalledWith("CHANGE_COMPOSER_CURSOR_SELECTION", { end: 0, start: 0 });
   });
 
   test("starting the edition with a key stroke =, the composer should have the focus after the key input", async () => {


### PR DESCRIPTION
There was a problem when selecting text in the topbar composer. If the
mouseDown event was in the composer, but the mouseUp event wasn't, the
text was selected but the composer didn't have the focus. Pressing
ctrl (for ctrl+c) was thus handled in the grid, and removed the selected
text.

Now we focus the composer on mouseDown instead of click.

Odoo task 2810363

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo