### PR TITLE
[REF] format: don't use formatter for integers

### DIFF
--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -197,6 +197,10 @@ function splitNumber(
   value: number,
   maxDecimals: number = MAX_DECIMAL_PLACES
 ): { integerDigits: string; decimalDigits: string | undefined } {
+  // don't use the formatter if it's an integer for performance reasons
+  if (Number.isInteger(value)) {
+    return { integerDigits: value.toString(), decimalDigits: undefined };
+  }
   let formatter = numberRepresentation[maxDecimals];
   if (!formatter) {
     formatter = new Intl.NumberFormat("en-US", {


### PR DESCRIPTION
Using `Intl.NumberFormat` to format the number seems slow.
When loading the large numbe data set, `splitNumber` takes up to 400ms

With this optimisation, `slipNumber` is ~90% faster for integers
and there's no noticable difference for floats.

Loading the large number data set is ~15% faster.
Rendering should also be slightly faster, but not by much since
we only render (format) a few cells.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo