### PR TITLE
[IMP] Format: add unit parameter to LARGE_NUMBER_FORMAT

### DIFF
--- a/src/functions/module_custom.ts
+++ b/src/functions/module_custom.ts
@@ -11,11 +11,25 @@ export const FORMAT_LARGE_NUMBER: AddFunctionDescription = {
   description: _lt(`Apply a large number format`),
   args: args(`
       value (number) ${_lt("The number.")}
+      unit (string, optional) ${_lt("The formatting unit. Use 'k', 'm', or 'b' to force the unit")}
     `),
   returns: ["NUMBER"],
-  computeFormat: (arg: PrimitiveArg) => {
+  computeFormat: (arg: PrimitiveArg, unit: PrimitiveArg | undefined) => {
     const value = Math.abs(toNumber(arg.value));
     const format = arg.format;
+    if (unit !== undefined) {
+      const postFix = unit?.value;
+      switch (postFix) {
+        case "k":
+          return createLargeNumberFormat(format, 1e3, "k");
+        case "m":
+          return createLargeNumberFormat(format, 1e6, "m");
+        case "b":
+          return createLargeNumberFormat(format, 1e9, "b");
+        default:
+          throw new Error(_lt("The formatting unit should be 'k', 'm' or 'b'."));
+      }
+    }
     if (value < 1e5) {
       return format || "#,##0";
     } else if (value < 1e8) {

--- a/tests/functions/module_custom.test.ts
+++ b/tests/functions/module_custom.test.ts
@@ -75,4 +75,44 @@ describe("FORMAT.LARGE.NUMBER formula", () => {
       })
     ).toBe("01/01/5022");
   });
+
+  test("formatting units are taken into account", () => {
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100, "k")' })).toBe("0k");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(1000, "k")' })).toBe("1k");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000, "k")' })).toBe("10k");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100000, "k")' })).toBe("100k");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(1000000, "k")' })).toBe("1,000k");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000000, "k")' })).toBe("10,000k");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100000000, "k")' })).toBe("100,000k");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(1000000000, "k")' })).toBe(
+      "1,000,000k"
+    );
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000000000, "k")' })).toBe(
+      "10,000,000k"
+    );
+
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100, "m")' })).toBe("0m");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(1000, "m")' })).toBe("0m");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000, "m")' })).toBe("0m");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100000, "m")' })).toBe("0m");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(1000000, "m")' })).toBe("1m");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000000, "m")' })).toBe("10m");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100000000, "m")' })).toBe("100m");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(1000000000, "m")' })).toBe("1,000m");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000000000, "m")' })).toBe(
+      "10,000m"
+    );
+
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100, "b")' })).toBe("0b");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(1000, "b")' })).toBe("0b");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000, "b")' })).toBe("0b");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100000, "b")' })).toBe("0b");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(1000000, "b")' })).toBe("0b");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000000, "b")' })).toBe("0b");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100000000, "b")' })).toBe("0b");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(1000000000, "b")' })).toBe("1b");
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(10000000000, "b")' })).toBe("10b");
+
+    expect(evaluateCellText("A1", { A1: '=FORMAT.LARGE.NUMBER(100, "something")' })).toBe("#ERROR");
+  });
 });


### PR DESCRIPTION
### Task Description:

The aim of this task is to add a new 'unit' parameter to the
LARGE.NUMBER.FORMAT function, in order to let the user choose the
formatting he want.
The available value are 'k', 'm' and 'b' (ie the same as the formating)
and, when no option are passed, we use the "ancient" way to induce the
correct representation, as it was done before.

### Odoo task ID : [2947398](https://www.odoo.com/web#id=2947398&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo