### PR TITLE
[FIX] functions: fix lookup for dates

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -7,6 +7,7 @@ import {
   toBoolean,
   toNumber,
 } from "./helpers";
+import { isPlainObject } from "../helpers/misc";
 
 /**
  * Perform a linear search and return the index of the perfect match.
@@ -21,6 +22,14 @@ import {
 function linearSearch(range: any[], target: any): number {
   for (let i = 0; i < range.length; i++) {
     if (range[i] === target) {
+      return i;
+    } else if (
+      isPlainObject(range[i]) &&
+      range[i].jsDate &&
+      isPlainObject(target) &&
+      target.jsDate &&
+      range[i].jsDate.getDate() === target.jsDate.getDate()
+    ) {
       return i;
     }
   }

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -43,7 +43,7 @@ export function deepCopy<T>(obj: T): T {
 /**
  * Check if the object is a plain old javascript object.
  */
-function isPlainObject(obj: unknown): boolean {
+export function isPlainObject(obj: unknown): boolean {
   return typeof obj === "object" && obj?.constructor === Object;
 }
 

--- a/tests/functions/module_lookup_test.ts
+++ b/tests/functions/module_lookup_test.ts
@@ -488,5 +488,17 @@ describe("lookup", () => {
         });
       });
     });
+    test("lookup number with string and date values", () => {
+      // prettier-ignore
+      const rangesGrid = {
+        A1: "Date", B1: "Amount", C1: "Target Date", D1: "VLOOKUP",
+        A2: "9/11/2001", B2: "666", C2: "9/11/2001",
+      };
+      const grid = evaluateGrid({
+        ...rangesGrid,
+        D2: "=VLOOKUP(C2, A1:B2, 2, 0)",
+      });
+      expect(grid.D2).toBe(666);
+    });
   });
 });


### PR DESCRIPTION
Datetime values are parsed to an object with `value`, `format`, `jsDate` attributes. Such objects are considered different even if the dates are the same.

Fix it by comparing `jsDate` value (those are Date objects and hence `getDate` method must be used)

Example:

```
| (A) Date      | (B) Amout | (C) Date      | VLOOKUP                  |
|---------------+-----------+---------------+--------------------------|
| 9/10/2022     |   999     | 9/10/2022     | =VLOOKUP(C2, A1:B2,2,0)  |
```

opw-2992901

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo