### PR TITLE
[IMP] chart: make size and position required

### DIFF
--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -417,8 +417,8 @@ export interface DeleteFigureCommand extends SheetDependentCommand {
 export interface CreateChartCommand extends SheetDependentCommand {
   type: "CREATE_CHART";
   id: UID;
-  position?: { x: number; y: number };
-  size?: { width: number; height: number };
+  position: { x: number; y: number };
+  size: { width: number; height: number };
   definition: ChartDefinition;
 }
 

--- a/tests/collaborative/ot/ot_sheet_deleted.test.ts
+++ b/tests/collaborative/ot/ot_sheet_deleted.test.ts
@@ -1,4 +1,5 @@
 import { transform } from "../../../src/collaborative/ot/ot";
+import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../../../src/constants";
 import { toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
@@ -107,6 +108,14 @@ describe("OT with DELETE_SHEET", () => {
     type: "CREATE_CHART",
     id: "1",
     definition: {} as any,
+    size: {
+      height: DEFAULT_FIGURE_HEIGHT,
+      width: DEFAULT_FIGURE_WIDTH,
+    },
+    position: {
+      x: 0,
+      y: 0,
+    },
   };
   const resizeColumns: Omit<ResizeColumnsRowsCommand, "sheetId"> = {
     type: "RESIZE_COLUMNS_ROWS",

--- a/tests/plugins/custom_colors.test.ts
+++ b/tests/plugins/custom_colors.test.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../src";
+import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../../src/constants";
 import { UID } from "../../src/types";
 import { createChart, createScorecardChart, setStyle } from "../test_helpers/commands_helpers";
 import { createColorScale, createEqualCF, target, toRangesData } from "../test_helpers/helpers";
@@ -135,6 +136,14 @@ describe("custom colors are correctly handled when editing charts", () => {
             value: "66",
           },
         },
+      },
+      size: {
+        height: DEFAULT_FIGURE_HEIGHT,
+        width: DEFAULT_FIGURE_WIDTH,
+      },
+      position: {
+        x: 0,
+        y: 0,
       },
     });
     expect(model.getters.getCustomColors()).toEqual(["#2468bd", "#112233", "#123456"]);

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -26,8 +26,8 @@ import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart"
 import { SelectionDirection, SelectionStep } from "../../src/types/selection";
 import { target } from "./helpers";
 
-const size = { width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
-const position = {
+const DEFAULT_FIGURE_SIZE = { width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
+const DEFAULT_FIGURE_POSITION = {
   x: 0,
   y: 0,
 };
@@ -113,8 +113,8 @@ export function createChart(
   return model.dispatch("CREATE_CHART", {
     id,
     sheetId,
-    position,
-    size,
+    position: DEFAULT_FIGURE_POSITION,
+    size: DEFAULT_FIGURE_SIZE,
     definition: {
       title: data.title || "test",
       dataSets: data.dataSets || [],
@@ -142,8 +142,8 @@ export function createScorecardChart(
   return model.dispatch("CREATE_CHART", {
     id,
     sheetId,
-    position,
-    size,
+    position: DEFAULT_FIGURE_POSITION,
+    size: DEFAULT_FIGURE_SIZE,
     definition: {
       type: "scorecard",
       title: data.title || "",
@@ -170,8 +170,8 @@ export function createGaugeChart(
   return model.dispatch("CREATE_CHART", {
     id,
     sheetId,
-    position,
-    size,
+    position: DEFAULT_FIGURE_POSITION,
+    size: DEFAULT_FIGURE_SIZE,
     definition: {
       type: "gauge",
       background: data.background,

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -1,4 +1,8 @@
-import { BACKGROUND_CHART_COLOR } from "../../src/constants";
+import {
+  BACKGROUND_CHART_COLOR,
+  DEFAULT_FIGURE_HEIGHT,
+  DEFAULT_FIGURE_WIDTH,
+} from "../../src/constants";
 import { isInside, lettersToNumber, toCartesian, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import {
@@ -21,6 +25,12 @@ import { PieChartDefinition } from "../../src/types/chart/pie_chart";
 import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart";
 import { SelectionDirection, SelectionStep } from "../../src/types/selection";
 import { target } from "./helpers";
+
+const size = { width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
+const position = {
+  x: 0,
+  y: 0,
+};
 
 /**
  * Dispatch an UNDO to the model
@@ -103,6 +113,8 @@ export function createChart(
   return model.dispatch("CREATE_CHART", {
     id,
     sheetId,
+    position,
+    size,
     definition: {
       title: data.title || "test",
       dataSets: data.dataSets || [],
@@ -130,6 +142,8 @@ export function createScorecardChart(
   return model.dispatch("CREATE_CHART", {
     id,
     sheetId,
+    position,
+    size,
     definition: {
       type: "scorecard",
       title: data.title || "",
@@ -156,6 +170,8 @@ export function createGaugeChart(
   return model.dispatch("CREATE_CHART", {
     id,
     sheetId,
+    position,
+    size,
     definition: {
       type: "gauge",
       background: data.background,


### PR DESCRIPTION
## Description:

When creating a new chart, the size and position should be required.

Odoo task ID : [2896073](https://www.odoo.com/web#id=2896073&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo