### PR TITLE
[IMP] figure: drag & drop detection

### DIFF
--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -6,7 +6,7 @@
           class="o-figure"
           t-on-mousedown.stop="(ev) => this.onMouseDown(ev)"
           t-att-style="getFigureStyle()"
-          t-att-class="{active: isSelected, 'o-dragging': !!dndManager}"
+          t-att-class="{active: isSelected, 'o-dragging': dndManager and dndManager.isActive}"
           t-ref="figure"
           tabindex="0"
           t-on-keydown.stop="(ev) => this.onKeyDown(ev)"

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -6,7 +6,7 @@
           class="o-figure"
           t-on-mousedown.stop="(ev) => this.onMouseDown(ev)"
           t-att-style="getFigureStyle()"
-          t-att-class="{active: isSelected, 'o-dragging': dnd.isActive}"
+          t-att-class="{active: isSelected, 'o-dragging': !!dndManager}"
           t-ref="figure"
           tabindex="0"
           t-on-keydown.stop="(ev) => this.onKeyDown(ev)"
@@ -21,6 +21,16 @@
         </div>
       </div>
       <t t-if="isSelected">
+        <div
+          t-if="dndManager and dndManager.hasHorizontalSnap()"
+          class="o-figure-snap-border horizontal"
+          t-att-style="horizontalSnapLineStyle"
+        />
+        <div
+          t-if="dndManager and dndManager.hasVerticalSnap()"
+          class="o-figure-snap-border vertical"
+          t-att-style="verticalSnapLineStyle"
+        />
         <div
           class="o-anchor o-top"
           t-att-style="this.getAnchorPosition('top')"

--- a/src/components/helpers/figure_dnd_manager.ts
+++ b/src/components/helpers/figure_dnd_manager.ts
@@ -1,0 +1,340 @@
+import { FIGURE_BORDER_WIDTH, MIN_FIG_SIZE } from "../../constants";
+import { Figure, Pixel, PixelPosition, SheetScrollInfo, UID } from "../../types";
+
+const SNAP_MARGIN: Pixel = 5;
+
+interface FigurePosition {
+  id: UID;
+  x: Pixel;
+  width: Pixel;
+  y: Pixel;
+  height: Pixel;
+}
+
+type HorizontalBorderName = "top" | "bottom" | "vCenter";
+type VerticalBorderName = "right" | "left" | "hCenter";
+
+interface HorizontalBorderPosition {
+  border: HorizontalBorderName;
+  position: Pixel;
+}
+
+interface VerticalBorderPosition {
+  border: VerticalBorderName;
+  position: Pixel;
+}
+
+interface VerticalSnapLine {
+  border: VerticalBorderName;
+  matchedFigs: FigurePosition[];
+  x: Pixel;
+}
+
+interface HorizontalSnapLine {
+  border: HorizontalBorderName;
+  matchedFigs: FigurePosition[];
+  y: Pixel;
+}
+
+export abstract class FigureDndManager {
+  protected dnd: FigurePosition;
+  protected readonly initialFigure: FigurePosition;
+
+  protected currentHorizontalSnapLine: HorizontalSnapLine | undefined = undefined;
+  protected currentVerticalSnapLine: VerticalSnapLine | undefined = undefined;
+
+  constructor(
+    draggedFigure: FigurePosition,
+    protected readonly otherFigures: Figure[],
+    protected readonly initialMousePosition: PixelPosition
+  ) {
+    this.initialFigure = { ...draggedFigure };
+    this.dnd = { ...draggedFigure };
+  }
+
+  getDnd() {
+    return this.dnd;
+  }
+
+  /**
+   * Get the position of horizontal borders for the given figure
+   *
+   * @param figure the figure
+   * @param borders the list of border names to return the positions of
+   */
+  private getHorizontalFigureBordersPositions(
+    figure: FigurePosition,
+    borders: HorizontalBorderName[]
+  ): HorizontalBorderPosition[] {
+    const allBorders: HorizontalBorderPosition[] = [
+      { border: "top", position: this.getBorderPosition(figure, "top") },
+      { border: "vCenter", position: this.getBorderPosition(figure, "vCenter") },
+      { border: "bottom", position: this.getBorderPosition(figure, "bottom") },
+    ];
+    return allBorders.filter((p) => borders.includes(p.border));
+  }
+
+  /**
+   * Get the position of vertical borders for the given figure
+   *
+   * @param figure the figure
+   * @param borders the list of border names to return the positions of
+   */
+  private getVerticalFigureBorders(
+    figure: FigurePosition,
+    borders: VerticalBorderName[]
+  ): VerticalBorderPosition[] {
+    const allBorders: VerticalBorderPosition[] = [
+      { border: "left", position: this.getBorderPosition(figure, "left") },
+      { border: "hCenter", position: this.getBorderPosition(figure, "hCenter") },
+      { border: "right", position: this.getBorderPosition(figure, "right") },
+    ];
+    return allBorders.filter((p) => borders.includes(p.border));
+  }
+
+  /**
+   * Get a horizontal snap line for the given figure, if the figure can snap to any other figure
+   *
+   * @param dnd figure to get the snap line for
+   * @param bordersOfDraggedToMatch borders of the given figure to be considered to find a snap match
+   * @param bordersOfOthersToMatch borders of the other figures to be considered to find a snap match
+   */
+  protected getHorizontalSnapLine(
+    dnd: FigurePosition,
+    bordersOfDraggedToMatch: HorizontalBorderName[],
+    bordersOfOthersToMatch: HorizontalBorderName[]
+  ): HorizontalSnapLine | undefined {
+    const dndBorders = this.getHorizontalFigureBordersPositions(dnd, bordersOfDraggedToMatch);
+    let match: { match: HorizontalSnapLine; offset: number } | undefined = undefined;
+    for (const matchedFig of this.otherFigures) {
+      const matchedBorders = this.getHorizontalFigureBordersPositions(
+        matchedFig,
+        bordersOfOthersToMatch
+      );
+
+      for (const dndBorder of dndBorders) {
+        for (const matchedBorder of matchedBorders) {
+          if (this.canSnap(dndBorder.position, matchedBorder.position)) {
+            const offset = Math.abs(dndBorder.position - matchedBorder.position);
+
+            if (match && offset === match.offset) {
+              match.match.matchedFigs.push(matchedFig);
+            } else if (!match || offset <= match.offset) {
+              match = {
+                match: {
+                  border: dndBorder.border,
+                  matchedFigs: [matchedFig],
+                  y: matchedBorder.position,
+                },
+                offset,
+              };
+            }
+          }
+        }
+      }
+    }
+    return match?.match;
+  }
+
+  /**
+   * Get a vertical snap line for the given figure, if the figure can snap to any other figure
+   *
+   * @param dnd figure to get the snap line for
+   * @param bordersOfDraggedToMatch borders of the given figure to be considered to find  snap match
+   * @param bordersOfOthersToMatch borders of the other figures to be considered to find a snap match
+   */
+  protected getVerticalSnapLine(
+    dnd: FigurePosition,
+    bordersOfDraggedToMatch: VerticalBorderName[],
+    bordersOfOthersToMatch: VerticalBorderName[]
+  ): VerticalSnapLine | undefined {
+    const dndBorders = this.getVerticalFigureBorders(dnd, bordersOfDraggedToMatch);
+    let match: { match: VerticalSnapLine; offset: number } | undefined = undefined;
+    for (const matchedFig of this.otherFigures) {
+      const matchedBorders = this.getVerticalFigureBorders(matchedFig, bordersOfOthersToMatch);
+
+      for (const dndBorder of dndBorders) {
+        for (const matchedBorder of matchedBorders) {
+          if (this.canSnap(dndBorder.position, matchedBorder.position)) {
+            const offset = Math.abs(dndBorder.position - matchedBorder.position);
+
+            if (match && offset === match.offset) {
+              match.match.matchedFigs.push(matchedFig);
+            } else if (!match || offset < match.offset) {
+              match = {
+                match: {
+                  border: dndBorder.border,
+                  matchedFigs: [matchedFig],
+                  x: matchedBorder.position,
+                },
+                offset,
+              };
+            }
+          }
+        }
+      }
+    }
+    return match?.match;
+  }
+
+  /** Check if two borders are close enough to snap */
+  private canSnap(borderPosition1: Pixel, borderPosition2: Pixel) {
+    return Math.abs(borderPosition1 - borderPosition2) <= SNAP_MARGIN;
+  }
+
+  hasHorizontalSnap(): boolean {
+    return !!this.currentHorizontalSnapLine;
+  }
+
+  hasVerticalSnap(): boolean {
+    return !!this.currentVerticalSnapLine;
+  }
+
+  getCurrentHorizontalSnapLine(): HorizontalSnapLine | undefined {
+    return this.currentHorizontalSnapLine;
+  }
+
+  getCurrentVerticalSnapLine(): VerticalSnapLine | undefined {
+    return this.currentVerticalSnapLine;
+  }
+
+  /** Get the position of a border of a figure */
+  protected getBorderPosition(
+    fig: FigurePosition,
+    border: HorizontalBorderName | VerticalBorderName
+  ): Pixel {
+    switch (border) {
+      case "top":
+        return fig.y;
+      case "bottom":
+        return fig.y + fig.height + FIGURE_BORDER_WIDTH;
+      case "vCenter":
+        return fig.y + Math.ceil((fig.height + FIGURE_BORDER_WIDTH) / 2);
+      case "left":
+        return fig.x;
+      case "right":
+        return fig.x + fig.width + FIGURE_BORDER_WIDTH;
+      case "hCenter":
+        return fig.x + Math.ceil((fig.width + FIGURE_BORDER_WIDTH) / 2);
+    }
+  }
+}
+
+export class FigureDnDMoveManager extends FigureDndManager {
+  constructor(
+    draggedFigure: FigurePosition,
+    otherFigures: Figure[],
+    initialMousePosition: PixelPosition,
+    private readonly mainViewportPosition: PixelPosition
+  ) {
+    super(draggedFigure, otherFigures, initialMousePosition);
+  }
+
+  drag(mousePosition: PixelPosition, scrollInfo: SheetScrollInfo) {
+    const initialMouseX = this.initialMousePosition.x;
+    const mouseX = mousePosition.x;
+    const viewportX = this.mainViewportPosition.x;
+
+    const initialMouseY = this.initialMousePosition.y;
+    const mouseY = mousePosition.y;
+    const viewportY = this.mainViewportPosition.y;
+
+    let deltaX = initialMouseX - mouseX;
+    // Put the figure on the frozen pane if the mouse is over the pane
+    if (mouseX > viewportX && initialMouseX < viewportX) {
+      deltaX -= scrollInfo.offsetX;
+    } else if (mouseX < viewportX && initialMouseX > viewportX) {
+      deltaX += scrollInfo.offsetX;
+    }
+
+    let deltaY = initialMouseY - mouseY;
+
+    // Put the figure on the frozen pane if the mouse is over the pane
+    if (mouseY > viewportY && initialMouseY < viewportY) {
+      deltaY -= scrollInfo.offsetY;
+    } else if (mouseY < viewportY && initialMouseY > viewportY) {
+      deltaY += scrollInfo.offsetY;
+    }
+
+    const x = Math.max(this.initialFigure.x - deltaX, 0);
+    const y = Math.max(this.initialFigure.y - deltaY, 0);
+
+    const dnd = { ...this.dnd, x, y };
+    let dndX = x;
+    const vSnap = this.getVerticalSnapLine(
+      dnd,
+      ["left", "right", "hCenter"],
+      ["left", "right", "hCenter"]
+    );
+    if (vSnap) {
+      const offset = this.getBorderPosition(this.dnd, vSnap.border) - this.dnd.x;
+      dndX = vSnap.x - offset;
+    }
+
+    let dndY = y;
+    const hSnap = this.getHorizontalSnapLine(
+      dnd,
+      ["top", "bottom", "vCenter"],
+      ["top", "bottom", "vCenter"]
+    );
+    if (hSnap) {
+      const offset = this.getBorderPosition(this.dnd, hSnap.border) - this.dnd.y;
+      dndY = hSnap.y - offset;
+    }
+
+    this.currentHorizontalSnapLine = hSnap;
+    this.currentVerticalSnapLine = vSnap;
+    this.dnd.x = Math.round(dndX);
+    this.dnd.y = Math.round(dndY);
+  }
+}
+
+export class FigureDnDResizeManager extends FigureDndManager {
+  resize(dirX: -1 | 0 | 1, dirY: -1 | 0 | 1, mousePosition: PixelPosition) {
+    this.currentHorizontalSnapLine = undefined;
+    this.currentVerticalSnapLine = undefined;
+
+    const deltaX = dirX * (mousePosition.x - this.initialMousePosition.x);
+    const deltaY = dirY * (mousePosition.y - this.initialMousePosition.y);
+
+    let { width, height, x, y } = this.initialFigure;
+    width = Math.max(this.initialFigure.width + deltaX, MIN_FIG_SIZE);
+    height = Math.max(this.initialFigure.height + deltaY, MIN_FIG_SIZE);
+    if (dirX < 0) {
+      x = this.initialFigure.x - deltaX;
+    }
+    if (dirY < 0) {
+      y = this.initialFigure.y - deltaY;
+    }
+
+    const dnd = { ...this.dnd, x, y, width, height };
+    const vSnap = this.getVerticalSnapLine(dnd, [dirX < 0 ? "left" : "right"], ["left", "right"]);
+    if (vSnap) {
+      if (dirX > 0) {
+        dnd.width = vSnap.x - dnd.x - FIGURE_BORDER_WIDTH;
+      } else if (dirX < 0) {
+        const rightPositionBeforeSnap = dnd.x + dnd.width;
+        dnd.x = vSnap.x;
+        dnd.width = rightPositionBeforeSnap - dnd.x;
+      }
+    }
+
+    const hSnap = this.getHorizontalSnapLine(dnd, [dirY < 0 ? "top" : "bottom"], ["top", "bottom"]);
+    if (hSnap) {
+      if (dirY > 0) {
+        dnd.height = hSnap.y - dnd.y - FIGURE_BORDER_WIDTH;
+      } else if (dirY < 0) {
+        const bottomPositionBeforeSnap = dnd.y + dnd.height;
+        dnd.y = hSnap.y;
+        dnd.height = bottomPositionBeforeSnap - dnd.y;
+      }
+    }
+
+    this.currentHorizontalSnapLine = dirY ? hSnap : undefined;
+    this.currentVerticalSnapLine = dirX ? vSnap : undefined;
+    this.dnd.x = Math.round(dnd.x);
+    this.dnd.y = Math.round(dnd.y);
+    this.dnd.height = Math.round(dnd.height);
+    this.dnd.width = Math.round(dnd.width);
+  }
+}

--- a/src/components/helpers/figure_dnd_manager.ts
+++ b/src/components/helpers/figure_dnd_manager.ts
@@ -43,6 +43,8 @@ export abstract class FigureDndManager {
   protected currentHorizontalSnapLine: HorizontalSnapLine | undefined = undefined;
   protected currentVerticalSnapLine: VerticalSnapLine | undefined = undefined;
 
+  isActive = false;
+
   constructor(
     draggedFigure: FigurePosition,
     protected readonly otherFigures: Figure[],
@@ -231,6 +233,7 @@ export class FigureDnDMoveManager extends FigureDndManager {
   }
 
   drag(mousePosition: PixelPosition, scrollInfo: SheetScrollInfo) {
+    this.isActive = true;
     const initialMouseX = this.initialMousePosition.x;
     const mouseX = mousePosition.x;
     const viewportX = this.mainViewportPosition.x;
@@ -291,6 +294,7 @@ export class FigureDnDMoveManager extends FigureDndManager {
 
 export class FigureDnDResizeManager extends FigureDndManager {
   resize(dirX: -1 | 0 | 1, dirY: -1 | 0 | 1, mousePosition: PixelPosition) {
+    this.isActive = true;
     this.currentHorizontalSnapLine = undefined;
     this.currentVerticalSnapLine = undefined;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -133,8 +133,6 @@ export const MENU_SEPARATOR_BORDER_WIDTH = 1;
 export const MENU_SEPARATOR_PADDING = 5;
 export const MENU_SEPARATOR_HEIGHT = MENU_SEPARATOR_BORDER_WIDTH + 2 * MENU_SEPARATOR_PADDING;
 
-export const FIGURE_BORDER_SIZE = 1;
-
 // Fonts
 export const DEFAULT_FONT_WEIGHT = "400";
 export const DEFAULT_FONT_SIZE = 10;
@@ -160,6 +158,8 @@ export const DEFAULT_REVISION_ID = "START_REVISION";
 // Figure
 export const DEFAULT_FIGURE_HEIGHT = 335;
 export const DEFAULT_FIGURE_WIDTH = 536;
+export const FIGURE_BORDER_WIDTH = 1;
+export const MIN_FIG_SIZE = 80;
 
 // Chart
 export const MAX_CHAR_LABEL = 20;

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -197,6 +197,12 @@ export interface Position {
   col: HeaderIndex;
   row: HeaderIndex;
 }
+
+export interface PixelPosition {
+  x: Pixel;
+  y: Pixel;
+}
+
 export interface Merge extends Zone {
   id: number;
   topLeft: Position;

--- a/src/xlsx/functions/drawings.ts
+++ b/src/xlsx/functions/drawings.ts
@@ -1,4 +1,4 @@
-import { FIGURE_BORDER_SIZE } from "../../constants";
+import { FIGURE_BORDER_WIDTH } from "../../constants";
 import { FigureData, HeaderData, SheetData } from "../../types";
 import { ExcelChartDefinition } from "../../types/chart/chart";
 import { XMLAttributes, XMLString } from "../../types/xlsx";
@@ -128,7 +128,7 @@ function figureCoordinates(
     if (currentPosition <= position && position < currentPosition + header.size!) {
       return {
         index: parseInt(headerIndex),
-        offset: convertDotValueToEMU(position - currentPosition + FIGURE_BORDER_SIZE),
+        offset: convertDotValueToEMU(position - currentPosition + FIGURE_BORDER_WIDTH),
       };
     } else {
       currentPosition += header.size!;
@@ -136,6 +136,6 @@ function figureCoordinates(
   }
   return {
     index: headers.length - 1,
-    offset: convertDotValueToEMU(position - currentPosition + FIGURE_BORDER_SIZE),
+    offset: convertDotValueToEMU(position - currentPosition + FIGURE_BORDER_WIDTH),
   };
 }

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -226,6 +226,24 @@ describe("figures", () => {
     expect(model.getters.getFigure(sheetId, figureId)).toMatchObject(expectedSize);
   });
 
+  test("Figure is considered dragging at mouseMove when resizing, not on mouseDown", async () => {
+    createFigure(model);
+    await nextTick();
+
+    const figureEl = fixture.querySelector(".o-figure")!;
+    await simulateClick(figureEl);
+    const anchorEl = fixture.querySelector(".o-anchor.o-top");
+    expect(figureEl.classList).not.toContain("o-dragging");
+
+    triggerMouseEvent(anchorEl, "mousedown");
+    await nextTick();
+    expect(figureEl.classList).not.toContain("o-dragging");
+
+    triggerMouseEvent(anchorEl, "mousemove");
+    await nextTick();
+    expect(figureEl.classList).toContain("o-dragging");
+  });
+
   describe("Move a figure with drag & drop ", () => {
     test("Can move a figure with drag & drop", async () => {
       createFigure(model, { id: "someuuid", x: 200, y: 100 });
@@ -277,6 +295,22 @@ describe("figures", () => {
         x: 4 * DEFAULT_CELL_WIDTH,
         y: 200,
       });
+    });
+
+    test("Figure is considered dragging at mouseMove, not on mouseDown", async () => {
+      createFigure(model);
+      await nextTick();
+
+      const figureEl = fixture.querySelector(".o-figure")!;
+      expect(figureEl.classList).not.toContain("o-dragging");
+
+      triggerMouseEvent(figureEl, "mousedown");
+      await nextTick();
+      expect(figureEl.classList).not.toContain("o-dragging");
+
+      triggerMouseEvent(figureEl, "mousemove");
+      await nextTick();
+      expect(figureEl.classList).toContain("o-dragging");
     });
   });
 

--- a/tests/plugins/figures.test.ts
+++ b/tests/plugins/figures.test.ts
@@ -352,7 +352,7 @@ describe("figure plugin", () => {
     expect(model.getters.getSelectedFigureId()).toBeNull();
   });
 
-  test("Selecting a cell cancel the edition of a cell", () => {
+  test("Selecting a figure cancel the edition of a cell", () => {
     const model = new Model();
     model.dispatch("CREATE_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -158,11 +158,12 @@ export async function dragElement(
   element: Element | string,
   dragX: Pixel,
   dragY: Pixel,
-  mouseUp = false
+  mouseUp = false,
+  mouseDownPosition = { x: 0, y: 0 }
 ) {
-  triggerMouseEvent(element, "mousedown");
+  triggerMouseEvent(element, "mousedown", mouseDownPosition.x, mouseDownPosition.y);
   await nextTick();
-  triggerMouseEvent(element, "mousemove", dragX, dragY);
+  triggerMouseEvent(element, "mousemove", mouseDownPosition.x + dragX, mouseDownPosition.y + dragY);
   await nextTick();
   if (mouseUp) {
     triggerMouseEvent(element, "mouseup");
@@ -178,4 +179,8 @@ export async function dragElement(
  */
 export function edgeScrollDelay(scrollDistance: Pixel, iterations: number) {
   return scrollDelay(Math.abs(Math.round(scrollDistance))) * (iterations + 1) - MIN_DELAY / 2;
+}
+
+export function pixelsToNumber(sizeInPixels: string) {
+  return Number(sizeInPixels.replace("px", ""));
 }

--- a/tests/xlsx_import_export.test.ts
+++ b/tests/xlsx_import_export.test.ts
@@ -1,5 +1,5 @@
 import { Model } from "../src";
-import { FIGURE_BORDER_SIZE } from "../src/constants";
+import { FIGURE_BORDER_WIDTH } from "../src/constants";
 import { toZone } from "../src/helpers";
 import { Align, BorderDescr, ConditionalFormatRule, Style } from "../src/types";
 import {
@@ -20,8 +20,8 @@ import { target, toRangesData } from "./test_helpers/helpers";
  *
  * Some side effects of exporting to xlsx then re-importing:
  *  - cols/row without a size will now have a explicitly defined size, close to the default size but not exactly the same (rounding error)
- *  - figure position : at export we add FIGURE_BORDER_SIZE to the position of the chart, so the charts at 0,0 are nicely displayed
- *          in excel, without their border being hidden below the overlay. We cannot subtract -FIGURE_BORDER_SIZE at import, as
+ *  - figure position : at export we add FIGURE_BORDER_WIDTH to the position of the chart, so the charts at 0,0 are nicely displayed
+ *          in excel, without their border being hidden below the overlay. We cannot subtract -FIGURE_BORDER_WIDTH at import, as
  *          this could lead to negative coordinates. The position of the figures is thus slightly off when exporting the re-importing.
  *  - charts: datasetHaveTitles boolean is lost. The dataset ranges that will be exported (and re-imported )are the
  *          ranges without the dataset titles (the range minus the first cell of the range) when datasetHaveTitles was true.
@@ -203,9 +203,9 @@ describe("Export data to xlsx then import it", () => {
     const importedFigure = importedModel.getters.getFigures(sheetId)[0];
     expect(importedFigure.height).toEqual(figure.height);
     expect(importedFigure.width).toBeBetween(figure.width - 1, figure.width + 1);
-    // See explanation at the top of the file for +FIGURE_BORDER_SIZE
-    expect(importedFigure.x).toEqual(figure.x + FIGURE_BORDER_SIZE);
-    expect(importedFigure.y).toEqual(figure.y + FIGURE_BORDER_SIZE);
+    // See explanation at the top of the file for +FIGURE_BORDER_WIDTH
+    expect(importedFigure.x).toEqual(figure.x + FIGURE_BORDER_WIDTH);
+    expect(importedFigure.y).toEqual(figure.y + FIGURE_BORDER_WIDTH);
   });
 
   test.each([


### PR DESCRIPTION
## Description:

When a figure is drag & dropped , its opacity is set to 0.9.
But the drag & drop starts when we press the mouse button,
and not when we start to move the figure. This means that when we click
a figure to select it, if will become transparent for a brief moment.

We should start the drag & drop state only on `mousemove`,
not on `mousedown`

PR based on #[1737](https://github.com/odoo/o-spreadsheet/pull/1737) to avoid rebases
Odoo task ID : [2951450](https://www.odoo.com/web#id=2951450&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo