### PR TITLE
[FIX] selection: allow to select columns/rows inside a merge

### DIFF
--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -390,12 +390,7 @@ export class SelectionStreamProcessor
    * be processed.
    */
   private processEvent(newAnchorEvent: Omit<SelectionEvent, "previousAnchor">): DispatchResult {
-    const sheetId = this.getters.getActiveSheetId();
-    const previousAnchor: AnchorZone = deepCopy({
-      cell: this.anchor.cell,
-      zone: this.getters.expandZone(sheetId, this.anchor.zone),
-    });
-    const event = { ...newAnchorEvent, previousAnchor };
+    const event = { ...newAnchorEvent, previousAnchor: deepCopy(this.anchor) };
     const commandResult = this.checkEventAnchorZone(event);
     if (commandResult !== CommandResult.Success) {
       return new DispatchResult(commandResult);

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -14,6 +14,7 @@ import { Model } from "../../src/model";
 import {
   hideColumns,
   hideRows,
+  merge,
   redo,
   resizeRows,
   setCellContent,
@@ -1121,5 +1122,23 @@ describe("move selected element(s)", () => {
       expect(getCell(model, "A3")!.evaluated.value).toBe("a3");
       expect(getCell(model, "A4")!.evaluated.value).toBe("a4");
     });
+  });
+
+  test("Can select a column within a merge", async () => {
+    merge(model, "B1:C1");
+    await selectColumn("A");
+    await selectColumn("B", { shiftKey: true });
+    expect(model.getters.getActiveCols()).toEqual(new Set([0, 1]));
+    await selectColumn("C", { shiftKey: true });
+    expect(model.getters.getActiveCols()).toEqual(new Set([0, 1, 2]));
+  });
+
+  test("Can select a row within a merge", async () => {
+    merge(model, "B2:B3");
+    await selectRow(0);
+    await selectRow(1, { shiftKey: true });
+    expect(model.getters.getActiveRows()).toEqual(new Set([0, 1]));
+    await selectRow(2, { shiftKey: true });
+    expect(model.getters.getActiveRows()).toEqual(new Set([0, 1, 2]));
   });
 });


### PR DESCRIPTION
Since 93644c4b5d6102dcfe22845f4ac95a6707ef0d34, the selection was blocked
while selecting a column/row inside a merge.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo