### PR TITLE
[FIX] selection_input: traceback when using unbounded ranges

### DIFF
--- a/src/plugins/ui_feature/selection_inputs_manager.ts
+++ b/src/plugins/ui_feature/selection_inputs_manager.ts
@@ -1,4 +1,4 @@
-import { positionToZone, rangeReference, toZone } from "../../helpers/index";
+import { positionToZone, rangeReference } from "../../helpers/index";
 import { Command, CommandResult, Highlight, LAYERS, UID } from "../../types/index";
 import { UIPlugin, UIPluginConfig } from "../ui_plugin";
 import { RangeInputValue, SelectionInputPlugin } from "./selection_input";
@@ -80,7 +80,8 @@ export class SelectionInputsManagerPlugin extends UIPlugin {
         if (cmd.id !== this.focusedInputId) {
           const input = this.inputs[cmd.id];
           const range = input.ranges.find((range) => range.id === cmd.rangeId);
-          const zone = toZone(range?.xc || "A1");
+          const sheetId = this.getters.getActiveSheetId();
+          const zone = this.getters.getRangeFromSheetXC(sheetId, range?.xc || "A1").zone;
           this.selection.capture(
             input,
             { cell: { col: zone.left, row: zone.top }, zone },

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -636,4 +636,12 @@ describe("selection input plugin", () => {
     moveAnchorCell(model, "down");
     expect(highlightedZones(model)).toEqual(["A3"]);
   });
+
+  test("focus and change range with unbounded ranges", () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, initialRanges: ["A:A"] });
+    model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("A:A");
+    model.dispatch("CHANGE_RANGE", { id, rangeId: idOfRange(model, id, 0), value: "1:1" });
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("1:1");
+  });
 });


### PR DESCRIPTION
## Description

3660bf27 introduced a `toZone()` in the handle of `FOCUS/CHANGE_RANGE`, but this was a place were the xc was possibly the xc of an unbounded zone, thus creating a traceback.

Odoo task ID : [3082065](https://www.odoo.com/web#id=3082065&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo