### PR TITLE
[FIX] GridComposer: display the style of the edited cell

### DIFF
--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -89,7 +89,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
 
   get containerStyle(): string {
     const isFormula = this.env.model.getters.getCurrentContent().startsWith("=");
-    const cell = this.env.model.getters.getActiveCell();
+    const cell = this.env.model.getters.getEditedCell();
     let style: Style = {};
     if (cell) {
       const cellPosition = this.env.model.getters.getCellPosition(cell.id);

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -14,7 +14,7 @@ import {
 } from "../../helpers/index";
 import { loopThroughReferenceType } from "../../helpers/reference_type";
 import { _lt } from "../../translation";
-import { Highlight, Range, RangePart, UID, Zone } from "../../types";
+import { Cell, Highlight, Range, RangePart, UID, Zone } from "../../types";
 import { SelectionEvent } from "../../types/event_stream";
 import {
   AddColumnsRowsCommand,
@@ -50,6 +50,7 @@ export class EditionPlugin extends UIPlugin {
     "getCurrentTokens",
     "getTokenAtCursor",
     "getComposerHighlights",
+    "getEditedCell",
   ] as const;
 
   private col: HeaderIndex = 0;
@@ -265,6 +266,12 @@ export class EditionPlugin extends UIPlugin {
     } else {
       return this.currentTokens.find((t) => t.start <= start && t.end >= end);
     }
+  }
+
+  getEditedCell(): Cell | undefined {
+    return this.mode !== "inactive"
+      ? this.getters.getCell(this.sheetId, this.col, this.row)
+      : undefined;
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -17,6 +17,7 @@ import {
   resizeAnchorZone,
   selectCell,
   setCellContent,
+  setStyle,
 } from "../test_helpers/commands_helpers";
 import {
   clickCell,
@@ -1077,6 +1078,28 @@ describe("composer", () => {
       expect(gridComposer.style.fontWeight).toBe("bold");
       expect(toHex(gridComposer.style.background)).toBe("#0000FF");
       expect(toHex(gridComposer.style.color)).toBe("#FF0000");
+    });
+
+    test("composer takes style of the edited cell and not the active selection", async () => {
+      const sheetId = model.getters.getActiveSheetId();
+      setStyle(model, "A1", { align: "right", bold: true });
+
+      const newSheetId = "Sheet2";
+      createSheet(model, { sheetId: newSheetId });
+      setStyle(model, "A1", { align: "center" }, newSheetId);
+
+      await nextTick();
+      await typeInComposerGrid("Hello");
+
+      let gridComposer = fixture.querySelector(".o-grid-composer")! as HTMLElement;
+      expect(gridComposer.style.textAlign).toBe("right");
+      expect(gridComposer.style.fontWeight).toBe("bold");
+
+      activateSheet(model, newSheetId, sheetId);
+      await nextTick();
+      gridComposer = fixture.querySelector(".o-grid-composer")! as HTMLElement;
+      expect(gridComposer.style.textAlign).toBe("right");
+      expect(gridComposer.style.fontWeight).toBe("bold");
     });
   });
 


### PR DESCRIPTION
How to reproduce:

On demo sheet,
Start editing an empty cell like G17 through the grid composer move to the 3rd sheet "Split Panes"
 => the grid composer has the style of "Split Panes":A1 and not G17.

Task 3093929

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo