### PR TITLE
[IMP] chart: aggregate data for labels

### DIFF
--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.ts
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.ts
@@ -8,4 +8,10 @@ export class BarConfigPanel extends LineBarPieConfigPanel {
       stacked: ev.target.checked,
     });
   }
+
+  onUpdateAggregated(ev) {
+    this.props.updateChart({
+      aggregated: ev.target.checked,
+    });
+  }
 }

--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
@@ -14,6 +14,18 @@
             Stacked barchart
           </label>
         </div>
+        <div class="o-checkbox">
+          <label>
+            <input
+              type="checkbox"
+              name="aggregated"
+              t-att-checked="props.definition.aggregated"
+              t-on-change="onUpdateAggregated"
+              class="align-middle"
+            />
+            Aggregate labels
+          </label>
+        </div>
       </div>
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
@@ -87,4 +87,10 @@ export class LineBarPieConfigPanel extends Component<Props, SpreadsheetChildEnv>
       labelRange: this.labelRange,
     });
   }
+
+  onUpdateAggregated(ev) {
+    this.props.updateChart({
+      aggregated: ev.target.checked,
+    });
+  }
 }

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
@@ -1,6 +1,22 @@
 <templates>
   <t t-name="o-spreadsheet-LineBarPieConfigPanel" owl="1">
     <div>
+      <div>
+        <div class="o-section pt-0">
+          <div class="o-checkbox">
+            <label>
+              <input
+                type="checkbox"
+                name="aggregated"
+                t-att-checked="props.definition.aggregated"
+                t-on-change="onUpdateAggregated"
+                class="align-middle"
+              />
+              Aggregate labels
+            </label>
+          </div>
+        </div>
+      </div>
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>
         <SelectionInput

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
@@ -23,4 +23,10 @@ export class LineConfigPanel extends LineBarPieConfigPanel {
       stacked: ev.target.checked,
     });
   }
+
+  onUpdateAggregated(ev) {
+    this.props.updateChart({
+      aggregated: ev.target.checked,
+    });
+  }
 }

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -14,6 +14,18 @@
             Stacked linechart
           </label>
         </div>
+        <div class="o-checkbox">
+          <label>
+            <input
+              type="checkbox"
+              name="aggregated"
+              t-att-checked="props.definition.aggregated"
+              t-on-change="onUpdateAggregated"
+              class="align-middle"
+            />
+            Aggregate labels
+          </label>
+        </div>
       </div>
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>

--- a/src/helpers/charts/bar_chart.ts
+++ b/src/helpers/charts/bar_chart.ts
@@ -37,6 +37,7 @@ import {
   updateChartRangesWithDataSets,
 } from "./chart_common";
 import {
+  aggregateDataForLabels,
   filterEmptyDataPoints,
   getChartDatasetValues,
   getChartLabelValues,
@@ -66,6 +67,7 @@ export class BarChart extends AbstractChart {
   readonly verticalAxisPosition: VerticalAxisPosition;
   readonly legendPosition: LegendPosition;
   readonly stacked: boolean;
+  readonly aggregated: boolean;
   readonly type = "bar";
 
   constructor(definition: BarChartDefinition, sheetId: UID, getters: CoreGetters) {
@@ -81,6 +83,7 @@ export class BarChart extends AbstractChart {
     this.verticalAxisPosition = definition.verticalAxisPosition;
     this.legendPosition = definition.legendPosition;
     this.stacked = definition.stacked;
+    this.aggregated = definition.aggregated;
   }
 
   static transformDefinition(
@@ -103,6 +106,7 @@ export class BarChart extends AbstractChart {
       dataSets: context.range ? context.range : [],
       dataSetsHaveTitle: false,
       stacked: false,
+      aggregated: false,
       legendPosition: "top",
       title: context.title || "",
       type: "bar",
@@ -163,6 +167,7 @@ export class BarChart extends AbstractChart {
         : undefined,
       title: this.title,
       stacked: this.stacked,
+      aggregated: this.aggregated,
     };
   }
 
@@ -246,6 +251,10 @@ function createBarChartRuntime(chart: BarChart, getters: Getters): BarChartRunti
   let dataSetsValues = getChartDatasetValues(getters, chart.dataSets);
 
   ({ labels, dataSetsValues } = filterEmptyDataPoints(labels, dataSetsValues));
+  if (chart.aggregated) {
+    ({ labels, dataSetsValues } = aggregateDataForLabels(labels, dataSetsValues));
+  }
+
   const config = getBarConfiguration(chart, labels);
   const colors = new ChartColors();
 

--- a/src/helpers/charts/chart_ui_common.ts
+++ b/src/helpers/charts/chart_ui_common.ts
@@ -50,6 +50,33 @@ export function filterEmptyDataPoints(
   };
 }
 
+export function aggregateDataForLabels(
+  labels: string[],
+  datasets: DatasetValues[]
+): { labels: string[]; dataSetsValues: DatasetValues[] } {
+  const parseNumber = (value) => (typeof value === "number" ? value : 0);
+
+  const labelMap = {};
+  for (let indexOfLabel = 0; indexOfLabel < labels.length; ++indexOfLabel) {
+    const label = labels[indexOfLabel];
+    if (!labelMap[label]) {
+      labelMap[label] = datasets.map((dataset) => parseNumber(dataset.data[indexOfLabel]));
+      continue;
+    }
+    for (let indexOfDataset = 0; indexOfDataset < datasets.length; ++indexOfDataset) {
+      labelMap[label][indexOfDataset] += parseNumber(datasets[indexOfDataset].data[indexOfLabel]);
+    }
+  }
+
+  return {
+    labels: Object.keys(labelMap),
+    dataSetsValues: datasets.map((dataset, indexOfDataset) => ({
+      ...dataset,
+      data: Object.values(labelMap).map((dataOfLabel: any[]) => dataOfLabel[indexOfDataset]),
+    })),
+  };
+}
+
 export function truncateLabel(label: string | undefined): string {
   if (!label) {
     return "";

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -43,6 +43,7 @@ import {
   updateChartRangesWithDataSets,
 } from "./chart_common";
 import {
+  aggregateDataForLabels,
   filterEmptyDataPoints,
   getChartDatasetValues,
   getChartLabelValues,
@@ -75,6 +76,7 @@ export class LineChart extends AbstractChart {
   readonly legendPosition: LegendPosition;
   readonly labelsAsText: boolean;
   readonly stacked: boolean;
+  readonly aggregated: boolean;
   readonly type = "line";
 
   constructor(definition: LineChartDefinition, sheetId: UID, getters: CoreGetters) {
@@ -91,6 +93,7 @@ export class LineChart extends AbstractChart {
     this.legendPosition = definition.legendPosition;
     this.labelsAsText = definition.labelsAsText;
     this.stacked = definition.stacked;
+    this.aggregated = definition.aggregated;
   }
 
   static validateChartDefinition(
@@ -119,6 +122,7 @@ export class LineChart extends AbstractChart {
       verticalAxisPosition: "left",
       labelRange: context.auxiliaryRange || undefined,
       stacked: false,
+      aggregated: false,
     };
   }
 
@@ -146,6 +150,7 @@ export class LineChart extends AbstractChart {
       title: this.title,
       labelsAsText: this.labelsAsText,
       stacked: this.stacked,
+      aggregated: this.aggregated,
     };
   }
 
@@ -341,6 +346,10 @@ function createLineChartRuntime(chart: LineChart, getters: Getters): LineChartRu
   if (axisType === "time") {
     ({ labels, dataSetsValues } = fixEmptyLabelsForDateCharts(labels, dataSetsValues));
   }
+  if (chart.aggregated) {
+    ({ labels, dataSetsValues } = aggregateDataForLabels(labels, dataSetsValues));
+  }
+
   const config = getLineConfiguration(chart, labels);
   const labelFormat = getLabelFormat(getters, chart.labelRange)!;
   if (axisType === "time") {

--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -44,6 +44,7 @@ import {
   updateChartRangesWithDataSets,
 } from "./chart_common";
 import {
+  aggregateDataForLabels,
   filterEmptyDataPoints,
   getChartDatasetValues,
   getChartLabelValues,
@@ -71,6 +72,7 @@ export class PieChart extends AbstractChart {
   readonly background?: Color;
   readonly legendPosition: LegendPosition;
   readonly type = "pie";
+  readonly aggregated: boolean;
 
   constructor(definition: PieChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -83,6 +85,7 @@ export class PieChart extends AbstractChart {
     this.labelRange = createRange(getters, sheetId, definition.labelRange);
     this.background = definition.background;
     this.legendPosition = definition.legendPosition;
+    this.aggregated = definition.aggregated;
   }
 
   static transformDefinition(
@@ -108,6 +111,7 @@ export class PieChart extends AbstractChart {
       title: context.title || "",
       type: "pie",
       labelRange: context.auxiliaryRange || undefined,
+      aggregated: false,
     };
   }
 
@@ -145,6 +149,7 @@ export class PieChart extends AbstractChart {
         ? this.getters.getRangeString(labelRange, targetSheetId || this.sheetId)
         : undefined,
       title: this.title,
+      aggregated: this.aggregated,
     };
   }
 
@@ -233,6 +238,10 @@ function createPieChartRuntime(chart: PieChart, getters: Getters): PieChartRunti
   let dataSetsValues = getChartDatasetValues(getters, chart.dataSets);
 
   ({ labels, dataSetsValues } = filterEmptyDataPoints(labels, dataSetsValues));
+
+  if (chart.aggregated) {
+    ({ labels, dataSetsValues } = aggregateDataForLabels(labels, dataSetsValues));
+  }
   const config = getPieConfiguration(chart, labels);
   const colors = new ChartColors();
   for (let { label, data } of dataSetsValues) {

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -191,7 +191,9 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
       for (let figure of sheetFigures) {
         if (figure && figure.tag === "chart") {
           const figureData = this.charts[figure.id]?.getDefinitionForExcel();
-          if (figureData) {
+          // Excel does not support aggregating labels directly
+          // GSheets does not export the chart if it aggregates the labels
+          if (figureData && !figureData.aggregated) {
             figures.push({
               ...figure,
               data: figureData,

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -625,6 +625,7 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
       type: "bar",
       background: BACKGROUND_CHART_COLOR,
       stacked: false,
+      aggregated: false,
       dataSetsHaveTitle,
       verticalAxisPosition: "left",
       legendPosition: newLegendPos,

--- a/src/types/chart/bar_chart.ts
+++ b/src/types/chart/bar_chart.ts
@@ -12,6 +12,7 @@ export interface BarChartDefinition {
   readonly verticalAxisPosition: VerticalAxisPosition;
   readonly legendPosition: LegendPosition;
   readonly stacked: boolean;
+  readonly aggregated: boolean;
 }
 
 export type BarChartRuntime = {

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -57,6 +57,7 @@ export interface ExcelChartDefinition {
   readonly verticalAxisPosition: VerticalAxisPosition;
   readonly legendPosition: LegendPosition;
   readonly stacked?: boolean;
+  readonly aggregated?: boolean;
 }
 
 export interface ChartCreationContext {

--- a/src/types/chart/line_chart.ts
+++ b/src/types/chart/line_chart.ts
@@ -13,6 +13,7 @@ export interface LineChartDefinition {
   readonly legendPosition: LegendPosition;
   readonly labelsAsText: boolean;
   readonly stacked: boolean;
+  readonly aggregated: boolean;
 }
 
 export type LineChartRuntime = {

--- a/src/types/chart/pie_chart.ts
+++ b/src/types/chart/pie_chart.ts
@@ -10,6 +10,7 @@ export interface PieChartDefinition {
   readonly title: string;
   readonly background?: Color;
   readonly legendPosition: LegendPosition;
+  readonly aggregated: boolean;
 }
 
 export type PieChartRuntime = {

--- a/src/xlsx/conversion/figure_conversion.ts
+++ b/src/xlsx/conversion/figure_conversion.ts
@@ -63,6 +63,7 @@ function convertChartData(chartData: ExcelChartDefinition): ChartDefinition | un
     verticalAxisPosition: chartData.verticalAxisPosition,
     legendPosition: chartData.legendPosition,
     stacked: chartData.stacked || false,
+    aggregated: chartData.aggregated || false,
     labelsAsText: false,
   };
 }

--- a/src/xlsx/functions/charts.ts
+++ b/src/xlsx/functions/charts.ts
@@ -204,6 +204,13 @@ function addBarChart(chart: ExcelChartDefinition): XMLString {
   //
   // overlap and gapWitdh seems to be by default at -20 and 20 in chart.js.
   // See https://www.chartjs.org/docs/latest/charts/bar.html and https://www.chartjs.org/docs/latest/charts/bar.html#barpercentage-vs-categorypercentage
+
+  // Excel does not support aggregating labels
+  // GSheets does not export the chart if it aggregates the labels
+  if (chart.aggregated) {
+    return escapeXml``;
+  }
+
   const colors = new ChartColors();
   const dataSetsNodes: XMLString[] = [];
   for (const [dsIndex, dataset] of Object.entries(chart.dataSets)) {
@@ -252,6 +259,12 @@ function addBarChart(chart: ExcelChartDefinition): XMLString {
 }
 
 function addLineChart(chart: ExcelChartDefinition): XMLString {
+  // Excel does not support aggregating labels
+  // GSheets does not export the chart if it aggregates the labels
+  if (chart.aggregated) {
+    return escapeXml``;
+  }
+
   const colors = new ChartColors();
   const dataSetsNodes: XMLString[] = [];
   for (const [dsIndex, dataset] of Object.entries(chart.dataSets)) {

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -4030,6 +4030,323 @@ Object {
 }
 `;
 
+exports[`Test XLSX export Charts charts that aggregate labels 1`] = `
+Object {
+  "files": Array [
+    Object {
+      "content": "<workbook xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <sheets>
+        <sheet state=\\"visible\\" name=\\"Sheet1\\" sheetId=\\"1\\" r:id=\\"rId1\\"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    Object {
+      "content": "<worksheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <sheetViews>
+        <sheetView showGridLines=\\"1\\" workbookViewId=\\"0\\">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight=\\"17.25\\" defaultColWidth=\\"12.64\\"/>
+    <cols>
+        <col min=\\"1\\" max=\\"1\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"2\\" max=\\"2\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"3\\" max=\\"3\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"4\\" max=\\"4\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"5\\" max=\\"5\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"6\\" max=\\"6\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"7\\" max=\\"7\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"8\\" max=\\"8\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"9\\" max=\\"9\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"10\\" max=\\"10\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"11\\" max=\\"11\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"12\\" max=\\"12\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"13\\" max=\\"13\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"14\\" max=\\"14\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"15\\" max=\\"15\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"16\\" max=\\"16\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"17\\" max=\\"17\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"18\\" max=\\"18\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"19\\" max=\\"19\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"20\\" max=\\"20\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"21\\" max=\\"21\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"22\\" max=\\"22\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"23\\" max=\\"23\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"24\\" max=\\"24\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"25\\" max=\\"25\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"26\\" max=\\"26\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+    </cols>
+    <sheetData>
+        <row r=\\"1\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"B1\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    0
+                </v>
+            </c>
+            <c r=\\"C1\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    1
+                </v>
+            </c>
+        </row>
+        <row r=\\"2\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A2\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    2
+                </v>
+            </c>
+            <c r=\\"B2\\" s=\\"1\\">
+                <v>
+                    10
+                </v>
+            </c>
+            <c r=\\"C2\\" s=\\"1\\">
+                <v>
+                    20
+                </v>
+            </c>
+        </row>
+        <row r=\\"3\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A3\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    3
+                </v>
+            </c>
+            <c r=\\"B3\\" s=\\"1\\">
+                <v>
+                    11
+                </v>
+            </c>
+            <c r=\\"C3\\" s=\\"1\\">
+                <v>
+                    19
+                </v>
+            </c>
+        </row>
+        <row r=\\"4\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A4\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    4
+                </v>
+            </c>
+            <c r=\\"B4\\" s=\\"1\\">
+                <v>
+                    12
+                </v>
+            </c>
+            <c r=\\"C4\\" s=\\"1\\">
+                <v>
+                    18
+                </v>
+            </c>
+        </row>
+        <row r=\\"5\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A5\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    5
+                </v>
+            </c>
+            <c r=\\"B5\\" s=\\"1\\">
+                <v>
+                    13
+                </v>
+            </c>
+            <c r=\\"C5\\" s=\\"1\\">
+                <v>
+                    17
+                </v>
+            </c>
+        </row>
+        <row r=\\"6\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A6\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    2
+                </v>
+            </c>
+            <c r=\\"B6\\" s=\\"1\\">
+                <v>
+                    17
+                </v>
+            </c>
+            <c r=\\"C6\\" s=\\"1\\">
+                <v>
+                    31
+                </v>
+            </c>
+        </row>
+        <row r=\\"7\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A7\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    3
+                </v>
+            </c>
+            <c r=\\"B7\\" s=\\"1\\">
+                <v>
+                    26
+                </v>
+            </c>
+            <c r=\\"C7\\" s=\\"1\\">
+                <v>
+                    18
+                </v>
+            </c>
+        </row>
+        <row r=\\"8\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A8\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    4
+                </v>
+            </c>
+            <c r=\\"B8\\" s=\\"1\\">
+                <v>
+                    13
+                </v>
+            </c>
+            <c r=\\"C8\\" s=\\"1\\">
+                <v>
+                    9
+                </v>
+            </c>
+        </row>
+        <row r=\\"9\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A9\\" s=\\"1\\" t=\\"s\\">
+                <v>
+                    5
+                </v>
+            </c>
+            <c r=\\"B9\\" s=\\"1\\">
+                <v>
+                    31
+                </v>
+            </c>
+            <c r=\\"C9\\" s=\\"1\\">
+                <v>
+                    27
+                </v>
+            </c>
+        </row>
+    </sheetData>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    Object {
+      "content": "<styleSheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <numFmts count=\\"0\\">
+    </numFmts>
+    <fonts count=\\"2\\">
+        <font>
+            <sz val=\\"10\\"/>
+            <color rgb=\\"000000\\"/>
+            <name val=\\"Calibri\\"/>
+        </font>
+        <font>
+            <sz val=\\"10\\"/>
+            <color rgb=\\"000000\\"/>
+            <name val=\\"Arial\\"/>
+        </font>
+    </fonts>
+    <fills count=\\"2\\">
+        <fill>
+            <patternFill patternType=\\"none\\"/>
+        </fill>
+        <fill>
+            <patternFill patternType=\\"gray125\\"/>
+        </fill>
+    </fills>
+    <borders count=\\"1\\">
+        <border>
+            <left/>
+            <right/>
+            <top/>
+            <bottom/>
+            <diagonal/>
+        </border>
+    </borders>
+    <cellXfs count=\\"2\\">
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"0\\" borderId=\\"0\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"1\\" borderId=\\"0\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+    </cellXfs>
+    <dxfs count=\\"0\\">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    Object {
+      "content": "<sst xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" count=\\"6\\" uniqueCount=\\"6\\">
+    <si>
+        <t>
+            first column dataset
+        </t>
+    </si>
+    <si>
+        <t>
+            second column dataset
+        </t>
+    </si>
+    <si>
+        <t>
+            P1
+        </t>
+    </si>
+    <si>
+        <t>
+            P2
+        </t>
+    </si>
+    <si>
+        <t>
+            P3
+        </t>
+    </si>
+    <si>
+        <t>
+            P4
+        </t>
+    </si>
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Target=\\"worksheets/sheet0.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\\"/>
+    <Relationship Id=\\"rId2\\" Target=\\"sharedStrings.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\\"/>
+    <Relationship Id=\\"rId3\\" Target=\\"styles.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    Object {
+      "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
+    <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\\" PartName=\\"/xl/worksheets/sheet0.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\\" PartName=\\"/xl/styles.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\\" PartName=\\"/xl/sharedStrings.xml\\"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\\" Target=\\"xl/workbook.xml\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
 exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
 Object {
   "files": Array [

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -566,6 +566,7 @@ describe("Collaborative Sheet manipulation", () => {
       background: BACKGROUND_CHART_COLOR,
       verticalAxisPosition: "left",
       legendPosition: "top",
+      aggregated: false,
     };
 
     test(`Concurrently chart creation & update and add columns`, () => {

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -1125,6 +1125,7 @@ describe("Menu Item actions", () => {
           labelRange: undefined,
           legendPosition: "none",
           stacked: false,
+          aggregated: false,
           title: expect.any(String),
           type: "bar",
           verticalAxisPosition: "left",

--- a/tests/plugins/custom_colors.test.ts
+++ b/tests/plugins/custom_colors.test.ts
@@ -99,6 +99,7 @@ describe("custom colors are correctly handled when editing charts", () => {
         verticalAxisPosition: "left",
         legendPosition: "none",
         background: "#112233",
+        aggregated: false,
       },
     });
     expect(model.getters.getCustomColors()).toEqual(["#112233", "#123456"]);

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -114,6 +114,7 @@ export function createChart(
       legendPosition: data.legendPosition || "top",
       stacked: ("stacked" in data && data.stacked) || false,
       labelsAsText: ("labelsAsText" in data && data.labelsAsText) || false,
+      aggregated: ("aggregated" in data && data.aggregated) || false,
     },
   });
 }

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -759,6 +759,62 @@ describe("Test XLSX export", () => {
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
 
+    test("charts that aggregate labels", async () => {
+      const model = new Model({
+        sheets: [
+          {
+            ...chartData.sheets,
+            cells: {
+              ...chartData.sheets[0].cells,
+              A6: { content: "P1" },
+              A7: { content: "P2" },
+              A8: { content: "P3" },
+              A9: { content: "P4" },
+              B6: { content: "17" },
+              B7: { content: "26" },
+              B8: { content: "13" },
+              B9: { content: "31" },
+              C6: { content: "31" },
+              C7: { content: "18" },
+              C8: { content: "9" },
+              C9: { content: "27" },
+            },
+          },
+        ],
+      });
+      createChart(
+        model,
+        {
+          dataSets: ["Sheet1!B1:B9"],
+          labelRange: "Sheet1!A2:A9",
+          aggregated: true,
+          type: "bar",
+        },
+        "1"
+      );
+      createChart(
+        model,
+        {
+          dataSets: ["Sheet1!B1:B9"],
+          labelRange: "Sheet1!A2:A9",
+          aggregated: true,
+          type: "line",
+        },
+        "1"
+      );
+      createChart(
+        model,
+        {
+          dataSets: ["Sheet1!B1:B9"],
+          labelRange: "Sheet1!A2:A9",
+          aggregated: true,
+          type: "pie",
+        },
+        "1"
+      );
+      expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
+    });
+
     test("stacked bar chart", async () => {
       const model = new Model(chartData);
       createChart(


### PR DESCRIPTION
## Description:
This commit makes aggregating data for labels in the bar, line and pie chart possible, which makes more sense in practice. 

It's done by pre-processing the data before passing them into ChartJS to draw the plot. 

When a chart aggregates the data for labels, it will not be exported into .xlsx file, which is the same in GSheets. Excel currently doesn't support aggregating data for labels directly. 

Odoo task ID : [2832459](https://www.odoo.com/web#id=2832459&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo