### PR TITLE
[FIX] scorecard: errors with baseline value - small fix

### DIFF
--- a/src/helpers/charts/chart_common.ts
+++ b/src/helpers/charts/chart_common.ts
@@ -371,17 +371,17 @@ export function getBaselineText(
   ) {
     return baseline.formattedValue;
   } else {
-    let diff = keyValue?.value - baselineEvaluated.value;
+    let diff = keyValue.value - baselineEvaluated.value;
     if (baselineMode === "percentage") {
       diff = (diff / baselineEvaluated.value) * 100;
     }
-    let baselineStr = Math.abs(parseFloat(diff.toFixed(2))).toLocaleString();
-    if (baselineMode === "percentage") {
-      baselineStr += "%";
-    } else if (baseline.format) {
-      baselineStr = formatValue(diff, baseline.format);
+
+    if (baselineMode !== "percentage" && baselineEvaluated.format) {
+      return formatValue(diff, baselineEvaluated.format);
     }
-    return baselineStr;
+
+    const baselineStr = Math.abs(parseFloat(diff.toFixed(2))).toLocaleString();
+    return baselineMode === "percentage" ? baselineStr + "%" : baselineStr;
   }
 }
 


### PR DESCRIPTION
## Description

Improve code of `getBaselineText()` and improve test for format of baseline value in scorecards.

Odoo task ID : [2977861](https://www.odoo.com/web#id=2977861&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo