### PR TITLE
[FIX] model: ensure that two getters cannot have the same name

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -239,6 +239,9 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       if (!(name in plugin)) {
         throw new Error(`Invalid getter name: ${name} for plugin ${plugin.constructor}`);
       }
+      if (name in this.getters) {
+        throw new Error(`Getter "${name}" is already defined.`);
+      }
       this.getters[name] = plugin[name].bind(plugin);
     }
     this.uiPlugins.push(plugin);
@@ -265,6 +268,9 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     for (let name of Plugin.getters) {
       if (!(name in plugin)) {
         throw new Error(`Invalid getter name: ${name} for plugin ${plugin.constructor}`);
+      }
+      if (name in this.coreGetters) {
+        throw new Error(`Getter "${name}" is already defined.`);
       }
       this.coreGetters[name] = plugin[name].bind(plugin);
     }

--- a/src/plugins/ui/header_visibility_ui.ts
+++ b/src/plugins/ui/header_visibility_ui.ts
@@ -5,7 +5,6 @@ import { UIPlugin } from "../ui_plugin";
 export class HeaderVisibilityUIPlugin extends UIPlugin {
   static getters = [
     "getNextVisibleCellPosition",
-    "getNextVisibleCellPosition",
     "findVisibleHeader",
     "findLastVisibleColRowIndex",
     "findFirstVisibleColRowIndex",

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -112,4 +112,46 @@ describe("Model", () => {
     const model = new Model({}, { custom: "42" } as unknown as ModelConfig);
     expect(model["config"]["custom"]).toBe("42");
   });
+
+  test("Cannot add an already existing core getters", () => {
+    class MyCorePlugin1 extends CorePlugin {
+      static getters = ["getSomething"];
+
+      getSomething() {}
+    }
+
+    class MyCorePlugin2 extends CorePlugin {
+      static getters = ["getSomething"];
+
+      getSomething() {}
+    }
+    corePluginRegistry.add("myCorePlugin1", MyCorePlugin1);
+    corePluginRegistry.add("myCorePlugin2", MyCorePlugin2);
+
+    expect(() => new Model()).toThrowError(`Getter "getSomething" is already defined.`);
+
+    corePluginRegistry.remove("myCorePlugin1");
+    corePluginRegistry.remove("myCorePlugin2");
+  });
+
+  test("Cannot add an already existing getters", () => {
+    class MyUIPlugin1 extends UIPlugin {
+      static getters = ["getSomething"];
+
+      getSomething() {}
+    }
+
+    class MyUIPlugin2 extends UIPlugin {
+      static getters = ["getSomething"];
+
+      getSomething() {}
+    }
+    uiPluginRegistry.add("myUIPlugin1", MyUIPlugin1);
+    uiPluginRegistry.add("myUIPlugin2", MyUIPlugin2);
+
+    expect(() => new Model()).toThrowError(`Getter "getSomething" is already defined.`);
+
+    uiPluginRegistry.remove("myUIPlugin1");
+    uiPluginRegistry.remove("myUIPlugin2");
+  });
 });


### PR DESCRIPTION
Before this revision, it was possible to define two getters with the same name, which could lead to errors.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo