### PR TITLE
[FIX] automatic_sum: evaluated date blocks automatic sum

### DIFF
--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -91,7 +91,7 @@ abstract class AbstractCell<T extends CellEvaluation = CellEvaluation> implement
       case CellValueType.text:
         return true;
       case CellValueType.number:
-        return !this.format?.match(DATETIME_FORMAT);
+        return !this.evaluated.format?.match(DATETIME_FORMAT);
       case CellValueType.error:
       case CellValueType.boolean:
         return false;

--- a/src/plugins/ui/automatic_sum.ts
+++ b/src/plugins/ui/automatic_sum.ts
@@ -196,7 +196,10 @@ export class AutomaticSumPlugin extends UIPlugin {
   }
 
   private isNumber(cell?: Cell): boolean {
-    return cell?.evaluated.type === CellValueType.number && !cell.format?.match(DATETIME_FORMAT);
+    return (
+      cell?.evaluated.type === CellValueType.number &&
+      !cell.evaluated.format?.match(DATETIME_FORMAT)
+    );
   }
 
   private isZoneValid(zone: Zone): boolean {

--- a/tests/plugins/automatic_sum.test.ts
+++ b/tests/plugins/automatic_sum.test.ts
@@ -91,6 +91,20 @@ describe("automatic sum", () => {
     expect(getCellText(model, "B4")).toBe("");
   });
 
+  test("with a date resulting from a formula after numbers", () => {
+    setCellContent(model, "B2", "4");
+    setCellContent(model, "B3", "=DATE(2020, 12, 31)");
+    automaticSum(model, "B4");
+    expect(getCellText(model, "B4")).toBe("");
+  });
+
+  test("with a date resulting from a formula before numbers", () => {
+    setCellContent(model, "B2", "=DATE(2020, 12, 31)");
+    setCellContent(model, "B3", "4");
+    automaticSum(model, "B4");
+    expect(getCellText(model, "B4")).toBe("=SUM(B3)");
+  });
+
   test("with a bad expression after numbers", () => {
     setCellContent(model, "B2", "4");
     setCellContent(model, "B3", "=THIS IS A BAD EXPRESSION");


### PR DESCRIPTION
Write the formula "=DATE(1,1,1)" in a cell
- Autosum this cell
--> The autosum take into account this cell --> should not
Task 2936794

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo