### PR TITLE
[IMP] components: set global filter on click on pivot header

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -644,7 +644,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onMouseDown(ev: MouseEvent) {
-    if (ev.button > 0 || this.env.isDashboard()) {
+    if (ev.button > 0) {
       // not main button, probably a context menu
       return;
     }
@@ -654,6 +654,11 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     }
     this.clickedCol = col;
     this.clickedRow = row;
+
+    if (this.env.model.getters.isDashboard()) {
+      this.env.model.selection.selectCell(col, row);
+      return;
+    }
 
     const sheetId = this.env.model.getters.getActiveSheetId();
     this.closeOpenedPopover();

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export { compile, functionCache } from "./formulas/compiler";
 export { astToFormula, convertAstNodes, parse } from "./formulas/parser";
 export { tokenize } from "./formulas/tokenizer";
 export { AbstractChart } from "./helpers/charts";
+export { findCellInNewZone } from "./helpers/zones";
 export { load } from "./migrations/data";
 export { Model } from "./model";
 export { CorePlugin } from "./plugins/core_plugin";

--- a/src/selection_stream/event_stream.ts
+++ b/src/selection_stream/event_stream.ts
@@ -55,7 +55,7 @@ export class EventStream<Event> {
   }
 
   /**
-   * Register callbacks to observe the steam
+   * Register callbacks to observe the stream
    */
   observe(owner: unknown, callbacks: Omit<StreamCallbacks<Event>, "unsubscribe">) {
     this.observers.push({ owner, callbacks });

--- a/tests/components/dashboard_grid.test.ts
+++ b/tests/components/dashboard_grid.test.ts
@@ -1,0 +1,125 @@
+import { App } from "@odoo/owl";
+import { Spreadsheet } from "../../src";
+import { toZone } from "../../src/helpers";
+import { Model } from "../../src/model";
+import { dashboardMenuRegistry } from "../../src/registries";
+import { clickCell, rightClickCell } from "../test_helpers/dom_helper";
+import { getActiveXc } from "../test_helpers/getters_helpers";
+import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+
+let fixture: HTMLElement;
+let model: Model;
+let parent: Spreadsheet;
+let app: App;
+
+describe("Grid component in dashboard mode", () => {
+  beforeEach(async () => {
+    fixture = makeTestFixture();
+    ({ app, parent } = await mountSpreadsheet(fixture));
+    model = parent.model;
+    model.updateMode("dashboard");
+  });
+
+  afterEach(() => {
+    app.destroy();
+    fixture.remove();
+  });
+
+  test("Open context menu in dashboard mode contains only items of dashboard registry", async () => {
+    dashboardMenuRegistry.add("A", {
+      name: "A",
+      sequence: 10,
+      isReadonlyAllowed: true,
+      action: () => {},
+    });
+    await nextTick();
+    await rightClickCell(model, "B2");
+    expect(fixture.querySelectorAll(".o-menu div")).toHaveLength(1);
+    expect(fixture.querySelector(".o-menu div[data-name='A']")).not.toBeNull();
+    dashboardMenuRegistry.remove("A");
+  });
+
+  test("Keyboard event are not dispatched in dashboard mode", async () => {
+    await clickCell(model, "H1");
+    expect(getActiveXc(model)).toBe("H1");
+    document.activeElement!.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
+    );
+    expect(getActiveXc(model)).not.toBe("I1");
+  });
+
+  describe("Single selection event is dispatched in dashoboard mode", () => {
+    let fn: jest.Mock<any, any>;
+    beforeEach(async () => {
+      fn = jest.fn();
+      model.selection.observe(model, {
+        handleEvent: fn,
+      });
+    });
+    test("Clicking on a cell in dashboard mode dispatch selection event", async () => {
+      await clickCell(model, "H1");
+      expect(fn).toHaveBeenCalledWith({
+        type: "ZonesSelected",
+        anchor: {
+          cell: {
+            col: 7,
+            row: 0,
+          },
+          zone: toZone("H1"),
+        },
+        mode: "overrideSelection",
+        previousAnchor: {
+          cell: {
+            col: 0,
+            row: 0,
+          },
+          zone: toZone("A1"),
+        },
+      });
+    });
+
+    test("CTRL+Clicking on a cell in dashboard mode dispatch single selection event", async () => {
+      await clickCell(model, "H1", { ctrlKey: true });
+      expect(fn).toHaveBeenCalledWith({
+        type: "ZonesSelected",
+        anchor: {
+          cell: {
+            col: 7,
+            row: 0,
+          },
+          zone: toZone("H1"),
+        },
+        mode: "overrideSelection",
+        previousAnchor: {
+          cell: {
+            col: 0,
+            row: 0,
+          },
+          zone: toZone("A1"),
+        },
+      });
+    });
+
+    test("SHIFT+Clicking on a cell in dashboard mode dispatch single selection event", async () => {
+      await clickCell(model, "H1", { shiftKey: true });
+      expect(fn).toHaveBeenCalledWith({
+        type: "ZonesSelected",
+        anchor: {
+          cell: {
+            col: 7,
+            row: 0,
+          },
+          zone: toZone("H1"),
+        },
+        mode: "overrideSelection",
+        previousAnchor: {
+          cell: {
+            col: 0,
+            row: 0,
+          },
+          zone: toZone("A1"),
+        },
+      });
+    });
+  });
+});

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -4,7 +4,6 @@ import { Grid } from "../../src/components/grid/grid";
 import { HEADER_WIDTH, MESSAGE_VERSION, SCROLLBAR_WIDTH } from "../../src/constants";
 import { scrollDelay, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
-import { dashboardMenuRegistry } from "../../src/registries";
 import {
   createSheet,
   hideColumns,
@@ -624,37 +623,6 @@ describe("Grid component", () => {
       await simulateClick(".o-menu div[data-name='add_row_before']");
       expect(fixture.querySelector(".o-menu div[data-name='add_row_before']")).toBeFalsy();
       expect(document.activeElement).toBe(fixture.querySelector(".o-grid-overlay"));
-    });
-
-    test("Open context menu in dashboard mode contains only items of dashboard registry", async () => {
-      dashboardMenuRegistry.add("A", {
-        name: "A",
-        sequence: 10,
-        isReadonlyAllowed: true,
-        action: () => {},
-      });
-      model.updateMode("dashboard");
-      await nextTick();
-      await rightClickCell(model, "B2");
-      expect(fixture.querySelectorAll(".o-menu div")).toHaveLength(1);
-      expect(fixture.querySelector(".o-menu div[data-name='A']")).not.toBeNull();
-      dashboardMenuRegistry.remove("A");
-    });
-
-    test("Cannot select a cell in dashboard mode", async () => {
-      model.updateMode("dashboard");
-      await clickCell(model, "H1");
-      expect(getActiveXc(model)).not.toBe("H1");
-    });
-
-    test("Keyboard event are not dispatched in dashboard mode", async () => {
-      await clickCell(model, "H1");
-      expect(getActiveXc(model)).toBe("H1");
-      model.updateMode("dashboard");
-      document.activeElement!.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
-      );
-      expect(getActiveXc(model)).not.toBe("I1");
     });
   });
 });


### PR DESCRIPTION
## Task Description

The aim of this task is to set a global filter, when clicking on
a pivot header, according to the pivot field and value of the header.

Two way to add a filter has been added :
1. In dashboard mode, left click on the pivot header
2. In spreadsheet mode, right click on the pivot header and select "Use as global filter"

## Related task

- Odoo task ID : [2870735](https://www.odoo.com/web#id=2870735&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
- OE PR: https://github.com/odoo/enterprise/pull/29900

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo