### PR TITLE
[IMP] keyboard shortcuts: Insert link

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -11,6 +11,7 @@ import { interactivePaste, interactivePasteFromOS } from "../../helpers/ui/paste
 import { ComposerSelection } from "../../plugins/ui/edition";
 import { cellMenuRegistry } from "../../registries/menus/cell_menu_registry";
 import { colMenuRegistry } from "../../registries/menus/col_menu_registry";
+import { INSERT_LINK } from "../../registries/menus/menu_items_actions";
 import { rowMenuRegistry } from "../../registries/menus/row_menu_registry";
 import {
   Client,
@@ -267,6 +268,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     },
     PAGEDOWN: () => this.env.model.dispatch("SHIFT_VIEWPORT_DOWN"),
     PAGEUP: () => this.env.model.dispatch("SHIFT_VIEWPORT_UP"),
+    "CTRL+K": () => INSERT_LINK(this.env),
   };
 
   focus() {

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -617,6 +617,14 @@ describe("Grid component", () => {
       expect(model.getters.getActiveSheetId()).toBe("third");
     });
 
+    test("pressing Ctrl+K opens the link editor", async () => {
+      document.activeElement!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "k", ctrlKey: true, bubbles: true })
+      );
+      await nextTick();
+      expect(fixture.querySelector(".o-link-editor")).not.toBeNull();
+    });
+
     test("Filter icon is correctly rendered", async () => {
       createFilter(model, "B2:C3");
       await nextTick();


### PR DESCRIPTION
This commit binds the key combination `Ctrl+k` to the insertion of a link to the currently selected cell.

Task 3037483

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo