### PR TITLE
[FIX] grid: cannot scroll when hovering popover

### DIFF
--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -54,7 +54,8 @@
         childWidth="cellPopover.Component.size.width"
         childHeight="cellPopover.Component.size.height"
         flipHorizontalOffset="cellPopover.cellWidth"
-        flipVerticalOffset="cellPopover.cellHeight">
+        flipVerticalOffset="cellPopover.cellHeight"
+        onMouseWheel="onMouseWheel.bind(this)">
         <t
           t-component="cellPopover.Component"
           t-props="{...cellPopover.props, onClosed : () => onClosePopover()}"

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -26,6 +26,7 @@ interface Props {
    * it is rendered on the top.
    */
   flipVerticalOffset: Pixel;
+  onMouseWheel: (ev: WheelEvent) => void;
 }
 
 export class Popover extends Component<Props, SpreadsheetChildEnv> {
@@ -35,6 +36,7 @@ export class Popover extends Component<Props, SpreadsheetChildEnv> {
     flipVerticalOffset: 0,
     verticalOffset: 0,
     marginTop: 0,
+    onMouseWheel: () => {},
   };
 
   private spreadsheetPosition = useSpreadsheetPosition();

--- a/src/components/popover/popover.xml
+++ b/src/components/popover/popover.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-Popover" owl="1">
     <t t-portal="'.o-spreadsheet'">
-      <div t-att-style="style" class="o-popover">
+      <div t-att-style="style" class="o-popover" t-on-wheel="props.onMouseWheel">
         <t t-slot="default"/>
       </div>
     </t>

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -770,6 +770,15 @@ describe("error tooltip", () => {
     await clickCell(model, "C8");
     expect(model.getters.getCurrentContent()).toBe("Hello");
   });
+
+  test("Wheel events on error tooltip are scrolling the grid", async () => {
+    setCellContent(model, "C1", "=0/0");
+    await hoverCell(model, "C1", 400);
+    const ev = new WheelEvent("wheel", { deltaY: 300, deltaX: 300, deltaMode: 0, bubbles: true });
+    document.querySelector(".o-error-tooltip")!.dispatchEvent(ev);
+    expect(getVerticalScroll()).toBe(300);
+    expect(getHorizontalScroll()).toBe(300);
+  });
 });
 
 describe("Events on Grid update viewport correctly", () => {


### PR DESCRIPTION
There was a problem that we couldn't scroll when hovering a error/link
popover in the grid.

This is because the Popovers aren't children of Grid, and they didn't
handle scroll events.

Add a new props "onWheel" to popover to allow grid to give a callback
to the popover to scroll the grid.

Odoo task ID : [2830825](https://www.odoo.com/web#id=2830825&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo