### PR TITLE
[FIX] figure: Avoid scroll on a focused figure

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -249,7 +249,15 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     useEffect(
       (selectedFigureId: UID | null, thisFigureId: UID, el: HTMLElement | null) => {
         if (selectedFigureId === thisFigureId) {
-          el?.focus();
+          /** Scrolling on a newly inserted figure that overflows outside the viewport
+           * will break the whole layout.
+           * NOTE: `preventScroll`does not work on mobile but then again,
+           * mobile is not really supported ATM.
+           *
+           * TODO: When implementing proper mobile, we will need to scroll the viewport
+           * correctly (and render?) before focusing the element.
+           */
+          el?.focus({ preventScroll: true });
         }
       },
       () => [this.env.model.getters.getSelectedFigureId(), this.props.figure.id, this.figureRef.el]

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -270,13 +270,14 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     ev.stopPropagation();
     const initialX = ev.clientX;
     const initialY = ev.clientY;
-    this.dnd.isActive = true;
+
     this.dnd.x = figure.x;
     this.dnd.y = figure.y;
     this.dnd.width = figure.width;
     this.dnd.height = figure.height;
 
     const onMouseMove = (ev: MouseEvent) => {
+      this.dnd.isActive = true;
       const deltaX = Math.max(dirX * (ev.clientX - initialX), MIN_FIG_SIZE - figure.width);
       const deltaY = Math.max(dirY * (ev.clientY - initialY), MIN_FIG_SIZE - figure.height);
       this.dnd.width = figure.width + deltaX;
@@ -331,13 +332,13 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
 
     const initialX = ev.clientX - position.left;
     const initialY = ev.clientY - position.top;
-    this.dnd.isActive = true;
     this.dnd.x = figure.x;
     this.dnd.y = figure.y;
     this.dnd.width = figure.width;
     this.dnd.height = figure.height;
 
     const onMouseMove = (ev: MouseEvent) => {
+      this.dnd.isActive = true;
       const newX = ev.clientX - position.left;
       let deltaX = newX - initialX;
       if (newX > offsetCorrectionX && initialX < offsetCorrectionX) {

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -5,7 +5,7 @@
       class="o-grid-overlay"
       t-att-style="props.gridOverlayDimensions"
       t-on-mousedown="onMouseDown"
-      t-on-dblclick="onDoubleClick"
+      t-on-dblclick.self="onDoubleClick"
       t-on-contextmenu="onContextMenu">
       <!-- TODO remove sidePanelIsOpen props. It is wrong.
       If you have a CF sidepanel open, selecting a figure should

--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -275,9 +275,10 @@ export class InternalViewport {
     return -1;
   }
 
-  get zone() {
+  private get zone() {
     return { left: this.left, right: this.right, top: this.top, bottom: this.bottom };
   }
+
   private setViewportOffsetX(offsetX: Pixel) {
     if (!this.canScrollHorizontally) {
       return;

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -316,8 +316,17 @@ describe("figures", () => {
   test("Selected figure isn't removed by scroll", async () => {
     createFigure(model);
     model.dispatch("SELECT_FIGURE", { id: "someuuid" });
+    await nextTick();
     fixture.querySelector(".o-grid")!.dispatchEvent(new WheelEvent("wheel", { deltaX: 1500 }));
     fixture.querySelector(".o-scrollbar.vertical")!.dispatchEvent(new Event("scroll"));
     expect(model.getters.getSelectedFigureId()).toEqual("someuuid");
+  });
+
+  test("Clicking a figure does not mark it a 'dragging'", async () => {
+    createFigure(model);
+    await nextTick();
+    triggerMouseEvent(".o-figure", "mousedown", 0, 0);
+    await nextTick();
+    expect(fixture.querySelector(".o-figure")?.classList.contains("o-dragging")).toBeFalsy();
   });
 });

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -48,6 +48,7 @@ import {
   Touch,
 } from "../test_helpers/helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
+import { mockChart } from "./__mocks__/chart";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("./__mocks__/content_editable_helper")
 );
@@ -1469,5 +1470,26 @@ describe("Copy paste keyboard shortcut", () => {
     document.body.dispatchEvent(await getClipboardEvent("paste"));
     expect(model.getters.getChartIds(sheetId)).toHaveLength(1);
     expect(model.getters.getChartIds(sheetId)[0]).not.toEqual("chartId");
+  });
+
+  test("Double clicking only opens composer when actually targetting grid overlay", async () => {
+    // creating a child  node
+    mockChart();
+    createChart(model, {}, "chartId");
+    await nextTick();
+    await simulateClick(".o-figure", 0, 0);
+    await nextTick();
+    expect(document.activeElement).toBe(fixture.querySelector(".o-figure"));
+    // double click on child
+    triggerMouseEvent(".o-figure", "dblclick");
+    await nextTick();
+    expect(model.getters.getEditionMode()).toBe("inactive");
+    expect(document.activeElement).toBe(fixture.querySelector(".o-figure"));
+
+    // double click on grid overlay
+    triggerMouseEvent(".o-grid-overlay", "dblclick");
+    await nextTick();
+    expect(model.getters.getEditionMode()).toBe("editing");
+    expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer"));
   });
 });


### PR DESCRIPTION
## [FIX] figure: Avoid scroll on a focused figure 

Focusing an element will (by default) scroll the element into view (https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) unfortunately, due to the current HTML architecture, the scroll will pull the whole grid overlay when trying to display a figure that overflow outside the currently visible viewport.

NOTE: The solution proposed is not supported on mobile browsers but a quick test on firefox Android showed that we do not have the same overflow issue.

To reproduce:
- Create a chart on a sheet
- copy chart (Ctrl+C)
- select a cell in the last visible row of the sheet
- paste the chart (Ctrl+V) -> the layout is broken

## [FIX] figure: apply dragging style on actual drag, not on mousedown

making the chart transparent on a simple click makes no sense

[FIX] GridOverlay: Only react to self targetted double clicks

a dbl click event targeting a child of gridOverlay will be caught by the latter and start the edition ....

Task 3090033

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3090033](https://www.odoo.com/web#id=3090033&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo