### PR TITLE
[spreadsheet] paste copied sheet range as table

### DIFF
--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -50,7 +50,7 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
       action: async () => {
         this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
         this.env.model.dispatch("COPY");
-        await this.env.clipboard.writeText(this.env.model.getters.getClipboardContent());
+        await this.env.clipboard.clear();
       },
     });
     registry.add("cut", {
@@ -59,7 +59,7 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
       action: async () => {
         this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
         this.env.model.dispatch("CUT");
-        await this.env.clipboard.writeText(this.env.model.getters.getClipboardContent());
+        await this.env.clipboard.clear();
       },
     });
     registry.add("delete", {

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -31,7 +31,7 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
       action: async () => {
         this.env.model.dispatch("SELECT_FIGURE", { id: this.figureId });
         this.env.model.dispatch("COPY");
-        await this.env.clipboard.writeText(this.env.model.getters.getClipboardContent());
+        await this.env.clipboard.clear();
       },
     });
     registry.add("cut", {
@@ -41,7 +41,7 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
       action: async () => {
         this.env.model.dispatch("SELECT_FIGURE", { id: this.figureId });
         this.env.model.dispatch("CUT");
-        await this.env.clipboard.writeText(this.env.model.getters.getClipboardContent());
+        await this.env.clipboard.clear();
       },
     });
     registry.add("reset_size", {

--- a/src/components/helpers/css.ts
+++ b/src/components/helpers/css.ts
@@ -98,6 +98,20 @@ export function getTextDecoration({
 }
 
 /**
+ * Convert the cell style to CSS properties.
+ */
+export function cellStyleToCss(style: Style | undefined): CSSProperties {
+  const attributes = cellTextStyleToCss(style);
+  if (!style) return attributes;
+
+  if (style.fillColor) {
+    attributes["background"] = style.fillColor;
+  }
+
+  return attributes;
+}
+
+/**
  * Convert the cell text style to CSS properties.
  */
 export function cellTextStyleToCss(style: Style | undefined): CSSProperties {
@@ -122,10 +136,11 @@ export function cellTextStyleToCss(style: Style | undefined): CSSProperties {
   return attributes;
 }
 
-export function cssPropertiesToCss(attributes: CSSProperties): string {
+export function cssPropertiesToCss(attributes: CSSProperties, newLine = true): string {
+  const separator = newLine ? "\n" : "";
   const str = Object.entries(attributes)
     .map(([attName, attValue]) => `${attName}: ${attValue};`)
-    .join("\n");
+    .join(separator);
 
-  return "\n" + str + "\n";
+  return str ? "\n" + str + "\n" : "";
 }

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -31,6 +31,7 @@ import { Grid } from "../grid/grid";
 import { css } from "../helpers/css";
 import { SidePanel } from "../side_panel/side_panel/side_panel";
 import { TopBar } from "../top_bar/top_bar";
+import { instantiateClipboard } from "./../../helpers/clipboard/navigator_clipboard_wrapper";
 
 // -----------------------------------------------------------------------------
 // SpreadSheet
@@ -172,7 +173,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       openSidePanel: this.openSidePanel.bind(this),
       toggleSidePanel: this.toggleSidePanel.bind(this),
       _t: Spreadsheet._t,
-      clipboard: navigator.clipboard,
+      clipboard: this.env.clipboard || instantiateClipboard(),
     });
 
     useExternalListener(window as any, "resize", () => this.render(true));

--- a/src/helpers/clipboard/clipboard_abstract_cell_state.ts
+++ b/src/helpers/clipboard/clipboard_abstract_cell_state.ts
@@ -9,7 +9,12 @@ import {
   UID,
   Zone,
 } from "../../types";
-import { ClipboardOperation, ClipboardOptions, ClipboardState } from "./../../types/clipboard";
+import {
+  ClipboardMIMEType,
+  ClipboardOperation,
+  ClipboardOptions,
+  ClipboardState,
+} from "./../../types/clipboard";
 
 /** Abstract state of the clipboard when copying/cutting content that is pasted in cells of the sheet */
 export abstract class ClipboardCellsAbstractState implements ClipboardState {
@@ -67,7 +72,7 @@ export abstract class ClipboardCellsAbstractState implements ClipboardState {
     }
   }
 
-  abstract getClipboardContent(): string;
+  abstract getClipboardContent(): Record<ClipboardMIMEType, string>;
 
   isColRowDirtyingClipboard(position: HeaderIndex, dimension: Dimension) {
     return false;

--- a/src/helpers/clipboard/clipboard_figure_state.ts
+++ b/src/helpers/clipboard/clipboard_figure_state.ts
@@ -14,7 +14,13 @@ import { Image } from "../../types/image";
 import { AbstractChart } from "../figures/charts";
 import { deepCopy } from "../misc";
 import { UuidGenerator } from "../uuid";
-import { ClipboardOperation, ClipboardOptions, ClipboardState } from "./../../types/clipboard";
+import {
+  ClipboardContent,
+  ClipboardMIMEType,
+  ClipboardOperation,
+  ClipboardOptions,
+  ClipboardState,
+} from "./../../types/clipboard";
 
 /** State of the clipboard when copying/cutting figures */
 export class ClipboardFigureState implements ClipboardState {
@@ -97,8 +103,8 @@ export class ClipboardFigureState implements ClipboardState {
     this.dispatch("SELECT_FIGURE", { id: newId });
   }
 
-  getClipboardContent() {
-    return "\t";
+  getClipboardContent(): ClipboardContent {
+    return { [ClipboardMIMEType.PlainText]: "\t" };
   }
 
   isColRowDirtyingClipboard(position: HeaderIndex, dimension: Dimension): boolean {

--- a/src/helpers/clipboard/clipboard_os_state.ts
+++ b/src/helpers/clipboard/clipboard_os_state.ts
@@ -1,5 +1,12 @@
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
-import { ClipboardOptions, CommandDispatcher, CommandResult, Getters, Zone } from "../../types";
+import {
+  ClipboardMIMEType,
+  ClipboardOptions,
+  CommandDispatcher,
+  CommandResult,
+  Getters,
+  Zone,
+} from "../../types";
 import { zoneToDimension } from "../zones";
 import { ClipboardCellsAbstractState } from "./clipboard_abstract_cell_state";
 
@@ -55,8 +62,10 @@ export class ClipboardOsState extends ClipboardCellsAbstractState {
     this.selection.selectZone({ cell: { col: activeCol, row: activeRow }, zone });
   }
 
-  getClipboardContent(): string {
-    return this.values.map((values) => values.join("\t")).join("\n");
+  getClipboardContent(): Record<string, string> {
+    return {
+      [ClipboardMIMEType.PlainText]: this.values.map((values) => values.join("\t")).join("\n"),
+    };
   }
 
   private getPasteZone(target: Zone[]): Zone {

--- a/src/helpers/clipboard/navigator_clipboard_wrapper.ts
+++ b/src/helpers/clipboard/navigator_clipboard_wrapper.ts
@@ -1,0 +1,69 @@
+import { ClipboardContent, ClipboardMIMEType } from "./../../types/clipboard";
+
+export type ClipboardReadResult =
+  | { status: "ok"; content: string }
+  | { status: "permissionDenied" | "notImplemented" };
+
+export interface ClipboardInterface {
+  write(clipboardContent: ClipboardContent): Promise<void>;
+  writeText(text: string): Promise<void>;
+  readText(): Promise<ClipboardReadResult>;
+  clear(): Promise<void>;
+}
+
+export function instantiateClipboard(): ClipboardInterface {
+  return new WebClipboardWrapper(navigator.clipboard);
+}
+
+class WebClipboardWrapper implements ClipboardInterface {
+  // Can be undefined because navigator.clipboard doesn't exist in old browsers
+  constructor(private clipboard: Clipboard | undefined) {}
+
+  async write(clipboardContent: ClipboardContent): Promise<void> {
+    try {
+      this.clipboard?.write(this.getClipboardItems(clipboardContent));
+    } catch (e) {}
+  }
+
+  async writeText(text: string): Promise<void> {
+    try {
+      this.clipboard?.writeText(text);
+    } catch (e) {}
+  }
+
+  async readText(): Promise<ClipboardReadResult> {
+    let permissionResult: PermissionStatus | undefined = undefined;
+    try {
+      //@ts-ignore - clipboard-read is not implemented in all browsers
+      permissionResult = await navigator.permissions.query({ name: "clipboard-read" });
+    } catch (e) {}
+    try {
+      const clipboardContent = await this.clipboard!.readText();
+      return { status: "ok", content: clipboardContent };
+    } catch (e) {
+      const status = permissionResult?.state === "denied" ? "permissionDenied" : "notImplemented";
+      return { status };
+    }
+  }
+
+  async clear(): Promise<void> {
+    try {
+      this.clipboard?.write([]);
+    } catch (e) {}
+  }
+
+  private getClipboardItems(content: ClipboardContent): ClipboardItems {
+    return [
+      new ClipboardItem({
+        [ClipboardMIMEType.PlainText]: this.getBlob(content, ClipboardMIMEType.PlainText),
+        [ClipboardMIMEType.Html]: this.getBlob(content, ClipboardMIMEType.Html),
+      }),
+    ];
+  }
+
+  private getBlob(clipboardContent: ClipboardContent, type: ClipboardMIMEType): Blob {
+    return new Blob([clipboardContent[type] || ""], {
+      type,
+    });
+  }
+}

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -1,7 +1,12 @@
 import { ClipboardCellsState } from "../../helpers/clipboard/clipboard_cells_state";
 import { ClipboardFigureState } from "../../helpers/clipboard/clipboard_figure_state";
 import { ClipboardOsState } from "../../helpers/clipboard/clipboard_os_state";
-import { ClipboardOperation, ClipboardState } from "../../types/clipboard";
+import {
+  ClipboardContent,
+  ClipboardMIMEType,
+  ClipboardOperation,
+  ClipboardState,
+} from "../../types/clipboard";
 import {
   Command,
   CommandResult,
@@ -26,7 +31,12 @@ interface InsertDeleteCellsTargets {
  */
 export class ClipboardPlugin extends UIPlugin {
   static layers = [LAYERS.Clipboard];
-  static getters = ["getClipboardContent", "isCutOperation", "isPaintingFormat"] as const;
+  static getters = [
+    "getClipboardContent",
+    "getClipboardTextContent",
+    "isCutOperation",
+    "isPaintingFormat",
+  ] as const;
 
   private status: "visible" | "invisible" = "invisible";
   private state?: ClipboardState;
@@ -168,8 +178,12 @@ export class ClipboardPlugin extends UIPlugin {
    * clipboard copy event to add it as data, otherwise an empty string is not
    * considered as a copy content.
    */
-  getClipboardContent(): string {
-    return this.state?.getClipboardContent() || "\t";
+  getClipboardContent(): ClipboardContent {
+    return this.state?.getClipboardContent() || { [ClipboardMIMEType.PlainText]: "\t" };
+  }
+
+  getClipboardTextContent(): string {
+    return this.state?.getClipboardContent()[ClipboardMIMEType.PlainText] || "\t";
   }
 
   isCutOperation(): boolean {

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -2,6 +2,13 @@ import { CommandResult } from "./commands";
 import { Dimension, HeaderIndex, UID, Zone } from "./misc";
 import { GridRenderingContext } from "./rendering";
 
+export enum ClipboardMIMEType {
+  PlainText = "text/plain",
+  Html = "text/html",
+}
+
+export type ClipboardContent = { [type in ClipboardMIMEType]?: string };
+
 export interface ClipboardOptions {
   pasteOption?: ClipboardPasteOptions;
   shouldPasteCF?: boolean;
@@ -19,7 +26,7 @@ export interface ClipboardState {
   isPasteAllowed(target: Zone[], clipboardOption?: ClipboardOptions): CommandResult;
 
   paste(target: Zone[], options?: ClipboardOptions | undefined): void;
-  getClipboardContent(): string;
+  getClipboardContent(): ClipboardContent;
   drawClipboard(renderingContext: GridRenderingContext): void;
 
   /**

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -1,4 +1,5 @@
 import { Model } from "..";
+import { ClipboardInterface } from "../helpers/clipboard/navigator_clipboard_wrapper";
 import { TranslationFunction } from "../translation";
 import { Currency } from "./currency";
 import { ImageProviderInterface } from "./files";
@@ -33,6 +34,6 @@ export interface SpreadsheetChildEnv extends SpreadsheetEnv {
   isDashboard: () => boolean;
   openSidePanel: (panel: string, panelProps?: any) => void;
   toggleSidePanel: (panel: string, panelProps?: any) => void;
-  clipboard: Clipboard;
+  clipboard: ClipboardInterface;
   _t: TranslationFunction;
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -183,6 +183,7 @@ export type FunctionReturnValue = string | number | boolean;
 
 export interface ClipboardCell {
   cell?: Cell;
+  style?: Style;
   evaluatedCell: EvaluatedCell;
   border?: Border;
   position: CellPosition;

--- a/src/xlsx/helpers/xml_helpers.ts
+++ b/src/xlsx/helpers/xml_helpers.ts
@@ -24,7 +24,7 @@ export function createXMLFile(
   };
 }
 
-function xmlEscape(str: XMLAttributeValue): string {
+export function xmlEscape(str: XMLAttributeValue): string {
   return String(str)
     .replace(/\&/g, "&amp;")
     .replace(/\</g, "&lt;")
@@ -37,8 +37,11 @@ export function formatAttributes(attrs: XMLAttributes): XMLString {
   return new XMLString(attrs.map(([key, val]) => `${key}="${xmlEscape(val)}"`).join(" "));
 }
 
-export function parseXML(xmlString: XMLString): XMLDocument {
-  const document = new DOMParser().parseFromString(xmlString.toString(), "text/xml");
+export function parseXML(
+  xmlString: XMLString,
+  mimeType: DOMParserSupportedType = "text/xml"
+): XMLDocument {
+  const document = new DOMParser().parseFromString(xmlString.toString(), mimeType);
   const parserError = document.querySelector("parsererror");
   if (parserError) {
     const errorString = parserError.innerHTML;

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -20,7 +20,6 @@ import {
 import {
   makeTestFixture,
   mockChart,
-  MockClipboard,
   mountSpreadsheet,
   nextTick,
   spyDispatch,
@@ -62,13 +61,6 @@ let parent: Spreadsheet;
 let app: App;
 describe("figures", () => {
   beforeEach(async () => {
-    const clipboard = new MockClipboard();
-    Object.defineProperty(navigator, "clipboard", {
-      get() {
-        return clipboard;
-      },
-      configurable: true,
-    });
     fixture = makeTestFixture();
     mockChartData = mockChart();
     chartId = "someuuid";

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -8,6 +8,7 @@ import { fontSizes } from "../../src/fonts";
 import { colors, toHex, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { Highlight } from "../../src/types";
+import { getClipboardEvent, MockClipboardData } from "../test_helpers/clipboard";
 import {
   activateSheet,
   createSheet,
@@ -37,7 +38,6 @@ import {
 import {
   createEqualCF,
   makeTestFixture,
-  MockClipboard,
   mountSpreadsheet,
   nextTick,
   startGridComposition,
@@ -1539,22 +1539,12 @@ describe("composer highlights color", () => {
 });
 
 describe("Copy/paste in composer", () => {
-  beforeAll(() => {
-    const clipboard = new MockClipboard();
-    Object.defineProperty(navigator, "clipboard", {
-      get() {
-        return clipboard;
-      },
-      configurable: true,
-    });
-  });
-
   test("Can copy random content inside the composer", async () => {
     const spyDispatch = jest.spyOn(model, "dispatch");
     await startComposition();
-    const clipboardEvent = new Event("paste", { bubbles: true, cancelable: true });
-    //@ts-ignore
-    clipboardEvent.clipboardData = { getData: () => "unimportant" };
+    const clipboardData = new MockClipboardData();
+    clipboardData.setText("Unimportant");
+    const clipboardEvent = getClipboardEvent("paste", clipboardData);
     fixture.querySelector(".o-grid-composer .o-composer")!.dispatchEvent(clipboardEvent);
     await nextTick();
     expect(model.getters.getEditionMode()).not.toBe("inactive");

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -6,6 +6,7 @@ import { Model } from "../../src/model";
 import { createFullMenuItem, FullMenuItem } from "../../src/registries";
 import { cellMenuRegistry } from "../../src/registries/menus/cell_menu_registry";
 import { OWL_TEMPLATES } from "../setup/jest.setup";
+import { MockClipboard } from "../test_helpers/clipboard";
 import { setCellContent } from "../test_helpers/commands_helpers";
 import {
   keyDown,
@@ -17,7 +18,6 @@ import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/gette
 import {
   getStylePropertyInPx,
   makeTestFixture,
-  MockClipboard,
   mountSpreadsheet,
   nextTick,
   Touch,

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -28,7 +28,6 @@ import {
   getFigureIds,
   makeTestFixture,
   mockChart,
-  MockClipboard,
   mountSpreadsheet,
   nextTick,
 } from "../test_helpers/helpers";
@@ -372,13 +371,6 @@ describe("figures", () => {
       let sheetId: UID;
       let figureId: UID;
       beforeEach(async () => {
-        const clipboard = new MockClipboard();
-        Object.defineProperty(navigator, "clipboard", {
-          get() {
-            return clipboard;
-          },
-          configurable: true,
-        });
         sheetId = model.getters.getActiveSheetId();
         figureId = "figureId";
         switch (type) {

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -23,7 +23,6 @@ import {
 import { getCellContent } from "../test_helpers/getters_helpers";
 import {
   makeTestFixture,
-  MockClipboard,
   mountSpreadsheet,
   nextTick,
   restoreDefaultFunctions,
@@ -42,14 +41,6 @@ let fixture: HTMLElement;
 let parent: Spreadsheet;
 let model: Model;
 let app: App;
-const clipboard = new MockClipboard();
-
-Object.defineProperty(navigator, "clipboard", {
-  get() {
-    return clipboard;
-  },
-  configurable: true,
-});
 
 describe("Simple Spreadsheet Component", () => {
   // default model and env
@@ -130,7 +121,7 @@ describe("Simple Spreadsheet Component", () => {
   });
 
   test("Clipboard is in spreadsheet env", () => {
-    expect(parent.env.clipboard).toBe(clipboard);
+    expect(parent.env.clipboard["clipboard"]).toBe(navigator.clipboard);
   });
 
   test("typing opens composer after toolbar clicked", async () => {

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -31,7 +31,6 @@ import {
   getName,
   getNode,
   makeTestFixture,
-  MockClipboard,
   mockUuidV4To,
   mountSpreadsheet,
   nextTick,
@@ -109,13 +108,6 @@ describe("Menu Item actions", () => {
   let dispatch;
 
   beforeEach(async () => {
-    const clipboard = new MockClipboard();
-    Object.defineProperty(navigator, "clipboard", {
-      get() {
-        return clipboard;
-      },
-      configurable: true,
-    });
     fixture = makeTestFixture();
     ({ app, parent, model } = await mountSpreadsheet(fixture));
     env = parent.env;
@@ -137,20 +129,17 @@ describe("Menu Item actions", () => {
   });
 
   test("Edit -> copy", () => {
-    const clipboard = new MockClipboard();
-    //@ts-ignore
-    jest.spyOn(navigator, "clipboard", "get").mockImplementation(() => clipboard);
-    env.clipboard.writeText = jest.fn(() => Promise.resolve());
+    const spyWriteClipboard = jest.spyOn(env.clipboard, "write");
     doAction(["edit", "copy"], env);
     expect(dispatch).toHaveBeenCalledWith("COPY");
-    expect(env.clipboard.writeText).toHaveBeenCalledWith(env.model.getters.getClipboardContent());
+    expect(spyWriteClipboard).toHaveBeenCalledWith(model.getters.getClipboardContent());
   });
 
   test("Edit -> cut", () => {
-    env.clipboard.writeText = jest.fn(() => Promise.resolve());
+    const spyWriteClipboard = jest.spyOn(env.clipboard, "write");
     doAction(["edit", "cut"], env);
     expect(dispatch).toHaveBeenCalledWith("CUT");
-    expect(env.clipboard.writeText).toHaveBeenCalledWith(env.model.getters.getClipboardContent());
+    expect(spyWriteClipboard).toHaveBeenCalledWith(model.getters.getClipboardContent());
   });
 
   test("Edit -> paste from OS clipboard if copied from outside world last", async () => {
@@ -159,7 +148,7 @@ describe("Menu Item actions", () => {
     doAction(["edit", "paste"], env);
     await nextTick();
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
-      text: await env.clipboard.readText(),
+      text: "Then copy in OS clipboard",
       target: [{ bottom: 0, left: 0, right: 0, top: 0 }],
     });
   });

--- a/tests/plugins/__snapshots__/clipboard.test.ts.snap
+++ b/tests/plugins/__snapshots__/clipboard.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`clipboard Copied cells HTML Copied HTML table snapshot 1`] = `"<table border=\\"1\\" style=\\"border-collapse:collapse\\"><tr><td style=\\"\\">1</td><td style=\\"\\">2</td></tr><tr><td style=\\"\\">3</td><td style=\\"\\"></td></tr></table>"`;

--- a/tests/test_helpers/clipboard.ts
+++ b/tests/test_helpers/clipboard.ts
@@ -1,0 +1,55 @@
+import {
+  ClipboardInterface,
+  ClipboardReadResult,
+} from "../../src/helpers/clipboard/navigator_clipboard_wrapper";
+import { ClipboardContent, ClipboardMIMEType } from "../../src/types";
+
+export class MockClipboard implements ClipboardInterface {
+  private content: string | undefined = "Some random clipboard content";
+
+  async readText(): Promise<ClipboardReadResult> {
+    return { status: "ok", content: this.content || "" };
+  }
+
+  async writeText(text: string): Promise<void> {
+    this.content = text;
+  }
+
+  async write(content: ClipboardContent) {
+    this.content = content[ClipboardMIMEType.PlainText];
+  }
+
+  async clear(): Promise<void> {
+    this.content = "";
+  }
+}
+
+export class MockClipboardData {
+  content: ClipboardContent = {};
+
+  setText(text: string) {
+    this.content[ClipboardMIMEType.PlainText] = text;
+  }
+
+  getData(type: ClipboardMIMEType) {
+    return this.content[type] || "";
+  }
+
+  setData(type: ClipboardMIMEType, content: string) {
+    this.content[type] = content;
+  }
+
+  get types() {
+    return Object.keys(this.content);
+  }
+}
+
+export function getClipboardEvent(
+  type: "copy" | "paste" | "cut",
+  clipboardData: MockClipboardData
+) {
+  const event = new Event(type, { bubbles: true });
+  //@ts-ignore
+  event.clipboardData = clipboardData;
+  return event;
+}

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -25,6 +25,7 @@ import { FileStore } from "../components/__mocks__/mock_file_store";
 import { ImageProvider } from "../components/__mocks__/mock_image_provider";
 import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { Currency } from "./../../src/types/currency";
+import { MockClipboard } from "./clipboard";
 import { redo, setCellContent, undo } from "./commands_helpers";
 import { getCellContent, getEvaluatedCell } from "./getters_helpers";
 
@@ -105,34 +106,6 @@ export function makeTestEnv(mockEnv: Partial<SpreadsheetChildEnv>): SpreadsheetC
         return [] as Currency[];
       }),
   };
-}
-
-export class MockClipboard implements Clipboard {
-  private content: string = "Some random clipboard content";
-
-  async read() {
-    throw new Error("Clipboard mock read function not implemented");
-    return [];
-  }
-
-  async write() {
-    throw new Error("Clipboard mock write function not implemented");
-  }
-
-  readText(): Promise<string> {
-    return Promise.resolve(this.content);
-  }
-
-  writeText(content: string): Promise<void> {
-    this.content = content;
-    return Promise.resolve();
-  }
-
-  addEventListener() {}
-  removeEventListener() {}
-  dispatchEvent() {
-    return false;
-  }
 }
 
 export function testUndoRedo(model: Model, expect: jest.Expect, command: CommandTypes, args: any) {


### PR DESCRIPTION
## Description:
In this commit, we add an 'text/html' part in the os clipboard when copying
cells. This allow to paste the cells as a table in an external application.

Also refractor a bit how we handle the clipboard : now we put the
navigator.clipboard in a ClipboardWrapper class, which hide the
implementation details and error handling of the navigator's clipboard.

Odoo task ID : [2832383](https://www.odoo.com/web#id=2832383&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo