### PR TITLE
[FIX] InternalViewport: compute the actual visible rect of a zone

### DIFF
--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -203,18 +203,34 @@ export class InternalViewport {
     this.adjustViewportZoneY();
   }
 
+  /**
+   *
+   * @param zone
+   * @returns Computes the absolute coordinate of a given zone inside the viewport
+   */
   getRect(zone: Zone): Rect | undefined {
     const targetZone = intersection(zone, this.zone);
     if (targetZone) {
+      const x =
+        this.getters.getColRowOffset("COL", this.zone.left, targetZone.left) +
+        this.offsetCorrectionX;
+
+      const y =
+        this.getters.getColRowOffset("ROW", this.zone.top, targetZone.top) + this.offsetCorrectionY;
+
+      const width = Math.min(
+        this.getters.getColRowOffset("COL", targetZone.left, targetZone.right + 1),
+        this.width
+      );
+      const height = Math.min(
+        this.getters.getColRowOffset("ROW", targetZone.top, targetZone.bottom + 1),
+        this.height
+      );
       return {
-        x:
-          this.getters.getColRowOffset("COL", this.zone.left, targetZone.left) +
-          this.offsetCorrectionX,
-        y:
-          this.getters.getColRowOffset("ROW", this.zone.top, targetZone.top) +
-          this.offsetCorrectionY,
-        width: this.getters.getColRowOffset("COL", targetZone.left, targetZone.right + 1),
-        height: this.getters.getColRowOffset("ROW", targetZone.top, targetZone.bottom + 1),
+        x,
+        y,
+        width,
+        height,
       };
     } else {
       return undefined;

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -568,24 +568,14 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
   const dataSets = [zoneToXc(dataSetZone)];
   const sheetId = getters.getActiveSheetId();
 
-  const { x: offsetCorrectionX, y: offsetCorrectionY } = getters.getMainViewportCoordinates();
-  const { offsetX, offsetY } = getters.getActiveSheetScrollInfo();
-  const { width, height } = getters.getSheetViewDimension();
   const size = { width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
-  const rect = getters.getVisibleRect(getters.getActiveMainViewport());
-
-  const scrollableViewportWidth = Math.min(rect.width, width - offsetCorrectionX);
-  const scrollableViewportHeight = Math.min(rect.height, height - offsetCorrectionY);
+  const { x, y } = getters.getMainViewportCoordinates();
+  const { offsetX, offsetY } = getters.getActiveSheetScrollInfo();
+  const { width, height } = getters.getVisibleRect(getters.getActiveMainViewport());
 
   const position = {
-    x:
-      offsetCorrectionX +
-      offsetX +
-      Math.max(0, (scrollableViewportWidth - DEFAULT_FIGURE_WIDTH) / 2),
-    y:
-      offsetCorrectionY +
-      offsetY +
-      Math.max(0, (scrollableViewportHeight - DEFAULT_FIGURE_HEIGHT) / 2),
+    x: x + offsetX + Math.max(0, (width - size.width) / 2),
+    y: y + offsetY + Math.max(0, (height - size.height) / 2),
   }; // Position at the center of the scrollable viewport
 
   let title = "";

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -888,6 +888,32 @@ describe("Viewport of Simple sheet", () => {
       top: 0,
     });
   });
+
+  test("getVisibleRect returns the actual visible part of a zone", () => {
+    const width = 4.5 * DEFAULT_CELL_WIDTH;
+    const height = 5.5 * DEFAULT_CELL_HEIGHT;
+    model.dispatch("RESIZE_SHEETVIEW", { gridOffsetX: 0, gridOffsetY: 0, width, height });
+    expect(model.getters.getVisibleRect(model.getters.getActiveMainViewport())).toEqual({
+      x: 0,
+      y: 0,
+      width,
+      height,
+    });
+  });
+
+  test("getVisibleRect with freezed panes returns the actual visible part of a zone", () => {
+    freezeColumns(model, 1);
+    freezeRows(model, 1);
+    const width = 4.5 * DEFAULT_CELL_WIDTH;
+    const height = 5.5 * DEFAULT_CELL_HEIGHT;
+    model.dispatch("RESIZE_SHEETVIEW", { gridOffsetX: 0, gridOffsetY: 0, width, height });
+    expect(model.getters.getVisibleRect(model.getters.getActiveMainViewport())).toEqual({
+      x: DEFAULT_CELL_WIDTH,
+      y: DEFAULT_CELL_HEIGHT,
+      width: 3.5 * DEFAULT_CELL_WIDTH,
+      height: 4.5 * DEFAULT_CELL_HEIGHT,
+    });
+  });
 });
 
 describe("Multi Panes viewport", () => {


### PR DESCRIPTION
The function `getRect` would compute the rect of a zone only based on
its own zone without considering that some of its cells are not completely
visible in the grid.

Task 3079048

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo