### PR TITLE
[IMP] format: support additional date formats

### DIFF
--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -40,6 +40,33 @@ type InternalFormat = (
   | { type: "DATE"; format: string }
 )[];
 
+// TODO in the future : remove these constants MONTHS/DAYS, and use a library such as luxon to handle it
+// + possibly handle automatic translation of day/month
+const MONTHS: Readonly<Record<number, string>> = {
+  0: "January",
+  1: "February",
+  2: "March",
+  3: "April",
+  4: "May",
+  5: "June",
+  6: "July",
+  7: "August",
+  8: "September",
+  9: "October",
+  10: "November",
+  11: "December",
+};
+
+const DAYS: Readonly<Record<number, string>> = {
+  0: "Sunday",
+  1: "Monday",
+  2: "Tuesday",
+  3: "Wednesday",
+  4: "Thursday",
+  5: "Friday",
+  6: "Saturday",
+};
+
 interface InternalNumberFormat {
   readonly integerPart: string;
   readonly isPercent: boolean;
@@ -244,8 +271,8 @@ export function applyDateTimeFormat(value: number, format: Format): FormattedVal
 }
 
 function formatJSDate(jsDate: Date, format: Format): FormattedValue {
-  const sep = format.match(/\/|-|\s/)![0];
-  const parts = format.split(sep);
+  const sep = format.match(/\/|-|\s/)?.[0];
+  const parts = sep ? format.split(sep) : [format];
   return parts
     .map((p) => {
       switch (p) {
@@ -253,10 +280,23 @@ function formatJSDate(jsDate: Date, format: Format): FormattedValue {
           return jsDate.getDate();
         case "dd":
           return jsDate.getDate().toString().padStart(2, "0");
+        case "ddd":
+          return DAYS[jsDate.getDay()].slice(0, 3);
+        case "dddd":
+          return DAYS[jsDate.getDay()];
         case "m":
           return jsDate.getMonth() + 1;
         case "mm":
           return String(jsDate.getMonth() + 1).padStart(2, "0");
+        case "mmm":
+          return MONTHS[jsDate.getMonth()].slice(0, 3);
+        case "mmmm":
+          return MONTHS[jsDate.getMonth()];
+        case "mmmmm":
+          return MONTHS[jsDate.getMonth()].slice(0, 1);
+        case "yy":
+          const fullYear = String(jsDate.getFullYear()).replace("-", "").padStart(2, "0");
+          return fullYear.slice(fullYear.length - 2);
         case "yyyy":
           return jsDate.getFullYear();
         default:

--- a/tests/__xlsx__/xlsx_demo_data/xl/sharedStrings.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/sharedStrings.xml
@@ -1211,7 +1211,7 @@
     <t>#,##0[$ EUR €]</t>
   </si>
   <si>
-    <t>not supported: non-standard date format</t>
+    <t>d/m/yy</t>
   </si>
   <si>
     <t>not supported: multiple escaped sequences</t>

--- a/tests/helpers/format.test.ts
+++ b/tests/helpers/format.test.ts
@@ -330,6 +330,12 @@ describe("formatValue on date and time", () => {
     "m d",
     "m-d",
     "m/d",
+    "yy-mm",
+    "ddd-mm",
+    "dddd-mm",
+    "mmm-yy",
+    "mmmm-yy",
+    "mmmmm-yy",
   ])("detect date time format %s", (format) => {
     expect(isDateTimeFormat(format)).toBe(true);
   });
@@ -581,6 +587,109 @@ describe("formatValue on date and time", () => {
       ["yyyy mm dd", "1954 01 02"],
     ])("year month day, with ' ' as separator", (format, result) => {
       expect(formatValue(value, format)).toBe(result);
+    });
+
+    test.each([
+      ["01/01/2023", "Sun-01-2023"],
+      ["01/02/2023", "Mon-01-2023"],
+      ["01/03/2023", "Tue-01-2023"],
+      ["01/04/2023", "Wed-01-2023"],
+      ["01/05/2023", "Thu-01-2023"],
+      ["01/06/2023", "Fri-01-2023"],
+      ["01/07/2023", "Sat-01-2023"],
+    ])("three letter day of the week (ddd) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "ddd-mm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      ["2023/01/01", "Sunday-01-2023"],
+      ["2023/01/02", "Monday-01-2023"],
+      ["2023/01/03", "Tuesday-01-2023"],
+      ["2023/01/04", "Wednesday-01-2023"],
+      ["2023/01/05", "Thursday-01-2023"],
+      ["2023/01/06", "Friday-01-2023"],
+      ["2023/01/07", "Saturday-01-2023"],
+    ])("Full letter day of the week (dddd) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "dddd-mm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      ["2023/01/01", "Jan-2023"],
+      ["2023/02/01", "Feb-2023"],
+      ["2023/03/01", "Mar-2023"],
+      ["2023/04/01", "Apr-2023"],
+      ["2023/05/01", "May-2023"],
+      ["2023/06/01", "Jun-2023"],
+      ["2023/07/01", "Jul-2023"],
+      ["2023/08/01", "Aug-2023"],
+      ["2023/09/01", "Sep-2023"],
+      ["2023/10/01", "Oct-2023"],
+      ["2023/11/01", "Nov-2023"],
+      ["2023/12/01", "Dec-2023"],
+    ])("Three letter day of month (mmm) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "mmm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      ["2023/01/01", "January-2023"],
+      ["2023/02/01", "February-2023"],
+      ["2023/03/01", "March-2023"],
+      ["2023/04/01", "April-2023"],
+      ["2023/05/01", "May-2023"],
+      ["2023/06/01", "June-2023"],
+      ["2023/07/01", "July-2023"],
+      ["2023/08/01", "August-2023"],
+      ["2023/09/01", "September-2023"],
+      ["2023/10/01", "October-2023"],
+      ["2023/11/01", "November-2023"],
+      ["2023/12/01", "December-2023"],
+    ])("Full letter day of month (mmmm) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "mmmm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      ["2023/01/01", "J-2023"],
+      ["2023/02/01", "F-2023"],
+      ["2023/03/01", "M-2023"],
+      ["2023/04/01", "A-2023"],
+      ["2023/05/01", "M-2023"],
+      ["2023/06/01", "J-2023"],
+      ["2023/07/01", "J-2023"],
+      ["2023/08/01", "A-2023"],
+      ["2023/09/01", "S-2023"],
+      ["2023/10/01", "O-2023"],
+      ["2023/11/01", "N-2023"],
+      ["2023/12/01", "D-2023"],
+    ])("One letter day of month (mmmmm) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "mmmmm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      [44927 /* 01/01/2023 */, "01-23"],
+      [45292 /* 01/01/2024 */, "01-24"],
+      [24838 /* 01/01/1968 */, "01-68"],
+      [38718 /* 01/01/2006 */, "01-06"],
+      [-691767 /* 01/01/0006 */, "01-06"],
+      [-715508 /* 01/01/-0059 */, "01-59"],
+      [-737422 /* 01/01/-0119 */, "01-19"],
+    ])("2 last digits of year (yy) %s", (value, result) => {
+      expect(formatValue(value, "mm-yy")).toBe(result);
+    });
+
+    test.each([
+      ["d", "1"],
+      ["dd", "01"],
+      ["ddd", "Sun"],
+      ["dddd", "Sunday"],
+      ["m", "1"],
+      ["mm", "01"],
+      ["mmm", "Jan"],
+      ["mmmm", "January"],
+      ["mmmmm", "J"],
+      ["yy", "23"],
+      ["yyyy", "2023"],
+    ])("Format without separators %s", (format, result) => {
+      expect(formatValue(parseDateTime("01/01/2023")!.value, format)).toBe(result);
     });
   });
 

--- a/tests/xlsx_import.test.ts
+++ b/tests/xlsx_import.test.ts
@@ -180,7 +180,7 @@ describe("Import xlsx data", () => {
     ["[$$]#,##0.000", "M6"],
     ["[$₪] #,##0", "M7"],
     ["#,##0[$ EUR €]", "M8"],
-    ["not supported: non-standard date format", "M9"],
+    ["d/m/yy", "M9"],
     ["not supported: multiple escaped sequences", "M10"],
   ])("Can import format %s", (format, cellXc) => {
     const testSheet = getWorkbookSheet("jestStyles", convertedData)!;
@@ -769,12 +769,15 @@ test.each([
   ["0.000%", "0.000%"],
   ["#,##0.00", "#,##0.00"],
   ["m/d/yyyy", "m/d/yyyy"],
+  ["mmm/dddd/yy", "mmm/dddd/yy"],
+  ["mmmm/ddd/yyyy", "mmmm/ddd/yyyy"],
+  ["mmmmm/dd/yy", "mmmmm/dd/yy"],
   ["m/d/yyyy\\ hh:mm:ss", "m/d/yyyy hh:mm:ss"],
   ["hh:mm:ss a", "hh:mm:ss a"],
   ['#,##0.00 "€"', "#,##0.00 [$€]"],
   ["[$$-409]#,##0.000", "[$$]#,##0.000"],
   ["[$-409]0.00", "0.00"],
-  ["d/m/yy;@", undefined],
+  ["d/m/yy;@", "d/m/yy"],
   ["[$₪-40D] #,##0", "[$₪] #,##0"],
   ['"€"#,##0.00 "€"', undefined],
 ])("convert format", async (excelFormat, convertedFormat) => {


### PR DESCRIPTION
## Description

Some date formats weren't supported in o_spreadsheet, and thus the xlsx import failed for these formats.

Added basic support for formats :
- yy
- mmm
- mmmm
- mmmmm
- ddd
- dddd

Also fixed a bug that prevented date formats without separators (eg. "yyyy") from working.

Follow up with more feature will be done in 3035270. The goal here was mainly to improve the xlsx import.

Odoo task ID : [3006028](https://www.odoo.com/web#id=3006028&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo