### PR TITLE
[FIX] chart: allow plugins to react to chart duplication

### DIFF
--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -86,16 +86,15 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
             const id = this.nextId.toString();
             this.history.update("nextId", this.nextId + 1);
             const chart = this.charts[fig.id]?.copyForSheetId(cmd.sheetIdTo);
-            // TODO:
-            // This is not really correct, it should be the role of figures to
-            // duplicate a figure.
-            this.addFigure(
-              id,
-              cmd.sheetIdTo,
-              { x: fig.x, y: fig.y },
-              { width: fig.width, height: fig.height }
-            );
-            this.history.update("charts", id, chart);
+            if (chart) {
+              this.dispatch("CREATE_CHART", {
+                id,
+                position: { x: fig.x, y: fig.y },
+                size: { width: fig.width, height: fig.height },
+                definition: chart.getDefinition(),
+                sheetId: cmd.sheetIdTo,
+              });
+            }
           }
         }
         break;


### PR DESCRIPTION
In order to facilitate the extension of charts, other plugins should be aware that a chart was duplicated following the duplication of a sheet.

The current implementation forces the plugin to hook on `DUPLICATE_SHEET` and to compare a list of previously existing charts with the actualised one, which means it will have to extract the information of a chart directly.

With this commit, the chart plugin re-dispatches a `CREATE_CHART` command which helps Plugins that extend charts specifically: they can now react to the command rather than fishing for new charts.

## Description:

description of this task, what is implemented and why it is implemented that way.

part of 2998207
Odoo task ID : [2998207](https://www.odoo.com/web#id=2998207&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo