### PR TITLE
[IMP] top bar: add menu item to insert formula functions

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -174,6 +174,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       toggleSidePanel: this.toggleSidePanel.bind(this),
       _t: Spreadsheet._t,
       clipboard: this.env.clipboard || instantiateClipboard(),
+      startCellEdition: (content: string) => this.onGridComposerCellFocused(content),
     });
 
     useExternalListener(window as any, "resize", () => this.render(true));

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -27,21 +27,23 @@ import * as web from "./module_web";
 
 export { args } from "./arguments";
 
-const functions: { [category: string]: { [name: string]: AddFunctionDescription } } = {
-  database,
-  date,
-  financial,
-  info,
-  lookup,
-  logical,
-  math,
-  misc,
-  operators,
-  statistical,
-  text,
-  engineering,
-  web,
-};
+type Functions = { [functionName: string]: AddFunctionDescription };
+type Category = { name: string; functions: Functions };
+const categories: Category[] = [
+  { name: _lt("Database"), functions: database },
+  { name: _lt("Date"), functions: date },
+  { name: _lt("Financial"), functions: financial },
+  { name: _lt("Info"), functions: info },
+  { name: _lt("Lookup"), functions: lookup },
+  { name: _lt("Logical"), functions: logical },
+  { name: _lt("Math"), functions: math },
+  { name: _lt("Misc"), functions: misc },
+  { name: _lt("Operator"), functions: operators },
+  { name: _lt("Statistical"), functions: statistical },
+  { name: _lt("Text"), functions: text },
+  { name: _lt("Engineering"), functions: engineering },
+  { name: _lt("Web"), functions: web },
+];
 
 const functionNameRegex = /^[A-Z0-9\_\.]+$/;
 
@@ -107,11 +109,11 @@ function _extractArgValuesFromArgs(arg: Arg): ArgValue {
 
 export const functionRegistry = new FunctionRegistry();
 
-for (let category in functions) {
-  const fns = functions[category];
+for (let category of categories) {
+  const fns = category.functions;
   for (let name in fns) {
     const addDescr = fns[name];
-    addDescr.category = category;
+    addDescr.category = addDescr.category || category.name;
     name = name.replace(/_/g, ".");
     functionRegistry.add(name, { isExported: false, ...addDescr });
   }

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -129,7 +129,11 @@ export class EditionPlugin extends UIPlugin {
         }
         break;
       case "START_EDITION":
-        this.startEdition(cmd.text, cmd.selection);
+        if (this.mode !== "inactive" && cmd.text) {
+          this.setContent(cmd.text, cmd.selection);
+        } else {
+          this.startEdition(cmd.text, cmd.selection);
+        }
         this.updateRangeColor();
         break;
       case "STOP_EDITION":

--- a/src/registries/menu_items_registry.ts
+++ b/src/registries/menu_items_registry.ts
@@ -25,7 +25,7 @@ import { Registry } from "./registry";
  *    NB: a separator defined on the last item is not displayed !
  *
  */
-interface MenuItemSpec {
+export interface MenuItemSpec {
   name: string | ((env: SpreadsheetChildEnv) => string);
   description?: string;
   sequence?: number;

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -1,9 +1,11 @@
 import { NumberFormatTerms } from "../../components/translations_terms";
 import { fontSizes } from "../../fonts";
+import { functionRegistry } from "../../functions/index";
+import { isDefined } from "../../helpers";
 import { interactiveFreezeColumnsRows } from "../../helpers/ui/freeze_interactive";
 import { _lt } from "../../translation";
 import { SpreadsheetChildEnv } from "../../types/env";
-import { MenuItemRegistry } from "../menu_items_registry";
+import { MenuItemRegistry, MenuItemSpec } from "../menu_items_registry";
 import * as ACTIONS from "./menu_items_actions";
 import { setStyle } from "./menu_items_actions";
 
@@ -181,15 +183,70 @@ topbarMenuRegistry
     action: ACTIONS.CREATE_IMAGE,
     isVisible: (env: SpreadsheetChildEnv) => env.imageProvider !== undefined,
   })
+  .addChild("insert_function", ["insert"], {
+    name: _lt("Function"),
+    sequence: 60,
+  })
+  .addChild("insert_function_sum", ["insert", "insert_function"], {
+    name: _lt("SUM"),
+    action: (env) => env.startCellEdition(`=SUM(`),
+    sequence: 0,
+  })
+  .addChild("insert_function_average", ["insert", "insert_function"], {
+    name: _lt("AVERAGE"),
+    action: (env) => env.startCellEdition(`=AVERAGE(`),
+    sequence: 10,
+  })
+  .addChild("insert_function_count", ["insert", "insert_function"], {
+    name: _lt("COUNT"),
+    action: (env) => env.startCellEdition(`=COUNT(`),
+    sequence: 20,
+  })
+  .addChild("insert_function_max", ["insert", "insert_function"], {
+    name: _lt("MAX"),
+    action: (env) => env.startCellEdition(`=MAX(`),
+    sequence: 30,
+  })
+  .addChild("insert_function_min", ["insert", "insert_function"], {
+    name: _lt("MIN"),
+    action: (env) => env.startCellEdition(`=MIN(`),
+    sequence: 40,
+    separator: true,
+  })
+  .addChild("categorie_function_all", ["insert", "insert_function"], {
+    name: _lt("All"),
+    sequence: 50,
+  })
+  .addChild("all_function_list", ["insert", "insert_function", "categorie_function_all"], () => {
+    const fnNames = functionRegistry.getKeys();
+    return createFormulaFunctionMenuItems(fnNames);
+  })
+  .addChild("categories_function_list", ["insert", "insert_function"], () => {
+    const functions = functionRegistry.content;
+    const categories = [...new Set(functionRegistry.getAll().map((fn) => fn.category))].filter(
+      isDefined
+    );
+
+    return categories.sort().map((category, i) => {
+      const functionsInCategory = Object.keys(functions).filter(
+        (key) => functions[key].category === category
+      );
+      return {
+        name: category,
+        sequence: 60 + i * 10,
+        children: createFormulaFunctionMenuItems(functionsInCategory),
+      };
+    });
+  })
   .addChild("insert_link", ["insert"], {
     name: _lt("Link"),
     separator: true,
-    sequence: 60,
+    sequence: 70,
     action: ACTIONS.INSERT_LINK,
   })
   .addChild("insert_sheet", ["insert"], {
     name: _lt("New sheet"),
-    sequence: 70,
+    sequence: 80,
     action: ACTIONS.CREATE_SHEET_ACTION,
     separator: true,
   })
@@ -477,5 +534,15 @@ for (let fs of fontSizes) {
     name: fs.pt.toString(),
     sequence: fs.pt,
     action: (env: SpreadsheetChildEnv) => ACTIONS.setStyle(env, { fontSize: fs.pt }),
+  });
+}
+
+function createFormulaFunctionMenuItems(fnNames: string[]): MenuItemSpec[] {
+  return fnNames.sort().map((fnName, i) => {
+    return {
+      name: fnName,
+      sequence: i * 10,
+      action: (env) => env.startCellEdition(`=${fnName}(`),
+    };
   });
 }

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -35,5 +35,6 @@ export interface SpreadsheetChildEnv extends SpreadsheetEnv {
   toggleSidePanel: (panel: string, panelProps?: any) => void;
   clipboard: ClipboardInterface;
   _t: TranslationFunction;
+  startCellEdition: (content: string) => void;
   loadCurrencies?: () => Promise<Currency[]>;
 }

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -535,6 +535,17 @@ describe("Menu Item actions", () => {
     });
   });
 
+  test("Insert -> Function", () => {
+    doAction(["insert", "insert_function", "insert_function_sum"], env);
+    expect(dispatch).toHaveBeenCalledWith("START_EDITION", {
+      text: "=SUM(",
+    });
+    doAction(["insert", "insert_function", "insert_function_sum"], env);
+    expect(dispatch).toHaveBeenCalledWith("SET_CURRENT_CONTENT", {
+      content: "=SUM(",
+    });
+  });
+
   describe("Format -> numbers", () => {
     test("Automatic", () => {
       doAction(["format", "format_number", "format_number_automatic"], env);

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -841,4 +841,12 @@ describe("edition", () => {
 
     expect(spyNotify).toHaveBeenCalled();
   });
+
+  test("start edition twice --> overwrites the contents of the first start edition", () => {
+    const model = new Model();
+    model.dispatch("START_EDITION", { text: "=SUM(" });
+    expect(model.getters.getCurrentContent()).toBe("=SUM(");
+    model.dispatch("START_EDITION", { text: "=DB(" });
+    expect(model.getters.getCurrentContent()).toBe("=DB(");
+  });
 });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -103,6 +103,7 @@ export function makeTestEnv(mockEnv: Partial<SpreadsheetChildEnv> = {}): Spreads
     raiseError: mockEnv.raiseError || (() => {}),
     askConfirmation: mockEnv.askConfirmation || (() => {}),
     editText: mockEnv.editText || (() => {}),
+    startCellEdition: mockEnv.startCellEdition || (() => {}),
     loadCurrencies:
       mockEnv.loadCurrencies ||
       (async () => {


### PR DESCRIPTION
## Description:

This commit allows to access and to insert all formula functions
developed in Spreadsheet. The insertion can be done via the
following menu items: 'insert' --> 'function'

Odoo task ID : [2802544](https://www.odoo.com/web#id=2802544&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo