### PR TITLE
[IMP] evaluation: add error "unknown function"

### DIFF
--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -2,7 +2,10 @@ import { DEFAULT_ERROR_MESSAGE } from "../constants";
 import { parseNumber, removeStringQuotes } from "../helpers/index";
 import { _lt } from "../translation";
 import { InvalidReferenceError } from "../types/errors";
+import { UnknownFunctionError } from "./../types/errors";
 import { Token, tokenize } from "./tokenizer";
+
+const functionRegex = /[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*/;
 
 const UNARY_OPERATORS_PREFIX = ["-", "+"];
 const UNARY_OPERATORS_POSTFIX = ["%"];
@@ -167,6 +170,9 @@ function parsePrefix(current: Token, tokens: Token[]): AST {
         return { type: "BOOLEAN", value: current.value.toUpperCase() === "TRUE" } as AST;
       } else {
         if (current.value) {
+          if (functionRegex.test(current.value) && tokens[0]?.type === "LEFT_PAREN") {
+            throw new UnknownFunctionError(current.value);
+          }
           throw new Error(_lt("Invalid formula"));
         }
         return { type: "STRING", value: current.value };

--- a/src/helpers/cells/cell_factory.ts
+++ b/src/helpers/cells/cell_factory.ts
@@ -3,7 +3,7 @@ import { DEFAULT_ERROR_MESSAGE } from "../../constants";
 import { compile } from "../../formulas";
 import { cellRegistry } from "../../registries/cell_types";
 import { Cell, CellDisplayProperties, CoreGetters, UID } from "../../types";
-import { BadExpressionError } from "../../types/errors";
+import { BadExpressionError, EvaluationError } from "../../types/errors";
 import { parseDateTime } from "../dates";
 import {
   isBoolean,
@@ -15,10 +15,10 @@ import {
 } from "../misc";
 import { isNumber, parseNumber } from "../numbers";
 import {
-  BadExpressionCell,
   BooleanCell,
   DateTimeCell,
   EmptyCell,
+  ErrorCell,
   FormulaCell,
   NumberCell,
   SheetLinkCell,
@@ -132,10 +132,12 @@ export function cellFactory(getters: CoreGetters) {
     try {
       return builder.createCell(id, content, properties, sheetId, getters);
     } catch (error) {
-      return new BadExpressionCell(
+      return new ErrorCell(
         id,
         content,
-        new BadExpressionError(error.message || DEFAULT_ERROR_MESSAGE),
+        error instanceof EvaluationError
+          ? error
+          : new BadExpressionError(error.message || DEFAULT_ERROR_MESSAGE),
         properties
       );
     }

--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -22,7 +22,7 @@ import {
   TextEvaluation,
   UID,
 } from "../../types";
-import { CellErrorType, EvaluationError } from "../../types/errors";
+import { EvaluationError } from "../../types/errors";
 import { formatValue } from "../format";
 import { lazy } from "../index";
 import { markdownLink, parseMarkdownLink, parseSheetLink } from "../misc";
@@ -319,7 +319,7 @@ export class FormulaCell extends AbstractCell implements IFormulaCell {
  * Cell containing a formula which could not be compiled
  * or a content which could not be parsed.
  */
-export class BadExpressionCell extends AbstractCell<InvalidEvaluation> {
+export class ErrorCell extends AbstractCell<InvalidEvaluation> {
   /**
    * @param id
    * @param content Invalid formula string
@@ -335,7 +335,7 @@ export class BadExpressionCell extends AbstractCell<InvalidEvaluation> {
     super(
       id,
       lazy({
-        value: CellErrorType.BadExpression,
+        value: error.errorType,
         type: CellValueType.error,
         error,
       }),

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -5,6 +5,7 @@ export enum CellErrorType {
   InvalidReference = "#REF",
   BadExpression = "#BAD_EXPR",
   CircularDependency = "#CYCLE",
+  UnknownFunction = "#NAME?",
   GenericError = "#ERROR",
 }
 
@@ -44,5 +45,11 @@ export class InvalidReferenceError extends EvaluationError {
 export class NotAvailableError extends EvaluationError {
   constructor() {
     super(CellErrorType.NotAvailable, _lt("Data not available"), CellErrorLevel.silent);
+  }
+}
+
+export class UnknownFunctionError extends EvaluationError {
+  constructor(fctName: string) {
+    super(CellErrorType.UnknownFunction, _lt('Unknown function: "%s"', fctName));
   }
 }

--- a/tests/functions/functions.test.ts
+++ b/tests/functions/functions.test.ts
@@ -20,7 +20,7 @@ describe("functions", () => {
   });
   test("can add a function", () => {
     const val = evaluateCell("A1", { A1: "=DOUBLEDOUBLE(3)" });
-    expect(val).toBe("#BAD_EXPR");
+    expect(val).toBe("#NAME?");
     functionRegistry.add("DOUBLEDOUBLE", {
       description: "Double the first argument",
       compute: ((arg: number) => 2 * arg) as ComputeFunction<ArgValue, FunctionReturnValue>,


### PR DESCRIPTION
## Description

This commit add a new error type `UnknownFunctionError` at evaluation to
replace the generic bad expression error.

Now the tokenizer defines function token as either a word that is on the
list of functions or as a word followed by an open parenthesis. Having
both allow us to :

1) Recognize that the user tried to insert a function but we haven't
implemented it (eg. '=YOLO()')

2) Still have nice error messages mentioning a malformed function when
the user forget the opening parenthesis (eg. '=SUM A1, A2)')

Odoo task ID : [2824111](https://www.odoo.com/web#id=2824111&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo