### PR TITLE
[FIX] chart panel: black color picker border

### DIFF
--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../../constants";
+import {
+  BACKGROUND_CHART_COLOR,
+  DEFAULT_FIGURE_HEIGHT,
+  DEFAULT_FIGURE_WIDTH,
+} from "../../constants";
 import { numberToLetters, zoneToXc } from "../../helpers/index";
 import { interactiveSortSelection } from "../../helpers/sort";
 import { interactiveCut } from "../../helpers/ui/cut";
@@ -599,6 +603,7 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
       dataSets,
       labelRange,
       type: "bar",
+      background: BACKGROUND_CHART_COLOR,
       stackedBar: false,
       dataSetsHaveTitle,
       verticalAxisPosition: "left",

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -13,6 +13,7 @@ import {
 import { getMenuChildren } from "../src/registries/menus/helpers";
 import { SpreadsheetChildEnv } from "../src/types";
 import {
+  BACKGROUND_CHART_COLOR,
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
   DEFAULT_FIGURE_HEIGHT,
@@ -985,6 +986,7 @@ describe("Menu Item actions", () => {
         sheetId: model.getters.getActiveSheetId(),
         definition: {
           dataSets: ["A1"],
+          background: BACKGROUND_CHART_COLOR,
           dataSetsHaveTitle: false,
           labelRange: undefined,
           legendPosition: "none",


### PR DESCRIPTION
## Description:

Earlier it was not given a default border color for chart background
in chart definition, so to fix it while creating a chart it's default
background color from our predined constants is passed.

Odoo task ID : [2951428](https://www.odoo.com/web#id=2951428&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo