### PR TITLE
[REF] cell: remove unused property normalizedText

### DIFF
--- a/src/helpers/cells/cell_factory.ts
+++ b/src/helpers/cells/cell_factory.ts
@@ -38,7 +38,6 @@ cellRegistry
       return new FormulaCell(
         (cell: FormulaCell) => getters.buildFormulaContent(sheetId, cell),
         id,
-        content,
         compiledFormula,
         dependencies,
         properties

--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -242,7 +242,6 @@ export class FormulaCell extends AbstractCell implements IFormulaCell {
   constructor(
     private buildFormulaString: (cell: FormulaCell) => string,
     id: UID,
-    readonly normalizedText: string,
     readonly compiledFormula: CompiledFormula,
     readonly dependencies: Range[],
     properties: CellDisplayProperties

--- a/src/types/cells.ts
+++ b/src/types/cells.ts
@@ -39,7 +39,6 @@ export interface ICell {
 export interface FormulaCell extends ICell {
   assignEvaluation: (value: CellValue | null, format?: Format) => void;
   assignError: (value: string, error: EvaluationError) => void;
-  readonly normalizedText: string;
   readonly compiledFormula: CompiledFormula;
   readonly dependencies: Range[];
 }


### PR DESCRIPTION
This comit remove cell property normalizedText.
Should have been removed since
0a2d7034c215f5060ab67012ea6f75b990874731

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo