### PR TITLE
[FIX] function: logical function "AND" traceback

### DIFF
--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -29,7 +29,7 @@ export const AND: FunctionDescription = {
       logical_expression1 (boolean, range<boolean>) ${_lt(
         "An expression or reference to a cell containing an expression that represents some logical value, i.e. TRUE or FALSE, or an expression that can be coerced to a logical value."
       )}
-      logical_expression1 (boolean, range<boolean>, optional, repeating) ${_lt(
+      logical_expression2 (boolean, range<boolean>, optional, repeating) ${_lt(
         "More expressions that represent logical values."
       )}
     `),


### PR DESCRIPTION
The logical function `AND` caused a traceback when owl was in debug mode.

This is because the two arguments of `AND` where both called
`logical_expression1`. But since their name was used as a `t-key` of a
`t-foreach`, it made owl crash because of the duplicated key.

Odoo task ID : [2937632](https://www.odoo.com/web#id=2937632&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo