### PR TITLE
[IMP] menu: keep menu highlighted when submenu is opened

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -53,7 +53,8 @@ css/* scss */ `
       }
 
       &:not(.disabled) {
-        &:hover {
+        &:hover,
+        &.o-menu-item-active {
           background-color: #ebebeb;
         }
         .o-menu-item-description {
@@ -84,6 +85,7 @@ interface Props {
 
 export interface MenuState {
   isOpen: boolean;
+  parentMenu?: FullMenuItem;
   position: null | DOMCoordinates;
   scrollOffset?: Pixel;
   menuItems: FullMenuItem[];
@@ -110,7 +112,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     useExternalListener(window, "contextmenu", this.onContextMenu);
     onWillUpdateProps((nextProps: Props) => {
       if (nextProps.menuItems !== this.props.menuItems) {
-        this.subMenu.isOpen = false;
+        this.closeSubMenu();
       }
     });
   }
@@ -154,7 +156,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private close() {
-    this.subMenu.isOpen = false;
+    this.closeSubMenu();
     this.props.onClose();
   }
 
@@ -182,7 +184,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     if (el && isChildEvent(el, ev)) {
       return;
     }
-    this.subMenu.isOpen = false;
+    this.closeSubMenu();
   }
 
   /**
@@ -229,6 +231,12 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     };
     this.subMenu.menuItems = getMenuChildren(menu, this.env);
     this.subMenu.isOpen = true;
+    this.subMenu.parentMenu = menu;
+  }
+
+  closeSubMenu() {
+    this.subMenu.isOpen = false;
+    this.subMenu.parentMenu = undefined;
   }
 
   onClickMenu(menu: FullMenuItem, position: Pixel) {
@@ -246,7 +254,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
       if (this.isRoot(menu)) {
         this.openSubMenu(menu, position);
       } else {
-        this.subMenu.isOpen = false;
+        this.closeSubMenu();
       }
     }
   }

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -24,7 +24,7 @@
             t-on-click="() => this.onClickMenu(menuItem, menuItem_index)"
             t-on-mouseover="() => this.onMouseOver(menuItem, menuItem_index)"
             class="o-menu-item"
-            t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled}"
+            t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': subMenu.parentMenu === menuItem}"
             t-att-style="getColor(menuItem)">
             <span class="o-menu-item-name" t-esc="getName(menuItem)"/>
             <span

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -114,7 +114,8 @@ css/* scss */ `
           cursor: pointer;
         }
 
-        .o-topbar-menu:hover {
+        .o-topbar-menu:hover,
+        .o-topbar-menu-active {
           background-color: #f1f3f4;
           border-radius: 2px;
         }
@@ -363,6 +364,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
     this.state.menuState.menuItems = getMenuChildren(menu, this.env).filter(
       (item) => !item.isVisible || item.isVisible(this.env)
     );
+    this.state.menuState.parentMenu = menu;
     this.isSelectingMenu = true;
     this.openedEl = ev.target as HTMLElement;
   }
@@ -370,6 +372,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   closeMenus() {
     this.state.activeTool = "";
     this.state.menuState.isOpen = false;
+    this.state.menuState.parentMenu = undefined;
     this.isSelectingMenu = false;
     this.openedEl = null;
   }

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -8,6 +8,7 @@
             <div
               t-if="menu.children.length !== 0"
               class="o-topbar-menu"
+              t-att-class="{'o-topbar-menu-active': state.menuState.parentMenu and state.menuState.parentMenu.id === menu.id}"
               t-on-click="(ev) => this.toggleContextMenu(menu, ev)"
               t-on-mouseover="(ev) => this.onMenuMouseOver(menu, ev)"
               t-att-data-id="menu.id">

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -355,6 +355,18 @@ describe("Context Menu", () => {
     expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
   });
 
+  test("Submenu parent is highlighted", async () => {
+    await renderContextMenu(300, 300, { menuItems: cellMenuRegistry.getAll() });
+    const menuItem = fixture.querySelector(".o-menu div[data-name='paste_special']");
+    expect(menuItem?.classList).not.toContain("o-menu-item-active");
+    triggerMouseEvent(menuItem, "mouseover");
+    await nextTick();
+    expect(menuItem?.classList).toContain("o-menu-item-active");
+    triggerMouseEvent(".o-menu div[data-name='paste_value_only']", "mouseover");
+    await nextTick();
+    expect(menuItem?.classList).toContain("o-menu-item-active");
+  });
+
   test("submenu does not open when disabled", async () => {
     const menuItems: FullMenuItem[] = [
       createFullMenuItem("root", {

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -371,6 +371,17 @@ describe("TopBar component", () => {
     app.destroy();
   });
 
+  test("Opened menu parent is highlighted", async () => {
+    const { app } = await mountParent();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
+    const menuItem = fixture.querySelector(".o-topbar-menu[data-id='file']");
+    expect(menuItem?.classList).not.toContain("o-topbar-menu-active");
+    triggerMouseEvent(menuItem, "click");
+    await nextTick();
+    expect(menuItem?.classList).toContain("o-topbar-menu-active");
+    app.destroy();
+  });
+
   test("Can add a custom component to topbar", async () => {
     const compDefinitions = Object.assign({}, topbarComponentRegistry.content);
     class Comp extends Component {


### PR DESCRIPTION
## Description

This commit makes the parent menu item highlighted whenever its submenu
is opened, on the topbar and on the context menu.

Odoo task ID : [2862750](https://www.odoo.com/web#id=2862750&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo