### PR TITLE
[IMP] style: add vertical text align option

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -2,17 +2,15 @@
 // Miscellaneous
 //------------------------------------------------------------------------------
 import {
-  DEFAULT_CELL_HEIGHT,
   DEFAULT_FONT,
   DEFAULT_FONT_SIZE,
   DEFAULT_FONT_WEIGHT,
   MIN_CELL_TEXT_MARGIN,
   MIN_CF_ICON_MARGIN,
-  PADDING_AUTORESIZE_VERTICAL,
 } from "../constants";
 import { fontSizeMap } from "../fonts";
 import { ConsecutiveIndexes, Lazy, Style, UID } from "../types";
-import { Cloneable, Pixel } from "./../types/misc";
+import { Cloneable } from "./../types/misc";
 import { parseDateTime } from "./dates";
 /**
  * Stringify an object, like JSON.stringify, except that the first level of keys
@@ -109,17 +107,8 @@ export function clip(val: number, min: number, max: number): number {
   return val < min ? min : val > max ? max : val;
 }
 
-/** Get the default height of the cell. The height depends on the font size and
- * the number of broken line text in the cell */
-export function getDefaultCellHeight(style: Style | undefined, numberOfLines?: number): Pixel {
-  if (!style?.fontSize) {
-    return DEFAULT_CELL_HEIGHT;
-  }
-  return (
-    (numberOfLines || 1) * (computeTextFontSizeInPixels(style) + MIN_CELL_TEXT_MARGIN) -
-    MIN_CELL_TEXT_MARGIN +
-    2 * PADDING_AUTORESIZE_VERTICAL
-  );
+export function computeTextLinesHeight(textLineHeight: number, numberOfLines: number = 1) {
+  return numberOfLines * (textLineHeight + MIN_CELL_TEXT_MARGIN) - MIN_CELL_TEXT_MARGIN;
 }
 
 export function computeTextWidth(context: CanvasRenderingContext2D, text: string, style: Style) {
@@ -137,8 +126,8 @@ export function computeTextFont(style: Style): string {
   return `${italic}${weight} ${size}px ${DEFAULT_FONT}`;
 }
 
-export function computeTextFontSizeInPixels(style: Style): number {
-  const sizeInPt = style.fontSize || DEFAULT_FONT_SIZE;
+export function computeTextFontSizeInPixels(style?: Style): number {
+  const sizeInPt = style?.fontSize || DEFAULT_FONT_SIZE;
   if (!fontSizeMap[sizeInPt]) {
     throw new Error("Size of the font is not supported");
   }

--- a/src/plugins/core/header_size.ts
+++ b/src/plugins/core/header_size.ts
@@ -1,5 +1,16 @@
-import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../constants";
-import { deepCopy, getAddHeaderStartIndex, getDefaultCellHeight, lazy, range } from "../../helpers";
+import {
+  DEFAULT_CELL_HEIGHT,
+  DEFAULT_CELL_WIDTH,
+  PADDING_AUTORESIZE_VERTICAL,
+} from "../../constants";
+import {
+  computeTextFontSizeInPixels,
+  computeTextLinesHeight,
+  deepCopy,
+  getAddHeaderStartIndex,
+  lazy,
+  range,
+} from "../../helpers";
 import { Command, ExcelWorkbookData, WorkbookData } from "../../types";
 import { CellPosition, Dimension, HeaderIndex, Lazy, Pixel, UID } from "../../types/misc";
 import { CorePlugin } from "../core_plugin";
@@ -178,8 +189,9 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
       return DEFAULT_CELL_HEIGHT;
     }
     const cell = this.getters.getCell(position);
-    // TO DO: take multiline cells into account to compute the cell height
-    return getDefaultCellHeight(cell?.style);
+    // TO DO: take multi text line into account to compute the real cell height in case of wrapping cell
+    const fontSize = computeTextFontSizeInPixels(cell?.style);
+    return computeTextLinesHeight(fontSize) + 2 * PADDING_AUTORESIZE_VERTICAL;
   }
 
   /**

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -386,10 +386,47 @@ topbarMenuRegistry
   .addChild("format_font_size", ["format"], {
     name: _lt("Font size"),
     sequence: 60,
+    separator: true,
+  })
+  .addChild("format_alignment", ["format"], {
+    name: _lt("Alignment"),
+    sequence: 70,
+  })
+  .addChild("format_alignment_left", ["format", "format_alignment"], {
+    name: "Left",
+    sequence: 10,
+    action: (env: SpreadsheetChildEnv) => setStyle(env, { align: "left" }),
+  })
+  .addChild("format_alignment_center", ["format", "format_alignment"], {
+    name: "Center",
+    sequence: 20,
+    action: (env: SpreadsheetChildEnv) => setStyle(env, { align: "center" }),
+  })
+  .addChild("format_alignment_right", ["format", "format_alignment"], {
+    name: "Right",
+    sequence: 30,
+    action: (env: SpreadsheetChildEnv) => setStyle(env, { align: "right" }),
+    separator: true,
+  })
+  .addChild("format_alignment_top", ["format", "format_alignment"], {
+    name: "Top",
+    sequence: 40,
+    action: (env: SpreadsheetChildEnv) => setStyle(env, { verticalAlign: "top" }),
+  })
+  .addChild("format_alignment_middle", ["format", "format_alignment"], {
+    name: "Middle",
+    sequence: 50,
+    action: (env: SpreadsheetChildEnv) => setStyle(env, { verticalAlign: "middle" }),
+  })
+  .addChild("format_alignment_bottom", ["format", "format_alignment"], {
+    name: "Bottom",
+    sequence: 60,
+    action: (env: SpreadsheetChildEnv) => setStyle(env, { verticalAlign: "bottom" }),
+    separator: true,
   })
   .addChild("format_wrapping", ["format"], {
     name: _lt("Wrapping"),
-    sequence: 70,
+    sequence: 80,
     separator: true,
   })
   .addChild("format_wrapping_overflow", ["format", "format_wrapping"], {
@@ -409,13 +446,13 @@ topbarMenuRegistry
   })
   .addChild("format_cf", ["format"], {
     name: _lt("Conditional formatting"),
-    sequence: 80,
+    sequence: 90,
     action: ACTIONS.OPEN_CF_SIDEPANEL_ACTION,
     separator: true,
   })
   .addChild("format_clearFormat", ["format"], {
     name: _lt("Clear formatting"),
-    sequence: 90,
+    sequence: 100,
     action: ACTIONS.FORMAT_CLEARFORMAT_ACTION,
     separator: true,
   })

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -91,6 +91,8 @@ export interface ZoneDimension {
 
 export type Align = "left" | "right" | "center" | undefined;
 
+export type VerticalAlign = "top" | "middle" | "bottom" | undefined;
+
 export type Wrapping = "overflow" | "wrap" | "clip" | undefined;
 
 export interface Style {
@@ -100,6 +102,7 @@ export interface Style {
   underline?: boolean;
   align?: Align;
   wrapping?: Wrapping;
+  verticalAlign?: VerticalAlign;
   fillColor?: string;
   textColor?: string;
   fontSize?: number; // in pt, not in px!

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -1,4 +1,4 @@
-import { Alias, Align, Border, Pixel, Style, Zone } from "./misc";
+import { Alias, Align, Border, Pixel, Style, VerticalAlign, Zone } from "./misc";
 
 export type Rect = {
   x: Pixel;
@@ -16,7 +16,7 @@ export interface DOMCoordinates {
 }
 
 export interface BoxTextContent {
-  multiLineText: string[];
+  textLines: string[];
   width: Pixel;
   align: Align;
 }
@@ -30,6 +30,7 @@ export interface Box extends Rect {
   error?: string;
   image?: Image;
   isMerge?: boolean;
+  verticalAlign?: VerticalAlign;
 }
 export interface Image {
   clipIcon: Rect | null;

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -689,6 +689,62 @@ describe("Menu Item actions", () => {
     });
   });
 
+  describe("Format -> Alignment", () => {
+    test("Left", () => {
+      doAction(["format", "format_alignment", "format_alignment_left"], env);
+      expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        target: env.model.getters.getSelectedZones(),
+        style: { align: "left" },
+      });
+    });
+
+    test("Center", () => {
+      doAction(["format", "format_alignment", "format_alignment_center"], env);
+      expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        target: env.model.getters.getSelectedZones(),
+        style: { align: "center" },
+      });
+    });
+
+    test("Right", () => {
+      doAction(["format", "format_alignment", "format_alignment_right"], env);
+      expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        target: env.model.getters.getSelectedZones(),
+        style: { align: "right" },
+      });
+    });
+
+    test("Top", () => {
+      doAction(["format", "format_alignment", "format_alignment_top"], env);
+      expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        target: env.model.getters.getSelectedZones(),
+        style: { verticalAlign: "top" },
+      });
+    });
+
+    test("Middle", () => {
+      doAction(["format", "format_alignment", "format_alignment_middle"], env);
+      expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        target: env.model.getters.getSelectedZones(),
+        style: { verticalAlign: "middle" },
+      });
+    });
+
+    test("Bottom", () => {
+      doAction(["format", "format_alignment", "format_alignment_bottom"], env);
+      expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        target: env.model.getters.getSelectedZones(),
+        style: { verticalAlign: "bottom" },
+      });
+    });
+  });
+
   describe("Format -> wrapping", () => {
     test("Overflow", () => {
       doAction(["format", "format_wrapping", "format_wrapping_overflow"], env);

--- a/tests/plugins/resizing.test.ts
+++ b/tests/plugins/resizing.test.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_CELL_WIDTH } from "../../src/constants";
-import { getDefaultCellHeight, toXC } from "../../src/helpers";
+import { DEFAULT_CELL_WIDTH, PADDING_AUTORESIZE_VERTICAL } from "../../src/constants";
+import { computeTextFontSizeInPixels, computeTextLinesHeight, toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
-import { CommandResult, Sheet } from "../../src/types";
+import { CommandResult, Sheet, Style } from "../../src/types";
 import {
   activateSheet,
   addColumns,
@@ -22,6 +22,11 @@ import {
   unMerge,
 } from "../test_helpers/commands_helpers";
 import { DEFAULT_CELL_HEIGHT } from "./../../src/constants";
+
+function getDefaultCellHeight(style: Style) {
+  const textFontSize = computeTextFontSizeInPixels(style);
+  return computeTextLinesHeight(textFontSize) + 2 * PADDING_AUTORESIZE_VERTICAL;
+}
 
 describe("Model resizer", () => {
   test("Can resize one column, undo, then redo", async () => {


### PR DESCRIPTION
## Description:

This commit makes it possible to vertically align text.
These options have been added to the format menu.
Thus, it is now possible to align text:
- to the top
- to the middle
- to the bottom

Also, the options to horizontally align the text (present in the tool bar)
have also been added to the format menu.

Odoo task ID : [2886061](https://www.odoo.com/web#id=2886061&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo