### PR TITLE
[IMP] Long centered aligned cell contents overlapping with end non-empty cells

### DIFF
--- a/src/plugins/ui_feature/renderer.ts
+++ b/src/plugins/ui_feature/renderer.ts
@@ -664,17 +664,20 @@ export class RendererPlugin extends UIPlugin {
         case "center": {
           const emptyZone = {
             ...zone,
-            right: nextColIndex,
             left: previousColIndex,
+            right: nextColIndex,
           };
-          const { x, y, width, height } = this.getters.getVisibleRect(emptyZone);
+          const { x, y, height, width } = this.getters.getVisibleRect(emptyZone);
+          const halfContentWidth = contentWidth / 2;
+          const boxMiddle = box.x + box.width / 2;
           if (
-            width < contentWidth ||
-            previousColIndex === col ||
-            nextColIndex === col ||
+            x + width < boxMiddle + halfContentWidth ||
+            x > boxMiddle - halfContentWidth ||
             fontSizePX > height
           ) {
-            box.clipRect = { x, y, width, height };
+            const clipX = x > boxMiddle - halfContentWidth ? x : boxMiddle - halfContentWidth;
+            const clipWidth = x + width - clipX;
+            box.clipRect = { x: clipX, y, width: clipWidth, height };
           }
           break;
         }


### PR DESCRIPTION
## Description:

Now when a cell with long contents (overflow) is centered aligned and the cell which is located at the end of the overflowing contents also has contents (not empty), both contents will overlap, which causes annoying visual results. This bug only occurs when only one end cell has contents and the other doesn't (when both end cells have contents it seems good). 

The root cause is that when the available space (rect width) is equal to or more than the text width, it is not guaranteed that both the left half and the right half of the contents are perfectly fitted into the empty cells. Hence the fix includes separate judgement for the left and right half of the available space and text width. 

Odoo task ID : [3088107](https://www.odoo.com/web#id=3088107&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo