### PR TITLE
[FIX] find_and_replace: select first match automatically

### DIFF
--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -110,7 +110,7 @@ export class FindAndReplacePlugin extends UIPlugin {
   private updateSearch(toSearch: string, searchOptions: SearchOptions) {
     this.searchOptions = searchOptions;
     if (toSearch !== this.toSearch) {
-      this.selectedMatchIndex = 0;
+      this.selectedMatchIndex = null;
     }
     this.toSearch = toSearch;
     this.updateRegex();
@@ -195,7 +195,7 @@ export class FindAndReplacePlugin extends UIPlugin {
     }
     //modulo of negative value to be able to cycle in both directions with previous and next
     nextIndex = ((nextIndex % matches.length) + matches.length) % matches.length;
-    if (this.selectedMatchIndex !== nextIndex) {
+    if (this.selectedMatchIndex === null || this.selectedMatchIndex !== nextIndex) {
       this.selectedMatchIndex = nextIndex;
       this.dispatch("SELECT_CELL", { col: matches[nextIndex].col, row: matches[nextIndex].row });
     }

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../src";
+import { toZone } from "../../src/helpers";
 import { ReplaceOptions, SearchOptions } from "../../src/plugins/ui/find_and_replace";
 import { activateSheet, createSheet, setCellContent } from "../test_helpers/commands_helpers";
 import { getCellContent, getCellText } from "../test_helpers/getters_helpers";
@@ -32,6 +33,11 @@ describe("basic search", () => {
     expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
     expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
     expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
+  });
+
+  test("Update search automatically select the first match", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "2", searchOptions });
+    expect(model.getters.getSelection().zones).toEqual([toZone("A6")]);
   });
 
   test("modifying cells won't change the search", () => {


### PR DESCRIPTION
Before this commit, the first match was not selected after a search update, so if the cell was not in the viewport, the first selection was not visible.

Task-id 2967139

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo