### PR TITLE
[FIX] scorecard: high contrast color on titles/descriptions

### DIFF
--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,6 +1,6 @@
 import { Component } from "@odoo/owl";
 import { DEFAULT_FONT } from "../../../../constants";
-import { getFontSizeMatchingWidth } from "../../../../helpers";
+import { getFontSizeMatchingWidth, relativeLuminance } from "../../../../helpers";
 import { chartComponentRegistry } from "../../../../registries";
 import { Color, Figure, Pixel, SpreadsheetChildEnv, Style } from "../../../../types";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
@@ -42,7 +42,6 @@ css/* scss */ `
     }
 
     .o-title-text {
-      color: #757575;
       text-align: left;
       height: ${LINE_HEIGHT + "em"};
       line-height: ${LINE_HEIGHT + "em"};
@@ -67,7 +66,6 @@ css/* scss */ `
     }
 
     .o-baseline-text {
-      color: #757575;
       line-height: ${LINE_HEIGHT + "em"};
       height: ${LINE_HEIGHT + "em"};
       overflow: hidden;
@@ -117,8 +115,12 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
     return this.runtime?.background || "white";
   }
 
-  get fontColor() {
-    return this.runtime?.fontColor || "black";
+  get primaryFontColor() {
+    return this.runtime?.fontColor || "#000000";
+  }
+
+  get secondaryFontColor() {
+    return relativeLuminance(this.primaryFontColor) <= 0.3 ? "#757575" : "#bbbbbb";
   }
 
   get figure() {
@@ -131,7 +133,6 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
       width:${this.figure.width}px;
       padding:${this.chartPadding}px;
       background:${this.backgroundColor};
-      color:${this.fontColor};
     `;
   }
 
@@ -166,10 +167,12 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
     return {
       titleStyle: this.getTextStyle({
         fontSize: TITLE_FONT_SIZE,
+        color: this.secondaryFontColor,
       }),
       keyStyle: this.getTextStyle({
         fontSize: keyFontSize,
         cellStyle: this.runtime?.keyValueStyle,
+        color: this.primaryFontColor,
       }),
       baselineStyle: this.getTextStyle({
         fontSize: baselineFontSize,
@@ -177,10 +180,11 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
       baselineValueStyle: this.getTextStyle({
         fontSize: baselineFontSize,
         cellStyle: this.runtime?.baselineStyle,
-        color: this.runtime?.baselineColor,
+        color: this.runtime?.baselineColor || this.secondaryFontColor,
       }),
       baselineDescrStyle: this.getTextStyle({
         fontSize: baselineFontSize * BASELINE_DESCR_FONT_RATIO,
+        color: this.secondaryFontColor,
       }),
     };
   }

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -47,7 +47,6 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
       width:536px;
       padding:10.72px;
       background:#FFFFFF;
-      color:#000000;
     "
     >
       <div
@@ -55,6 +54,7 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
         style="
 font-size: 18px;
 display: inline-block;
+color: #757575;
 "
       >
         hello
@@ -71,6 +71,7 @@ display: inline-block;
           style="
 font-size: 69.24101876395092px;
 display: inline-block;
+color: #000000;
 "
         >
           2
@@ -113,6 +114,7 @@ color: #00A04A;
             style="
 font-size: 33.55526293945314px;
 display: inline-block;
+color: #757575;
 "
           >
              description

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -36,6 +36,10 @@ function getChartBaselineTextElement(): HTMLElement {
   return fixture.querySelector(".o-figure .o-baseline-text-value")!;
 }
 
+function getChartBaselineDescrElement(): HTMLElement {
+  return fixture.querySelector(".o-figure .o-baseline-text-description")!;
+}
+
 function getElementFontSize(element: HTMLElement): number {
   const fontSizeAttr = element.style.fontSize;
   return Number(fontSizeAttr.slice(0, fontSizeAttr.length - 2));
@@ -147,7 +151,7 @@ describe("Scorecard charts", () => {
 
     expect(getChartElement()).toBeTruthy();
     expect(getChartBaselineTextContent()).toEqual("1");
-    expect(getChartBaselineElement().querySelector("span")!.style["color"]).toEqual("");
+    expect(toHex(getChartBaselineTextElement()!.style["color"])).toEqual("#757575");
   });
 
   test("Key < baseline display in red with down arrow", async () => {
@@ -176,7 +180,7 @@ describe("Scorecard charts", () => {
 
     const baselineElement = getChartBaselineElement();
     expect(baselineElement.querySelector("svg")).toBeFalsy();
-    expect(baselineElement.querySelector("span")!.style["color"]).toEqual("");
+    expect(toHex(baselineElement.querySelector("span")!.style["color"])).toEqual("#757575");
     expect(getChartBaselineTextContent()).toEqual("0");
   });
 
@@ -240,6 +244,26 @@ describe("Scorecard charts", () => {
     await nextTick();
     expect(getChartBaselineTextElement()!.style["font-weight"]).not.toEqual("bold");
     expect(getChartBaselineTextContent()).toEqual("100%");
+  });
+
+  test("High contrast font colors with dark background", async () => {
+    createScorecardChart(
+      model,
+      {
+        keyValue: "A1",
+        baseline: "A1",
+        baselineDescr: "descr",
+        title: "title",
+        background: "#000000",
+      },
+      chartId
+    );
+    await nextTick();
+
+    expect(toHex(getChartTitleElement()!.style["color"])).toEqual("#BBBBBB");
+    expect(toHex(getChartBaselineTextElement()!.style["color"])).toEqual("#BBBBBB");
+    expect(toHex(getChartBaselineDescrElement()!.style["color"])).toEqual("#BBBBBB");
+    expect(toHex(getChartKeyElement()!.style["color"])).toEqual("#FFFFFF");
   });
 
   test("Increasing size of the chart scale up the font sizes", async () => {


### PR DESCRIPTION
## Description

Before this commit, the font color of the title and baseline description
of a scorecard were always dark gray. This caused readability problems
when the chart had a dark background.

Now change the font color to a light gray for dark backgrounds.

Odoo task Odoo task ID : [2945466](https://www.odoo.com/web#id=2945466&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo