### PR TITLE
[REF] plugins: use position with sheet everywhere

### DIFF
--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -5,6 +5,7 @@ import {
   SELECTION_BORDER_COLOR,
 } from "../../../constants";
 import { fontSizeMap } from "../../../fonts";
+import { positionToZone } from "../../../helpers";
 import { ComposerSelection } from "../../../plugins/ui_stateful/edition";
 import { DOMDimension, Rect, Ref, SpreadsheetChildEnv, Zone } from "../../../types/index";
 import { getTextDecoration } from "../../helpers";
@@ -56,13 +57,8 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
       rect: undefined,
       delimitation: undefined,
     });
-    const { col, row } = this.env.model.getters.getActivePosition();
-    this.zone = this.env.model.getters.expandZone(this.env.model.getters.getActiveSheetId(), {
-      left: col,
-      right: col,
-      top: row,
-      bottom: row,
-    });
+    const { sheetId, col, row } = this.env.model.getters.getActivePosition();
+    this.zone = this.env.model.getters.expandZone(sheetId, positionToZone({ col, row }));
     this.rect = this.env.model.getters.getVisibleRect(this.zone);
     onMounted(() => {
       const el = this.gridComposerRef.el!;
@@ -91,8 +87,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     const isFormula = this.env.model.getters.getCurrentContent().startsWith("=");
     const cell = this.env.model.getters.getActiveCell();
     const position = this.env.model.getters.getActivePosition();
-    const sheetId = this.env.model.getters.getActiveSheetId();
-    const style = this.env.model.getters.getCellComputedStyle(sheetId, position.col, position.row);
+    const style = this.env.model.getters.getCellComputedStyle(position);
 
     // position style
     const { x: left, y: top, width, height } = this.rect;

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -92,16 +92,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     const cell = this.env.model.getters.getActiveCell();
     const position = this.env.model.getters.getPosition();
     const sheetId = this.env.model.getters.getActiveSheetId();
-    const cellPosition = this.env.model.getters.getMainCellPosition(
-      sheetId,
-      position.col,
-      position.row
-    );
-    const style = this.env.model.getters.getCellComputedStyle(
-      sheetId,
-      cellPosition.col,
-      cellPosition.row
-    );
+    const style = this.env.model.getters.getCellComputedStyle(sheetId, position.col, position.row);
 
     // position style
     const { x: left, y: top, width, height } = this.rect;

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -56,7 +56,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
       rect: undefined,
       delimitation: undefined,
     });
-    const { col, row } = this.env.model.getters.getPosition();
+    const { col, row } = this.env.model.getters.getActivePosition();
     this.zone = this.env.model.getters.expandZone(this.env.model.getters.getActiveSheetId(), {
       left: col,
       right: col,
@@ -90,7 +90,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
   get containerStyle(): string {
     const isFormula = this.env.model.getters.getCurrentContent().startsWith("=");
     const cell = this.env.model.getters.getActiveCell();
-    const position = this.env.model.getters.getPosition();
+    const position = this.env.model.getters.getActivePosition();
     const sheetId = this.env.model.getters.getActiveSheetId();
     const style = this.env.model.getters.getCellComputedStyle(sheetId, position.col, position.row);
 

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -108,13 +108,14 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
     const sheetId = this.env.model.getters.getActiveSheetId();
     for (const col of this.env.model.getters.getSheetViewVisibleCols()) {
       for (const row of this.env.model.getters.getSheetViewVisibleRows()) {
-        const action = this.getClickableAction({ sheetId, col, row });
+        const position = { sheetId, col, row };
+        const action = this.getClickableAction(position);
         if (!action) {
           continue;
         }
         let zone: Zone;
-        if (this.env.model.getters.isInMerge(sheetId, col, row)) {
-          zone = this.env.model.getters.getMerge(sheetId, col, row)!;
+        if (this.env.model.getters.isInMerge(position)) {
+          zone = this.env.model.getters.getMerge(position)!;
         } else {
           zone = positionToZone({ col, row });
         }

--- a/src/components/filters/filter_icons_overlay/fitler_icons_overlay.ts
+++ b/src/components/filters/filter_icons_overlay/fitler_icons_overlay.ts
@@ -44,7 +44,7 @@ export class FilterIconsOverlay extends Component<Props, SpreadsheetChildEnv> {
 
   isFilterActive(position: Position): boolean {
     const sheetId = this.env.model.getters.getActiveSheetId();
-    return this.env.model.getters.isFilterActive(sheetId, position.col, position.row);
+    return this.env.model.getters.isFilterActive({ sheetId, ...position });
   }
 
   toggleFilterMenu(position: Position) {

--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -156,7 +156,7 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
 
   private getFilterValues(position: Position): Value[] {
     const sheetId = this.env.model.getters.getActiveSheetId();
-    const filter = this.env.model.getters.getFilter(sheetId, position.col, position.row);
+    const filter = this.env.model.getters.getFilter({ sheetId, ...position });
     if (!filter) {
       return [];
     }
@@ -168,11 +168,7 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
           this.env.model.getters.getEvaluatedCell({ sheetId, col, row }).formattedValue
       );
 
-    const filterValues = this.env.model.getters.getFilterValues(
-      sheetId,
-      position.col,
-      position.row
-    );
+    const filterValues = this.env.model.getters.getFilterValues({ sheetId, ...position });
 
     const strValues = [...cellValues, ...filterValues];
     const normalizedFilteredValues = filterValues.map(toLowerCase);
@@ -216,7 +212,7 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
   get filterTable() {
     const sheetId = this.env.model.getters.getActiveSheetId();
     const position = this.props.filterPosition;
-    return this.env.model.getters.getFilterTable(sheetId, position.col, position.row);
+    return this.env.model.getters.getFilterTable({ sheetId, ...position });
   }
 
   get displayedValues() {

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -217,7 +217,11 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     },
     "CTRL+HOME": () => {
       const sheetId = this.env.model.getters.getActiveSheetId();
-      const { col, row } = this.env.model.getters.getNextVisibleCellPosition(sheetId, 0, 0);
+      const { col, row } = this.env.model.getters.getNextVisibleCellPosition({
+        sheetId,
+        col: 0,
+        row: 0,
+      });
       this.env.model.selection.selectCell(col, row);
     },
     "CTRL+END": () => {

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -241,7 +241,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         left: 0,
         right: this.env.model.getters.getNumberCols(sheetId) - 1,
       };
-      const position = this.env.model.getters.getPosition();
+      const position = this.env.model.getters.getActivePosition();
       this.env.model.selection.selectZone({ cell: position, zone: newZone });
     },
     "CTRL+ ": () => {
@@ -251,7 +251,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         top: 0,
         bottom: this.env.model.getters.getNumberRows(sheetId) - 1,
       };
-      const position = this.env.model.getters.getPosition();
+      const position = this.env.model.getters.getActivePosition();
       this.env.model.selection.selectZone({ cell: position, zone: newZone });
     },
     "CTRL+SHIFT+ ": () => {

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -102,7 +102,7 @@ export class LinkDisplay extends Component<LinkDisplayProps, SpreadsheetChildEnv
   unlink() {
     const sheetId = this.env.model.getters.getActiveSheetId();
     const { col, row } = this.props.cellPosition;
-    const style = this.env.model.getters.getCellComputedStyle(sheetId, col, row);
+    const style = this.env.model.getters.getCellComputedStyle({ sheetId, col, row });
     const textColor = style?.textColor === LINK_COLOR ? undefined : style?.textColor;
     this.env.model.dispatch("UPDATE_CELL", {
       col,
@@ -116,12 +116,9 @@ export class LinkDisplay extends Component<LinkDisplayProps, SpreadsheetChildEnv
 
 export const LinkCellPopoverBuilder: PopoverBuilders = {
   onHover: (position, getters): CellPopoverComponent<typeof LinkDisplay> => {
-    const sheetId = getters.getActiveSheetId();
     const cell = getters.getEvaluatedCell(position);
     const shouldDisplayLink =
-      !getters.isDashboard() &&
-      cell.link &&
-      getters.isVisibleInViewport(sheetId, position.col, position.row);
+      !getters.isDashboard() && cell.link && getters.isVisibleInViewport(position);
     if (!shouldDisplayLink) return { isOpen: false };
     return {
       isOpen: true,

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -7,7 +7,7 @@ import {
 } from "@odoo/owl";
 import { BACKGROUND_HEADER_COLOR, ComponentsImportance, DEFAULT_FONT_SIZE } from "../../constants";
 import { fontSizes } from "../../fonts";
-import { areZonesContinuous, isEqual } from "../../helpers/index";
+import { areZonesContinuous, isEqual, positionToZone } from "../../helpers/index";
 import { interactiveAddFilter } from "../../helpers/ui/filter_interactive";
 import { interactiveAddMerge } from "../../helpers/ui/merge_interactive";
 import { ComposerSelection } from "../../plugins/ui_stateful/edition";
@@ -407,7 +407,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
 
   updateCellState() {
     const zones = this.env.model.getters.getSelectedZones();
-    const sheetId = this.env.model.getters.getActiveSheetId();
+    const { col, row, sheetId } = this.env.model.getters.getActivePosition();
     this.inMerge = false;
     const { top, left, right, bottom } = this.env.model.getters.getSelectedZone();
     const { xSplit, ySplit } = this.env.model.getters.getPaneDivisions(sheetId);
@@ -417,13 +417,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
       (left < xSplit && xSplit <= right) ||
       (top < ySplit && ySplit <= bottom);
     if (!this.cannotMerge) {
-      const { col, row } = this.env.model.getters.getActivePosition();
-      const zone = this.env.model.getters.expandZone(sheetId, {
-        left: col,
-        right: col,
-        top: row,
-        bottom: row,
-      });
+      const zone = this.env.model.getters.expandZone(sheetId, positionToZone({ col, row }));
       this.inMerge = isEqual(zones[0], zone);
     }
     this.undoTool = this.env.model.getters.canUndo();

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -417,7 +417,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
       (left < xSplit && xSplit <= right) ||
       (top < ySplit && ySplit <= bottom);
     if (!this.cannotMerge) {
-      const { col, row } = this.env.model.getters.getPosition();
+      const { col, row } = this.env.model.getters.getActivePosition();
       const zone = this.env.model.getters.expandZone(sheetId, {
         left: col,
         right: col,

--- a/src/helpers/charts/chart_factory.ts
+++ b/src/helpers/charts/chart_factory.ts
@@ -125,7 +125,7 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
   const dataSets = [zoneToXc(dataSetZone)];
   const sheetId = getters.getActiveSheetId();
 
-  const topLeftCell = getters.getCell(sheetId, zone.left, zone.top);
+  const topLeftCell = getters.getCell({ sheetId, col: zone.left, row: zone.top });
   if (getZoneArea(zone) === 1 && topLeftCell?.content) {
     return {
       type: "scorecard",

--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -68,11 +68,12 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
     for (let row of rowsIndex) {
       let cellsInRow: ClipboardCell[] = [];
       for (let col of columnsIndex) {
+        const position = { col, row, sheetId };
         cellsInRow.push({
-          cell: getters.getCell(sheetId, col, row),
-          evaluatedCell: getters.getEvaluatedCell({ sheetId, col, row }),
-          border: getters.getCellBorder(sheetId, col, row) || undefined,
-          position: { col, row, sheetId },
+          cell: getters.getCell(position),
+          evaluatedCell: getters.getEvaluatedCell(position),
+          border: getters.getCellBorder(position) || undefined,
+          position,
         });
       }
       cellsInClipboard.push(cellsInRow);
@@ -83,7 +84,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
       for (const table of this.getters.getFilterTablesInZone(sheetId, zone)) {
         const values: Array<string[]> = [];
         for (const col of range(table.zone.left, table.zone.right + 1)) {
-          values.push(this.getters.getFilterValues(sheetId, col, table.zone.top));
+          values.push(this.getters.getFilterValues({ sheetId, col, row: table.zone.top }));
         }
         tables.push({ filtersValues: values, zone: table.zone });
       }
@@ -348,7 +349,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
     const targetCell = this.getters.getEvaluatedCell(target);
 
     if (clipboardOption?.pasteOption !== "onlyValue") {
-      const targetBorders = this.getters.getCellBorder(sheetId, col, row);
+      const targetBorders = this.getters.getCellBorder(target);
       const originBorders = origin.border;
       const border = {
         top: targetBorders?.top || originBorders?.top,
@@ -418,13 +419,10 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
   private pasteMergeIfExist(origin: CellPosition, target: CellPosition) {
     let { sheetId, col, row } = origin;
 
-    const { col: mainCellColOrigin, row: mainCellRowOrigin } = this.getters.getMainCellPosition(
-      sheetId,
-      col,
-      row
-    );
+    const { col: mainCellColOrigin, row: mainCellRowOrigin } =
+      this.getters.getMainCellPosition(origin);
     if (mainCellColOrigin === col && mainCellRowOrigin === row) {
-      const merge = this.getters.getMerge(sheetId, col, row);
+      const merge = this.getters.getMerge(origin);
       if (!merge) {
         return;
       }

--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -127,13 +127,9 @@ export class InternalViewport {
     if (!position) {
       position = this.getters.getSheetPosition(sheetId);
     }
-    const mainCellPosition = this.getters.getMainCellPosition(sheetId, position.col, position.row);
+    const mainCellPosition = this.getters.getMainCellPosition({ sheetId, ...position });
 
-    const { col, row } = this.getters.getNextVisibleCellPosition(
-      sheetId,
-      mainCellPosition.col,
-      mainCellPosition.row
-    );
+    const { col, row } = this.getters.getNextVisibleCellPosition(mainCellPosition);
     if (isInside(col, this.boundaries.top, this.boundaries)) {
       this.adjustPositionX(col);
     }

--- a/src/helpers/sort.ts
+++ b/src/helpers/sort.ts
@@ -69,10 +69,10 @@ export function interactiveSortSelection(
   if (env.model.getters.doesIntersectMerge(sheetId, zone)) {
     multiColumns = false;
     let table: UID[];
-    for (let r = zone.top; r <= zone.bottom; r++) {
+    for (let row = zone.top; row <= zone.bottom; row++) {
       table = [];
-      for (let c = zone.left; c <= zone.right; c++) {
-        let merge = env.model.getters.getMerge(sheetId, c, r);
+      for (let col = zone.left; col <= zone.right; col++) {
+        let merge = env.model.getters.getMerge({ sheetId, col, row });
         if (merge && !table.includes(merge.id.toString())) {
           table.push(merge.id.toString());
         }

--- a/src/model.ts
+++ b/src/model.ts
@@ -420,7 +420,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
    * 2. This allows us to define its type by using the interface CommandDispatcher
    */
   dispatch: CommandDispatcher["dispatch"] = (type: string, payload?: any) => {
-    const command: Command = { type, ...payload };
+    const command: Command = { ...payload, type };
     let status: Status = this.status;
     if (this.getters.isReadonly() && !canExecuteInReadonly(command)) {
       return new DispatchResult(CommandResult.Readonly);
@@ -466,7 +466,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
    * A command dispatched from this function is not added to the history.
    */
   private dispatchFromCorePlugin: CommandDispatcher["dispatch"] = (type: string, payload?: any) => {
-    const command: Command = { type, ...payload };
+    const command: Command = { ...payload, type };
     const previousStatus = this.status;
     this.status = Status.RunningCore;
     const handlers = this.isReplayingCommand

--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -5,6 +5,7 @@ import {
   Border,
   BorderCommand,
   BorderDescription,
+  CellPosition,
   Command,
   ExcelWorkbookData,
   HeaderIndex,
@@ -138,7 +139,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   // Getters
   // ---------------------------------------------------------------------------
 
-  getCellBorder(sheetId: UID, col: HeaderIndex, row: HeaderIndex): Border | null {
+  getCellBorder({ sheetId, col, row }: CellPosition): Border | null {
     const border = {
       top: this.borders[sheetId]?.[col]?.[row]?.horizontal,
       bottom: this.borders[sheetId]?.[col]?.[row + 1]?.horizontal,
@@ -167,8 +168,8 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   ) {
     const targetCols = range(leftColumn + 1, rightColumn);
     for (let row: HeaderIndex = 0; row < this.getters.getNumberRows(sheetId); row++) {
-      const leftBorder = this.getCellBorder(sheetId, leftColumn, row);
-      const rightBorder = this.getCellBorder(sheetId, rightColumn, row);
+      const leftBorder = this.getCellBorder({ sheetId, col: leftColumn, row });
+      const rightBorder = this.getCellBorder({ sheetId, col: rightColumn, row });
       if (leftBorder && rightBorder) {
         const commonSides = this.getCommonSides(leftBorder, rightBorder);
         for (let col of targetCols) {
@@ -186,8 +187,8 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   private ensureRowBorderContinuity(sheetId: UID, topRow: HeaderIndex, bottomRow: HeaderIndex) {
     const targetRows = range(topRow + 1, bottomRow);
     for (let col: HeaderIndex = 0; col < this.getters.getNumberCols(sheetId); col++) {
-      const aboveBorder = this.getCellBorder(sheetId, col, topRow);
-      const belowBorder = this.getCellBorder(sheetId, col, bottomRow);
+      const aboveBorder = this.getCellBorder({ sheetId, col, row: topRow });
+      const belowBorder = this.getCellBorder({ sheetId, col, row: bottomRow });
       if (aboveBorder && belowBorder) {
         const commonSides = this.getCommonSides(aboveBorder, belowBorder);
         for (let row of targetRows) {
@@ -406,7 +407,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
    */
   private addBorder(sheetId: UID, col: HeaderIndex, row: HeaderIndex, border: Border) {
     this.setBorder(sheetId, col, row, {
-      ...this.getCellBorder(sheetId, col, row),
+      ...this.getCellBorder({ sheetId, col, row }),
       ...border,
     });
   }
@@ -462,8 +463,8 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
    */
   private addBordersToMerge(sheetId: UID, zone: Zone) {
     const { left, right, top, bottom } = zone;
-    const bordersTopLeft = this.getCellBorder(sheetId, left, top);
-    const bordersBottomRight = this.getCellBorder(sheetId, right, bottom);
+    const bordersTopLeft = this.getCellBorder({ sheetId, col: left, row: top });
+    const bordersBottomRight = this.getCellBorder({ sheetId, col: right, row: bottom });
     this.clearBorders(sheetId, [zone]);
     if (bordersTopLeft?.top) {
       this.setBorders(sheetId, [{ ...zone, bottom: top }], "top");
@@ -526,7 +527,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     for (let sheet of data.sheets) {
       for (let col: HeaderIndex = 0; col < sheet.colNumber; col++) {
         for (let row: HeaderIndex = 0; row < sheet.rowNumber; row++) {
-          const border = this.getCellBorder(sheet.id, col, row);
+          const border = this.getCellBorder({ sheetId: sheet.id, col, row });
           if (border) {
             const xc = toXC(col, row);
             const cell = sheet.cells[xc];

--- a/src/plugins/core/filters.ts
+++ b/src/plugins/core/filters.ts
@@ -17,6 +17,7 @@ import {
 import { Filter, FilterTable } from "../../helpers/filters";
 import {
   AddColumnsRowsCommand,
+  CellPosition,
   CommandResult,
   CoreCommand,
   ExcelWorkbookData,
@@ -145,15 +146,15 @@ export class FiltersPlugin extends CorePlugin<FiltersState> implements FiltersSt
     return this.tables[sheetId] ? Object.values(this.tables[sheetId]).filter(isDefined) : [];
   }
 
-  getFilter(sheetId: UID, col: number, row: number): Filter | undefined {
-    return this.getFilterTable(sheetId, col, row)?.filters.find((filter) => filter.col === col);
+  getFilter(position: CellPosition): Filter | undefined {
+    return this.getFilterTable(position)?.filters.find((filter) => filter.col === position.col);
   }
 
-  getFilterId(sheetId: UID, col: number, row: number): FilterId | undefined {
-    return this.getFilter(sheetId, col, row)?.id;
+  getFilterId(position: CellPosition): FilterId | undefined {
+    return this.getFilter(position)?.id;
   }
 
-  getFilterTable(sheetId: UID, col: number, row: number): FilterTable | undefined {
+  getFilterTable({ sheetId, col, row }: CellPosition): FilterTable | undefined {
     return this.getFilterTables(sheetId).find((filterTable) =>
       isInside(col, row, filterTable.zone)
     );
@@ -297,17 +298,18 @@ export class FiltersPlugin extends CorePlugin<FiltersState> implements FiltersSt
     }
 
     for (const col of range(zone.left, zone.right + 1)) {
+      const position = { sheetId, col, row };
       // Since this plugin is loaded before CellPlugin, the getters still give us the old cell content
-      const cellContent = this.getters.getCell(sheetId, col, row)?.content;
+      const cellContent = this.getters.getCell(position)?.content;
       if (cellContent) {
         return false;
       }
 
-      if (this.getters.getFilter(sheetId, col, row)) {
+      if (this.getters.getFilter(position)) {
         return false;
       }
 
-      if (this.getters.isInMerge(sheetId, col, row)) {
+      if (this.getters.isInMerge(position)) {
         return false;
       }
     }

--- a/src/plugins/core/header_size.ts
+++ b/src/plugins/core/header_size.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../constants";
 import { deepCopy, getAddHeaderStartIndex, getDefaultCellHeight, lazy, range } from "../../helpers";
 import { Command, ExcelWorkbookData, WorkbookData } from "../../types";
-import { Dimension, HeaderIndex, Lazy, Pixel, UID } from "../../types/misc";
+import { CellPosition, Dimension, HeaderIndex, Lazy, Pixel, UID } from "../../types/misc";
 import { CorePlugin } from "../core_plugin";
 
 interface HeaderSize {
@@ -172,12 +172,12 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
    * Return the height the cell should have in the sheet, which is either DEFAULT_CELL_HEIGHT if the cell is in a multi-row
    * merge, or the height of the cell computed based on its font size.
    */
-  private getCellHeight(sheetId: UID, col: HeaderIndex, row: HeaderIndex): Pixel {
-    const merge = this.getters.getMerge(sheetId, col, row);
+  private getCellHeight(position: CellPosition): Pixel {
+    const merge = this.getters.getMerge(position);
     if (merge && merge.bottom !== merge.top) {
       return DEFAULT_CELL_HEIGHT;
     }
-    const cell = this.getters.getCell(sheetId, col, row);
+    const cell = this.getters.getCell(position);
     // TO DO: take multiline cells into account to compute the cell height
     return getDefaultCellHeight(cell?.style);
   }
@@ -194,8 +194,8 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
     for (let i = 0; i < cellIds.length; i++) {
       const cell = this.getters.getCellById(cellIds[i]);
       if (!cell) continue;
-      const { col, row } = this.getters.getCellPosition(cell.id);
-      const cellHeight = this.getCellHeight(sheetId, col, row);
+      const position = this.getters.getCellPosition(cell.id);
+      const cellHeight = this.getCellHeight(position);
       if (cellHeight > maxHeight && cellHeight > DEFAULT_CELL_HEIGHT) {
         maxHeight = cellHeight;
       }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -354,7 +354,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     return row;
   }
 
-  getCell(sheetId: UID, col: HeaderIndex, row: HeaderIndex): Cell | undefined {
+  getCell({ sheetId, col, row }: CellPosition): Cell | undefined {
     const sheet = this.tryGetSheet(sheetId);
     const cellId = sheet?.rows[row]?.cells[col];
     if (cellId === undefined) {
@@ -455,7 +455,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
    */
   isEmpty(sheetId: UID, zone: Zone): boolean {
     return positions(zone)
-      .map(({ col, row }) => this.getCell(sheetId, col, row))
+      .map(({ col, row }) => this.getCell({ sheetId, col, row }))
       .every((cell) => !cell || cell.content === "");
   }
 

--- a/src/plugins/ui_core_views/evaluation.ts
+++ b/src/plugins/ui_core_views/evaluation.ts
@@ -139,7 +139,7 @@ export class EvaluationPlugin extends UIPlugin {
   }
 
   getEvaluatedCell({ sheetId, col, row }: CellPosition): EvaluatedCell {
-    const cell = this.getters.getCell(sheetId, col, row);
+    const cell = this.getters.getCell({ sheetId, col, row });
     if (cell === undefined) {
       return createEvaluatedCell("");
     }
@@ -286,7 +286,7 @@ export class EvaluationPlugin extends UIPlugin {
       if (!getters.tryGetSheet(range.sheetId)) {
         throw new Error(_lt("Invalid sheet name"));
       }
-      cell = getters.getCell(range.sheetId, range.zone.left, range.zone.top);
+      cell = getters.getCell({ sheetId: range.sheetId, col: range.zone.left, row: range.zone.top });
       if (!cell || cell.content === "") {
         // magic "empty" value
         // Returning {value: null} instead of undefined will ensure that we don't
@@ -334,7 +334,7 @@ export class EvaluationPlugin extends UIPlugin {
       for (let col = zone.left; col <= zone.right; col++) {
         const rowValues: ({ value: CellValue; format?: Format } | undefined)[] = [];
         for (let row = zone.top; row <= zone.bottom; row++) {
-          const cell = evalContext.getters.getCell(range.sheetId, col, row);
+          const cell = evalContext.getters.getCell({ sheetId: range.sheetId, col, row });
           rowValues.push(cell ? getEvaluatedCell(cell) : undefined);
         }
         result.push(rowValues);
@@ -397,11 +397,11 @@ export class EvaluationPlugin extends UIPlugin {
   exportForExcel(data: ExcelWorkbookData) {
     for (let sheet of data.sheets) {
       for (const xc in sheet.cells) {
-        const { col, row } = toCartesian(xc);
-        const cell = this.getters.getCell(sheet.id, col, row);
+        const position = { sheetId: sheet.id, ...toCartesian(xc) };
+        const cell = this.getters.getCell(position);
         if (cell) {
           const exportedCellData = sheet.cells[xc]!;
-          exportedCellData.value = this.getEvaluatedCell({ sheetId: sheet.id, col, row }).value;
+          exportedCellData.value = this.getEvaluatedCell(position).value;
           exportedCellData.isFormula = cell.isFormula && !this.isBadExpression(cell.content);
         }
       }

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -74,7 +74,8 @@ export class EvaluationChartPlugin extends UIPlugin {
     }
     const col = mainRange.zone.left;
     const row = mainRange.zone.top;
-    const style = this.getters.getCellComputedStyle(mainRange.sheetId, col, row);
+    const sheetId = mainRange.sheetId;
+    const style = this.getters.getCellComputedStyle({ sheetId, col, row });
     return style.fillColor || BACKGROUND_CHART_COLOR;
   }
 }

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -18,6 +18,7 @@ import {
   IconThreshold,
   invalidateCFEvaluationCommands,
   NumberCell,
+  Position,
   Style,
   UID,
   Zone,
@@ -79,27 +80,28 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
   // Getters
   // ---------------------------------------------------------------------------
 
-  getCellComputedStyle(sheetId: UID, col: HeaderIndex, row: HeaderIndex): Style {
+  getCellComputedStyle(position: CellPosition): Style {
     // TODO move this getter out of CF: it also depends on filters and link
-    const cell = this.getters.getCell(sheetId, col, row);
+    const { sheetId, col, row } = position;
+    const cell = this.getters.getCell(position);
     const styles = this.computedStyles[sheetId];
     const cfStyle = styles && styles[col]?.[row];
     const computedStyle = {
       ...cell?.style,
       ...cfStyle,
     };
-    const evaluatedCell = this.getters.getEvaluatedCell({ sheetId, col, row });
+    const evaluatedCell = this.getters.getEvaluatedCell(position);
     if (evaluatedCell.link && !computedStyle.textColor) {
       computedStyle.textColor = LINK_COLOR;
     }
 
-    if (this.getters.isFilterHeader(sheetId, col, row)) {
+    if (this.getters.isFilterHeader(position)) {
       computedStyle.bold = true;
     }
     return computedStyle;
   }
 
-  getConditionalIcon(col: HeaderIndex, row: HeaderIndex): string | undefined {
+  getConditionalIcon({ col, row }: Position): string | undefined {
     const activeSheet = this.getters.getActiveSheetId();
     const icon = this.computedIcons[activeSheet];
     return icon && icon[col]?.[row];

--- a/src/plugins/ui_core_views/sheetview.ts
+++ b/src/plugins/ui_core_views/sheetview.ts
@@ -4,6 +4,7 @@ import { scrollDelay } from "../../helpers/index";
 import { InternalViewport } from "../../helpers/internal_viewport";
 import { SelectionEvent } from "../../types/event_stream";
 import {
+  CellPosition,
   Command,
   CommandResult,
   Dimension,
@@ -374,7 +375,7 @@ export class SheetViewPlugin extends UIPlugin {
   /**
    * Check if a given position is visible in the viewport.
    */
-  isVisibleInViewport(sheetId: UID, col: number, row: number): boolean {
+  isVisibleInViewport({ sheetId, col, row }: CellPosition): boolean {
     return this.getSubViewports(sheetId).some((pane) => pane.isVisible(col, row));
   }
 

--- a/src/plugins/ui_feature/autofill.ts
+++ b/src/plugins/ui_feature/autofill.ts
@@ -344,7 +344,7 @@ export class AutofillPlugin extends UIPlugin {
     const sheetId = this.getters.getActiveSheetId();
     for (let xc of source) {
       const { col, row } = toCartesian(xc);
-      const cell = this.getters.getCell(sheetId, col, row);
+      const cell = this.getters.getCell({ sheetId, col, row });
       cellsData.push({
         col,
         row,
@@ -359,8 +359,7 @@ export class AutofillPlugin extends UIPlugin {
         const newRule = this.getRule(cellData.cell, cells);
         rule = newRule || rule;
       }
-      const { sheetId, col, row } = cellData;
-      const border = this.getters.getCellBorder(sheetId, col, row) || undefined;
+      const border = this.getters.getCellBorder(cellData) || undefined;
       nextCells.push({
         data: { ...cellData, border },
         rule,
@@ -406,23 +405,22 @@ export class AutofillPlugin extends UIPlugin {
     col: HeaderIndex,
     row: HeaderIndex
   ) {
-    const activeSheet = this.getters.getActiveSheet();
-    if (
-      this.getters.isInMerge(activeSheet.id, col, row) &&
-      !this.getters.isInMerge(activeSheet.id, originCol, originRow)
-    ) {
-      const zone = this.getters.getMerge(activeSheet.id, col, row);
+    const sheetId = this.getters.getActiveSheetId();
+    const position = { sheetId, col, row };
+    const originPosition = { sheetId, col: originCol, row: originRow };
+    if (this.getters.isInMerge(position) && !this.getters.isInMerge(originPosition)) {
+      const zone = this.getters.getMerge(position);
       if (zone) {
         this.dispatch("REMOVE_MERGE", {
-          sheetId: activeSheet.id,
+          sheetId,
           target: [zone],
         });
       }
     }
-    const originMerge = this.getters.getMerge(activeSheet.id, originCol, originRow);
+    const originMerge = this.getters.getMerge(originPosition);
     if (originMerge?.topLeft.col === originCol && originMerge?.topLeft.row === originRow) {
       this.dispatch("ADD_MERGE", {
-        sheetId: activeSheet.id,
+        sheetId,
         target: [
           {
             top: row,

--- a/src/plugins/ui_feature/automatic_sum.ts
+++ b/src/plugins/ui_feature/automatic_sum.ts
@@ -119,7 +119,7 @@ export class AutomaticSumPlugin extends UIPlugin {
    */
   private findAdjacentData(sheetId: UID, col: HeaderIndex, row: HeaderIndex): Zone | undefined {
     const sheet = this.getters.getSheet(sheetId);
-    const mainCellPosition = this.getters.getMainCellPosition(sheetId, col, row);
+    const mainCellPosition = this.getters.getMainCellPosition({ sheetId, col, row });
     const zone = this.findSuitableZoneToSum(sheet, mainCellPosition.col, mainCellPosition.row);
     if (zone) {
       return this.getters.expandZone(sheetId, zone);

--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -221,7 +221,7 @@ export class FindAndReplacePlugin extends UIPlugin {
     const matches = this.searchMatches;
     const selectedMatch = matches[this.selectedMatchIndex];
     const sheetId = this.getters.getActiveSheetId();
-    const cell = this.getters.getCell(sheetId, selectedMatch.col, selectedMatch.row);
+    const cell = this.getters.getCell({ sheetId, ...selectedMatch });
     if (cell?.isFormula && !this.searchOptions.searchFormulas) {
       this.selectNextCell(Direction.next);
     } else {
@@ -255,12 +255,12 @@ export class FindAndReplacePlugin extends UIPlugin {
     }
   }
 
-  private getSearchableString({ sheetId, col, row }: CellPosition): string {
-    const cell = this.getters.getCell(sheetId, col, row);
+  private getSearchableString(position: CellPosition): string {
+    const cell = this.getters.getCell(position);
     if (this.searchOptions.searchFormulas && cell?.isFormula) {
       return cell.content;
     }
-    return this.getters.getEvaluatedCell({ sheetId, col, row }).formattedValue;
+    return this.getters.getEvaluatedCell(position).formattedValue;
   }
 
   // ---------------------------------------------------------------------------
@@ -272,7 +272,7 @@ export class FindAndReplacePlugin extends UIPlugin {
     const sheetId = this.getters.getActiveSheetId();
 
     for (const match of this.searchMatches) {
-      const merge = this.getters.getMerge(sheetId, match.col, match.row);
+      const merge = this.getters.getMerge({ sheetId, col: match.col, row: match.row });
       const left = merge ? merge.left : match.col;
       const right = merge ? merge.right : match.col;
       const top = merge ? merge.top : match.row;

--- a/src/plugins/ui_feature/header_visibility_ui.ts
+++ b/src/plugins/ui_feature/header_visibility_ui.ts
@@ -1,5 +1,5 @@
 import { range } from "../../helpers";
-import { Dimension, ExcelWorkbookData, HeaderIndex, Position, UID } from "../../types";
+import { CellPosition, Dimension, ExcelWorkbookData, HeaderIndex, UID } from "../../types";
 import { UIPlugin } from "../ui_plugin";
 
 export class HeaderVisibilityUIPlugin extends UIPlugin {
@@ -29,8 +29,9 @@ export class HeaderVisibilityUIPlugin extends UIPlugin {
       : this.isRowHidden(sheetId, index);
   }
 
-  getNextVisibleCellPosition(sheetId: UID, col: number, row: number): Position {
+  getNextVisibleCellPosition({ sheetId, col, row }: CellPosition): CellPosition {
     return {
+      sheetId,
       col: this.findVisibleHeader(sheetId, "COL", range(col, this.getters.getNumberCols(sheetId)))!,
       row: this.findVisibleHeader(sheetId, "ROW", range(row, this.getters.getNumberRows(sheetId)))!,
     };

--- a/src/plugins/ui_feature/selection_input.ts
+++ b/src/plugins/ui_feature/selection_input.ts
@@ -104,7 +104,11 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
       }
       case "ACTIVATE_SHEET": {
         if (cmd.sheetIdFrom !== cmd.sheetIdTo) {
-          const { col, row } = this.getters.getNextVisibleCellPosition(cmd.sheetIdTo, 0, 0);
+          const { col, row } = this.getters.getNextVisibleCellPosition({
+            sheetId: cmd.sheetIdTo,
+            col: 0,
+            row: 0,
+          });
           const zone = this.getters.expandZone(cmd.sheetIdTo, positionToZone({ col, row }));
           this.selection.resetAnchor(this, { cell: { col, row }, zone });
         }

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -95,7 +95,7 @@ export class EditionPlugin extends UIPlugin {
         if (cmd.selection) {
           const sheetId = this.getters.getActiveSheetId();
           const content =
-            cmd.text || this.getComposerContent({ sheetId, ...this.getters.getPosition() });
+            cmd.text || this.getComposerContent({ sheetId, ...this.getters.getActivePosition() });
           return this.validateSelection(content.length, cmd.selection.start, cmd.selection.end);
         } else {
           return CommandResult.Success;
@@ -238,7 +238,7 @@ export class EditionPlugin extends UIPlugin {
   getCurrentContent(): string {
     if (this.mode === "inactive") {
       const sheetId = this.getters.getActiveSheetId();
-      return this.getComposerContent({ sheetId, ...this.getters.getPosition() });
+      return this.getComposerContent({ sheetId, ...this.getters.getActivePosition() });
     }
     return this.currentContent;
   }
@@ -396,7 +396,7 @@ export class EditionPlugin extends UIPlugin {
       str = `${str}%`;
     }
     const sheetId = this.getters.getActiveSheetId();
-    const { col, row } = this.getters.getPosition();
+    const { col, row } = this.getters.getActivePosition();
     this.col = col;
     this.sheetId = sheetId;
     this.row = row;

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -98,7 +98,7 @@ export class GridSelectionPlugin extends UIPlugin {
     "getAggregate",
     "getSelectedFigureId",
     "getSelection",
-    "getPosition",
+    "getActivePosition",
     "getSheetPosition",
     "isSelected",
     "getElementsFromSelection",
@@ -386,7 +386,7 @@ export class GridSelectionPlugin extends UIPlugin {
     return this.selectedFigureId;
   }
 
-  getPosition(): Position {
+  getActivePosition(): Position {
     return this.getters.getMainCellPosition(
       this.getActiveSheetId(),
       this.gridSelection.anchor.cell.col,
@@ -396,7 +396,7 @@ export class GridSelectionPlugin extends UIPlugin {
 
   getSheetPosition(sheetId: UID): Position {
     if (sheetId === this.getters.getActiveSheetId()) {
-      return this.getPosition();
+      return this.getActivePosition();
     } else {
       const sheetData = this.sheetsData[sheetId];
       return sheetData
@@ -721,7 +721,7 @@ export class GridSelectionPlugin extends UIPlugin {
     ctx.globalCompositeOperation = "source-over";
     // active zone
     const activeSheet = this.getters.getActiveSheetId();
-    const { col, row } = this.getPosition();
+    const { col, row } = this.getActivePosition();
 
     ctx.strokeStyle = SELECTION_BORDER_COLOR;
     ctx.lineWidth = 3 * thinLineWidth;

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -7,6 +7,7 @@ import {
   formatValue,
   isEqual,
   positions,
+  positionToZone,
   uniqueZones,
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
@@ -386,7 +387,11 @@ export class GridSelectionPlugin extends UIPlugin {
   }
 
   getPosition(): Position {
-    return { col: this.gridSelection.anchor.cell.col, row: this.gridSelection.anchor.cell.row };
+    return this.getters.getMainCellPosition(
+      this.getActiveSheetId(),
+      this.gridSelection.anchor.cell.col,
+      this.gridSelection.anchor.cell.row
+    );
   }
 
   getSheetPosition(sheetId: UID): Position {
@@ -724,12 +729,7 @@ export class GridSelectionPlugin extends UIPlugin {
     if (this.getters.isInMerge(activeSheet, col, row)) {
       zone = this.getters.getMerge(activeSheet, col, row)!;
     } else {
-      zone = {
-        top: row,
-        bottom: row,
-        left: col,
-        right: col,
-      };
+      zone = positionToZone({ col, row });
     }
     const { x, y, width, height } = this.getters.getVisibleRect(zone);
     if (width > 0 && height > 0) {

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -639,7 +639,7 @@ export const OPEN_CUSTOM_CURRENCY_SIDEPANEL_ACTION = (env: SpreadsheetChildEnv) 
 };
 
 export const INSERT_LINK = (env: SpreadsheetChildEnv) => {
-  let { col, row } = env.model.getters.getPosition();
+  let { col, row } = env.model.getters.getActivePosition();
   env.model.dispatch("OPEN_CELL_POPOVER", { col, row, popoverType: "LinkEditor" });
 };
 

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -184,7 +184,7 @@ export class SelectionStreamProcessor
    */
   addCellToSelection(col: HeaderIndex, row: HeaderIndex): DispatchResult {
     const sheetId = this.getters.getActiveSheetId();
-    ({ col, row } = this.getters.getMainCellPosition(sheetId, col, row));
+    ({ col, row } = this.getters.getMainCellPosition({ sheetId, col, row }));
     const zone = this.getters.expandZone(sheetId, positionToZone({ col, row }));
     return this.processEvent({
       type: "ZonesSelected",
@@ -601,8 +601,8 @@ export class SelectionStreamProcessor
    * check if the merge containing the cell is empty.
    */
   private isCellEmpty({ col, row }: Position, sheetId = this.getters.getActiveSheetId()): boolean {
-    const mainCellPosition = this.getters.getMainCellPosition(sheetId, col, row);
-    const cell = this.getters.getEvaluatedCell({ sheetId, ...mainCellPosition });
+    const position = this.getters.getMainCellPosition({ sheetId, col, row });
+    const cell = this.getters.getEvaluatedCell(position);
     return cell.type === CellValueType.empty;
   }
 

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -28,6 +28,7 @@ import {
   getCell,
   getCellContent,
   getEvaluatedCell,
+  getStyle,
 } from "../test_helpers/getters_helpers";
 import { createEqualCF, target, toRangesData } from "../test_helpers/helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
@@ -826,11 +827,9 @@ describe("Multi users synchronisation", () => {
       moveConditionalFormat(bob, "3", "up", sheetId);
       moveConditionalFormat(alice, "3", "up", sheetId);
     });
-    const { col, row } = toCartesian("A1");
-    expect([alice, bob, charlie]).toHaveSynchronizedValue(
-      (user) => user.getters.getCellComputedStyle(sheetId, col, row),
-      { fillColor: "#00FF00" }
-    );
+    expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getStyle(user, "A1"), {
+      fillColor: "#00FF00",
+    });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getConditionalFormats(sheetId)[0].id,
       "3"
@@ -865,11 +864,9 @@ describe("Multi users synchronisation", () => {
         sheetId: sheetId,
       });
     });
-    const { col, row } = toCartesian("A1");
-    expect([alice, bob]).toHaveSynchronizedValue(
-      (user) => user.getters.getCellComputedStyle(sheetId, col, row),
-      { fillColor: "#FF0000" }
-    );
+    expect([alice, bob]).toHaveSynchronizedValue((user) => getStyle(user, "A1"), {
+      fillColor: "#FF0000",
+    });
   });
 
   test("Create overlapping data filter concurrently", () => {

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -5,7 +5,7 @@ import {
   tokenColor,
 } from "../../src/components/composer/composer/composer";
 import { fontSizes } from "../../src/fonts";
-import { colors, toCartesian, toHex, toZone } from "../../src/helpers/index";
+import { colors, toHex, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { Highlight } from "../../src/types";
 import {
@@ -27,10 +27,11 @@ import {
   simulateClick,
 } from "../test_helpers/dom_helper";
 import {
-  getActiveXc,
+  getActivePosition,
   getCellContent,
   getCellText,
   getEvaluatedCell,
+  getSelectionAnchorCellXc,
 } from "../test_helpers/getters_helpers";
 import {
   createEqualCF,
@@ -445,7 +446,7 @@ describe("composer", () => {
   test("starting the edition with enter, the composer should have the focus", async () => {
     await startComposition();
     expect(model.getters.getEditionMode()).toBe("editing");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
+    expect(getActivePosition(model)).toBe("A1");
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer")!);
   });
 
@@ -464,18 +465,18 @@ describe("composer", () => {
     expect(composerEl.textContent).toBe("a");
     await keyDown("ArrowRight");
     expect(getCellText(model, "A1")).toBe("a");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
+    expect(getActivePosition(model)).toBe("B1");
 
     composerEl = await startComposition("b");
     expect(composerEl.textContent).toBe("b");
     await keyDown("ArrowRight");
     expect(getCellText(model, "B1")).toBe("b");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("C1"));
+    expect(getActivePosition(model)).toBe("C1");
 
     await keyDown("ArrowLeft");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
+    expect(getActivePosition(model)).toBe("B1");
     await keyDown("ArrowLeft");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
+    expect(getActivePosition(model)).toBe("A1");
     composerEl = await startComposition("c");
     expect(composerEl.textContent).toBe("c");
     await keyDown("Enter");
@@ -497,18 +498,18 @@ describe("composer", () => {
     expect(composerEl.textContent).toBe("a");
     await keyDown("ArrowDown");
     expect(getCellText(model, "A1")).toBe("a");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A2"));
+    expect(getActivePosition(model)).toBe("A2");
 
     composerEl = await startComposition("b");
     expect(composerEl.textContent).toBe("b");
     await keyDown("ArrowDown");
     expect(getCellText(model, "A2")).toBe("b");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A3"));
+    expect(getActivePosition(model)).toBe("A3");
 
     await keyDown("ArrowUp");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A2"));
+    expect(getActivePosition(model)).toBe("A2");
     await keyDown("ArrowUp");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
+    expect(getActivePosition(model)).toBe("A1");
     composerEl = await startComposition("c");
     expect(composerEl.textContent).toBe("c");
     await keyDown("Enter");
@@ -523,7 +524,7 @@ describe("composer", () => {
     composerEl.dispatchEvent(new Event("input"));
     composerEl.dispatchEvent(new Event("keyup"));
     await rightClickCell(model, "C8");
-    expect(getActiveXc(model)).toBe("C8");
+    expect(getSelectionAnchorCellXc(model)).toBe("C8");
     expect(fixture.querySelectorAll(".o-grid div.o-composer")).toHaveLength(0);
   });
 
@@ -1196,12 +1197,12 @@ describe("composer", () => {
     await keyDown("Enter");
     expect(getCellText(model, "C8")).toBe("=");
     expect(getEvaluatedCell(model, "C8").value).toBe("#BAD_EXPR");
-    expect(getActiveXc(model)).toBe("C9");
+    expect(getSelectionAnchorCellXc(model)).toBe("C9");
     expect(model.getters.getEditionMode()).toBe("inactive");
 
     // click on the modified cell C8
     await clickCell(model, "C8");
-    expect(getActiveXc(model)).toBe("C8");
+    expect(getSelectionAnchorCellXc(model)).toBe("C8");
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
 

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -445,7 +445,7 @@ describe("composer", () => {
   test("starting the edition with enter, the composer should have the focus", async () => {
     await startComposition();
     expect(model.getters.getEditionMode()).toBe("editing");
-    expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer")!);
   });
 
@@ -464,18 +464,18 @@ describe("composer", () => {
     expect(composerEl.textContent).toBe("a");
     await keyDown("ArrowRight");
     expect(getCellText(model, "A1")).toBe("a");
-    expect(model.getters.getPosition()).toEqual(toCartesian("B1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
 
     composerEl = await startComposition("b");
     expect(composerEl.textContent).toBe("b");
     await keyDown("ArrowRight");
     expect(getCellText(model, "B1")).toBe("b");
-    expect(model.getters.getPosition()).toEqual(toCartesian("C1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("C1"));
 
     await keyDown("ArrowLeft");
-    expect(model.getters.getPosition()).toEqual(toCartesian("B1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
     await keyDown("ArrowLeft");
-    expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
     composerEl = await startComposition("c");
     expect(composerEl.textContent).toBe("c");
     await keyDown("Enter");
@@ -497,18 +497,18 @@ describe("composer", () => {
     expect(composerEl.textContent).toBe("a");
     await keyDown("ArrowDown");
     expect(getCellText(model, "A1")).toBe("a");
-    expect(model.getters.getPosition()).toEqual(toCartesian("A2"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A2"));
 
     composerEl = await startComposition("b");
     expect(composerEl.textContent).toBe("b");
     await keyDown("ArrowDown");
     expect(getCellText(model, "A2")).toBe("b");
-    expect(model.getters.getPosition()).toEqual(toCartesian("A3"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A3"));
 
     await keyDown("ArrowUp");
-    expect(model.getters.getPosition()).toEqual(toCartesian("A2"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A2"));
     await keyDown("ArrowUp");
-    expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
     composerEl = await startComposition("c");
     expect(composerEl.textContent).toBe("c");
     await keyDown("Enter");

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -38,8 +38,8 @@ afterEach(() => {
   fixture.remove();
 });
 
-function getActiveXc(model: Model): string {
-  const { col, row } = model.getters.getActivePosition();
+function getSelectionAnchorCellXc(model: Model): string {
+  const { col, row } = model.getters.getSelection().anchor.cell;
   return toXC(col, row);
 }
 
@@ -204,16 +204,16 @@ describe("Context Menu", () => {
   });
 
   test("right click on a cell opens a context menu", async () => {
-    expect(getActiveXc(model)).toBe("A1");
+    expect(getSelectionAnchorCellXc(model)).toBe("A1");
     expect(fixture.querySelector(".o-menu")).toBeFalsy();
     await rightClickCell(model, "C8");
-    expect(getActiveXc(model)).toBe("C8");
+    expect(getSelectionAnchorCellXc(model)).toBe("C8");
     expect(fixture.querySelector(".o-menu")).toBeTruthy();
   });
 
   test("right click on a cell, then left click elsewhere closes a context menu", async () => {
     await rightClickCell(model, "C8");
-    expect(getActiveXc(model)).toBe("C8");
+    expect(getSelectionAnchorCellXc(model)).toBe("C8");
     await nextTick();
     expect(fixture.querySelector(".o-menu")).toBeTruthy();
 
@@ -225,7 +225,7 @@ describe("Context Menu", () => {
     setCellContent(model, "B1", "b1");
 
     await rightClickCell(model, "B1");
-    expect(getActiveXc(model)).toBe("B1");
+    expect(getSelectionAnchorCellXc(model)).toBe("B1");
 
     // click on 'copy' menu item
     await simulateClick(".o-menu div[data-name='copy']");
@@ -249,7 +249,7 @@ describe("Context Menu", () => {
     // right click on B2
     await rightClickCell(model, "B2");
     await nextTick();
-    expect(getActiveXc(model)).toBe("B2");
+    expect(getSelectionAnchorCellXc(model)).toBe("B2");
 
     // click on 'paste' menu item
     await simulateClick(".o-menu div[data-name='paste']");

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -39,7 +39,7 @@ afterEach(() => {
 });
 
 function getActiveXc(model: Model): string {
-  const { col, row } = model.getters.getPosition();
+  const { col, row } = model.getters.getActivePosition();
   return toXC(col, row);
 }
 

--- a/tests/components/dashboard_grid.test.ts
+++ b/tests/components/dashboard_grid.test.ts
@@ -8,7 +8,7 @@ import {
 import { Model } from "../../src/model";
 import { createFilter, setCellContent } from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
-import { getActiveXc } from "../test_helpers/getters_helpers";
+import { getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
@@ -33,11 +33,11 @@ describe("Grid component in dashboard mode", () => {
   });
 
   test("Keyboard event are not dispatched in dashboard mode", async () => {
-    expect(getActiveXc(model)).toBe("A1");
+    expect(getSelectionAnchorCellXc(model)).toBe("A1");
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
     );
-    expect(getActiveXc(model)).not.toBe("B1");
+    expect(getSelectionAnchorCellXc(model)).not.toBe("B1");
   });
 
   test("Can click on a link in dashboard mode", async () => {

--- a/tests/components/filter_menu.test.ts
+++ b/tests/components/filter_menu.test.ts
@@ -163,21 +163,21 @@ describe("Filter menu component", () => {
 
     test("Confirm button updates the filter with formatted cell value", async () => {
       setFormat(model, "m/d/yyyy", target("A4"));
-      expect(model.getters.getFilterValues(sheetId, 0, 0)).toEqual([]);
+      expect(model.getters.getFilterValues({ sheetId, col: 0, row: 0 })).toEqual([]);
       await openFilterMenu();
       await simulateClick(".o-filter-menu-value:nth-of-type(2)");
       await simulateClick(".o-filter-menu-value:nth-of-type(3)");
       await simulateClick(".o-filter-menu-button-primary");
-      expect(model.getters.getFilterValues(sheetId, 0, 0)).toEqual(["1", "1/1/1900"]);
+      expect(model.getters.getFilterValues({ sheetId, col: 0, row: 0 })).toEqual(["1", "1/1/1900"]);
     });
 
     test("Cancel button don't save the changes", async () => {
-      expect(model.getters.getFilterValues(sheetId, 0, 0)).toEqual([]);
+      expect(model.getters.getFilterValues({ sheetId, col: 0, row: 0 })).toEqual([]);
       await openFilterMenu();
       await simulateClick(".o-filter-menu-value:nth-of-type(1)");
       await simulateClick(".o-filter-menu-value:nth-of-type(2)");
       await simulateClick(".o-filter-menu-button-cancel");
-      expect(model.getters.getFilterValues(sheetId, 0, 0)).toEqual([]);
+      expect(model.getters.getFilterValues({ sheetId, col: 0, row: 0 })).toEqual([]);
     });
 
     test("Can clear and select all", async () => {

--- a/tests/components/grid_manipulation.test.ts
+++ b/tests/components/grid_manipulation.test.ts
@@ -4,7 +4,7 @@ import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { Model } from "../../src/model";
 import { selectColumn, selectRow } from "../test_helpers/commands_helpers";
 import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { getActiveXc } from "../test_helpers/getters_helpers";
+import { getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 
 const COLUMN_D = { x: 340, y: 10 };
@@ -37,7 +37,7 @@ describe("Context Menu add/remove row/col", () => {
   test("can open contextmenu for columns then click elsewhere to close it", async () => {
     expect(fixture.querySelector(".o-menu")).toBeFalsy();
     simulateContextMenu(".o-col-resizer", COLUMN_D);
-    expect(getActiveXc(model)).toBe("D1");
+    expect(getSelectionAnchorCellXc(model)).toBe("D1");
     await nextTick();
     expect(fixture.querySelector(".o-menu")).toBeTruthy();
     await simulateClick(".o-grid-overlay", OUTSIDE_CM.x, OUTSIDE_CM.y);
@@ -47,7 +47,7 @@ describe("Context Menu add/remove row/col", () => {
   test("can open contextmenu for rows then click elsewhere to close it", async () => {
     expect(fixture.querySelector(".o-menu")).toBeFalsy();
     simulateContextMenu(".o-row-resizer", ROW_5);
-    expect(getActiveXc(model)).toBe("A5");
+    expect(getSelectionAnchorCellXc(model)).toBe("A5");
     await nextTick();
     expect(fixture.querySelector(".o-menu")).toBeTruthy();
     await simulateClick(".o-grid-overlay", OUTSIDE_CM.x, OUTSIDE_CM.y);

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -20,7 +20,7 @@ import {
   undo,
 } from "../test_helpers/commands_helpers";
 import { edgeScrollDelay, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { getActiveXc, getEvaluatedCell } from "../test_helpers/getters_helpers";
+import { getEvaluatedCell, getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
@@ -164,30 +164,30 @@ describe("Resizer component", () => {
   test("can click on a header to select a column", async () => {
     await selectColumn("C");
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 2, top: 0, right: 2, bottom: 9 });
-    expect(getActiveXc(model)).toBe("C1");
+    expect(getSelectionAnchorCellXc(model)).toBe("C1");
     expect(model.getters.getSelectedZones()).toEqual([toZone("C1:C10")]);
   });
 
   test("resizing a column does not change the selection", async () => {
     const index = lettersToNumber("C");
     const x = model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
-    expect(getActiveXc(model)).toBe("A1");
+    expect(getSelectionAnchorCellXc(model)).toBe("A1");
     triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", x, 10);
     await nextTick();
-    expect(getActiveXc(model)).toBe("A1");
+    expect(getSelectionAnchorCellXc(model)).toBe("A1");
     triggerMouseEvent(".o-overlay .o-col-resizer .o-handle", "mousedown", x, 10);
     triggerMouseEvent(window, "mousemove", x + 50, 10);
     await nextTick();
-    expect(getActiveXc(model)).toBe("A1");
+    expect(getSelectionAnchorCellXc(model)).toBe("A1");
     triggerMouseEvent(window, "mouseup", x + 50, 10);
     await nextTick();
-    expect(getActiveXc(model)).toBe("A1");
+    expect(getSelectionAnchorCellXc(model)).toBe("A1");
   });
 
   test("can click on a row-header to select a row", async () => {
     await selectRow(2);
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 2, right: 9, bottom: 2 });
-    expect(getActiveXc(model)).toBe("A3");
+    expect(getSelectionAnchorCellXc(model)).toBe("A3");
   });
 
   test("can select multiple rows/cols", async () => {
@@ -197,13 +197,13 @@ describe("Resizer component", () => {
     await selectRow(3, { ctrlKey: true });
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 2, right: 9, bottom: 2 });
     expect(model.getters.getSelectedZones()[1]).toEqual({ left: 0, top: 3, right: 9, bottom: 3 });
-    expect(getActiveXc(model)).toBe("A4");
+    expect(getSelectionAnchorCellXc(model)).toBe("A4");
 
     await selectColumn("C", { ctrlKey: true });
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 2, right: 9, bottom: 2 });
     expect(model.getters.getSelectedZones()[1]).toEqual({ left: 0, top: 3, right: 9, bottom: 3 });
     expect(model.getters.getSelectedZones()[2]).toEqual({ left: 2, top: 0, right: 2, bottom: 9 });
-    expect(getActiveXc(model)).toBe("C1");
+    expect(getSelectionAnchorCellXc(model)).toBe("C1");
   });
 
   test("Can resize a column", async () => {
@@ -231,7 +231,7 @@ describe("Resizer component", () => {
     await selectColumn("D", { ctrlKey: true });
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 2, top: 0, right: 2, bottom: 9 });
     expect(model.getters.getSelectedZones()[1]).toEqual({ left: 3, top: 0, right: 3, bottom: 9 });
-    expect(getActiveXc(model)).toBe("D1");
+    expect(getSelectionAnchorCellXc(model)).toBe("D1");
 
     await resizeColumn("D", 50);
     expect(model.getters.getColSize(model.getters.getActiveSheetId(), 1)).toBe(
@@ -256,7 +256,7 @@ describe("Resizer component", () => {
     await selectRow(3, { ctrlKey: true });
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 2, right: 9, bottom: 2 });
     expect(model.getters.getSelectedZones()[1]).toEqual({ left: 0, top: 3, right: 9, bottom: 3 });
-    expect(getActiveXc(model)).toBe("A4");
+    expect(getSelectionAnchorCellXc(model)).toBe("A4");
 
     await resizeRow(3, 50);
     expect(model.getters.getRowSize(model.getters.getActiveSheetId(), 1)).toBe(
@@ -339,7 +339,7 @@ describe("Resizer component", () => {
   test("can select the entire sheet", async () => {
     triggerMouseEvent(".o-overlay .all", "mousedown", 5, 5);
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 0, right: 9, bottom: 9 });
-    expect(getActiveXc(model)).toBe("A1");
+    expect(getSelectionAnchorCellXc(model)).toBe("A1");
   });
 
   test("Mousemove hover something else than a header", async () => {

--- a/tests/formulas/formulas.test.ts
+++ b/tests/formulas/formulas.test.ts
@@ -2,11 +2,12 @@ import { Model } from "../../src";
 import { INCORRECT_RANGE_STRING } from "../../src/constants";
 import { FormulaCell } from "../../src/types";
 import { createSheetWithName, setCellContent } from "../test_helpers/commands_helpers";
+import { getCell } from "../test_helpers/getters_helpers";
 
 function moveFormula(model: Model, formula: string, offsetX: number, offsetY: number): string {
   const sheetId = model.getters.getActiveSheetId();
   setCellContent(model, "A1", formula);
-  const cell = model.getters.getCell(sheetId, 0, 0) as FormulaCell;
+  const cell = getCell(model, "A1") as FormulaCell;
   const newDependencies = model.getters.createAdaptedRanges(
     cell.dependencies,
     offsetX,

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -6,7 +6,7 @@ import { UIPlugin } from "../src/plugins/ui_plugin";
 import { Command, CoreCommand, coreTypes, DispatchResult } from "../src/types";
 import { setupCollaborativeEnv } from "./collaborative/collaborative_helpers";
 import { copy, selectCell, setCellContent } from "./test_helpers/commands_helpers";
-import { getCellContent, getCellText } from "./test_helpers/getters_helpers";
+import { getCell, getCellContent, getCellText } from "./test_helpers/getters_helpers";
 
 describe("Model", () => {
   test("core plugin can refuse command from UI plugin", () => {
@@ -112,6 +112,19 @@ describe("Model", () => {
   test("Can add custom elements in the config of model", () => {
     const model = new Model({}, { custom: "42" } as unknown as ModelConfig);
     expect(model["config"]["custom"]).toBe("42");
+  });
+
+  test("type property in command payload is ignored", () => {
+    const model = new Model();
+    const payload = {
+      col: 0,
+      row: 0,
+      sheetId: model.getters.getActiveSheetId(),
+      content: "hello",
+      type: "greeting",
+    };
+    model.dispatch("UPDATE_CELL", payload);
+    expect(getCell(model, "A1")?.content).toBe("hello");
   });
 
   test("Cannot add an already existing core getters", () => {

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -13,7 +13,14 @@ import {
   setCellContent,
   setSelection,
 } from "../test_helpers/commands_helpers";
-import { getCell, getCellContent, getCellText, getMerges } from "../test_helpers/getters_helpers"; // to have getcontext mocks
+import {
+  getBorder,
+  getCell,
+  getCellContent,
+  getCellText,
+  getMerges,
+  getStyle,
+} from "../test_helpers/getters_helpers"; // to have getcontext mocks
 import "../test_helpers/helpers";
 import {
   getMergeCellMap,
@@ -128,7 +135,7 @@ describe("Autofill", () => {
     autofill("A1", "A2");
     const cell = getCell(model, "A2")!;
     expect(cell.style).toEqual(style);
-    expect(model.getters.getCellBorder(sheetId, 0, 1)).toEqual(border);
+    expect(getBorder(model, "A2")).toEqual(border);
     expect(cell.format).toBe("m/d/yyyy");
   });
 
@@ -160,32 +167,23 @@ describe("Autofill", () => {
       sheetId,
       ranges: toRangesData(sheetId, cf.ranges.join(",")),
     });
-    let col: number, row: number;
-    ({ col, row } = toCartesian("A1"));
-    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
-    ({ col, row } = toCartesian("A2"));
-    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({
+    expect(getStyle(model, "A2")).toEqual({
       fillColor: "#FF0000",
     });
-    ({ col, row } = toCartesian("A3"));
-    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({});
-    ({ col, row } = toCartesian("A4"));
-    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({});
+    expect(getStyle(model, "A3")).toEqual({});
+    expect(getStyle(model, "A4")).toEqual({});
     autofill("A1:A4", "A8");
-    ({ col, row } = toCartesian("A5"));
-    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({
+    expect(getStyle(model, "A5")).toEqual({
       fillColor: "#FF0000",
     });
-    ({ col, row } = toCartesian("A6"));
-    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({
+    expect(getStyle(model, "A6")).toEqual({
       fillColor: "#FF0000",
     });
-    ({ col, row } = toCartesian("A7"));
-    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({});
-    ({ col, row } = toCartesian("A8"));
-    expect(model.getters.getCellComputedStyle(sheetId, col, row)).toEqual({});
+    expect(getStyle(model, "A7")).toEqual({});
+    expect(getStyle(model, "A8")).toEqual({});
   });
 
   describe("Autofill multiple values", () => {
@@ -404,7 +402,7 @@ describe("Autofill", () => {
       autofill("A1", "A2");
       const cell = getCell(model, "A2")!;
       expect(cell.style).toBeUndefined();
-      expect(model.getters.getCellBorder(sheetId, col, row)).toBeNull();
+      expect(getBorder(model, "A2")).toBeNull();
       expect(cell.format).toBeUndefined();
       expect(cell["content"]).toBe("1");
     });
@@ -447,8 +445,8 @@ describe("Autofill", () => {
     autofill("A1", "A3");
     expect(getCell(model, "A2")).toBeUndefined();
     expect(getCell(model, "A3")).toBeUndefined();
-    expect(model.getters.getCellBorder(sheetId, 0, 1)).toBeNull();
-    expect(model.getters.getCellBorder(sheetId, 0, 2)).toBeNull();
+    expect(getBorder(model, "A2")).toBeNull();
+    expect(getBorder(model, "A3")).toBeNull();
   });
 
   test("Auto-autofill left", () => {

--- a/tests/plugins/borders.test.ts
+++ b/tests/plugins/borders.test.ts
@@ -523,7 +523,7 @@ test("Cells that have undefined borders don't override borders of neighboring ce
     },
   };
   const model = new Model(data);
-  expect(model.getters.getCellBorder("Sheet1", 1, 1)).toEqual({
+  expect(getBorder(model, "B2", "Sheet1")).toEqual({
     top: ["thin", "#000"],
     bottom: ["thin", "#000"],
     left: ["thin", "#000"],

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -1,3 +1,4 @@
+import { toCartesian } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult, ConditionalFormattingOperatorValues, UID } from "../../src/types";
 import {
@@ -14,12 +15,8 @@ import {
   setStyle,
   undo,
 } from "../test_helpers/commands_helpers";
-import {
-  createColorScale,
-  createEqualCF,
-  toCartesianArray,
-  toRangesData,
-} from "../test_helpers/helpers";
+import { getStyle } from "../test_helpers/getters_helpers";
+import { createColorScale, createEqualCF, toRangesData } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
 let model: Model;
@@ -72,12 +69,12 @@ describe("conditional format", () => {
         ranges: ["A:A"],
       },
     ]);
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({});
+    expect(getStyle(model, "A2")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
+    expect(getStyle(model, "A3")).toEqual({});
+    expect(getStyle(model, "A4")).toEqual({
       fillColor: "#0000FF",
     });
   });
@@ -93,17 +90,17 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1, A2"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+    expect(getStyle(model, "A2")).toEqual({
       fillColor: "#FF0000",
       bold: true,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
+    expect(getStyle(model, "A3")).toEqual({
       fillColor: "orange",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({});
+    expect(getStyle(model, "A4")).toEqual({});
   });
 
   test("Add conditional formatting on inactive sheet", () => {
@@ -205,24 +202,24 @@ describe("conditional format", () => {
         ranges: ["A1:A4"],
       },
     ]);
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({});
+    expect(getStyle(model, "A2")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
+    expect(getStyle(model, "A3")).toEqual({});
+    expect(getStyle(model, "A4")).toEqual({
       fillColor: "#0000FF",
     });
     model.dispatch("REMOVE_CONDITIONAL_FORMAT", {
       id: "2",
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({});
+    expect(getStyle(model, "A2")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({});
+    expect(getStyle(model, "A3")).toEqual({});
+    expect(getStyle(model, "A4")).toEqual({});
   });
 
   test("works on multiple ranges", () => {
@@ -233,10 +230,10 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1, A2"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+    expect(getStyle(model, "A2")).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -249,24 +246,24 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1, A2"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+    expect(getStyle(model, "A2")).toEqual({
       fillColor: "#FF0000",
     });
 
     undo(model);
 
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({});
+    expect(getStyle(model, "A1")).toEqual({});
+    expect(getStyle(model, "A2")).toEqual({});
 
     redo(model);
 
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+    expect(getStyle(model, "A2")).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -289,10 +286,10 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "B1,B2"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({
+    expect(getStyle(model, "B1")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({
+    expect(getStyle(model, "B2")).toEqual({
       fillColor: "#FF0000",
     });
     addColumns(model, "after", "A", 1);
@@ -308,12 +305,12 @@ describe("conditional format", () => {
         },
       },
     ]);
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({
+    expect(getStyle(model, "B1")).toEqual({});
+    expect(getStyle(model, "B2")).toEqual({});
+    expect(getStyle(model, "C1")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({
+    expect(getStyle(model, "C2")).toEqual({
       fillColor: "#FF0000",
     });
 
@@ -330,22 +327,22 @@ describe("conditional format", () => {
         },
       },
     ]);
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({
+    expect(getStyle(model, "B1")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({
+    expect(getStyle(model, "B2")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({});
+    expect(getStyle(model, "C1")).toEqual({});
+    expect(getStyle(model, "C2")).toEqual({});
 
     redo(model);
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B1"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C1"))).toEqual({
+    expect(getStyle(model, "B1")).toEqual({});
+    expect(getStyle(model, "B2")).toEqual({});
+    expect(getStyle(model, "C1")).toEqual({
       fillColor: "#FF0000",
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))).toEqual({
+    expect(getStyle(model, "C2")).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -381,15 +378,15 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+    expect(getStyle(model, "A1")).toEqual({});
     setCellContent(model, "A1", "2");
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
     setCellContent(model, "A1", "1");
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+    expect(getStyle(model, "A1")).toEqual({});
     setCellContent(model, "A1", "=A2");
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -402,7 +399,7 @@ describe("conditional format", () => {
       sheetId,
     });
     setCellContent(model, "A1", "=BLA");
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+    expect(getStyle(model, "A1")).toEqual({});
   });
 
   test("multiple conditional formats for one cell", () => {
@@ -417,7 +414,7 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
       textColor: "#445566",
     });
@@ -435,7 +432,7 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -462,7 +459,7 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -474,7 +471,7 @@ describe("conditional format", () => {
       sheetId,
     });
     expect(result).toBeSuccessfullyDispatched();
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
   });
@@ -516,11 +513,9 @@ describe("conditional format", () => {
         { id: "6", ranges: ["F1:F2"], rule },
         { id: "7", ranges: ["G1:G2"], rule },
       ]);
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
-      expect(
-        model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C2"))!.fillColor
-      ).toBe("orange");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C3"))).toEqual({});
+      expect(getStyle(model, "B2")).toEqual({});
+      expect(getStyle(model, "C2")!.fillColor).toBe("orange");
+      expect(getStyle(model, "C3")).toEqual({});
     });
     test("On column deletion", () => {
       model = new Model({
@@ -556,11 +551,9 @@ describe("conditional format", () => {
         { id: "8", ranges: ["A7", "B7"], rule },
         { id: "9", ranges: ["A7", "B7"], rule },
       ]);
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B2"))).toEqual({});
-      expect(
-        model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B3"))!.fillColor
-      ).toBe("orange");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C3"))).toEqual({});
+      expect(getStyle(model, "B2")).toEqual({});
+      expect(getStyle(model, "B3")!.fillColor).toBe("orange");
+      expect(getStyle(model, "C3")).toEqual({});
     });
     test("On column addition", () => {
       model = new Model({
@@ -588,10 +581,8 @@ describe("conditional format", () => {
         { id: "3", ranges: ["C3:F3"], rule },
         { id: "4", ranges: ["C4"], rule },
       ]);
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("B4"))).toEqual({});
-      expect(
-        model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("C4"))!.fillColor
-      ).toBe("orange");
+      expect(getStyle(model, "B4")).toEqual({});
+      expect(getStyle(model, "C4")!.fillColor).toBe("orange");
     });
     test("On row addition", () => {
       model = new Model({
@@ -619,10 +610,8 @@ describe("conditional format", () => {
         { id: "3", ranges: ["C3:C6"], rule },
         { id: "4", ranges: ["D3"], rule },
       ]);
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("D2"))).toEqual({});
-      expect(
-        model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("D3"))!.fillColor
-      ).toBe("orange");
+      expect(getStyle(model, "D2")).toEqual({});
+      expect(getStyle(model, "D3")!.fillColor).toBe("orange");
     });
   });
 
@@ -718,11 +707,11 @@ describe("conditional format", () => {
       ranges: toRangesData(sheetId, "A1"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });
     moveConditionalFormat(model, idRule1, "down", sheetId);
-    expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#0000FF",
     });
   });
@@ -754,7 +743,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
 
       test.each([
@@ -778,7 +767,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
     });
 
@@ -798,25 +787,25 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "0");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "1");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "1.5");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "3");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "3.5");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
     });
 
     describe("Operator ContainsText", () => {
@@ -844,7 +833,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
 
       test.each([
@@ -869,7 +858,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
     });
 
@@ -896,7 +885,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
 
       test.each([
@@ -920,7 +909,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
     });
 
@@ -939,13 +928,13 @@ describe("conditional formats types", () => {
         sheetId,
       });
       setCellContent(model, "A1", "5");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "12");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "13");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -966,15 +955,15 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "5");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "12");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "13");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -995,13 +984,13 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "11");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "10");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "9");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -1022,15 +1011,15 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "11");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "10");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "9");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -1051,23 +1040,23 @@ describe("conditional formats types", () => {
       });
 
       setCellContent(model, "A1", "4");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "0");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "5");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "10");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "10.1");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -1086,15 +1075,15 @@ describe("conditional formats types", () => {
         ranges: toRangesData(sheetId, "A1"),
         sheetId,
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "hellqsdfo");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "hello");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -1123,7 +1112,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
 
       test.each([
@@ -1147,7 +1136,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
     });
 
@@ -1173,7 +1162,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
 
       test.each([
@@ -1198,7 +1187,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
 
       test.each([
@@ -1223,7 +1212,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
     });
 
@@ -1249,7 +1238,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
 
       test.each([
@@ -1274,7 +1263,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
 
       test.each([
@@ -1299,7 +1288,7 @@ describe("conditional formats types", () => {
         });
         setCellContent(model, "A1", cellContent);
         const computedStyle = shouldMatch ? { fillColor: "#ff0f0f" } : {};
-        expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual(computedStyle);
+        expect(getStyle(model, "A1")).toEqual(computedStyle);
       });
     });
 
@@ -1318,31 +1307,31 @@ describe("conditional formats types", () => {
         sheetId,
       });
       setCellContent(model, "A1", "");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", " ");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A2", "");
       setCellContent(model, "A1", "=A2");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", '=""');
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", '=" "');
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
 
       setCellContent(model, "A1", "helabclo");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
     });
 
     test("Operator IsNotEmpty", () => {
@@ -1360,13 +1349,13 @@ describe("conditional formats types", () => {
         sheetId,
       });
       setCellContent(model, "A1", "");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", " ");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
 
       setCellContent(model, "A1", "helabclo");
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#ff0f0f",
       });
     });
@@ -1521,7 +1510,7 @@ describe("conditional formats types", () => {
       sheetId,
     });
     setCellContent(model, "A1", "=B1");
-    expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual({
+    expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0FFF",
     });
   });
@@ -1648,8 +1637,8 @@ describe("conditional formats types", () => {
         ranges: toRangesData(sheetId, "A1"),
         sheetId,
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A1"))).toEqual("arrowNeutral");
+      expect(getStyle(model, "A1")).toEqual({});
+      expect(model.getters.getConditionalIcon(toCartesian("A1"))).toEqual("arrowNeutral");
     });
 
     test.each(["hello", "TRUE", "=TRUE", `="hello"`, ""])(
@@ -1673,8 +1662,8 @@ describe("conditional formats types", () => {
           ranges: toRangesData(sheetId, "A1"),
           sheetId,
         });
-        expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
-        expect(model.getters.getConditionalIcon(...toCartesianArray("A1"))).toBeUndefined();
+        expect(getStyle(model, "A1")).toEqual({});
+        expect(model.getters.getConditionalIcon(toCartesian("A1"))).toBeUndefined();
       }
     );
 
@@ -1703,11 +1692,11 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A1"))).toEqual("arrowBad");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A2"))).toEqual("arrowBad");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A3"))).toEqual("arrowNeutral");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A4"))).toEqual("arrowNeutral");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A5"))).toEqual("arrowGood");
+      expect(model.getters.getConditionalIcon(toCartesian("A1"))).toEqual("arrowBad");
+      expect(model.getters.getConditionalIcon(toCartesian("A2"))).toEqual("arrowBad");
+      expect(model.getters.getConditionalIcon(toCartesian("A3"))).toEqual("arrowNeutral");
+      expect(model.getters.getConditionalIcon(toCartesian("A4"))).toEqual("arrowNeutral");
+      expect(model.getters.getConditionalIcon(toCartesian("A5"))).toEqual("arrowGood");
     });
 
     test("2 points with 'ge', value scale", () => {
@@ -1735,11 +1724,11 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A1"))).toEqual("arrowBad");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A2"))).toEqual("arrowNeutral");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A3"))).toEqual("arrowNeutral");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A4"))).toEqual("arrowGood");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A5"))).toEqual("arrowGood");
+      expect(model.getters.getConditionalIcon(toCartesian("A1"))).toEqual("arrowBad");
+      expect(model.getters.getConditionalIcon(toCartesian("A2"))).toEqual("arrowNeutral");
+      expect(model.getters.getConditionalIcon(toCartesian("A3"))).toEqual("arrowNeutral");
+      expect(model.getters.getConditionalIcon(toCartesian("A4"))).toEqual("arrowGood");
+      expect(model.getters.getConditionalIcon(toCartesian("A5"))).toEqual("arrowGood");
     });
 
     test("same upper and lower inflection point", () => {
@@ -1767,11 +1756,11 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A1"))).toEqual("arrowBad");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A2"))).toEqual("arrowBad");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A3"))).toEqual("arrowBad");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A4"))).toEqual("arrowBad");
-      expect(model.getters.getConditionalIcon(...toCartesianArray("A5"))).toEqual("arrowGood");
+      expect(model.getters.getConditionalIcon(toCartesian("A1"))).toEqual("arrowBad");
+      expect(model.getters.getConditionalIcon(toCartesian("A2"))).toEqual("arrowBad");
+      expect(model.getters.getConditionalIcon(toCartesian("A3"))).toEqual("arrowBad");
+      expect(model.getters.getConditionalIcon(toCartesian("A4"))).toEqual("arrowBad");
+      expect(model.getters.getConditionalIcon(toCartesian("A5"))).toEqual("arrowGood");
     });
   });
   describe("color scale", () => {
@@ -1898,7 +1887,7 @@ describe("conditional formats types", () => {
         ranges: toRangesData(sheetId, "A1"),
         sheetId,
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
     });
 
     test("2 points, value scale", () => {
@@ -1918,19 +1907,19 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#FF00FF",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+      expect(getStyle(model, "A2")).toEqual({
         fillColor: "#E705EE",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
+      expect(getStyle(model, "A3")).toEqual({
         fillColor: "#592489",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
+      expect(getStyle(model, "A4")).toEqual({
         fillColor: "#2A2F67",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A5"))).toEqual({
+      expect(getStyle(model, "A5")).toEqual({
         fillColor: "#123456",
       });
     });
@@ -1952,19 +1941,19 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#FF00FF",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+      expect(getStyle(model, "A2")).toEqual({
         fillColor: "#E705EE",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
+      expect(getStyle(model, "A3")).toEqual({
         fillColor: "#592489",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
+      expect(getStyle(model, "A4")).toEqual({
         fillColor: "#2A2F67",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A5"))).toEqual({
+      expect(getStyle(model, "A5")).toEqual({
         fillColor: "#123456",
       });
     });
@@ -1986,19 +1975,19 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#FF00FF",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+      expect(getStyle(model, "A2")).toEqual({
         fillColor: "#E705EE",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
+      expect(getStyle(model, "A3")).toEqual({
         fillColor: "#592489",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A4"))).toEqual({
+      expect(getStyle(model, "A4")).toEqual({
         fillColor: "#2A2F67",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A5"))).toEqual({
+      expect(getStyle(model, "A5")).toEqual({
         fillColor: "#123456",
       });
     });
@@ -2018,13 +2007,13 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({
+      expect(getStyle(model, "A1")).toEqual({
         fillColor: "#808000",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({
+      expect(getStyle(model, "A2")).toEqual({
         fillColor: "#FF0000",
       });
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A3"))).toEqual({
+      expect(getStyle(model, "A3")).toEqual({
         fillColor: "#00FF00",
       });
     });
@@ -2042,8 +2031,8 @@ describe("conditional formats types", () => {
         sheetId,
       });
 
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A1"))).toEqual({});
-      expect(model.getters.getCellComputedStyle(sheetId, ...toCartesianArray("A2"))).toEqual({});
+      expect(getStyle(model, "A1")).toEqual({});
+      expect(getStyle(model, "A2")).toEqual({});
     });
 
     test("CF is not updated with insert/delete cells", () => {
@@ -2074,9 +2063,9 @@ describe("conditional formats types", () => {
         ranges: toRangesData(sheetId, "A1:A3"),
         sheetId,
       });
-      expect(model.getters.getCellComputedStyle(sheetId, 0, 0)).toEqual({ fillColor: "#123456" });
-      expect(model.getters.getCellComputedStyle(sheetId, 0, 1)).toEqual({});
-      expect(model.getters.getCellComputedStyle(sheetId, 0, 2)).toEqual({ fillColor: "#FF00FF" });
+      expect(getStyle(model, "A1")).toEqual({ fillColor: "#123456" });
+      expect(getStyle(model, "A2")).toEqual({});
+      expect(getStyle(model, "A3")).toEqual({ fillColor: "#FF00FF" });
     });
   });
 });

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -391,7 +391,7 @@ describe("core", () => {
   test("core cell getter does not crash if invalid col/row", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
-    expect(model.getters.getCell(sheetId, -1, -1)).toBeUndefined();
+    expect(model.getters.getCell({ sheetId, col: -1, row: -1 })).toBeUndefined();
   });
 
   test("single cell XC conversion", () => {

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -486,7 +486,7 @@ describe("edition", () => {
 
   test("set value of the active cell updates the content", () => {
     const model = new Model();
-    expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
     setCellContent(model, "A1", "Hello sir");
     expect(model.getters.getCurrentContent()).toBe("Hello sir");
   });

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -1,4 +1,4 @@
-import { toCartesian, toZone } from "../../src/helpers";
+import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
@@ -17,7 +17,12 @@ import {
   setCellContent,
   setSelection,
 } from "../test_helpers/commands_helpers";
-import { getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers"; // to have getcontext mocks
+import {
+  getActivePosition,
+  getCell,
+  getCellContent,
+  getCellText,
+} from "../test_helpers/getters_helpers"; // to have getcontext mocks
 import "../test_helpers/helpers";
 import { target } from "../test_helpers/helpers";
 
@@ -486,7 +491,7 @@ describe("edition", () => {
 
   test("set value of the active cell updates the content", () => {
     const model = new Model();
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
+    expect(getActivePosition(model)).toBe("A1");
     setCellContent(model, "A1", "Hello sir");
     expect(model.getters.getCurrentContent()).toBe("Hello sir");
   });
@@ -505,8 +510,7 @@ describe("edition", () => {
     const model = new Model();
     setCellContent(model, "A1", "Hello sir");
     expect(model.getters.getCurrentContent()).toBe("Hello sir");
-    const { col, row } = toCartesian("A2");
-    expect(model.getters.getCell(model.getters.getActiveSheetId(), col, row)).toBeUndefined();
+    expect(getCell(model, "A2")).toBeUndefined();
     selectCell(model, "A2");
     expect(model.getters.getCurrentContent()).toBe("");
   });
@@ -577,8 +581,7 @@ describe("edition", () => {
 
   test("select an empty cell, start selecting mode at the composer position", () => {
     const model = new Model();
-    const { col, row } = toCartesian("A2");
-    expect(model.getters.getCell(model.getters.getActiveSheetId(), col, row)).toBeUndefined();
+    expect(getCell(model, "A2")).toBeUndefined();
     selectCell(model, "A2");
     model.dispatch("START_EDITION", { text: "=" });
     moveAnchorCell(model, "right");

--- a/tests/plugins/filter_evaluation.test.ts
+++ b/tests/plugins/filter_evaluation.test.ts
@@ -107,7 +107,7 @@ describe("Filter Evaluation Plugin", () => {
     const zone = toZone("A7:B9");
     for (let row = zone.top; row <= zone.bottom; row++) {
       for (let col = zone.left; col <= zone.right; col++) {
-        const filterBorder = model.getters.getCellBorderWithFilterBorder(sheetId, col, row);
+        const filterBorder = model.getters.getCellBorderWithFilterBorder({ sheetId, col, row });
         const expected = {};
         expected["top"] = row === zone.top ? DEFAULT_FILTER_BORDER_DESC : undefined;
         expected["bottom"] = row === zone.bottom ? DEFAULT_FILTER_BORDER_DESC : undefined;
@@ -123,7 +123,7 @@ describe("Filter Evaluation Plugin", () => {
     createFilter(model, "A7:A9");
     const zone = toZone("A7:A9");
     for (let row = zone.top; row <= zone.bottom; row++) {
-      const filterBorder = model.getters.getCellBorderWithFilterBorder(sheetId, 0, row);
+      const filterBorder = model.getters.getCellBorderWithFilterBorder({ sheetId, col: 0, row });
       const expected = {
         top: row === zone.top ? DEFAULT_FILTER_BORDER_DESC : undefined,
         bottom: row === zone.bottom ? DEFAULT_FILTER_BORDER_DESC : undefined,
@@ -142,7 +142,7 @@ describe("Filter Evaluation Plugin", () => {
     const zone = toZone("C8:D12");
     for (let row = zone.top; row <= zone.bottom; row++) {
       for (let col = zone.left; col <= zone.right; col++) {
-        const filterBorder = model.getters.getCellBorderWithFilterBorder(sheetId, col, row);
+        const filterBorder = model.getters.getCellBorderWithFilterBorder({ sheetId, col, row });
         const expected = {};
         expected["top"] = row === zone.top ? DEFAULT_FILTER_BORDER_DESC : undefined;
         expected["bottom"] = row === zone.bottom ? DEFAULT_FILTER_BORDER_DESC : undefined;
@@ -155,12 +155,12 @@ describe("Filter Evaluation Plugin", () => {
 
   test("Sheet duplication after importing filter don't break", () => {
     const model = new Model({ sheets: [{ id: "sh1", filterTables: [{ range: "A1:A8" }] }] });
-    expect(model.getters.getFilter("sh1", 0, 0)).toBeTruthy();
+    expect(model.getters.getFilter({ sheetId: "sh1", col: 0, row: 0 })).toBeTruthy();
 
     model.dispatch("DUPLICATE_SHEET", {
       sheetId: "sh1",
       sheetIdTo: "sh2",
     });
-    expect(model.getters.getFilter("sh2", 0, 0)).toBeTruthy();
+    expect(model.getters.getFilter({ sheetId: "sh2", col: 0, row: 0 })).toBeTruthy();
   });
 });

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -8,7 +8,7 @@ import {
   setSelection,
   setViewportOffset,
 } from "../test_helpers/commands_helpers";
-import { getCellContent, getCellText } from "../test_helpers/getters_helpers";
+import { getActivePosition, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 
 let model: Model;
 let searchOptions: SearchOptions;
@@ -185,7 +185,7 @@ describe("next/previous cycle", () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
     let matches = model.getters.getSearchMatches();
     let matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 0 });
+    expect(getActivePosition(model)).toBe("A1");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(0);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
@@ -195,7 +195,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 1 });
+    expect(getActivePosition(model)).toBe("A2");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(1);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -205,7 +205,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 2 });
+    expect(getActivePosition(model)).toBe("A3");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(2);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -215,7 +215,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 0 });
+    expect(getActivePosition(model)).toBe("A1");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(0);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
@@ -225,7 +225,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 1 });
+    expect(getActivePosition(model)).toBe("A2");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(1);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -236,7 +236,7 @@ describe("next/previous cycle", () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
     let matches = model.getters.getSearchMatches();
     let matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 0 });
+    expect(getActivePosition(model)).toBe("A1");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(0);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
@@ -246,7 +246,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 2 });
+    expect(getActivePosition(model)).toBe("A3");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(2);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -256,7 +256,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 1 });
+    expect(getActivePosition(model)).toBe("A2");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(1);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -266,7 +266,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 0 });
+    expect(getActivePosition(model)).toBe("A1");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(0);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
@@ -276,7 +276,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 2 });
+    expect(getActivePosition(model)).toBe("A3");
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(2);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -185,7 +185,7 @@ describe("next/previous cycle", () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
     let matches = model.getters.getSearchMatches();
     let matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 0 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 0 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(0);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
@@ -195,7 +195,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 1 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 1 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(1);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -205,7 +205,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 2 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 2 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(2);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -215,7 +215,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 0 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 0 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(0);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
@@ -225,7 +225,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 1 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 1 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(1);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -236,7 +236,7 @@ describe("next/previous cycle", () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
     let matches = model.getters.getSearchMatches();
     let matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 0 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 0 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(0);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
@@ -246,7 +246,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 2 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 2 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(2);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -256,7 +256,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 1 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 1 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(1);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });
@@ -266,7 +266,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 0 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 0 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(0);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
@@ -276,7 +276,7 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(model.getters.getPosition()).toStrictEqual({ col: 0, row: 2 });
+    expect(model.getters.getActivePosition()).toStrictEqual({ col: 0, row: 2 });
     expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(2);
     expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: false });

--- a/tests/plugins/import_export.test.ts
+++ b/tests/plugins/import_export.test.ts
@@ -629,7 +629,7 @@ test("can import cells outside sheet size", () => {
   expect(model.getters.getNumberCols(sheetId)).toBe(26);
   const { col, row } = toCartesian("Z100");
 
-  expect(model.getters.getCell(sheetId, col, row)?.content).toBe("hello");
+  expect(model.getters.getCell({ sheetId, col, row })?.content).toBe("hello");
 });
 
 test("Data of a duplicate sheet are correctly duplicated", () => {

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -21,12 +21,12 @@ import {
 } from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
 import {
-  getActiveXc,
   getBorder,
   getCell,
   getCellContent,
   getEvaluatedCell,
   getMerges,
+  getSelectionAnchorCellXc,
   getStyle,
 } from "../test_helpers/getters_helpers";
 import {
@@ -101,8 +101,8 @@ describe("merges", () => {
       { ...toZone("C2:C3"), id: 2, topLeft: toCartesian("C2") },
       { ...toZone("B2:B3"), id: 3, topLeft: toCartesian("B2") },
     ]);
-    expect(model.getters.getMerge(secondSheetId, 2, 1)?.id).toBe(2);
-    expect(model.getters.getMerge(secondSheetId, 1, 1)?.id).toBe(3);
+    expect(model.getters.getMerge({ sheetId: secondSheetId, col: 2, row: 1 })?.id).toBe(2);
+    expect(model.getters.getMerge({ sheetId: secondSheetId, col: 1, row: 1 })?.id).toBe(3);
   });
 
   test("delete a duplicated sheet with merge", () => {
@@ -143,7 +143,7 @@ describe("merges", () => {
     expect(merge(model, "A1:C3")).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
     const { col, row } = toCartesian("A1");
 
-    expect(model.getters.getMerge(sheetId, col, row)).toBeUndefined();
+    expect(model.getters.getMerge({ sheetId, col, row })).toBeUndefined();
   });
 
   test("editing a merge cell actually edits the top left", () => {
@@ -159,7 +159,7 @@ describe("merges", () => {
     });
 
     selectCell(model, "C3");
-    expect(getActiveXc(model)).toBe("C3");
+    expect(getSelectionAnchorCellXc(model)).toBe("C3");
     model.dispatch("START_EDITION");
     expect(model.getters.getCurrentContent()).toBe("b2");
     model.dispatch("SET_CURRENT_CONTENT", { content: "new value" });
@@ -180,7 +180,7 @@ describe("merges", () => {
     });
 
     selectCell(model, "C3");
-    expect(getActiveXc(model)).toBe("C3");
+    expect(getSelectionAnchorCellXc(model)).toBe("C3");
     expect(getCellsXC(model)).toEqual(["B2"]);
     expect(getCell(model, "B2")!.style).not.toBeDefined();
     const sheet1 = model.getters.getSheetIds()[0];
@@ -208,10 +208,10 @@ describe("merges", () => {
       ],
     });
     selectCell(model, "C4");
-    expect(getActiveXc(model)).toBe("C4");
+    expect(getSelectionAnchorCellXc(model)).toBe("C4");
     expect(getCell(model, "C4")).toBeUndefined(); // no active cell in C4
     moveAnchorCell(model, "up");
-    expect(getActiveXc(model)).toBe("C3");
+    expect(getSelectionAnchorCellXc(model)).toBe("C3");
     expect(model.getters.getSelection().anchor).toEqual({
       cell: {
         col: 2,
@@ -643,9 +643,9 @@ describe("merges", () => {
     const sheetId = model.getters.getActiveSheetId();
     let col: number, row: number;
     ({ col, row } = toCartesian("B4"));
-    expect(model.getters.getMerge(sheetId, col, row)).toBeTruthy();
+    expect(model.getters.getMerge({ sheetId, col, row })).toBeTruthy();
     ({ col, row } = toCartesian("C4"));
-    expect(model.getters.getMerge(sheetId, col, row)).toBeTruthy();
+    expect(model.getters.getMerge({ sheetId, col, row })).toBeTruthy();
     expect(getCell(model, "B4")!.style).toEqual({ textColor: "#fe0000" });
     expect(getBorder(model, "B4")).toEqual({ top: ["thin", "#000"] });
     unMerge(model, "B4:C5");

--- a/tests/plugins/navigation.test.ts
+++ b/tests/plugins/navigation.test.ts
@@ -10,7 +10,7 @@ import {
   selectCell,
   setViewportOffset,
 } from "../test_helpers/commands_helpers";
-import { getActiveXc } from "../test_helpers/getters_helpers";
+import { getActivePosition, getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
 
 function getViewport(
   model: Model,
@@ -28,23 +28,23 @@ describe("navigation", () => {
   test("normal move to the right", () => {
     const model = new Model();
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 0, left: 0, bottom: 0 });
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
+    expect(getActivePosition(model)).toBe("A1");
     expect(model.getters.getSelection().anchor.cell).toEqual(toCartesian("A1"));
 
     moveAnchorCell(model, "right");
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 1, left: 1, bottom: 0 });
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
+    expect(getActivePosition(model)).toBe("B1");
     expect(model.getters.getSelection().anchor.cell).toEqual(toCartesian("B1"));
   });
 
   test("move up from top row", () => {
     const model = new Model();
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 0, left: 0, bottom: 0 });
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
+    expect(getActivePosition(model)).toBe("A1");
 
     moveAnchorCell(model, "up");
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 0, left: 0, bottom: 0 });
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
+    expect(getActivePosition(model)).toBe("A1");
   });
 
   test("move right from right row", () => {
@@ -54,9 +54,9 @@ describe("navigation", () => {
     const xc = toXC(colNumber - 1, 0);
     selectCell(model, xc);
 
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
     moveAnchorCell(model, "right");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
   });
 
   test("move bottom from bottom row", () => {
@@ -65,9 +65,9 @@ describe("navigation", () => {
     const rowNumber = model.getters.getNumberRows(activeSheetId);
     const xc = toXC(0, rowNumber - 1);
     selectCell(model, xc);
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
     moveAnchorCell(model, "down");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
   });
 
   test("move bottom from merge in last position", () => {
@@ -80,9 +80,9 @@ describe("navigation", () => {
     });
     const xc = toXC(0, rowNumber - 2);
     selectCell(model, xc);
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
     moveAnchorCell(model, "down");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
   });
 
   test("Cannot move bottom from merge in last position if last row is hidden", () => {
@@ -100,9 +100,9 @@ describe("navigation", () => {
     });
     const xc = toXC(0, rowNumber - 3);
     selectCell(model, xc);
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
     moveAnchorCell(model, "down");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
   });
 
   test("move right from merge in last position", () => {
@@ -115,9 +115,9 @@ describe("navigation", () => {
     });
     const xc = toXC(colNumber - 2, 0);
     selectCell(model, xc);
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
     moveAnchorCell(model, "right");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
+    expect(getActivePosition(model)).toBe(xc);
   });
 
   test("move in and out of a merge", () => {
@@ -130,19 +130,19 @@ describe("navigation", () => {
         },
       ],
     });
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
+    expect(getActivePosition(model)).toBe("A1");
 
     // move to the right, inside the merge
     moveAnchorCell(model, "right");
 
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 2, left: 1, bottom: 1 });
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
+    expect(getActivePosition(model)).toBe("B1");
 
     // move to the right, outside the merge
     moveAnchorCell(model, "right");
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 3, left: 3, bottom: 0 });
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("D1"));
-    expect(getActiveXc(model)).toBe("D1");
+    expect(getActivePosition(model)).toBe("D1");
+    expect(getSelectionAnchorCellXc(model)).toBe("D1");
   });
 
   test("do nothing if moving out of merge is out of grid", () => {
@@ -155,23 +155,23 @@ describe("navigation", () => {
         },
       ],
     });
-    expect(getActiveXc(model)).toEqual("A1");
+    expect(getSelectionAnchorCellXc(model)).toEqual("A1");
 
     // put selection below merge
     selectCell(model, "B3");
 
     // enter merge from below
-    expect(getActiveXc(model)).toBe("B3");
+    expect(getSelectionAnchorCellXc(model)).toBe("B3");
     moveAnchorCell(model, "up");
-    expect(getActiveXc(model)).toBe("B2");
+    expect(getSelectionAnchorCellXc(model)).toBe("B2");
 
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 2, left: 1, bottom: 1 });
-    expect(getActiveXc(model)).toEqual("B2");
+    expect(getSelectionAnchorCellXc(model)).toEqual("B2");
 
     // move to the top, outside the merge
     moveAnchorCell(model, "up");
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 2, left: 1, bottom: 1 });
-    expect(getActiveXc(model)).toEqual("B2");
+    expect(getSelectionAnchorCellXc(model)).toEqual("B2");
   });
 
   test("move right from right col (of the viewport)", () => {
@@ -274,10 +274,10 @@ describe("navigation", () => {
     //from the right
     selectCell(model, "D1");
     moveAnchorCell(model, "left");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
+    expect(getActivePosition(model)).toBe("B1");
     //from the left
     moveAnchorCell(model, "right");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("D1"));
+    expect(getActivePosition(model)).toBe("D1");
   });
 
   test("don't move through hidden col if out of grid", () => {
@@ -293,11 +293,11 @@ describe("navigation", () => {
     // move left from the first visible column
     selectCell(model, "B1");
     moveAnchorCell(model, "left");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
+    expect(getActivePosition(model)).toBe("B1");
     // move right from last visible column
     selectCell(model, "D1");
     moveAnchorCell(model, "right");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("D1"));
+    expect(getActivePosition(model)).toBe("D1");
   });
 
   test("move through hidden row", () => {
@@ -312,10 +312,10 @@ describe("navigation", () => {
     });
     selectCell(model, "A4");
     moveAnchorCell(model, "up");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A2"));
+    expect(getActivePosition(model)).toBe("A2");
     //from the top
     moveAnchorCell(model, "down");
-    expect(model.getters.getActivePosition()).toEqual(toCartesian("A4"));
+    expect(getActivePosition(model)).toBe("A4");
   });
 });
 
@@ -373,7 +373,7 @@ describe("Navigation starting from hidden cells", () => {
       selectCell(model, startPosition);
       hideColumns(model, hiddenCols);
       moveAnchorCell(model, direction);
-      expect(model.getters.getActivePosition()).toEqual(toCartesian(endPosition));
+      expect(getActivePosition(model)).toBe(endPosition);
     }
   );
   test.each([
@@ -395,7 +395,7 @@ describe("Navigation starting from hidden cells", () => {
       selectCell(model, startPosition);
       hideRows(model, hiddenRows);
       moveAnchorCell(model, direction);
-      expect(model.getters.getActivePosition()).toEqual(toCartesian(endPosition));
+      expect(getActivePosition(model)).toBe(endPosition);
     }
   );
 

--- a/tests/plugins/navigation.test.ts
+++ b/tests/plugins/navigation.test.ts
@@ -28,23 +28,23 @@ describe("navigation", () => {
   test("normal move to the right", () => {
     const model = new Model();
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 0, left: 0, bottom: 0 });
-    expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
     expect(model.getters.getSelection().anchor.cell).toEqual(toCartesian("A1"));
 
     moveAnchorCell(model, "right");
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 1, left: 1, bottom: 0 });
-    expect(model.getters.getPosition()).toEqual(toCartesian("B1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
     expect(model.getters.getSelection().anchor.cell).toEqual(toCartesian("B1"));
   });
 
   test("move up from top row", () => {
     const model = new Model();
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 0, left: 0, bottom: 0 });
-    expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
 
     moveAnchorCell(model, "up");
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 0, left: 0, bottom: 0 });
-    expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
   });
 
   test("move right from right row", () => {
@@ -54,9 +54,9 @@ describe("navigation", () => {
     const xc = toXC(colNumber - 1, 0);
     selectCell(model, xc);
 
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
     moveAnchorCell(model, "right");
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
   });
 
   test("move bottom from bottom row", () => {
@@ -65,9 +65,9 @@ describe("navigation", () => {
     const rowNumber = model.getters.getNumberRows(activeSheetId);
     const xc = toXC(0, rowNumber - 1);
     selectCell(model, xc);
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
     moveAnchorCell(model, "down");
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
   });
 
   test("move bottom from merge in last position", () => {
@@ -80,9 +80,9 @@ describe("navigation", () => {
     });
     const xc = toXC(0, rowNumber - 2);
     selectCell(model, xc);
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
     moveAnchorCell(model, "down");
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
   });
 
   test("Cannot move bottom from merge in last position if last row is hidden", () => {
@@ -100,9 +100,9 @@ describe("navigation", () => {
     });
     const xc = toXC(0, rowNumber - 3);
     selectCell(model, xc);
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
     moveAnchorCell(model, "down");
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
   });
 
   test("move right from merge in last position", () => {
@@ -115,9 +115,9 @@ describe("navigation", () => {
     });
     const xc = toXC(colNumber - 2, 0);
     selectCell(model, xc);
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
     moveAnchorCell(model, "right");
-    expect(model.getters.getPosition()).toEqual(toCartesian(xc));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian(xc));
   });
 
   test("move in and out of a merge", () => {
@@ -130,18 +130,18 @@ describe("navigation", () => {
         },
       ],
     });
-    expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A1"));
 
     // move to the right, inside the merge
     moveAnchorCell(model, "right");
 
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 2, left: 1, bottom: 1 });
-    expect(model.getters.getPosition()).toEqual(toCartesian("B1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
 
     // move to the right, outside the merge
     moveAnchorCell(model, "right");
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 3, left: 3, bottom: 0 });
-    expect(model.getters.getPosition()).toEqual(toCartesian("D1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("D1"));
     expect(getActiveXc(model)).toBe("D1");
   });
 
@@ -274,10 +274,10 @@ describe("navigation", () => {
     //from the right
     selectCell(model, "D1");
     moveAnchorCell(model, "left");
-    expect(model.getters.getPosition()).toEqual(toCartesian("B1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
     //from the left
     moveAnchorCell(model, "right");
-    expect(model.getters.getPosition()).toEqual(toCartesian("D1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("D1"));
   });
 
   test("don't move through hidden col if out of grid", () => {
@@ -293,11 +293,11 @@ describe("navigation", () => {
     // move left from the first visible column
     selectCell(model, "B1");
     moveAnchorCell(model, "left");
-    expect(model.getters.getPosition()).toEqual(toCartesian("B1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
     // move right from last visible column
     selectCell(model, "D1");
     moveAnchorCell(model, "right");
-    expect(model.getters.getPosition()).toEqual(toCartesian("D1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("D1"));
   });
 
   test("move through hidden row", () => {
@@ -312,10 +312,10 @@ describe("navigation", () => {
     });
     selectCell(model, "A4");
     moveAnchorCell(model, "up");
-    expect(model.getters.getPosition()).toEqual(toCartesian("A2"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A2"));
     //from the top
     moveAnchorCell(model, "down");
-    expect(model.getters.getPosition()).toEqual(toCartesian("A4"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("A4"));
   });
 });
 
@@ -373,7 +373,7 @@ describe("Navigation starting from hidden cells", () => {
       selectCell(model, startPosition);
       hideColumns(model, hiddenCols);
       moveAnchorCell(model, direction);
-      expect(model.getters.getPosition()).toEqual(toCartesian(endPosition));
+      expect(model.getters.getActivePosition()).toEqual(toCartesian(endPosition));
     }
   );
   test.each([
@@ -395,7 +395,7 @@ describe("Navigation starting from hidden cells", () => {
       selectCell(model, startPosition);
       hideRows(model, hiddenRows);
       moveAnchorCell(model, direction);
-      expect(model.getters.getPosition()).toEqual(toCartesian(endPosition));
+      expect(model.getters.getActivePosition()).toEqual(toCartesian(endPosition));
     }
   );
 

--- a/tests/plugins/navigation.test.ts
+++ b/tests/plugins/navigation.test.ts
@@ -155,7 +155,7 @@ describe("navigation", () => {
         },
       ],
     });
-    expect(model.getters.getPosition()).toEqual(toCartesian("A1"));
+    expect(getActiveXc(model)).toEqual("A1");
 
     // put selection below merge
     selectCell(model, "B3");
@@ -166,12 +166,12 @@ describe("navigation", () => {
     expect(getActiveXc(model)).toBe("B2");
 
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 2, left: 1, bottom: 1 });
-    expect(model.getters.getPosition()).toEqual(toCartesian("B2"));
+    expect(getActiveXc(model)).toEqual("B2");
 
     // move to the top, outside the merge
     moveAnchorCell(model, "up");
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, right: 2, left: 1, bottom: 1 });
-    expect(model.getters.getPosition()).toEqual(toCartesian("B2"));
+    expect(getActiveXc(model)).toEqual("B2");
   });
 
   test("move right from right col (of the viewport)", () => {

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -168,7 +168,7 @@ describe("simple selection", () => {
       },
       zones: [A1Zone],
     });
-    expect(model.getters.getPosition()).toEqual({ col: A1Zone.left, row: A1Zone.top });
+    expect(model.getters.getActivePosition()).toEqual({ col: A1Zone.left, row: A1Zone.top });
   });
   test("update selection in some different directions", () => {
     const model = new Model({
@@ -428,7 +428,7 @@ describe("simple selection", () => {
     addColumns(model, "after", "A", 1);
     selectCell(model, "D1");
     undo(model);
-    expect(model.getters.getPosition()).toEqual(toCartesian("C1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("C1"));
     expect(model.getters.getSheetPosition("42")).toEqual(toCartesian("C1"));
   });
 
@@ -446,7 +446,7 @@ describe("simple selection", () => {
     undo(model);
     selectCell(model, "C1");
     redo(model);
-    expect(model.getters.getPosition()).toEqual(toCartesian("B1"));
+    expect(model.getters.getActivePosition()).toEqual(toCartesian("B1"));
     expect(model.getters.getSheetPosition("42")).toEqual(toCartesian("B1"));
   });
 
@@ -1045,7 +1045,7 @@ describe("Selection loop (ctrl + a)", () => {
       model.selection.loopSelection();
       const selection = model.getters.getSelectedZone();
       expect(zoneToXc(selection)).toEqual(zone);
-      expect(zoneToXc(positionToZone(model.getters.getPosition()))).toEqual(anchor);
+      expect(zoneToXc(positionToZone(model.getters.getActivePosition()))).toEqual(anchor);
     }
   });
 

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -1,5 +1,5 @@
 import { FORBIDDEN_SHEET_CHARS } from "../../src/constants";
-import { getComposerSheetName, toCartesian, toZone } from "../../src/helpers";
+import { getComposerSheetName, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
@@ -28,6 +28,7 @@ import {
   getCellContent,
   getCellText,
   getEvaluatedCell,
+  getStyle,
 } from "../test_helpers/getters_helpers";
 import "../test_helpers/helpers";
 import { createEqualCF, testUndoRedo, toRangesData } from "../test_helpers/helpers";
@@ -645,8 +646,7 @@ describe("sheets", () => {
     expect(getCellContent(model, "A1")).toBe("42");
     expect(model.getters.getNumberCols(model.getters.getActiveSheetId())).toBe(5);
     expect(model.getters.getNumberRows(model.getters.getActiveSheetId())).toBe(5);
-    const { col, row } = toCartesian("A1");
-    expect(model.getters.getCellComputedStyle(newSheet, col, row)).toEqual({
+    expect(getStyle(model, "A1", newSheet)).toEqual({
       fillColor: "orange",
     });
   });
@@ -679,8 +679,7 @@ describe("sheets", () => {
     const newSheetId = model.getters.getSheetIds()[1];
     activateSheet(model, newSheetId);
     expect(getCellContent(model, "A1")).toBe("42");
-    const { col, row } = toCartesian("A1");
-    expect(model.getters.getCellComputedStyle(newSheetId, col, row)).toEqual({
+    expect(getStyle(model, "A1", newSheetId)).toEqual({
       fillColor: "orange",
     });
     expect(model.getters.getConditionalFormats(newSheetId)).toHaveLength(1);
@@ -690,10 +689,10 @@ describe("sheets", () => {
       ranges: toRangesData(sheetId, "A1:A2"),
       sheetId,
     });
-    expect(model.getters.getCellComputedStyle(newSheetId, col, row)).toEqual({ fillColor: "blue" });
+    expect(getStyle(model, "A1", newSheetId)).toEqual({ fillColor: "blue" });
     expect(model.getters.getConditionalFormats(newSheetId)).toHaveLength(1);
     activateSheet(model, sheet);
-    expect(model.getters.getCellComputedStyle(sheet, col, row)).toEqual({
+    expect(getStyle(model, "A1", sheet)).toEqual({
       fillColor: "orange",
     });
     expect(model.getters.getConditionalFormats(newSheetId)).toHaveLength(1);

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -1076,8 +1076,8 @@ describe("multi sheet with different sizes", () => {
       left: 0,
       right: 0,
     });
-    const { col, row } = model.getters.getActivePosition();
-    expect(model.getters.getCell(sheetId, col, row)).toBeUndefined();
+    const position = model.getters.getActivePosition();
+    expect(model.getters.getCell(position)).toBeUndefined();
   });
 
   test("deleting the row that has the active cell doesn't crash", () => {
@@ -1091,8 +1091,8 @@ describe("multi sheet with different sizes", () => {
       left: 0,
       right: 1,
     });
-    const { col, row } = model.getters.getActivePosition();
-    expect(model.getters.getCell(sheetId, col, row)).toBeUndefined();
+    const position = model.getters.getActivePosition();
+    expect(model.getters.getCell(position)).toBeUndefined();
   });
 
   test("Client resize impacts all sheets", () => {

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -1076,7 +1076,7 @@ describe("multi sheet with different sizes", () => {
       left: 0,
       right: 0,
     });
-    const { col, row } = model.getters.getPosition();
+    const { col, row } = model.getters.getActivePosition();
     expect(model.getters.getCell(sheetId, col, row)).toBeUndefined();
   });
 
@@ -1091,7 +1091,7 @@ describe("multi sheet with different sizes", () => {
       left: 0,
       right: 1,
     });
-    const { col, row } = model.getters.getPosition();
+    const { col, row } = model.getters.getActivePosition();
     expect(model.getters.getCell(sheetId, col, row)).toBeUndefined();
   });
 

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -53,7 +53,7 @@ export async function clickCell(
 ) {
   const zone = toZone(xc);
   const sheetId = model.getters.getActiveSheetId();
-  if (!model.getters.isVisibleInViewport(sheetId, zone.left, zone.top)) {
+  if (!model.getters.isVisibleInViewport({ sheetId, col: zone.left, row: zone.top })) {
     throw new Error(`You can't click on ${xc} because it is not visible`);
   }
   let { x, y } = model.getters.getVisibleRect(zone);

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -16,8 +16,13 @@ import { setSelection } from "./commands_helpers";
 /**
  * Get the active XC
  */
-export function getActiveXc(model: Model): string {
+export function getSelectionAnchorCellXc(model: Model): string {
   const { col, row } = model.getters.getSelection().anchor.cell;
+  return toXC(col, row);
+}
+
+export function getActivePosition(model: Model): string {
+  const { col, row } = model.getters.getActivePosition();
   return toXC(col, row);
 }
 
@@ -30,7 +35,7 @@ export function getCell(
   sheetId: UID = model.getters.getActiveSheetId()
 ): Cell | undefined {
   let { col, row } = toCartesian(xc);
-  return model.getters.getCell(sheetId, col, row);
+  return model.getters.getCell({ sheetId, col, row });
 }
 
 export function getEvaluatedCell(
@@ -77,10 +82,13 @@ export function getCellText(
   return model.getters.getCellText({ sheetId, col, row }, true);
 }
 
-export function getStyle(model: Model, xc: string): Style {
-  const sheetId = model.getters.getActiveSheetId();
+export function getStyle(
+  model: Model,
+  xc: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+): Style {
   const { col, row } = toCartesian(xc);
-  return model.getters.getCellComputedStyle(sheetId, col, row);
+  return model.getters.getCellComputedStyle({ sheetId, col, row });
 }
 
 export function getRangeFormattedValues(
@@ -108,7 +116,7 @@ export function getBorder(
   sheetId: UID = model.getters.getActiveSheetId()
 ): Border | null {
   const { col, row } = toCartesian(xc);
-  return model.getters.getCellBorder(sheetId, col, row);
+  return model.getters.getCellBorder({ sheetId, col, row });
 }
 
 /**
@@ -139,4 +147,22 @@ export function automaticSumMulti(
   }
   setSelection(model, xcs, { anchor });
   return model.dispatch("SUM_SELECTION");
+}
+
+export function getFilterTable(
+  model: Model,
+  xc: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+) {
+  const { col, row } = toCartesian(xc);
+  return model.getters.getFilterTable({ sheetId, col, row });
+}
+
+export function getFilter(
+  model: Model,
+  xc: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+) {
+  const { col, row } = toCartesian(xc);
+  return model.getters.getFilter({ sheetId, col, row });
 }

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -17,7 +17,7 @@ import { setSelection } from "./commands_helpers";
  * Get the active XC
  */
 export function getActiveXc(model: Model): string {
-  const { col, row } = model.getters.getPosition();
+  const { col, row } = model.getters.getSelection().anchor.cell;
   return toXC(col, row);
 }
 

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -307,7 +307,7 @@ export function XCToMergeCellMap(
   const sheetId = model.getters.getActiveSheetId();
   for (const mergeXC of mergeXCList) {
     const { col, row } = toCartesian(mergeXC);
-    const merge = model.getters.getMerge(sheetId, col, row);
+    const merge = model.getters.getMerge({ sheetId, col, row });
     if (!mergeCellMap[col]) mergeCellMap[col] = [];
     mergeCellMap[col][row] = merge ? merge.id : undefined;
   }
@@ -498,10 +498,6 @@ export const mockChart = () => {
   return mockChartData;
 };
 
-export function toCartesianArray(xc: string): [number, number] {
-  const { col, row } = toCartesian(xc);
-  return [col, row];
-}
 interface CellValue {
   value: string | number | boolean;
   style?: Style;

--- a/tests/xlsx_import_export.test.ts
+++ b/tests/xlsx_import_export.test.ts
@@ -13,6 +13,7 @@ import {
   resizeRows,
   setCellContent,
 } from "./test_helpers/commands_helpers";
+import { getBorder, getCell } from "./test_helpers/getters_helpers";
 import { target, toRangesData } from "./test_helpers/helpers";
 
 /**
@@ -89,9 +90,9 @@ describe("Export data to xlsx then import it", () => {
     setCellContent(model, "A2", "=A1");
     setCellContent(model, "A3", "text");
     const importedModel = exportToXlsxThenImport(model);
-    expect(importedModel.getters.getCell(sheetId, 0, 0)!.content).toEqual("0");
-    expect(importedModel.getters.getCell(sheetId, 0, 1)!.content).toEqual("=A1");
-    expect(importedModel.getters.getCell(sheetId, 0, 2)!.content).toEqual("text");
+    expect(getCell(importedModel, "A1")!.content).toEqual("0");
+    expect(getCell(importedModel, "A2")!.content).toEqual("=A1");
+    expect(getCell(importedModel, "A3")!.content).toEqual("text");
   });
 
   test.each([
@@ -103,7 +104,7 @@ describe("Export data to xlsx then import it", () => {
   ])("Cell style %s", (style: Style) => {
     model.dispatch("SET_FORMATTING", { sheetId, target: target("A1"), style });
     const importedModel = exportToXlsxThenImport(model);
-    expect(importedModel.getters.getCell(sheetId, 0, 0)!.style).toMatchObject(style);
+    expect(getCell(importedModel, "A1")!.style).toMatchObject(style);
   });
 
   test("Cell border", () => {
@@ -116,7 +117,7 @@ describe("Export data to xlsx then import it", () => {
       border,
     });
     const importedModel = exportToXlsxThenImport(model);
-    expect(importedModel.getters.getCellBorder(sheetId, 0, 0)).toEqual(border);
+    expect(getBorder(importedModel, "A1")).toEqual(border);
   });
 
   test.each(["0.00%", "#,##0.00", "m/d/yyyy", "m/d/yyyy hh:mm:ss", "#,##0.00 [$€]"])(


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3076136](https://www.odoo.com/web#id=3076136&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo