### PR TITLE
[FIX] composer: grid composer missing CF style

### DIFF
--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -9,6 +9,7 @@ import { DOMDimension, Rect, Ref, SpreadsheetChildEnv, Zone } from "../../../typ
 import { css } from "../../helpers/css";
 import { getTextDecoration } from "../../helpers/dom_helpers";
 import { Composer } from "../composer/composer";
+import { Style } from "./../../../types/misc";
 
 const SCROLLBAR_WIDTH = 14;
 const SCROLLBAR_HIGHT = 15;
@@ -91,7 +92,15 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
 
   get containerStyle(): string {
     const isFormula = this.env.model.getters.getCurrentContent().startsWith("=");
-    const style = this.env.model.getters.getCurrentStyle();
+    const cell = this.env.model.getters.getActiveCell();
+    let style: Style = {};
+    if (cell) {
+      const cellPosition = this.env.model.getters.getCellPosition(cell.id);
+      style = {
+        ...cell.style,
+        ...this.env.model.getters.getConditionalStyle(cellPosition.col, cellPosition.row),
+      };
+    }
 
     // position style
     const { x: left, y: top, width, height } = this.rect;
@@ -110,7 +119,6 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     let textAlign = "left";
 
     if (!isFormula) {
-      const cell = this.env.model.getters.getActiveCell();
       textAlign = style.align || cell?.defaultAlign || "left";
     }
 

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -6,7 +6,7 @@ import {
   tokenColor,
 } from "../../src/components/composer/composer/composer";
 import { fontSizes } from "../../src/fonts";
-import { colors, toCartesian, toZone } from "../../src/helpers/index";
+import { colors, toCartesian, toHex, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { Highlight, LinkCell } from "../../src/types";
 import {
@@ -29,10 +29,12 @@ import {
 } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
+  createEqualCF,
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
   startGridComposition,
+  toRangesData,
   typeInComposerGrid as typeInComposerGridHelper,
 } from "../test_helpers/helpers";
 import { ContentEditableHelper } from "./__mocks__/content_editable_helper";
@@ -1048,6 +1050,33 @@ describe("composer", () => {
       await typeInComposerGrid("Hello");
       const gridComposer = fixture.querySelector(".o-grid-composer")! as HTMLElement;
       expect(gridComposer.style.textAlign).toBe("right");
+    });
+
+    test("Composer inherit cell's CF formatting", async () => {
+      const sheetId = model.getters.getActiveSheetId();
+      model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: createEqualCF(
+          "4",
+          {
+            fillColor: "#0000FF",
+            bold: true,
+            italic: true,
+            strikethrough: true,
+            underline: true,
+            textColor: "#FF0000",
+          },
+          "cfId"
+        ),
+        ranges: toRangesData(sheetId, "A1"),
+        sheetId,
+      });
+      setCellContent(model, "A1", "4");
+      await typeInComposerGrid("Hello");
+      const gridComposer = fixture.querySelector(".o-grid-composer")! as HTMLElement;
+      expect(gridComposer.style.textDecoration).toBe("line-through underline");
+      expect(gridComposer.style.fontWeight).toBe("bold");
+      expect(toHex(gridComposer.style.background)).toBe("#0000FF");
+      expect(toHex(gridComposer.style.color)).toBe("#FF0000");
     });
   });
 


### PR DESCRIPTION
## Description:

The style of the grid composer (background color, bold, ...) change
with the cell style, but not if the style comes from a CF.
CF style should also affect the grid composer.

Odoo task ID : [2930443](https://www.odoo.com/web#id=2930443&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo