### PR TITLE
[FIX] find and replace: scroll on single match.

### DIFF
--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -189,10 +189,8 @@ export class FindAndReplacePlugin extends UIPlugin {
     }
     //modulo of negative value to be able to cycle in both directions with previous and next
     nextIndex = ((nextIndex % matches.length) + matches.length) % matches.length;
-    if (this.selectedMatchIndex === null || this.selectedMatchIndex !== nextIndex) {
-      this.selectedMatchIndex = nextIndex;
-      this.selection.selectCell(matches[nextIndex].col, matches[nextIndex].row);
-    }
+    this.selectedMatchIndex = nextIndex;
+    this.selection.selectCell(matches[nextIndex].col, matches[nextIndex].row);
     for (let index = 0; index < this.searchMatches.length; index++) {
       this.searchMatches[index].selected = index === this.selectedMatchIndex;
     }


### PR DESCRIPTION
## Description

Before this commit, there was a bug in the find and replace side panel that occurred when a single match was found. The previous/next buttons weren't working and, past the initial search, the panel didn't scroll to the matched cell and didn't select it.

For example after searching a value, and then scrolling in the sheet, it was impossible to scroll back to the matched cell using the side panel.

Odoo task ID : [3018173](https://www.odoo.com/web#id=3018173&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo