### PR TITLE
[FIX] filters: show rows when filter table is removed

### DIFF
--- a/src/plugins/ui/filter_evaluation.ts
+++ b/src/plugins/ui/filter_evaluation.ts
@@ -43,6 +43,7 @@ export class FilterEvaluationPlugin extends UIPlugin {
       case "UPDATE_CELL":
       case "EVALUATE_CELLS":
       case "ACTIVATE_SHEET":
+      case "REMOVE_FILTER_TABLE":
         this.isEvaluationDirty = true;
         break;
       case "UPDATE_FILTER":

--- a/tests/plugins/filter_evaluation.test.ts
+++ b/tests/plugins/filter_evaluation.test.ts
@@ -3,6 +3,7 @@ import { toZone } from "../../src/helpers";
 import { UID } from "../../src/types";
 import {
   createFilter,
+  deleteFilter,
   hideColumns,
   hideRows,
   setBorder,
@@ -49,6 +50,16 @@ describe("Filter Evaluation Plugin", () => {
     setFormat(model, "m/d/yyyy", target("A2"));
     updateFilter(model, "A2", ["1/1/1900"]);
     expect(model.getters.isRowHidden(sheetId, 1)).toEqual(true);
+  });
+
+  test("deleting a filter table show rows again", () => {
+    const model = new Model();
+    createFilter(model, "A1:A3");
+    setCellContent(model, "A2", "Hi");
+    updateFilter(model, "A2", ["Hi"]);
+    expect(model.getters.isRowHidden(sheetId, 1)).toEqual(true);
+    deleteFilter(model, "A1:A3");
+    expect(model.getters.isRowHidden(sheetId, 1)).toEqual(false);
   });
 
   test("Filters ignore lowercase/uppercase", () => {


### PR DESCRIPTION
## Description:

Create a data filter
Hide some values
select the filter zone and remove the filter
=> the rows are still hidden

Odoo task ID : [3028057](https://www.odoo.com/web#id=3028057&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo