### PR TITLE
[FIX] scorecard: display percentage between 0 and 0

### DIFF
--- a/src/helpers/charts/chart_common.ts
+++ b/src/helpers/charts/chart_common.ts
@@ -372,7 +372,7 @@ export function getBaselineText(
     return baseline.formattedValue;
   } else {
     let diff = keyValue.value - baselineEvaluated.value;
-    if (baselineMode === "percentage") {
+    if (baselineMode === "percentage" && diff !== 0) {
       diff = (diff / baselineEvaluated.value) * 100;
     }
 

--- a/tests/plugins/chart/scorecard_chart.test.ts
+++ b/tests/plugins/chart/scorecard_chart.test.ts
@@ -203,6 +203,136 @@ describe("datasource tests", function () {
     expect(model.getters.getSheetIds()).toHaveLength(1);
     expect(model.getters.getFigures(secondSheetId)).toEqual([duplicatedFigure]);
   });
+
+  test("percentage with key value smaller than baseline", () => {
+    setCellContent(model, "A1", "40");
+    setCellContent(model, "A2", "100");
+    createScorecardChart(model, {
+      keyValue: "A1",
+      baseline: "A2",
+      baselineMode: "percentage",
+    });
+    const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
+    expect(model.getters.getChartRuntime(scorecardId)).toMatchObject({
+      baselineArrow: "down",
+      baselineColor: "#DC6965",
+      baselineDisplay: "60%",
+      keyValue: "40",
+    });
+  });
+
+  test("percentage with key value greater than baseline", () => {
+    setCellContent(model, "A1", "140");
+    setCellContent(model, "A2", "100");
+    createScorecardChart(model, {
+      keyValue: "A1",
+      baseline: "A2",
+      baselineMode: "percentage",
+    });
+    const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
+    expect(model.getters.getChartRuntime(scorecardId)).toMatchObject({
+      baselineArrow: "up",
+      baselineColor: "#00A04A",
+      baselineDisplay: "40%",
+      keyValue: "140",
+    });
+  });
+
+  test("percentage with key value equal to baseline", () => {
+    setCellContent(model, "A1", "140");
+    setCellContent(model, "A2", "140");
+    createScorecardChart(model, {
+      keyValue: "A1",
+      baseline: "A2",
+      baselineMode: "percentage",
+    });
+    const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
+    expect(model.getters.getChartRuntime(scorecardId)).toMatchObject({
+      baselineArrow: "neutral",
+      baselineColor: undefined,
+      baselineDisplay: "0%",
+      keyValue: "140",
+    });
+  });
+
+  test("percentage with key value not defined", () => {
+    setCellContent(model, "A2", "140");
+    createScorecardChart(model, {
+      keyValue: "A1",
+      baseline: "A2",
+      baselineMode: "percentage",
+    });
+    const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
+    expect(model.getters.getChartRuntime(scorecardId)).toMatchObject({
+      baselineArrow: "neutral",
+      baselineColor: undefined,
+      baselineDisplay: "140",
+      keyValue: "",
+    });
+  });
+
+  test("percentage with baseline value not defined", () => {
+    setCellContent(model, "A1", "140");
+    createScorecardChart(model, {
+      keyValue: "A1",
+      baseline: "A2",
+      baselineMode: "percentage",
+    });
+    const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
+    expect(model.getters.getChartRuntime(scorecardId)).toMatchObject({
+      baselineArrow: "neutral",
+      baselineColor: undefined,
+      baselineDisplay: "",
+      keyValue: "140",
+    });
+  });
+
+  test("percentage with key value not defined and baseline value not defined", () => {
+    createScorecardChart(model, {
+      keyValue: "A1",
+      baseline: "A2",
+      baselineMode: "percentage",
+    });
+    const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
+    expect(model.getters.getChartRuntime(scorecardId)).toMatchObject({
+      baselineArrow: "neutral",
+      baselineColor: undefined,
+      baselineDisplay: "",
+      keyValue: "",
+    });
+  });
+
+  test("percentage with baseline value being 0", () => {
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "0");
+    createScorecardChart(model, {
+      keyValue: "A1",
+      baseline: "A2",
+      baselineMode: "percentage",
+    });
+    const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
+    expect(model.getters.getChartRuntime(scorecardId)).toMatchObject({
+      baselineArrow: "up",
+      baselineColor: "#00A04A",
+      baselineDisplay: "∞%",
+    });
+  });
+
+  test("percentage with key value and baseline value being 0", () => {
+    setCellContent(model, "A1", "0");
+    setCellContent(model, "A2", "0");
+    createScorecardChart(model, {
+      keyValue: "A1",
+      baseline: "A2",
+      baselineMode: "percentage",
+    });
+    const [scorecardId] = model.getters.getChartIds(model.getters.getActiveSheetId());
+    expect(model.getters.getChartRuntime(scorecardId)).toMatchObject({
+      baselineArrow: "neutral",
+      baselineColor: undefined,
+      baselineDisplay: "0%",
+    });
+  });
 });
 
 describe("multiple sheets", () => {


### PR DESCRIPTION
If both the key value and the baseline value are 0, a scorecard with a percentage format displays NaN% instead of 0%

This commit also adds some missing tests for the
percentage format.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [x] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo