### PR TITLE
[IMP] grid: allow to remove content of a cell with backspace

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -169,6 +169,12 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         target: this.env.model.getters.getSelectedZones(),
       });
     },
+    BACKSPACE: () => {
+      this.env.model.dispatch("DELETE_CONTENT", {
+        sheetId: this.env.model.getters.getActiveSheetId(),
+        target: this.env.model.getters.getSelectedZones(),
+      });
+    },
     "CTRL+A": () => this.env.model.selection.loopSelection(),
     "CTRL+S": () => {
       this.props.onSaveRequested?.();

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -276,6 +276,17 @@ describe("Grid component", () => {
       expect(getCellContent(model, "A1")).toBe("a");
     });
 
+    test("pressing BACKSPACE remove the content of a cell", async () => {
+      setCellContent(model, "A1", "test");
+      await nextTick();
+      fixture
+        .querySelector("div.o-grid")!
+        .dispatchEvent(new KeyboardEvent("keydown", { key: "Backspace" }));
+      expect(getActiveXc(model)).toBe("A1");
+      expect(model.getters.getEditionMode()).toBe("inactive");
+      expect(getCellContent(model, "A1")).toBe("");
+    });
+
     test("pressing shift+ENTER in edit mode stop editing and move one cell up", async () => {
       selectCell(model, "A2");
       expect(getActiveXc(model)).toBe("A2");


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo