### PR TITLE
[FIX] scorecard: errors with baseline value

### DIFF
--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -206,17 +206,20 @@ function createScorecardChartRuntime(
     const baselineZone = chart.baseline.zone;
     baselineCell = getters.getCell(chart.baseline.sheetId, baselineZone.left, baselineZone.top);
   }
-  const baselineValue = baselineCell?.content || "";
   const background = getters.getBackgroundOfSingleCellChart(chart.background, chart.keyValue);
   return {
     title: chart.title,
     keyValue: formattedKeyValue || keyValue,
-    baselineDisplay: getBaselineText(baselineCell, keyValue, chart.baselineMode),
-    baselineArrow: getBaselineArrowDirection(baselineValue, keyValue, chart.baselineMode),
+    baselineDisplay: getBaselineText(baselineCell, keyValueCell?.evaluated, chart.baselineMode),
+    baselineArrow: getBaselineArrowDirection(
+      baselineCell?.evaluated,
+      keyValueCell?.evaluated,
+      chart.baselineMode
+    ),
     baselineColor: getBaselineColor(
-      baselineValue,
+      baselineCell?.evaluated,
       chart.baselineMode,
-      keyValue,
+      keyValueCell?.evaluated,
       chart.baselineColorUp,
       chart.baselineColorDown
     ),

--- a/tests/plugins/chart/scorecard_chart.test.ts
+++ b/tests/plugins/chart/scorecard_chart.test.ts
@@ -309,3 +309,20 @@ test("font color is white with a dark background color", () => {
     "#FFFFFF"
   );
 });
+
+test("Scorecard with formula cell", () => {
+  setCellContent(model, "A2", "=MULTIPLY(1, 2)");
+  setCellContent(model, "A1", "=SUM(1, 3)");
+  createScorecardChart(
+    model,
+    {
+      keyValue: "A1",
+      baseline: "A2",
+      baselineMode: "percentage",
+    },
+    "1"
+  );
+  const runtime = model.getters.getChartRuntime("1") as ScorecardChartRuntime;
+  expect(runtime.keyValue).toEqual("4");
+  expect(runtime.baselineDisplay).toEqual("100%");
+});


### PR DESCRIPTION
## Description

There was 2 problems with the baseline value:

1) the baseline mode "percentage" wasn't working if the baseline was a formula cell

2) if the baseline cell had a format, the value of the baseline was displayed instead of the difference between the key and the baseline.

Odoo task ID : [2977861](https://www.odoo.com/web#id=2977861&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo