### PR TITLE
[FIX] topbar: menu highlight persisting after closing menu

### DIFF
--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -19,7 +19,7 @@
             t-if="state.menuState.isOpen"
             position="state.menuState.position"
             menuItems="state.menuState.menuItems"
-            onClose="() => this.state.menuState.isOpen=false"
+            onClose="() => this.closeMenus()"
           />
         </div>
         <div class="o-topbar-topright">

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -374,11 +374,16 @@ describe("TopBar component", () => {
   test("Opened menu parent is highlighted", async () => {
     const { app } = await mountParent();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    const menuItem = fixture.querySelector(".o-topbar-menu[data-id='file']");
+    const menuItem = fixture.querySelector(".o-topbar-menu[data-id='edit']");
     expect(menuItem?.classList).not.toContain("o-topbar-menu-active");
     triggerMouseEvent(menuItem, "click");
     await nextTick();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     expect(menuItem?.classList).toContain("o-topbar-menu-active");
+    triggerMouseEvent(".o-menu-item", "click");
+    await nextTick();
+    expect(menuItem?.classList).not.toContain("o-topbar-menu-active");
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     app.destroy();
   });
 


### PR DESCRIPTION
cd7691c3 made it so the parent menu was highlighted when opening a sub
menu. But the highlight didn't go away when closing a menu in the top bar.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo