### PR TITLE
[FIX] tests: fix in-determinist helper

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -169,8 +169,9 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
 
     useExternalListener(window as any, "resize", () => this.render(true));
     useExternalListener(window, "beforeunload", this.unbindModelEvents.bind(this));
+
+    this.bindModelEvents();
     onMounted(() => {
-      this.bindModelEvents();
       this.checkViewportSize();
     });
     onWillUnmount(() => this.unbindModelEvents());

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -63,7 +63,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   <div
     class="o-autofill"
-    style="top:19px;left:92px"
+    style="top:45px;left:140px"
   >
     <div
       class="o-autofill-handler"

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -430,7 +430,7 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
     
     <div
       class="o-autofill"
-      style="top:19px;left:92px"
+      style="top:45px;left:140px"
     >
       <div
         class="o-autofill-handler"

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -63,7 +63,6 @@ afterEach(() => {
 
 describe("Spreadsheet", () => {
   test("simple rendering snapshot", async () => {
-    await nextTick();
     expect(fixture.querySelector(".o-spreadsheet")).toMatchSnapshot();
   });
 

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -138,6 +138,11 @@ export async function mountSpreadsheet(
   const app = new App(Spreadsheet, { props, env: mockEnv, test: true });
   app.addTemplates(OWL_TEMPLATES);
   const parent = (await app.mount(fixture)) as Spreadsheet;
+  /**
+   * The following nextTick is necessary to ensure that a re-render is correctly
+   * done after the resize of the sheet view.
+   */
+  await nextTick();
   return { app, parent };
 }
 


### PR DESCRIPTION
Before this revision, we had one test non-determinist, but this test was actually false. The falsy part of the snapshot was the position of the autofill, which was not placed correctly because of the absence of re-rendering after a `RESIZE_SHEETVIEW`.

Here is how the rendering worked before this revision to render a spreadsheet:

- Render the Spreadsheet Component - Render the Grid - onMounted of Grid => dispatch of `RESIZE_SHEETVIEW` - trigger "update" - onMounted of Spreadsheet => register "update" event to re-render

With this process, "update" event was triggered **before** the registration of the event.
=> Spreadsheet was not re-rendered so the autofill was not correctly placed.

With this revision, we register the listener during the setup of Spreadsheet Component.

A second issue which explains why the test was non-determinist is that the test had a `await nextTick()` inside. This `nextTick` have to be in the helper `mountSpreadsheet`.

This revision highlight another incorrect test, which is fixed in this revision

Co-authored-by: Rémi Rahir <rar@odoo>
