### PR TITLE
[IMP] figure: add snap to figure drag & drop

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -59,7 +59,7 @@ css/*SCSS*/ `
     box-sizing: content-box;
 
     .o-fig-anchor {
-      z-index: ${ComponentsImportance.ChartAnchor};
+      z-index: ${ComponentsImportance.FigureAnchor};
       position: absolute;
       width: ${ANCHOR_SIZE}px;
       height: ${ANCHOR_SIZE}px;

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -7,6 +7,7 @@
         t-on-contextmenu.prevent.stop="onContextMenu"
         t-ref="figure"
         t-att-style="props.style"
+        t-att-data-id="props.figure.id"
         tabindex="0"
         t-on-keydown="(ev) => this.onKeyDown(ev)"
         t-on-keyup.stop="">

--- a/src/components/figures/figure_container/figure_container.xml
+++ b/src/components/figures/figure_container/figure_container.xml
@@ -22,5 +22,19 @@
         </div>
       </t>
     </div>
+    <div
+      class="o-figure-container position-absolute pe-none overflow-hidden"
+      t-if="dnd.horizontalSnap"
+      t-att-style="dnd.horizontalSnap.containerStyle"
+      t-att-data-id="'HorizontalSnapContainer'">
+      <div class="o-figure-snap-line horizontal" t-att-style="dnd.horizontalSnap.lineStyle"/>
+    </div>
+    <div
+      class="o-figure-container position-absolute pe-none overflow-hidden"
+      t-if="dnd.verticalSnap"
+      t-att-style="dnd.verticalSnap.containerStyle"
+      t-att-data-id="'VerticalSnapContainer'">
+      <div class="o-figure-snap-line vertical" t-att-style="dnd.verticalSnap.lineStyle"/>
+    </div>
   </t>
 </templates>

--- a/src/components/helpers/css.ts
+++ b/src/components/helpers/css.ts
@@ -136,6 +136,9 @@ export function cellTextStyleToCss(style: Style | undefined): CSSProperties {
   return attributes;
 }
 
+/**
+ * Transform CSS properties into a CSS string.
+ */
 export function cssPropertiesToCss(attributes: CSSProperties): string {
   const str = Object.entries(attributes)
     .filter(([attName, attValue]) => attValue !== undefined)

--- a/src/components/helpers/figure_container_helper.ts
+++ b/src/components/helpers/figure_container_helper.ts
@@ -1,0 +1,40 @@
+import { DOMCoordinates, Figure, Getters } from "../../types";
+
+/**
+ * Transform a figure with coordinates from the model, to coordinates as they are shown on the screen,
+ * taking into account the scroll position of the active sheet and the frozen panes.
+ */
+export function internalFigureToScreen(getters: Getters, fig: Figure): Figure {
+  return { ...fig, ...internalToScreenCoordinates(getters, { x: fig.x, y: fig.y }) };
+}
+
+/**
+ * Transform a figure with coordinates as they are shown on the screen, to coordinates as they are in the model,
+ * taking into account the scroll position of the active sheet and the frozen panes.
+ *
+ * Note that this isn't  exactly the reverse operation as internalFigureToScreen, because the figure will always be on top
+ * of the frozen panes.
+ */
+export function screenFigureToInternal(getters: Getters, fig: Figure): Figure {
+  return { ...fig, ...screenCoordinatesToInternal(getters, { x: fig.x, y: fig.y }) };
+}
+
+function internalToScreenCoordinates(getters: Getters, { x, y }: DOMCoordinates): DOMCoordinates {
+  const { x: viewportX, y: viewportY } = getters.getMainViewportCoordinates();
+  const { scrollX, scrollY } = getters.getActiveSheetScrollInfo();
+
+  x = x < viewportX ? x : x - scrollX;
+  y = y < viewportY ? y : y - scrollY;
+
+  return { x, y };
+}
+
+function screenCoordinatesToInternal(getters: Getters, { x, y }: DOMCoordinates): DOMCoordinates {
+  const { x: viewportX, y: viewportY } = getters.getMainViewportCoordinates();
+  const { scrollX, scrollY } = getters.getActiveSheetScrollInfo();
+
+  x = viewportX && x < viewportX ? x : x + scrollX;
+  y = viewportY && y < viewportY ? y : y + scrollY;
+
+  return { x, y };
+}

--- a/src/components/helpers/figure_drag_helper.ts
+++ b/src/components/helpers/figure_drag_helper.ts
@@ -1,0 +1,59 @@
+import { Figure, PixelPosition, SheetScrollInfo } from "../../types";
+
+export function dragFigureForMove(
+  { x: mouseX, y: mouseY }: PixelPosition,
+  { x: mouseInitialX, y: mouseInitialY }: PixelPosition,
+  initialFigure: Figure,
+  { x: viewportX, y: viewportY }: PixelPosition,
+  { scrollX, scrollY }: SheetScrollInfo
+): Figure {
+  const minX = viewportX ? 0 : -scrollX;
+  const minY = viewportY ? 0 : -scrollY;
+
+  let deltaX = mouseX - mouseInitialX;
+  const newX = Math.max(initialFigure.x + deltaX, minX);
+  let deltaY = mouseY - mouseInitialY;
+  const newY = Math.max(initialFigure.y + deltaY, minY);
+
+  return { ...initialFigure, x: newX, y: newY };
+}
+
+export function dragFigureForResize(
+  initialFigure: Figure,
+  dirX: -1 | 0 | 1,
+  dirY: -1 | 0 | 1,
+  { x: mouseX, y: mouseY }: PixelPosition,
+  { x: mouseInitialX, y: mouseInitialY }: PixelPosition,
+  keepRatio: boolean,
+  minFigSize: number
+): Figure {
+  let { x, y, width, height } = initialFigure;
+
+  if (keepRatio && dirX != 0 && dirY != 0) {
+    const deltaX = Math.min(dirX * (mouseInitialX - mouseX), initialFigure.width - minFigSize);
+    const deltaY = Math.min(dirY * (mouseInitialY - mouseY), initialFigure.height - minFigSize);
+    const fraction = Math.min(deltaX / initialFigure.width, deltaY / initialFigure.height);
+    width = initialFigure.width * (1 - fraction);
+    height = initialFigure.height * (1 - fraction);
+    if (dirX < 0) {
+      x = initialFigure.x + initialFigure.width * fraction;
+    }
+    if (dirY < 0) {
+      y = initialFigure.y + initialFigure.height * fraction;
+    }
+  } else {
+    const deltaX = Math.max(dirX * (mouseX - mouseInitialX), minFigSize - initialFigure.width);
+    const deltaY = Math.max(dirY * (mouseY - mouseInitialY), minFigSize - initialFigure.height);
+    width = initialFigure.width + deltaX;
+    height = initialFigure.height + deltaY;
+
+    if (dirX < 0) {
+      x = initialFigure.x - deltaX;
+    }
+    if (dirY < 0) {
+      y = initialFigure.y - deltaY;
+    }
+  }
+
+  return { ...initialFigure, x, y, width, height };
+}

--- a/src/components/helpers/figure_snap_helper.ts
+++ b/src/components/helpers/figure_snap_helper.ts
@@ -1,0 +1,275 @@
+import { Figure, Getters, Pixel, PixelPosition, UID } from "../../types";
+import { FIGURE_BORDER_WIDTH } from "./../../constants";
+import { internalFigureToScreen } from "./figure_container_helper";
+
+const SNAP_MARGIN: Pixel = 5;
+
+export type HFigureAxisType = "top" | "bottom" | "vCenter";
+export type VFigureAxisType = "right" | "left" | "hCenter";
+
+type FigureAxis<T extends HFigureAxisType | VFigureAxisType> = {
+  axisType: T;
+  position: Pixel;
+};
+
+export interface SnapLine<T extends HFigureAxisType | VFigureAxisType> {
+  matchedFigIds: UID[];
+  snapOffset: number;
+  snappedAxisType: T;
+  position: Pixel;
+}
+
+interface SnapReturn {
+  snappedFigure: Figure;
+  verticalSnapLine?: SnapLine<VFigureAxisType>;
+  horizontalSnapLine?: SnapLine<HFigureAxisType>;
+}
+
+/**
+ * Try to snap the given figure to other figures when moving the figure, and return the snapped
+ * figure and the possible snap lines, if any were found
+ */
+export function snapForMove(
+  getters: Getters,
+  figureToSnap: Figure,
+  otherFigures: Figure[]
+): SnapReturn {
+  const snappedFigure = { ...figureToSnap };
+
+  const verticalSnapLine = getSnapLine(
+    getters,
+    snappedFigure,
+    ["hCenter", "right", "left"],
+    otherFigures,
+    ["hCenter", "right", "left"]
+  );
+
+  const horizontalSnapLine = getSnapLine(
+    getters,
+    snappedFigure,
+    ["vCenter", "bottom", "top"],
+    otherFigures,
+    ["vCenter", "bottom", "top"]
+  );
+
+  const { y: viewportY, x: viewportX } = getters.getMainViewportCoordinates();
+  const { scrollY, scrollX } = getters.getActiveSheetScrollInfo();
+
+  // If the snap cause the figure to change pane, we need to also apply the scroll as an offset
+  if (horizontalSnapLine) {
+    snappedFigure.y -= horizontalSnapLine.snapOffset;
+
+    const isBaseFigFrozenY = figureToSnap.y < viewportY;
+    const isSnappedFrozenY = snappedFigure.y < viewportY;
+
+    if (isBaseFigFrozenY && !isSnappedFrozenY) snappedFigure.y += scrollY;
+    else if (!isBaseFigFrozenY && isSnappedFrozenY) snappedFigure.y -= scrollY;
+  }
+
+  if (verticalSnapLine) {
+    snappedFigure.x -= verticalSnapLine.snapOffset;
+
+    const isBaseFigFrozenX = figureToSnap.x < viewportX;
+    const isSnappedFrozenX = snappedFigure.x < viewportX;
+
+    if (isBaseFigFrozenX && !isSnappedFrozenX) snappedFigure.x += scrollX;
+    else if (!isBaseFigFrozenX && isSnappedFrozenX) snappedFigure.x -= scrollX;
+  }
+
+  return { snappedFigure, verticalSnapLine, horizontalSnapLine };
+}
+
+/**
+ * Try to snap the given figure to the other figures when resizing the figure, and return the snapped
+ * figure and the possible snap lines, if any were found
+ */
+export function snapForResize(
+  getters: Getters,
+  resizeDirX: -1 | 0 | 1,
+  resizeDirY: -1 | 0 | 1,
+  figureToSnap: Figure,
+  otherFigures: Figure[]
+): SnapReturn {
+  const snappedFigure = { ...figureToSnap };
+
+  // Vertical snap line
+  const verticalSnapLine = getSnapLine(
+    getters,
+    snappedFigure,
+    [resizeDirX === -1 ? "left" : "right"],
+    otherFigures,
+    ["right", "left"]
+  );
+  if (verticalSnapLine) {
+    if (resizeDirX === 1) {
+      snappedFigure.width -= verticalSnapLine.snapOffset;
+    } else if (resizeDirX === -1) {
+      snappedFigure.x -= verticalSnapLine.snapOffset;
+      snappedFigure.width += verticalSnapLine.snapOffset;
+    }
+  }
+
+  // Horizontal snap line
+  const horizontalSnapLine = getSnapLine(
+    getters,
+    snappedFigure,
+    [resizeDirY === -1 ? "top" : "bottom"],
+    otherFigures,
+    ["bottom", "top"]
+  );
+  if (horizontalSnapLine) {
+    if (resizeDirY === 1) {
+      snappedFigure.height -= horizontalSnapLine.snapOffset;
+    } else if (resizeDirY === -1) {
+      snappedFigure.y -= horizontalSnapLine.snapOffset;
+      snappedFigure.height += horizontalSnapLine.snapOffset;
+    }
+  }
+
+  snappedFigure.x = Math.round(snappedFigure.x);
+  snappedFigure.y = Math.round(snappedFigure.y);
+  snappedFigure.height = Math.round(snappedFigure.height);
+  snappedFigure.width = Math.round(snappedFigure.width);
+
+  return { snappedFigure, verticalSnapLine, horizontalSnapLine };
+}
+
+/**
+ * Get the position of snap axes for the given figure
+ *
+ * @param figure the figure
+ * @param axesTypes the list of axis types to return the positions of
+ */
+function getVisibleAxes<T extends HFigureAxisType | VFigureAxisType>(
+  getters: Getters,
+  figure: Figure,
+  axesTypes: T[]
+): FigureAxis<T>[] {
+  const axes = axesTypes.map((axisType) => getAxis(figure, axisType));
+  return axes
+    .filter((axis) => isAxisVisible(getters, figure, axis))
+    .map((axis) => getAxisScreenPosition(getters, figure, axis));
+}
+
+/**
+ * We need two positions for the figure axis :
+ *  - the position (core) of the axis in the figure. This is used to know whether or not the axis is
+ *      displayed, or is hidden by the scroll/the frozen panes
+ *  - the position in the screen, which is used to find snap matches. We cannot use the core position for this,
+ *      because figures partially in frozen panes aren't displayed at their actual coordinates
+ */
+function getAxisScreenPosition<T extends HFigureAxisType | VFigureAxisType>(
+  getters: Getters,
+  figure: Figure,
+  figureAxis: FigureAxis<T>
+): FigureAxis<T> {
+  const screenFigure = internalFigureToScreen(getters, figure);
+  return getAxis(screenFigure, figureAxis.axisType);
+}
+
+function isAxisVisible<T extends HFigureAxisType | VFigureAxisType>(
+  getters: Getters,
+  figure: Figure,
+  axis: FigureAxis<T>
+): boolean {
+  const { x: mainViewportX, y: mainViewportY } = getters.getMainViewportCoordinates();
+
+  const axisStartEndPositions: PixelPosition[] = [];
+  switch (axis.axisType) {
+    case "top":
+    case "bottom":
+    case "vCenter":
+      if (figure.y < mainViewportY) return true;
+      axisStartEndPositions.push({ x: figure.x, y: axis.position });
+      axisStartEndPositions.push({ x: figure.x + figure.width, y: axis.position });
+      break;
+    case "left":
+    case "right":
+    case "hCenter":
+      if (figure.x < mainViewportX) return true;
+      axisStartEndPositions.push({ x: axis.position, y: figure.y });
+      axisStartEndPositions.push({ x: axis.position, y: figure.y + figure.height });
+      break;
+  }
+
+  return axisStartEndPositions.some(getters.isPositionVisible);
+}
+
+/**
+ * Get a snap line for the given figure, if the figure can snap to any other figure
+ *
+ * @param figureToSnap figure to get the snap line for
+ * @param figAxesTypes figure axes of the given figure to be considered to find a snap line
+ * @param otherFigures figures to match against the snapped figure to find a snap line
+ * @param otherAxesTypes figure axes of the other figures to be considered to find a snap line
+ */
+
+function getSnapLine<T extends HFigureAxisType[] | VFigureAxisType[]>(
+  getters: Getters,
+  figureToSnap: Figure,
+  figAxesTypes: T,
+  otherFigures: Figure[],
+  otherAxesTypes: T
+): SnapLine<T[number]> | undefined {
+  const axesOfFigure = getVisibleAxes(getters, figureToSnap, figAxesTypes);
+
+  let closestMatch: SnapLine<T[number]> | undefined = undefined;
+
+  for (const otherFigure of otherFigures) {
+    const axesOfOtherFig = getVisibleAxes(getters, otherFigure, otherAxesTypes);
+
+    for (const axisOfFigure of axesOfFigure) {
+      for (const axisOfOtherFig of axesOfOtherFig) {
+        if (!canSnap(axisOfFigure.position, axisOfOtherFig.position)) continue;
+
+        const snapOffset = axisOfFigure.position - axisOfOtherFig.position;
+
+        if (closestMatch && snapOffset === closestMatch.snapOffset) {
+          closestMatch.matchedFigIds.push(otherFigure.id);
+        } else if (!closestMatch || Math.abs(snapOffset) <= Math.abs(closestMatch.snapOffset)) {
+          closestMatch = {
+            matchedFigIds: [otherFigure.id],
+            snapOffset,
+            snappedAxisType: axisOfFigure.axisType,
+            position: axisOfOtherFig.position,
+          };
+        }
+      }
+    }
+  }
+  return closestMatch;
+}
+
+/** Check if two axes are close enough to snap */
+function canSnap(axisPosition1: Pixel, axisPosition2: Pixel) {
+  return Math.abs(axisPosition1 - axisPosition2) <= SNAP_MARGIN;
+}
+
+function getAxis<T extends HFigureAxisType | VFigureAxisType>(
+  fig: Figure,
+  axisType: T
+): FigureAxis<T> {
+  let position = 0;
+  switch (axisType) {
+    case "top":
+      position = fig.y;
+      break;
+    case "bottom":
+      position = fig.y + fig.height - FIGURE_BORDER_WIDTH;
+      break;
+    case "vCenter":
+      position = fig.y + Math.floor(fig.height / 2) - FIGURE_BORDER_WIDTH;
+      break;
+    case "left":
+      position = fig.x;
+      break;
+    case "right":
+      position = fig.x + fig.width - FIGURE_BORDER_WIDTH;
+      break;
+    case "hCenter":
+      position = fig.x + Math.floor(fig.width / 2) - FIGURE_BORDER_WIDTH;
+      break;
+  }
+
+  return { position, axisType: axisType };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -138,8 +138,6 @@ export const MENU_SEPARATOR_BORDER_WIDTH = 1;
 export const MENU_SEPARATOR_PADDING = 5;
 export const MENU_SEPARATOR_HEIGHT = MENU_SEPARATOR_BORDER_WIDTH + 2 * MENU_SEPARATOR_PADDING;
 
-export const FIGURE_BORDER_SIZE = 1;
-
 // Fonts
 export const DEFAULT_FONT_WEIGHT = "400";
 export const DEFAULT_FONT_SIZE = 10;
@@ -165,6 +163,9 @@ export const DEFAULT_REVISION_ID = "START_REVISION";
 // Figure
 export const DEFAULT_FIGURE_HEIGHT = 335;
 export const DEFAULT_FIGURE_WIDTH = 536;
+export const FIGURE_BORDER_WIDTH = 1;
+export const ACTIVE_BORDER_WIDTH = 2;
+export const MIN_FIG_SIZE = 80;
 
 // Chart
 export const MAX_CHAR_LABEL = 20;
@@ -179,8 +180,6 @@ export const DEFAULT_SCORECARD_BASELINE_COLOR_UP = "#00A04A";
 export const DEFAULT_SCORECARD_BASELINE_COLOR_DOWN = "#DC6965";
 
 export const LINE_FILL_TRANSPARENCY = 0.4;
-
-export const MIN_FIG_SIZE = 80;
 
 // session
 export const DEBOUNCE_TIME = 200;
@@ -206,7 +205,8 @@ export enum ComponentsImportance {
   TopBarComposer = 21,
   IconPicker = 25,
   Popover = 30,
-  ChartAnchor = 1000,
+  FigureAnchor = 1000,
+  FigureSnapLine = 1001,
 }
 
 export const DEFAULT_SHEETVIEW_SIZE = 1000;

--- a/src/helpers/rectangle.ts
+++ b/src/helpers/rectangle.ts
@@ -1,11 +1,16 @@
 import { Rect, Zone } from "../types";
-import { intersection } from "./zones";
+import { intersection, union } from "./zones";
 
 /**
  * Compute the intersection of two rectangles. Returns nothing if the two rectangles don't overlap
  */
 export function rectIntersection(rect1: Rect, rect2: Rect): Rect | undefined {
   return zoneToRect(intersection(rectToZone(rect1), rectToZone(rect2)));
+}
+
+/** Compute the union of the rectangles, ie. the smallest rectangle that contain them all */
+export function rectUnion(...rects: Rect[]): Rect {
+  return zoneToRect(union(...rects.map(rectToZone)))!;
 }
 
 function rectToZone(rect: Rect): Zone {

--- a/src/plugins/ui_core_views/sheetview.ts
+++ b/src/plugins/ui_core_views/sheetview.ts
@@ -25,6 +25,7 @@ import {
   Zone,
 } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
+import { PixelPosition } from "./../../types/misc";
 
 type SheetViewports = {
   topLeft: InternalViewport | undefined;
@@ -95,6 +96,7 @@ export class SheetViewPlugin extends UIPlugin {
     "getSheetViewVisibleCols",
     "getSheetViewVisibleRows",
     "getFrozenSheetViewRatio",
+    "isPositionVisible",
   ] as const;
 
   readonly viewports: Record<UID, SheetViewports | undefined> = {};
@@ -749,6 +751,27 @@ export class SheetViewPlugin extends UIPlugin {
       result.push(figure);
     }
     return result;
+  }
+
+  isPositionVisible(position: PixelPosition): boolean {
+    const { scrollX, scrollY } = this.getters.getActiveSheetScrollInfo();
+    const { x: mainViewportX, y: mainViewportY } = this.getters.getMainViewportCoordinates();
+    const { width, height } = this.getters.getSheetViewDimension();
+
+    if (
+      position.x >= mainViewportX &&
+      (position.x < mainViewportX + scrollX || position.x > width + scrollX + mainViewportX)
+    ) {
+      return false;
+    }
+    if (
+      position.y >= mainViewportY &&
+      (position.y < mainViewportY + scrollY || position.y > height + scrollY + mainViewportY)
+    ) {
+      return false;
+    }
+
+    return true;
   }
 
   getFrozenSheetViewRatio(sheetId: UID) {

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -203,6 +203,12 @@ export interface Position {
   col: HeaderIndex;
   row: HeaderIndex;
 }
+
+export interface PixelPosition {
+  x: Pixel;
+  y: Pixel;
+}
+
 export interface Merge extends Zone {
   id: number;
   topLeft: Position;

--- a/src/xlsx/functions/drawings.ts
+++ b/src/xlsx/functions/drawings.ts
@@ -1,4 +1,4 @@
-import { FIGURE_BORDER_SIZE } from "../../constants";
+import { FIGURE_BORDER_WIDTH } from "../../constants";
 import { HeaderData, SheetData } from "../../types";
 import { ExcelChartDefinition } from "../../types/chart/chart";
 import { XMLAttributes, XMLString } from "../../types/xlsx";
@@ -106,7 +106,7 @@ function figureCoordinates(
     if (currentPosition <= position && position < currentPosition + header.size!) {
       return {
         index: parseInt(headerIndex),
-        offset: convertDotValueToEMU(position - currentPosition + FIGURE_BORDER_SIZE),
+        offset: convertDotValueToEMU(position - currentPosition + FIGURE_BORDER_WIDTH),
       };
     } else {
       currentPosition += header.size!;
@@ -114,7 +114,7 @@ function figureCoordinates(
   }
   return {
     index: headers.length - 1,
-    offset: convertDotValueToEMU(position - currentPosition + FIGURE_BORDER_SIZE),
+    offset: convertDotValueToEMU(position - currentPosition + FIGURE_BORDER_WIDTH),
   };
 }
 

--- a/tests/components/__snapshots__/dashboard_grid.test.ts.snap
+++ b/tests/components/__snapshots__/dashboard_grid.test.ts.snap
@@ -16,6 +16,8 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
       <div>
         
       </div>
+      
+      
     </div>
     
     <canvas

--- a/tests/components/__snapshots__/figure.test.ts.snap
+++ b/tests/components/__snapshots__/figure.test.ts.snap
@@ -7,6 +7,7 @@ exports[`figures selected figure snapshot 1`] = `
 >
   <div
     class="o-figure w-100 h-100"
+    data-id="someuuid"
     style=""
     tabindex="0"
   >

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -12,6 +12,8 @@ exports[`Grid component simple rendering snapshot 1`] = `
     <div>
       
     </div>
+    
+    
   </div>
   
   <div

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Scorecard charts Scorecard snapshot 1`] = `
 <div
   class="o-figure w-100 h-100"
+  data-id="someuuid"
   style=""
   tabindex="0"
 >
@@ -110,6 +111,7 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
 exports[`Scorecard charts scorecard text is resized while figure is resized 1`] = `
 <div
   class="o-figure w-100 h-100"
+  data-id="someuuid"
   style="opacity:0.9; cursor:grabbing;"
   tabindex="0"
 >

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -533,6 +533,8 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       <div>
         
       </div>
+      
+      
     </div>
     
     <div

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -7,7 +7,7 @@ import {
   setCellContent,
   updateChart,
 } from "../test_helpers/commands_helpers";
-import { dragElement, getElComputedStyle, simulateClick } from "../test_helpers/dom_helper";
+import { dragElement, getElStyle, simulateClick } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
 import { mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
 
@@ -118,11 +118,11 @@ describe("Scorecard charts", () => {
       chartId
     );
     await simulateClick(".o-figure");
-    expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("536px");
-    expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("335px");
+    expect(getElStyle(".o-figure-wrapper", "width")).toBe("536px");
+    expect(getElStyle(".o-figure-wrapper", "height")).toBe("335px");
     await dragElement(".o-fig-anchor.o-topLeft", { x: 300, y: 200 });
-    expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("236px");
-    expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("135px");
+    expect(getElStyle(".o-figure-wrapper", "width")).toBe("236px");
+    expect(getElStyle(".o-figure-wrapper", "height")).toBe("135px");
     // force a triggering of all resizeObservers to ensure the grid is resized
     //@ts-ignore
     window.resizers.resize();

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -180,6 +180,12 @@ export function getElComputedStyle(selector: string, style: string): string {
   return window.getComputedStyle(element)[style];
 }
 
+export function getElStyle(selector: string, style: string): string {
+  const element = document.querySelector<HTMLElement>(selector);
+  if (!element) throw new Error(`No element matching selector "${selector}"`);
+  return element.style[style];
+}
+
 /**
  * Select a column
  * @param model
@@ -205,13 +211,11 @@ export async function dragElement(
   const { x: startX, y: startY } = startingPosition;
   const { x: offsetX, y: offsetY } = dragOffset;
   triggerMouseEvent(element, "mousedown", startX, startY);
-  await nextTick();
   triggerMouseEvent(element, "mousemove", startX + offsetX, startY + offsetY);
-  await nextTick();
   if (mouseUp) {
     triggerMouseEvent(element, "mouseup", startX + offsetX, startY + offsetY);
-    await nextTick();
   }
+  await nextTick();
 }
 
 /**

--- a/tests/xlsx_import_export.test.ts
+++ b/tests/xlsx_import_export.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../src";
-import { FIGURE_BORDER_SIZE } from "../src/constants";
+import { FIGURE_BORDER_WIDTH } from "../src/constants";
 import { buildSheetLink, toZone } from "../src/helpers";
 import { Align, BorderDescr, ConditionalFormatRule, Style } from "../src/types";
 import { isXLSXExportXMLFile } from "../src/xlsx/helpers/xlsx_helper";
@@ -23,8 +23,8 @@ import { target, toRangesData } from "./test_helpers/helpers";
  *
  * Some side effects of exporting to xlsx then re-importing:
  *  - cols/row without a size will now have a explicitly defined size, close to the default size but not exactly the same (rounding error)
- *  - figure position : at export we add FIGURE_BORDER_SIZE to the position of the chart, so the charts at 0,0 are nicely displayed
- *          in excel, without their border being hidden below the overlay. We cannot subtract -FIGURE_BORDER_SIZE at import, as
+ *  - figure position : at export we add FIGURE_BORDER_WIDTH to the position of the chart, so the charts at 0,0 are nicely displayed
+ *          in excel, without their border being hidden below the overlay. We cannot subtract -FIGURE_BORDER_WIDTH at import, as
  *          this could lead to negative coordinates. The position of the figures is thus slightly off when exporting the re-importing.
  *  - charts: datasetHaveTitles boolean is lost. The dataset ranges that will be exported (and re-imported )are the
  *          ranges without the dataset titles (the range minus the first cell of the range) when datasetHaveTitles was true.
@@ -208,9 +208,9 @@ describe("Export data to xlsx then import it", () => {
     const importedFigure = importedModel.getters.getFigures(sheetId)[0];
     expect(importedFigure.height).toEqual(figure.height);
     expect(importedFigure.width).toBeBetween(figure.width - 1, figure.width + 1);
-    // See explanation at the top of the file for +FIGURE_BORDER_SIZE
-    expect(importedFigure.x).toEqual(figure.x + FIGURE_BORDER_SIZE);
-    expect(importedFigure.y).toEqual(figure.y + FIGURE_BORDER_SIZE);
+    // See explanation at the top of the file for +FIGURE_BORDER_WIDTH
+    expect(importedFigure.x).toEqual(figure.x + FIGURE_BORDER_WIDTH);
+    expect(importedFigure.y).toEqual(figure.y + FIGURE_BORDER_WIDTH);
   });
 
   test.each([


### PR DESCRIPTION
## Description

With this commit, when moving/resizing a figure with the mouse the figure will try to snap to other visible figures. This make it easy to align figures together.

"Snap lines" will be displayed to the user to visually see where the snap is happening.

Odoo task ID : [2907730](https://www.odoo.com/web#id=2907730&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo