### PR TITLE
[REF] conditional_formatting: introduce getCellComputedStyle

### DIFF
--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -96,10 +96,11 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     let style: Style = {};
     if (cell) {
       const cellPosition = this.env.model.getters.getCellPosition(cell.id);
-      style = {
-        ...cell.style,
-        ...this.env.model.getters.getConditionalStyle(cellPosition.col, cellPosition.row),
-      };
+      style = this.env.model.getters.getCellComputedStyle(
+        cellPosition.sheetId,
+        cellPosition.col,
+        cellPosition.row
+      );
     }
 
     // position style

--- a/src/plugins/ui/evaluation_chart.ts
+++ b/src/plugins/ui/evaluation_chart.ts
@@ -97,14 +97,7 @@ export class EvaluationChartPlugin extends UIPlugin {
     }
     const col = mainRange.zone.left;
     const row = mainRange.zone.top;
-    const cfFormat = this.getters.getConditionalStyle(col, row, mainRange.sheetId);
-    if (cfFormat && cfFormat.fillColor) {
-      return cfFormat.fillColor;
-    }
-    const cell = this.getters.getCell(mainRange.sheetId, col, row);
-    if (cell && cell.style && cell.style.fillColor) {
-      return cell.style.fillColor;
-    }
-    return BACKGROUND_CHART_COLOR;
+    const style = this.getters.getCellComputedStyle(mainRange.sheetId, col, row);
+    return style.fillColor || BACKGROUND_CHART_COLOR;
   }
 }

--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -28,7 +28,7 @@ import { UIPlugin } from "../ui_plugin";
 // -----------------------------------------------------------------------------
 
 export class EvaluationConditionalFormatPlugin extends UIPlugin {
-  static getters = ["getConditionalStyle", "getConditionalIcon"] as const;
+  static getters = ["getConditionalIcon", "getCellComputedStyle"] as const;
   private isStale: boolean = true;
   // stores the computed styles in the format of computedStyles.sheetName[col][row] = Style
   private computedStyles: { [sheet: string]: { [col: HeaderIndex]: (Style | undefined)[] } } = {};
@@ -78,19 +78,14 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
   // Getters
   // ---------------------------------------------------------------------------
 
-  /**
-   * Returns the conditional style property for a given cell reference or
-   * undefined if this cell doesn't have a conditional style set.
-   *
-   * @param sheetId: take the cell in the active sheet if the method is not given a sheetId
-   */
-  getConditionalStyle(
-    col: HeaderIndex,
-    row: HeaderIndex,
-    sheetId = this.getters.getActiveSheetId()
-  ): Style | undefined {
+  getCellComputedStyle(sheetId: UID, col: HeaderIndex, row: HeaderIndex): Style {
+    const cell = this.getters.getCell(sheetId, col, row);
     const styles = this.computedStyles[sheetId];
-    return styles && styles[col]?.[row];
+    const cfStyle = styles && styles[col]?.[row];
+    return {
+      ...cell?.style,
+      ...cfStyle,
+    };
   }
 
   getConditionalIcon(col: HeaderIndex, row: HeaderIndex): string | undefined {

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -605,10 +605,7 @@ export class RendererPlugin extends UIPlugin {
       width,
       height,
       border: this.getters.getCellBorder(sheetId, col, row) || undefined,
-      style: {
-        ...this.getters.getCellStyle(cell),
-        ...this.getters.getConditionalStyle(col, row),
-      },
+      style: this.getters.getCellComputedStyle(sheetId, col, row),
     };
 
     if (!cell) {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -822,7 +822,7 @@ describe("Multi users synchronisation", () => {
     });
     const { col, row } = toCartesian("A1");
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getConditionalStyle(col, row),
+      (user) => user.getters.getCellComputedStyle(sheetId, col, row),
       { fillColor: "#00FF00" }
     );
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
@@ -861,7 +861,7 @@ describe("Multi users synchronisation", () => {
     });
     const { col, row } = toCartesian("A1");
     expect([alice, bob]).toHaveSynchronizedValue(
-      (user) => user.getters.getConditionalStyle(col, row),
+      (user) => user.getters.getCellComputedStyle(sheetId, col, row),
       { fillColor: "#FF0000" }
     );
   });

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -160,30 +160,30 @@ describe("Autofill", () => {
     });
     let col: number, row: number;
     ({ col, row } = toCartesian("A1"));
-    expect(model.getters.getConditionalStyle(col, row)).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({
       fillColor: "#FF0000",
     });
     ({ col, row } = toCartesian("A2"));
-    expect(model.getters.getConditionalStyle(col, row)).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({
       fillColor: "#FF0000",
     });
     ({ col, row } = toCartesian("A3"));
-    expect(model.getters.getConditionalStyle(col, row)).toBeFalsy();
+    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({});
     ({ col, row } = toCartesian("A4"));
-    expect(model.getters.getConditionalStyle(col, row)).toBeFalsy();
+    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({});
     autofill("A1:A4", "A8");
     ({ col, row } = toCartesian("A5"));
-    expect(model.getters.getConditionalStyle(col, row)).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({
       fillColor: "#FF0000",
     });
     ({ col, row } = toCartesian("A6"));
-    expect(model.getters.getConditionalStyle(col, row)).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({
       fillColor: "#FF0000",
     });
     ({ col, row } = toCartesian("A7"));
-    expect(model.getters.getConditionalStyle(col, row)).toBeFalsy();
+    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({});
     ({ col, row } = toCartesian("A8"));
-    expect(model.getters.getConditionalStyle(col, row)).toBeFalsy();
+    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({});
   });
 
   describe("Autofill multiple values", () => {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -1253,12 +1253,12 @@ describe("clipboard", () => {
     paste(model, "C1", false, "onlyValue");
     copy(model, "A2");
     paste(model, "C2", false, "onlyValue");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({});
   });
 
   test("paste value only does not remove style", () => {
@@ -1672,14 +1672,14 @@ describe("clipboard", () => {
     paste(model, "C1");
     copy(model, "A2");
     paste(model, "C2");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({});
   });
   test("can cut and paste a conditional formatted cell", () => {
     const model = new Model({
@@ -1704,12 +1704,12 @@ describe("clipboard", () => {
     paste(model, "C1");
     cut(model, "A2");
     paste(model, "C2");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({});
   });
 
   test("can copy and paste a conditional formatted zone", () => {
@@ -1732,22 +1732,22 @@ describe("clipboard", () => {
     copy(model, "A1:A2");
     paste(model, "B1");
     paste(model, "C1");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B2"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({});
     setCellContent(model, "C1", "2");
     setCellContent(model, "C2", "1");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -1771,16 +1771,16 @@ describe("clipboard", () => {
     });
     cut(model, "A1:A2");
     paste(model, "B1");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
     setCellContent(model, "B1", "2");
     setCellContent(model, "B2", "1");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -1811,14 +1811,14 @@ describe("clipboard", () => {
     copy(model, "A1:A2");
     activateSheet(model, "s2");
     paste(model, "A1");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle("s2", ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle("s2", ...toCartesianArray("A2"))).toEqual({});
     setCellContent(model, "A1", "2");
     setCellContent(model, "A2", "1");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+    expect(model.getters.getCellComputedStyle("s2", ...toCartesianArray("A1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle("s2", ...toCartesianArray("A2"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -1849,19 +1849,19 @@ describe("clipboard", () => {
     cut(model, "A1:A2");
     activateSheet(model, sheet2);
     paste(model, "A1");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheet2, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheet2, ...toCartesianArray("A2"))).toEqual({});
     setCellContent(model, "A1", "2");
     setCellContent(model, "A2", "1");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheet2, ...toCartesianArray("A1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheet2, ...toCartesianArray("A2"))).toEqual({
       fillColor: "#FF0000",
     });
     activateSheet(model, sheet1);
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheet1, ...toCartesianArray("A1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheet1, ...toCartesianArray("A2"))).toEqual({});
   });
 
   test("can copy and paste a cell which contains a cross-sheet reference", () => {

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -11,6 +11,7 @@ import {
   moveConditionalFormat,
   redo,
   setCellContent,
+  setStyle,
   undo,
 } from "../test_helpers/commands_helpers";
 import {
@@ -71,14 +72,38 @@ describe("conditional format", () => {
         ranges: ["A:A"],
       },
     ]);
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A4"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
       fillColor: "#0000FF",
     });
+  });
+
+  test("getCellComputedStyle", () => {
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "1");
+    setStyle(model, "A1", { fillColor: "blue" });
+    setStyle(model, "A2", { bold: true });
+    setStyle(model, "A3", { fillColor: "orange" });
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
+      ranges: toRangesData(sheetId, "A1, A2"),
+      sheetId,
+    });
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      fillColor: "#FF0000",
+    });
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+      fillColor: "#FF0000",
+      bold: true,
+    });
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
+      fillColor: "orange",
+    });
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({});
   });
 
   test("Add conditional formatting on inactive sheet", () => {
@@ -180,24 +205,24 @@ describe("conditional format", () => {
         ranges: ["A1:A4"],
       },
     ]);
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A4"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
       fillColor: "#0000FF",
     });
     model.dispatch("REMOVE_CONDITIONAL_FORMAT", {
       id: "2",
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A4"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({});
   });
 
   test("works on multiple ranges", () => {
@@ -208,10 +233,10 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1, A2"),
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -224,24 +249,24 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1, A2"),
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
       fillColor: "#FF0000",
     });
 
     undo(model);
 
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({});
 
     redo(model);
 
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -264,10 +289,10 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "B1,B2"),
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({
       fillColor: "#FF0000",
     });
     addColumns(model, "after", "A", 1);
@@ -283,12 +308,12 @@ describe("conditional format", () => {
         },
       },
     ]);
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B2"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({
       fillColor: "#FF0000",
     });
 
@@ -305,22 +330,22 @@ describe("conditional format", () => {
         },
       },
     ]);
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C2"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({});
 
     redo(model);
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("B2"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("C2"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -356,15 +381,15 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
     setCellContent(model, "A1", "2");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
     setCellContent(model, "A1", "1");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
     setCellContent(model, "A1", "=A2");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -377,7 +402,7 @@ describe("conditional format", () => {
       sheetId,
     });
     setCellContent(model, "A1", "=BLA");
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
   });
 
   test("multiple conditional formats for one cell", () => {
@@ -392,7 +417,7 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
       textColor: "#445566",
     });
@@ -410,7 +435,7 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -437,7 +462,7 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -449,7 +474,7 @@ describe("conditional format", () => {
       sheetId,
     });
     expect(result).toBeSuccessfullyDispatched();
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -491,11 +516,11 @@ describe("conditional format", () => {
         { id: "6", ranges: ["F1:F2"], rule },
         { id: "7", ranges: ["G1:G2"], rule },
       ]);
-      expect(model.getters.getConditionalStyle(...toCartesianArray("B2"))).toBeUndefined();
-      expect(model.getters.getConditionalStyle(...toCartesianArray("C2"))!.fillColor).toBe(
-        "orange"
-      );
-      expect(model.getters.getConditionalStyle(...toCartesianArray("C3"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
+      expect(
+        model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))!.fillColor
+      ).toBe("orange");
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C3"))).toEqual({});
     });
     test("On column deletion", () => {
       model = new Model({
@@ -531,11 +556,11 @@ describe("conditional format", () => {
         { id: "8", ranges: ["A7", "B7"], rule },
         { id: "9", ranges: ["A7", "B7"], rule },
       ]);
-      expect(model.getters.getConditionalStyle(...toCartesianArray("B2"))).toBeUndefined();
-      expect(model.getters.getConditionalStyle(...toCartesianArray("B3"))!.fillColor).toBe(
-        "orange"
-      );
-      expect(model.getters.getConditionalStyle(...toCartesianArray("C3"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
+      expect(
+        model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B3"))!.fillColor
+      ).toBe("orange");
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C3"))).toEqual({});
     });
     test("On column addition", () => {
       model = new Model({
@@ -563,10 +588,10 @@ describe("conditional format", () => {
         { id: "3", ranges: ["C3:F3"], rule },
         { id: "4", ranges: ["C4"], rule },
       ]);
-      expect(model.getters.getConditionalStyle(...toCartesianArray("B4"))).toBeUndefined();
-      expect(model.getters.getConditionalStyle(...toCartesianArray("C4"))!.fillColor).toBe(
-        "orange"
-      );
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B4"))).toEqual({});
+      expect(
+        model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C4"))!.fillColor
+      ).toBe("orange");
     });
     test("On row addition", () => {
       model = new Model({
@@ -594,10 +619,10 @@ describe("conditional format", () => {
         { id: "3", ranges: ["C3:C6"], rule },
         { id: "4", ranges: ["D3"], rule },
       ]);
-      expect(model.getters.getConditionalStyle(...toCartesianArray("D2"))).toBeUndefined();
-      expect(model.getters.getConditionalStyle(...toCartesianArray("D3"))!.fillColor).toBe(
-        "orange"
-      );
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("D2"))).toEqual({});
+      expect(
+        model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("D3"))!.fillColor
+      ).toBe("orange");
     });
   });
 
@@ -693,11 +718,11 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#FF0000",
     });
     moveConditionalFormat(model, idRule1, "down", sheetId);
-    expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
       fillColor: "#0000FF",
     });
   });
@@ -728,8 +753,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
 
       test.each([
@@ -752,8 +777,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
     });
 
@@ -773,25 +798,25 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "0");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "1");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "1.5");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "3");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "3.5");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
     });
 
     describe("Operator ContainsText", () => {
@@ -818,8 +843,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
 
       test.each([
@@ -843,8 +868,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
     });
 
@@ -870,8 +895,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
 
       test.each([
@@ -894,8 +919,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
     });
 
@@ -914,13 +939,13 @@ describe("conditional formats types", () => {
         sheetId,
       });
       setCellContent(model, "A1", "5");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "12");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "13");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -941,15 +966,15 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "5");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "12");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "13");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -970,13 +995,13 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "11");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "10");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "9");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -997,15 +1022,15 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "11");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "10");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "9");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -1026,23 +1051,23 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "4");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "0");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "5");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "10");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "10.1");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -1061,15 +1086,15 @@ describe("conditional formats types", () => {
         ranges: toRangesData(sheetId, "A1"),
         sheetId,
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "hellqsdfo");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "hello");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -1097,8 +1122,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
 
       test.each([
@@ -1121,8 +1146,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
     });
 
@@ -1147,8 +1172,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
 
       test.each([
@@ -1172,8 +1197,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
 
       test.each([
@@ -1197,8 +1222,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
     });
 
@@ -1223,8 +1248,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
 
       test.each([
@@ -1248,8 +1273,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
 
       test.each([
@@ -1273,8 +1298,8 @@ describe("conditional formats types", () => {
           sheetId,
         });
         setCellContent(model, "A1", cellContent);
-        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : undefined;
-        expect(model.getters.getConditionalStyle(0, 0)).toEqual(computedStyle);
+        const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
+        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
       });
     });
 
@@ -1293,31 +1318,31 @@ describe("conditional formats types", () => {
         sheetId,
       });
       setCellContent(model, "A1", "");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", " ");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A2", "");
       setCellContent(model, "A1", "=A2");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", '=""');
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", '=" "');
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "helabclo");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
     });
 
     test("Operator IsNotEmpty", () => {
@@ -1335,13 +1360,13 @@ describe("conditional formats types", () => {
         sheetId,
       });
       setCellContent(model, "A1", "");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", " ");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
 
       setCellContent(model, "A1", "helabclo");
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -1496,7 +1521,9 @@ describe("conditional formats types", () => {
       sheetId,
     });
     setCellContent(model, "A1", "=B1");
-    expect(model.getters.getConditionalStyle(0, 0, sheetId)).toEqual({ fillColor: "#FF0FFF" });
+    expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual({
+      fillColor: "#FF0FFF",
+    });
   });
 
   describe("Icon set", () => {
@@ -1621,7 +1648,7 @@ describe("conditional formats types", () => {
         ranges: toRangesData(sheetId, "A1"),
         sheetId,
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual(undefined);
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
       expect(model.getters.getConditionalIcon(...toCartesianArray("A1"))).toEqual("arrowNeutral");
     });
 
@@ -1646,7 +1673,7 @@ describe("conditional formats types", () => {
           ranges: toRangesData(sheetId, "A1"),
           sheetId,
         });
-        expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toBeUndefined();
+        expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
         expect(model.getters.getConditionalIcon(...toCartesianArray("A1"))).toBeUndefined();
       }
     );
@@ -1871,7 +1898,7 @@ describe("conditional formats types", () => {
         ranges: toRangesData(sheetId, "A1"),
         sheetId,
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual(undefined);
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
     });
 
     test("2 points, value scale", () => {
@@ -1891,19 +1918,19 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#FF00FF",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
         fillColor: "#E705EE",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
         fillColor: "#592489",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A4"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
         fillColor: "#2A2F67",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A5"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A5"))).toEqual({
         fillColor: "#123456",
       });
     });
@@ -1925,19 +1952,19 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#FF00FF",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
         fillColor: "#E705EE",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
         fillColor: "#592489",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A4"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
         fillColor: "#2A2F67",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A5"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A5"))).toEqual({
         fillColor: "#123456",
       });
     });
@@ -1959,19 +1986,19 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#FF00FF",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
         fillColor: "#E705EE",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
         fillColor: "#592489",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A4"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
         fillColor: "#2A2F67",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A5"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A5"))).toEqual({
         fillColor: "#123456",
       });
     });
@@ -1991,13 +2018,13 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
         fillColor: "#808000",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
         fillColor: "#FF0000",
       });
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A3"))).toEqual({
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
         fillColor: "#00FF00",
       });
     });
@@ -2015,8 +2042,8 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A1"))).toEqual(undefined);
-      expect(model.getters.getConditionalStyle(...toCartesianArray("A2"))).toEqual(undefined);
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({});
     });
 
     test("CF is not updated with insert/delete cells", () => {
@@ -2047,9 +2074,9 @@ describe("conditional formats types", () => {
         ranges: toRangesData(sheetId, "A1:A3"),
         sheetId,
       });
-      expect(model.getters.getConditionalStyle(0, 0)).toEqual({ fillColor: "#123456" });
-      expect(model.getters.getConditionalStyle(0, 1)).toEqual(undefined);
-      expect(model.getters.getConditionalStyle(0, 2)).toEqual({ fillColor: "#FF00FF" });
+      expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual({ fillColor: "#123456" });
+      expect(model.getters.getCellComputedStyle(sheetId, 0, 1)).toEqual({});
+      expect(model.getters.getCellComputedStyle(sheetId, 0, 2)).toEqual({ fillColor: "#FF00FF" });
     });
   });
 });

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -624,7 +624,7 @@ describe("sheets", () => {
     expect(model.getters.getNumberCols(model.getters.getActiveSheetId())).toBe(5);
     expect(model.getters.getNumberRows(model.getters.getActiveSheetId())).toBe(5);
     const { col, row } = toCartesian("A1");
-    expect(model.getters.getConditionalStyle(col, row)).toEqual({
+    expect(model.getters.getCellComputedStyle(newSheet, col, row)).toEqual({
       fillColor: "orange",
     });
   });
@@ -658,7 +658,7 @@ describe("sheets", () => {
     activateSheet(model, newSheetId);
     expect(getCellContent(model, "A1")).toBe("42");
     const { col, row } = toCartesian("A1");
-    expect(model.getters.getConditionalStyle(col, row)).toEqual({
+    expect(model.getters.getCellComputedStyle(newSheetId, col, row)).toEqual({
       fillColor: "orange",
     });
     expect(model.getters.getConditionalFormats(newSheetId)).toHaveLength(1);
@@ -668,10 +668,10 @@ describe("sheets", () => {
       ranges: toRangesData(sheetId, "A1:A2"),
       sheetId,
     });
-    expect(model.getters.getConditionalStyle(col, row)).toEqual({ fillColor: "blue" });
+    expect(model.getters.getCellComputedStyle(newSheetId, col, row)).toEqual({ fillColor: "blue" });
     expect(model.getters.getConditionalFormats(newSheetId)).toHaveLength(1);
     activateSheet(model, sheet);
-    expect(model.getters.getConditionalStyle(col, row)).toEqual({
+    expect(model.getters.getCellComputedStyle(sheet, col, row)).toEqual({
       fillColor: "orange",
     });
     expect(model.getters.getConditionalFormats(newSheetId)).toHaveLength(1);


### PR DESCRIPTION
The getter `getConditionalStyle` was kinda useless, every time we use it
we had to get the cell.style, get the CF style, and merge the two.
The problem with that is that we have to:
- remember that we also have to get the CF style, cell.style isn't enough
- merge them in the correct order (CF style should override the cell.style)

This commit introduces a new getter `getCellComputedStyle` which returns
the combination of the cell's style and the cf style.

Task-id 2936962

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo