### PR TITLE
[FIX]ColorPicker: resetting chart background returns wrong color on icon

### DIFF
--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -220,7 +220,7 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
   }
 
   resetColor() {
-    this.props.onColorPicked("");
+    this.props.onColorPicked("#FFFFFF");
   }
 
   setCustomColor(ev: Event) {

--- a/tests/components/color_picker.test.ts
+++ b/tests/components/color_picker.test.ts
@@ -75,7 +75,7 @@ describe("Color Picker buttons", () => {
     const onColorPicked = jest.fn();
     await mountColorPicker({ currentColor: "#45818e", onColorPicked });
     await simulateClick(".o-cancel");
-    expect(onColorPicked).toHaveBeenCalledWith("");
+    expect(onColorPicked).toHaveBeenCalledWith("#FFFFFF");
   });
 
   test("Click on '+' button toggle the custom color part", async () => {


### PR DESCRIPTION
## Description:

Open a chart, change it's background, now click on reset, it will reset chart background to default white but on color picker icon it will show black, to fix this default BACKGROUND_CHART_COLOR is passed on reset.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo