### PR TITLE
[FIX] collaborative: fix transformation of dimensions

### DIFF
--- a/src/collaborative/ot/ot.ts
+++ b/src/collaborative/ot/ot.ts
@@ -138,7 +138,8 @@ function transformDimension(
           if (executed.elements.includes(element)) {
             return undefined;
           }
-          for (let removedElement of executed.elements) {
+          const executedElements = executed.elements.sort((a, b) => b - a);
+          for (let removedElement of executedElements) {
             if (element > removedElement) {
               element--;
             }

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -225,6 +225,12 @@ describe("OT with REMOVE_COLUMN", () => {
       const result = transform(command, removeColumns);
       expect(result).toEqual(command);
     });
+
+    test("Remove a column adjacent to removed columns", () => {
+      const command = { ...toTransform, elements: [2] };
+      const result = transform(command, { ...removeColumns, elements: [0, 1] });
+      expect(result).toEqual({ ...command, elements: [0] });
+    });
   });
 
   const resizeColumnsCommand: Omit<ResizeColumnsRowsCommand, "elements"> = {

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -202,28 +202,34 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
       expect(result).toEqual({ ...command, elements: [0] });
     });
 
-    test("Remove a column before removed rows", () => {
+    test("Remove a row before removed rows", () => {
       const command = { ...toTransform, elements: [0] };
       const result = transform(command, removeRows);
       expect(result).toEqual(command);
     });
 
-    test("Remove a column after removed rows", () => {
+    test("Remove a row after removed rows", () => {
       const command = { ...toTransform, elements: [8] };
       const result = transform(command, removeRows);
       expect(result).toEqual({ ...command, elements: [5] });
     });
 
-    test("Remove a column inside removed rows", () => {
+    test("Remove a row inside removed rows", () => {
       const command = { ...toTransform, elements: [4] };
       const result = transform(command, removeRows);
       expect(result).toEqual({ ...command, elements: [2] });
     });
 
-    test("Remove a column on another sheet", () => {
+    test("Remove a row on another sheet", () => {
       const command = { ...toTransform, elements: [4], sheetId: "42" };
       const result = transform(command, removeRows);
       expect(result).toEqual(command);
+    });
+
+    test("Remove a row adjacent to removed row", () => {
+      const command = { ...toTransform, elements: [2] };
+      const result = transform(command, { ...removeRows, elements: [0, 1] });
+      expect(result).toEqual({ ...command, elements: [0] });
     });
   });
 


### PR DESCRIPTION
commit 00830c35 addressed an issue where we mutated the commands in
place. This issue was highlighted when transforming `position` dependent
commands but it actually also affected `dimension` dependent commands.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo