### PR TITLE
[FIX] grid: Capture context menu events triggered by keyboard

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -180,7 +180,11 @@ const TEMPLATE = xml/* xml */ `
         />
     </t>
     <t else="1">
-      <input class="position-absolute" style="z-index:-1000;" t-on-input="onInput" t-ref="hiddenInput"/>
+      <input class="position-absolute"
+        style="z-index:-1000;"
+        t-on-input="onInput"
+        t-on-contextmenu="onInputContextMenu"
+        t-ref="hiddenInput"/>
     </t>
     <canvas t-ref="canvas"
       t-on-mousedown="onMouseDown"
@@ -863,6 +867,25 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
   // ---------------------------------------------------------------------------
   // Context Menu
   // ---------------------------------------------------------------------------
+
+  onInputContextMenu(ev: MouseEvent) {
+    ev.preventDefault();
+    const lastZone = this.getters.getSelectedZone();
+    const { left: col, top: row } = lastZone;
+    let type: ContextMenuType = "CELL";
+    this.dispatch("STOP_EDITION");
+    if (this.getters.getActiveCols().has(col)) {
+      type = "COL";
+    } else if (this.getters.getActiveRows().has(row)) {
+      type = "ROW";
+    }
+    const [x, y, width, height] = this.getters.getRect(
+      lastZone,
+      this.getters.getActiveSnappedViewport()
+    );
+
+    this.toggleContextMenu(type, x + width, y + height);
+  }
 
   onCanvasContextMenu(ev: MouseEvent) {
     ev.preventDefault();

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -597,6 +597,15 @@ describe("Grid component", () => {
       expect(fixture.querySelector(".o-menu div[data-name='add_row_before']")).toBeFalsy();
       expect(document.activeElement).toBe(fixture.querySelector(".o-grid>input"));
     });
+
+    test("Can open context menu with a keyboard input ", async () => {
+      const selector = ".o-grid>input";
+      const target = document.querySelector(selector)! as HTMLElement;
+      target.focus();
+      triggerMouseEvent(selector, "contextmenu", 0, 0, { button: 1, bubbles: true });
+      await nextTick();
+      expect(fixture.querySelector(".o-menu")).toBeTruthy();
+    });
   });
 });
 


### PR DESCRIPTION
Currently, we handle the contextmenu events by capturing the event on the canvas. This made complete sense when the canvas was the default focused element in the DOM but its no longer the case since 19a7ccf1.

The current code would still work because when clicking on the contextmenu mouse button, the DOM will first dispatch a focus event on the canvas and dispatch the context menu event afterwards.

However, a user can trigger a contextmenu event with his keyboard (on non retard proprietary keyboards, hit "Menu key" or Shift+F10). With the change introduced in 19a7ccf1, the event will not be captured by the canvas since there wasn't a click to focus it beforehand and we end up displaying the default browser context menu.

This commit introduced a dedicated callback for this situation that will display the contextmenu under the top left cell of the current selection.

Task 3093099

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo