### PR TITLE
[IMP] Error: Lookup module's functions now return NA Errors

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -6,6 +6,7 @@ import {
   MatrixArgValue,
   PrimitiveArgValue,
 } from "../types";
+import { NotAvailableError } from "../types/errors";
 import { args } from "./arguments";
 import {
   assert,
@@ -22,6 +23,14 @@ import {
 const DEFAULT_IS_SORTED = true;
 const DEFAULT_MATCH_MODE = 0;
 const DEFAULT_SEARCH_MODE = 1;
+
+function assertAvailable(variable, searchKey) {
+  if (variable === undefined) {
+    throw new NotAvailableError(
+      _lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
+    );
+  }
+}
 
 // -----------------------------------------------------------------------------
 // COLUMN
@@ -116,13 +125,9 @@ export const HLOOKUP: AddFunctionDescription = {
         getNormalizedValueFromRowRange
       );
     }
-
-    assert(
-      () => colIndex > -1,
-      _lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
-    );
-
-    return range[colIndex][_index - 1] as FunctionReturnValue;
+    const col = range[colIndex];
+    assertAvailable(col, searchKey);
+    return col[_index - 1] as FunctionReturnValue;
   },
   isExported: true,
 };
@@ -165,10 +170,7 @@ export const LOOKUP: AddFunctionDescription = {
       rangeLength,
       getElement
     );
-    assert(
-      () => index >= 0,
-      _lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
-    );
+    assertAvailable(searchArray[0][index], searchKey);
 
     if (resultRange === undefined) {
       return (
@@ -247,10 +249,7 @@ export const MATCH: AddFunctionDescription = {
         break;
     }
 
-    assert(
-      () => index >= 0,
-      _lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
-    );
+    assertAvailable(nbCol === 1 ? range[0][index] : range[index], searchKey);
 
     return index + 1;
   },
@@ -349,12 +348,9 @@ export const VLOOKUP: AddFunctionDescription = {
       );
     }
 
-    assert(
-      () => rowIndex > -1,
-      _lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
-    );
-
-    return range[_index - 1][rowIndex] as FunctionReturnValue;
+    const value = range[_index - 1][rowIndex];
+    assertAvailable(value, searchKey);
+    return value as FunctionReturnValue;
   },
   isExported: true,
 };
@@ -446,10 +442,7 @@ export const XLOOKUP: AddFunctionDescription = {
     }
 
     const _defaultValue = defaultValue?.();
-    assert(
-      () => !!_defaultValue,
-      _lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
-    );
+    assertAvailable(_defaultValue, searchKey);
     return _defaultValue!;
   },
   isExported: true,

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -43,8 +43,12 @@ export class InvalidReferenceError extends EvaluationError {
 }
 
 export class NotAvailableError extends EvaluationError {
-  constructor() {
-    super(CellErrorType.NotAvailable, _lt("Data not available"), CellErrorLevel.silent);
+  constructor(errorMessage: string | undefined = undefined) {
+    super(
+      CellErrorType.NotAvailable,
+      errorMessage || _lt("Data not available"),
+      errorMessage ? CellErrorLevel.error : CellErrorLevel.silent
+    );
   }
 }
 

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -851,6 +851,17 @@ describe("error tooltip", () => {
     expect(document.querySelector(".o-error-tooltip")).toBeNull();
   });
 
+  test("Display error on #N/A 'non-silent' ", async () => {
+    Date.now = jest.fn(() => 0);
+    setCellContent(model, "A1", "=VLOOKUP(6,A1:A2,B2:B4)");
+    await nextTick();
+    gridMouseEvent(model, "mousemove", "A1");
+    Date.now = jest.fn(() => 500);
+    jest.advanceTimersByTime(300);
+    await nextTick();
+    expect(document.querySelector(".o-error-tooltip")).not.toBeNull();
+  });
+
   test("can display error tooltip", async () => {
     setCellContent(model, "C8", "=1/0");
     await hoverCell(model, "C8", 200);

--- a/tests/functions/module_lookup.test.ts
+++ b/tests/functions/module_lookup.test.ts
@@ -95,7 +95,7 @@ describe("LOOKUP formula", () => {
     expect(evaluatedGrid.A13).toBe("#ERROR"); // @compatibility: on googlesheets, return #NUM!
     expect(evaluatedGrid.A14).toBe("#ERROR"); // @compatibility: on googlesheets, return #NUM!
 
-    expect(evaluatedGrid.A15).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(evaluatedGrid.A15).toBe("#N/A");
     expect(evaluatedGrid.A16).toBe("res 09");
   });
 
@@ -148,7 +148,7 @@ describe("MATCH formula", () => {
     const ascendingAsAscending = { ...rangeAscending, ...evAsAscending };
     const aAsA = evaluateGrid(ascendingAsAscending);
 
-    expect(aAsA.B1).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(aAsA.B1).toBe("#N/A");
     expect(aAsA.B2).toBe(1);
     expect(aAsA.B3).toBe(3);
     expect(aAsA.B4).toBe(4);
@@ -160,14 +160,14 @@ describe("MATCH formula", () => {
     const ascendingAsUnsorted = { ...rangeAscending, ...evAsUnsorted };
     const aAsU = evaluateGrid(ascendingAsUnsorted);
 
-    expect(aAsU.C1).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(aAsU.C1).toBe("#N/A");
     expect(aAsU.C2).toBe(1);
     expect(aAsU.C3).toBe(2);
     expect(aAsU.C4).toBe(4);
-    expect(aAsU.C5).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(aAsU.C5).toBe("#N/A");
     expect(aAsU.C6).toBe(5);
     expect(aAsU.C7).toBe(6);
-    expect(aAsU.C8).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(aAsU.C8).toBe("#N/A");
 
     const ascendingAsDescending = { ...rangeAscending, ...evAsDescending };
     const aAsD = evaluateGrid(ascendingAsDescending);
@@ -175,18 +175,18 @@ describe("MATCH formula", () => {
     expect(aAsD.D1).toBe(3); // @compatibility: on googlesheets, return 6
     expect(aAsD.D2).toBe(3); // @compatibility: on googlesheets, return 6
     expect(aAsD.D3).toBe(3); // @compatibility: on googlesheets, return 6
-    expect(aAsD.D4).toBe("#ERROR"); // @compatibility: on googlesheets, return 6
-    expect(aAsD.D5).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
-    expect(aAsD.D6).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
-    expect(aAsD.D7).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
-    expect(aAsD.D8).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(aAsD.D4).toBe("#N/A"); // @compatibility: on googlesheets, return 6
+    expect(aAsD.D5).toBe("#N/A");
+    expect(aAsD.D6).toBe("#N/A");
+    expect(aAsD.D7).toBe("#N/A");
+    expect(aAsD.D8).toBe("#N/A");
   });
 
   test("range evaluate unsorted", () => {
     const unsortedAsAscending = { ...rangeUnsorted, ...evAsAscending };
     const uAsA = evaluateGrid(unsortedAsAscending);
 
-    expect(uAsA.B1).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(uAsA.B1).toBe("#N/A");
     expect(uAsA.B2).toBe(1);
     expect(uAsA.B3).toBe(1);
     expect(uAsA.B4).toBe(3); // @compatibility: on googlesheets, return 5
@@ -198,13 +198,13 @@ describe("MATCH formula", () => {
     const unsortedAsUnsorted = { ...rangeUnsorted, ...evAsUnsorted };
     const uAsU = evaluateGrid(unsortedAsUnsorted);
 
-    expect(uAsU.C1).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(uAsU.C1).toBe("#N/A");
     expect(uAsU.C2).toBe(1);
     expect(uAsU.C3).toBe(5);
     expect(uAsU.C4).toBe(3);
-    expect(uAsU.C5).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(uAsU.C5).toBe("#N/A");
     expect(uAsU.C6).toBe(2);
-    expect(uAsU.C7).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(uAsU.C7).toBe("#N/A");
     expect(uAsU.C8).toBe(6);
 
     const unsortedAsDescending = { ...rangeUnsorted, ...evAsDescending };
@@ -214,19 +214,19 @@ describe("MATCH formula", () => {
     expect(uAsD.D2).toBe(5); // @compatibility: on googlesheets, return 6
     expect(uAsD.D3).toBe(5); // @compatibility: on googlesheets, return 6
     expect(uAsD.D4).toBe(3);
-    expect(uAsD.D5).toBe("#ERROR"); // @compatibility: on googlesheets, return 2
-    expect(uAsD.D6).toBe("#ERROR"); // @compatibility: on googlesheets, return 2
-    expect(uAsD.D7).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
-    expect(uAsD.D8).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(uAsD.D5).toBe("#N/A"); // @compatibility: on googlesheets, return 2
+    expect(uAsD.D6).toBe("#N/A"); // @compatibility: on googlesheets, return 2
+    expect(uAsD.D7).toBe("#N/A");
+    expect(uAsD.D8).toBe("#N/A");
   });
 
   test("range evaluate sorted descending", () => {
     const descendingAsAscending = { ...rangeDescending, ...evAsAscending };
     const dAsA = evaluateGrid(descendingAsAscending);
 
-    expect(dAsA.B1).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
-    expect(dAsA.B2).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
-    expect(dAsA.B3).toBe("#ERROR"); // @compatibility: on googlesheets, return 6
+    expect(dAsA.B1).toBe("#N/A");
+    expect(dAsA.B2).toBe("#N/A");
+    expect(dAsA.B3).toBe("#N/A"); // @compatibility: on googlesheets, return 6
     expect(dAsA.B4).toBe(3); // @compatibility: on googlesheets, return 6
     expect(dAsA.B5).toBe(3); // @compatibility: on googlesheets, return 6
     expect(dAsA.B6).toBe(3); // @compatibility: on googlesheets, return 6
@@ -236,14 +236,14 @@ describe("MATCH formula", () => {
     const descendingAsUnsorted = { ...rangeDescending, ...evAsUnsorted };
     const dAsU = evaluateGrid(descendingAsUnsorted);
 
-    expect(dAsU.C1).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(dAsU.C1).toBe("#N/A");
     expect(dAsU.C2).toBe(6);
     expect(dAsU.C3).toBe(4);
     expect(dAsU.C4).toBe(3);
-    expect(dAsU.C5).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(dAsU.C5).toBe("#N/A");
     expect(dAsU.C6).toBe(2);
     expect(dAsU.C7).toBe(1);
-    expect(dAsU.C8).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(dAsU.C8).toBe("#N/A");
 
     const descendingAsDescending = { ...rangeDescending, ...evAsDescending };
     const dAsD = evaluateGrid(descendingAsDescending);
@@ -255,7 +255,7 @@ describe("MATCH formula", () => {
     expect(dAsD.D5).toBe(2);
     expect(dAsD.D6).toBe(2);
     expect(dAsD.D7).toBe(1);
-    expect(dAsD.D8).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(dAsD.D8).toBe("#N/A");
   });
 
   test("grid of STRING ascending", () => {
@@ -291,7 +291,7 @@ describe("MATCH formula", () => {
 
     expect(unsortedString.C1).toBe(1);
     expect(unsortedString.C2).toBe(2);
-    expect(unsortedString.C3).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(unsortedString.C3).toBe("#N/A");
     expect(unsortedString.C4).toBe(4);
     expect(unsortedString.C5).toBe(5);
   });
@@ -310,7 +310,7 @@ describe("MATCH formula", () => {
 
     expect(descendingString.D1).toBe(5);
     expect(descendingString.D2).toBe(1);
-    expect(descendingString.D3).toBe("#ERROR"); // @compatibility: on googlesheets, return #N/A
+    expect(descendingString.D3).toBe("#N/A");
     expect(descendingString.D4).toBe(4);
     expect(descendingString.D5).toBe(3);
   });
@@ -393,7 +393,7 @@ describe("VLOOKUP formula", () => {
       expect(grid.B9).toBe(3);
       expect(grid.C9).toBe(5);
       expect(grid.D9).toBe(5);
-      expect(grid.E9).toBe("#ERROR");
+      expect(grid.E9).toBe("#N/A");
     });
 
     test("lookup string with string and number values", () => {
@@ -419,7 +419,7 @@ describe("VLOOKUP formula", () => {
       expect(grid.B9).toBe(3);
       expect(grid.C9).toBe(5);
       expect(grid.D9).toBe(5);
-      expect(grid.E9).toBe("#ERROR");
+      expect(grid.E9).toBe("#N/A");
       expect(grid.F9).toBe(3);
     });
 
@@ -444,7 +444,7 @@ describe("VLOOKUP formula", () => {
       expect(grid.B9).toBe(3);
       expect(grid.C9).toBe(5);
       expect(grid.D9).toBe(5);
-      expect(grid.E9).toBe("#ERROR");
+      expect(grid.E9).toBe("#N/A");
     });
   });
 
@@ -539,7 +539,7 @@ describe("VLOOKUP formula", () => {
         });
         expect(grid.Z1).toBe("C4");
         expect(grid.Z2).toBe("C6");
-        expect(grid.Z3).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
+        expect(grid.Z3).toBe("#N/A");
       });
 
       test("if all values in the search column are greater than the search key --> return #ERROR ", () => {
@@ -548,8 +548,8 @@ describe("VLOOKUP formula", () => {
           Z1: "=VLOOKUP( X3, A1:E6, 3, TRUE )",
           Z2: "=VLOOKUP( X4, A1:E6, 3, TRUE )",
         });
-        expect(grid.Z1).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
-        expect(grid.Z2).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
+        expect(grid.Z1).toBe("#N/A");
+        expect(grid.Z2).toBe("#N/A");
       });
     });
 
@@ -597,12 +597,12 @@ describe("VLOOKUP formula", () => {
         };
 
         const gridS = evaluateGrid({ ...gridSorted, ...formulas });
-        expect(gridS.Z1).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
-        expect(gridS.Z2).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
+        expect(gridS.Z1).toBe("#N/A");
+        expect(gridS.Z2).toBe("#N/A");
 
         const gridU = evaluateGrid({ ...gridUnsorted, ...formulas });
-        expect(gridU.Z1).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
-        expect(gridU.Z2).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
+        expect(gridU.Z1).toBe("#N/A");
+        expect(gridU.Z2).toBe("#N/A");
       });
     });
   });
@@ -709,8 +709,8 @@ describe("HLOOKUP formula", () => {
           Z1: "=HLOOKUP( X3, A1:F5, 3, TRUE )",
           Z2: "=HLOOKUP( X4, A1:F5, 3, TRUE )",
         });
-        expect(grid.Z1).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
-        expect(grid.Z2).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
+        expect(grid.Z1).toBe("#N/A");
+        expect(grid.Z2).toBe("#N/A");
       });
     });
 
@@ -758,12 +758,12 @@ describe("HLOOKUP formula", () => {
         };
 
         const gridS = evaluateGrid({ ...gridSorted, ...formulas });
-        expect(gridS.Z1).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
-        expect(gridS.Z2).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
+        expect(gridS.Z1).toBe("#N/A");
+        expect(gridS.Z2).toBe("#N/A");
 
         const gridU = evaluateGrid({ ...gridUnsorted, ...formulas });
-        expect(gridU.Z1).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
-        expect(gridU.Z2).toBe("#ERROR"); // @compatibility: on google sheets return #N/A
+        expect(gridU.Z1).toBe("#N/A");
+        expect(gridU.Z2).toBe("#N/A");
       });
     });
   });
@@ -820,7 +820,7 @@ describe("XLOOKUP formula", () => {
     });
     expect(grid.Z1).toBe(5);
     expect(grid.Z2).toBe("C3");
-    expect(grid.Z3).toBe("#ERROR");
+    expect(grid.Z3).toBe("#N/A");
   });
 
   test("if_not_found argument", () => {
@@ -831,7 +831,7 @@ describe("XLOOKUP formula", () => {
       Z2: '=XLOOKUP( "ola", B1:B6, C1:C6, 5 )',
       Z3: "=XLOOKUP( 5, B1:B6, C1:C6, Y2 )",
     });
-    expect(grid.Z1).toBe("#ERROR");
+    expect(grid.Z1).toBe("#N/A");
     expect(grid.Z2).toBe(5);
     expect(grid.Z3).toBe("C3");
   });
@@ -843,7 +843,7 @@ describe("XLOOKUP formula", () => {
         Z1: '=XLOOKUP( "c", B1:B6, B1:B6,, 0 )',
         Z2: '=XLOOKUP( "B1", B1:B6, B1:B6,, 0 )',
       });
-      expect(grid.Z1).toBe("#ERROR");
+      expect(grid.Z1).toBe("#N/A");
       expect(grid.Z2).toBe("B1");
     });
 
@@ -856,7 +856,7 @@ describe("XLOOKUP formula", () => {
       });
       expect(grid.Z1).toBe("b2");
       expect(grid.Z2).toBe(5);
-      expect(grid.Z3).toBe("#ERROR");
+      expect(grid.Z3).toBe("#N/A");
     });
 
     test("Next greater item", () => {
@@ -870,7 +870,7 @@ describe("XLOOKUP formula", () => {
       expect(grid.Z1).toBe("épinards");
       expect(grid.Z2).toBe("B1");
       expect(grid.Z3).toBe(5);
-      expect(grid.Z4).toBe("#ERROR");
+      expect(grid.Z4).toBe("#N/A");
     });
   });
 
@@ -926,10 +926,10 @@ describe("XLOOKUP formula", () => {
       });
       expect(grid.Z1).toBe("C2");
       expect(grid.Z2).toBe("C4");
-      expect(grid.Z3).toBe("#ERROR");
+      expect(grid.Z3).toBe("#N/A");
       expect(grid.Z4).toBe("C2");
       expect(grid.Z5).toBe("C2");
-      expect(grid.Z6).toBe("#ERROR");
+      expect(grid.Z6).toBe("#N/A");
       expect(grid.Z7).toBe("C3");
     });
 
@@ -946,10 +946,10 @@ describe("XLOOKUP formula", () => {
       });
       expect(grid.Z1).toBe("C5");
       expect(grid.Z2).toBe("C3");
-      expect(grid.Z3).toBe("#ERROR");
+      expect(grid.Z3).toBe("#N/A");
       expect(grid.Z4).toBe("C5");
       expect(grid.Z5).toBe("C5");
-      expect(grid.Z6).toBe("#ERROR");
+      expect(grid.Z6).toBe("#N/A");
       expect(grid.Z7).toBe("C4");
     });
   });


### PR DESCRIPTION
## Task Description

When using a function of the LOOKUP module, whe should get a N/A error when the value we are looking for doesn't exist in the specified range. To be able to get error that make sense anyway (as the NA error is silent nowadays), we then added the possibility to put a custom error message when throwing a NA error. If a custom message is added, the error will have the classical error level, while it will have the silent error level in the other case.

## Related task
Odoo task ID : [3067622](https://www.odoo.com/web#id=3067622&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo