### PR TITLE
[FIX] conditional formats: color scale breaks with error cell

### DIFF
--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -1,5 +1,5 @@
 import { parseDateTime } from "../helpers/dates";
-import { isNumber } from "../helpers/index";
+import { isNumber, percentile } from "../helpers/index";
 import { _lt } from "../translation";
 import { AddFunctionDescription, Arg, ArgValue, MatrixArgValue, PrimitiveArgValue } from "../types";
 import { args } from "./arguments";
@@ -118,24 +118,15 @@ function centile(data: ArgValue[], percent: PrimitiveArgValue, isInclusive: bool
   });
   assert(() => count !== 0, _lt(`[[FUNCTION_NAME]] has no valid input data.`));
 
-  let percentIndex = (count + (isInclusive ? -1 : 1)) * _percent;
   if (!isInclusive) {
+    // 2nd argument must be between 1/(n+1) and n/(n+1) with n the number of data
     assert(
-      () => 1 <= percentIndex && percentIndex <= count,
+      () => 1 / (count + 1) <= _percent && _percent <= count / (count + 1),
       _lt(`Function [[FUNCTION_NAME]] parameter 2 value is out of range.`)
     );
+  }
 
-    percentIndex--;
-  }
-  if (Number.isInteger(percentIndex)) {
-    return sortedArray[percentIndex];
-  }
-  const indexSup = Math.ceil(percentIndex);
-  const indexLow = Math.floor(percentIndex);
-  return (
-    sortedArray[indexSup] * (percentIndex - indexLow) +
-    sortedArray[indexLow] * (indexSup - percentIndex)
-  );
+  return percentile(sortedArray, _percent, isInclusive);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -58,3 +58,21 @@ export function parseNumber(str: string): number {
   }
   return n;
 }
+
+export function percentile(values: number[], percent: number, isInclusive: boolean) {
+  const sortedValues = [...values].sort((a, b) => a - b);
+
+  let percentIndex = (sortedValues.length + (isInclusive ? -1 : 1)) * percent;
+  if (!isInclusive) {
+    percentIndex--;
+  }
+  if (Number.isInteger(percentIndex)) {
+    return sortedValues[percentIndex];
+  }
+  const indexSup = Math.ceil(percentIndex);
+  const indexLow = Math.floor(percentIndex);
+  return (
+    sortedValues[indexSup] * (percentIndex - indexLow) +
+    sortedValues[indexLow] * (indexSup - percentIndex)
+  );
+}

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -2014,5 +2014,24 @@ describe("conditional formats types", () => {
       deleteCells(model, "A2:A3", "up");
       expect(model.getters.getConditionalFormats(sheetId)[0].ranges[0]).toBe("A1:A10");
     });
+
+    test("Color scale with error cell in range", () => {
+      setCellContent(model, "A1", "10");
+      setCellContent(model, "A2", "=0/0");
+      setCellContent(model, "A3", "1");
+
+      model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: createColorScale(
+          "1",
+          { type: "value", color: 0xff00ff },
+          { type: "value", color: 0x123456 }
+        ),
+        ranges: toRangesData(sheetId, "A1:A3"),
+        sheetId,
+      });
+      expect(model.getters.getConditionalStyle(0, 0)).toEqual({ fillColor: "#123456" });
+      expect(model.getters.getConditionalStyle(0, 1)).toEqual(undefined);
+      expect(model.getters.getConditionalStyle(0, 2)).toEqual({ fillColor: "#ff00ff" });
+    });
   });
 });


### PR DESCRIPTION
## Description

There was a problem where if a cell was in error in the range of a
color scale CF, the color scale stopped working.

This was because the color scale rule evaluation used the same mechanism
as the cell evaluation to compute things such as the min/max/percentile
of the range. But since the evaluation throws an error at the evaluation
of a formula that depend of a cell in error, the evaluation of the CF
rule also threw an error if there was an error cell in the range.

Solve this by using JS functions to compute min/max/percentile.

Odoo task Odoo task ID : [2937047](https://www.odoo.com/web#id=2937047&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo