### PR TITLE
[IMP] data: reorganize data top menu

### DIFF
--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -72,7 +72,7 @@ topbarMenuRegistry
   })
   .addChild("sort_range", ["data"], {
     name: _lt("Sort range"),
-    sequence: 62,
+    sequence: 20,
     isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
     separator: true,
   })
@@ -414,15 +414,15 @@ topbarMenuRegistry
     separator: true,
   })
   .addChild("add_data_filter", ["data"], {
-    name: _lt("Add Filter"),
-    sequence: 20,
+    name: _lt("Create filter"),
+    sequence: 10,
     action: ACTIONS.FILTERS_CREATE_FILTER_TABLE,
     isVisible: (env) => !ACTIONS.SELECTION_CONTAINS_FILTER(env),
     isEnabled: (env) => ACTIONS.SELECTION_IS_CONTINUOUS(env),
   })
   .addChild("remove_data_filter", ["data"], {
-    name: _lt("Remove Filter"),
-    sequence: 20,
+    name: _lt("Remove filter"),
+    sequence: 10,
     action: ACTIONS.FILTERS_REMOVE_FILTER_TABLE,
     isVisible: ACTIONS.SELECTION_CONTAINS_FILTER,
   });

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -944,7 +944,7 @@ describe("Menu Item actions", () => {
 
       test("Filters -> Create filter", () => {
         setSelection(model, ["A1:A5"]);
-        expect(getName(createFilterPath, env)).toBe("Add Filter");
+        expect(getName(createFilterPath, env)).toBe("Create filter");
         expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
         expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
         doAction(createFilterPath, env);
@@ -954,10 +954,10 @@ describe("Menu Item actions", () => {
         });
       });
 
-      test("Filters -> Remove Filter", () => {
+      test("Filters -> Remove filter", () => {
         createFilter(model, "A1:A5");
         setSelection(model, ["A1:A5"]);
-        expect(getName(removeFilterPath, env)).toBe("Remove Filter");
+        expect(getName(removeFilterPath, env)).toBe("Remove filter");
         expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
         expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
         doAction(removeFilterPath, env);
@@ -979,7 +979,7 @@ describe("Menu Item actions", () => {
         expect(getNode(createFilterPath).isEnabled(env)).toBeTruthy();
       });
 
-      test("Filters -> Remove Filter is displayed instead of add filter when the selection contains a filter", () => {
+      test("Filters -> Remove filter is displayed instead of add filter when the selection contains a filter", () => {
         setSelection(model, ["A1:A5"]);
         expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
         expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();


### PR DESCRIPTION
## Description:

This PR is a part of re organizing data top menu. Here the "Add Filter" is renamed as "Create filter"
Second part of this task is in Enterprise

Odoo task ID : [3040923](https://www.odoo.com/web#id=3040923&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo