### PR TITLE
[FIX] scorecard: use up-to-date cell evaluation

### DIFF
--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -20,6 +20,7 @@ import {
   ScorecardChartRuntime,
 } from "../../types/chart/scorecard_chart";
 import { Validator } from "../../types/validator";
+import { FormulaCell } from "../cells";
 import { createRange } from "../range";
 import { rangeReference } from "../references";
 import { toUnboundedZone, zoneToXc } from "../zones";
@@ -199,8 +200,17 @@ function createScorecardChartRuntime(
   if (chart.keyValue) {
     const keyValueZone = chart.keyValue.zone;
     keyValueCell = getters.getCell(chart.keyValue.sheetId, keyValueZone.left, keyValueZone.top);
-    keyValue = keyValueCell?.evaluated.value ? String(keyValueCell?.evaluated.value) : "";
-    formattedKeyValue = keyValueCell?.formattedValue || "";
+    if (keyValueCell instanceof FormulaCell) {
+      const { value, formattedValue } = getters.evaluateFormula(
+        keyValueCell.content,
+        chart.keyValue.sheetId
+      );
+      keyValue = String(value);
+      formattedKeyValue = formattedValue;
+    } else {
+      keyValue = keyValueCell?.evaluated.value ? String(keyValueCell?.evaluated.value) : "";
+      formattedKeyValue = keyValueCell?.formattedValue || "";
+    }
   }
   let baselineCell: Cell | undefined;
   if (chart.baseline) {

--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -1,6 +1,6 @@
 import { compile } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { intersection, isZoneValid, toXC, zoneToXc } from "../../helpers/index";
+import { formatValue, intersection, isZoneValid, toXC, zoneToXc } from "../../helpers/index";
 import { ModelConfig } from "../../model";
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
 import { StateObserver } from "../../state_observer";
@@ -95,7 +95,7 @@ export class EvaluationPlugin extends UIPlugin {
   // Getters
   // ---------------------------------------------------------------------------
 
-  evaluateFormula(formulaString: string, sheetId: UID = this.getters.getActiveSheetId()): any {
+  evaluateFormula(formulaString: string, sheetId: UID = this.getters.getActiveSheetId()) {
     const compiledFormula = compile(formulaString);
     const params = this.getCompilationParameters(() => {});
 
@@ -103,7 +103,12 @@ export class EvaluationPlugin extends UIPlugin {
     for (let xc of compiledFormula.dependencies) {
       ranges.push(this.getters.getRangeFromSheetXC(sheetId, xc));
     }
-    return compiledFormula.execute(ranges, ...params).value;
+    const { format, value } = compiledFormula.execute(ranges, ...params);
+    return {
+      format,
+      value,
+      formattedValue: value ? formatValue(value, format) : "",
+    };
   }
 
   /**

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -180,8 +180,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       case "percentile":
         return percentile(rangeValues, Number(threshold.value) / 100, true);
       case "formula":
-        const value = threshold.value && this.getters.evaluateFormula(threshold.value);
-        return !(value instanceof Promise) ? value : null;
+        return threshold.value ? Number(this.getters.evaluateFormula(threshold.value).value) : null;
       default:
         return null;
     }

--- a/tests/plugins/chart/scoreboard_chart.test.ts
+++ b/tests/plugins/chart/scoreboard_chart.test.ts
@@ -7,6 +7,7 @@ import {
   addColumns,
   createScorecardChart,
   createSheet,
+  createSheetWithName,
   deleteSheet,
   redo,
   setCellContent,
@@ -149,6 +150,36 @@ describe("datasource tests", function () {
       "1"
     );
     expect(result).toBeCancelledBecause(CommandResult.InvalidScorecardBaseline);
+  });
+
+  test("Scoreboard chart with formula on another sheet is correctly loaded", () => {
+    createSheetWithName(model, { sheetId: "sheet2" }, "Sheet2");
+    setCellContent(model, "A1", "=1", "sheet2");
+    createScorecardChart(
+      model,
+      {
+        keyValue: "Sheet2!A1",
+      },
+      "1"
+    );
+    const getRuntime = () => model.getters.getChartRuntime("1") as ScorecardChartRuntime;
+    expect(getRuntime().keyValue).toBe("1");
+  });
+
+  test("Scoreboard chart with formula on another sheet is correctly updated", () => {
+    createSheetWithName(model, { sheetId: "sheet2" }, "Sheet2");
+    setCellContent(model, "A1", "1", "sheet2");
+    createScorecardChart(
+      model,
+      {
+        keyValue: "Sheet2!A1",
+      },
+      "1"
+    );
+    const getRuntime = () => model.getters.getChartRuntime("1") as ScorecardChartRuntime;
+    expect(getRuntime().keyValue).toBe("1");
+    setCellContent(model, "A1", "=2", "sheet2");
+    expect(getRuntime().keyValue).toBe("2");
   });
 
   test("Scorecard Chart is deleted on sheet deletion", () => {

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -1037,14 +1037,14 @@ describe("evaluate formula getter", () => {
 
   test("a ref in the current sheet", () => {
     setCellContent(model, "A1", "12");
-    expect(model.getters.evaluateFormula("=A1")).toBe(12);
+    expect(model.getters.evaluateFormula("=A1").value).toBe(12);
   });
 
   test("in another sheet", () => {
     createSheet(model, { sheetId: "42" });
     const sheet2 = model.getters.getSheetIds()[1];
     setCellContent(model, "A1", "11", sheet2);
-    expect(model.getters.evaluateFormula("=Sheet2!A1")).toBe(11);
+    expect(model.getters.evaluateFormula("=Sheet2!A1").value).toBe(11);
   });
 
   // i think these formulas should throw


### PR DESCRIPTION
Before this commit, the scorecard data was the value of the cell even if
the evaluation of the cell's sheet was dirty.
Now, we evaluate directly the cell if it's a formula.

This solution is far from ideal: it will recompute the value even if the
value is up-to-date.
Also, scorecard should not care about the up-to-date state of a cell.
The good solution will follow thanks to lazy evaluation but a little
work is needed before having it, reason why we did this fix.

Task-id 2959765

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo