### PR TITLE
[IMP] clipboard: paste on merge consistency

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -18,7 +18,7 @@ import {
 } from "../../constants";
 import { findCellInNewZone, isInside, MAX_DELAY, range } from "../../helpers/index";
 import { interactiveCut } from "../../helpers/ui/cut_interactive";
-import { interactivePaste } from "../../helpers/ui/paste_interactive";
+import { interactivePaste, interactivePasteFromOS } from "../../helpers/ui/paste_interactive";
 import { ComposerSelection } from "../../plugins/ui/edition";
 import { cellMenuRegistry } from "../../registries/menus/cell_menu_registry";
 import { colMenuRegistry } from "../../registries/menus/col_menu_registry";
@@ -942,10 +942,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         // the paste actually comes from o-spreadsheet itself
         interactivePaste(this.env, target);
       } else {
-        this.env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
-          target,
-          text: content,
-        });
+        interactivePasteFromOS(this.env, target, content);
       }
     }
   }

--- a/src/helpers/ui/paste_interactive.ts
+++ b/src/helpers/ui/paste_interactive.ts
@@ -30,3 +30,8 @@ export function interactivePaste(
   const result = env.model.dispatch("PASTE", { target, pasteOption });
   handlePasteResult(env, result);
 }
+
+export function interactivePasteFromOS(env: SpreadsheetChildEnv, target: Zone[], text: string) {
+  const result = env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", { target, text });
+  handlePasteResult(env, result);
+}

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -50,6 +50,7 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     "doesRowsHaveCommonMerges",
     "getMerges",
     "getMerge",
+    "getMergesInZone",
     "isSingleCellOrMerge",
   ] as const;
 
@@ -128,6 +129,23 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     const sheetMap = this.mergeCellMap[sheetId];
     const mergeId = sheetMap ? col in sheetMap && sheetMap[col]?.[row] : undefined;
     return mergeId ? this.getMergeById(sheetId, mergeId) : undefined;
+  }
+
+  getMergesInZone(sheetId: UID, zone: Zone): Merge[] {
+    const sheetMap = this.mergeCellMap[sheetId];
+    if (!sheetMap) return [];
+    const mergeIds = new Set<number>();
+
+    for (const { col, row } of positions(zone)) {
+      const mergeId = sheetMap[col]?.[row];
+      if (mergeId) {
+        mergeIds.add(mergeId);
+      }
+    }
+
+    return Array.from(mergeIds)
+      .map((mergeId) => this.getMergeById(sheetId, mergeId))
+      .filter(isDefined);
   }
 
   /**

--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -48,6 +48,10 @@ export class ClipboardPlugin extends UIPlugin {
         }
         const pasteOption = cmd.pasteOption || (this._isPaintingFormat ? "onlyFormat" : undefined);
         return this.state.isPasteAllowed(cmd.target, { pasteOption });
+      case "PASTE_FROM_OS_CLIPBOARD": {
+        const state = new ClipboardOsState(cmd.text, this.getters, this.dispatch, this.selection);
+        return state.isPasteAllowed(cmd.target);
+      }
       case "INSERT_CELL": {
         const { cut, paste } = this.getInsertCellsTargets(cmd.zone, cmd.shiftDimension);
         const state = this.getClipboardStateForCopyCells(cut, "CUT");

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -6,7 +6,11 @@ import {
 import { numberToLetters, zoneToXc } from "../../helpers/index";
 import { interactiveSortSelection } from "../../helpers/sort";
 import { interactiveCut } from "../../helpers/ui/cut_interactive";
-import { handlePasteResult, interactivePaste } from "../../helpers/ui/paste_interactive";
+import {
+  handlePasteResult,
+  interactivePaste,
+  interactivePasteFromOS,
+} from "../../helpers/ui/paste_interactive";
 import { _lt } from "../../translation";
 import { CellValueType, Format, SpreadsheetChildEnv, Style } from "../../types/index";
 
@@ -84,10 +88,7 @@ export const PASTE_ACTION = async (env: SpreadsheetChildEnv) => {
   const osClipboard = await readOsClipboard(env);
   const target = env.model.getters.getSelectedZones();
   if (osClipboard && osClipboard !== spreadsheetClipboard) {
-    env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
-      target,
-      text: osClipboard,
-    });
+    interactivePasteFromOS(env, target, osClipboard);
   } else {
     interactivePaste(env, target);
   }

--- a/tests/helpers/ui.test.ts
+++ b/tests/helpers/ui.test.ts
@@ -3,7 +3,11 @@ import {
   AddMergeInteractiveContent,
   interactiveAddMerge,
 } from "../../src/helpers/ui/merge_interactive";
-import { interactivePaste, PasteInteractiveContent } from "../../src/helpers/ui/paste_interactive";
+import {
+  interactivePaste,
+  interactivePasteFromOS,
+  PasteInteractiveContent,
+} from "../../src/helpers/ui/paste_interactive";
 import { interactiveRenameSheet } from "../../src/helpers/ui/sheet_interactive";
 import { Model } from "../../src/model";
 import { EditTextOptions, SpreadsheetChildEnv, UID } from "../../src/types";
@@ -182,6 +186,27 @@ describe("UI Helpers", () => {
       expect(notifyUserTextSpy).toHaveBeenCalledWith(
         PasteInteractiveContent.willRemoveExistingMerge.toString()
       );
+    });
+
+    describe("Paste from OS", () => {
+      const clipboardString = "a\t1\nb\t2";
+
+      test("Can interactive paste", () => {
+        interactivePasteFromOS(env, target("D2"), clipboardString);
+        expect(getCellContent(model, "D2")).toBe("a");
+        expect(getCellContent(model, "E2")).toBe("1");
+        expect(getCellContent(model, "D3")).toBe("b");
+        expect(getCellContent(model, "E3")).toBe("2");
+      });
+
+      test("Pasting content that will destroy a merge will notify the user", async () => {
+        merge(model, "B2:C3");
+        selectCell(model, "A1");
+        interactivePasteFromOS(env, model.getters.getSelectedZones(), clipboardString);
+        expect(notifyUserTextSpy).toHaveBeenCalledWith(
+          PasteInteractiveContent.willRemoveExistingMerge.toString()
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Currently if we paste some cells on a merge, we get a warning that there
is a merge and we cannot paste. But if we do the same with clipboard
from OS, we get no warning and only the top-left value of the merge is
kept, the rest are lost.

Make the behaviour consistent by giving a warning when pasting from OS.

Odoo task ID : [2918762](https://www.odoo.com/web#id=2918762&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo