### PR TITLE
[FIX] data filters: traceback at sheet duplication

### DIFF
--- a/src/plugins/ui/filter_evaluation.ts
+++ b/src/plugins/ui/filter_evaluation.ts
@@ -46,6 +46,17 @@ export class FilterEvaluationPlugin extends UIPlugin {
       case "REMOVE_FILTER_TABLE":
         this.isEvaluationDirty = true;
         break;
+      case "START":
+        for (const sheetId of this.getters.getSheetIds()) {
+          this.filterValues[sheetId] = {};
+          for (const filter of this.getters.getFilters(sheetId)) {
+            this.filterValues[sheetId][filter.id] = [];
+          }
+        }
+        break;
+      case "CREATE_SHEET":
+        this.filterValues[cmd.sheetId] = {};
+        break;
       case "UPDATE_FILTER":
         this.updateFilter(cmd);
         this.updateHiddenRows();
@@ -55,7 +66,7 @@ export class FilterEvaluationPlugin extends UIPlugin {
         for (const copiedFilter of this.getters.getFilters(cmd.sheetId)) {
           const zone = copiedFilter.zoneWithHeaders;
           const newFilter = this.getters.getFilter(cmd.sheetIdTo, zone.left, zone.top)!;
-          filterValues[newFilter.id] = this.filterValues[cmd.sheetId][copiedFilter.id];
+          filterValues[newFilter.id] = this.filterValues[cmd.sheetId]?.[copiedFilter.id] || [];
         }
         this.filterValues[cmd.sheetIdTo] = filterValues;
         break;

--- a/tests/plugins/filter_evaluation.test.ts
+++ b/tests/plugins/filter_evaluation.test.ts
@@ -152,4 +152,15 @@ describe("Filter Evaluation Plugin", () => {
       }
     }
   });
+
+  test("Sheet duplication after importing filter don't break", () => {
+    const model = new Model({ sheets: [{ id: "sh1", filterTables: [{ range: "A1:A8" }] }] });
+    expect(model.getters.getFilter("sh1", 0, 0)).toBeTruthy();
+
+    model.dispatch("DUPLICATE_SHEET", {
+      sheetId: "sh1",
+      sheetIdTo: "sh2",
+    });
+    expect(model.getters.getFilter("sh2", 0, 0)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Description

There was a traceback at the duplication of a sheet containing data filters, but only if the sheet was imported with the data filters, not if they were freshly created.

This happened because the state of `filter_evaluation` wasn't correctly initialized at import, and there was a `?.` missing.

Odoo task ID : [3034403](https://www.odoo.com/web#id=3034403&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo