### PR TITLE
[FIX] ClearFormat: clear format actually clears the format

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -97,7 +97,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
         }
         break;
       case "CLEAR_FORMATTING":
-        this.clearStyles(cmd.sheetId, cmd.target);
+        this.clearFormatting(cmd.sheetId, cmd.target);
         break;
       case "ADD_COLUMNS_ROWS":
         if (cmd.dimension === "COL") {
@@ -142,9 +142,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   }
 
   /**
-   * Clear the styles of zones
+   * Clear the styles and format of zones
    */
-  private clearStyles(sheetId: UID, zones: Zone[]) {
+  private clearFormatting(sheetId: UID, zones: Zone[]) {
     for (let zone of zones) {
       for (let col = zone.left; col <= zone.right; col++) {
         for (let row = zone.top; row <= zone.bottom; row++) {
@@ -154,6 +154,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
             col,
             row,
             style: null,
+            format: "",
           });
         }
       }

--- a/tests/plugins/style.test.ts
+++ b/tests/plugins/style.test.ts
@@ -64,8 +64,10 @@ describe("styles", () => {
       sheetId: model.getters.getActiveSheetId(),
       target: model.getters.getSelectedZones(),
       style: { fillColor: "red" },
+      format: "#,##0.0",
     });
     expect(getCell(model, "B1")!.style).toBeDefined();
+    expect(getCell(model, "B1")!.format).toBeDefined();
     model.dispatch("CLEAR_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
       target: model.getters.getSelectedZones(),
@@ -81,6 +83,7 @@ describe("styles", () => {
       sheetId: model.getters.getActiveSheetId(),
       target: model.getters.getSelectedZones(),
       style: { fillColor: "red" },
+      format: "#,##0.0",
     });
     expect(getCell(model, "B1")!.style).toBeDefined();
     model.dispatch("CLEAR_FORMATTING", {
@@ -90,9 +93,10 @@ describe("styles", () => {
     expect(getCell(model, "B1")!.style).not.toBeDefined();
     undo(model);
     expect(getCell(model, "B1")!.style).toBeDefined();
+    expect(getCell(model, "B1")!.format).toBeDefined();
   });
 
-  test("clear formatting does not remove format", () => {
+  test("clear formatting should remove format", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("SET_FORMATTING", {
@@ -104,7 +108,7 @@ describe("styles", () => {
       sheetId,
       target: target("A1"),
     });
-    expect(getCell(model, "A1")?.format).toBe("#,##0.0");
+    expect(getCell(model, "A1")?.format).toBeUndefined();
   });
 
   test("Can set a format in another than the active one", () => {


### PR DESCRIPTION
## Description:

Earlier CLEAR_FORMATTING command used to clear style applied on a cell. This commit modifies it to also clear format applied on a cell.

Odoo task ID : [2975831](https://www.odoo.com/web#id=2975831&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo