### PR TITLE
[FIX] Chart Panel: Chart title is updated when typing

### DIFF
--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -51,6 +51,7 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartPanel";
 
   private state!: State;
+  private shouldUpdateChart: boolean = true;
 
   get figureId(): UID {
     return this.state.figureId;
@@ -70,6 +71,9 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
       const selectedFigureId = this.env.model.getters.getSelectedFigureId();
       if (selectedFigureId && selectedFigureId !== this.state.figureId) {
         this.state.figureId = selectedFigureId;
+        this.shouldUpdateChart = false;
+      } else {
+        this.shouldUpdateChart = true;
       }
       if (!this.env.model.getters.isChartDefined(this.figureId)) {
         this.props.onCloseSidePanel();
@@ -79,6 +83,9 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   updateChart<T extends ChartDefinition>(updateDefinition: Partial<T>) {
+    if (!this.shouldUpdateChart) {
+      return;
+    }
     const definition: T = {
       ...(this.getChartDefinition() as T),
       ...updateDefinition,

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -404,6 +404,43 @@ describe("figures", () => {
     }
   );
 
+  test("changing property and selecting another chart doesn't change first chart", async () => {
+    createChart(
+      model,
+      {
+        dataSets: ["C1:C4"],
+        labelRange: "A2:A4",
+        type: "line",
+        title: "old_title_1",
+      },
+      "1"
+    );
+    await nextTick();
+    createChart(
+      model,
+      {
+        dataSets: ["C1:C4"],
+        labelRange: "A2:A4",
+        type: "line",
+        title: "old_title_2",
+      },
+      "2"
+    );
+    await nextTick();
+
+    const figures = fixture.querySelectorAll(".o-figure");
+    await simulateClick(figures[0] as HTMLElement);
+    await simulateClick(".o-chart-menu-item");
+    await simulateClick(".o-menu div[data-name='edit']");
+    await simulateClick(".o-panel .inactive");
+    await simulateClick(".o-chart-title input");
+    setInputValueAndTrigger(".o-chart-title input", "first_title", "input");
+
+    await simulateClick(figures[1] as HTMLElement);
+    expect(model.getters.getChartDefinition("1").title).toBe("old_title_1");
+    expect(model.getters.getChartDefinition("2").title).toBe("old_title_2");
+  });
+
   test.each(["basicChart", "scorecard"])(
     "can edit charts %s background",
     async (chartType: string) => {


### PR DESCRIPTION
## Task Description

When having two charts on a sheet, if we change the title of the first one (without typing enter) and then select the second chart, the new title is set for the second chart instead of the first one.

## Reproducibility
This issue can be reproduced following these steps:
1. Create two charts
2. Go to the settings panel of the first one
3. Type a new title (but don't click out yet)
4. Click out on the second chart

## Fix Description
This issue comes from the fact we linked the title update to the "onChange" event of the input textbox. Unfortunately,
this event is triggered when the textbox loose focus, which happen here when clicking on the second chart. But clicking
on the second chart also change the id of the figure we try to edit, meaning the onChange event is called only after
having changed the target figure.
In this fix, we use another event (onInput), leading us to change the title each time the value in the textbox is changed.

## Related task
Odoo task ID : [2961701](https://www.odoo.com/web#id=2961701&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo