### PR TITLE
[FIX] spreadsheet: keyboard events don't work in side panels

### DIFF
--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -4,7 +4,7 @@
       class="o-grid"
       t-att-class="{'o-two-columns': !props.sidePanelIsOpen}"
       t-on-click="focus"
-      t-on-keydown="onKeydown"
+      t-on-keydown="onGridKeydown"
       t-on-wheel="onMouseWheel"
       t-ref="grid">
       <!-- tabindex="-1" is necessary to keep the focus on composer while selecting a cell -->

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -39,7 +39,9 @@ beforeEach(async () => {
   model = parent.model;
 
   // start composition
-  fixture.querySelector(".o-grid")!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+  fixture
+    .querySelector(".o-grid")!
+    .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
   await nextTick();
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
 });
@@ -287,7 +289,9 @@ describe("Autocomplete parenthesis", () => {
     await nextTick();
     selectCell(model, "A1");
     //edit A1
-    fixture.querySelector(".o-grid")!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    fixture
+      .querySelector(".o-grid")!
+      .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     await nextTick();
     composerEl = fixture.querySelector(".o-grid div.o-composer")!;
     // @ts-ignore

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -1425,9 +1425,11 @@ describe("composer highlights color", () => {
     expect(getHighlights(model)[0].color).toBe(colors[0]);
     expect(getHighlights(model)[1].color).toBe(colors[1]);
 
-    document.activeElement!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    document.activeElement!.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+    );
     await nextTick();
-    canvasEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    canvasEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     await nextTick();
     expect(getHighlights(model).length).toBe(2);
     expect(getHighlights(model)[0].color).toBe(colors[0]);

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -26,7 +26,9 @@ beforeEach(async () => {
   model = parent.model;
 
   // start composition
-  document.querySelector(".o-grid")!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+  document
+    .querySelector(".o-grid")!
+    .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
   await nextTick();
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
 });

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -239,7 +239,7 @@ describe("Grid component", () => {
       // change this
       document
         .querySelector(".o-grid")!
-        .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+        .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
       expect(getActiveXc(model)).toBe("A1");
       expect(model.getters.getEditionMode()).toBe("editing");
     });
@@ -273,7 +273,9 @@ describe("Grid component", () => {
       await nextTick();
       fixture
         .querySelector("div.o-composer")!
-        .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", shiftKey: true }));
+        .dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Enter", shiftKey: true, bubbles: true })
+        );
       expect(getActiveXc(model)).toBe("A1");
       expect(model.getters.getEditionMode()).toBe("inactive");
       expect(getCellContent(model, "A1")).toBe("a");
@@ -282,7 +284,7 @@ describe("Grid component", () => {
     test("pressing TAB move to next cell", async () => {
       document
         .querySelector(".o-grid")!
-        .dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
+        .dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
       expect(getActiveXc(model)).toBe("B1");
     });
 
@@ -291,7 +293,7 @@ describe("Grid component", () => {
       expect(getActiveXc(model)).toBe("B1");
       document
         .querySelector(".o-grid")!
-        .dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true }));
+        .dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }));
       expect(getActiveXc(model)).toBe("A1");
     });
 

--- a/tests/components/side_panel.test.ts
+++ b/tests/components/side_panel.test.ts
@@ -2,7 +2,9 @@ import { App, Component, xml } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import { sidePanelRegistry } from "../../src/registries/index";
 import { SidePanelContent } from "../../src/registries/side_panel_registry";
+import { setCellContent } from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
+import { getCellContent } from "../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
@@ -140,5 +142,20 @@ describe("Side Panel", () => {
     simulateClick(".o-sidePanelClose");
     await nextTick();
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid-overlay"));
+  });
+
+  test("keyboards event on the side panel are handled in the grid", async () => {
+    const model = parent.model;
+    sidePanelRegistry.add("CUSTOM_PANEL", {
+      title: "Custom Panel",
+      Body: Body,
+    });
+    parent.env.openSidePanel("CUSTOM_PANEL");
+    await nextTick();
+    setCellContent(model, "A1", "a");
+    expect(getCellContent(model, "A1")).toEqual("a");
+    const keyDown = new KeyboardEvent("keydown", { key: "z", bubbles: true, ctrlKey: true });
+    document.querySelector(".o-sidePanel")!.dispatchEvent(keyDown);
+    expect(getCellContent(model, "A1")).toEqual("");
   });
 });


### PR DESCRIPTION
The keyboard events (for example undo/redo) didn't work in the side
panels, or after clicking a popover.

This was because the events were handled by `Grid`, when clicking on
either the side panel or on a popover the focus was on document.body,
and thus were never handled by grid.

Fixed this by making the grid listen to the keyboard events on
document.body, which is the element focused by default.

Odoo task ID : [2744038](https://www.odoo.com/web#id=2744038&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo