### PR TITLE
[FIX] grid: capture IME altered inputs

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -41,6 +41,7 @@ const TEMPLATE = xml/* xml */ `
       t-on-link-editor-closed="closeLinkEditor"
       t-ref="grid"
       focusComposer="focusGridComposer"
+      exposeFocus="(focus) => this._focusGrid = focus"
       t-on-composer-content-focused="onGridComposerContentFocused"
       t-on-composer-cell-focused="onGridComposerCellFocused"
       t-att-class="{'o-two-columns': !sidePanel.isOpen}"/>
@@ -133,6 +134,8 @@ export class Spreadsheet extends Component<Props, SpreadsheetEnv> {
     topBarFocus: "inactive",
     gridFocusMode: "inactive",
   } as { topBarFocus: "inactive" | "contentFocus"; gridFocusMode: "inactive" | "cellFocus" | "contentFocus" });
+
+  private _focusGrid?: () => void;
 
   // last string that was cut or copied. It is necessary so we can make the
   // difference between a paste coming from the sheet itself, or from the
@@ -244,7 +247,10 @@ export class Spreadsheet extends Component<Props, SpreadsheetEnv> {
     }
   }
   focusGrid() {
-    (<any>this.grid.comp).focus();
+    if (!this._focusGrid) {
+      throw new Error("_focusGrid should be exposed by the grid component");
+    }
+    this._focusGrid();
   }
 
   copy(cut: boolean, ev: ClipboardEvent) {

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -4,6 +4,10 @@ exports[`Grid component simple rendering snapshot 1`] = `
 <div
   class="o-grid o-two-columns"
 >
+  <input
+    class="position-absolute"
+    style="z-index:-1000;"
+  />
   <canvas
     height="985"
     style="width:985px;height:985px;"

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -344,6 +344,10 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
   <div
     class="o-grid o-two-columns"
   >
+    <input
+      class="position-absolute"
+      style="z-index:-1000;"
+    />
     <canvas
       height="985"
       style="width:985px;height:985px;"

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -32,7 +32,7 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 
 let model: Model;
 let composerEl: Element;
-let canvasEl: Element;
+let gridInputEl: Element;
 let fixture: HTMLElement;
 let parent: Spreadsheet;
 let cehMock: ContentEditableHelper;
@@ -79,7 +79,7 @@ beforeEach(async () => {
     width: 1000,
     height: 1000,
   });
-  canvasEl = parent.el?.querySelector(".o-grid")!;
+  gridInputEl = parent.el?.querySelector(".o-grid>input")!;
 });
 
 afterEach(() => {
@@ -529,16 +529,15 @@ describe("composer", () => {
   });
 
   test("typing CTRL+C does not type C in the cell", async () => {
-    canvasEl.dispatchEvent(
+    gridInputEl.dispatchEvent(
       new KeyboardEvent("keydown", { key: "c", ctrlKey: true, bubbles: true })
     );
     await nextTick();
     expect(model.getters.getCurrentContent()).toBe("");
   });
+
   test("keyup event triggered after edition end", async () => {
-    canvasEl.dispatchEvent(
-      new KeyboardEvent("keydown", Object.assign({ key: "d", bubbles: true }))
-    );
+    gridInputEl.dispatchEvent(new InputEvent("input", Object.assign({ data: "d", bubbles: true })));
     await nextTick();
     const composerEl = fixture.querySelector("div.o-composer")!;
     expect(model.getters.getEditionMode()).toBe("editing");
@@ -1242,9 +1241,11 @@ describe("composer highlights color", () => {
     expect(getHighlights(model)[0].color).toBe(colors[0]);
     expect(getHighlights(model)[1].color).toBe(colors[1]);
 
-    document.activeElement!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    document.activeElement!.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+    );
     await nextTick();
-    canvasEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    gridInputEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     await nextTick();
     expect(getHighlights(model).length).toBe(2);
     expect(getHighlights(model)[0].color).toBe(colors[0]);

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -111,7 +111,7 @@ describe("figures", () => {
     expect(document.activeElement).toBe(fixture.querySelector(".o-figure"));
   });
 
-  test("deleting a figure focuses the canvas", async () => {
+  test("deleting a figure focuses the grid hidden input", async () => {
     model.dispatch("CREATE_TEXT_FIGURE", {
       sheetId: model.getters.getActiveSheetId(),
       id: "someuuid",
@@ -124,7 +124,7 @@ describe("figures", () => {
     figure.dispatchEvent(new KeyboardEvent("keydown", { key: "Delete" }));
     await nextTick();
     expect(fixture.querySelector(".o-figure")).toBeNull();
-    expect(document.activeElement).toBe(fixture.querySelector("canvas"));
+    expect(document.activeElement).toBe(fixture.querySelector(".o-grid>input"));
   });
 
   test("deleting a figure doesn't delete selection", async () => {

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -595,7 +595,7 @@ describe("Grid component", () => {
       await rightClickCell(model, "B2");
       await simulateClick(".o-menu div[data-name='add_row_before']");
       expect(fixture.querySelector(".o-menu div[data-name='add_row_before']")).toBeFalsy();
-      expect(document.activeElement).toBe(fixture.querySelector("canvas"));
+      expect(document.activeElement).toBe(fixture.querySelector(".o-grid>input"));
     });
   });
 });

--- a/tests/components/link/link_editor.test.ts
+++ b/tests/components/link/link_editor.test.ts
@@ -20,12 +20,17 @@ describe("link editor component", () => {
     await simulateClick(".o-menu-item[data-name='insert_link']");
   }
 
+  // TODO: type this correcly in master
   function labelInput(): HTMLInputElement {
-    const inputs = fixture?.querySelectorAll("input")!;
+    const inputs = fixture?.querySelectorAll(
+      ".o-link-editor input"
+    )! as NodeListOf<HTMLInputElement>;
     return inputs[0];
   }
   function urlInput(): HTMLInputElement {
-    const inputs = fixture?.querySelectorAll("input")!;
+    const inputs = fixture?.querySelectorAll(
+      ".o-link-editor input"
+    )! as NodeListOf<HTMLInputElement>;
     return inputs[1];
   }
 

--- a/tests/components/side_panel.test.ts
+++ b/tests/components/side_panel.test.ts
@@ -147,7 +147,7 @@ describe("Side Panel", () => {
     expect(document.querySelector(".props_body_2")!.textContent).toBe("field");
   });
 
-  test("Closing a side panel focuses the grid/canvas", async () => {
+  test("Closing a side panel focuses the grid hidden input", async () => {
     sidePanelRegistry.add("CUSTOM_PANEL", {
       title: "Custom Panel",
       Body: Body,
@@ -156,6 +156,6 @@ describe("Side Panel", () => {
     await nextTick();
     simulateClick(".o-sidePanelClose");
     await nextTick();
-    expect(document.activeElement).toBe(fixture.querySelector("canvas"));
+    expect(document.activeElement).toBe(fixture.querySelector(".o-grid>input"));
   });
 });

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -80,14 +80,14 @@ describe("Spreadsheet", () => {
   });
 
   test("focus is properly set, initially and after switching sheet", async () => {
-    expect(document.activeElement!.tagName).toEqual("CANVAS");
+    expect(document.activeElement!.tagName).toEqual("INPUT");
     document.querySelector(".o-add-sheet")!.dispatchEvent(new Event("click"));
     // simulate the fact that a user clicking on the add sheet button will
     // move the focus to the document.body
     (document.activeElement as any).blur();
     await nextTick();
     expect(document.querySelectorAll(".o-sheet").length).toBe(2);
-    expect(document.activeElement!.tagName).toEqual("CANVAS");
+    expect(document.activeElement!.tagName).toEqual("INPUT");
   });
 
   test("Can use the env in a function", () => {
@@ -206,9 +206,7 @@ describe("Spreadsheet", () => {
   test("typing opens composer after toolbar clicked", async () => {
     await simulateClick(`div[title="Bold"]`);
     expect(document.activeElement).not.toBeNull();
-    document.activeElement?.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "d", bubbles: true })
-    );
+    document.activeElement?.dispatchEvent(new InputEvent("input", { data: "d", bubbles: true }));
     await nextTick();
     expect(parent.model.getters.getEditionMode()).toBe("editing");
     expect(parent.model.getters.getCurrentContent()).toBe("d");

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -260,9 +260,14 @@ export async function typeInComposer(composerEl: Element, text: string) {
   await nextTick();
 }
 
-export async function startGridComposition(key: string = "Enter") {
-  const gridEl = document.querySelector(".o-grid");
-  gridEl!.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+export async function startGridComposition(key?: string) {
+  if (key) {
+    const gridInputEl = document.querySelector(".o-grid>input");
+    gridInputEl!.dispatchEvent(new InputEvent("input", { data: key, bubbles: true }));
+  } else {
+    const gridInputEl = document.querySelector(".o-grid");
+    gridInputEl!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+  }
   await nextTick();
   return document.querySelector(".o-grid .o-composer")!;
 }


### PR DESCRIPTION
As stated in https://github.com/odoo/odoo/issues/76133 IME will only work properly when focusing actual inputs.

Sofar, when wanting to start composing without any composer open/focused, the approach was to capture the keypresses but this meant not supporting IME. The correct way would be to capture the input event which contains the character that the IME outputs.
To achieve this, we need to give the default focus to an input field rather than the grid. By placing the input cleverly, we can only capture input event and let every other bubble to be captured by the grid div.

Note that this also cleans the handling of key presses wher we had to ignore specific combinations to avoid conflicts of behaviours.

THe tests were adapted accordingly but we unfortunately cannot reproduce an actual IME behaviour.

Task 3050465

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo