### PR TITLE
[IMP] Add drag&drop on bottom bar sheets (✨ ✨ ✨ With animation ! ✨ ✨ ✨)

### DIFF
--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -26,14 +26,16 @@
           t-if="state.isSheetListScrollableLeft"
         />
         <div
-          class="o-sheet-list d-flex w-100 overflow-hidden"
+          class="o-sheet-list d-flex w-100 overflow-hidden px-1"
           t-ref="sheetList"
           t-on-wheel="onWheel"
           t-on-scroll="onScroll">
-          <t t-foreach="getVisibleSheets()" t-as="sheet" t-key="sheet.id">
+          <t t-foreach="getSheets()" t-as="sheet" t-key="sheet.id">
             <BottomBarSheet
+              style="getSheetStyle(sheet.id)"
               sheetId="sheet.id"
               openContextMenu="(registry, ev) => this.onSheetContextMenu(sheet.id, registry, ev)"
+              onMouseDown="(ev) => this.onSheetMouseDown(sheet.id, ev)"
             />
           </t>
         </div>

--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -14,6 +14,8 @@ css/* scss */ `
     padding-right: 10px;
     height: ${BOTTOMBAR_HEIGHT}px;
     border-left: 1px solid #c1c1c1;
+    border-right: 1px solid #c1c1c1;
+    margin-left: -1px;
     cursor: pointer;
     &:hover {
       background-color: rgba(0, 0, 0, 0.08);
@@ -51,6 +53,8 @@ css/* scss */ `
 interface Props {
   sheetId: string;
   openContextMenu: (registry: MenuItemRegistry, ev: MouseEvent) => void;
+  style?: string;
+  onMouseDown: (ev: MouseEvent) => void;
 }
 
 interface State {
@@ -60,6 +64,10 @@ interface State {
 export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BottomBarSheet";
   static components = { Ripple };
+  static defaultProps = {
+    onMouseDown: () => {},
+    style: "",
+  };
 
   private state = useState<State>({ isEditing: false });
 
@@ -107,8 +115,9 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 
-  clickSheet() {
+  onMouseDown(ev) {
     this.activateSheet();
+    this.props.onMouseDown(ev);
   }
 
   private activateSheet() {
@@ -203,4 +212,6 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
 BottomBarSheet.props = {
   sheetId: String,
   openContextMenu: Function,
+  style: { type: String, optional: true },
+  onMouseDown: { type: Function, optional: true },
 };

--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -3,9 +3,10 @@
     <Ripple>
       <div
         class="o-sheet position-relative d-flex align-items-center user-select-none text-nowrap "
-        t-on-click="() => this.clickSheet()"
+        t-on-mousedown="(ev) => this.onMouseDown(ev)"
         t-on-contextmenu.prevent="(ev) => this.onContextMenu(ev)"
         t-ref="sheetDiv"
+        t-att-style="props.style"
         t-att-title="sheetName"
         t-att-data-id="props.sheetId"
         t-att-class="{active: isSheetActive}">

--- a/src/components/helpers/dom_dnd_helper.ts
+++ b/src/components/helpers/dom_dnd_helper.ts
@@ -1,0 +1,206 @@
+import { Pixel, UID } from "../../types";
+import { startDnd } from "./drag_and_drop";
+
+interface DragAndDropItemsPartial {
+  id: UID;
+  size: Pixel;
+  position: Pixel;
+}
+
+interface DragAndDropItems extends DragAndDropItemsPartial {
+  positionAtStart: Pixel;
+}
+
+export class DOMDndHelper {
+  draggedItemId: UID;
+  private items: DragAndDropItems[];
+  private containerEl: HTMLElement;
+
+  private initialMousePosition: Pixel;
+  private currentMousePosition: Pixel;
+
+  private minPosition: Pixel;
+  private maxPosition: Pixel;
+
+  private edgeScrollIntervalId: number | undefined;
+  private edgeScrollOffset: Pixel = 0;
+
+  private onChange: (newPositions: Record<UID, Pixel>) => void;
+  private onCancel: () => void;
+  private onDragEnd: (itemId: UID, indexAtEnd: number) => void;
+
+  /**
+   * The dead zone is an area in which the mousemove events are ignored.
+   *
+   * This is useful when swapping the dragged item with a larger item. After the swap,
+   * the mouse is still hovering on the item  we just swapped with. In this case, we don't want
+   * a mouse move to trigger another swap the other way around, so we create a dead zone. We will clear
+   * the dead zone when the mouse leaves the swapped item.
+   */
+  private deadZone: { start: Pixel; end: Pixel } | undefined;
+
+  constructor(args: {
+    draggedItemId: UID;
+    mouseX: Pixel;
+    items: DragAndDropItemsPartial[];
+    containerEl: HTMLElement;
+    onChange: (newPositions: Record<UID, Pixel>) => void;
+    onCancel: () => void;
+    onDragEnd: (itemId: UID, indexAtEnd: Pixel) => void;
+  }) {
+    this.items = args.items.map((item) => ({ ...item, positionAtStart: item.position }));
+    this.draggedItemId = args.draggedItemId;
+    this.containerEl = args.containerEl;
+    this.onChange = args.onChange;
+    this.onCancel = args.onCancel;
+    this.onDragEnd = args.onDragEnd;
+
+    this.initialMousePosition = args.mouseX;
+    this.currentMousePosition = args.mouseX;
+
+    this.minPosition = this.items[0].position;
+    this.maxPosition =
+      this.items[this.items.length - 1].position + this.items[this.items.length - 1].size;
+
+    startDnd(this.onMouseMove.bind(this), this.onMouseUp.bind(this));
+  }
+
+  private onMouseMove(ev: MouseEvent) {
+    if (ev.button !== 0) {
+      this.onCancel();
+      return;
+    }
+    const mousePosition = ev.clientX;
+
+    if (mousePosition < this.containerRect.left || mousePosition > this.containerRect.right) {
+      this.startEdgeScroll(mousePosition < this.containerRect.left ? -1 : 1);
+      return;
+    } else {
+      this.stopEdgeScroll();
+    }
+
+    this.moveDraggedItemToPosition(mousePosition + this.edgeScrollOffset);
+  }
+
+  private moveDraggedItemToPosition(position: Pixel) {
+    this.currentMousePosition = position;
+
+    const hoveredItemIndex = this.getHoveredItemIndex(position, this.items);
+    const draggedItemIndex = this.items.findIndex((item) => item.id === this.draggedItemId);
+    const draggedItem = this.items[draggedItemIndex];
+
+    if (this.deadZone && this.isInZone(position, this.deadZone)) {
+      this.onChange(this.getItemsPositions());
+      return;
+    } else if (
+      this.isInZone(position, {
+        start: draggedItem.position,
+        end: draggedItem.position + draggedItem.size,
+      })
+    ) {
+      this.deadZone = undefined;
+    }
+
+    if (draggedItemIndex === hoveredItemIndex) {
+      this.onChange(this.getItemsPositions());
+      return;
+    }
+
+    const leftIndex = Math.min(draggedItemIndex, hoveredItemIndex);
+    const rightIndex = Math.max(draggedItemIndex, hoveredItemIndex);
+    const direction = Math.sign(hoveredItemIndex - draggedItemIndex);
+
+    let draggedItemMoveSize = 0;
+    for (let i = leftIndex; i <= rightIndex; i++) {
+      if (i === draggedItemIndex) {
+        continue;
+      }
+      this.items[i].position -= direction * draggedItem.size;
+      draggedItemMoveSize += this.items[i].size;
+    }
+
+    draggedItem.position += direction * draggedItemMoveSize;
+    this.items.sort((item1, item2) => item1.position - item2.position);
+
+    this.deadZone =
+      direction > 0
+        ? { start: position, end: draggedItem.position }
+        : { start: draggedItem.position + draggedItem.size, end: position };
+
+    this.onChange(this.getItemsPositions());
+  }
+
+  private onMouseUp(ev: MouseEvent) {
+    if (ev.button !== 0) {
+      this.onCancel();
+    }
+
+    const targetItemIndex = this.items.findIndex((item) => item.id === this.draggedItemId);
+    this.onDragEnd(this.draggedItemId, targetItemIndex);
+    this.stopEdgeScroll();
+  }
+
+  private startEdgeScroll(direction: -1 | 1) {
+    if (this.edgeScrollIntervalId) return;
+    this.edgeScrollIntervalId = window.setInterval(() => {
+      const offset = direction * 3;
+      let newPosition = this.currentMousePosition + offset;
+
+      if (newPosition < this.minPosition) {
+        newPosition = this.minPosition;
+      } else if (newPosition > this.maxPosition) {
+        newPosition = this.maxPosition;
+      }
+
+      this.edgeScrollOffset += newPosition - this.currentMousePosition;
+      this.moveDraggedItemToPosition(newPosition);
+
+      this.containerEl.scrollLeft += offset;
+    }, 5);
+  }
+
+  private stopEdgeScroll() {
+    window.clearInterval(this.edgeScrollIntervalId);
+    this.edgeScrollIntervalId = undefined;
+  }
+
+  /**
+   * Get the index of the item the given mouse position is inside.
+   * If the mouse is outside the container, return the first or last item index.
+   */
+  private getHoveredItemIndex(mousePosition: Pixel, items: DragAndDropItems[]): number {
+    if (mousePosition <= this.minPosition) return 0;
+    if (mousePosition >= this.maxPosition) return items.length - 1;
+    return items.findIndex((item) => item.position + item.size >= mousePosition);
+  }
+
+  private getItemsPositions() {
+    const positions: Record<UID, Pixel> = {};
+    for (let item of this.items) {
+      if (item.id !== this.draggedItemId) {
+        positions[item.id] = item.position - item.positionAtStart;
+        continue;
+      }
+
+      let mouseOffset = this.currentMousePosition - this.initialMousePosition;
+      let left = mouseOffset;
+      left = Math.max(this.minPosition - item.positionAtStart, left);
+      left = Math.min(this.maxPosition - item.positionAtStart - item.size, left);
+
+      positions[item.id] = left;
+    }
+    return positions;
+  }
+
+  private get containerRect() {
+    return this.containerEl.getBoundingClientRect();
+  }
+
+  private isInZone(position: Pixel, zone: { start: Pixel; end: Pixel }) {
+    return position >= zone.start && position <= zone.end;
+  }
+
+  destroy() {
+    this.stopEdgeScroll();
+  }
+}

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -520,3 +520,12 @@ export function replaceSpecialSpaces(text: string | undefined): string {
   text = text.replace(newLineRegex, NEWLINE);
   return text;
 }
+
+/** Move the item at the starting index to the target index in an array */
+export function moveItemToIndex<T>(array: T[], startIndex: number, targetIndex: number): T[] {
+  array = [...array];
+  const item = array[startIndex];
+  array.splice(startIndex, 1);
+  array.splice(targetIndex, 0, item);
+  return array;
+}

--- a/src/registries/menus/sheet_menu_registry.ts
+++ b/src/registries/menus/sheet_menu_registry.ts
@@ -45,7 +45,7 @@ export function getSheetMenuRegistry(args: { renameSheetCallback: () => void }):
       action: (env) =>
         env.model.dispatch("MOVE_SHEET", {
           sheetId: env.model.getters.getActiveSheetId(),
-          direction: "right",
+          delta: 1,
         }),
     })
     .add("move_left", {
@@ -58,7 +58,7 @@ export function getSheetMenuRegistry(args: { renameSheetCallback: () => void }):
       action: (env) =>
         env.model.dispatch("MOVE_SHEET", {
           sheetId: env.model.getters.getActiveSheetId(),
-          direction: "left",
+          delta: -1,
         }),
     })
     .add("hide_sheet", {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -341,7 +341,7 @@ export interface DuplicateSheetCommand extends SheetDependentCommand {
 
 export interface MoveSheetCommand extends SheetDependentCommand {
   type: "MOVE_SHEET";
-  direction: "left" | "right";
+  delta: number;
 }
 
 export interface RenameSheetCommand extends SheetDependentCommand {

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -101,7 +101,7 @@ describe("Collaborative Sheet manipulation", () => {
     createSheet(bob, { sheetId: "42", activate: true });
     network.concurrent(() => {
       createSheet(alice, { sheetId: "2", position: 1 });
-      moveSheet(bob, "right", sheet1);
+      moveSheet(bob, 1, sheet1);
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getSheetIds(),
@@ -115,8 +115,8 @@ describe("Collaborative Sheet manipulation", () => {
     createSheet(bob, { sheetId: "1", activate: true, position: 1 });
     createSheet(bob, { sheetId: "2", activate: true, position: 2 });
     network.concurrent(() => {
-      moveSheet(alice, "right", sheet1);
-      moveSheet(bob, "left", "2");
+      moveSheet(alice, 1, sheet1);
+      moveSheet(bob, -1, "2");
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getSheetIds(),

--- a/tests/collaborative/ot/ot_sheet_deleted.test.ts
+++ b/tests/collaborative/ot/ot_sheet_deleted.test.ts
@@ -76,7 +76,7 @@ describe("OT with DELETE_SHEET", () => {
     type: "REMOVE_MERGE",
     target: target("A1:B1"),
   };
-  const moveSheet: Omit<MoveSheetCommand, "sheetId"> = { type: "MOVE_SHEET", direction: "left" };
+  const moveSheet: Omit<MoveSheetCommand, "sheetId"> = { type: "MOVE_SHEET", delta: -1 };
   const renameSheet: Omit<RenameSheetCommand, "sheetId"> = { type: "RENAME_SHEET", name: "test" };
   const hideSheet: Omit<HideSheetCommand, "sheetId"> = { type: "HIDE_SHEET" };
   const showSheet: Omit<ShowSheetCommand, "sheetId"> = { type: "SHOW_SHEET" };

--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -170,7 +170,7 @@ exports[`BottomBar component simple rendering 1`] = `
   >
     
     <div
-      class="o-sheet-list d-flex w-100 overflow-hidden"
+      class="o-sheet-list d-flex w-100 overflow-hidden px-1"
     >
       <div
         class="o-ripple-container position-relative"
@@ -184,6 +184,7 @@ exports[`BottomBar component simple rendering 1`] = `
           <div
             class="o-sheet position-relative d-flex align-items-center user-select-none text-nowrap active"
             data-id="Sheet1"
+            style=""
             title="Sheet1"
           >
             <span

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -679,7 +679,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
     >
       
       <div
-        class="o-sheet-list d-flex w-100 overflow-hidden"
+        class="o-sheet-list d-flex w-100 overflow-hidden px-1"
       >
         <div
           class="o-ripple-container position-relative"
@@ -693,6 +693,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
             <div
               class="o-sheet position-relative d-flex align-items-center user-select-none text-nowrap active"
               data-id="sh1"
+              style=""
               title="Sheet1"
             >
               <span

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -3,6 +3,8 @@ import { Model, Spreadsheet } from "../../src";
 import { ChartJsComponent } from "../../src/components/figures/chart/chartJs/chartjs";
 import { ScorecardChart } from "../../src/components/figures/chart/scorecard/chart_scorecard";
 import {
+  DEFAULT_CELL_HEIGHT,
+  DEFAULT_CELL_WIDTH,
   FIGURE_BORDER_COLOR,
   MENU_WIDTH,
   MIN_FIG_SIZE,
@@ -10,8 +12,6 @@ import {
 } from "../../src/constants";
 import { chartComponentRegistry, figureRegistry } from "../../src/registries";
 import { CreateFigureCommand, Figure, SpreadsheetChildEnv, UID } from "../../src/types";
-
-import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import {
   activateSheet,
   addColumns,
@@ -78,7 +78,7 @@ const anchorSelectors = {
   topLeft: ".o-fig-anchor.o-topLeft",
 };
 async function dragAnchor(anchor: string, dragX: number, dragY: number, mouseUp = false) {
-  await dragElement(anchorSelectors[anchor], dragX, dragY, mouseUp);
+  await dragElement(anchorSelectors[anchor], { x: dragX, y: dragY }, { x: 0, y: 0 }, mouseUp);
 }
 
 //Test Component required as we don't especially want/need to load an entire chart
@@ -340,7 +340,7 @@ describe("figures", () => {
     test("Can move a figure with drag & drop", async () => {
       createFigure(model, { id: "someuuid", x: 200, y: 100 });
       await nextTick();
-      await dragElement(".o-figure", 150, 100, true);
+      await dragElement(".o-figure", { x: 150, y: 100 }, undefined, true);
       await nextTick();
       expect(model.getters.getFigure(model.getters.getActiveSheetId(), "someuuid")).toMatchObject({
         x: 350,
@@ -367,7 +367,7 @@ describe("figures", () => {
       test("Figure in frozen rows can be dragged to main viewport", async () => {
         createFigure(model, { id, x: 16 * cellWidth, y: 4 * cellHeight });
         await nextTick();
-        await dragElement(figureSelector, 0, 3 * cellHeight, true);
+        await dragElement(figureSelector, { x: 0, y: 3 * cellHeight }, undefined, true);
         expect(model.getters.getFigure(sheetId, id)).toMatchObject({
           x: 16 * cellWidth,
           y: 17 * cellHeight, // initial position + drag offset + scroll offset
@@ -376,7 +376,7 @@ describe("figures", () => {
       test("Figure in main viewport can be dragged to frozen rows", async () => {
         createFigure(model, { id, x: 16 * cellWidth, y: 16 * cellHeight });
         await nextTick();
-        await dragElement(figureSelector, 0, -3 * cellHeight, true);
+        await dragElement(figureSelector, { x: 0, y: -3 * cellHeight }, undefined, true);
         expect(model.getters.getFigure(sheetId, id)).toMatchObject({
           x: 16 * cellWidth,
           y: 3 * cellHeight, // initial position + drag offset - scroll offset
@@ -385,7 +385,7 @@ describe("figures", () => {
       test("Dragging figure that is half hidden by frozen rows will put in on top of the freeze pane", async () => {
         createFigure(model, { id, x: 16 * cellWidth, y: 14 * cellHeight, height: 5 * cellHeight });
         await nextTick();
-        await dragElement(figureSelector, 1, 0, true);
+        await dragElement(figureSelector, { x: 1, y: 0 }, undefined, true);
         expect(model.getters.getFigure(sheetId, id)).toMatchObject({
           x: 16 * cellWidth + 1,
           y: 4 * cellHeight, // initial position - scroll offset
@@ -394,7 +394,7 @@ describe("figures", () => {
       test("Figure in frozen cols can be dragged to main viewport", async () => {
         createFigure(model, { id, x: 4 * cellWidth, y: 16 * cellHeight });
         await nextTick();
-        await dragElement(figureSelector, 3 * cellWidth, 0, true);
+        await dragElement(figureSelector, { x: 3 * cellWidth, y: 0 }, undefined, true);
         expect(model.getters.getFigure(sheetId, id)).toMatchObject({
           x: 17 * cellWidth, // initial position + drag offset + scroll offset
           y: 16 * cellHeight,
@@ -403,7 +403,7 @@ describe("figures", () => {
       test("Figure in main viewport can be dragged to frozen cols", async () => {
         createFigure(model, { id, x: 16 * cellWidth, y: 16 * cellHeight });
         await nextTick();
-        await dragElement(figureSelector, -3 * cellWidth, 0, true);
+        await dragElement(figureSelector, { x: -3 * cellWidth, y: 0 }, undefined, true);
         expect(model.getters.getFigure(sheetId, id)).toMatchObject({
           x: 3 * cellWidth, // initial position + drag offset - scroll offset
           y: 16 * cellHeight,
@@ -412,7 +412,7 @@ describe("figures", () => {
       test("Dragging figure that is half hidden by frozen cols will put in on top of the freeze pane", async () => {
         createFigure(model, { id, x: 14 * cellWidth, y: 16 * cellHeight, width: 5 * cellWidth });
         await nextTick();
-        await dragElement(figureSelector, 0, 1, true);
+        await dragElement(figureSelector, { x: 0, y: 1 }, undefined, true);
         expect(model.getters.getFigure(sheetId, id)).toMatchObject({
           x: 4 * cellWidth, // initial position - scroll offset
           y: 16 * cellHeight + 1,

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -120,7 +120,7 @@ describe("Scorecard charts", () => {
     await simulateClick(".o-figure");
     expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("536px");
     expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("335px");
-    await dragElement(".o-fig-anchor.o-topLeft", 300, 200);
+    await dragElement(".o-fig-anchor.o-topLeft", { x: 300, y: 200 });
     expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("236px");
     expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("135px");
     // force a triggering of all resizeObservers to ensure the grid is resized

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -403,7 +403,7 @@ describe("sheets", () => {
     const sheet1 = model.getters.getSheetIds()[0];
     const sheet2 = model.getters.getSheetIds()[1];
     const beforeMoveSheet = model.exportData();
-    moveSheet(model, "right", sheet1);
+    moveSheet(model, 1, sheet1);
     expect(model.getters.getActiveSheetId()).toEqual(sheet1);
     expect(model.getters.getSheetIds()[0]).toEqual(sheet2);
     expect(model.getters.getSheetIds()[1]).toEqual(sheet1);
@@ -418,8 +418,8 @@ describe("sheets", () => {
     createSheet(model, { sheetId: "42" });
     const sheet1 = model.getters.getSheetIds()[0];
     const sheet2 = model.getters.getSheetIds()[1];
-    expect(moveSheet(model, "left", sheet1)).toBeCancelledBecause(CommandResult.WrongSheetMove);
-    expect(moveSheet(model, "right", sheet2)).toBeCancelledBecause(CommandResult.WrongSheetMove);
+    expect(moveSheet(model, -1, sheet1)).toBeCancelledBecause(CommandResult.WrongSheetMove);
+    expect(moveSheet(model, 1, sheet2)).toBeCancelledBecause(CommandResult.WrongSheetMove);
   });
 
   test("Cannot hide a sheet with only one sheet", () => {
@@ -471,8 +471,20 @@ describe("sheets", () => {
     createSheet(model, { sheetId: "sheet2" });
     createSheet(model, { sheetId: "sheet1" });
     hideSheet(model, "sheet1");
-    moveSheet(model, "left", "sheet2");
+    moveSheet(model, -1, "sheet2");
     expect(model.getters.getVisibleSheetIds()).toEqual(["sheet2", "sheet0"]);
+  });
+
+  test("Can move a sheet 2 right", () => {
+    const model = new Model({ sheets: [{ id: "sheet0" }, { id: "sheet1" }, { id: "sheet2" }] });
+    moveSheet(model, 2, "sheet0");
+    expect(model.getters.getVisibleSheetIds()).toEqual(["sheet1", "sheet2", "sheet0"]);
+  });
+
+  test("Can move a sheet 2 left", () => {
+    const model = new Model({ sheets: [{ id: "sheet0" }, { id: "sheet1" }, { id: "sheet2" }] });
+    moveSheet(model, -2, "sheet2");
+    expect(model.getters.getVisibleSheetIds()).toEqual(["sheet2", "sheet0", "sheet1"]);
   });
 
   test("Can move right a sheet with invisible sheet in between", () => {
@@ -481,7 +493,7 @@ describe("sheets", () => {
     createSheet(model, { sheetId: "sheet1" });
     hideSheet(model, "sheet1");
     expect(model.getters.getVisibleSheetIds()).toEqual(["sheet0", "sheet2"]);
-    moveSheet(model, "right", "sheet0");
+    moveSheet(model, 1, "sheet0");
     expect(model.getters.getVisibleSheetIds()).toEqual(["sheet2", "sheet0"]);
   });
 
@@ -490,7 +502,7 @@ describe("sheets", () => {
     createSheet(model, { sheetId: "sheet2" });
     createSheet(model, { sheetId: "sheet1" });
     hideSheet(model, "sheet0");
-    expect(moveSheet(model, "left", "sheet1")).toBeCancelledBecause(CommandResult.WrongSheetMove);
+    expect(moveSheet(model, -1, "sheet1")).toBeCancelledBecause(CommandResult.WrongSheetMove);
   });
 
   test("Cannot move right a sheet with invisible sheet to the right", () => {
@@ -498,7 +510,7 @@ describe("sheets", () => {
     createSheet(model, { sheetId: "sheet2" });
     createSheet(model, { sheetId: "sheet1" });
     hideSheet(model, "sheet2");
-    expect(moveSheet(model, "right", "sheet1")).toBeCancelledBecause(CommandResult.WrongSheetMove);
+    expect(moveSheet(model, 1, "sheet1")).toBeCancelledBecause(CommandResult.WrongSheetMove);
   });
 
   test("Can rename a sheet", () => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -716,12 +716,12 @@ export function moveRows(
 
 export function moveSheet(
   model: Model,
-  direction: "left" | "right",
+  delta: number,
   sheetId: UID = model.getters.getActiveSheetId()
 ) {
   return model.dispatch("MOVE_SHEET", {
     sheetId,
-    direction,
+    delta,
   });
 }
 

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -198,16 +198,18 @@ export async function selectColumnByClicking(model: Model, letter: string, extra
 
 export async function dragElement(
   element: Element | string,
-  dragX: Pixel,
-  dragY: Pixel,
+  dragOffset: { x: Pixel; y: Pixel },
+  startingPosition: { x: Pixel; y: Pixel } = { x: 0, y: 0 },
   mouseUp = false
 ) {
-  triggerMouseEvent(element, "mousedown");
+  const { x: startX, y: startY } = startingPosition;
+  const { x: offsetX, y: offsetY } = dragOffset;
+  triggerMouseEvent(element, "mousedown", startX, startY);
   await nextTick();
-  triggerMouseEvent(element, "mousemove", dragX, dragY);
+  triggerMouseEvent(element, "mousemove", startX + offsetX, startY + offsetY);
   await nextTick();
   if (mouseUp) {
-    triggerMouseEvent(element, "mouseup");
+    triggerMouseEvent(element, "mouseup", startX + offsetX, startY + offsetY);
     await nextTick();
   }
 }

--- a/tests/test_helpers/index.ts
+++ b/tests/test_helpers/index.ts
@@ -1,3 +1,4 @@
 export * from "./commands_helpers";
 export * from "./dom_helper";
 export * from "./getters_helpers";
+export * from "./mock_helpers";

--- a/tests/test_helpers/mock_helpers.ts
+++ b/tests/test_helpers/mock_helpers.ts
@@ -24,12 +24,16 @@ export function mockGetBoundingClientRect(
 function populateDOMRect(partialRect: Partial<DOMRect>): Partial<DOMRect> {
   const rect = { ...partialRect };
 
-  if (rect.x && !rect.left) rect.left = rect.x;
-  if (rect.y && !rect.top) rect.top = rect.y;
-  if (rect.width && rect.x && !rect.right) rect.right = rect.x + rect.width;
-  if (rect.height && rect.y && !rect.bottom) rect.bottom = rect.y + rect.height;
-  if (rect.left && rect.right && !rect.width) rect.width = rect.right - rect.left;
-  if (rect.top && rect.bottom && !rect.height) rect.height = rect.bottom - rect.top;
+  if (rect.x !== undefined && !rect.left) rect.left = rect.x;
+  if (rect.y !== undefined && !rect.top) rect.top = rect.y;
+  if (rect.width !== undefined && rect.x !== undefined && !rect.right)
+    rect.right = rect.x + rect.width;
+  if (rect.height !== undefined && rect.y !== undefined && !rect.bottom)
+    rect.bottom = rect.y + rect.height;
+  if (rect.left !== undefined && rect.right !== undefined && !rect.width)
+    rect.width = rect.right - rect.left;
+  if (rect.top !== undefined && rect.bottom !== undefined && !rect.height)
+    rect.height = rect.bottom - rect.top;
 
   return rect;
 }


### PR DESCRIPTION
## Description:
Implement drag&drop sheet tab in the bottom bar. 

Odoo task ID : [3062322](https://www.odoo.com/web#id=3062322&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo