### PR TITLE
[FIX] spreadsheet: deactivate keystroke inputs in dashboard mode

### DIFF
--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -19,12 +19,9 @@
         sidePanelIsOpen="props.sidePanelIsOpen"
         onFigureDeleted.bind="focus"
       />
-      <HeadersOverlay
-        t-if="!env.isDashboard()"
-        onOpenContextMenu="(type, x, y) => this.toggleContextMenu(type, x, y)"
-      />
+      <HeadersOverlay onOpenContextMenu="(type, x, y) => this.toggleContextMenu(type, x, y)"/>
 
-      <t t-if="env.model.getters.getEditionMode() !== 'inactive' and !env.isDashboard()">
+      <t t-if="env.model.getters.getEditionMode() !== 'inactive'">
         <GridComposer
           onComposerUnmounted="() => this.focus()"
           onComposerContentFocused="props.onComposerContentFocused"
@@ -33,7 +30,6 @@
       </t>
       <canvas t-ref="canvas"/>
       <t
-        t-if="!env.isDashboard()"
         t-foreach="env.model.getters.getClientsToDisplay()"
         t-as="client"
         t-key="getClientPositionKey(client)">
@@ -52,11 +48,10 @@
         onMouseWheel.bind="onMouseWheel"
         onClosePopover.bind="onClosePopover"
       />
-      <t
-        t-if="env.model.getters.getEditionMode() === 'inactive' and isAutoFillActive() and !env.isDashboard()">
+      <t t-if="env.model.getters.getEditionMode() === 'inactive' and isAutoFillActive()">
         <Autofill position="getAutofillPosition()"/>
       </t>
-      <t t-if="env.model.getters.getEditionMode() !== 'inactive' and !env.isDashboard()">
+      <t t-if="env.model.getters.getEditionMode() !== 'inactive'">
         <t t-foreach="env.model.getters.getHighlights()" t-as="highlight" t-key="highlight_index">
           <t t-if="highlight.sheetId === env.model.getters.getActiveSheetId()">
             <Highlight zone="highlight.zone" color="highlight.color"/>

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -1,6 +1,9 @@
 <templates>
   <t t-name="o-spreadsheet-Spreadsheet" owl="1">
-    <div class="o-spreadsheet" t-on-keydown="onKeydown" t-att-style="getStyle()">
+    <div
+      class="o-spreadsheet"
+      t-on-keydown="(ev) => !env.isDashboard() and this.onKeydown(ev)"
+      t-att-style="getStyle()">
       <t t-if="env.isDashboard()">
         <SpreadsheetDashboard/>
       </t>

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -492,4 +492,16 @@ describe("Composer / selectionInput interactions", () => {
     expect(colorPickerZIndex).toBeLessThan(contextMenuZIndex);
     expect(contextMenuZIndex).toBeLessThan(figureAnchorZIndex);
   });
+
+  test("Keydown is ineffective in dashboard mode", async () => {
+    const spreadsheetKeyDown = jest.spyOn(parent, "onKeydown");
+    const spreadsheetDiv = fixture.querySelector(".o-spreadsheet")!;
+    spreadsheetDiv.dispatchEvent(new KeyboardEvent("keydown", { key: "H", ctrlKey: true }));
+    expect(spreadsheetKeyDown).toHaveBeenCalled();
+    jest.clearAllMocks();
+    parent.model.updateMode("dashboard");
+    await nextTick();
+    spreadsheetDiv.dispatchEvent(new KeyboardEvent("keydown", { key: "H", ctrlKey: true }));
+    expect(spreadsheetKeyDown).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
All keybinds in spreadsheet only make sense in non-dashboard mode. This commit deactivates the keydown callback when on dashboard mode. A more suitable/long-term solution would be to make independant components altogether.

Task 3036813

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo