### PR TITLE
 Filter changed files [FIX] grid: handle selectionInput modes on click events

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -676,6 +676,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       // not main button, probably a context menu
       return;
     }
+    if (ev.ctrlKey) {
+      this.env.model.dispatch("PREPARE_SELECTION_INPUT_EXPANSION");
+    }
     const [col, row] = this.getCartesianCoordinates(ev);
     if (col < 0 || row < 0) {
       return;
@@ -770,9 +773,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     };
     const onMouseUp = (ev: MouseEvent) => {
       clearTimeout(timeOutId);
-      this.env.model.dispatch(
-        ev.ctrlKey ? "PREPARE_SELECTION_INPUT_EXPANSION" : "STOP_SELECTION_INPUT"
-      );
+      this.env.model.dispatch("STOP_SELECTION_INPUT");
       this.gridOverlay.el!.removeEventListener("mousemove", onMouseMove);
       if (this.env.model.getters.isPaintingFormat()) {
         this.env.model.dispatch("PASTE", {

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -125,7 +125,6 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     });
 
     useExternalListener(window as any, "resize", () => this.render(true));
-    useExternalListener(document.body, "keyup", this.onKeyup.bind(this));
     useExternalListener(window, "beforeunload", this.unbindModelEvents.bind(this));
     onMounted(() => this.bindModelEvents());
     onWillUnmount(() => this.unbindModelEvents());
@@ -191,16 +190,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     this.props.onContentSaved?.(this.model.exportData());
   }
 
-  onKeyup(ev: KeyboardEvent) {
-    if (ev.key === "Control") {
-      this.model.dispatch("STOP_SELECTION_INPUT");
-    }
-  }
-
   onKeydown(ev: KeyboardEvent) {
-    if (ev.key === "Control" && !ev.repeat) {
-      this.model.dispatch("PREPARE_SELECTION_INPUT_EXPANSION");
-    }
     let keyDownString = "";
     if (ev.ctrlKey || ev.metaKey) {
       keyDownString += "CTRL+";

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -160,9 +160,8 @@ describe("Selection Input", () => {
     await simulateClick(input);
     clickCell(parent.model, "B4");
     await nextTick();
-    await keyDown("Control");
-    clickCell(parent.model, "B5");
-    await keyUp("Control");
+    clickCell(parent.model, "B5", { ctrlKey: true });
+    await nextTick();
     const inputs = fixture.querySelectorAll(
       ".o-selection-input input"
     ) as unknown as HTMLInputElement[];


### PR DESCRIPTION
## Description:

Currently  we trigger a rerendering of the components when pressing the
Ctrl key up and down. Certain components that lack a proper internal
state are badly affected by those rendering, e.g. it can sometimes reset
an input value (see task video).

This behaviour was introduced to notify the plugins before we start
a selection of zone by mouse to determine if we extend the current zone
or start selecting a new one. Since we only need this information when we
click on the grid (selecting a zone), it should be handled with the click
events, not in a separate flow, and certainly not in the Spreadsheet
component.

Odoo task ID : [2955856](https://www.odoo.com/web#id=2955856&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo