### PR TITLE
[FIX] color scale: wrong color border in side panel

### DIFF
--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -415,10 +415,10 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
       const minColor = colorNumberString(rule.minimum.color);
       const midColor = rule.midpoint ? colorNumberString(rule.midpoint.color) : null;
       const maxColor = colorNumberString(rule.maximum.color);
-      const baseString = "background-image: linear-gradient(to right, #";
+      const baseString = "background-image: linear-gradient(to right, ";
       return midColor
-        ? baseString + minColor + ", #" + midColor + ", #" + maxColor + ")"
-        : baseString + minColor + ", #" + maxColor + ")";
+        ? baseString + minColor + ", " + midColor + ", " + maxColor + ")"
+        : baseString + minColor + ", " + maxColor + ")";
     }
     return "";
   }
@@ -681,10 +681,10 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
     const minColor = colorNumberString(rule.minimum.color);
     const midColor = colorNumberString(rule.midpoint?.color || DEFAULT_COLOR_SCALE_MIDPOINT_COLOR);
     const maxColor = colorNumberString(rule.maximum.color);
-    const baseString = "background-image: linear-gradient(to right, #";
+    const baseString = "background-image: linear-gradient(to right, ";
     return rule.midpoint === undefined
-      ? baseString + minColor + ", #" + maxColor + ")"
-      : baseString + minColor + ", #" + midColor + ", #" + maxColor + ")";
+      ? baseString + minColor + ", " + maxColor + ")"
+      : baseString + minColor + ", " + midColor + ", " + maxColor + ")";
   }
 
   getThresholdColor(threshold?: ColorScaleThreshold) {

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -20,10 +20,10 @@ export const colors = [
 ];
 
 /*
- * transform a color number (R * 256^2 + G * 256 + B) into classic RGB
+ * transform a color number (R * 256^2 + G * 256 + B) into classic hex6 value
  * */
 export function colorNumberString(color: number): Color {
-  return color.toString(16).padStart(6, "0");
+  return toHex(color.toString(16).padStart(6, "0"));
 }
 
 let colorIndex = 0;

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -328,7 +328,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
           }
           if (!computedStyle[col]) computedStyle[col] = [];
           computedStyle[col][row] = computedStyle[col]?.[row] || {};
-          computedStyle[col][row]!.fillColor = "#" + colorNumberString(color);
+          computedStyle[col][row]!.fillColor = colorNumberString(color);
         }
       }
     }

--- a/src/xlsx/functions/conditional_formatting.ts
+++ b/src/xlsx/functions/conditional_formatting.ts
@@ -12,6 +12,7 @@ import {
 } from "../../types";
 import { ExcelIconSet, XLSXDxf, XMLAttributes, XMLString } from "../../types/xlsx";
 import { XLSX_ICONSET_MAP } from "../constants";
+import { toXlsxHexColor } from "../helpers/colors";
 import { convertOperator, pushElement } from "../helpers/content_helpers";
 import { escapeXml, formatAttributes, joinXmlNodes } from "../helpers/xml_helpers";
 import { adaptFormulaToExcel } from "./cells";
@@ -160,7 +161,7 @@ function addColorScaleRule(cf: ConditionalFormat, rule: ColorScaleRule): XMLStri
       }
 
       cfValueObject.push(thresholdAttributes(threshold, position));
-      colors.push([["rgb", colorNumberString(threshold.color)]]);
+      colors.push([["rgb", toXlsxHexColor(colorNumberString(threshold.color))]]);
     }
     if (!canExport) {
       console.warn(

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -8712,8 +8712,8 @@ Object {
             <colorScale>
                 <cfvo type=\\"min\\"/>
                 <cfvo type=\\"max\\"/>
-                <color rgb=\\"ffffff\\"/>
-                <color rgb=\\"ff0000\\"/>
+                <color rgb=\\"FFFFFF\\"/>
+                <color rgb=\\"FF0000\\"/>
             </colorScale>
         </cfRule>
     </conditionalFormatting>
@@ -8722,8 +8722,8 @@ Object {
             <colorScale>
                 <cfvo type=\\"percent\\" val=\\"12\\"/>
                 <cfvo type=\\"percent\\" val=\\"80\\"/>
-                <color rgb=\\"ffffff\\"/>
-                <color rgb=\\"ff0000\\"/>
+                <color rgb=\\"FFFFFF\\"/>
+                <color rgb=\\"FF0000\\"/>
             </colorScale>
         </cfRule>
     </conditionalFormatting>
@@ -8733,9 +8733,9 @@ Object {
                 <cfvo type=\\"min\\"/>
                 <cfvo type=\\"percent\\" val=\\"12\\"/>
                 <cfvo type=\\"max\\"/>
-                <color rgb=\\"ffffff\\"/>
-                <color rgb=\\"33ff33\\"/>
-                <color rgb=\\"ff0000\\"/>
+                <color rgb=\\"FFFFFF\\"/>
+                <color rgb=\\"33FF33\\"/>
+                <color rgb=\\"FF0000\\"/>
             </colorScale>
         </cfRule>
     </conditionalFormatting>

--- a/tests/components/__snapshots__/conditional_formatting.test.ts.snap
+++ b/tests/components/__snapshots__/conditional_formatting.test.ts.snap
@@ -90,7 +90,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
             
             <div
               class="o-cf-preview-image"
-              style="background-image: linear-gradient(to right, #ff00ff, #123456)"
+              style="background-image: linear-gradient(to right, #FF00FF, #123456)"
             >
               123
             </div>

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -1874,16 +1874,16 @@ describe("conditional formats types", () => {
       });
 
       expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
-        fillColor: "#ff00ff",
+        fillColor: "#FF00FF",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
-        fillColor: "#e705ee",
+        fillColor: "#E705EE",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toEqual({
         fillColor: "#592489",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A4"))).toEqual({
-        fillColor: "#2a2f67",
+        fillColor: "#2A2F67",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A5"))).toEqual({
         fillColor: "#123456",
@@ -1908,16 +1908,16 @@ describe("conditional formats types", () => {
       });
 
       expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
-        fillColor: "#ff00ff",
+        fillColor: "#FF00FF",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
-        fillColor: "#e705ee",
+        fillColor: "#E705EE",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toEqual({
         fillColor: "#592489",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A4"))).toEqual({
-        fillColor: "#2a2f67",
+        fillColor: "#2A2F67",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A5"))).toEqual({
         fillColor: "#123456",
@@ -1942,16 +1942,16 @@ describe("conditional formats types", () => {
       });
 
       expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
-        fillColor: "#ff00ff",
+        fillColor: "#FF00FF",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
-        fillColor: "#e705ee",
+        fillColor: "#E705EE",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toEqual({
         fillColor: "#592489",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A4"))).toEqual({
-        fillColor: "#2a2f67",
+        fillColor: "#2A2F67",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A5"))).toEqual({
         fillColor: "#123456",
@@ -1977,10 +1977,10 @@ describe("conditional formats types", () => {
         fillColor: "#808000",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
-        fillColor: "#ff0000",
+        fillColor: "#FF0000",
       });
       expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toEqual({
-        fillColor: "#00ff00",
+        fillColor: "#00FF00",
       });
     });
 
@@ -2031,7 +2031,7 @@ describe("conditional formats types", () => {
       });
       expect(model.getters.getConditionalStyle(0, 0)).toEqual({ fillColor: "#123456" });
       expect(model.getters.getConditionalStyle(0, 1)).toEqual(undefined);
-      expect(model.getters.getConditionalStyle(0, 2)).toEqual({ fillColor: "#ff00ff" });
+      expect(model.getters.getConditionalStyle(0, 2)).toEqual({ fillColor: "#FF00FF" });
     });
   });
 });


### PR DESCRIPTION
## Description

The border below the ColorPickers in the color scale edit side panel
weren't correctly displayed in Odoo. The border was always black.

This is because we put the colors as `RRGGBB` in the CSS instead of
`#RRGGBB`, which is wrong but for some reason works in `o_spreadsheet`.

This happens because the helper `colorNumberString()` returns a color
code without the `#`, which is very error prone since we need to add it
by hand every time we called the function.

Now the helper `colorNumberString()` return a valid color HEX code.

Odoo task ID : [2937049](https://www.odoo.com/web#id=2937049&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo