### PR TITLE
[IMP] formulas: IFERROR preserves the format

### DIFF
--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -1,5 +1,11 @@
 import { _lt } from "../translation";
-import { AddFunctionDescription, ArgValue, FunctionReturnValue, PrimitiveArgValue } from "../types";
+import {
+  AddFunctionDescription,
+  ArgValue,
+  FunctionReturnValue,
+  PrimitiveArg,
+  PrimitiveArgValue,
+} from "../types";
 import { args } from "./arguments";
 import { assert, conditionalVisitBoolean, toBoolean } from "./helpers";
 
@@ -71,6 +77,16 @@ export const IFERROR: AddFunctionDescription = {
   )}
   `),
   returns: ["ANY"],
+  computeFormat: (
+    value: () => PrimitiveArg,
+    valueIfError: () => PrimitiveArg = () => ({ value: "" })
+  ) => {
+    try {
+      return value().format;
+    } catch (e) {
+      return valueIfError()?.format;
+    }
+  },
   compute: function (
     value: () => PrimitiveArgValue,
     valueIfError: () => PrimitiveArgValue = () => ""

--- a/tests/functions/module_logical.test.ts
+++ b/tests/functions/module_logical.test.ts
@@ -1,3 +1,6 @@
+import { Model } from "../../src";
+import { setCellContent, setCellFormat } from "../test_helpers/commands_helpers";
+import { getCell } from "../test_helpers/getters_helpers";
 import { evaluateCell } from "../test_helpers/helpers";
 
 describe("AND formula", () => {
@@ -126,6 +129,22 @@ describe("IFERROR formula", () => {
     expect(evaluateCell("A1", { A1: "=IFERROR(1, 1/0) + IFERROR(1, 1/0)" })).toBe(2);
     expect(evaluateCell("A1", { A1: "=IF(TRUE, 1/(1/1), 1/(1/0))" })).toBe(1);
     expect(evaluateCell("A1", { A1: "=IF(FALSE, 1/(1/1), 1/(1/0))" })).toBe("#ERROR");
+  });
+
+  test("format is preserved from value", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellFormat(model, "A1", "0.00%");
+    setCellContent(model, "A3", "=IFERROR(A1, 2)");
+    expect(getCell(model, "A3")?.formattedValue).toBe("100.00%");
+  });
+
+  test("format is preserved from error value", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellFormat(model, "A1", "0.00%");
+    setCellContent(model, "A3", "=IFERROR(0/0, A1)");
+    expect(getCell(model, "A3")?.formattedValue).toBe("100.00%");
   });
 });
 


### PR DESCRIPTION
Given a formula `IFERROR(A1, A2)`, if A1 has a given
format (let's say a currency format), the function
result looses that format.

With this commit, the format is preserved.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2973819](https://www.odoo.com/web#id=2973819&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo