### PR TITLE
[IMP] evaluation: referencing an empty cell returns blank

### DIFF
--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -282,9 +282,9 @@ export class FormulaCell extends AbstractCell implements IFormulaCell {
         break;
       case "object": // null
         this.evaluated = {
-          value: 0,
+          value: "",
           format,
-          type: CellValueType.number,
+          type: CellValueType.text,
         };
         break;
     }

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -414,10 +414,6 @@ describe("BottomBar component", () => {
     selectCell(model, "A2");
     await nextTick();
     expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Sum: 24");
-
-    selectCell(model, "A3");
-    await nextTick();
-    expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Sum: 0");
     app.destroy();
   });
 

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -241,7 +241,7 @@ describe("datasource tests", function () {
       type: "line",
     });
     const runtime = model.getters.getChartRuntime("1") as LineChartRuntime;
-    expect(runtime.chartJsConfig.data?.datasets?.[0].data).toEqual([0]);
+    expect(runtime.chartJsConfig.data?.datasets?.[0].data).toEqual([]);
   });
 
   test("create a chart with stacked bar", () => {
@@ -1593,7 +1593,7 @@ describe("Chart evaluation", () => {
     expect(
       (model.getters.getChartRuntime("1") as BarChartRuntime).chartJsConfig.data!.datasets![0]!
         .data![0]
-    ).toBe(0);
+    ).toBe("");
     setCellContent(model, "C3", "1");
     expect(
       (model.getters.getChartRuntime("1") as BarChartRuntime).chartJsConfig.data!.datasets![0]!

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -1329,7 +1329,9 @@ describe("conditional formats types", () => {
 
       setCellContent(model, "A2", "");
       setCellContent(model, "A1", "=A2");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+        fillColor: "#ff0f0f",
+      });
 
       setCellContent(model, "A1", '=""');
       expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
@@ -1506,7 +1508,7 @@ describe("conditional formats types", () => {
     }
   );
 
-  test("CF with cell referencing empty cell is treated as zero", () => {
+  test("CF with cell referencing empty cell is not treated as zero", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: {
         rule: {
@@ -1521,9 +1523,7 @@ describe("conditional formats types", () => {
       sheetId,
     });
     setCellContent(model, "A1", "=B1");
-    expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual({
-      fillColor: "#FF0FFF",
-    });
+    expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual({});
   });
 
   describe("Icon set", () => {

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -72,7 +72,7 @@ describe("core", () => {
         selectCell(model, "A1");
         setAnchorCorner(model, "A7");
         let statisticFnResults = model.getters.getStatisticFnResults();
-        expect(statisticFnResults["Avg"]).toBe(22);
+        expect(statisticFnResults["Avg"]).toBe(33);
 
         selectCell(model, "A7");
         statisticFnResults = model.getters.getStatisticFnResults();
@@ -84,7 +84,7 @@ describe("core", () => {
         selectCell(model, "A1");
         setAnchorCorner(model, "A7");
         let statisticFnResults = model.getters.getStatisticFnResults();
-        expect(statisticFnResults["Min"]).toBe(0);
+        expect(statisticFnResults["Min"]).toBe(24);
 
         selectCell(model, "A7");
         statisticFnResults = model.getters.getStatisticFnResults();
@@ -173,7 +173,7 @@ describe("core", () => {
       const model = new Model();
       setCellContent(model, "A1", "=A2");
 
-      expect(getCellContent(model, "A1")).toBe("0");
+      expect(getCellContent(model, "A1")).toBe("");
     });
 
     test("format cell without content: empty string", () => {

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -960,7 +960,7 @@ describe("evaluateCells", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A2", "=A1");
-    expect(getCell(model, "A2")!.evaluated.value).toBe(0);
+    expect(getCell(model, "A2")!.evaluated.value).toBe("");
     model.dispatch("SET_FORMATTING", {
       sheetId,
       target: target("A1"),
@@ -969,8 +969,8 @@ describe("evaluateCells", () => {
       },
     });
     setCellContent(model, "A12", "this re-evaluates cells");
-    expect(getCellContent(model, "A2")).toBe("0");
-    expect(getCell(model, "A2")!.evaluated.value).toBe(0);
+    expect(getCellContent(model, "A2")).toBe("");
+    expect(getCell(model, "A2")!.evaluated.value).toBe("");
   });
 
   test("evaluation follows dependencies", () => {

--- a/tests/plugins/history.test.ts
+++ b/tests/plugins/history.test.ts
@@ -246,7 +246,7 @@ describe("Model history", () => {
     setCellContent(model, "A2", "11");
     expect(getCell(model, "A1")!.evaluated.value).toBe(11);
     undo(model);
-    expect(getCell(model, "A1")!.evaluated.value).toBe(0);
+    expect(getCell(model, "A1")!.evaluated.value).toBe("");
     redo(model);
     expect(getCell(model, "A1")!.evaluated.value).toBe(11);
   });

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -147,7 +147,7 @@ describe("renderer", () => {
     });
 
     model.drawGrid(ctx);
-    expect(textAligns).toEqual(["right", "center"]); // center for headers
+    expect(textAligns).toEqual(["left", "center"]); // center for headers
   });
 
   test("numbers are aligned right when overflowing vertically", () => {

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -366,7 +366,7 @@ describe("sheets", () => {
     activateSheet(model, sheet1);
     expect(model.getters.getActiveSheetId()).toEqual(sheet1);
     setCellContent(model, "A1", "=Sheet2!A1");
-    expect(getCellContent(model, "A1")).toEqual("0");
+    expect(getCellContent(model, "A1")).toEqual("");
     activateSheet(model, sheet2);
     setCellContent(model, "A1", "3");
     activateSheet(model, sheet1);


### PR DESCRIPTION
## Task Description

When referencing an empty cell, the returned value is 0, and the cell is set as a number. To be consistent with GSheet, it
should return the same content as the referenced cell, i.e. a blank string.

## Related Task
Odoo task ID : [2838639](https://www.odoo.com/web#id=2838639&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo