### PR TITLE
[IMP] selection: dont select chart when it's updated

### DIFF
--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -265,7 +265,6 @@ export class GridSelectionPlugin extends UIPlugin {
           this.onMoveElements(cmd);
         }
         break;
-      case "UPDATE_CHART":
       case "SELECT_FIGURE":
         this.selectedFigureId = cmd.id;
         break;

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -575,7 +575,7 @@ describe("datasource tests", function () {
     expect(result).toBeCancelledBecause(CommandResult.InvalidDataSet);
   });
 
-  test("chart is focused after creation and update", () => {
+  test("chart is not selected after creation and update", () => {
     const chartId = "1234";
     createChart(
       model,
@@ -595,7 +595,7 @@ describe("datasource tests", function () {
       labelRange: "A2:A4",
       title: "updated chart",
     });
-    expect(model.getters.getSelectedFigureId()).toBe(chartId);
+    expect(model.getters.getSelectedFigureId()).toBeNull();
   });
 
   test("create chart with invalid labels", () => {


### PR DESCRIPTION
When a chart is updated, it's automatically selected. It brings weird behavior:
- in a collaborative context, when another user updates a chart, it's also selected on your side.
- when loading a spreadsheet with initial revisions containing UPDATE_CHART commands, the figure is initially selected.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo