### PR TITLE
[FIX] composer: when changing sheet

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -267,7 +267,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   };
 
   focus() {
-    if (!this.env.model.getters.getSelectedFigureId()) {
+    if (
+      !this.env.model.getters.getSelectedFigureId() &&
+      this.env.model.getters.getEditionMode() === "inactive"
+    ) {
       this.hiddenInput.el!.focus();
     }
   }

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -967,6 +967,17 @@ describe("composer", () => {
     expect(fixture.querySelector(".o-grid .o-composer")).toBeTruthy();
   });
 
+  test("the composer should keep the focus after changing sheet", async () => {
+    createSheet(model, { sheetId: "42", name: "Sheet2" });
+    await nextTick();
+
+    await startComposition("=");
+    expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer")!);
+    await simulateClick(fixture.querySelectorAll(".o-sheet-item.o-sheet")[1]);
+    expect(model.getters.getActiveSheetId()).toEqual("42");
+    expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer")!);
+  });
+
   describe("composer's style depends on the style of the cell", () => {
     test("with text color", async () => {
       model.dispatch("SET_FORMATTING", {

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -947,6 +947,26 @@ describe("composer", () => {
     expect(composerEl.textContent).toBe("=C8");
   });
 
+  test("Composer is closed when changing sheet while not editing a formula", async () => {
+    const baseSheetId = model.getters.getActiveSheetId();
+    createSheet(model, { sheetId: "42", name: "Sheet2" });
+    await nextTick();
+
+    // Editing text
+    await typeInComposerGrid("hey");
+    expect(fixture.querySelector(".o-grid .o-composer")).toBeTruthy();
+    activateSheet(model, "42");
+    await nextTick();
+    expect(fixture.querySelector(".o-grid .o-composer")).toBeFalsy();
+
+    // Editing formula
+    await typeInComposerGrid("=");
+    expect(fixture.querySelector(".o-grid .o-composer")).toBeTruthy();
+    activateSheet(model, baseSheetId);
+    await nextTick();
+    expect(fixture.querySelector(".o-grid .o-composer")).toBeTruthy();
+  });
+
   describe("composer's style depends on the style of the cell", () => {
     test("with text color", async () => {
       model.dispatch("SET_FORMATTING", {

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -765,6 +765,16 @@ describe("Grid component", () => {
       expect(fixture.querySelector(".o-menu div[data-name='add_row_before']")).toBeFalsy();
       expect(document.activeElement).toBe(fixture.querySelector(".o-grid>input"));
     });
+
+    test("Duplicating sheet in the bottom bar focus the grid afterward", async () => {
+      expect(document.activeElement).toBe(fixture.querySelector(".o-grid>input"));
+
+      // open and close sheet context menu
+      await simulateClick(".o-spreadsheet-bottom-bar .o-all-sheets .o-sheet-item .o-icon");
+      await simulateClick(".o-menu-item[title='Duplicate']");
+
+      expect(document.activeElement).toBe(fixture.querySelector(".o-grid>input"));
+    });
   });
 });
 

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -70,11 +70,10 @@ describe("Spreadsheet", () => {
     // TODO check
     expect(document.activeElement!.tagName).toEqual("INPUT");
     document.querySelector(".o-add-sheet")!.dispatchEvent(new Event("click"));
-    // simulate the fact that a user clicking on the add sheet button will
-    // move the focus to the document.body
-    (document.activeElement as any).blur();
     await nextTick();
     expect(document.querySelectorAll(".o-sheet").length).toBe(2);
+    expect(document.activeElement!.tagName).toEqual("INPUT");
+    await simulateClick(document.querySelectorAll(".o-sheet")[1]);
     expect(document.activeElement!.tagName).toEqual("INPUT");
   });
 

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -63,9 +63,17 @@ describe("edition", () => {
     expect(getCellContent(model, "A2")).toBe("");
   });
 
-  test("editing a cell, then activating a new sheet: edition should not be stopped", () => {
+  test("editing a cell, then activating a new sheet: edition should be stopped when editing text", () => {
     const model = new Model();
     model.dispatch("START_EDITION", { text: "a" });
+    expect(model.getters.getEditionMode()).toBe("editing");
+    createSheet(model, { activate: true, sheetId: "42" });
+    expect(model.getters.getEditionMode()).toBe("inactive");
+  });
+
+  test("editing a cell, then activating a new sheet: edition should not be stopped when editing formula", () => {
+    const model = new Model();
+    model.dispatch("START_EDITION", { text: "=A1" });
     expect(model.getters.getEditionMode()).toBe("editing");
     createSheet(model, { activate: true, sheetId: "42" });
     expect(model.getters.getEditionMode()).not.toBe("inactive");


### PR DESCRIPTION
# [FIX] composer: keep focus after changing sheet

Currently the composer lose focus when changing sheet. This is because
of the `useEffect()` in grid, that focus the grid when changing sheet.

Change it to only focus the grid when the grid was focused before
changing sheet.

# [FIX] composer: close text composer when changing sheet

The composer currently stays open when switching to another sheet.
This is useful when editing a formula, to allow the user to select a range
in another sheet, but perfectly useless when editing a text cell.

Odoo task ID : [2974535](https://www.odoo.com/web#id=2974535&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo