### PR TITLE
[FIX] search & replace: next scroll not working on single search

### DIFF
--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -192,6 +192,9 @@ export class FindAndReplacePlugin extends UIPlugin {
       this.selectedMatchIndex = nextIndex;
       this.selection.selectCell(matches[nextIndex].col, matches[nextIndex].row);
     }
+
+    if (this.searchMatches.length === 1) this.selection.selectCell(matches[0].col, matches[0].row);
+
     for (let index = 0; index < this.searchMatches.length; index++) {
       this.searchMatches[index].selected = index === this.selectedMatchIndex;
     }


### PR DESCRIPTION
## Description:

Search for a single word which is outside of viewport, sheet will auto scroll to that word, now again scroll back in such a way that the cell is out of the viewport, now even if you press enter or click on next / previous in searcg panel nothing will happen. This behavior is changed here and now it again scrolls you back to that cell.

Odoo task ID : [3018173](https://www.odoo.com/web#id=3018173&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo