### PR TITLE
[REF] ranges: make Range immutable object

### DIFF
--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -12,21 +12,21 @@ import {
 import { isRowReference } from "./references";
 
 interface ConstructorArgs {
-  zone: Zone | UnboundedZone;
-  parts: RangePart[];
-  invalidXc?: string;
+  readonly zone: Readonly<Zone | UnboundedZone>;
+  readonly parts: readonly RangePart[];
+  readonly invalidXc?: string;
   /** true if the user provided the range with the sheet name */
-  prefixSheet: boolean;
+  readonly prefixSheet: boolean;
   /** the name of any sheet that is invalid */
-  invalidSheetName?: string;
+  readonly invalidSheetName?: string;
   /** the sheet on which the range is defined */
-  sheetId: UID;
+  readonly sheetId: UID;
 }
 
 export class RangeImpl implements Range {
-  private readonly _zone: Zone | UnboundedZone;
-  readonly parts: RangePart[];
-  readonly invalidXc?: string | undefined;
+  private readonly _zone: Readonly<Zone | UnboundedZone>;
+  readonly parts: Range["parts"];
+  readonly invalidXc?: string;
   readonly prefixSheet: boolean = false;
   readonly sheetId: UID; // the sheet on which the range is defined
   readonly invalidSheetName?: string; // the name of any sheet that is invalid
@@ -64,7 +64,7 @@ export class RangeImpl implements Range {
   }
 
   static getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {
-    const parts: RangePart[] = xc.split(":").map((p) => {
+    const parts = xc.split(":").map((p) => {
       const isFullRow = isRowReference(p);
       return {
         colFixed: isFullRow ? false : p.startsWith("$"),
@@ -114,28 +114,42 @@ export class RangeImpl implements Range {
    * Check that a zone is valid regarding the order of top-bottom and left-right.
    * Left should be smaller than right, top should be smaller than bottom.
    * If it's not the case, simply invert them, and invert the linked parts
-   * (in place!)
    */
-  orderZone() {
-    if (this._zone.right !== undefined && this._zone.right < this._zone.left) {
-      let right = this._zone.right;
-      this._zone.right = this._zone.left;
-      this._zone.left = right;
-
-      let rightFixed = this.parts[1].colFixed;
-      this.parts[1].colFixed = this.parts[0].colFixed;
-      this.parts[0].colFixed = rightFixed;
+  orderZone(): RangeImpl {
+    const zone = { ...this._zone };
+    let parts = this.parts;
+    if (zone.right !== undefined && zone.right < zone.left) {
+      let right = zone.right;
+      zone.right = zone.left;
+      zone.left = right;
+      parts = [
+        {
+          colFixed: parts[1]?.colFixed || false,
+          rowFixed: parts[0]?.rowFixed || false,
+        },
+        {
+          colFixed: parts[0]?.colFixed || false,
+          rowFixed: parts[1]?.rowFixed || false,
+        },
+      ];
     }
 
-    if (this._zone.bottom !== undefined && this._zone.bottom < this._zone.top) {
-      let bottom = this._zone.bottom;
-      this._zone.bottom = this._zone.top;
-      this._zone.top = bottom;
-
-      let bottomFixed = this.parts[1].rowFixed;
-      this.parts[1].rowFixed = this.parts[0].rowFixed;
-      this.parts[0].rowFixed = bottomFixed;
+    if (zone.bottom !== undefined && zone.bottom < zone.top) {
+      let bottom = zone.bottom;
+      zone.bottom = zone.top;
+      zone.top = bottom;
+      parts = [
+        {
+          colFixed: parts[0]?.colFixed || false,
+          rowFixed: parts[1]?.rowFixed || false,
+        },
+        {
+          colFixed: parts[1]?.colFixed || false,
+          rowFixed: parts[0]?.rowFixed || false,
+        },
+      ];
     }
+    return this.clone({ zone, parts });
   }
 
   /**

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -275,9 +275,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
           : range.unboundedZone.bottom! +
             ((range.parts[1] || range.parts[0]).rowFixed ? 0 : offsetY),
       };
-      range = range.clone({ sheetId: copySheetId, zone: unboundZone });
-      range.orderZone();
-      return range;
+      return range.clone({ sheetId: copySheetId, zone: unboundZone }).orderZone();
     });
   }
 
@@ -316,10 +314,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
 
     const rangeInterface = { prefixSheet, zone, sheetId, invalidSheetName, parts };
 
-    const range = new RangeImpl(rangeInterface, this.getters.getSheetSize);
-    range.orderZone();
-
-    return range;
+    return new RangeImpl(rangeInterface, this.getters.getSheetSize).orderZone();
   }
 
   /**

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -519,14 +519,15 @@ export class EditionPlugin extends UIPlugin {
 
   private getRangeReference(
     range: Range,
-    fixedParts: RangePart[] = [{ colFixed: false, rowFixed: false }]
+    fixedParts: Range["parts"] = [{ colFixed: false, rowFixed: false }]
   ) {
+    let _fixedParts = [...fixedParts];
     if (fixedParts.length === 1 && getZoneArea(range.zone) > 1) {
-      fixedParts.push({ ...fixedParts[0] });
+      _fixedParts.push({ ...fixedParts[0] });
     } else if (fixedParts.length === 2 && getZoneArea(range.zone) === 1) {
-      fixedParts.pop();
+      _fixedParts.pop();
     }
-    const newRange = range.clone({ parts: this.previousRange!.parts });
+    const newRange = range.clone({ parts: _fixedParts });
     return this.getters.getSelectionRangeString(newRange, this.getters.getEditionSheet());
   }
 

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -1,20 +1,20 @@
 import { Cloneable, UID, UnboundedZone, Zone } from "./misc";
 
 export interface RangePart {
-  colFixed: boolean;
-  rowFixed: boolean;
+  readonly colFixed: boolean;
+  readonly rowFixed: boolean;
 }
 
 export interface Range extends Cloneable<Range> {
-  zone: Zone;
-  parts: RangePart[];
-  invalidXc?: string;
+  readonly zone: Readonly<Zone>;
+  readonly parts: readonly RangePart[];
+  readonly invalidXc?: string;
   /** true if the user provided the range with the sheet name */
-  prefixSheet: boolean;
+  readonly prefixSheet: boolean;
   /** the name of any sheet that is invalid */
-  invalidSheetName?: string;
+  readonly invalidSheetName?: string;
   /** the sheet on which the range is defined */
-  sheetId: UID;
+  readonly sheetId: UID;
 }
 
 export interface RangeData {


### PR DESCRIPTION
## Description:

Immutable data structures are less error prone.
It also allows to safely share instances to multiple parts of the system without one part altering others. Memoizing Ranges and sharing instances between plugins might be a future improvement if we use ranges massively.

Odoo task ID : [3035517](https://www.odoo.com/web#id=3035517&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo