### PR TITLE
[FIX] topbar: empty space between dropdown and button

### DIFF
--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -228,7 +228,7 @@ css/* scss */ `
 
           .o-dropdown-content {
             position: absolute;
-            top: calc(100% + 5px);
+            top: 100%;
             left: 0;
             z-index: ${ComponentsImportance.Dropdown};
             box-shadow: 1px 2px 5px 2px rgba(51, 51, 51, 0.15);


### PR DESCRIPTION
## Description

This commit removes the empty space between the top bar dropdowns and the buttons that open them.

Odoo task ID : [3025195](https://www.odoo.com/web#id=3025195&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

Based on branch `master-dropdwon-closing-on-inside-click-adrm` because it changes the hierarchy of the DOM elements of the topbar

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo