### PR TITLE
[FIX] collaborative: do not transform commands in other dimension

### DIFF
--- a/src/collaborative/ot/ot.ts
+++ b/src/collaborative/ot/ot.ts
@@ -129,6 +129,9 @@ function transformDimension(
   executed: CoreCommand
 ): CoreCommand | TransformResult {
   if (executed.type === "ADD_COLUMNS_ROWS" || executed.type === "REMOVE_COLUMNS_ROWS") {
+    if (executed.dimension !== cmd.dimension) {
+      return cmd;
+    }
     const isUnique = cmd.type === "ADD_COLUMNS_ROWS";
     const field = isUnique ? "base" : "elements";
     let elements: number[] = isUnique ? [cmd[field]] : cmd[field];

--- a/tests/collaborative/ot/ot_columns_added.test.ts
+++ b/tests/collaborative/ot/ot_columns_added.test.ts
@@ -294,4 +294,16 @@ describe("OT with ADD_COLUMNS_ROWS with dimension COL", () => {
       expect(result).toEqual(command);
     });
   });
+  describe("Adding column does not impact commands in dimension 'ROW'", () => {
+    test("Add rows after add columns after", () => {
+      const command = { ...addColumnsAfter, dimension: "ROW" } as AddColumnsRowsCommand;
+      const result = transform(command, addColumnsAfter);
+      expect(result).toEqual(command);
+    });
+    test("Add rows after add columns before", () => {
+      const command = { ...addColumnsBefore, dimension: "ROW" } as AddColumnsRowsCommand;
+      const result = transform(command, addColumnsBefore);
+      expect(result).toEqual(command);
+    });
+  });
 });

--- a/tests/collaborative/ot/ot_columns_removed.test.ts
+++ b/tests/collaborative/ot/ot_columns_removed.test.ts
@@ -306,4 +306,32 @@ describe("OT with REMOVE_COLUMN", () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe("Removing column does not transform commands in dimension 'ROW'", () => {
+    const addRowsAfter: AddColumnsRowsCommand = {
+      type: "ADD_COLUMNS_ROWS",
+      dimension: "ROW",
+      position: "after",
+      base: 5,
+      quantity: 2,
+      sheetId,
+    };
+    const addRowsBefore: AddColumnsRowsCommand = {
+      type: "ADD_COLUMNS_ROWS",
+      dimension: "ROW",
+      position: "after",
+      base: 5,
+      quantity: 2,
+      sheetId,
+    };
+
+    test("Add rows (after) after delete columns", () => {
+      const result = transform(addRowsAfter, removeColumns);
+      expect(result).toEqual(addRowsAfter);
+    });
+    test("Add rows (before) after delete columns", () => {
+      const result = transform(addRowsBefore, removeColumns);
+      expect(result).toEqual(addRowsBefore);
+    });
+  });
 });

--- a/tests/collaborative/ot/ot_rows_added.test.ts
+++ b/tests/collaborative/ot/ot_rows_added.test.ts
@@ -295,4 +295,17 @@ describe("OT with ADD_COLUMNS_ROWS with dimension ROW", () => {
       expect(result).toEqual(command);
     });
   });
+
+  describe("Adding column does not impact commands in dimension 'ROW'", () => {
+    test("Add rows after add columns after", () => {
+      const command = { ...addRowsAfter, dimension: "COL" } as AddColumnsRowsCommand;
+      const result = transform(command, addRowsAfter);
+      expect(result).toEqual(command);
+    });
+    test("Add rows after add columns before", () => {
+      const command = { ...addRowsBefore, dimension: "COL" } as AddColumnsRowsCommand;
+      const result = transform(command, addRowsBefore);
+      expect(result).toEqual(command);
+    });
+  });
 });

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -306,4 +306,32 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe("Removing column does not transform commands in dimension 'ROW'", () => {
+    const addColumnsAfter: AddColumnsRowsCommand = {
+      type: "ADD_COLUMNS_ROWS",
+      dimension: "COL",
+      position: "after",
+      base: 5,
+      quantity: 2,
+      sheetId,
+    };
+    const addColumnsBefore: AddColumnsRowsCommand = {
+      type: "ADD_COLUMNS_ROWS",
+      dimension: "COL",
+      position: "after",
+      base: 5,
+      quantity: 2,
+      sheetId,
+    };
+
+    test("Add columns (after) after delete columns", () => {
+      const result = transform(addColumnsAfter, removeRows);
+      expect(result).toEqual(addColumnsAfter);
+    });
+    test("Add rows (before) after delete columns", () => {
+      const result = transform(addColumnsBefore, removeRows);
+      expect(result).toEqual(addColumnsBefore);
+    });
+  });
 });


### PR DESCRIPTION
Transformations of `gridDependentCommand's should skip the transformation when the executed and transformed commands  are applied to different dimensions.

e.g. `DELETE_COLUMNS_ROWS` in dimension `COL` should not alter
   `HIDE_COLUMSN_ROWS` in dimension `ROW`.

task 2996249

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo