### PR TITLE
[IMP] formula: ignore space when caching compiled formula

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -361,7 +361,9 @@ export function compile(formula: string): CompiledFormula {
  * the compiled formula does not depend on their actual value.
  * Both `=A1+1+"2"` and `=A2+2+"3"` are compiled to the exact same function.
  *
- * A formula `=A1+A2+SUM(2, 2, "2")` have the cache key `=|0|+|1|+SUM(|N0|, |N0|, |S0|)`
+ * Spaces are also ignored to compute the cache key.
+ *
+ * A formula `=A1+A2+SUM(2, 2, "2")` have the cache key `=|0|+|1|+SUM(|N0|,|N0|,|S0|)`
  */
 function compilationCacheKey(
   tokens: Token[],
@@ -379,6 +381,8 @@ function compilationCacheKey(
         case "REFERENCE":
         case "INVALID_REFERENCE":
           return `|${dependencies.indexOf(token.value)}|`;
+        case "SPACE":
+          return "";
         default:
           return token.value;
       }

--- a/tests/formulas/__snapshots__/compiler.test.ts.snap
+++ b/tests/formulas/__snapshots__/compiler.test.ts.snap
@@ -125,7 +125,7 @@ return _1;
 exports[`expression compiler expressions with a debugger 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
-// =? |0| / |N0|
+// =?|0|/|N0|
 debugger;
 let _2 = ref(deps[0], false, \\"DIVIDE\\",  undefined);
 let _3 = { value: this.constantValues.numbers[0] };
@@ -138,7 +138,7 @@ return _1;
 exports[`expression compiler read some values and functions 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
-// =|0| + sum(|1|)
+// =|0|+sum(|1|)
 let _2 = ref(deps[0], false, \\"ADD\\",  undefined);
 let _4 = range(deps[1]);
 ctx.__lastFnCalled = 'SUM';
@@ -178,7 +178,7 @@ return _1;
 exports[`expression compiler some arithmetic expressions 4`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
-// =|N0| + |N1|
+// =|N0|+|N1|
 let _2 = { value: this.constantValues.numbers[0] };
 let _3 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'ADD';
@@ -190,7 +190,7 @@ return _1;
 exports[`expression compiler some arithmetic expressions 5`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
-// =|N0| * |N1|
+// =|N0|*|N1|
 let _2 = { value: this.constantValues.numbers[0] };
 let _3 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'MULTIPLY';
@@ -202,7 +202,7 @@ return _1;
 exports[`expression compiler some arithmetic expressions 6`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
-// =|N0| - |N1|
+// =|N0|-|N1|
 let _2 = { value: this.constantValues.numbers[0] };
 let _3 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'MINUS';
@@ -214,7 +214,7 @@ return _1;
 exports[`expression compiler some arithmetic expressions 7`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
-// =|N0| / |N1|
+// =|N0|/|N1|
 let _2 = { value: this.constantValues.numbers[0] };
 let _3 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'DIVIDE';
@@ -237,7 +237,7 @@ return _1;
 exports[`expression compiler some arithmetic expressions 9`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
-// =(|N0| + |N1|) * (-|N1| + |N2|)
+// =(|N0|+|N1|)*(-|N1|+|N2|)
 let _3 = { value: this.constantValues.numbers[0] };
 let _4 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'ADD';
@@ -269,7 +269,7 @@ return _1;
 exports[`expression compiler some arithmetic expressions 11`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
-// =sum(true, |S0|)
+// =sum(true,|S0|)
 let _2 = { value: this.constantValues.strings[0] };
 ctx.__lastFnCalled = 'SUM';
 let _1 = ctx['SUM']({ value: true },_2);
@@ -328,7 +328,7 @@ return _1;
 exports[`expression compiler with the same reference multiple times 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
-// =SUM(|0|, |0|, |2|)
+// =SUM(|0|,|0|,|2|)
 let _2 = range(deps[0]);
 let _3 = range(deps[0]);
 let _4 = range(deps[2]);

--- a/tests/formulas/compiler.test.ts
+++ b/tests/formulas/compiler.test.ts
@@ -469,4 +469,14 @@ describe("compile functions", () => {
       refFn.mockReset();
     });
   });
+
+  test("function cache ignore spaces in functions", () => {
+    compiledBaseFunction("=SUM(A1)");
+    expect(Object.keys(functionCache)).toEqual(["=SUM(|0|)"]);
+    compile("= SUM(A1)");
+    compile("=SUM( A1)");
+    compile("= SUM(A1 )");
+    compile("= SUM   (    A1    )");
+    expect(Object.keys(functionCache)).toEqual(["=SUM(|0|)"]);
+  });
 });


### PR DESCRIPTION
## Description:

When the formula are compiled, they are cached to avoid compiling
multiple time similar formula.

But formulas like `=SUM(A1)` and `=SUM( A1 )` that should have the same
result were recompiled because of the added spaces, because their cache
keys contained additional spaces.

This commit remove the spaces in the computation of the cache key of
a formula.

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo