### PR TITLE
[FIX] selection: Properly add merge when adding them to the selection

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -854,7 +854,11 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       const newZone = this.env.model.getters.getSelectedZone();
       const viewport = this.env.model.getters.getActiveSnappedViewport();
       const sheet = this.env.model.getters.getActiveSheet();
-      let [col, row] = findCellInNewZone(oldZone, newZone);
+      let [col, row] = findCellInNewZone(
+        oldZone,
+        newZone,
+        this.env.model.getters.getActiveSnappedViewport()
+      );
       col = Math.min(col, sheet.cols.length - 1);
       row = Math.min(row, sheet.rows.length - 1);
       const { left, right, top, bottom, offsetX, offsetY } = viewport;

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -1,4 +1,4 @@
-import { Position, Zone, ZoneDimension } from "../types";
+import { Position, Viewport, Zone, ZoneDimension } from "../types";
 import { toCartesian, toXC } from "./coordinates";
 import { range } from "./misc";
 
@@ -484,7 +484,11 @@ export function mergeOverlappingZones(zones: Zone[]) {
  * This function will compare the modifications of selection to determine
  * a cell that is part of the new zone and not the previous one.
  */
-export function findCellInNewZone(oldZone: Zone, currentZone: Zone): [number, number] {
+export function findCellInNewZone(
+  oldZone: Zone,
+  currentZone: Zone,
+  viewport: Viewport
+): [number, number] {
   let col: number, row: number;
   const { left: oldLeft, right: oldRight, top: oldTop, bottom: oldBottom } = oldZone!;
   const { left, right, top, bottom } = currentZone;
@@ -493,14 +497,16 @@ export function findCellInNewZone(oldZone: Zone, currentZone: Zone): [number, nu
   } else if (right != oldRight) {
     col = right;
   } else {
-    col = left;
+    // left and right don't change
+    col = viewport.left > left || left > viewport.right ? viewport.left : left;
   }
   if (top != oldTop) {
     row = top;
   } else if (bottom != oldBottom) {
     row = bottom;
   } else {
-    row = top;
+    // top and bottom don't change
+    row = viewport.top > top || top > viewport.bottom ? viewport.top : top;
   }
   return [col, row];
 }

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -111,7 +111,7 @@ export class GridSelectionPlugin extends UIPlugin {
   ] as const;
 
   private gridSelection: {
-    readonly anchor: AnchorZone; // the anchor is managed by the selection processor. It must not be reassigned
+    readonly anchor: AnchorZone;
     zones: Zone[];
   } = {
     anchor: {
@@ -178,6 +178,7 @@ export class GridSelectionPlugin extends UIPlugin {
         break;
     }
     this.setSelectionMixin(event.anchor, zones);
+    this.selection.resetDefaultAnchor(this, deepCopy(this.gridSelection.anchor));
     const { col, row } = this.gridSelection.anchor.cell;
     this.moveClient({
       sheetId: this.getters.getActiveSheetId(),
@@ -214,11 +215,11 @@ export class GridSelectionPlugin extends UIPlugin {
           sheetIdTo: firstSheet.id,
           sheetIdFrom: firstSheet.id,
         });
-        this.selection.registerAsDefault(this, this.gridSelection.anchor, {
-          handleEvent: this.handleEvent.bind(this),
-        });
         const firstVisiblePosition = getNextVisibleCellCoords(firstSheet, 0, 0);
         this.selectCell(...firstVisiblePosition);
+        this.selection.registerAsDefault(this, deepCopy(this.gridSelection.anchor), {
+          handleEvent: this.handleEvent.bind(this),
+        });
         this.moveClient({ sheetId: firstSheet.id, col: 0, row: 0 });
         break;
       case "ACTIVATE_SHEET": {
@@ -228,7 +229,7 @@ export class GridSelectionPlugin extends UIPlugin {
         };
         if (cmd.sheetIdTo in this.sheetsData) {
           Object.assign(this, this.sheetsData[cmd.sheetIdTo]);
-          this.selection.resetDefaultAnchor(this, this.gridSelection.anchor);
+          this.selection.resetDefaultAnchor(this, deepCopy(this.gridSelection.anchor));
         } else {
           this.selectCell(...getNextVisibleCellCoords(this.getters.getSheet(cmd.sheetIdTo), 0, 0));
         }
@@ -508,8 +509,7 @@ export class GridSelectionPlugin extends UIPlugin {
       this.getters.getActiveSheetId(),
       { anchor, zones }
     );
-    this.gridSelection.anchor.cell.col = clippedAnchor.cell.col;
-    this.gridSelection.anchor.cell.row = clippedAnchor.cell.row;
+    this.gridSelection.anchor.cell = clippedAnchor.cell;
     this.gridSelection.anchor.zone = clippedAnchor.zone;
     this.gridSelection.zones = uniqueZones(clippedZones);
   }

--- a/src/plugins/ui/viewport.ts
+++ b/src/plugins/ui/viewport.ts
@@ -82,7 +82,11 @@ export class ViewportPlugin extends UIPlugin {
       case "ZonesSelected":
         // altering a zone should not move the viewport
         const sheet = this.getters.getActiveSheet();
-        let [col, row] = findCellInNewZone(event.previousAnchor.zone, event.anchor.zone);
+        let [col, row] = findCellInNewZone(
+          event.previousAnchor.zone,
+          event.anchor.zone,
+          this.getActiveSnappedViewport()
+        );
         col = Math.min(col, sheet.cols.length - 1);
         row = Math.min(row, sheet.rows.length - 1);
         this.refreshViewport(this.getters.getActiveSheetId(), { col, row });

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -175,7 +175,7 @@ export class SelectionStreamProcessor
   addCellToSelection(col: number, row: number): DispatchResult {
     const sheetId = this.getters.getActiveSheetId();
     [col, row] = this.getters.getMainCell(sheetId, col, row);
-    const zone = positionToZone({ col, row });
+    const zone = this.getters.expandZone(sheetId, positionToZone({ col, row }));
     return this.processEvent({
       type: "ZonesSelected",
       anchor: { zone, cell: { col, row } },

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -46,6 +46,25 @@ describe("simple selection", () => {
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 0, right: 1, bottom: 2 });
   });
 
+  test("Adding a cell of a merge in the selection adds the whole merge", () => {
+    const model = new Model({
+      sheets: [
+        {
+          colNumber: 10,
+          rowNumber: 10,
+          merges: ["A2:B3"],
+        },
+      ],
+    });
+
+    expect(model.getters.getSelectedZones()).toEqual([{ left: 0, top: 0, right: 0, bottom: 0 }]);
+    addCellToSelection(model, "A2");
+    expect(model.getters.getSelectedZones()).toEqual([
+      { left: 0, top: 0, right: 0, bottom: 0 },
+      { left: 0, top: 1, right: 1, bottom: 2 },
+    ]);
+  });
+
   test("can select selection with shift-arrow", () => {
     const model = new Model({
       sheets: [

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -538,6 +538,9 @@ describe("multiple sheets", () => {
     model.dispatch("DELETE_SHEET", { sheetId: firstSheetId });
     expect(model.getters.getSelectedZone()).toEqual(toZone("C4"));
     expect(model.getters.getActiveSheetId()).toBe(secondSheetId);
+    moveAnchorCell(model, "right");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("D4"));
+    expect(model.getters.getActiveSheetId()).toBe(secondSheetId);
   });
 
   test("Do not share selections between sheets", () => {


### PR DESCRIPTION
When adding a cell to the selection and that cell was part of a merge, the cell was added as a new anchor but the anchor zone was the one of the cell, not the whole merge.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo