### PR TITLE
[FIX] chart: blurry chart on screen with devicePixelRatio != 1

### DIFF
--- a/src/helpers/charts/chart_ui_common.ts
+++ b/src/helpers/charts/chart_ui_common.ts
@@ -87,7 +87,6 @@ export function getDefaultChartJsRuntime(
       animation: {
         duration: 0, // general animation time
       },
-      devicePixelRatio: 1, // at import from xlsx having devicePixelRatio < 1 messes up the scale
       hover: {
         animationDuration: 10, // duration of animations when hovering an item
       },

--- a/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
@@ -42,7 +42,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -150,7 +149,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -265,7 +263,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -354,7 +351,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -444,7 +440,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -547,7 +542,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -650,7 +644,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -730,7 +723,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -833,7 +825,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -936,7 +927,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -1039,7 +1029,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,

--- a/tests/plugins/chart/__snapshots__/gauge_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/gauge_chart.test.ts.snap
@@ -27,7 +27,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,
@@ -110,7 +109,6 @@ Object {
       "animation": Object {
         "duration": 0,
       },
-      "devicePixelRatio": 1,
       "elements": Object {
         "line": Object {
           "fill": false,


### PR DESCRIPTION
## Description

The `devicePixelRatio` was forced to one in the runtimes of chartJS. This
caused charts to be blurry on screens with `devicePixelRatio` != 1.

Originally I forced the `devicePixelRatio` to fix a scaling issue of charts
at the import of an xlsx, but this bug don't seem to happens anymore.

Odoo task Odoo task ID : [2945362](https://www.odoo.com/web#id=2945362&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo