### PR TITLE
[IMP] components: Remove sidePanelIsOpen props from components

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -118,7 +118,6 @@ css/*SCSS*/ `
 
 interface Props {
   figure: Figure;
-  sidePanelIsOpen: boolean;
   onFigureDeleted: () => void;
 }
 
@@ -126,7 +125,6 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FigureComponent";
   static components = {};
   static defaultProps = {
-    sidePanelIsOpen: false,
     onFigureDeleted: function () {},
   };
 
@@ -360,9 +358,6 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     if (!selectResult.isSuccessful) {
       return;
     }
-    if (this.props.sidePanelIsOpen) {
-      this.env.openSidePanel("ChartPanel");
-    }
 
     const position = gridOverlayPosition();
     const { x: offsetCorrectionX, y: offsetCorrectionY } =
@@ -448,6 +443,5 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
 
 FigureComponent.props = {
   figure: Object,
-  sidePanelIsOpen: { type: Boolean, optional: true },
   onFigureDeleted: { type: Function, optional: true },
 };

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -14,7 +14,6 @@
           <t
             t-component="figureRegistry.get(props.figure.tag).Component"
             t-key="props.figure.id"
-            sidePanelIsOpen="props.sidePanelIsOpen"
             onFigureDeleted="props.onFigureDeleted"
             figure="displayedFigure"
           />

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -21,7 +21,6 @@ css/* scss */ `
 
 interface Props {
   figure: Figure;
-  sidePanelIsOpen: boolean;
   onFigureDeleted: () => void;
 }
 
@@ -71,9 +70,6 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
           sheetId: this.env.model.getters.getActiveSheetId(),
           id: this.props.figure.id,
         });
-        if (this.props.sidePanelIsOpen) {
-          this.env.toggleSidePanel("ChartPanel");
-        }
         this.props.onFigureDeleted();
       },
     });
@@ -119,6 +115,5 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
 
 ChartFigure.props = {
   figure: Object,
-  sidePanelIsOpen: Boolean,
   onFigureDeleted: Function,
 };

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -5,7 +5,6 @@ import { FigureComponent } from "../figure/figure";
 import { ChartFigure } from "../figure_chart/figure_chart";
 
 interface Props {
-  sidePanelIsOpen: Boolean;
   onFigureDeleted: () => void;
 }
 
@@ -32,7 +31,6 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
 }
 
 FiguresContainer.props = {
-  sidePanelIsOpen: Boolean,
   onFigureDeleted: Function,
 };
 

--- a/src/components/figures/figure_container/figure_container.xml
+++ b/src/components/figures/figure_container/figure_container.xml
@@ -2,11 +2,7 @@
   <t t-name="o-spreadsheet-FiguresContainer" owl="1">
     <div>
       <t t-foreach="getVisibleFigures()" t-as="figure" t-key="figure.id">
-        <FigureComponent
-          sidePanelIsOpen="this.props.sidePanelIsOpen"
-          onFigureDeleted="this.props.onFigureDeleted"
-          figure="figure"
-        />
+        <FigureComponent onFigureDeleted="this.props.onFigureDeleted" figure="figure"/>
       </t>
     </div>
   </t>

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -16,7 +16,6 @@
         onGridResized.bind="onGridResized"
         onGridMoved.bind="moveCanvas"
         gridOverlayDimensions="gridOverlayDimensions"
-        sidePanelIsOpen="props.sidePanelIsOpen"
         onFigureDeleted.bind="focus"
       />
       <HeadersOverlay onOpenContextMenu="(type, x, y) => this.toggleContextMenu(type, x, y)"/>

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -145,7 +145,6 @@ interface Props {
   onGridResized: (dimension: DOMDimension) => void;
   onGridMoved: (deltaX: Pixel, deltaY: Pixel) => void;
   gridOverlayDimensions: string;
-  sidePanelIsOpen: boolean;
   onFigureDeleted: () => void;
 }
 
@@ -159,7 +158,6 @@ export class GridOverlay extends Component<Props> {
     onCellRightClicked: () => {},
     onGridResized: () => {},
     onFigureDeleted: () => {},
-    sidePanelIsOpen: false,
   };
   private gridOverlay!: Ref<HTMLElement>;
 
@@ -223,5 +221,4 @@ GridOverlay.props = {
   onFigureDeleted: { type: Function, optional: true },
   onGridMoved: Function,
   gridOverlayDimensions: String,
-  sidePanelIsOpen: { type: Boolean, optional: true },
 };

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -7,13 +7,7 @@
       t-on-mousedown="onMouseDown"
       t-on-dblclick="onDoubleClick"
       t-on-contextmenu="onContextMenu">
-      <!-- TODO remove sidePanelIsOpen props. It is wrong.
-      If you have a CF sidepanel open, selecting a figure should
-      not open the figure side panel -->
-      <FiguresContainer
-        sidePanelIsOpen="props.sidePanelIsOpen"
-        onFigureDeleted="props.onFigureDeleted"
-      />
+      <FiguresContainer onFigureDeleted="props.onFigureDeleted"/>
     </div>
   </t>
 </templates>

--- a/tests/components/__snapshots__/dashboard_grid.test.ts.snap
+++ b/tests/components/__snapshots__/dashboard_grid.test.ts.snap
@@ -18,13 +18,9 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
       width: 100%
     "
     >
-      <!-- TODO remove sidePanelIsOpen props. It is wrong.
-      If you have a CF sidepanel open, selecting a figure should
-      not open the figure side panel -->
       <div>
         
       </div>
-      
     </div>
     
     <canvas

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -14,13 +14,9 @@ exports[`Grid component simple rendering snapshot 1`] = `
       width: calc(100% - 63px);
     "
   >
-    <!-- TODO remove sidePanelIsOpen props. It is wrong.
-      If you have a CF sidepanel open, selecting a figure should
-      not open the figure side panel -->
     <div>
       
     </div>
-    
   </div>
   
   <div

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -419,13 +419,9 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       width: calc(100% - 63px);
     "
     >
-      <!-- TODO remove sidePanelIsOpen props. It is wrong.
-      If you have a CF sidepanel open, selecting a figure should
-      not open the figure side panel -->
       <div>
         
       </div>
-      
     </div>
     
     <div


### PR DESCRIPTION
This props was forwarded all the way down to the figures so they could register themsleves as the content of the side panel. However, this was not the right way to handle it for several reasons:

1. This feature only made sense to change the side panel content when a user would alter selecting figures. The implementation here would display the figure side panel even though another type of side panel was already open,e.g. Conditional formats or Search and Replace.

2. The chart side panel already handles this itself since it updates itself when the user selects a new figure.

task 3087981

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo