### PR TITLE
[REV] composer: bad cursor placement on focus

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -142,9 +142,6 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
   });
   private isKeyStillDown: boolean = false;
 
-  /** Should be true if a mousedown was called on the composer, and the mouseUp still hasn't been handled */
-  private mouseDownActive: boolean = false;
-
   get assistantStyle(): string {
     if (this.props.delimitation && this.props.rect) {
       const { x: cellX, y: cellY, height: cellHeight } = this.props.rect;
@@ -365,18 +362,10 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
       // not main button, probably a context menu
       return;
     }
-
-    if (this.props.focus === "inactive") {
-      const newSelection = this.contentHelper.getCurrentSelection();
-      this.props.onComposerContentFocused(newSelection);
-    } else {
-      this.contentHelper.removeSelection();
-      this.mouseDownActive = true;
-    }
+    this.contentHelper.removeSelection();
   }
 
   onClick() {
-    this.mouseDownActive = false;
     if (this.env.model.getters.isReadonly()) {
       return;
     }
@@ -391,11 +380,6 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onBlur() {
-    if (this.mouseDownActive && this.props.focus !== "inactive") {
-      const newSelection = this.contentHelper.getCurrentSelection();
-      this.env.model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", newSelection);
-      this.mouseDownActive = false;
-    }
     this.isKeyStillDown = false;
   }
 

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -26,7 +26,6 @@ import {
   keyUp,
   rightClickCell,
   simulateClick,
-  triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
@@ -34,7 +33,6 @@ import {
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
-  spyDispatch,
   startGridComposition,
   toRangesData,
   typeInComposerGrid as typeInComposerGridHelper,
@@ -446,24 +444,6 @@ describe("composer", () => {
     expect(model.getters.getEditionMode()).toBe("editing");
     expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer")!);
-  });
-
-  test("Composer take focus on mouse down", async () => {
-    triggerMouseEvent("div.o-composer", "mousedown");
-    await nextTick();
-    expect(model.getters.getEditionMode()).toBe("editing");
-    expect(document.activeElement).toBe(fixture.querySelector("div.o-composer"));
-  });
-
-  test("Composer update its selection when mouseup isn't in the composer", async () => {
-    triggerMouseEvent("div.o-composer", "click");
-    await nextTick();
-
-    const dispatch = spyDispatch(parent);
-    triggerMouseEvent("div.o-composer", "mousedown");
-    triggerMouseEvent("div.o-spreadsheet-topbar", "mouseup");
-    triggerMouseEvent("div.o-spreadsheet-topbar", "click");
-    expect(dispatch).toHaveBeenCalledWith("CHANGE_COMPOSER_CURSOR_SELECTION", { end: 0, start: 0 });
   });
 
   test("starting the edition with a key stroke =, the composer should have the focus after the key input", async () => {


### PR DESCRIPTION
## Description

This reverts commit f19fdbfa5836d5ade44790a3cccb93df8c917419.

The commit made the composer focused on mouseDown instead of onClick. The problem is that `document.getSelection()` isn't updated yet on mouse down, and thus the composer selection was wrong.

b4dbb747 fixed the most annoying issue the reverted commit aimed to fix, that the selection was sometime cleared when pressing "ctrl".

Task 2993853 is created as a follow up of this revert to fix the issue of focus not being gained when the mouseup event isn't in the composer, which is a was smaller problem that the selection being wrong on a click in the composer.

Odoo task ID : [2986167](https://www.odoo.com/web#id=2986167&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo