### PR TITLE
[FIX] scrollbar: fixe the scrollbar full size

### DIFF
--- a/src/components/scrollbar/scrollbar_horizontal.ts
+++ b/src/components/scrollbar/scrollbar_horizontal.ts
@@ -42,6 +42,7 @@ export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
     return {
       left: `${this.props.position.left + x}px`,
       bottom: "0px",
+      height: `${SCROLLBAR_WIDTH}px`,
       right: `${SCROLLBAR_WIDTH}px`,
     };
   }

--- a/src/components/scrollbar/scrollbar_vertical.ts
+++ b/src/components/scrollbar/scrollbar_vertical.ts
@@ -42,6 +42,7 @@ export class VerticalScrollBar extends Component<Props, SpreadsheetChildEnv> {
     return {
       top: `${this.props.position.top + y}px`,
       right: "0px",
+      width: `${SCROLLBAR_WIDTH}px`,
       bottom: `${SCROLLBAR_WIDTH}px`,
     };
   }

--- a/tests/components/__snapshots__/dashboard_grid.test.ts.snap
+++ b/tests/components/__snapshots__/dashboard_grid.test.ts.snap
@@ -44,6 +44,7 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
     style="
 top: 0px;
 right: 0px;
+width: 15px;
 bottom: 15px;
 "
   >
@@ -60,6 +61,7 @@ height: 2328px;
     style="
 left: 0px;
 bottom: 0px;
+height: 15px;
 right: 15px;
 "
   >

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -86,6 +86,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
     style="
 top: 26px;
 right: 0px;
+width: 15px;
 bottom: 15px;
 "
   >
@@ -102,6 +103,7 @@ height: 2328px;
     style="
 left: 48px;
 bottom: 0px;
+height: 15px;
 right: 15px;
 "
   >

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -475,6 +475,7 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
       style="
 top: 26px;
 right: 0px;
+width: 15px;
 bottom: 15px;
 "
     >
@@ -491,6 +492,7 @@ height: 2328px;
       style="
 left: 48px;
 bottom: 0px;
+height: 15px;
 right: 15px;
 "
     >

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -101,6 +101,11 @@ describe("Grid component", () => {
     expect(fixture.querySelector(".o-grid-overlay")).not.toBeNull();
   });
 
+  test("scrollbars thickness should be set", async () => {
+    expect(getElComputedStyle(".o-scrollbar.horizontal", "height")).toBe(`${SCROLLBAR_WIDTH}px`);
+    expect(getElComputedStyle(".o-scrollbar.vertical", "width")).toBe(`${SCROLLBAR_WIDTH}px`);
+  });
+
   test("can click on a cell to select it", async () => {
     setCellContent(model, "B2", "b2");
     setCellContent(model, "B3", "b3");


### PR DESCRIPTION
The introduction of a dedicated scrollbar component left a css property aside: the thickness of the scrollbar. Unfortunately, when not set, every browser will decide itself of the thickness and it depends on the browser but also the OS you are using. This commit reinstates the thickness.

task 3077557

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo