### PR TITLE
[IMP] filters: allow to update a filter in readonly mode

### DIFF
--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -133,6 +133,8 @@ export const readonlyAllowedCommands = new Set<CommandTypes>([
 
   "OPEN_CELL_POPOVER",
   "CLOSE_CELL_POPOVER",
+
+  "UPDATE_FILTER",
 ]);
 
 export const coreTypes = new Set<CoreCommandTypes>([

--- a/tests/plugins/filters.test.ts
+++ b/tests/plugins/filters.test.ts
@@ -119,6 +119,13 @@ describe("Filters plugin", () => {
       expect(model.getters.getFilterValues(sheetId, 0, 0)).toEqual(["2", "A"]);
     });
 
+    test("Can update  a filter in readonly mode", () => {
+      createFilter(model, "A1:A5");
+      model.updateMode("readonly");
+      updateFilter(model, "A1", ["2", "A"]);
+      expect(model.getters.getFilterValues(sheetId, 0, 0)).toEqual(["2", "A"]);
+    });
+
     test("Create a filter with multiple target create a single filter of the union of the targets", () => {
       createFilter(model, "A1:A5, B1:B5");
       expect(model.getters.getFilterTable(sheetId, 0, 0)!.zone).toEqual(toZone("A1:B5"));


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo