### PR TITLE
[FIX] formulas: `FORMAT.LARGE.NUMBER` format purges decimals

### DIFF
--- a/src/functions/module_custom.ts
+++ b/src/functions/module_custom.ts
@@ -31,7 +31,7 @@ export const FORMAT_LARGE_NUMBER: AddFunctionDescription = {
       }
     }
     if (value < 1e5) {
-      return format || "#,##0";
+      return createLargeNumberFormat(format, 0, "");
     } else if (value < 1e8) {
       return createLargeNumberFormat(format, 1e3, "k");
     } else if (value < 1e11) {

--- a/tests/functions/module_custom.test.ts
+++ b/tests/functions/module_custom.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../src";
-import { setCellContent } from "../test_helpers/commands_helpers";
+import { setCellContent, setCellFormat } from "../test_helpers/commands_helpers";
 import { getCellContent, getCellError } from "../test_helpers/getters_helpers";
 import { evaluateCellText } from "../test_helpers/helpers";
 
@@ -46,6 +46,20 @@ describe("FORMAT.LARGE.NUMBER formula", () => {
     expect(evaluateCellText("A1", { A1: `=FORMAT.LARGE.NUMBER("100000")` })).toBe("100k");
   });
 
+  test("Result does not contain decimals", () => {
+    // < 100k
+    const model = new Model();
+    setCellContent(model, "A1", "100.60");
+    setCellFormat(model, "A1", "#,000.00");
+    setCellContent(model, "A2", "=FORMAT.LARGE.NUMBER(A1)");
+    expect(getCellContent(model, "A2")).toBe("101");
+    // < 100m
+    expect(evaluateCellText("A1", { A1: "=FORMAT.LARGE.NUMBER(100000.60)" })).toBe("100k");
+    // < 100b
+    expect(evaluateCellText("A1", { A1: "=FORMAT.LARGE.NUMBER(100000000.60)" })).toBe("100m");
+    // >= 100b
+    expect(evaluateCellText("A1", { A1: "=FORMAT.LARGE.NUMBER(100000000000.60)" })).toBe("100b");
+  });
   test("not a number", () => {
     const model = new Model();
     setCellContent(model, "A1", `=FORMAT.LARGE.NUMBER("a string")`);


### PR DESCRIPTION
Task 2954506

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2954506](https://www.odoo.com/web#id=2954506&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo