### PR TITLE
[IMP] export: don't export empty content

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -220,7 +220,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
         cells[xc] = {
           style: cell.style ? getItemId<Style>(cell.style, styles) : undefined,
           format: cell.format ? getItemId<Format>(cell.format, formats) : undefined,
-          content: cell.content,
+          content: cell.content || undefined,
         };
       }
       _sheet.cells = cells;

--- a/tests/plugins/import_export.test.ts
+++ b/tests/plugins/import_export.test.ts
@@ -16,8 +16,9 @@ import {
   resizeColumns,
   resizeRows,
   setCellContent,
+  setStyle,
 } from "../test_helpers/commands_helpers";
-import { getCellContent, getMerges } from "../test_helpers/getters_helpers";
+import { getCell, getCellContent, getMerges } from "../test_helpers/getters_helpers";
 import "../test_helpers/helpers";
 
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
@@ -442,6 +443,24 @@ describe("Import", () => {
     expect(Object.keys(getMerges(model))).toHaveLength(1);
     expect(Object.values(getMerges(model))[0].topLeft).toEqual(toCartesian("A2"));
   });
+
+  test("can import cell without content", () => {
+    const model = new Model({
+      sheets: [
+        {
+          id: "1",
+          cells: {
+            A1: { format: 1 },
+          },
+        },
+      ],
+      formats: {
+        1: "0.00%",
+      },
+    });
+    expect(getCell(model, "A1")?.content).toBe("");
+    expect(getCell(model, "A1")?.format).toBe("0.00%");
+  });
 });
 
 describe("Export", () => {
@@ -504,6 +523,13 @@ describe("Export", () => {
     });
     const exp = model.exportData();
     expect(exp.sheets![0].cells!.A1!.format).toBe(1);
+  });
+
+  test("empty content is not exported", () => {
+    const model = new Model();
+    setStyle(model, "A1", { fillColor: "#123456" });
+    const exp = model.exportData();
+    expect(exp.sheets![0].cells!.A1!).toEqual({ style: 1 });
   });
 });
 


### PR DESCRIPTION


## Description:

When exporting cells with no content (but a style or format),
we export an empty string as the content: `content: ""`

It uselessly bloats the exported json.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo