### PR TITLE
[IMP] grid: use correct event attribute

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -665,10 +665,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
    * Get the coordinates in pixels, with 0,0 being the top left of the grid itself
    */
   getCoordinates(ev: MouseEvent): [Pixel, Pixel] {
-    const rect = this.gridOverlay.el!.getBoundingClientRect();
-    const x = ev.pageX - rect.left;
-    const y = ev.pageY - rect.top;
-    return [x, y];
+    return [ev.offsetX, ev.offsetY];
   }
 
   getCartesianCoordinates(ev: MouseEvent): [HeaderIndex, HeaderIndex] {

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -86,8 +86,6 @@ export function triggerMouseEvent(
   });
   (ev as any).offsetX = x;
   (ev as any).offsetY = y;
-  (ev as any).pageX = x;
-  (ev as any).pageY = y;
   if (typeof selector === "string") {
     document.querySelector(selector)!.dispatchEvent(ev);
   } else {


### PR DESCRIPTION
Since the introduction of grid overlay, the computation for the coordinates are simply the offsets of the click event.

Co-authored-by: Lucas Lefèvre <lul@odoo.com>

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo