### PR TITLE
[FIX] topbar: dropdown closing when clicking inside

### DIFF
--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-ColorPicker" owl="1">
-    <div class="o-color-picker" t-att-class="props.dropdownDirection || 'right'">
+    <div class="o-color-picker" t-att-class="props.dropdownDirection || 'right'" t-on-click.stop="">
       <div class="o-color-picker-section-name">Standard</div>
       <div class="colors-grid">
         <div

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -66,7 +66,7 @@
           <div
             class="o-tool"
             title="Format as percent"
-            t-on-click="(ev) => this.toogleFormat('percent', ev)">
+            t-on-click="(ev) => this.toggleFormat('percent', ev)">
             %
           </div>
           <div
@@ -81,48 +81,58 @@
             t-on-click="(ev) => this.setDecimal(+1, ev)">
             .00
           </div>
-          <div
-            class="o-tool o-dropdown"
-            title="More formats"
-            t-on-click="(ev) => this.toggleDropdownTool('formatTool', ev)">
-            <div class="o-text-icon">
+          <div class="o-dropdown">
+            <div
+              class="o-tool o-dropdown-button o-text-icon"
+              title="More formats"
+              t-on-click="(ev) => this.toggleDropdownTool('formatTool', ev)">
               123
               <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
             </div>
             <div
               class="o-dropdown-content o-text-options  o-format-tool "
               t-if="state.activeTool === 'formatTool'"
-              t-on-click="setFormat">
+              t-on-click.stop="">
               <t t-foreach="commonFormats" t-as="commonFormat" t-key="commonFormat.name">
                 <div
+                  class="o-dropdown-item"
                   t-att-data-format="commonFormat.name"
+                  t-on-click="() => this.setFormat(commonFormat.name)"
                   t-att-class="{active: currentFormatName === commonFormat.name}">
                   <t t-esc="commonFormat.text"/>
                   <span class="float-end text-muted" t-esc="commonFormat.description"/>
                 </div>
               </t>
               <t t-foreach="customFormats" t-as="customFormat" t-key="customFormat.name">
-                <div t-att-data-custom="customFormat.name">
+                <div
+                  t-att-data-custom="customFormat.name"
+                  class="o-dropdown-item"
+                  t-on-click="() => this.setFormat(customFormat.name, true)">
                   <t t-esc="customFormat.text"/>
                 </div>
               </t>
             </div>
           </div>
           <div class="o-divider"/>
-          <div
-            class="o-tool o-dropdown"
-            title="Font Size"
-            t-on-click="(ev) => this.toggleDropdownTool('fontSizeTool', ev)">
-            <div class="o-text-icon">
+          <div class="o-dropdown">
+            <div
+              class="o-tool o-dropdown-button o-text-icon"
+              title="Font Size"
+              t-on-click="(ev) => this.toggleDropdownTool('fontSizeTool', ev)">
               <t t-esc="style.fontSize || DEFAULT_FONT_SIZE"/>
               <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
             </div>
             <div
               class="o-dropdown-content o-text-options "
               t-if="state.activeTool === 'fontSizeTool'"
-              t-on-click="setSize">
+              t-on-click.stop="">
               <t t-foreach="fontSizes" t-as="font" t-key="font_index">
-                <div t-esc="font.pt" t-att-data-size="font.pt"/>
+                <div
+                  t-esc="font.pt"
+                  t-att-data-size="font.pt"
+                  class="o-dropdown-item"
+                  t-on-click="() => this.setSize(font.pt)"
+                />
               </t>
             </div>
           </div>
@@ -131,30 +141,32 @@
             class="o-tool"
             title="Bold"
             t-att-class="{active:style.bold}"
-            t-on-click="(ev) => this.toogleStyle('bold', ev)">
+            t-on-click="(ev) => this.toggleStyle('bold', ev)">
             <t t-call="o-spreadsheet-Icon.BOLD"/>
           </div>
           <div
             class="o-tool"
             title="Italic"
             t-att-class="{active:style.italic}"
-            t-on-click="(ev) => this.toogleStyle('italic', ev)">
+            t-on-click="(ev) => this.toggleStyle('italic', ev)">
             <t t-call="o-spreadsheet-Icon.ITALIC"/>
           </div>
           <div
             class="o-tool"
             title="Strikethrough"
             t-att-class="{active:style.strikethrough}"
-            t-on-click="(ev) => this.toogleStyle('strikethrough', ev)">
+            t-on-click="(ev) => this.toggleStyle('strikethrough', ev)">
             <t t-call="o-spreadsheet-Icon.STRIKE"/>
           </div>
-          <div
-            class="o-tool o-dropdown o-with-color"
-            title="Text Color"
-            t-on-click="(ev) => this.toggleDropdownTool('textColorTool', ev)">
-            <span t-attf-style="border-color:{{textColor}}">
-              <t t-call="o-spreadsheet-Icon.TEXT_COLOR"/>
-            </span>
+          <div class="o-dropdown">
+            <div
+              class="o-tool o-dropdown-button o-with-color"
+              title="Text Color"
+              t-on-click="(ev) => this.toggleDropdownTool('textColorTool', ev)">
+              <span t-attf-style="border-color:{{textColor}}">
+                <t t-call="o-spreadsheet-Icon.TEXT_COLOR"/>
+              </span>
+            </div>
             <ColorPicker
               t-if="state.activeTool === 'textColorTool'"
               onColorPicked="(color) => this.setColor('textColor', color)"
@@ -163,13 +175,15 @@
             />
           </div>
           <div class="o-divider"/>
-          <div
-            class="o-tool  o-dropdown o-with-color"
-            title="Fill Color"
-            t-on-click="(ev) => this.toggleDropdownTool('fillColorTool', ev)">
-            <span t-attf-style="border-color:{{fillColor}}">
-              <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
-            </span>
+          <div class="o-dropdown ">
+            <div
+              class="o-tool o-dropdown-button o-with-color"
+              title="Fill Color"
+              t-on-click="(ev) => this.toggleDropdownTool('fillColorTool', ev)">
+              <span t-attf-style="border-color:{{fillColor}}">
+                <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
+              </span>
+            </div>
             <ColorPicker
               t-if="state.activeTool === 'fillColorTool'"
               onColorPicked="(color) => this.setColor('fillColor', color)"
@@ -177,47 +191,50 @@
               t-key="fillColor"
             />
           </div>
-          <div
-            class="o-tool o-dropdown"
-            title="Borders"
-            t-on-click="(ev) => this.toggleDropdownTool('borderTool', ev)">
-            <span>
-              <t t-call="o-spreadsheet-Icon.BORDERS"/>
-            </span>
+          <div class="o-dropdown">
+            <div
+              class="o-tool o-dropdown-button"
+              title="Borders"
+              t-on-click="(ev) => this.toggleDropdownTool('borderTool', ev)">
+              <span>
+                <t t-call="o-spreadsheet-Icon.BORDERS"/>
+              </span>
+            </div>
             <div
               class="o-dropdown-content o-border-dropdown"
-              t-if="state.activeTool === 'borderTool'">
+              t-if="state.activeTool === 'borderTool'"
+              t-on-click.stop="">
               <div class="o-dropdown-line">
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('all', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('all')">
                   <t t-call="o-spreadsheet-Icon.BORDERS"/>
                 </span>
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('hv', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('hv')">
                   <t t-call="o-spreadsheet-Icon.BORDER_HV"/>
                 </span>
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('h', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('h')">
                   <t t-call="o-spreadsheet-Icon.BORDER_H"/>
                 </span>
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('v', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('v')">
                   <t t-call="o-spreadsheet-Icon.BORDER_V"/>
                 </span>
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('external', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('external')">
                   <t t-call="o-spreadsheet-Icon.BORDER_EXTERNAL"/>
                 </span>
               </div>
               <div class="o-dropdown-line">
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('left', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('left')">
                   <t t-call="o-spreadsheet-Icon.BORDER_LEFT"/>
                 </span>
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('top', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('top')">
                   <t t-call="o-spreadsheet-Icon.BORDER_TOP"/>
                 </span>
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('right', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('right')">
                   <t t-call="o-spreadsheet-Icon.BORDER_RIGHT"/>
                 </span>
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('bottom', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('bottom')">
                   <t t-call="o-spreadsheet-Icon.BORDER_BOTTOM"/>
                 </span>
-                <span class="o-line-item" t-on-click="(ev) => this.setBorder('clear', ev)">
+                <span class="o-line-item" t-on-click="(ev) => this.setBorder('clear')">
                   <t t-call="o-spreadsheet-Icon.BORDER_CLEAR"/>
                 </span>
               </div>
@@ -231,30 +248,41 @@
             <t t-call="o-spreadsheet-Icon.MERGE_CELL"/>
           </div>
           <div class="o-divider"/>
-          <div
-            class="o-tool o-dropdown"
-            title="Horizontal align"
-            t-on-click="(ev) => this.toggleDropdownTool('alignTool', ev)">
-            <span>
-              <t t-if="style.align === 'right'">
-                <t t-call="o-spreadsheet-Icon.ALIGN_RIGHT"/>
-              </t>
-              <t t-elif="style.align === 'center'">
-                <t t-call="o-spreadsheet-Icon.ALIGN_CENTER"/>
-              </t>
-              <t t-else="">
-                <t t-call="o-spreadsheet-Icon.ALIGN_LEFT"/>
-              </t>
-              <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
-            </span>
-            <div t-if="state.activeTool === 'alignTool'" class="o-dropdown-content">
-              <div class="o-dropdown-item" t-on-click="(ev) => this.toggleAlign('left', ev)">
+          <div class="o-dropdown">
+            <div
+              class="o-tool o-dropdown-button"
+              title="Horizontal align"
+              t-on-click="(ev) => this.toggleDropdownTool('alignTool', ev)">
+              <span>
+                <t t-if="style.align === 'right'">
+                  <t t-call="o-spreadsheet-Icon.ALIGN_RIGHT"/>
+                </t>
+                <t t-elif="style.align === 'center'">
+                  <t t-call="o-spreadsheet-Icon.ALIGN_CENTER"/>
+                </t>
+                <t t-else="">
+                  <t t-call="o-spreadsheet-Icon.ALIGN_LEFT"/>
+                </t>
+                <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
+              </span>
+            </div>
+            <div
+              t-if="state.activeTool === 'alignTool'"
+              class="o-dropdown-content"
+              t-on-click.stop="">
+              <div
+                class="o-dropdown-item o-dropdown-align-item"
+                t-on-click="(ev) => this.toggleAlign('left', ev)">
                 <t t-call="o-spreadsheet-Icon.ALIGN_LEFT"/>
               </div>
-              <div class="o-dropdown-item" t-on-click="(ev) => this.toggleAlign('center', ev)">
+              <div
+                class="o-dropdown-item o-dropdown-align-item"
+                t-on-click="(ev) => this.toggleAlign('center', ev)">
                 <t t-call="o-spreadsheet-Icon.ALIGN_CENTER"/>
               </div>
-              <div class="o-dropdown-item" t-on-click="(ev) => this.toggleAlign('right', ev)">
+              <div
+                class="o-dropdown-item o-dropdown-align-item"
+                t-on-click="(ev) => this.toggleAlign('right', ev)">
                 <t t-call="o-spreadsheet-Icon.ALIGN_RIGHT"/>
               </div>
             </div>

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -149,11 +149,11 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
            .00 
         </div>
         <div
-          class="o-tool o-dropdown"
-          title="More formats"
+          class="o-dropdown"
         >
           <div
-            class="o-text-icon"
+            class="o-tool o-dropdown-button o-text-icon"
+            title="More formats"
           >
              123 
             <svg
@@ -173,11 +173,11 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
           class="o-divider"
         />
         <div
-          class="o-tool o-dropdown"
-          title="Font Size"
+          class="o-dropdown"
         >
           <div
-            class="o-text-icon"
+            class="o-tool o-dropdown-button o-text-icon"
+            title="Font Size"
           >
             10
             <svg
@@ -242,22 +242,26 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
           </svg>
         </div>
         <div
-          class="o-tool o-dropdown o-with-color"
-          title="Text Color"
+          class="o-dropdown"
         >
-          <span
-            style="border-color:#000000"
+          <div
+            class="o-tool o-dropdown-button o-with-color"
+            title="Text Color"
           >
-            <svg
-              class="o-icon"
+            <span
+              style="border-color:#000000"
             >
-              <path
-                d="M7,0 L5,0 L0.5,12 L2.5,12 L3.62,9 L8.37,9 L9.49,12 L11.49,12 L7,0 L7,0 Z M4.38,7 L6,2.67 L7.62,7 L4.38,7 L4.38,7 Z"
-                fill="#000000"
-                transform="translate(3 1)"
-              />
-            </svg>
-          </span>
+              <svg
+                class="o-icon"
+              >
+                <path
+                  d="M7,0 L5,0 L0.5,12 L2.5,12 L3.62,9 L8.37,9 L9.49,12 L11.49,12 L7,0 L7,0 Z M4.38,7 L6,2.67 L7.62,7 L4.38,7 L4.38,7 Z"
+                  fill="#000000"
+                  transform="translate(3 1)"
+                />
+              </svg>
+            </span>
+          </div>
           
           
         </div>
@@ -265,39 +269,47 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
           class="o-divider"
         />
         <div
-          class="o-tool  o-dropdown o-with-color"
-          title="Fill Color"
+          class="o-dropdown "
         >
-          <span
-            style="border-color:#ffffff"
+          <div
+            class="o-tool o-dropdown-button o-with-color"
+            title="Fill Color"
           >
-            <svg
-              class="o-icon"
+            <span
+              style="border-color:#ffffff"
             >
-              <path
-                d="M14.5,8.87 C14.5,8.87 13,10.49 13,11.49 C13,12.32 13.67,12.99 14.5,12.99 C15.33,12.99 16,12.32 16,11.49 C16,10.5 14.5,8.87 14.5,8.87 L14.5,8.87 Z M12.71,6.79 L5.91,0 L4.85,1.06 L6.44,2.65 L2.29,6.79 C1.9,7.18 1.9,7.81 2.29,8.2 L6.79,12.7 C6.99,12.9 7.24,13 7.5,13 C7.76,13 8.01,12.9 8.21,12.71 L12.71,8.21 C13.1,7.82 13.1,7.18 12.71,6.79 L12.71,6.79 Z M4.21,7 L7.5,3.71 L10.79,7 L4.21,7 L4.21,7 Z"
-                fill="#000000"
-              />
-            </svg>
-          </span>
+              <svg
+                class="o-icon"
+              >
+                <path
+                  d="M14.5,8.87 C14.5,8.87 13,10.49 13,11.49 C13,12.32 13.67,12.99 14.5,12.99 C15.33,12.99 16,12.32 16,11.49 C16,10.5 14.5,8.87 14.5,8.87 L14.5,8.87 Z M12.71,6.79 L5.91,0 L4.85,1.06 L6.44,2.65 L2.29,6.79 C1.9,7.18 1.9,7.81 2.29,8.2 L6.79,12.7 C6.99,12.9 7.24,13 7.5,13 C7.76,13 8.01,12.9 8.21,12.71 L12.71,8.21 C13.1,7.82 13.1,7.18 12.71,6.79 L12.71,6.79 Z M4.21,7 L7.5,3.71 L10.79,7 L4.21,7 L4.21,7 Z"
+                  fill="#000000"
+                />
+              </svg>
+            </span>
+          </div>
           
           
         </div>
         <div
-          class="o-tool o-dropdown"
-          title="Borders"
+          class="o-dropdown"
         >
-          <span>
-            <svg
-              class="o-icon"
-            >
-              <path
-                d="M0,0 L0,14 L14,14 L14,0 L0,0 L0,0 Z M6,12 L2,12 L2,8 L6,8 L6,12 L6,12 Z M6,6 L2,6 L2,2 L6,2 L6,6 L6,6 Z M12,12 L8,12 L8,8 L12,8 L12,12 L12,12 Z M12,6 L8,6 L8,2 L12,2 L12,6 L12,6 Z"
-                fill="#000000"
-                transform="translate(2 2)"
-              />
-            </svg>
-          </span>
+          <div
+            class="o-tool o-dropdown-button"
+            title="Borders"
+          >
+            <span>
+              <svg
+                class="o-icon"
+              >
+                <path
+                  d="M0,0 L0,14 L14,14 L14,0 L0,0 L0,0 Z M6,12 L2,12 L2,8 L6,8 L6,12 L6,12 Z M6,6 L2,6 L2,2 L6,2 L6,6 L6,6 Z M12,12 L8,12 L8,8 L12,8 L12,12 L12,12 Z M12,6 L8,6 L8,2 L12,2 L12,6 L12,6 Z"
+                  fill="#000000"
+                  transform="translate(2 2)"
+                />
+              </svg>
+            </span>
+          </div>
           
         </div>
         <div
@@ -317,33 +329,37 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
           class="o-divider"
         />
         <div
-          class="o-tool o-dropdown"
-          title="Horizontal align"
+          class="o-dropdown"
         >
-          <span>
-            
-            
-            <svg
-              class="o-icon align-left"
-            >
-              <path
-                d="M0,14 L10,14 L10,12 L0,12 L0,14 Z M10,4 L0,4 L0,6 L10,6 L10,4 Z M0,0 L0,2 L14,2 L14,0 L0,0 Z M0,10 L14,10 L14,8 L0,8 L0,10 Z"
-                fill="#000000"
-                transform="translate(2 2)"
-              />
-            </svg>
-            
-            <svg
-              class="o-icon"
-            >
-              <polygon
-                fill="#000000"
-                points="0 0 4 4 8 0"
-                transform="translate(5 7)"
-              />
-            </svg>
-            
-          </span>
+          <div
+            class="o-tool o-dropdown-button"
+            title="Horizontal align"
+          >
+            <span>
+              
+              
+              <svg
+                class="o-icon align-left"
+              >
+                <path
+                  d="M0,14 L10,14 L10,12 L0,12 L0,14 Z M10,4 L0,4 L0,6 L10,6 L10,4 Z M0,0 L0,2 L14,2 L14,0 L0,0 Z M0,10 L14,10 L14,8 L0,8 L0,10 Z"
+                  fill="#000000"
+                  transform="translate(2 2)"
+                />
+              </svg>
+              
+              <svg
+                class="o-icon"
+              >
+                <polygon
+                  fill="#000000"
+                  points="0 0 4 4 8 0"
+                  transform="translate(5 7)"
+                />
+              </svg>
+              
+            </span>
+          </div>
           
         </div>
         <div

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -148,11 +148,11 @@ exports[`TopBar component can set cell format 1`] = `
              .00 
           </div>
           <div
-            class="o-tool o-dropdown"
-            title="More formats"
+            class="o-dropdown"
           >
             <div
-              class="o-text-icon"
+              class="o-tool o-dropdown-button o-text-icon"
+              title="More formats"
             >
                123 
               <svg
@@ -170,7 +170,7 @@ exports[`TopBar component can set cell format 1`] = `
               class="o-dropdown-content o-text-options  o-format-tool "
             >
               <div
-                class="active"
+                class="o-dropdown-item active"
                 data-format="automatic"
               >
                 Automatic
@@ -181,6 +181,7 @@ exports[`TopBar component can set cell format 1`] = `
                 </span>
               </div>
               <div
+                class="o-dropdown-item"
                 data-format="number"
               >
                 Number
@@ -191,6 +192,7 @@ exports[`TopBar component can set cell format 1`] = `
                 </span>
               </div>
               <div
+                class="o-dropdown-item"
                 data-format="percent"
               >
                 Percent
@@ -201,6 +203,7 @@ exports[`TopBar component can set cell format 1`] = `
                 </span>
               </div>
               <div
+                class="o-dropdown-item"
                 data-format="currency"
               >
                 Currency
@@ -211,6 +214,7 @@ exports[`TopBar component can set cell format 1`] = `
                 </span>
               </div>
               <div
+                class="o-dropdown-item"
                 data-format="currency_rounded"
               >
                 Currency rounded
@@ -221,6 +225,7 @@ exports[`TopBar component can set cell format 1`] = `
                 </span>
               </div>
               <div
+                class="o-dropdown-item"
                 data-format="date"
               >
                 Date
@@ -231,6 +236,7 @@ exports[`TopBar component can set cell format 1`] = `
                 </span>
               </div>
               <div
+                class="o-dropdown-item"
                 data-format="time"
               >
                 Time
@@ -241,6 +247,7 @@ exports[`TopBar component can set cell format 1`] = `
                 </span>
               </div>
               <div
+                class="o-dropdown-item"
                 data-format="datetime"
               >
                 Date time
@@ -251,6 +258,7 @@ exports[`TopBar component can set cell format 1`] = `
                 </span>
               </div>
               <div
+                class="o-dropdown-item"
                 data-format="duration"
               >
                 Duration
@@ -263,6 +271,7 @@ exports[`TopBar component can set cell format 1`] = `
               
               
               <div
+                class="o-dropdown-item"
                 data-custom="custom_currency"
               >
                 Custom currency
@@ -276,11 +285,11 @@ exports[`TopBar component can set cell format 1`] = `
             class="o-divider"
           />
           <div
-            class="o-tool o-dropdown"
-            title="Font Size"
+            class="o-dropdown"
           >
             <div
-              class="o-text-icon"
+              class="o-tool o-dropdown-button o-text-icon"
+              title="Font Size"
             >
               10
               <svg
@@ -345,22 +354,26 @@ exports[`TopBar component can set cell format 1`] = `
             </svg>
           </div>
           <div
-            class="o-tool o-dropdown o-with-color"
-            title="Text Color"
+            class="o-dropdown"
           >
-            <span
-              style="border-color:#000000"
+            <div
+              class="o-tool o-dropdown-button o-with-color"
+              title="Text Color"
             >
-              <svg
-                class="o-icon"
+              <span
+                style="border-color:#000000"
               >
-                <path
-                  d="M7,0 L5,0 L0.5,12 L2.5,12 L3.62,9 L8.37,9 L9.49,12 L11.49,12 L7,0 L7,0 Z M4.38,7 L6,2.67 L7.62,7 L4.38,7 L4.38,7 Z"
-                  fill="#000000"
-                  transform="translate(3 1)"
-                />
-              </svg>
-            </span>
+                <svg
+                  class="o-icon"
+                >
+                  <path
+                    d="M7,0 L5,0 L0.5,12 L2.5,12 L3.62,9 L8.37,9 L9.49,12 L11.49,12 L7,0 L7,0 Z M4.38,7 L6,2.67 L7.62,7 L4.38,7 L4.38,7 Z"
+                    fill="#000000"
+                    transform="translate(3 1)"
+                  />
+                </svg>
+              </span>
+            </div>
             
             
           </div>
@@ -368,39 +381,47 @@ exports[`TopBar component can set cell format 1`] = `
             class="o-divider"
           />
           <div
-            class="o-tool  o-dropdown o-with-color"
-            title="Fill Color"
+            class="o-dropdown "
           >
-            <span
-              style="border-color:#ffffff"
+            <div
+              class="o-tool o-dropdown-button o-with-color"
+              title="Fill Color"
             >
-              <svg
-                class="o-icon"
+              <span
+                style="border-color:#ffffff"
               >
-                <path
-                  d="M14.5,8.87 C14.5,8.87 13,10.49 13,11.49 C13,12.32 13.67,12.99 14.5,12.99 C15.33,12.99 16,12.32 16,11.49 C16,10.5 14.5,8.87 14.5,8.87 L14.5,8.87 Z M12.71,6.79 L5.91,0 L4.85,1.06 L6.44,2.65 L2.29,6.79 C1.9,7.18 1.9,7.81 2.29,8.2 L6.79,12.7 C6.99,12.9 7.24,13 7.5,13 C7.76,13 8.01,12.9 8.21,12.71 L12.71,8.21 C13.1,7.82 13.1,7.18 12.71,6.79 L12.71,6.79 Z M4.21,7 L7.5,3.71 L10.79,7 L4.21,7 L4.21,7 Z"
-                  fill="#000000"
-                />
-              </svg>
-            </span>
+                <svg
+                  class="o-icon"
+                >
+                  <path
+                    d="M14.5,8.87 C14.5,8.87 13,10.49 13,11.49 C13,12.32 13.67,12.99 14.5,12.99 C15.33,12.99 16,12.32 16,11.49 C16,10.5 14.5,8.87 14.5,8.87 L14.5,8.87 Z M12.71,6.79 L5.91,0 L4.85,1.06 L6.44,2.65 L2.29,6.79 C1.9,7.18 1.9,7.81 2.29,8.2 L6.79,12.7 C6.99,12.9 7.24,13 7.5,13 C7.76,13 8.01,12.9 8.21,12.71 L12.71,8.21 C13.1,7.82 13.1,7.18 12.71,6.79 L12.71,6.79 Z M4.21,7 L7.5,3.71 L10.79,7 L4.21,7 L4.21,7 Z"
+                    fill="#000000"
+                  />
+                </svg>
+              </span>
+            </div>
             
             
           </div>
           <div
-            class="o-tool o-dropdown"
-            title="Borders"
+            class="o-dropdown"
           >
-            <span>
-              <svg
-                class="o-icon"
-              >
-                <path
-                  d="M0,0 L0,14 L14,14 L14,0 L0,0 L0,0 Z M6,12 L2,12 L2,8 L6,8 L6,12 L6,12 Z M6,6 L2,6 L2,2 L6,2 L6,6 L6,6 Z M12,12 L8,12 L8,8 L12,8 L12,12 L12,12 Z M12,6 L8,6 L8,2 L12,2 L12,6 L12,6 Z"
-                  fill="#000000"
-                  transform="translate(2 2)"
-                />
-              </svg>
-            </span>
+            <div
+              class="o-tool o-dropdown-button"
+              title="Borders"
+            >
+              <span>
+                <svg
+                  class="o-icon"
+                >
+                  <path
+                    d="M0,0 L0,14 L14,14 L14,0 L0,0 L0,0 Z M6,12 L2,12 L2,8 L6,8 L6,12 L6,12 Z M6,6 L2,6 L2,2 L6,2 L6,6 L6,6 Z M12,12 L8,12 L8,8 L12,8 L12,12 L12,12 Z M12,6 L8,6 L8,2 L12,2 L12,6 L12,6 Z"
+                    fill="#000000"
+                    transform="translate(2 2)"
+                  />
+                </svg>
+              </span>
+            </div>
             
           </div>
           <div
@@ -420,33 +441,37 @@ exports[`TopBar component can set cell format 1`] = `
             class="o-divider"
           />
           <div
-            class="o-tool o-dropdown"
-            title="Horizontal align"
+            class="o-dropdown"
           >
-            <span>
-              
-              
-              <svg
-                class="o-icon align-left"
-              >
-                <path
-                  d="M0,14 L10,14 L10,12 L0,12 L0,14 Z M10,4 L0,4 L0,6 L10,6 L10,4 Z M0,0 L0,2 L14,2 L14,0 L0,0 Z M0,10 L14,10 L14,8 L0,8 L0,10 Z"
-                  fill="#000000"
-                  transform="translate(2 2)"
-                />
-              </svg>
-              
-              <svg
-                class="o-icon"
-              >
-                <polygon
-                  fill="#000000"
-                  points="0 0 4 4 8 0"
-                  transform="translate(5 7)"
-                />
-              </svg>
-              
-            </span>
+            <div
+              class="o-tool o-dropdown-button"
+              title="Horizontal align"
+            >
+              <span>
+                
+                
+                <svg
+                  class="o-icon align-left"
+                >
+                  <path
+                    d="M0,14 L10,14 L10,12 L0,12 L0,14 Z M10,4 L0,4 L0,6 L10,6 L10,4 Z M0,0 L0,2 L14,2 L14,0 L0,0 Z M0,10 L14,10 L14,8 L0,8 L0,10 Z"
+                    fill="#000000"
+                    transform="translate(2 2)"
+                  />
+                </svg>
+                
+                <svg
+                  class="o-icon"
+                >
+                  <polygon
+                    fill="#000000"
+                    points="0 0 4 4 8 0"
+                    transform="translate(5 7)"
+                  />
+                </svg>
+                
+              </span>
+            </div>
             
           </div>
           <div
@@ -641,11 +666,11 @@ exports[`TopBar component simple rendering 1`] = `
          .00 
       </div>
       <div
-        class="o-tool o-dropdown"
-        title="More formats"
+        class="o-dropdown"
       >
         <div
-          class="o-text-icon"
+          class="o-tool o-dropdown-button o-text-icon"
+          title="More formats"
         >
            123 
           <svg
@@ -665,11 +690,11 @@ exports[`TopBar component simple rendering 1`] = `
         class="o-divider"
       />
       <div
-        class="o-tool o-dropdown"
-        title="Font Size"
+        class="o-dropdown"
       >
         <div
-          class="o-text-icon"
+          class="o-tool o-dropdown-button o-text-icon"
+          title="Font Size"
         >
           10
           <svg
@@ -734,22 +759,26 @@ exports[`TopBar component simple rendering 1`] = `
         </svg>
       </div>
       <div
-        class="o-tool o-dropdown o-with-color"
-        title="Text Color"
+        class="o-dropdown"
       >
-        <span
-          style="border-color:#000000"
+        <div
+          class="o-tool o-dropdown-button o-with-color"
+          title="Text Color"
         >
-          <svg
-            class="o-icon"
+          <span
+            style="border-color:#000000"
           >
-            <path
-              d="M7,0 L5,0 L0.5,12 L2.5,12 L3.62,9 L8.37,9 L9.49,12 L11.49,12 L7,0 L7,0 Z M4.38,7 L6,2.67 L7.62,7 L4.38,7 L4.38,7 Z"
-              fill="#000000"
-              transform="translate(3 1)"
-            />
-          </svg>
-        </span>
+            <svg
+              class="o-icon"
+            >
+              <path
+                d="M7,0 L5,0 L0.5,12 L2.5,12 L3.62,9 L8.37,9 L9.49,12 L11.49,12 L7,0 L7,0 Z M4.38,7 L6,2.67 L7.62,7 L4.38,7 L4.38,7 Z"
+                fill="#000000"
+                transform="translate(3 1)"
+              />
+            </svg>
+          </span>
+        </div>
         
         
       </div>
@@ -757,39 +786,47 @@ exports[`TopBar component simple rendering 1`] = `
         class="o-divider"
       />
       <div
-        class="o-tool  o-dropdown o-with-color"
-        title="Fill Color"
+        class="o-dropdown "
       >
-        <span
-          style="border-color:#ffffff"
+        <div
+          class="o-tool o-dropdown-button o-with-color"
+          title="Fill Color"
         >
-          <svg
-            class="o-icon"
+          <span
+            style="border-color:#ffffff"
           >
-            <path
-              d="M14.5,8.87 C14.5,8.87 13,10.49 13,11.49 C13,12.32 13.67,12.99 14.5,12.99 C15.33,12.99 16,12.32 16,11.49 C16,10.5 14.5,8.87 14.5,8.87 L14.5,8.87 Z M12.71,6.79 L5.91,0 L4.85,1.06 L6.44,2.65 L2.29,6.79 C1.9,7.18 1.9,7.81 2.29,8.2 L6.79,12.7 C6.99,12.9 7.24,13 7.5,13 C7.76,13 8.01,12.9 8.21,12.71 L12.71,8.21 C13.1,7.82 13.1,7.18 12.71,6.79 L12.71,6.79 Z M4.21,7 L7.5,3.71 L10.79,7 L4.21,7 L4.21,7 Z"
-              fill="#000000"
-            />
-          </svg>
-        </span>
+            <svg
+              class="o-icon"
+            >
+              <path
+                d="M14.5,8.87 C14.5,8.87 13,10.49 13,11.49 C13,12.32 13.67,12.99 14.5,12.99 C15.33,12.99 16,12.32 16,11.49 C16,10.5 14.5,8.87 14.5,8.87 L14.5,8.87 Z M12.71,6.79 L5.91,0 L4.85,1.06 L6.44,2.65 L2.29,6.79 C1.9,7.18 1.9,7.81 2.29,8.2 L6.79,12.7 C6.99,12.9 7.24,13 7.5,13 C7.76,13 8.01,12.9 8.21,12.71 L12.71,8.21 C13.1,7.82 13.1,7.18 12.71,6.79 L12.71,6.79 Z M4.21,7 L7.5,3.71 L10.79,7 L4.21,7 L4.21,7 Z"
+                fill="#000000"
+              />
+            </svg>
+          </span>
+        </div>
         
         
       </div>
       <div
-        class="o-tool o-dropdown"
-        title="Borders"
+        class="o-dropdown"
       >
-        <span>
-          <svg
-            class="o-icon"
-          >
-            <path
-              d="M0,0 L0,14 L14,14 L14,0 L0,0 L0,0 Z M6,12 L2,12 L2,8 L6,8 L6,12 L6,12 Z M6,6 L2,6 L2,2 L6,2 L6,6 L6,6 Z M12,12 L8,12 L8,8 L12,8 L12,12 L12,12 Z M12,6 L8,6 L8,2 L12,2 L12,6 L12,6 Z"
-              fill="#000000"
-              transform="translate(2 2)"
-            />
-          </svg>
-        </span>
+        <div
+          class="o-tool o-dropdown-button"
+          title="Borders"
+        >
+          <span>
+            <svg
+              class="o-icon"
+            >
+              <path
+                d="M0,0 L0,14 L14,14 L14,0 L0,0 L0,0 Z M6,12 L2,12 L2,8 L6,8 L6,12 L6,12 Z M6,6 L2,6 L2,2 L6,2 L6,6 L6,6 Z M12,12 L8,12 L8,8 L12,8 L12,12 L12,12 Z M12,6 L8,6 L8,2 L12,2 L12,6 L12,6 Z"
+                fill="#000000"
+                transform="translate(2 2)"
+              />
+            </svg>
+          </span>
+        </div>
         
       </div>
       <div
@@ -809,33 +846,37 @@ exports[`TopBar component simple rendering 1`] = `
         class="o-divider"
       />
       <div
-        class="o-tool o-dropdown"
-        title="Horizontal align"
+        class="o-dropdown"
       >
-        <span>
-          
-          
-          <svg
-            class="o-icon align-left"
-          >
-            <path
-              d="M0,14 L10,14 L10,12 L0,12 L0,14 Z M10,4 L0,4 L0,6 L10,6 L10,4 Z M0,0 L0,2 L14,2 L14,0 L0,0 Z M0,10 L14,10 L14,8 L0,8 L0,10 Z"
-              fill="#000000"
-              transform="translate(2 2)"
-            />
-          </svg>
-          
-          <svg
-            class="o-icon"
-          >
-            <polygon
-              fill="#000000"
-              points="0 0 4 4 8 0"
-              transform="translate(5 7)"
-            />
-          </svg>
-          
-        </span>
+        <div
+          class="o-tool o-dropdown-button"
+          title="Horizontal align"
+        >
+          <span>
+            
+            
+            <svg
+              class="o-icon align-left"
+            >
+              <path
+                d="M0,14 L10,14 L10,12 L0,12 L0,14 Z M10,4 L0,4 L0,6 L10,6 L10,4 Z M0,0 L0,2 L14,2 L14,0 L0,0 Z M0,10 L14,10 L14,8 L0,8 L0,10 Z"
+                fill="#000000"
+                transform="translate(2 2)"
+              />
+            </svg>
+            
+            <svg
+              class="o-icon"
+            >
+              <polygon
+                fill="#000000"
+                points="0 0 4 4 8 0"
+                transform="translate(5 7)"
+              />
+            </svg>
+            
+          </span>
+        </div>
         
       </div>
       <div

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -472,7 +472,7 @@ describe("Composer / selectionInput interactions", () => {
     const gridComposerZIndex = getZIndex("div.o-grid-composer");
     const highlighZIndex = getZIndex(".o-highlight");
 
-    triggerMouseEvent(".o-tool.o-dropdown.o-with-color", "click");
+    triggerMouseEvent(".o-tool.o-dropdown-button.o-with-color", "click");
     await nextTick();
     const colorPickerZIndex = getZIndex("div.o-color-picker");
 


### PR DESCRIPTION
## Description

There was a bug where clicking inside a color picker/border dropdown
closed the dropdown even when clicking between the clickable elements.
Clicking inside the dropdown shouldn't close it.

The dropdown was actually closed by 2 separate mechanisms:

- the dropdown was a child of the tool button that opens/closes the
dropdown. Thus clicking on the dropdown called the click event of the
tool and closed the dropdown.
- the topBar uses a externalListener on clicks, and this closed the
dropdown too.

Fixed the issue by :

1) making the dropdown content a sibling of the button that opens it rather
than a child. This means it won't call the button onClick, and don't inherit
css, like cursor style, from it.
2) stopping the propagation of click events in the dropdown. The onClick
of the items in the dropdown now have the responsibility to close it.

Odoo task ID : [2937081](https://www.odoo.com/web#id=2937081&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo