### PR TITLE
[IMP] InteractiveTests: Moved sort interactive tests to ui helper tests

### DIFF
--- a/tests/helpers/ui.test.ts
+++ b/tests/helpers/ui.test.ts
@@ -1,3 +1,5 @@
+import { toCartesian, toXC, toZone, zoneToXc } from "../../src/helpers/index";
+import { interactiveSortSelection } from "../../src/helpers/sort";
 import { interactiveCut } from "../../src/helpers/ui/cut_interactive";
 import {
   AddMergeInteractiveContent,
@@ -6,7 +8,13 @@ import {
 import { interactivePaste, PasteInteractiveContent } from "../../src/helpers/ui/paste_interactive";
 import { interactiveRenameSheet } from "../../src/helpers/ui/sheet_interactive";
 import { Model } from "../../src/model";
-import { EditTextOptions, SpreadsheetChildEnv, UID } from "../../src/types";
+import {
+  CommandResult,
+  EditTextOptions,
+  Position,
+  SpreadsheetChildEnv,
+  UID,
+} from "../../src/types";
 import {
   addCellToSelection,
   copy,
@@ -17,9 +25,25 @@ import {
   selectCell,
   setCellContent,
   setSelection,
+  sort,
+  undo,
 } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import { makeInteractiveTestEnv, target } from "../test_helpers/helpers";
+
+function getCellsObject(model: Model, sheetId: UID) {
+  const cells = {};
+  for (let cell of Object.values(model.getters.getCells(sheetId))) {
+    const { col, row } = model.getters.getCellPosition(cell.id);
+    cell = model.getters.getCell(sheetId, col, row)!;
+    cells[toXC(col, row)] = {
+      ...cell,
+      value: cell.evaluated.value,
+      content: cell.content,
+    };
+  }
+  return cells;
+}
 
 describe("Interactive rename sheet", () => {
   test.each([
@@ -208,6 +232,183 @@ describe("UI Helpers", () => {
       expect(askConfirmationTextSpy).toHaveBeenCalledWith(
         AddMergeInteractiveContent.mergeIsDestructive.toString()
       );
+    });
+  });
+
+  describe("Sort multi adjacent columns", () => {
+    let askConfirmation: jest.Mock;
+    const sheetId: UID = "sheet3";
+    let anchor: Position;
+    const modelData = {
+      sheets: [
+        {
+          id: sheetId,
+          colNumber: 4,
+          rowNumber: 5,
+          cells: {
+            A1: { content: "Alpha" },
+            A2: { content: "Tango" },
+            A3: { content: "Delta" },
+            A4: { content: "Zulu" },
+            B1: { content: "3" },
+            B2: { content: "4" },
+            B3: { content: "2" },
+            C2: { content: "5" },
+            C4: { content: "Charlie" },
+            D5: { content: "6" },
+          },
+        },
+      ],
+    };
+    test("Sort with adjacent values to the selection ask for confirmation", () => {
+      askConfirmation = jest.fn();
+      model = new Model(modelData);
+      const zone = toZone("A2:A3");
+      anchor = toCartesian("A2");
+      const env = makeInteractiveTestEnv(model, { askConfirmation });
+      interactiveSortSelection(env, sheetId, anchor, zone, "descending");
+      expect(askConfirmation).toHaveBeenCalled();
+    });
+    test("Sort without adjacent values to the selection does not ask for confirmation", () => {
+      askConfirmation = jest.fn();
+      model = new Model(modelData);
+      const zone = toZone("A2:A3");
+      const contiguousZone = model.getters.getContiguousZone(sheetId, zone);
+      const env = makeInteractiveTestEnv(model, { askConfirmation });
+      interactiveSortSelection(env, sheetId, anchor, contiguousZone, "descending");
+      expect(askConfirmation).not.toHaveBeenCalled();
+    });
+
+    test("Sort on first column w/ confirming contiguous", () => {
+      askConfirmation = jest.fn((text, confirm, cancel) => confirm());
+      model = new Model(modelData);
+      const zone = toZone("A3:A4");
+      anchor = toCartesian("A3");
+      const env = makeInteractiveTestEnv(model, { askConfirmation });
+      interactiveSortSelection(env, sheetId, anchor, zone, "descending");
+      expect(getCellsObject(model, sheetId)).toMatchObject({
+        A1: { content: "Zulu" },
+        A2: { content: "Tango" },
+        A3: { content: "Delta" },
+        A4: { content: "Alpha" },
+        B2: { content: "4" },
+        B3: { content: "2" },
+        B4: { content: "3" },
+        C1: { content: "Charlie" },
+        C2: { content: "5" },
+        D5: { content: "6" },
+      });
+    });
+    test("Sort on first column w/ refusing contiguous", () => {
+      askConfirmation = jest.fn((text, confirm, cancel) => cancel());
+      model = new Model(modelData);
+      const zone = toZone("A3:A4");
+      anchor = toCartesian("A3");
+      const env = makeInteractiveTestEnv(model, { askConfirmation });
+      interactiveSortSelection(env, sheetId, anchor, zone, "descending");
+      expect(getCellsObject(model, sheetId)).toMatchObject({
+        A1: { content: "Alpha" },
+        A2: { content: "Tango" },
+        A3: { content: "Zulu" },
+        A4: { content: "Delta" },
+        B1: { content: "3" },
+        B2: { content: "4" },
+        B3: { content: "2" },
+        C2: { content: "5" },
+        C4: { content: "Charlie" },
+        D5: { content: "6" },
+      });
+    });
+  });
+
+  describe("Sort Merges", () => {
+    const notifyUser = jest.fn();
+    const sheetId: UID = "sheet5";
+    let anchor: Position;
+    const modelData = {
+      sheets: [
+        {
+          id: sheetId,
+          colNumber: 6,
+          rowNumber: 10,
+          cells: {
+            B2: { content: "20" },
+            B5: { content: "6" },
+            B8: { content: "9" },
+            C2: { content: "Zulu" },
+            C5: { content: "Echo" },
+            C8: { content: "Golf" },
+            D2: { content: "09/20/2020" },
+            D5: { content: "08/20/2020" },
+            D8: { content: "07/20/2020" },
+          },
+          merges: [
+            "B2:B4",
+            "B5:B7",
+            "B8:B10",
+            "C2:C4",
+            "C5:C7",
+            "C8:C10",
+            "D2:D4",
+            "D5:D7",
+            "D8:D10",
+          ],
+        },
+      ],
+    };
+    beforeEach(() => {
+      model = new Model(modelData);
+    });
+    test("Failed Sort of merges with single adjacent cell with and without interactive mode", () => {
+      // add value in adjacent cell
+      setCellContent(model, "E6", "Bad Cell!", sheetId);
+
+      // sort
+      const zone = toZone("B2:B8");
+      const contiguousZone = model.getters.getContiguousZone(sheetId, zone);
+      anchor = toCartesian("B2");
+      const env = makeInteractiveTestEnv(model, { notifyUser });
+      interactiveSortSelection(env, sheetId, anchor, contiguousZone, "ascending");
+      expect(notifyUser).toHaveBeenCalled();
+      expect(model.getters.getSelection()).toEqual({
+        anchor: { cell: anchor, zone: contiguousZone },
+        zones: [contiguousZone],
+      });
+      undo(model);
+      expect(
+        sort(model, {
+          zone: zoneToXc(contiguousZone),
+          anchor: "B2",
+          direction: "ascending",
+        })
+      ).toBeCancelledBecause(CommandResult.InvalidSortZone);
+    });
+
+    test("Failed Sort of merges with adjacent merge with and without interactive mode", () => {
+      const sheetId = model.getters.getActiveSheetId();
+      //add merge [cols:2, rows: 1] above existing merges
+      setCellContent(model, "B1", "Bad Merge!", sheetId);
+      merge(model, "B1:C1");
+      // sort
+      const zone = toZone("B2:B8");
+      const contiguousZone = model.getters.getContiguousZone(sheetId, zone);
+
+      const anchor = toCartesian("B2");
+      const env = makeInteractiveTestEnv(model, { notifyUser });
+      interactiveSortSelection(env, sheetId, anchor, contiguousZone, "ascending");
+      expect(notifyUser).toHaveBeenCalled();
+      expect(model.getters.getSelection()).toEqual({
+        anchor: { cell: anchor, zone: contiguousZone },
+        zones: [contiguousZone],
+      });
+      undo(model);
+      expect(
+        sort(model, {
+          zone: zoneToXc(contiguousZone),
+          anchor: "B2",
+          direction: "ascending",
+        })
+      ).toBeCancelledBecause(CommandResult.InvalidSortZone);
     });
   });
 });


### PR DESCRIPTION
## Description:

Few interactive sort test cases were written under plugins,
those are moved under helpers/ui since Interactive is helping with UI.

Odoo task ID : [2965421](https://www.odoo.com/web#id=2965421&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo