### PR TITLE
[FIX] figures: positions are not wysiwyg

### DIFF
--- a/src/components/figures/container/container.xml
+++ b/src/components/figures/container/container.xml
@@ -2,59 +2,68 @@
   <t t-name="o-spreadsheet-FiguresContainer" owl="1">
     <div>
       <t t-foreach="getVisibleFigures()" t-as="info" t-key="info.id">
-        <div
-          class="o-figure-wrapper"
-          t-att-style="getWrapperStyle(info)"
-          t-on-mousedown.stop="(ev) => this.onMouseDown(info.figure, ev)">
+        <div class="o-figure-container" t-att-style="getContainerStyle(info)">
           <div
-            class="o-figure"
-            t-att-class="{active: info.isSelected, 'o-dragging': info.id === dnd.figureId}"
-            t-att-style="getFigureStyle(info)"
-            tabindex="0"
-            t-on-keydown.stop="(ev) => this.onKeyDown(info.figure, ev)"
-            t-on-keyup.stop="">
-            <t
-              t-component="figureRegistry.get(info.figure.tag).Component"
-              t-key="info.id"
-              sidePanelIsOpen="props.sidePanelIsOpen"
-              onFigureDeleted="props.onFigureDeleted"
-              figure="info.figure"
-            />
-            <t t-if="info.isSelected">
-              <div
-                class="o-anchor o-top"
-                t-on-mousedown.stop="(ev) => this.resize(info.figure, 0,-1, ev)"
+            class="o-figure-wrapper"
+            t-on-mousedown.stop="(ev) => this.onMouseDown(info.figure, ev)">
+            <div
+              class="o-figure"
+              t-att-style="getFigureStyle(info)"
+              t-att-class="{active: info.isSelected, 'o-dragging': info.id === dnd.figureId}"
+              tabindex="0"
+              t-on-keydown.stop="(ev) => this.onKeyDown(info.figure, ev)"
+              t-on-keyup.stop="">
+              <t
+                t-component="figureRegistry.get(info.figure.tag).Component"
+                t-key="info.id"
+                sidePanelIsOpen="props.sidePanelIsOpen"
+                onFigureDeleted="props.onFigureDeleted"
+                figure="info.figure"
               />
-              <div
-                class="o-anchor o-topRight"
-                t-on-mousedown.stop="(ev) => this.resize(info.figure, 1,-1, ev)"
-              />
-              <div
-                class="o-anchor o-right"
-                t-on-mousedown.stop="(ev) => this.resize(info.figure, 1,0, ev)"
-              />
-              <div
-                class="o-anchor o-bottomRight"
-                t-on-mousedown.stop="(ev) => this.resize(info.figure, 1,1, ev)"
-              />
-              <div
-                class="o-anchor o-bottom"
-                t-on-mousedown.stop="(ev) => this.resize(info.figure, 0,1, ev)"
-              />
-              <div
-                class="o-anchor o-bottomLeft"
-                t-on-mousedown.stop="(ev) => this.resize(info.figure, -1,1, ev)"
-              />
-              <div
-                class="o-anchor o-left"
-                t-on-mousedown.stop="(ev) => this.resize(info.figure, -1,0, ev)"
-              />
-              <div
-                class="o-anchor o-topLeft"
-                t-on-mousedown.stop="(ev) => this.resize(info.figure, -1,-1, ev)"
-              />
-            </t>
+            </div>
           </div>
+          <t t-if="info.isSelected">
+            <div
+              class="o-anchor o-top"
+              t-att-style="this.getAnchorPosition('top', info)"
+              t-on-mousedown.stop="(ev) => this.resize(info.figure, 0,-1, ev)"
+            />
+            <div
+              class="o-anchor o-topRight"
+              t-att-style="this.getAnchorPosition('top right', info)"
+              t-on-mousedown.stop="(ev) => this.resize(info.figure, 1,-1, ev)"
+            />
+            <div
+              class="o-anchor o-right"
+              t-att-style="this.getAnchorPosition('right', info)"
+              t-on-mousedown.stop="(ev) => this.resize(info.figure, 1,0, ev)"
+            />
+            <div
+              class="o-anchor o-bottomRight"
+              t-att-style="this.getAnchorPosition('bottom right', info)"
+              t-on-mousedown.stop="(ev) => this.resize(info.figure, 1,1, ev)"
+            />
+            <div
+              class="o-anchor o-bottom"
+              t-att-style="this.getAnchorPosition('bottom', info)"
+              t-on-mousedown.stop="(ev) => this.resize(info.figure, 0,1, ev)"
+            />
+            <div
+              class="o-anchor o-bottomLeft"
+              t-att-style="this.getAnchorPosition('bottom left', info)"
+              t-on-mousedown.stop="(ev) => this.resize(info.figure, -1,1, ev)"
+            />
+            <div
+              class="o-anchor o-left"
+              t-att-style="this.getAnchorPosition('left', info)"
+              t-on-mousedown.stop="(ev) => this.resize(info.figure, -1,0, ev)"
+            />
+            <div
+              class="o-anchor o-topLeft"
+              t-att-style="this.getAnchorPosition('top left', info)"
+              t-on-mousedown.stop="(ev) => this.resize(info.figure, -1,-1, ev)"
+            />
+          </t>
         </div>
       </t>
     </div>

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Scorecard charts Scorecard snapshot 1`] = `
 <div
   class="o-figure"
-  style="width:538px;height:337px; border: 1px solid #c9ccd2;"
+  style="width:536px;height:335px;border-width: 1px;"
   tabindex="0"
 >
   <div
@@ -127,7 +127,5 @@ color: #757575;
     
     
   </div>
-  
-  
 </div>
 `;

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -214,27 +214,31 @@ describe("figures", () => {
     createFigure(model, { id: figureId, y: 200 });
     await nextTick();
     const figure = fixture.querySelector(".o-figure")! as HTMLElement;
-    expect(window.getComputedStyle(figure).border).toBeTruthy();
+    expect(window.getComputedStyle(figure)["border-width"]).toEqual("1px");
 
     model.updateMode("dashboard");
     await nextTick();
-    expect(figure.style.border).toBeFalsy();
+    expect(window.getComputedStyle(figure)["border-width"]).toEqual("0px");
   });
 
   test("Figures are cropped to avoid overlap with headers", async () => {
     const figureId = "someuuid";
     createFigure(model, { id: figureId, x: 100, y: 20, height: 200, width: 100 });
     await nextTick();
-    const figure = fixture.querySelector(".o-figure-wrapper")!;
-    expect(window.getComputedStyle(figure).width).toBe("111px"); // width + borders
-    expect(window.getComputedStyle(figure).height).toBe("211px"); // height + borders
+    const figure = fixture.querySelector(".o-figure-container")!;
+    expect(window.getComputedStyle(figure).width).toBe("102px"); // width + borders
+    expect(window.getComputedStyle(figure).height).toBe("202px"); // height + borders
     model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: 2 * DEFAULT_CELL_WIDTH,
       offsetY: 3 * DEFAULT_CELL_HEIGHT,
     });
     await nextTick();
-    expect(window.getComputedStyle(figure).width).toBe("18px"); // width + borders - 2 * DEFAULT_CELL_WIDTH
-    expect(window.getComputedStyle(figure).height).toBe("161px"); // height + offset - 2 * DEFAULT_CELL_WIDTH
+
+    const expectedWidth = 102 - (2 * DEFAULT_CELL_WIDTH - 100); // = width + borders - (overflow = viewport offset X - x)
+    const expectedHeight = 202 - (3 * DEFAULT_CELL_HEIGHT - 20); // = height + borders - (overflow = viewport offset Y - y)
+
+    expect(window.getComputedStyle(figure).width).toBe(`${expectedWidth}px`);
+    expect(window.getComputedStyle(figure).height).toBe(`${expectedHeight}px`);
   });
 
   test("Selected figure isn't removed by scroll", async () => {


### PR DESCRIPTION
## Description

We had a problem where the figures position was (0;0), but the figures
were clearly not displayed in (0;0).

This happened because of a CSS `left:3px;top:3px;` in the figures. This
was added because of the bad structure of the figure wrapper HTML :
the wrapper had `overflow:hidden` to avoid having the figure overlapping
with the headers. At the same time, the anchors to move the figure were
naturally overflowing beyond the figure border, so the solution to display
them was to have an offset of 3px to always be able to display them
without overflow.

The fixed structure of the container is (Bottom-Up):

- o-figure: this div contains the actual chart. It has a fixed size
that don't depend on the scroll offset, and its overflow will be cut by
its parent. The borders need to go on this div to be cut with the chart.

- o-figure-wrapper: wraps the figure to avoid overflows. Has the same
size as its parent.

- o-figure-container: root element that contains the wrapper and the
anchors. We resize and shift it to only display the visible part of the
figure (with regard to the scroll offset).  We need an additional offset
to move it when the figure is selected since the border of o-figure
changes size. The div allows overflows to display the anchors correctly.

Odoo task ID : [2543173](https://www.odoo.com/web#id=2543173&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo