### PR TITLE
[FIX] figure: Change component structure to leverage navigator native behaviour

### DIFF
--- a/src/components/figures/chart/scorecard/chart_scorecard.xml
+++ b/src/components/figures/chart/scorecard/chart_scorecard.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-ScorecardChart" owl="1">
-    <div class="o-scorecard" t-att-style="chartStyle">
+    <div class="o-scorecard w-100 h-100" t-att-style="chartStyle" t-ref="chart">
       <t t-set="textStyles" t-value="getTextStyles()"/>
       <div t-if="title" class="o-title-text" t-esc="title" t-att-style="textStyles.titleStyle"/>
       <div class="o-scorecard-content" t-att-style="chartContentStyle">

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -11,7 +11,7 @@ import { css } from "../../helpers/css";
 import { gridOverlayPosition } from "../../helpers/dom_helpers";
 import { startDnd } from "../../helpers/drag_and_drop";
 
-type Anchor =
+type ResizeAnchor =
   | "top left"
   | "top"
   | "top right"
@@ -30,19 +30,14 @@ const ACTIVE_BORDER_WIDTH = 2;
 
 css/*SCSS*/ `
   div.o-figure {
-    box-sizing: content-box;
+    box-sizing: border-box;
     position: absolute;
     width: 100%;
     height: 100%;
 
-    bottom: 0px;
-    right: 0px;
     border: solid ${FIGURE_BORDER_COLOR};
     &:focus {
       outline: none;
-    }
-    &.active {
-      border: solid ${SELECTION_BORDER_COLOR};
     }
 
     &.o-dragging {
@@ -51,17 +46,17 @@ css/*SCSS*/ `
     }
   }
 
+  div.o-active-figure-border {
+    box-sizing: border-box;
+    z-index: 1;
+    border: ${ACTIVE_BORDER_WIDTH}px solid ${SELECTION_BORDER_COLOR};
+  }
+
   .o-figure-wrapper {
     position: absolute;
     box-sizing: content-box;
 
-    .o-figure-overflow-wrapper {
-      position: absolute;
-      overflow: hidden;
-      width: 100%;
-      height: 100%;
-    }
-    .o-anchor {
+    .o-fig-resizer {
       z-index: ${ComponentsImportance.ChartAnchor};
       position: absolute;
       width: ${ANCHOR_SIZE}px;
@@ -97,11 +92,75 @@ css/*SCSS*/ `
   }
 `;
 
+interface DndState {
+  isActive: boolean;
+  x: Pixel;
+  y: Pixel;
+  width: Pixel;
+  height: Pixel;
+}
+
 interface Props {
   sidePanelIsOpen: Boolean;
   onFigureDeleted: () => void;
   figure: Figure;
 }
+
+/**
+ * Each figure ⭐ is positioned inside a container `div` placed and sized
+ * according to the split pane the figure is part of.
+ * Any part of the figure outside of the container is hidden
+ * thanks to its `overflow: hidden` property.
+ *
+ * Additionally, the figure is placed inside a "inverse viewport" `div` 🟥.
+ * Its position represents the viewport position in the grid: its top/left
+ * corner represents the top/left corner of the grid.
+ *
+ * It allows to position the figure inside this div regardless of the
+ * (possibly freezed) viewports and the scrolling position.
+ *
+ * --: container limits
+ * 🟥: inverse viewport
+ * ⭐: figure top/left position
+ *
+ *                     container
+ *                         ↓
+ * |🟥--------------------------------------------
+ * |  \                                          |
+ * |   \                                         |
+ * |    \                                        |
+ * |     \          visible area                 |  no scroll
+ * |      ⭐                                     |
+ * |                                             |
+ * |                                             |
+ * -----------------------------------------------
+ *
+ * the scrolling of the pane is applied as an inverse offset
+ * to the div which will in turn move the figure up and down
+ * inside the container.
+ * Hence, once the figure position is (resp. partly) out of
+ * the container dimensions, it will be (resp. partly) hidden.
+ *
+ * The same reasoning applies to the horizontal axis.
+ *
+ *  🟥 ························
+ *    \                       ↑
+ *     \                      |
+ *      \                     | inverse viewport = -1 * scroll of pane
+ *       \                    |
+ *        ⭐ <- not visible   |
+ *                            ↓
+ * -----------------------------------------------
+ * |                                             |
+ * |                                             |
+ * |                                             |
+ * |               visible area                  |
+ * |                                             |
+ * |                                             |
+ * |                                             |
+ * -----------------------------------------------
+ *
+ */
 
 export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FigureComponent";
@@ -110,7 +169,7 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
 
   private figureRef = useRef("figure");
 
-  dnd = useState({
+  dnd: DndState = useState({
     isActive: false,
     x: 0,
     y: 0,
@@ -126,123 +185,76 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     return this.env.model.getters.getSelectedFigureId() === this.props.figure.id;
   }
 
-  /** Get the current figure size, which is either the stored figure size of the DnD figure size */
-  private getFigureSize() {
-    const { width, height } = this.displayedFigure;
-    return { width, height };
+  get containerStyle(): string {
+    const { x: figureX, y: figureY } = this.props.figure;
+    const { width: viewWidth, height: viewHeight } = this.env.model.getters.getMainViewportRect();
+    const { x, y } = this.env.model.getters.getMainViewportCoordinates();
+
+    const left = figureX >= x ? x : 0;
+    const width = viewWidth - left;
+    const top = figureY >= y ? y : 0;
+    const height = viewHeight - top;
+
+    return `
+      left: ${left}px;
+      top: ${top}px;
+      width: ${width}px;
+      height: ${height}px
+    `;
   }
 
-  private getFigureSizeWithBorders() {
-    const { width, height } = this.getFigureSize();
-    const borders = this.getBorderWidth() * 2;
-    return { width: width + borders, height: height + borders };
+  get inverseViewportPositionStyle(): string {
+    const { x: figureX, y: figureY } = this.props.figure;
+    const { offsetX, offsetY } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { x, y } = this.env.model.getters.getMainViewportCoordinates();
+
+    const left = figureX >= x ? -(x + offsetX) : 0;
+    const top = figureY >= y ? -(y + offsetY) : 0;
+
+    return `
+      left: ${left}px;
+      top: ${top}px;
+    `;
   }
 
   private getBorderWidth() {
-    return this.isSelected ? ACTIVE_BORDER_WIDTH : this.env.isDashboard() ? 0 : BORDER_WIDTH;
+    return this.env.isDashboard() ? 0 : BORDER_WIDTH;
   }
 
-  getFigureStyle() {
-    const { width, height } = this.displayedFigure;
-    return `width:${width}px;height:${height}px;border-width: ${this.getBorderWidth()}px;`;
+  get figureStyle() {
+    return `border-width: ${this.getBorderWidth()}px;`;
   }
 
-  getContainerStyle() {
-    const target = this.displayedFigure;
-    const { x: offsetCorrectionX, y: offsetCorrectionY } =
-      this.env.model.getters.getMainViewportCoordinates();
-
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSheetScrollInfo();
-    let { width, height } = this.getFigureSizeWithBorders();
-    let x: Pixel, y: Pixel;
-
-    // Visually, the content of the container is slightly shifted as it includes borders and/or corners.
-    // If we want to make assertions on the position of the content, we need to take this shift into account
-    const borderShift = ANCHOR_SIZE / 2;
-
-    if (target.x + borderShift < offsetCorrectionX) {
-      x = target.x;
-    } else if (target.x + borderShift < offsetCorrectionX + offsetX) {
-      x = offsetCorrectionX;
-      width += target.x - offsetCorrectionX - offsetX;
-    } else {
-      x = target.x - offsetX;
-    }
-
-    if (target.y + borderShift < offsetCorrectionY) {
-      y = target.y;
-    } else if (target.y + borderShift < offsetCorrectionY + offsetY) {
-      y = offsetCorrectionY;
-      height += target.y - offsetCorrectionY - offsetY;
-    } else {
-      y = target.y - offsetY;
-    }
-
-    if (width < 0 || height < 0) {
-      return `display:none;`;
-    }
-    const borderOffset = BORDER_WIDTH - this.getBorderWidth();
-    // TODO : remove the +1 once 2951210 is fixed
+  get wrapperStyle() {
+    const { x, y, width, height } = this.displayedFigure;
     return (
-      `top:${y + borderOffset + 1}px;` +
-      `left:${x + borderOffset}px;` +
+      `top:${y}px;` +
+      `left:${x}px;` +
       `width:${width}px;` +
       `height:${height}px;` +
       `z-index: ${ComponentsImportance.Figure + (this.isSelected ? 1 : 0)}`
     );
   }
 
-  getAnchorPosition(anchor: Anchor) {
-    let { width, height } = this.getFigureSizeWithBorders();
-
+  getResizerPosition(resizer: ResizeAnchor) {
     const anchorCenteringOffset = (ANCHOR_SIZE - ACTIVE_BORDER_WIDTH) / 2;
-    const target = this.displayedFigure;
-
-    let x = 0;
-    let y = 0;
-
-    const { x: offsetCorrectionX, y: offsetCorrectionY } =
-      this.env.model.getters.getMainViewportCoordinates();
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSheetScrollInfo();
-    const borderShift = ANCHOR_SIZE / 2;
-
-    if (target.x + borderShift < offsetCorrectionX) {
-      x = 0;
-    } else if (target.x + borderShift < offsetCorrectionX + offsetX) {
-      x = target.x - offsetCorrectionX - offsetX;
+    let style = "";
+    if (resizer.includes("top")) {
+      style += `top: ${-anchorCenteringOffset}px;`;
+    } else if (resizer.includes("bottom")) {
+      style += `bottom: ${-anchorCenteringOffset}px;`;
     } else {
-      x = 0;
+      style += ` bottom: calc(50% - ${anchorCenteringOffset}px);`;
     }
 
-    if (target.y + borderShift < offsetCorrectionY) {
-      y = 0;
-    } else if (target.y + borderShift < offsetCorrectionY + offsetY) {
-      y = target.y - offsetCorrectionY - offsetY;
+    if (resizer.includes("left")) {
+      style += `left: ${-anchorCenteringOffset}px;`;
+    } else if (resizer.includes("right")) {
+      style += `right: ${-anchorCenteringOffset}px;`;
     } else {
-      y = 0;
+      style += ` right: calc(50% - ${anchorCenteringOffset}px);`;
     }
-
-    if (anchor.includes("top")) {
-      y -= anchorCenteringOffset;
-    } else if (anchor.includes("bottom")) {
-      y += height - ACTIVE_BORDER_WIDTH - anchorCenteringOffset;
-    } else {
-      y += (height - ACTIVE_BORDER_WIDTH) / 2 - anchorCenteringOffset;
-    }
-
-    if (anchor.includes("left")) {
-      x += -anchorCenteringOffset;
-    } else if (anchor.includes("right")) {
-      x += width - ACTIVE_BORDER_WIDTH - anchorCenteringOffset;
-    } else {
-      x += (width - ACTIVE_BORDER_WIDTH) / 2 - anchorCenteringOffset;
-    }
-
-    let visibility = "visible";
-    if (x < -anchorCenteringOffset || y < -anchorCenteringOffset) {
-      visibility = "hidden";
-    }
-    return `visibility:${visibility};top:${y}px; left:${x}px;`;
+    return style;
   }
 
   setup() {
@@ -312,7 +324,6 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
 
   onMouseDown(ev: MouseEvent) {
     const figure = this.props.figure;
-
     if (ev.button > 0 || this.env.model.getters.isReadonly()) {
       // not main button, probably a context menu
       return;
@@ -329,6 +340,7 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     const { x: offsetCorrectionX, y: offsetCorrectionY } =
       this.env.model.getters.getMainViewportCoordinates();
     const { offsetX, offsetY } = this.env.model.getters.getActiveSheetScrollInfo();
+    const sheetId = this.env.model.getters.getActiveSheetId();
 
     const initialX = ev.clientX - position.left;
     const initialY = ev.clientY - position.top;
@@ -341,31 +353,27 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
       this.dnd.isActive = true;
       const newX = ev.clientX - position.left;
       let deltaX = newX - initialX;
-      if (newX > offsetCorrectionX && initialX < offsetCorrectionX) {
-        deltaX += offsetX;
-      } else if (newX < offsetCorrectionX && initialX > offsetCorrectionX) {
-        deltaX -= offsetX;
-      }
       this.dnd.x = Math.max(figure.x + deltaX, 0);
 
       const newY = ev.clientY - position.top;
       let deltaY = newY - initialY;
-
-      if (newY > offsetCorrectionY && initialY < offsetCorrectionY) {
-        deltaY += offsetY;
-      } else if (newY < offsetCorrectionY && initialY > offsetCorrectionY) {
-        deltaY -= offsetY;
-      }
       this.dnd.y = Math.max(figure.y + deltaY, 0);
     };
     const onMouseUp = (ev: MouseEvent) => {
+      let { x, y } = this.dnd;
+      // Correct position in case of moving to/from a frozen pane
+      if (this.dnd.x > offsetCorrectionX && figure.x < offsetCorrectionX) {
+        x += offsetX;
+      } else if (this.dnd.x < offsetCorrectionX && figure.x > offsetCorrectionX) {
+        x -= offsetX;
+      }
+      if (this.dnd.y > offsetCorrectionY && figure.y < offsetCorrectionY) {
+        y += offsetY;
+      } else if (this.dnd.y < offsetCorrectionY && figure.y > offsetCorrectionY) {
+        y -= offsetY;
+      }
       this.dnd.isActive = false;
-      this.env.model.dispatch("UPDATE_FIGURE", {
-        sheetId: this.env.model.getters.getActiveSheetId(),
-        id: figure.id,
-        x: this.dnd.x,
-        y: this.dnd.y,
-      });
+      this.env.model.dispatch("UPDATE_FIGURE", { sheetId, id: figure.id, x, y });
     };
     startDnd(onMouseMove, onMouseUp);
   }

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -1,67 +1,75 @@
 <templates>
   <t t-name="o-spreadsheet-FigureComponent" owl="1">
-    <div class="o-figure-wrapper" t-att-style="getContainerStyle()">
-      <div class="o-figure-overflow-wrapper">
-        <div
-          class="o-figure"
-          t-on-mousedown.stop="(ev) => this.onMouseDown(ev)"
-          t-att-style="getFigureStyle()"
-          t-att-class="{active: isSelected, 'o-dragging': dnd.isActive}"
-          t-ref="figure"
-          tabindex="0"
-          t-on-keydown.stop="(ev) => this.onKeyDown(ev)"
-          t-on-keyup.stop="">
-          <t
-            t-component="figureRegistry.get(this.props.figure.tag).Component"
-            t-key="this.props.figure.id"
-            sidePanelIsOpen="props.sidePanelIsOpen"
-            onFigureDeleted="props.onFigureDeleted"
-            figure="displayedFigure"
-          />
+    <div
+      class="position-absolute pe-none"
+      t-att-class="{'overflow-hidden': !dnd.isActive}"
+      t-att-style="containerStyle">
+      <div
+        class="o-figure-viewport-inverse w-0 h-0 overflow-visible position-absolute"
+        t-att-style="inverseViewportPositionStyle">
+        <div class="o-figure-wrapper pe-auto" t-att-style="wrapperStyle">
+          <div
+            class="o-figure w-100 h-100"
+            t-on-mousedown.stop="(ev) => this.onMouseDown(ev)"
+            t-att-class="{'o-dragging': dnd.isActive}"
+            t-ref="figure"
+            t-att-style="figureStyle"
+            tabindex="0"
+            t-on-keydown.stop="(ev) => this.onKeyDown(ev)"
+            t-on-keyup.stop="">
+            <t
+              t-component="figureRegistry.get(this.props.figure.tag).Component"
+              t-key="this.props.figure.id"
+              sidePanelIsOpen="props.sidePanelIsOpen"
+              onFigureDeleted="props.onFigureDeleted"
+              figure="displayedFigure"
+            />
+          </div>
+          <t t-if="isSelected">
+            <div class="w-100 h-100 o-active-figure-border position-absolute pe-none"/>
+            <div
+              class="o-fig-resizer o-top"
+              t-att-style="this.getResizerPosition('top')"
+              t-on-mousedown="(ev) => this.resize(0,-1, ev)"
+            />
+            <div
+              class="o-fig-resizer o-topRight"
+              t-att-style="this.getResizerPosition('top right')"
+              t-on-mousedown="(ev) => this.resize(1,-1, ev)"
+            />
+            <div
+              class="o-fig-resizer o-right"
+              t-att-style="this.getResizerPosition('right')"
+              t-on-mousedown="(ev) => this.resize(1,0, ev)"
+            />
+            <div
+              class="o-fig-resizer o-bottomRight"
+              t-att-style="this.getResizerPosition('bottom right')"
+              t-on-mousedown="(ev) => this.resize(1,1, ev)"
+            />
+            <div
+              class="o-fig-resizer o-bottom"
+              t-att-style="this.getResizerPosition('bottom')"
+              t-on-mousedown="(ev) => this.resize(0,1, ev)"
+            />
+            <div
+              class="o-fig-resizer o-bottomLeft"
+              t-att-style="this.getResizerPosition('bottom left')"
+              t-on-mousedown="(ev) => this.resize(-1,1, ev)"
+            />
+            <div
+              class="o-fig-resizer o-left"
+              t-att-style="this.getResizerPosition('left')"
+              t-on-mousedown="(ev) => this.resize(-1,0, ev)"
+            />
+            <div
+              class="o-fig-resizer o-topLeft"
+              t-att-style="this.getResizerPosition('top left')"
+              t-on-mousedown="(ev) => this.resize(-1,-1, ev)"
+            />
+          </t>
         </div>
       </div>
-      <t t-if="isSelected">
-        <div
-          class="o-anchor o-top"
-          t-att-style="this.getAnchorPosition('top')"
-          t-on-mousedown.stop="(ev) => this.resize(0,-1, ev)"
-        />
-        <div
-          class="o-anchor o-topRight"
-          t-att-style="this.getAnchorPosition('top right')"
-          t-on-mousedown.stop="(ev) => this.resize(1,-1, ev)"
-        />
-        <div
-          class="o-anchor o-right"
-          t-att-style="this.getAnchorPosition('right')"
-          t-on-mousedown.stop="(ev) => this.resize(1,0, ev)"
-        />
-        <div
-          class="o-anchor o-bottomRight"
-          t-att-style="this.getAnchorPosition('bottom right', info)"
-          t-on-mousedown.stop="(ev) => this.resize(1,1, ev)"
-        />
-        <div
-          class="o-anchor o-bottom"
-          t-att-style="this.getAnchorPosition('bottom')"
-          t-on-mousedown.stop="(ev) => this.resize(0,1, ev)"
-        />
-        <div
-          class="o-anchor o-bottomLeft"
-          t-att-style="this.getAnchorPosition('bottom left')"
-          t-on-mousedown.stop="(ev) => this.resize(-1,1, ev)"
-        />
-        <div
-          class="o-anchor o-left"
-          t-att-style="this.getAnchorPosition('left')"
-          t-on-mousedown.stop="(ev) => this.resize(-1,0, ev)"
-        />
-        <div
-          class="o-anchor o-topLeft"
-          t-att-style="this.getAnchorPosition('top left')"
-          t-on-mousedown.stop="(ev) => this.resize(-1,-1, ev)"
-        />
-      </t>
     </div>
   </t>
 </templates>

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-ChartFigure" owl="1">
     <div
-      class="o-chart-container"
+      class="o-chart-container w-100 h-100"
       t-ref="chartContainer"
       t-on-contextmenu.prevent.stop="(ev) => !env.isDashboard() and this.onContextMenu(ev)">
       <div class="o-chart-menu" t-if="!env.isDashboard()">

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-GridOverlay" owl="1">
     <div
       t-ref="gridOverlay"
-      class="o-grid-overlay"
+      class="o-grid-overlay overflow-hidden"
       t-att-style="props.gridOverlayDimensions"
       t-on-mousedown="onMouseDown"
       t-on-dblclick.self="onDoubleClick"

--- a/tests/components/__snapshots__/dashboard_grid.test.ts.snap
+++ b/tests/components/__snapshots__/dashboard_grid.test.ts.snap
@@ -12,7 +12,7 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
     "
   >
     <div
-      class="o-grid-overlay"
+      class="o-grid-overlay overflow-hidden"
       style="
       height: 100%;
       width: 100%

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   tabindex="-1"
 >
   <div
-    class="o-grid-overlay"
+    class="o-grid-overlay overflow-hidden"
     style="
       top: 26px;
       left: 48px;

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`Scorecard charts Scorecard snapshot 1`] = `
 <div
-  class="o-figure"
-  style="width:536px;height:335px;border-width: 1px;"
+  class="o-figure w-100 h-100"
+  style="border-width: 1px;"
   tabindex="0"
 >
   <div
-    class="o-chart-container"
+    class="o-chart-container w-100 h-100"
   >
     <div
       class="o-chart-menu"
@@ -42,10 +42,8 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
     </div>
     
     <div
-      class="o-scorecard"
+      class="o-scorecard w-100 h-100"
       style="
-      height:335px;
-      width:536px;
       padding:10.72px;
       background:#FFFFFF;
     "
@@ -132,12 +130,12 @@ color: #757575;
 
 exports[`Scorecard charts scorecard text is resized while figure is resized 1`] = `
 <div
-  class="o-figure active o-dragging"
-  style="width:236px;height:135px;border-width: 2px;"
+  class="o-figure w-100 h-100 o-dragging"
+  style="border-width: 1px;"
   tabindex="0"
 >
   <div
-    class="o-chart-container"
+    class="o-chart-container w-100 h-100"
   >
     <div
       class="o-chart-menu"
@@ -172,10 +170,8 @@ exports[`Scorecard charts scorecard text is resized while figure is resized 1`] 
     </div>
     
     <div
-      class="o-scorecard"
+      class="o-scorecard w-100 h-100"
       style="
-      height:135px;
-      width:236px;
       padding:4.72px;
       background:#FFFFFF;
     "

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -395,7 +395,7 @@ exports[`Spreadsheet simple rendering snapshot 1`] = `
     tabindex="-1"
   >
     <div
-      class="o-grid-overlay"
+      class="o-grid-overlay overflow-hidden"
       style="
       top: 26px;
       left: 48px;

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -1,6 +1,6 @@
 import { App, Component, xml } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
-import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH, MIN_FIG_SIZE } from "../../src/constants";
+import { MIN_FIG_SIZE } from "../../src/constants";
 import { figureRegistry } from "../../src/registries";
 import { CreateFigureCommand, Figure, SpreadsheetChildEnv, UID } from "../../src/types";
 import {
@@ -39,14 +39,14 @@ function createFigure(
 }
 
 const anchorSelectors = {
-  top: ".o-anchor.o-top",
-  topRight: ".o-anchor.o-topRight",
-  right: ".o-anchor.o-right",
-  bottomRight: ".o-anchor.o-bottomRight",
-  bottom: ".o-anchor.o-bottom",
-  bottomLeft: ".o-anchor.o-bottomLeft",
-  left: ".o-anchor.o-left",
-  topLeft: ".o-anchor.o-topLeft",
+  top: ".o-fig-resizer.o-top",
+  topRight: ".o-fig-resizer.o-topRight",
+  right: ".o-fig-resizer.o-right",
+  bottomRight: ".o-fig-resizer.o-bottomRight",
+  bottom: ".o-fig-resizer.o-bottom",
+  bottomLeft: ".o-fig-resizer.o-bottomLeft",
+  left: ".o-fig-resizer.o-left",
+  topLeft: ".o-fig-resizer.o-topLeft",
 };
 async function dragAnchor(anchor: string, dragX: number, dragY: number, mouseUp = false) {
   const anchorElement = fixture.querySelector(anchorSelectors[anchor])!;
@@ -192,7 +192,7 @@ describe("figures", () => {
     createFigure(model);
     model.dispatch("SELECT_FIGURE", { id: "someuuid" });
     await nextTick();
-    const anchors = fixture.querySelectorAll(".o-anchor");
+    const anchors = fixture.querySelectorAll(".o-fig-resizer");
     expect(anchors).toHaveLength(8);
   });
 
@@ -255,7 +255,7 @@ describe("figures", () => {
     expect(model.getters.getSelectedFigureId()).toBe(figureId);
     expect(model.getters.getFigure(model.getters.getActiveSheetId(), figureId)!.height).toBe(100);
     // increase height by 50 pixels from the top anchor
-    const resizeTopSelector = fixture.querySelector(".o-anchor.o-top");
+    const resizeTopSelector = fixture.querySelector(".o-fig-resizer.o-top");
     triggerMouseEvent(resizeTopSelector, "mousedown", 0, 200);
     await nextTick();
     triggerMouseEvent(resizeTopSelector, "mousemove", 0, 150);
@@ -273,7 +273,7 @@ describe("figures", () => {
     const figure = fixture.querySelector(".o-figure")!;
     await simulateClick(".o-figure");
     expect(document.activeElement).not.toBe(figure);
-    expect(fixture.querySelector(".o-anchor")).toBeNull();
+    expect(fixture.querySelector(".o-fig-resizer")).toBeNull();
 
     triggerMouseEvent(figure, "mousedown", 300, 200);
     await nextTick();
@@ -291,26 +291,6 @@ describe("figures", () => {
     await nextTick();
     figure = fixture.querySelector(".o-figure")! as HTMLElement;
     expect(window.getComputedStyle(figure)["border-width"]).toEqual("0px");
-  });
-
-  test("Figures are cropped to avoid overlap with headers", async () => {
-    const figureId = "someuuid";
-    createFigure(model, { id: figureId, x: 100, y: 20, height: 200, width: 100 });
-    await nextTick();
-    const figure = fixture.querySelector(".o-figure-wrapper")!;
-    expect(window.getComputedStyle(figure).width).toBe("102px"); // width + borders
-    expect(window.getComputedStyle(figure).height).toBe("202px"); // height + borders
-    model.dispatch("SET_VIEWPORT_OFFSET", {
-      offsetX: 2 * DEFAULT_CELL_WIDTH,
-      offsetY: 3 * DEFAULT_CELL_HEIGHT,
-    });
-    await nextTick();
-
-    const expectedWidth = 102 - (2 * DEFAULT_CELL_WIDTH - 100); // = width + borders - (overflow = viewport offset X - x)
-    const expectedHeight = 202 - (3 * DEFAULT_CELL_HEIGHT - 20); // = height + borders - (overflow = viewport offset Y - y)
-
-    expect(window.getComputedStyle(figure).width).toBe(`${expectedWidth}px`);
-    expect(window.getComputedStyle(figure).height).toBe(`${expectedHeight}px`);
   });
 
   test("Selected figure isn't removed by scroll", async () => {

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -1,8 +1,11 @@
 import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
+import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../../src/constants";
 import { toHex } from "../../src/helpers";
+import { Rect, UID } from "../../src/types";
+import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart";
 import {
-  createScorecardChart,
+  createScorecardChart as createScorecardChartHelper,
   setCellContent,
   updateChart,
 } from "../test_helpers/commands_helpers";
@@ -17,6 +20,21 @@ let sheetId: string;
 
 let parent: Spreadsheet;
 let app: App;
+
+const figureRect: Rect = { x: 0, y: 0, width: 0, height: 0 };
+const defaultRect = { x: 0, y: 0, width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
+
+const originalGetBoundingClientRect = HTMLDivElement.prototype.getBoundingClientRect;
+// @ts-ignore the mock should return a complete DOMRect, not only { top, left }
+jest
+  .spyOn(HTMLDivElement.prototype, "getBoundingClientRect")
+  .mockImplementation(function (this: HTMLDivElement) {
+    const isScoreCard = this.className.includes("o-scorecard");
+    if (isScoreCard) {
+      return figureRect;
+    }
+    return originalGetBoundingClientRect.call(this);
+  });
 
 function getChartElement(): HTMLElement {
   return fixture.querySelector(".o-figure")!;
@@ -47,7 +65,21 @@ function getElementFontSize(element: HTMLElement): number {
   return Number(fontSizeAttr.slice(0, fontSizeAttr.length - 2));
 }
 
-function updateChartSize(width: number, height: number) {
+async function createScorecardChart(
+  model: Model,
+  data: Partial<ScorecardChartDefinition>,
+  chartId?: UID,
+  sheetId?: UID
+) {
+  figureRect.width = DEFAULT_FIGURE_WIDTH;
+  figureRect.height = DEFAULT_FIGURE_HEIGHT;
+  createScorecardChartHelper(model, data, chartId, sheetId);
+  await nextTick();
+  // second tick required for the useEffect to be effective
+  await nextTick();
+}
+
+async function updateScorecardChartSize(width: number, height: number) {
   model.dispatch("UPDATE_FIGURE", {
     sheetId,
     id: chartId,
@@ -56,6 +88,9 @@ function updateChartSize(width: number, height: number) {
     width,
     height,
   });
+  figureRect.width = width;
+  figureRect.height = height;
+  await nextTick();
 }
 
 function getChartBaselineTextContent() {
@@ -92,48 +127,49 @@ describe("Scorecard charts", () => {
       ],
     };
     ({ app, parent } = await mountSpreadsheet(fixture, { model: new Model(data) }));
+    Object.assign(figureRect, defaultRect);
     model = parent.model;
-    await nextTick();
-    await nextTick();
   });
+
   afterEach(() => {
     app.destroy();
     fixture.remove();
+    Object.assign(figureRect, defaultRect);
   });
 
   test("Scorecard snapshot", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B1", title: "hello", baselineDescr: "description" },
       chartId
     );
-    await nextTick();
     expect(getChartElement()).toMatchSnapshot();
   });
 
   test("scorecard text is resized while figure is resized", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B1", title: "hello", baselineDescr: "description" },
       chartId
     );
-    await nextTick();
     await simulateClick(".o-figure");
-    expect(getElComputedStyle(".o-figure", "width")).toBe("536px");
-    expect(getElComputedStyle(".o-figure", "height")).toBe("335px");
-    await dragElement(".o-anchor.o-topLeft", 300, 200);
-    expect(getElComputedStyle(".o-figure", "width")).toBe("236px");
-    expect(getElComputedStyle(".o-figure", "height")).toBe("135px");
+    expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("536px");
+    expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("335px");
+    // required to mock getBoundingClientRect
+    figureRect.width -= 300;
+    figureRect.height -= 200;
+    await dragElement(".o-fig-resizer.o-topLeft", 300, 200);
+    expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("236px");
+    expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("135px");
     expect(getChartElement()).toMatchSnapshot();
   });
 
   test("Chart display correct info", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B1", title: "hello", baselineDescr: "description" },
       chartId
     );
-    await nextTick();
 
     expect(getChartElement()).toBeTruthy();
     expect(getChartTitleElement()?.textContent).toEqual("hello");
@@ -144,8 +180,7 @@ describe("Scorecard charts", () => {
   test("Baseline = 0 correctly displayed", async () => {
     setCellContent(model, "B1", "0");
     setCellContent(model, "A1", "0");
-    createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
-    await nextTick();
+    await createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
 
     expect(getChartElement()).toBeTruthy();
     expect(getChartKeyElement()?.textContent).toEqual("0");
@@ -153,20 +188,22 @@ describe("Scorecard charts", () => {
   });
 
   test("Percentage baseline display a percentage", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
       chartId
     );
-    await nextTick();
 
     expect(getChartElement()).toBeTruthy();
     expect(getChartBaselineTextContent()).toEqual("100%");
   });
 
   test("Baseline with mode 'text' is plainly displayed", async () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B1", baselineMode: "text" }, chartId);
-    await nextTick();
+    await createScorecardChart(
+      model,
+      { keyValue: "A1", baseline: "B1", baselineMode: "text" },
+      chartId
+    );
 
     expect(getChartElement()).toBeTruthy();
     expect(getChartBaselineTextContent()).toEqual("1");
@@ -174,8 +211,7 @@ describe("Scorecard charts", () => {
   });
 
   test("Key < baseline display in red with down arrow", async () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B3" }, chartId);
-    await nextTick();
+    await createScorecardChart(model, { keyValue: "A1", baseline: "B3" }, chartId);
 
     const baselineElement = getChartBaselineElement();
     expect(baselineElement.querySelector("svg.arrow-down")).toBeTruthy();
@@ -184,8 +220,7 @@ describe("Scorecard charts", () => {
   });
 
   test("Key > baseline display in green with up arrow", async () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
-    await nextTick();
+    await createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
 
     const baselineElement = getChartBaselineElement();
     expect(baselineElement.querySelector("svg.arrow-up")).toBeTruthy();
@@ -194,8 +229,7 @@ describe("Scorecard charts", () => {
   });
 
   test("Key = baseline display default font color with no arrow", async () => {
-    createScorecardChart(model, { keyValue: "A1", baseline: "B2" }, chartId);
-    await nextTick();
+    await createScorecardChart(model, { keyValue: "A1", baseline: "B2" }, chartId);
 
     const baselineElement = getChartBaselineElement();
     expect(baselineElement.querySelector("svg")).toBeFalsy();
@@ -210,15 +244,13 @@ describe("Scorecard charts", () => {
       target: target("A1"),
       format: "0%",
     });
-    createScorecardChart(model, { keyValue: "C1" }, chartId);
-    await nextTick();
+    await createScorecardChart(model, { keyValue: "C1" }, chartId);
     expect(getChartKeyElement()?.textContent).toEqual("200%");
   });
 
   test("Baseline is displayed with the cell evaluated format", async () => {
     setCellContent(model, "C1", "=B2");
-    createScorecardChart(model, { keyValue: "A3", baseline: "C1" }, chartId);
-    await nextTick();
+    await createScorecardChart(model, { keyValue: "A3", baseline: "C1" }, chartId);
     expect(getChartBaselineElement()?.textContent).toEqual((0.12).toLocaleString());
 
     model.dispatch("SET_FORMATTING", {
@@ -232,14 +264,13 @@ describe("Scorecard charts", () => {
 
   test("Baseline with lot of decimal is truncated", async () => {
     setCellContent(model, "C1", "=B2");
-    createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
-    await nextTick();
+    await createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
     expect(getCellContent(model, "A3")).toEqual("2.1234");
     expect(getChartBaselineElement()?.textContent).toEqual((0.12).toLocaleString());
   });
 
   test("Baseline with lot of decimal isn't truncated if the cell has a format", async () => {
-    createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
+    await createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
     model.dispatch("SET_FORMATTING", {
       sheetId,
       target: target("B2"),
@@ -250,7 +281,7 @@ describe("Scorecard charts", () => {
   });
 
   test("Baseline percentage mode format has priority over cell format", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
       chartId
@@ -276,8 +307,7 @@ describe("Scorecard charts", () => {
         underline: true,
       },
     });
-    createScorecardChart(model, { keyValue: "A1", baseline: "A1" }, chartId);
-    await nextTick();
+    await createScorecardChart(model, { keyValue: "A1", baseline: "A1" }, chartId);
     for (const el of [getChartKeyElement()!, getChartBaselineTextElement()!]) {
       const style = el!.style;
       expect(style["font-style"]).toEqual("italic");
@@ -294,18 +324,17 @@ describe("Scorecard charts", () => {
       style: { bold: true },
       format: "0.0",
     });
-    createScorecardChart(
+    await createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
       chartId
     );
-    await nextTick();
     expect(getChartBaselineTextElement()!.style["font-weight"]).not.toEqual("bold");
     expect(getChartBaselineTextContent()).toEqual("100%");
   });
 
   test("High contrast font colors with dark background", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       {
         keyValue: "A1",
@@ -316,7 +345,6 @@ describe("Scorecard charts", () => {
       },
       chartId
     );
-    await nextTick();
 
     expect(toHex(getChartTitleElement()!.style["color"])).toEqual("#BBBBBB");
     expect(toHex(getChartBaselineTextElement()!.style["color"])).toEqual("#BBBBBB");
@@ -325,23 +353,19 @@ describe("Scorecard charts", () => {
   });
 
   test("Increasing size of the chart scale up the font sizes", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B2", title: "This is a title" },
       chartId
     );
-    await nextTick();
 
-    updateChartSize(100, 100);
-    await nextTick();
-    await nextTick();
+    await updateScorecardChartSize(100, 100);
 
     const baselineFontSize = getElementFontSize(getChartBaselineElement());
     const titleFontSize = getElementFontSize(getChartTitleElement());
     const keyFontSize = getElementFontSize(getChartKeyElement());
 
-    updateChartSize(200, 200);
-    await nextTick();
+    await updateScorecardChartSize(200, 200);
 
     expect(getElementFontSize(getChartBaselineElement())).toBeGreaterThan(baselineFontSize);
     expect(getElementFontSize(getChartTitleElement())).toEqual(titleFontSize);
@@ -349,23 +373,19 @@ describe("Scorecard charts", () => {
   });
 
   test("Decreasing size of the chart scale down the font sizes", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B2", title: "This is a title" },
       chartId
     );
-    await nextTick();
 
-    updateChartSize(200, 200);
-    await nextTick();
-    await nextTick();
+    await updateScorecardChartSize(200, 200);
 
     const baselineFontSize = getElementFontSize(getChartBaselineElement());
     const titleFontSize = getElementFontSize(getChartTitleElement());
     const keyFontSize = getElementFontSize(getChartKeyElement());
 
-    updateChartSize(100, 100);
-    await nextTick();
+    await updateScorecardChartSize(100, 100);
 
     expect(getElementFontSize(getChartBaselineElement())).toBeLessThan(baselineFontSize);
     expect(getElementFontSize(getChartTitleElement())).toEqual(titleFontSize);
@@ -373,12 +393,11 @@ describe("Scorecard charts", () => {
   });
 
   test("Font size scale down if we put a long key value", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B2", title: "This is a title" },
       chartId
     );
-    await nextTick();
     const baselineFontSize = getElementFontSize(getChartBaselineElement());
     const titleFontSize = getElementFontSize(getChartTitleElement());
     const keyFontSize = getElementFontSize(getChartKeyElement());
@@ -390,7 +409,7 @@ describe("Scorecard charts", () => {
   });
 
   test("Font size scale up if we remove a long description", async () => {
-    createScorecardChart(
+    await createScorecardChart(
       model,
       {
         keyValue: "A1",
@@ -399,8 +418,8 @@ describe("Scorecard charts", () => {
       },
       chartId
     );
-    await nextTick();
     const baselineFontSize = getElementFontSize(getChartBaselineElement());
+
     updateChart(model, chartId, { baselineDescr: "" }, sheetId);
     await nextTick();
     expect(getElementFontSize(getChartBaselineElement())).toBeGreaterThan(baselineFontSize);

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -478,7 +478,7 @@ describe("Composer / selectionInput interactions", () => {
     model.dispatch("SELECT_FIGURE", { id: "thisIsAnId" });
     await nextTick();
     const figureZIndex = getZIndex(".o-figure-wrapper");
-    const figureAnchorZIndex = getZIndex(".o-anchor");
+    const figureAnchorZIndex = getZIndex(".o-fig-resizer");
 
     expect(gridZIndex).toBeLessThan(highlighZIndex);
     expect(highlighZIndex).toBeLessThan(figureZIndex);

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -4,6 +4,7 @@
 import { getParsedOwlTemplateBundle } from "../../tools/bundle_xml/bundle_xml_templates";
 import "./canvas.mock";
 import "./jest_extend";
+import "./resize_observer.mock";
 
 export let OWL_TEMPLATES: Document;
 beforeAll(async () => {
@@ -28,4 +29,9 @@ beforeEach(() => {
       }
       return 0;
     });
+});
+
+afterEach(() => {
+  //@ts-ignore
+  global.resizers.removeAll();
 });

--- a/tests/setup/resize_observer.mock.ts
+++ b/tests/setup/resize_observer.mock.ts
@@ -1,0 +1,45 @@
+class MockResizeObserver {
+  public cb: Function;
+  constructor(cb: Function) {
+    this.cb = cb;
+  }
+  observe() {
+    //@ts-ignore
+    global.resizers.add(this);
+    this.cb();
+  }
+
+  unobserve() {
+    //@ts-ignore
+    global.resizers.remove(this);
+  }
+
+  disconnect() {
+    //@ts-ignore
+    global.resizers.remove(this);
+  }
+}
+global.ResizeObserver = MockResizeObserver;
+
+class Resizers {
+  private resizers: Set<MockResizeObserver> = new Set();
+
+  add(resizeObserver: MockResizeObserver) {
+    this.resizers.add(resizeObserver);
+  }
+
+  remove(resizeObserver: MockResizeObserver) {
+    this.resizers.delete(resizeObserver);
+  }
+
+  removeAll() {
+    this.resizers = new Set();
+  }
+
+  resize() {
+    this.resizers.forEach((r) => r.cb());
+  }
+}
+
+//@ts-ignore
+global.resizers = new Resizers();

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -54,6 +54,8 @@ Scheduler.requestAnimationFrame = function (callback: FrameRequestCallback) {
 };
 
 export async function nextTick(): Promise<void> {
+  //@ts-ignore
+  window.resizers.resize();
   await new Promise((resolve) => realTimeSetTimeout(resolve));
   await new Promise((resolve) => Scheduler.requestAnimationFrame(resolve));
 }


### PR DESCRIPTION
## Description:

Up until now, we'd have to run some nauseating computations to display a
figure according to their position in the spreadsheet (both pane and
scroll of the panes were used). This commit introduc a new html
architecture where a figure is enclosed in a container that hide any
overflowing part. The figuer will then be translated inside that
container, effectively being hidden when positioned outside the visible
scrope of the wrapper.

This approach allows us to get rid of some of the more tedious
computations to determine which part of a figure should be visible as
well as offering the possibility to remove most of the borders logic as
well. All in all, simpler code.

In the long run, it'd be great to have the figure component completely
agnostic of its container and to have its parent (figure container) in
charge of handling the frozen pane/scroll.

Odoo task ID : [3103586](https://www.odoo.com/web#id=3103586&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo