### PR TITLE
[FIX] top/bottom bar: very large numbers can break the layout

### DIFF
--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -13,7 +13,7 @@
       <div class="o-sheet-item o-list-sheets" t-on-click="listSheets">
         <t t-call="o-spreadsheet-Icon.LIST"/>
       </div>
-      <div class="o-all-sheets">
+      <div class="o-all-sheets flex-shrink-0 me-3">
         <t t-foreach="getVisibleSheets()" t-as="sheet" t-key="sheet.id">
           <div
             class="o-sheet-item o-sheet"
@@ -37,7 +37,7 @@
       <t t-set="selectedStatistic" t-value="getSelectedStatistic()"/>
       <div
         t-if="selectedStatistic !== undefined"
-        class="o-selection-statistic"
+        class="o-selection-statistic text-truncate"
         t-on-click="listSelectionStatistics">
         <t t-esc="selectedStatistic"/>
         <span>

--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -142,7 +142,7 @@ exports[`BottomBar component simple rendering 1`] = `
     </svg>
   </div>
   <div
-    class="o-all-sheets"
+    class="o-all-sheets flex-shrink-0 me-3"
   >
     <div
       class="o-sheet-item o-sheet active"

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -552,7 +552,7 @@ height: 1px;
       </svg>
     </div>
     <div
-      class="o-all-sheets"
+      class="o-all-sheets flex-shrink-0 me-3"
     >
       <div
         class="o-sheet-item o-sheet active"


### PR DESCRIPTION
## Description

If we have a cell with a very large number or a very long text, the top bar composer will overflow and break the layout. The automatic sum in the bottom bar will also overflow, and be put on multiple lines.

Odoo task ID : [3090433](https://www.odoo.com/web#id=3090433&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo