### PR TITLE
[FIX] sheetview: resize viewport when font size changes

### DIFF
--- a/src/plugins/ui/sheetview.ts
+++ b/src/plugins/ui/sheetview.ts
@@ -209,7 +209,7 @@ export class SheetViewPlugin extends UIPlugin {
         break;
       case "UPDATE_CELL":
         // update cell content or format can change hidden rows because of data filters
-        if ("content" in cmd || "format" in cmd) {
+        if ("content" in cmd || "format" in cmd || cmd.style?.fontSize !== undefined) {
           this.sheetsWithDirtyViewports.add(cmd.sheetId);
         }
         break;

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -31,6 +31,7 @@ import {
   setCellContent,
   setFormat,
   setSelection,
+  setStyle,
   setViewportOffset,
   undo,
   unfreezeColumns,
@@ -843,6 +844,29 @@ describe("Viewport of Simple sheet", () => {
     oldViewport = { ...model.getters.getActiveMainViewport() };
     setFormat(model, "0.00%", target("A5"));
     expect(model.getters.getActiveMainViewport()).not.toEqual(oldViewport);
+  });
+
+  test("viewport is recomputed when font size changes", () => {
+    expect(model.getters.getActiveMainViewport()).toEqual({
+      bottom: 43,
+      left: 0,
+      right: 10,
+      top: 0,
+    });
+    setStyle(model, "A1:A20", { fontSize: 36 });
+    expect(model.getters.getActiveMainViewport()).toEqual({
+      bottom: 18,
+      left: 0,
+      right: 10,
+      top: 0,
+    });
+    setStyle(model, "A1:A20", { fontSize: 8 });
+    expect(model.getters.getActiveMainViewport()).toEqual({
+      bottom: 43,
+      left: 0,
+      right: 10,
+      top: 0,
+    });
   });
 });
 


### PR DESCRIPTION
select a full column, set its font size to 36, select another cell, then select the column again and set the font size to 10
=>  the bottom part of the grid is not rendered on the canvas because the viewport is still considered small.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3030280](https://www.odoo.com/web#id=3030280&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo