### PR TITLE
[FIX] overflowing cell with border rendering

### DIFF
--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -491,23 +491,37 @@ export class RendererPlugin extends UIPlugin {
     ctx.stroke();
   }
 
-  private hasContent(col: HeaderIndex, row: HeaderIndex): boolean {
-    const sheetId = this.getters.getActiveSheetId();
-    const cell = this.getters.getCell(sheetId, col, row);
-    return (cell && !cell.isEmpty()) || this.getters.isInMerge(sheetId, col, row);
-  }
-
   private findNextEmptyCol(base: HeaderIndex, max: HeaderIndex, row: HeaderIndex): HeaderIndex {
+    const sheetId = this.getters.getActiveSheetId();
     let col: HeaderIndex = base;
-    while (col < max && !this.hasContent(col + 1, row)) {
+    while (col < max) {
+      const nextCell = this.getters.getCell(sheetId, col + 1, row);
+      const nextCellBorder = this.getters.getCellBorderWithFilterBorder(sheetId, col + 1, row);
+      if (
+        (nextCell && !nextCell.isEmpty()) ||
+        this.getters.isInMerge(sheetId, col + 1, row) ||
+        nextCellBorder?.left
+      ) {
+        return col;
+      }
       col++;
     }
     return col;
   }
 
   private findPreviousEmptyCol(base: HeaderIndex, min: HeaderIndex, row: HeaderIndex): HeaderIndex {
+    const sheetId = this.getters.getActiveSheetId();
     let col: HeaderIndex = base;
-    while (col > min && !this.hasContent(col - 1, row)) {
+    while (col > min) {
+      const previousCell = this.getters.getCell(sheetId, col - 1, row);
+      const previousCellBorder = this.getters.getCellBorderWithFilterBorder(sheetId, col - 1, row);
+      if (
+        (previousCell && !previousCell.isEmpty()) ||
+        this.getters.isInMerge(sheetId, col + 1, row) ||
+        previousCellBorder?.right
+      ) {
+        return col;
+      }
       col--;
     }
     return col;


### PR DESCRIPTION
## Description

There was a problem where the content of the cells could overflow over cell borders.

Fix this by preventing cell overflow in a direction where there is a cell border.

Odoo task ID : [3010033](https://www.odoo.com/web#id=3010033&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo