### PR TITLE
[REF] grid: remove useless clip

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -315,8 +315,8 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     const { offsetScrollbarX, offsetScrollbarY } =
       this.env.model.getters.getActiveSheetScrollInfo();
     this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
-      offsetX: Math.max(offsetScrollbarX + deltaX, 0),
-      offsetY: Math.max(offsetScrollbarY + deltaY, 0),
+      offsetX: offsetScrollbarX + deltaX,
+      offsetY: offsetScrollbarY + deltaY,
     });
   }
 


### PR DESCRIPTION
Since 7b1c16b, offsets are automatically clipped by the plugin.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo