### PR TITLE
[FIX] merge: cells overridden by merge should lose their style

### DIFF
--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -388,7 +388,7 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
             sheetId: sheet.id,
             col,
             row,
-            style: topLeft ? topLeft.style : undefined,
+            style: topLeft ? topLeft.style : null,
             content: undefined,
           });
         }

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -329,6 +329,22 @@ describe("merges", () => {
     expect(getCell(model, "A4")!.evaluated.value).toBe(1);
   });
 
+  test("merging => unmerging  : cell styles are overridden even if the top left cell had no style", () => {
+    const model = new Model();
+
+    model.dispatch("SET_FORMATTING", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: target("B1"),
+      style: { fillColor: "red" },
+    });
+    merge(model, "A1:B1");
+    expect(getStyle(model, "A1")).toBeUndefined();
+    expect(getStyle(model, "B1")).toBeUndefined();
+    unMerge(model, "A1:B1");
+    expect(getStyle(model, "A1")).toBeUndefined();
+    expect(getStyle(model, "B1")).toBeUndefined();
+  });
+
   test("merging => setting background color => unmerging", () => {
     const model = new Model();
     const sheet1 = model.getters.getVisibleSheets()[0];


### PR DESCRIPTION
The cells overridden by merges didn't loose their styles if the top-left
cell of the cell had no style. The expected behaviour is to have all
the cells of the merge have the same style as the top-left cell.

Odoo task ID : [2766282](https://www.odoo.com/web#id=2766282&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo