### PR TITLE
[FIX] model: do not replay core commands in ui plugins

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -104,6 +104,12 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
   private session: Session;
 
   /**
+   * In a collaborative context, some commands can be replayed, we have to ensure
+   * that these commands are not replayed on the UI plugins.
+   */
+  private isReplayingCommand: boolean = false;
+
+  /**
    * A plugin can draw some contents on the canvas. But even better: it can do
    * so multiple times.  The order of the render calls will determine a list of
    * "layers" (i.e., earlier calls will be obviously drawn below later calls).
@@ -270,8 +276,11 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
       buildRevisionLog(
         revisionId,
         this.state.recordChanges.bind(this.state),
-        (command: CoreCommand) =>
-          this.dispatchToHandlers([this.range, ...this.corePlugins], command)
+        (command: CoreCommand) => {
+          this.isReplayingCommand = true;
+          this.dispatchToHandlers([this.range, ...this.corePlugins], command);
+          this.isReplayingCommand = false;
+        }
       ),
       this.config.transportService,
       revisionId
@@ -408,7 +417,8 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
     const command: Command = { type, ...payload };
     const previousStatus = this.status;
     this.status = Status.RunningCore;
-    this.dispatchToHandlers(this.handlers, command);
+    const handlers = this.isReplayingCommand ? [this.range, ...this.corePlugins] : this.handlers;
+    this.dispatchToHandlers(handlers, command);
     this.status = previousStatus;
     return DispatchResult.Success;
   };

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -16,7 +16,8 @@ import { FindAndReplacePlugin } from "../src/plugins/ui/find_and_replace";
 import { SortPlugin } from "../src/plugins/ui/sort";
 import { SheetUIPlugin } from "../src/plugins/ui/ui_sheet";
 import { UIPlugin } from "../src/plugins/ui_plugin";
-import { Command, CoreCommand, DispatchResult } from "../src/types";
+import { Command, CoreCommand, coreTypes, DispatchResult } from "../src/types";
+import { setupCollaborativeEnv } from "./collaborative/collaborative_helpers";
 import { selectCell, setCellContent } from "./test_helpers/commands_helpers";
 import { getCell, getCellText } from "./test_helpers/getters_helpers";
 
@@ -173,7 +174,7 @@ describe("Model", () => {
     model.dispatch("COPY", { target: [toZone("A1")] });
     expect(result).toBeSuccessfullyDispatched();
     expect(getCellText(model, "A2")).toBe("copy&paste me");
-    corePluginRegistry.remove("myUIPlugin");
+    uiPluginRegistry.remove("myUIPlugin");
   });
 
   test("Can open a model in readonly mode", () => {
@@ -189,5 +190,47 @@ describe("Model", () => {
   test("Moving the selection is allowed in readonly mode", () => {
     const model = new Model({}, { isReadonly: true });
     expect(selectCell(model, "A15")).toBeSuccessfullyDispatched();
+  });
+
+  test("Replayed commands are not send to UI plugins", () => {
+    let numberCall = 0;
+    //@ts-ignore
+    coreTypes.add("MY_CMD_1");
+    //@ts-ignore
+    coreTypes.add("MY_CMD_2");
+    class MyUIPlugin extends UIPlugin {
+      handle(cmd: Command) {
+        //@ts-ignore
+        if (cmd.type === "MY_CMD_2") {
+          if (this.getters.getClient().id === "bob") {
+            numberCall++;
+          }
+        }
+      }
+    }
+    uiPluginRegistry.add("myUIPlugin", MyUIPlugin);
+
+    class MyCorePlugin extends CorePlugin {
+      public readonly state: number = 0;
+      handle(cmd: CoreCommand) {
+        //@ts-ignore
+        if (cmd.type === "MY_CMD_1") {
+          this.history.update("state", 1);
+          //@ts-ignore
+          this.dispatch("MY_CMD_2");
+        }
+      }
+    }
+    corePluginRegistry.add("myCorePlugin", MyCorePlugin);
+
+    const { alice, bob, network } = setupCollaborativeEnv();
+    network.concurrent(() => {
+      setCellContent(alice, "A1", "Hello");
+      //@ts-ignore
+      bob.dispatch("MY_CMD_1");
+    });
+    expect(numberCall).toEqual(1);
+    uiPluginRegistry.remove("myUIPlugin");
+    corePluginRegistry.remove("myCorePlugin");
   });
 });


### PR DESCRIPTION
This fix is a bit tricky, let's try to resume the situation:

In a collaborative context [1], commands are applied locally and then sent to the server. This is done on purpose in order to not block the user each time he performs an operation.
The server is responsible to order the operations it received. When at least two users perform concurrent operations, the operations are applied locally and then ordered par the server. After that, we have to ensure that in both clients the operations are applied in the order defined by the server. For the user who have applied it's operation locally and who received an operation that should be applied **before** its own operation, we have to revert the state to the state before its operation, then apply the received operation and then re-apply its operation (with a transformation if needed). The re-apply of the operation should be done **only** on core plugins.

Before this revision, if a command to replay itself dispatch another command, this command was also dispatched in the ui plugins.

With this revision, a such command is now only dispatched on core plugins.

[1] For more details on how the collaborative works, please see the documentation.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo