### PR TITLE
[FIX] menu: Only display submenus with `isVisible=true`

### DIFF
--- a/src/components/menu.ts
+++ b/src/components/menu.ts
@@ -262,7 +262,9 @@ export class Menu extends Component<Props, SpreadsheetEnv> {
       x: this.position.x + MENU_WIDTH,
       y: y - (this.subMenu.scrollOffset || 0),
     };
-    this.subMenu.menuItems = cellMenuRegistry.getChildren(menu, this.env);
+    this.subMenu.menuItems = cellMenuRegistry
+      .getChildren(menu, this.env)
+      .filter((item) => !item.isVisible || item.isVisible(this.env));
     this.subMenu.isOpen = true;
   }
 

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -447,7 +447,7 @@ describe("Context Menu", () => {
     expect(fixture.querySelector("div[data-name='root2'] > i")?.classList).toContain("my-class");
   });
 
-  test("Submenus are correctly hidden", async () => {
+  test("Only submenus of the current parent are visible", async () => {
     const menuItems: FullMenuItem[] = [
       createFullMenuItem("root_1", {
         name: "root_1",
@@ -494,6 +494,44 @@ describe("Context Menu", () => {
     triggerMouseEvent(".o-menu div[data-name='root_2']", "mouseover");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu_1']")).toBeFalsy();
+    expect(fixture.querySelector(".o-menu div[data-name='root_2_1']")).toBeTruthy();
+  });
+
+  test("Submenu visibility is taken into account", async () => {
+    const menuItems: FullMenuItem[] = [
+      createFullMenuItem("root", {
+        name: "root_1",
+        sequence: 1,
+        children: () => [
+          createFullMenuItem("menu_1", {
+            name: "root_1_1",
+            sequence: 1,
+            children: () => [
+              createFullMenuItem("visible_submenu_1", {
+                name: "visible_submenu_1",
+                sequence: 1,
+                action() {},
+                isVisible: () => true,
+              }),
+              createFullMenuItem("invisible_submenu_1", {
+                name: "invisible_submenu_1",
+                sequence: 1,
+                action() {},
+                isVisible: () => false,
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+    await renderContextMenu(300, 300, { menuItems });
+    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu div[data-name='menu_1']")).toBeTruthy();
+    triggerMouseEvent(".o-menu div[data-name='menu_1']", "mouseover");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu div[data-name='visible_submenu_1']")).toBeTruthy();
+    expect(fixture.querySelector(".o-menu div[data-name='invisible_submenu_1']")).toBeFalsy();
   });
 
   test("scroll through the menu with the wheel / scrollbar prevents the grid from scrolling", async () => {


### PR DESCRIPTION
## Description:

Currently, the menus visibility is not handled in the `Menu` component.
We feed it a list a menu already filtered by their visibility, bu this
filtering does not apply to the menu children.
This commit ensures that the menu component is correcly filtering the
children.

One can notice that as far as menuItems are concerned, we are only
interessed in those that are visible. As such, we could introduce new
functions or extend some (`getAll`, `getChildren`) to apply the
visibility filtering in order to prevent this issue. This could be an
improvement to consider.

Task 2962713

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2962713](https://www.odoo.com/web#id=2962713&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo