### PR TITLE
[FIX] linkDisplay: Hide edit/remove on readonly mode

### DIFF
--- a/src/components/link/link_display.ts
+++ b/src/components/link/link_display.ts
@@ -25,8 +25,8 @@ const TEMPLATE = xml/* xml */ `
       t-att-title="cell.urlRepresentation">
       <t t-esc="cell.urlRepresentation"/>
     </a>
-    <span class="o-link-icon o-unlink" t-on-click="unlink" title="${LinkEditorTerms.Remove}">${UNLINK}</span>
-    <span class="o-link-icon o-edit-link" t-on-click="edit" title="${LinkEditorTerms.Edit}">${EDIT}</span>
+    <span t-if="!env.getters.isReadonly()" class="o-link-icon o-unlink" t-on-click="unlink" title="${LinkEditorTerms.Remove}">${UNLINK}</span>
+    <span t-if="!env.getters.isReadonly()" class="o-link-icon o-edit-link" t-on-click="edit" title="${LinkEditorTerms.Edit}">${EDIT}</span>
   </div>
 `;
 

--- a/tests/components/link/link_display.test.ts
+++ b/tests/components/link/link_display.test.ts
@@ -170,4 +170,15 @@ describe("link display component", () => {
     expect(model.getters.getActiveSheetId()).toBe(sheetId);
     expect(fixture.querySelector(".o-link-tool")).toBeFalsy();
   });
+
+  test("remove/edit link are hidden in readonly mode", async () => {
+    setCellContent(model, "A1", "[label](url.com)");
+    await nextTick();
+    model.updateReadOnly(true);
+    await clickCell(model, "A1");
+    const linkTool = fixture.querySelector(".o-link-tool");
+    expect(linkTool).toBeTruthy();
+    expect(linkTool!.querySelector(".o-unlink")).toBeFalsy();
+    expect(linkTool!.querySelector(".o-edit-link")).toBeFalsy();
+  });
 });


### PR DESCRIPTION
A readonly user could see the edit/remove buttons of the linkDisplay component but clicking on those won't do anything since they cannot edit the spreadsheet.

Task 3037635

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo