### PR TITLE
[FIX] evaluation: formula cell evaluated.value as null

### DIFF
--- a/src/functions/module_database.ts
+++ b/src/functions/module_database.ts
@@ -3,9 +3,9 @@ import {
   AddFunctionDescription,
   ArgValue,
   CellValue,
+  FunctionReturnValue,
   MatrixArgValue,
   PrimitiveArgValue,
-  ReturnValue,
 } from "../types";
 import { args } from "./arguments";
 import { assert, toString, visitMatchingRanges } from "./helpers";
@@ -216,7 +216,7 @@ export const DGET: AddFunctionDescription = {
     database: MatrixArgValue,
     field: PrimitiveArgValue,
     criteria: MatrixArgValue
-  ): ReturnValue {
+  ): FunctionReturnValue {
     const cells = getMatchingCells(database, field, criteria);
     assert(() => cells.length === 1, _lt("More than one match found in DGET evaluation."));
     return cells[0];

--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -1,5 +1,5 @@
 import { _lt } from "../translation";
-import { AddFunctionDescription, ArgValue, PrimitiveArgValue, ReturnValue } from "../types";
+import { AddFunctionDescription, ArgValue, FunctionReturnValue, PrimitiveArgValue } from "../types";
 import { args } from "./arguments";
 import { assert, conditionalVisitBoolean, toBoolean } from "./helpers";
 
@@ -52,7 +52,7 @@ export const IF: AddFunctionDescription = {
     logicalExpression: PrimitiveArgValue,
     valueIfTrue: () => PrimitiveArgValue,
     valueIfFalse: () => PrimitiveArgValue = () => false
-  ): ReturnValue {
+  ): FunctionReturnValue {
     const result = toBoolean(logicalExpression) ? valueIfTrue() : valueIfFalse();
     return result === null || result === undefined ? "" : result;
   },
@@ -74,7 +74,7 @@ export const IFERROR: AddFunctionDescription = {
   compute: function (
     value: () => PrimitiveArgValue,
     valueIfError: () => PrimitiveArgValue = () => ""
-  ): ReturnValue {
+  ): FunctionReturnValue {
     let result;
     try {
       result = value();
@@ -104,7 +104,7 @@ export const IFS: AddFunctionDescription = {
       )}
   `),
   returns: ["ANY"],
-  compute: function (...values: (() => PrimitiveArgValue)[]): ReturnValue {
+  compute: function (...values: (() => PrimitiveArgValue)[]): FunctionReturnValue {
     assert(
       () => values.length % 2 === 0,
       _lt(`Wrong number of arguments. Expected an even number of arguments.`)

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -3,9 +3,9 @@ import { _lt } from "../translation";
 import {
   AddFunctionDescription,
   CellValue,
+  FunctionReturnValue,
   MatrixArgValue,
   PrimitiveArgValue,
-  ReturnValue,
 } from "../types";
 import { args } from "./arguments";
 import {
@@ -103,7 +103,7 @@ export const HLOOKUP: AddFunctionDescription = {
     range: MatrixArgValue,
     index: PrimitiveArgValue,
     isSorted: PrimitiveArgValue = DEFAULT_IS_SORTED
-  ): ReturnValue {
+  ): FunctionReturnValue {
     const _index = Math.trunc(toNumber(index));
     assert(
       () => 1 <= _index && _index <= range[0].length,
@@ -124,7 +124,7 @@ export const HLOOKUP: AddFunctionDescription = {
       _lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
     );
 
-    return range[colIndex][_index - 1] as ReturnValue;
+    return range[colIndex][_index - 1] as FunctionReturnValue;
   },
   isExported: true,
 };
@@ -149,7 +149,7 @@ export const LOOKUP: AddFunctionDescription = {
     searchKey: PrimitiveArgValue,
     searchArray: MatrixArgValue,
     resultRange: MatrixArgValue | undefined
-  ): ReturnValue {
+  ): FunctionReturnValue {
     let nbCol = searchArray.length;
     let nbRow = searchArray[0].length;
 
@@ -164,7 +164,7 @@ export const LOOKUP: AddFunctionDescription = {
     if (resultRange === undefined) {
       return (
         verticalSearch ? searchArray[nbCol - 1][index] : searchArray[index][nbRow - 1]
-      ) as ReturnValue;
+      ) as FunctionReturnValue;
     }
 
     nbCol = resultRange.length;
@@ -179,7 +179,7 @@ export const LOOKUP: AddFunctionDescription = {
         () => index <= nbCol - 1,
         _lt("[[FUNCTION_NAME]] evaluates to an out of range row value %s.", (index + 1).toString())
       );
-      return resultRange[index][0] as ReturnValue;
+      return resultRange[index][0] as FunctionReturnValue;
     }
 
     assert(
@@ -187,7 +187,7 @@ export const LOOKUP: AddFunctionDescription = {
       _lt("[[FUNCTION_NAME]] evaluates to an out of range column value %s.", (index + 1).toString())
     );
 
-    return resultRange[0][index] as ReturnValue;
+    return resultRange[0][index] as FunctionReturnValue;
   },
   isExported: true,
 };
@@ -308,7 +308,7 @@ export const VLOOKUP: AddFunctionDescription = {
     range: MatrixArgValue,
     index: PrimitiveArgValue,
     isSorted: PrimitiveArgValue = DEFAULT_IS_SORTED
-  ): ReturnValue {
+  ): FunctionReturnValue {
     const _index = Math.trunc(toNumber(index));
     assert(
       () => 1 <= _index && _index <= range.length,
@@ -329,7 +329,7 @@ export const VLOOKUP: AddFunctionDescription = {
       _lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
     );
 
-    return range[_index - 1][rowIndex] as ReturnValue;
+    return range[_index - 1][rowIndex] as FunctionReturnValue;
   },
   isExported: true,
 };

--- a/src/functions/module_operators.ts
+++ b/src/functions/module_operators.ts
@@ -1,5 +1,10 @@
 import { _lt } from "../translation";
-import { AddFunctionDescription, PrimitiveArg, PrimitiveArgValue, ReturnValue } from "../types";
+import {
+  AddFunctionDescription,
+  FunctionReturnValue,
+  PrimitiveArg,
+  PrimitiveArgValue,
+} from "../types";
 import { args } from "./arguments";
 import { assert, toNumber, toString } from "./helpers";
 import { POWER } from "./module_math";
@@ -276,7 +281,7 @@ export const UPLUS: AddFunctionDescription = {
     `),
   returns: ["ANY"],
   computeFormat: (value: PrimitiveArg) => value?.format,
-  compute: function (value: PrimitiveArgValue): ReturnValue {
+  compute: function (value: PrimitiveArgValue): FunctionReturnValue {
     return value === null ? "" : value;
   },
 };

--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -259,7 +259,7 @@ export class FormulaCell extends AbstractCell implements IFormulaCell {
     return true;
   }
 
-  assignEvaluation(value: CellValue, format: Format) {
+  assignEvaluation(value: CellValue | null, format: Format) {
     switch (typeof value) {
       case "number":
         this.evaluated = {
@@ -282,21 +282,11 @@ export class FormulaCell extends AbstractCell implements IFormulaCell {
           type: CellValueType.text,
         };
         break;
-      // `null` and `undefined` values are not allowed according to `CellValue`
-      // but it actually happens with empty evaluated cells.
-      // TODO fix `CellValue`
       case "object": // null
         this.evaluated = {
-          value,
+          value: 0,
           format,
-          type: CellValueType.empty,
-        };
-        break;
-      case "undefined":
-        this.evaluated = {
-          value,
-          format,
-          type: CellValueType.empty,
+          type: CellValueType.number,
         };
         break;
     }

--- a/src/types/cells.ts
+++ b/src/types/cells.ts
@@ -1,7 +1,7 @@
 import { SpreadsheetChildEnv } from "./env";
 import { EvaluationError } from "./errors";
 import { Format, FormattedValue } from "./format";
-import { CompiledFormula, Link, ReturnValue, Style, UID } from "./misc";
+import { CompiledFormula, Link, Style, UID } from "./misc";
 import { Range } from "./range";
 
 export type Cell = ICell | FormulaCell;
@@ -37,7 +37,7 @@ export interface ICell {
 }
 
 export interface FormulaCell extends ICell {
-  assignEvaluation: (value: ReturnValue, format?: Format) => void;
+  assignEvaluation: (value: CellValue | null, format?: Format) => void;
   assignError: (value: string, error: EvaluationError) => void;
   readonly normalizedText: string;
   readonly compiledFormula: CompiledFormula;

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -1,5 +1,5 @@
 import { Format } from "./format";
-import { Arg, ArgValue, ReturnValue } from "./misc";
+import { Arg, ArgValue, FunctionReturnValue } from "./misc";
 
 export type ArgType =
   | "ANY"
@@ -30,7 +30,7 @@ export type ComputeFunction<T, R> = (this: EvalContext, ...args: ComputeFunction
 
 export interface AddFunctionDescription {
   description: string;
-  compute: ComputeFunction<ArgValue, ReturnValue>;
+  compute: ComputeFunction<ArgValue, FunctionReturnValue>;
   computeFormat?: ComputeFunction<Arg, Format | undefined>;
   category?: string;
   args: ArgDefinition[];

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -146,7 +146,7 @@ export type _CompiledFormula = (
   refFn: ReferenceDenormalizer,
   range: EnsureRange,
   ctx: {}
-) => FunctionReturn;
+) => FormulaReturn;
 
 export interface CompiledFormula {
   execute: _CompiledFormula;
@@ -162,8 +162,12 @@ export type ArgValue = PrimitiveArgValue | MatrixArgValue;
 export type MatrixArgValue = (CellValue | undefined)[][];
 export type PrimitiveArgValue = string | number | boolean | null;
 
-export type FunctionReturn = { value: ReturnValue; format?: Format };
-export type ReturnValue = string | number | boolean;
+export type FunctionReturn = { value: FunctionReturnValue; format?: Format };
+interface FormulaReturn extends Omit<FunctionReturn, "value"> {
+  value: FunctionReturnValue | null; // Formulas can return a cell value that can be null for empty cells
+  format?: Format;
+}
+export type FunctionReturnValue = string | number | boolean;
 
 export interface ClipboardCell {
   cell?: Cell;

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -417,7 +417,7 @@ describe("BottomBar component", () => {
 
     selectCell(model, "A3");
     await nextTick();
-    expect(fixture.querySelector(".o-selection-statistic")).toBeFalsy();
+    expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Sum: 0");
     app.destroy();
   });
 

--- a/tests/functions/functions.test.ts
+++ b/tests/functions/functions.test.ts
@@ -6,9 +6,9 @@ import {
   ArgValue,
   ComputeFunction,
   Format,
+  FunctionReturnValue,
   PrimitiveArg,
   PrimitiveArgValue,
-  ReturnValue,
 } from "../../src/types";
 import { setCellContent, setCellFormat } from "../test_helpers/commands_helpers";
 import { getCell } from "../test_helpers/getters_helpers";
@@ -23,7 +23,7 @@ describe("functions", () => {
     expect(val).toBe("#BAD_EXPR");
     functionRegistry.add("DOUBLEDOUBLE", {
       description: "Double the first argument",
-      compute: ((arg: number) => 2 * arg) as ComputeFunction<ArgValue, ReturnValue>,
+      compute: ((arg: number) => 2 * arg) as ComputeFunction<ArgValue, FunctionReturnValue>,
       args: args(`number (number) my number`),
       returns: ["NUMBER"],
     });
@@ -50,7 +50,7 @@ describe("functions", () => {
       description: "return value depending on input value",
       compute: function (arg: PrimitiveArgValue) {
         return toNumber(arg) * 2;
-      } as ComputeFunction<ArgValue, ReturnValue>,
+      } as ComputeFunction<ArgValue, FunctionReturnValue>,
       args: args(`number (number) blabla`),
       returns: ["NUMBER"],
     });
@@ -71,7 +71,7 @@ describe("functions", () => {
       } as ComputeFunction<Arg, Format | undefined>,
       compute: function (arg: PrimitiveArgValue) {
         return arg;
-      } as ComputeFunction<ArgValue, ReturnValue>,
+      } as ComputeFunction<ArgValue, FunctionReturnValue>,
       args: args(`number (number) blabla`),
       returns: ["NUMBER"],
     });
@@ -94,7 +94,7 @@ describe("functions", () => {
       } as ComputeFunction<Arg, Format | undefined>,
       compute: function (arg: PrimitiveArgValue) {
         return arg;
-      } as ComputeFunction<ArgValue, ReturnValue>,
+      } as ComputeFunction<ArgValue, FunctionReturnValue>,
       args: args(`number (number) blabla`),
       returns: ["NUMBER"],
     });

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -223,6 +223,26 @@ describe("datasource tests", function () {
     expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
   });
 
+  test("create chart dataset of one cell referencing an empty cell", () => {
+    setCellContent(model, "A1", "");
+    setCellContent(model, "B1", "=A1");
+    createChart(
+      model,
+      {
+        dataSets: ["B1"],
+        dataSetsHaveTitle: false,
+        type: "line",
+      },
+      "1"
+    );
+    expect(model.getters.getChartDefinition("1")).toMatchObject({
+      dataSets: ["B1"],
+      type: "line",
+    });
+    const runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
+    expect(runtime.chartJsConfig.data?.datasets?.[0].data).toEqual([0]);
+  });
+
   test("create a chart with stacked bar", () => {
     createChart(
       model,
@@ -1570,7 +1590,7 @@ describe("Chart evaluation", () => {
     expect(
       (model.getters.getChartRuntime("1") as BarChartRuntime).chartJsConfig.data!.datasets![0]!
         .data![0]
-    ).toBeNull();
+    ).toBe(0);
     setCellContent(model, "C3", "1");
     expect(
       (model.getters.getChartRuntime("1") as BarChartRuntime).chartJsConfig.data!.datasets![0]!

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -1481,6 +1481,24 @@ describe("conditional formats types", () => {
     }
   );
 
+  test("CF with cell referencing empty cell is treated as zero", () => {
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: {
+        rule: {
+          values: ["0"],
+          operator: "Equal",
+          type: "CellIsRule",
+          style: { fillColor: "#FF0FFF" },
+        },
+        id: "11",
+      },
+      ranges: toRangesData(sheetId, "A1"),
+      sheetId,
+    });
+    setCellContent(model, "A1", "=B1");
+    expect(model.getters.getConditionalStyle(0, 0, sheetId)).toEqual({ fillColor: "#FF0FFF" });
+  });
+
   describe("Icon set", () => {
     describe.each(["", "aaaa", "=SUM(1, 2)"])(
       "dispatch is not allowed if value is not a number",

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -61,9 +61,8 @@ describe("core", () => {
         setAnchorCorner(model, "A7");
         let statisticFnResults = model.getters.getStatisticFnResults();
         expect(statisticFnResults["Sum"]).toBe(66);
-        // select the range A3:A7
-        selectCell(model, "A3");
-        setAnchorCorner(model, "A7");
+
+        selectCell(model, "A7");
         statisticFnResults = model.getters.getStatisticFnResults();
         expect(statisticFnResults["Sum"]).toBe(undefined);
       });
@@ -73,10 +72,9 @@ describe("core", () => {
         selectCell(model, "A1");
         setAnchorCorner(model, "A7");
         let statisticFnResults = model.getters.getStatisticFnResults();
-        expect(statisticFnResults["Avg"]).toBe(33);
-        // select the range A3:A7
-        selectCell(model, "A3");
-        setAnchorCorner(model, "A7");
+        expect(statisticFnResults["Avg"]).toBe(22);
+
+        selectCell(model, "A7");
         statisticFnResults = model.getters.getStatisticFnResults();
         expect(statisticFnResults["Avg"]).toBe(undefined);
       });
@@ -86,10 +84,9 @@ describe("core", () => {
         selectCell(model, "A1");
         setAnchorCorner(model, "A7");
         let statisticFnResults = model.getters.getStatisticFnResults();
-        expect(statisticFnResults["Min"]).toBe(24);
-        // select the range A3:A7
-        selectCell(model, "A3");
-        setAnchorCorner(model, "A7");
+        expect(statisticFnResults["Min"]).toBe(0);
+
+        selectCell(model, "A7");
         statisticFnResults = model.getters.getStatisticFnResults();
         expect(statisticFnResults["Min"]).toBe(undefined);
       });
@@ -100,9 +97,8 @@ describe("core", () => {
         setAnchorCorner(model, "A7");
         let statisticFnResults = model.getters.getStatisticFnResults();
         expect(statisticFnResults["Max"]).toBe(42);
-        // select the range A3:A7
-        selectCell(model, "A3");
-        setAnchorCorner(model, "A7");
+
+        selectCell(model, "A7");
         statisticFnResults = model.getters.getStatisticFnResults();
         expect(statisticFnResults["Max"]).toBe(undefined);
       });
@@ -112,10 +108,9 @@ describe("core", () => {
         selectCell(model, "A1");
         setAnchorCorner(model, "A7");
         let statisticFnResults = model.getters.getStatisticFnResults();
-        expect(statisticFnResults["Count"]).toBe(5);
-        // select the range A6:A7
-        selectCell(model, "A6");
-        setAnchorCorner(model, "A7");
+        expect(statisticFnResults["Count"]).toBe(6);
+
+        selectCell(model, "A7");
         statisticFnResults = model.getters.getStatisticFnResults();
         expect(statisticFnResults["Count"]).toBe(undefined);
       });
@@ -145,7 +140,7 @@ describe("core", () => {
         selectCell(model, "A6");
         setAnchorCorner(model, "A7");
         statisticFnResults = model.getters.getStatisticFnResults();
-        expect(statisticFnResults["Count"]).toBe(undefined);
+        expect(statisticFnResults["Count"]).toBe(1);
       });
     });
 

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -4,9 +4,9 @@ import {
   ArgValue,
   CellValueType,
   ComputeFunction,
+  FunctionReturnValue,
   InvalidEvaluation,
   MatrixArgValue,
-  ReturnValue,
 } from "../../src/types";
 import {
   activateSheet,
@@ -244,7 +244,7 @@ describe("evaluateCells", () => {
       description: "any function",
       compute: ((range: MatrixArgValue) => range.flat().length) as ComputeFunction<
         ArgValue,
-        ReturnValue
+        FunctionReturnValue
       >,
       args: [{ name: "range", description: "", type: ["RANGE"] }],
       returns: ["NUMBER"],
@@ -960,7 +960,7 @@ describe("evaluateCells", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A2", "=A1");
-    expect(getCell(model, "A2")!.evaluated.value).toBe(null);
+    expect(getCell(model, "A2")!.evaluated.value).toBe(0);
     model.dispatch("SET_FORMATTING", {
       sheetId,
       target: target("A1"),
@@ -970,7 +970,7 @@ describe("evaluateCells", () => {
     });
     setCellContent(model, "A12", "this re-evaluates cells");
     expect(getCellContent(model, "A2")).toBe("0");
-    expect(getCell(model, "A2")!.evaluated.value).toBe(null);
+    expect(getCell(model, "A2")!.evaluated.value).toBe(0);
   });
 
   test("evaluation follows dependencies", () => {

--- a/tests/plugins/formatting.test.ts
+++ b/tests/plugins/formatting.test.ts
@@ -16,9 +16,9 @@ import {
   CommandResult,
   ComputeFunction,
   Format,
+  FunctionReturnValue,
   PrimitiveArg,
   PrimitiveArgValue,
-  ReturnValue,
   SetDecimalStep,
   UID,
 } from "../../src/types";
@@ -181,7 +181,7 @@ describe("formatting values (with formatters)", () => {
       `),
       compute: function (value: PrimitiveArgValue, format: PrimitiveArgValue) {
         return value || 0;
-      } as ComputeFunction<ArgValue, ReturnValue>,
+      } as ComputeFunction<ArgValue, FunctionReturnValue>,
       computeFormat: function (value: PrimitiveArg, format: PrimitiveArg) {
         return toString(format.value);
       } as ComputeFunction<Arg, Format>,

--- a/tests/plugins/history.test.ts
+++ b/tests/plugins/history.test.ts
@@ -246,7 +246,7 @@ describe("Model history", () => {
     setCellContent(model, "A2", "11");
     expect(getCell(model, "A1")!.evaluated.value).toBe(11);
     undo(model);
-    expect(getCell(model, "A1")!.evaluated.value).toBe(null);
+    expect(getCell(model, "A1")!.evaluated.value).toBe(0);
     redo(model);
     expect(getCell(model, "A1")!.evaluated.value).toBe(11);
   });


### PR DESCRIPTION
## Description

Before this, it was possible that the evaluated.value of a formula cell
was null. This happened if the formula was a simple reference to an
empty cell. The evaluated value was thus null, but the formatted value
was "0". This lead to a discrepancy between what the user see (a "0"),
and the internal value of null.

This was problematic for example when evaluating CFs, the user see a
cell "0", but internally it's null thus not matching a CF "equal 0".

This commit make it so formula cells cannot have an empty evaluated value.
If the formula return "null", it's converted to 0.

Odoo task ID : [2867122](https://www.odoo.com/web#id=2867122&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo