### PR TITLE
[FIX] config: Allow to build outside of git repository

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,14 @@
 import { version } from "./package.json";
 import git from "git-rev-sync";
 
+let commitHash = "";
+
+try {
+  commitHash = git.short();
+}
+catch(_) {
+}
+
 export default {
   input: "dist/js/index.js",
   external: ["@odoo/owl"],
@@ -10,6 +18,6 @@ export default {
     name: "o_spreadsheet",
     extend: true,
     globals: { "@odoo/owl": "owl" /*, "chart.js": "chart_js" */ },
-    outro: `exports.__info__.version = '${version}';\nexports.__info__.date = '${new Date().toISOString()}';\nexports.__info__.hash = '${git.short()}';`,
+    outro: `exports.__info__.version = '${version}';\nexports.__info__.date = '${new Date().toISOString()}';\nexports.__info__.hash = '${commitHash}';`,
   },
 };


### PR DESCRIPTION
The lib used to extract the hash commit will raise when run outside a git repository. Since we need to perform this action on runbot, we catch the error in that specific case.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo