### PR TITLE
[FIX] popovers: display bug when scrolling with an opened popover

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -81,6 +81,8 @@ function useCellHovered(env: SpreadsheetChildEnv): Partial<Position> {
   const hoveredPosition: Partial<Position> = useState({} as Partial<Position>);
   const { Date } = window;
   const gridRef = useRef("gridOverlay");
+  const vScrollbarRef = useRef("vscrollbar");
+  const hScrollbarRef = useRef("hscrollbar");
   let x = 0;
   let y = 0;
   let lastMoved = 0;
@@ -114,7 +116,7 @@ function useCellHovered(env: SpreadsheetChildEnv): Partial<Position> {
     lastMoved = Date.now();
   }
 
-  function reset() {
+  function recompute() {
     const { col, row } = getPosition();
     if (col !== hoveredPosition.col || row !== hoveredPosition.row) {
       hoveredPosition.col = undefined;
@@ -122,12 +124,20 @@ function useCellHovered(env: SpreadsheetChildEnv): Partial<Position> {
     }
   }
 
+  function reset() {
+    hoveredPosition.col = undefined;
+    hoveredPosition.row = undefined;
+  }
+
   onMounted(() => {
     const grid = gridRef.el!;
     grid.addEventListener("mousemove", updateMousePosition);
     grid.addEventListener("mouseleave", pause);
     grid.addEventListener("mouseenter", resume);
-    grid.addEventListener("mousedown", reset);
+    grid.addEventListener("mousedown", recompute);
+
+    vScrollbarRef.el!.addEventListener("scroll", reset);
+    hScrollbarRef.el!.addEventListener("scroll", reset);
   });
 
   onWillUnmount(() => {
@@ -135,7 +145,10 @@ function useCellHovered(env: SpreadsheetChildEnv): Partial<Position> {
     grid.removeEventListener("mousemove", updateMousePosition);
     grid.removeEventListener("mouseleave", pause);
     grid.removeEventListener("mouseenter", resume);
-    grid.removeEventListener("mousedown", reset);
+    grid.removeEventListener("mousedown", recompute);
+
+    vScrollbarRef.el!.removeEventListener("scroll", reset);
+    hScrollbarRef.el!.removeEventListener("scroll", reset);
   });
   return hoveredPosition;
 }

--- a/src/plugins/ui/cell_popovers.ts
+++ b/src/plugins/ui/cell_popovers.ts
@@ -52,7 +52,16 @@ export class CellPopoverPlugin extends UIPlugin {
 
   getCellPopover({ col, row }: Partial<Position>): ClosedCellPopover | PositionedCellPopover {
     const sheetId = this.getters.getActiveSheetId();
-    if (this.persistentPopover) {
+    const viewport = this.getters.getActiveViewport();
+
+    if (
+      this.persistentPopover &&
+      this.getters.isVisibleInViewport(
+        this.persistentPopover.col,
+        this.persistentPopover.row,
+        viewport
+      )
+    ) {
       const mainPosition = this.getters.getMainCellPosition(
         sheetId,
         this.persistentPopover.col,
@@ -68,7 +77,13 @@ export class CellPopoverPlugin extends UIPlugin {
             ...this.computePopoverProps(this.persistentPopover, popover.cellCorner),
           };
     }
-    if (col === undefined || row === undefined) return { isOpen: false };
+    if (
+      col === undefined ||
+      row === undefined ||
+      !this.getters.isVisibleInViewport(col, row, viewport)
+    ) {
+      return { isOpen: false };
+    }
     const mainPosition = this.getters.getMainCellPosition(sheetId, col, row);
     const popover = cellPopoverRegistry
       .getAll()

--- a/tests/plugins/cell_popovers.test.ts
+++ b/tests/plugins/cell_popovers.test.ts
@@ -26,13 +26,6 @@ describe("cell popover plugin", () => {
         y: HEADER_HEIGHT,
       },
     });
-    model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: DEFAULT_CELL_WIDTH + 1, offsetY: 0 });
-    expect(model.getters.getCellPopover({ col: 0, row: 0 })).toMatchObject({
-      coordinates: {
-        x: startColOne,
-        y: HEADER_HEIGHT,
-      },
-    });
   });
 
   test("bottom left position is correct on a merge", () => {


### PR DESCRIPTION
Scrolling when there is a cell popover open and making the popover go out
of the grid with the scroll, breaks the display of the page.

Fix this by closing all the popover of the grid on scroll events.


Odoo task ID : [2880803](https://www.odoo.com/web#id=2880803&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo