### PR TITLE
[FIX] find_and_replace: clear input clears search matches

### DIFF
--- a/src/components/side_panel/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace.ts
@@ -182,12 +182,10 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetEnv> {
     this.env.dispatch("SELECT_SEARCH_NEXT_MATCH");
   }
   updateSearch() {
-    if (this.state.toSearch) {
-      this.env.dispatch("UPDATE_SEARCH", {
-        toSearch: this.state.toSearch,
-        searchOptions: this.state.searchOptions,
-      });
-    }
+    this.env.dispatch("UPDATE_SEARCH", {
+      toSearch: this.state.toSearch,
+      searchOptions: this.state.searchOptions,
+    });
   }
   debouncedUpdateSearch() {
     clearTimeout(this.inDebounce);

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -1,5 +1,6 @@
 import { Model, Spreadsheet } from "../../src";
 import { DispatchResult } from "../../src/types/commands";
+import { setCellContent } from "../test_helpers/commands_helpers";
 import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
@@ -135,11 +136,37 @@ describe("find and replace sidePanel component", () => {
       expect(parent.env.dispatch).toHaveBeenCalledWith("SELECT_SEARCH_PREVIOUS_MATCH");
     });
 
-    test("won't search on empty string", async () => {
+    test("search on empty string", async () => {
       setInputValueAndTrigger(selectors.inputSearch, "", "input");
       jest.runAllTimers();
       await nextTick();
-      expect(parent.env.dispatch).not.toHaveBeenCalled();
+      expect(parent.env.dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
+        searchOptions: { exactMatch: false, matchCase: false, searchFormulas: false },
+        toSearch: "",
+      });
+    });
+  });
+
+  describe("search count match", () => {
+    test("search match count is displayed", async () => {
+      setCellContent(model, "A1", "Hello");
+      expect(fixture.querySelector(".o-input-count")).toBeNull();
+      setInputValueAndTrigger(selectors.inputSearch, "Hel", "input");
+      jest.runAllTimers();
+      await nextTick();
+      expect(fixture.querySelector(".o-input-count")?.innerHTML).toBe("1 / 1");
+    });
+
+    test("search match count is removed when input is cleared", async () => {
+      setCellContent(model, "A1", "Hello");
+      setInputValueAndTrigger(selectors.inputSearch, "Hel", "input");
+      jest.runAllTimers();
+      await nextTick();
+      expect(fixture.querySelector(".o-input-count")?.innerHTML).toBe("1 / 1");
+      setInputValueAndTrigger(selectors.inputSearch, "", "input");
+      jest.runAllTimers();
+      await nextTick();
+      expect(fixture.querySelector(".o-input-count")).toBeNull();
     });
   });
 

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -83,6 +83,18 @@ describe("basic search", () => {
     expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
   });
 
+  test("search on empty string does not match anything", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "", searchOptions });
+    expect(model.getters.getSearchMatches()).toHaveLength(0);
+  });
+
+  test("search on empty string clears matches", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
+    expect(model.getters.getSearchMatches()).toHaveLength(4);
+    model.dispatch("UPDATE_SEARCH", { toSearch: "", searchOptions });
+    expect(model.getters.getSearchMatches()).toHaveLength(0);
+  });
+
   test.skip("Will search a modified cell", () => {
     // not implemented
     model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });


### PR DESCRIPTION
## Description:

Open the Find & replace side panel
Match some cells in the sheet
Clears the input, rapidly such that the call is debounced and only called when the input is empty
=> the search matches are still matched

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo