### PR TITLE
[FIX] chart: don't translate empty starting

### DIFF
--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -224,7 +224,7 @@ function createScorecardChartRuntime(
       chart.baselineColorUp,
       chart.baselineColorDown
     ),
-    baselineDescr: _t(chart.baselineDescr || ""),
+    baselineDescr: chart.baselineDescr ? _t(chart.baselineDescr) : "",
     fontColor: chartFontColor(background),
     background,
     baselineStyle: chart.baselineMode !== "percentage" ? baselineCell?.style : undefined,


### PR DESCRIPTION
## Description:

Extracting this translated text leads to a warning in odoo

Odoo task ID : [2998303](https://www.odoo.com/web#id=2998303&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo