### PR TITLE
[IMP] Grid: hit ESC to clean clipboard selection and close opened popover and context menus

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -172,6 +172,15 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         target: this.env.model.getters.getSelectedZones(),
       });
     },
+    ESCAPE: () => {
+      if (this.env.model.getters.hasOpenedPopover()) {
+        this.closeOpenedPopover();
+      } else if (this.menuState.isOpen) {
+        this.closeMenu();
+      } else {
+        this.env.model.dispatch("CLEAN_CLIPBOARD_HIGHLIGHT");
+      }
+    },
     "CTRL+A": () => this.env.model.selection.loopSelection(),
     "CTRL+S": () => {
       this.props.onSaveRequested?.();

--- a/src/plugins/ui/cell_popovers.ts
+++ b/src/plugins/ui/cell_popovers.ts
@@ -13,7 +13,11 @@ import { UIPlugin } from "../ui_plugin";
  * Plugin managing the display of components next to cells.
  */
 export class CellPopoverPlugin extends UIPlugin {
-  static getters = ["getCellPopover", "getPersistentPopoverTypeAtPosition"] as const;
+  static getters = [
+    "hasOpenedPopover",
+    "getCellPopover",
+    "getPersistentPopoverTypeAtPosition",
+  ] as const;
   static modes: Mode[] = ["normal"];
 
   private persistentPopover?: Position & { type: CellPopoverType };
@@ -94,6 +98,10 @@ export class CellPopoverPlugin extends UIPlugin {
           ...popover,
           ...this.computePopoverProps(mainPosition, popover.cellCorner),
         };
+  }
+
+  hasOpenedPopover() {
+    return this.persistentPopover != null;
   }
 
   getPersistentPopoverTypeAtPosition({ col, row }: Position): CellPopoverType | undefined {

--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -86,6 +86,9 @@ export class ClipboardPlugin extends UIPlugin {
         }
         this.status = "invisible";
         break;
+      case "CLEAN_CLIPBOARD_HIGHLIGHT":
+        this.status = "invisible";
+        break;
       case "DELETE_CELL": {
         const { cut, paste } = this.getDeleteCellsTargets(cmd.zone, cmd.shiftDimension);
         const state = this.getClipboardStateForCopyCells(cut, "CUT");

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -485,6 +485,10 @@ export interface PasteCommand {
   pasteOption?: ClipboardPasteOptions;
 }
 
+export interface CleanClipBoardHighlightCommand {
+  type: "CLEAN_CLIPBOARD_HIGHLIGHT";
+}
+
 export interface AutoFillCellCommand {
   type: "AUTOFILL_CELL";
   originCol: number;
@@ -941,6 +945,7 @@ export type LocalCommand =
   | CopyCommand
   | CutCommand
   | PasteCommand
+  | CleanClipBoardHighlightCommand
   | AutoFillCellCommand
   | PasteFromOSClipboardCommand
   | ActivatePaintFormatCommand

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -224,6 +224,19 @@ describe("Context Menu", () => {
     expect(fixture.querySelector(".o-menu")).toBeFalsy();
   });
 
+  test("right click on a cell, then hitting esc key closes a context menu", async () => {
+    await rightClickCell(model, "C8");
+    expect(getActiveXc(model)).toBe("C8");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeTruthy();
+
+    document
+      .querySelector(".o-grid-overlay")!
+      .dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeFalsy();
+  });
+
   test("can copy/paste with context menu", async () => {
     setCellContent(model, "B1", "b1");
 

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -8,6 +8,7 @@ import {
   addCellToSelection,
   addColumns,
   addRows,
+  cleanClipBoardHighlight,
   copy,
   createSheet,
   createSheetWithName,
@@ -115,6 +116,28 @@ describe("clipboard", () => {
     paste(model, "D3");
 
     expect(getCell(model, "D3")).toBeUndefined();
+  });
+
+  test("can clean the clipboard visible zones", () => {
+    const model = new Model();
+    setCellContent(model, "B2", "b2");
+    expect(getCell(model, "B2")).toMatchObject({
+      content: "b2",
+      evaluated: {
+        type: CellValueType.text,
+        value: "b2",
+      },
+    });
+
+    copy(model, "B2");
+    expect(getClipboardVisibleZones(model).length).toBe(1);
+    cleanClipBoardHighlight(model);
+    expect(getClipboardVisibleZones(model).length).toBe(0);
+
+    cut(model, "B2");
+    expect(getClipboardVisibleZones(model).length).toBe(1);
+    cleanClipBoardHighlight(model);
+    expect(getClipboardVisibleZones(model).length).toBe(0);
   });
 
   test("cut command will cut the selection if no target were given", () => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -243,6 +243,13 @@ export function pasteFromOSClipboard(model: Model, range: string, content: strin
 }
 
 /**
+ * Clean clipboard highlight selection.
+ */
+export function cleanClipBoardHighlight(model: Model): DispatchResult {
+  return model.dispatch("CLEAN_CLIPBOARD_HIGHLIGHT");
+}
+
+/**
  * Add columns
  */
 export function addColumns(


### PR DESCRIPTION
## Description:

Now if there is a clipboard selection and we don't copy/paste in the spreadsheet, the clipboard selection will stay. 

This PR makes hitting esc key to clean clipboard highlight selection possible. The idea of implementation is basically to add a new command to clean the selection in the clipboard, and add a keyboard event handler in `grid`, which dispatch the new command. 

To copy GSheets behaviors, if a popover or context menu is opened at the same time with a clipboard highlight selection, hitting ESC key will first close the popover/cell context menu without cleaning the clipboard selection. After that, hitting ESC again will clean the clipboard selection. 
The top bar/bottom bar menus are not handled. 

Odoo task ID : [2714347](https://www.odoo.com/web#id=2714347&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo