### PR TITLE
[FIX] dashboard: copy event is still present

### DIFF
--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -164,13 +164,4 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
       offsetY: offsetScrollbarY + deltaY,
     });
   }
-
-  copy(ev: ClipboardEvent) {
-    this.env.model.dispatch("COPY");
-    const content = this.env.model.getters.getClipboardContent();
-    // TODO use env.clipboard
-    // TODO add a test
-    ev.clipboardData!.setData("text/plain", content);
-    ev.preventDefault();
-  }
 }

--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -4,7 +4,6 @@
       class="o-grid o-two-columns"
       tabindex="-1"
       t-on-wheel="onMouseWheel"
-      t-on-copy="copy"
       t-on-click="onClosePopover">
       <div class="mx-auto h-100 position-relative" t-ref="grid" t-att-style="gridContainer">
         <GridOverlay


### PR DESCRIPTION
## Description

The copy event handling was still present in the dashboard component, but it wasn't supposed to be there since there is no selection in dashboard mode. This made the borders of the clipboard appears on A1 when pressing ctrl+c.

Odoo task ID : [3095466](https://www.odoo.com/web#id=3095466&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo