### PR TITLE
[IMP] functions: make ISTEXT/ISNUMBER/... compatible with Excel/GSheet

### DIFF
--- a/src/functions/module_info.ts
+++ b/src/functions/module_info.ts
@@ -44,10 +44,14 @@ export const ISERROR: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 export const ISLOGICAL: AddFunctionDescription = {
   description: _lt("Whether a value is `true` or `false`."),
-  args: args(`value (any) ${_lt("The value to be verified as a logical TRUE or FALSE.")}`),
+  args: args(`value (any, lazy) ${_lt("The value to be verified as a logical TRUE or FALSE.")}`),
   returns: ["BOOLEAN"],
-  compute: function (value: PrimitiveArgValue): boolean {
-    return typeof value === "boolean";
+  compute: function (value: () => PrimitiveArgValue): boolean {
+    try {
+      return typeof value() === "boolean";
+    } catch (e) {
+      return false;
+    }
   },
   isExported: true,
 };
@@ -75,10 +79,14 @@ export const ISNA: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 export const ISNONTEXT: AddFunctionDescription = {
   description: _lt("Whether a value is non-textual."),
-  args: args(`value (any) ${_lt("The value to be checked.")}`),
+  args: args(`value (any, lazy) ${_lt("The value to be checked.")}`),
   returns: ["BOOLEAN"],
-  compute: function (value: PrimitiveArgValue): boolean {
-    return typeof value !== "string";
+  compute: function (value: () => PrimitiveArgValue): boolean {
+    try {
+      return typeof value() !== "string";
+    } catch (e) {
+      return true;
+    }
   },
   isExported: true,
 };
@@ -89,10 +97,14 @@ export const ISNONTEXT: AddFunctionDescription = {
 
 export const ISNUMBER: AddFunctionDescription = {
   description: _lt("Whether a value is a number."),
-  args: args(`value (any) ${_lt("The value to be verified as a number.")}`),
+  args: args(`value (any, lazy) ${_lt("The value to be verified as a number.")}`),
   returns: ["BOOLEAN"],
-  compute: function (value: PrimitiveArgValue): boolean {
-    return typeof value === "number";
+  compute: function (value: () => PrimitiveArgValue): boolean {
+    try {
+      return typeof value() === "number";
+    } catch (e) {
+      return false;
+    }
   },
   isExported: true,
 };
@@ -102,10 +114,14 @@ export const ISNUMBER: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 export const ISTEXT: AddFunctionDescription = {
   description: _lt("Whether a value is text."),
-  args: args(`value (any) ${_lt("The value to be verified as text.")}`),
+  args: args(`value (any, lazy) ${_lt("The value to be verified as text.")}`),
   returns: ["BOOLEAN"],
-  compute: function (value: PrimitiveArgValue): boolean {
-    return typeof value === "string";
+  compute: function (value: () => PrimitiveArgValue): boolean {
+    try {
+      return typeof value() === "string";
+    } catch (e) {
+      return false;
+    }
   },
   isExported: true,
 };

--- a/tests/functions/module_info.test.ts
+++ b/tests/functions/module_info.test.ts
@@ -87,6 +87,8 @@ describe("ISLOGICAL formula", () => {
     expect(evaluateCell("A1", { A1: "=ISLOGICAL(1)" })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISLOGICAL(1.2)" })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISLOGICAL(3%)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISLOGICAL(1/0)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISLOGICAL(NA())" })).toBe(false);
   });
 
   test("functional tests on cell arguments", () => {
@@ -102,6 +104,10 @@ describe("ISLOGICAL formula", () => {
     expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=true" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=false" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=123" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=A2" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=1/0" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=+(" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISLOGICAL(A2)", A2: "=NA()" })).toBe(false);
   });
 });
 
@@ -147,6 +153,8 @@ describe("ISNONTEXT formula", () => {
     expect(evaluateCell("A1", { A1: "=ISNONTEXT(TRUE)" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISNONTEXT(123)" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISNONTEXT(3%)" })).toBe(true);
+    expect(evaluateCell("A1", { A1: "=ISNONTEXT(1/0)" })).toBe(true);
+    expect(evaluateCell("A1", { A1: "=ISNONTEXT(NA())" })).toBe(true);
   });
 
   test("functional tests on cell arguments", () => {
@@ -160,6 +168,10 @@ describe("ISNONTEXT formula", () => {
     expect(evaluateCell("A1", { A1: "=ISNONTEXT(A2)", A2: '="TRUE"' })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISNONTEXT(A2)", A2: "=true" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISNONTEXT(A2)", A2: "=123" })).toBe(true);
+    expect(evaluateCell("A1", { A1: "=ISNONTEXT(A2)", A2: "=A2" })).toBe(true);
+    expect(evaluateCell("A1", { A1: "=ISNONTEXT(A2)", A2: "=1/0" })).toBe(true);
+    expect(evaluateCell("A1", { A1: "=ISNONTEXT(A2)", A2: "=+(" })).toBe(true);
+    expect(evaluateCell("A1", { A1: "=ISNONTEXT(A2)", A2: "=NA()" })).toBe(true);
   });
 });
 
@@ -173,6 +185,8 @@ describe("ISNUMBER formula", () => {
     expect(evaluateCell("A1", { A1: "=ISNUMBER(123)" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISNUMBER(1.2)" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISNUMBER(3%)" })).toBe(true);
+    expect(evaluateCell("A1", { A1: "=ISNUMBER(1/0)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNUMBER(NA())" })).toBe(false);
   });
 
   test("functional tests on cell arguments", () => {
@@ -186,6 +200,10 @@ describe("ISNUMBER formula", () => {
     expect(evaluateCell("A1", { A1: "=ISNUMBER(A2)", A2: '="TRUE"' })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISNUMBER(A2)", A2: "=true" })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISNUMBER(A2)", A2: "=123" })).toBe(true);
+    expect(evaluateCell("A1", { A1: "=ISNUMBER(A2)", A2: "=A2" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNUMBER(A2)", A2: "=1/0" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNUMBER(A2)", A2: "=+(" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISNUMBER(A2)", A2: "=NA()" })).toBe(false);
   });
 });
 
@@ -198,6 +216,8 @@ describe("ISTEXT formula", () => {
     expect(evaluateCell("A1", { A1: "=ISTEXT(TRUE)" })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISTEXT(123)" })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISTEXT(3%)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISTEXT(1/0)" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISTEXT(NA())" })).toBe(false);
   });
 
   test("functional tests on cell arguments", () => {
@@ -211,6 +231,10 @@ describe("ISTEXT formula", () => {
     expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: '="TRUE"' })).toBe(true);
     expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: "=true" })).toBe(false);
     expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: "=123" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: "=A2" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: "=1/0" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: "=+(" })).toBe(false);
+    expect(evaluateCell("A1", { A1: "=ISTEXT(A2)", A2: "=NA()" })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Task Description
In Excel and Google Sheet, calling `ISTEXT`/`ISNUMBER`/`ISLOGICAL` on an error cell returns `FALSE`, while in our case it returns the original error.
In the same way, calling `ISNONTEXT` on an errored cell should return `TRUE`, while in our case it simply propagate the error.

## Related Task
Odoo task ID : [2967127](https://www.odoo.com/web#id=2967127&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist
- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo