### PR TITLE
[REF] sheetview: don't reset viewports uselessly

### DIFF
--- a/src/plugins/ui/sheetview.ts
+++ b/src/plugins/ui/sheetview.ts
@@ -107,7 +107,7 @@ export class SheetViewPlugin extends UIPlugin {
   private gridOffsetX: Pixel = 0;
   private gridOffsetY: Pixel = 0;
 
-  private sheetsWithDirtyViewports: UID[] = [];
+  private sheetsWithDirtyViewports: Set<UID> = new Set();
   // ---------------------------------------------------------------------------
   // Command Handling
   // ---------------------------------------------------------------------------
@@ -210,7 +210,7 @@ export class SheetViewPlugin extends UIPlugin {
       case "UPDATE_CELL":
         // update cell content or format can change hidden rows because of data filters
         if ("content" in cmd || "format" in cmd) {
-          this.sheetsWithDirtyViewports.push(cmd.sheetId);
+          this.sheetsWithDirtyViewports.add(cmd.sheetId);
         }
         break;
       case "ACTIVATE_SHEET":
@@ -231,7 +231,7 @@ export class SheetViewPlugin extends UIPlugin {
     for (const sheetId of this.sheetsWithDirtyViewports) {
       this.resetViewports(sheetId);
     }
-    this.sheetsWithDirtyViewports = [];
+    this.sheetsWithDirtyViewports = new Set();
     this.setViewports();
   }
 


### PR DESCRIPTION
If 260k UPDATE_CELL commands are dispatched (e.g. if you change the
backgound color of a 10000x26 sheet), the viewports will be reset
260k times instead of only once.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo