### PR TITLE
[REF] chart: remove side panel type from state

### DIFF
--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -43,7 +43,6 @@ interface Props {
 }
 
 interface State {
-  type: ChartType;
   panel: "configuration" | "design";
 }
 
@@ -58,7 +57,6 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
 
   setup(): void {
     this.state = useState({
-      type: this.getChartDefinition().type,
       panel: "configuration",
     });
 
@@ -66,9 +64,6 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
       if (!this.env.model.getters.isChartDefined(nextProps.figureId)) {
         this.props.onCloseSidePanel();
         return;
-      }
-      if (nextProps.figureId !== this.figureId) {
-        this.state.type = this.getChartDefinition(nextProps.figureId).type;
       }
     });
   }
@@ -96,7 +91,6 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
       id: this.figureId,
       sheetId: this.env.model.getters.getActiveSheetId(),
     });
-    this.state.type = type;
   }
 
   get chartPanel(): ChartSidePanel {

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
@@ -24,7 +24,6 @@
           <div class="o-section-title">Chart type</div>
           <t t-set="types" t-value="chartTypes"/>
           <select
-            t-att-value="state.type"
             class="o-input o-type-selector"
             t-on-change="(ev) => this.onTypeChange(ev.target.value)">
             <option
@@ -33,7 +32,7 @@
               t-key="type"
               t-att-value="type"
               t-esc="types[type]"
-              t-att-selected="state.type === type"
+              t-att-selected="definition.type === type"
             />
           </select>
         </div>
@@ -42,7 +41,7 @@
           definition="definition"
           figureId="figureId"
           updateChart.bind="updateChart"
-          t-key="figureId + state.type"
+          t-key="figureId + definition.type"
         />
       </t>
       <t t-else="">
@@ -51,7 +50,7 @@
           definition="definition"
           figureId="figureId"
           updateChart.bind="updateChart"
-          t-key="figureId + state.type"
+          t-key="figureId + definition.type"
         />
       </t>
     </div>


### PR DESCRIPTION
The `type` in the side panel state is useless and error prone (it must be
kept in-sync with the actual chart type, there's no "single source of truth").
This commit removes it from the state.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo