### PR TITLE
[FIX] Topbar: closes dropdown on right-click

### DIFF
--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -1,6 +1,9 @@
 <templates>
   <t t-name="o-spreadsheet-ColorPicker" owl="1">
-    <div class="o-color-picker" t-att-class="props.dropdownDirection || 'right'">
+    <div
+      class="o-color-picker"
+      t-att-class="props.dropdownDirection || 'right'"
+      t-on-contextmenu.stop="">
       <div class="o-color-picker-section-name">Standard</div>
       <div class="colors-grid">
         <div

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -117,6 +117,7 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private openContextMenu(position: DOMCoordinates) {
+    this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
     const registry = this.getMenuItemRegistry();
     this.menuState.isOpen = true;
     this.menuState.menuItems = registry.getAll().filter((x) => x.isVisible(this.env));
@@ -130,5 +131,15 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
       throw new Error(`Component is not defined for type ${type}`);
     }
     return component;
+  }
+
+  isMenuOpen(): boolean {
+    if (this.menuState.isOpen) {
+      if (this.env.model.getters.getSelectedFigureId() === this.props.figure.id) {
+        return true;
+      }
+      this.menuState.isOpen = false;
+    }
+    return false;
   }
 }

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -3,7 +3,7 @@
     <div
       class="o-chart-container"
       t-ref="chartContainer"
-      t-on-contextmenu.prevent.stop="(ev) => !env.isDashboard() and this.onContextMenu(ev)">
+      t-on-contextmenu.prevent="(ev) => !env.isDashboard() and this.onContextMenu(ev)">
       <div class="o-chart-menu" t-if="!env.isDashboard()">
         <div
           class="o-chart-menu-item"
@@ -20,7 +20,7 @@
       />
 
       <Menu
-        t-if="menuState.isOpen"
+        t-if="this.isMenuOpen()"
         position="menuState.position"
         menuItems="menuState.menuItems"
         onClose="() => this.menuState.isOpen=false"

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -809,6 +809,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   // ---------------------------------------------------------------------------
 
   onCanvasContextMenu(ev: MouseEvent) {
+    if (ev.currentTarget !== ev.target) {
+      this.closeMenu();
+      return;
+    }
     ev.preventDefault();
     const [col, row] = this.getCartesianCoordinates(ev);
     if (col < 0 || row < 0) {

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -306,6 +306,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
 
   setup() {
     useExternalListener(window as any, "click", this.onClick);
+    useExternalListener(window as any, "contextmenu", this.onClick);
     onWillStart(() => this.updateCellState());
     onWillUpdateProps(() => this.updateCellState());
   }

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -37,7 +37,7 @@
             Readonly Access
           </span>
         </div>
-        <div t-else="" class="o-toolbar-tools">
+        <div t-else="" class="o-toolbar-tools" t-on-contextmenu.prevent="">
           <div
             class="o-tool"
             title="Undo"

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -1,4 +1,5 @@
 import { App, Component, onMounted, onWillUnmount, useState, useSubEnv, xml } from "@odoo/owl";
+import { Spreadsheet } from "../../src";
 import { TopBar } from "../../src/components/top_bar/top_bar";
 import { DEFAULT_FONT_SIZE } from "../../src/constants";
 import { toZone } from "../../src/helpers";
@@ -15,7 +16,7 @@ import {
   setCellContent,
   setSelection,
 } from "../test_helpers/commands_helpers";
-import { triggerMouseEvent } from "../test_helpers/dom_helper";
+import { rightClickCell, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getBorder, getCell } from "../test_helpers/getters_helpers";
 import {
   makeTestFixture,
@@ -104,6 +105,21 @@ describe("TopBar component", () => {
     await nextTick();
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
     expect(fixture.querySelectorAll(".o-color-line").length).toBe(0);
+    app.destroy();
+  });
+
+  test("opening a context menu closes an already opened topbar menu", async () => {
+    const { app, parent } = await mountSpreadsheet(fixture);
+    const model = (parent as Spreadsheet).model;
+
+    expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
+    fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
+    expect(fixture.querySelectorAll(".o-line-item").length).not.toBe(0);
+    await rightClickCell(model, "B2");
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
     app.destroy();
   });
 


### PR DESCRIPTION
## Task Description

When opening a dropdown menu in the topBar (may it be in the menu or from an action button), and right-clicking somewhere else after (e.g. in a cell), you will get bot the context menu of the clicked component and the previously opened dropdown menu, while the last should be closed. This is fixed here by adding an eventListener on the contextMenu event

## Related Task
Odoo task ID : [2862746](https://www.odoo.com/web#id=2862746&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo