### PR TITLE
[FIX] ui_sheet: do not resize empty columns

### DIFF
--- a/src/plugins/ui/ui_sheet.ts
+++ b/src/plugins/ui/ui_sheet.ts
@@ -86,12 +86,14 @@ export class SheetUIPlugin extends UIPlugin {
       contentWidth += ICON_EDGE_LENGTH + FILTER_ICON_MARGIN;
     }
 
-    contentWidth += 2 * PADDING_AUTORESIZE_HORIZONTAL;
+    if (contentWidth > 0) {
+      contentWidth += 2 * PADDING_AUTORESIZE_HORIZONTAL;
 
-    if (this.getters.getCellStyle(cell).wrapping === "wrap") {
-      const zone = positionToZone({ col, row });
-      const colWidth = this.getters.getColSize(this.getters.getActiveSheetId(), zone.left);
-      return Math.min(colWidth, contentWidth);
+      if (this.getters.getCellStyle(cell).wrapping === "wrap") {
+        const zone = positionToZone({ col, row });
+        const colWidth = this.getters.getColSize(this.getters.getActiveSheetId(), zone.left);
+        return Math.min(colWidth, contentWidth);
+      }
     }
     return contentWidth;
   }

--- a/tests/plugins/formatting.test.ts
+++ b/tests/plugins/formatting.test.ts
@@ -532,4 +532,13 @@ describe("Autoresize", () => {
     expect(model.getters.getRowSize(sheetId, 0)).toBe(initialSize);
     expect(model.getters.getRowSize(newSheetId, 0)).toBe(DEFAULT_CELL_HEIGHT);
   });
+
+  test("Autoresizing empty cols has no effect", () => {
+    const initialSize = model.getters.getColSize(sheetId, 0);
+    model.dispatch("AUTORESIZE_COLUMNS", { sheetId, cols: [0] });
+    expect(model.getters.getColSize(sheetId, 0)).toBe(initialSize);
+    setCellContent(model, "A1", '=""');
+    model.dispatch("AUTORESIZE_COLUMNS", { sheetId, cols: [0] });
+    expect(model.getters.getColSize(sheetId, 0)).toBe(initialSize);
+  });
 });


### PR DESCRIPTION
Since https://github.com/odoo/o-spreadsheet/pull/1590, the automatic resize would wrongly compute cell widths by automatically adding the padding even if the cell did not have a content.

task 3012575

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo