### PR TITLE
[FIX] charts: duplicating a sheet preserves figure dimensions

### DIFF
--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -89,7 +89,12 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
             // TODO:
             // This is not really correct, it should be the role of figures to
             // duplicate a figure.
-            this.addFigure(id, cmd.sheetIdTo, { x: fig.x, y: fig.y });
+            this.addFigure(
+              id,
+              cmd.sheetIdTo,
+              { x: fig.x, y: fig.y },
+              { width: fig.width, height: fig.height }
+            );
             this.history.update("charts", id, chart);
           }
         }

--- a/tests/plugins/chart/common_chart.test.ts
+++ b/tests/plugins/chart/common_chart.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../../src";
 import { Color, UID } from "../../../src/types";
 import {
+  createChart,
   createGaugeChart,
   createScorecardChart,
   setCellContent,
@@ -83,4 +84,30 @@ describe("Single cell chart background color", () => {
       expect(model.getters.getChartRuntime(chartId).background).toEqual("#0000FF");
     }
   );
+
+  test("Duplicating a sheet preserves the figure dimensions", () => {
+    const firstSheetId = model.getters.getActiveSheetId();
+    const secondSheetId = "42";
+    createChart(model, { type: "bar" });
+    const firstSheetFigures = model.getters.getFigures(firstSheetId);
+    expect(firstSheetFigures.length).toBe(1);
+    model.dispatch("UPDATE_FIGURE", {
+      sheetId,
+      id: firstSheetFigures[0].id,
+      x: 0,
+      y: 0,
+      width: 123,
+      height: 321,
+    });
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetIdTo: secondSheetId,
+      sheetId: firstSheetId,
+    });
+    const secondSheetFigures = model.getters.getFigures(secondSheetId);
+    expect(secondSheetFigures.length).toBe(1);
+    expect(firstSheetFigures[0]).toMatchObject({
+      ...secondSheetFigures[0],
+      id: expect.any(String),
+    });
+  });
 });


### PR DESCRIPTION
task 2937694

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2937694](https://www.odoo.com/web#id=2937694&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo