### PR TITLE
[FIX] composer: Pasting/editing fixes

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -452,10 +452,11 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
 
   private getContent(): HtmlContent[] {
     let content: HtmlContent[];
-    let value = this.getters.getCurrentContent();
+    const value = this.getters.getCurrentContent();
+    const isValidFormula = value.startsWith("=") && this.getters.getCurrentTokens().length > 0;
     if (value === "") {
       content = [];
-    } else if (value.startsWith("=") && this.getters.getEditionMode() !== "inactive") {
+    } else if (isValidFormula && this.getters.getEditionMode() !== "inactive") {
       content = this.getColoredTokens();
     } else {
       content = [{ value }];
@@ -468,7 +469,7 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     const tokenAtCursor = this.getters.getTokenAtCursor();
     const result: any[] = [];
     const { end } = this.getters.getComposerSelection();
-    for (let token of tokens) {
+    for (const token of tokens) {
       switch (token.type) {
         case "OPERATOR":
         case "NUMBER":

--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -66,6 +66,7 @@ const TEMPLATE = xml/* xml */ `
     t-on-keyup="onKeyup"
     t-on-click.stop="onClick"
     t-on-blur="onBlur"
+    t-on-paste.stop=""
   />
 
   <div t-if="props.focus !== 'inactive' and (autoCompleteState.showProvider or functionDescriptionState.showDescription)"

--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -1,7 +1,6 @@
 import { FORMULA_REF_IDENTIFIER, INCORRECT_RANGE_STRING } from "../constants";
 import { functionRegistry } from "../functions/index";
 import { formulaNumberRegexp } from "../helpers/index";
-import { _lt } from "../translation";
 
 /**
  * Tokenizer
@@ -50,17 +49,8 @@ export interface Token {
 export function tokenize(str: string): Token[] {
   const chars = str.split("");
   const result: Token[] = [];
-  let tokenCount = 0;
 
   while (chars.length) {
-    tokenCount++;
-    if (tokenCount > 100) {
-      throw new Error(
-        _lt(
-          "This formula has over 100 parts. It can't be processed properly, consider splitting it into multiple cells"
-        )
-      );
-    }
     let token =
       tokenizeSpace(chars) ||
       tokenizeMisc(chars) ||

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -116,7 +116,7 @@ export class EditionPlugin extends UIPlugin {
         }
         break;
       case "SET_CURRENT_CONTENT":
-        this.setContent(cmd.content, cmd.selection);
+        this.setContent(cmd.content, cmd.selection, true);
         break;
       case "REPLACE_COMPOSER_CURSOR_SELECTION":
         this.replaceSelection(cmd.text);
@@ -416,7 +416,7 @@ export class EditionPlugin extends UIPlugin {
     this.setContent(this.initialContent || "");
   }
 
-  private setContent(text: string, selection?: ComposerSelection) {
+  private setContent(text: string, selection?: ComposerSelection, raise?: boolean) {
     const isNewCurrentContent = this.currentContent !== text;
     this.currentContent = text;
 
@@ -428,6 +428,15 @@ export class EditionPlugin extends UIPlugin {
     }
     if (isNewCurrentContent || this.mode !== "inactive") {
       this.currentTokens = text.startsWith("=") ? composerTokenize(text) : [];
+      if (this.currentTokens.length > 100) {
+        if (raise) {
+          this.ui.notifyUser(
+            _lt(
+              "This formula has over 100 parts. It can't be processed properly, consider splitting it into multiple cells"
+            )
+          );
+        }
+      }
     }
     if (this.canStartComposerRangeSelection()) {
       this.startComposerRangeSelection();

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -20,6 +20,7 @@ import { clickCell, simulateClick, triggerMouseEvent } from "../test_helpers/dom
 import { getActiveXc, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
   makeTestFixture,
+  MockClipboard,
   mountSpreadsheet,
   nextTick,
   startGridComposition,
@@ -1291,5 +1292,32 @@ describe("composer highlights color", () => {
     expect(highlights[1].sheet).toBe("42");
     expect(highlights[1].zone).toEqual({ left: 0, right: 0, top: 0, bottom: 0 });
   });
+
   test("grid composer is resized when top bar composer grows", async () => {});
+});
+
+describe("Copy/paste in composer", () => {
+  beforeAll(() => {
+    const clipboard = new MockClipboard();
+    Object.defineProperty(navigator, "clipboard", {
+      get() {
+        return clipboard;
+      },
+      configurable: true,
+    });
+  });
+
+  test("Can copy random content inside the composer", async () => {
+    const sypeDispatch = jest.spyOn(parent.model, "dispatch");
+    await startComposition();
+    const clipboardEvent = new Event("paste", { bubbles: true, cancelable: true });
+    //@ts-ignore
+    clipboardEvent.clipboardData = { getData: () => "unimportant" };
+    fixture.querySelector(".o-grid-composer .o-composer")!.dispatchEvent(clipboardEvent);
+    await nextTick();
+    expect(parent.model.getters.getEditionMode()).not.toBe("inactive");
+    expect(fixture.querySelectorAll(".o-grid-composer .o-composer")).toHaveLength(1);
+    expect(sypeDispatch).not.toBeCalledWith("PASTE_FROM_OS_CLIPBOARD", expect.any);
+    expect(sypeDispatch).not.toBeCalledWith("PASTE", expect.any);
+  });
 });

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -643,4 +643,16 @@ describe("edition", () => {
     });
     expect(getCell(model, "A1")?.composerContent).toBe("44124");
   });
+
+  test("write too long formulas raises an error", async () => {
+    const notifyUser = jest.fn();
+    const model = new Model({}, { notifyUser });
+    model.dispatch("START_EDITION");
+    const content = // 101 tokens
+      "=1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1";
+    model.dispatch("SET_CURRENT_CONTENT", { content });
+    model.dispatch("STOP_EDITION");
+
+    expect(notifyUser).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
When copying in the composer, the paste event was still propagated to the parent (i.e. `Spreadsheet`) which would handle it and dispath either `PASTE` or `PASTE_FROM_OS_CLIPBOARD` basically writing the wrong content on the cell on top of endin the edition and closing the composer.

Note: couldn't manage to properly mock the paste event on the contenteditable div. The test at least ensure taht we stop the propagation of the paste event.

Part of 2863362

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [2863362](https://www.odoo.com/web#id=2863362&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo