### PR TITLE
[IMP] figures: border design improvements

### DIFF
--- a/src/components/figures/container/container.ts
+++ b/src/components/figures/container/container.ts
@@ -1,5 +1,9 @@
 import { Component, onMounted, useState } from "@odoo/owl";
-import { ComponentsImportance, SELECTION_BORDER_COLOR } from "../../../constants";
+import {
+  ComponentsImportance,
+  FIGURE_BORDER_COLOR,
+  SELECTION_BORDER_COLOR,
+} from "../../../constants";
 import { figureRegistry } from "../../../registries/index";
 import { Figure, SpreadsheetChildEnv, UID } from "../../../types/index";
 import { css } from "../../helpers/css";
@@ -26,7 +30,6 @@ css/*SCSS*/ `
   }
 
   div.o-figure {
-    border: 1px solid black;
     box-sizing: border-box;
     position: absolute;
     bottom: 3px;
@@ -136,14 +139,17 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 
-  getDims(info: FigureInfo) {
+  getFigureStyle(info: FigureInfo) {
     const { figure, isSelected } = info;
     const borders = 2 * (isSelected ? ACTIVE_BORDER_WIDTH : BORDER_WIDTH);
     const { width, height } = isSelected && this.dnd.figureId ? this.dnd : figure;
-    return `width:${width + borders}px;height:${height + borders}px`;
+
+    const borderStyle =
+      this.env.isDashboard() || isSelected ? "" : `1px solid ${FIGURE_BORDER_COLOR}`;
+    return `width:${width + borders}px;height:${height + borders}px; border: ${borderStyle};`;
   }
 
-  getStyle(info: FigureInfo) {
+  getWrapperStyle(info: FigureInfo) {
     const { figure, isSelected } = info;
     const { offsetX, offsetY } = this.env.model.getters.getActiveViewport();
     const target = figure.id === (isSelected && this.dnd.figureId) ? this.dnd : figure;
@@ -164,7 +170,7 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
       ANCHOR_SIZE + ACTIVE_BORDER_WIDTH + (isSelected ? ACTIVE_BORDER_WIDTH : BORDER_WIDTH);
     return `position:absolute; top:${y + 1}px; left:${x + 1}px; width:${
       width - correctionX + offset
-    }px; height:${height - correctionY + offset}px`;
+    }px; height:${height - correctionY + offset}px;`;
   }
 
   setup() {

--- a/src/components/figures/container/container.xml
+++ b/src/components/figures/container/container.xml
@@ -4,12 +4,12 @@
       <t t-foreach="getVisibleFigures()" t-as="info" t-key="info.id">
         <div
           class="o-figure-wrapper"
-          t-att-style="getStyle(info)"
+          t-att-style="getWrapperStyle(info)"
           t-on-mousedown.stop="(ev) => this.onMouseDown(info.figure, ev)">
           <div
             class="o-figure"
             t-att-class="{active: info.isSelected, 'o-dragging': info.id === dnd.figureId}"
-            t-att-style="getDims(info)"
+            t-att-style="getFigureStyle(info)"
             tabindex="0"
             t-on-keydown.stop="(ev) => this.onKeyDown(info.figure, ev)"
             t-on-keyup.stop="">

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -3,8 +3,8 @@
     <div
       class="o-chart-container"
       t-ref="chartContainer"
-      t-on-contextmenu.prevent.stop="onContextMenu">
-      <div class="o-chart-menu">
+      t-on-contextmenu.prevent.stop="(ev) => !env.isDashboard() and this.onContextMenu(ev)">
+      <div class="o-chart-menu" t-if="!env.isDashboard()">
         <div
           class="o-chart-menu-item"
           t-on-click="showMenu"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const BACKGROUND_HEADER_COLOR = "#F8F9FA";
 export const BACKGROUND_HEADER_SELECTED_COLOR = "#E8EAED";
 export const BACKGROUND_HEADER_ACTIVE_COLOR = "#595959";
 export const TEXT_HEADER_COLOR = "#666666";
+export const FIGURE_BORDER_COLOR = "#c9ccd2";
 export const SELECTION_BORDER_COLOR = "#3266ca";
 export const HEADER_BORDER_COLOR = "#C0C0C0";
 export const CELL_BORDER_COLOR = "#E2E3E3";

--- a/src/helpers/charts/bar_chart.ts
+++ b/src/helpers/charts/bar_chart.ts
@@ -211,7 +211,7 @@ function getBarConfiguration(chart: BarChart, labels: string[]): ChartConfigurat
   } else {
     legend.position = chart.legendPosition;
   }
-  config.options!.legend = legend;
+  config.options!.legend = { ...config.options?.legend, ...legend };
   config.options!.layout = {
     padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
   };

--- a/src/helpers/charts/chart_ui_common.ts
+++ b/src/helpers/charts/chart_ui_common.ts
@@ -99,6 +99,11 @@ export function getDefaultChartJsRuntime(
         text: chart.title,
         fontColor,
       },
+      legend: {
+        // Disable default legend onClick (show/hide dataset), to allow us to set a global onClick on the chart container.
+        // If we want to re-enable this in the future, we need to override the default onClick to stop the event propagation
+        onClick: undefined,
+      },
     },
     data: {
       labels: labels.map(truncateLabel),

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -285,7 +285,7 @@ function getLineConfiguration(chart: LineChart, labels: string[]): ChartConfigur
   } else {
     legend.position = chart.legendPosition;
   }
-  config.options!.legend = legend;
+  config.options!.legend = { ...config.options?.legend, ...legend };
   config.options!.layout = {
     padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
   };

--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -209,7 +209,7 @@ function getPieConfiguration(chart: PieChart, labels: string[]): ChartConfigurat
   } else {
     legend.position = chart.legendPosition;
   }
-  config.options!.legend = legend;
+  config.options!.legend = { ...config.options?.legend, ...legend };
   config.options!.layout = {
     padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
   };

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Scorecard charts Scorecard snapshot 1`] = `
 <div
   class="o-figure"
-  style="width:538px;height:337px"
+  style="width:538px;height:337px; border: 1px solid #c9ccd2;"
   tabindex="0"
 >
   <div
@@ -40,6 +40,7 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
         </svg>
       </div>
     </div>
+    
     <div
       class="o-scorecard"
       style="

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -183,6 +183,17 @@ describe("figures", () => {
   );
 
   test.each(["basicChart", "scorecard", "gauge"])(
+    "charts don't have a menu button in dashboard mode",
+    async (chartType: string) => {
+      createTestChart(chartType);
+      model.updateMode("dashboard");
+      await nextTick();
+      expect(fixture.querySelector(".o-figure")).not.toBeNull();
+      expect(fixture.querySelector(".o-chart-menu-item")).toBeNull();
+    }
+  );
+
+  test.each(["basicChart", "scorecard", "gauge"])(
     "Click on Menu button open context menu in %s",
     async (chartType: string) => {
       createTestChart(chartType);
@@ -563,6 +574,19 @@ describe("figures", () => {
       triggerMouseEvent(".o-chart-container", "contextmenu");
       await nextTick();
       expect(document.querySelectorAll(".o-menu").length).toBe(1);
+    }
+  );
+
+  test.each(["basicChart", "scorecard", "gauge"])(
+    "Cannot open context menu on right click in dashboard mode",
+    async (chartType: string) => {
+      createTestChart(chartType);
+      model.updateMode("dashboard");
+      await nextTick();
+
+      triggerMouseEvent(".o-chart-container", "contextmenu");
+      await nextTick();
+      expect(document.querySelector(".o-menu")).toBeFalsy();
     }
   );
 

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -209,6 +209,18 @@ describe("figures", () => {
     expect(figure.classList).not.toContain("o-dragging");
   });
 
+  test("Figure border disabled on dashboard mode", async () => {
+    const figureId = "someuuid";
+    createFigure(model, { id: figureId, y: 200 });
+    await nextTick();
+    const figure = fixture.querySelector(".o-figure")! as HTMLElement;
+    expect(window.getComputedStyle(figure).border).toBeTruthy();
+
+    model.updateMode("dashboard");
+    await nextTick();
+    expect(figure.style.border).toBeFalsy();
+  });
+
   test("Figures are cropped to avoid overlap with headers", async () => {
     const figureId = "someuuid";
     createFigure(model, { id: figureId, x: 100, y: 20, height: 200, width: 100 });

--- a/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
@@ -66,6 +66,7 @@ Object {
         "labels": Object {
           "fontColor": "#FFFFFF",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -174,6 +175,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -289,6 +291,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -378,6 +381,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -468,6 +472,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -571,6 +576,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -674,6 +680,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -754,6 +761,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -857,6 +865,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -960,6 +969,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,
@@ -1063,6 +1073,7 @@ Object {
         "labels": Object {
           "fontColor": "#000000",
         },
+        "onClick": undefined,
         "position": "top",
       },
       "maintainAspectRatio": false,

--- a/tests/plugins/chart/__snapshots__/gauge_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/gauge_chart.test.ts.snap
@@ -46,6 +46,9 @@ Object {
           "top": 10,
         },
       },
+      "legend": Object {
+        "onClick": undefined,
+      },
       "maintainAspectRatio": false,
       "needle": Object {
         "color": "#000000",
@@ -128,6 +131,9 @@ Object {
           "right": 30,
           "top": 25,
         },
+      },
+      "legend": Object {
+        "onClick": undefined,
       },
       "maintainAspectRatio": false,
       "needle": Object {


### PR DESCRIPTION
## Description

Change figure border color to a light gray instead of black.
Disable figure border and chart menu button on dashboard mode.

Also disable default onClick of legends in chartJS (hide/unhide datasets).
This allow us to define a onClick on the chart container without having
to worry whether the chart or the legend was clicked.

Fix some details for figures in dashboard mode:
- disable figure border
- hide chart menu button
- disable context menu on right click

Odoo task ID : [2947461](https://www.odoo.com/web#id=2947461&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo