### PR TITLE
[FIX] interactive merge: remove useless user confirmation

### DIFF
--- a/src/helpers/ui/merge_interactive.ts
+++ b/src/helpers/ui/merge_interactive.ts
@@ -10,13 +10,11 @@ export const AddMergeInteractiveContent = {
 
 export function interactiveAddMerge(env: SpreadsheetChildEnv, sheetId: UID, target: Zone[]) {
   const result = env.model.dispatch("ADD_MERGE", { sheetId, target });
-  if (!result.isSuccessful) {
-    if (result.isCancelledBecause(CommandResult.MergeIsDestructive)) {
-      env.askConfirmation(AddMergeInteractiveContent.MergeIsDestructive, () => {
-        env.model.dispatch("ADD_MERGE", { sheetId, target, force: true });
-      });
-    } else if (result.isCancelledBecause(CommandResult.MergeInFilter)) {
-      env.raiseError(AddMergeInteractiveContent.MergeInFilter);
-    }
+  if (result.isCancelledBecause(CommandResult.MergeInFilter)) {
+    env.raiseError(AddMergeInteractiveContent.MergeInFilter);
+  } else if (result.isCancelledBecause(CommandResult.MergeIsDestructive)) {
+    env.askConfirmation(AddMergeInteractiveContent.MergeIsDestructive, () => {
+      env.model.dispatch("ADD_MERGE", { sheetId, target, force: true });
+    });
   }
 }

--- a/tests/helpers/ui.test.ts
+++ b/tests/helpers/ui.test.ts
@@ -343,6 +343,16 @@ describe("UI Helpers", () => {
         AddMergeInteractiveContent.MergeInFilter.toString()
       );
     });
+
+    test("Destructive merge inside a filter", () => {
+      createFilter(model, "A1:A2");
+      setCellContent(model, "A2", ":)");
+      interactiveAddMerge(env, sheetId, target("A1:B5"));
+      expect(notifyUserTextSpy).toHaveBeenCalledWith(
+        AddMergeInteractiveContent.MergeInFilter.toString()
+      );
+      expect(askConfirmationTextSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("Sort multi adjacent columns", () => {


### PR DESCRIPTION
## Description

If the user try to create a merge that both overwrite a value and is inside a data filters, the user will be prompted to confirm overwriting values, then the merge will fail because it's created inside a data filter. But no error message will show up.

Fix this by displaying the MergeInFilter error before prompting the user. It's useless to ask confirmation from the user for something that won't work.

Odoo task ID : [2977521](https://www.odoo.com/web#id=2977521&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo