### PR TITLE
[FIX] Close data filter popover in dashboard

### DIFF
--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -1,6 +1,11 @@
 <templates>
   <t t-name="o-spreadsheet-SpreadsheetDashboard" owl="1">
-    <div class="o-grid o-two-columns" tabindex="-1" t-on-wheel="onMouseWheel" t-on-copy="copy">
+    <div
+      class="o-grid o-two-columns"
+      tabindex="-1"
+      t-on-wheel="onMouseWheel"
+      t-on-copy="copy"
+      t-on-click="onClosePopover">
       <div class="mx-auto h-100 position-relative" t-ref="grid" t-att-style="gridContainer">
         <GridOverlay
           onCellHovered.bind="onCellHovered"

--- a/src/components/filters/filter_icon/filter_icon.xml
+++ b/src/components/filters/filter_icon/filter_icon.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-FilterIcon" owl="1">
-    <div class="o-filter-icon" t-att-style="style" t-on-click="props.onClick">
+    <div class="o-filter-icon" t-att-style="style" t-on-click.stop="props.onClick">
       <t t-if="props.isActive" t-call="o-spreadsheet-Icon.FILTER_ICON_ACTIVE"/>
       <t t-else="" t-call="o-spreadsheet-Icon.FILTER_ICON"/>
     </div>


### PR DESCRIPTION
## Description:

Now in the dashboard mode, if users want to close an open filter popover, they need to click the filter icon button again and cannot do it just by clicking the grids. 

This PR makes closing popover via clicking grids possible.

Odoo task ID : [3089264](https://www.odoo.com/web#id=3089264&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo