### PR TITLE
[FIX] collaborative: don't endlessly dispatch new revision

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -286,7 +286,8 @@ export function repairInitialMessages(
   initialMessages: StateUpdateMessage[]
 ): StateUpdateMessage[] {
   initialMessages = fixTranslatedSheetIds(data, initialMessages);
-  initialMessages = dropSortCommands(data, initialMessages);
+  initialMessages = dropCommands(initialMessages, "SORT_CELLS");
+  initialMessages = dropCommands(initialMessages, "SET_DECIMAL");
   return initialMessages;
 }
 
@@ -327,17 +328,13 @@ function fixTranslatedSheetIds(
   return messages;
 }
 
-function dropSortCommands(
-  data: Partial<WorkbookData>,
-  initialMessages: StateUpdateMessage[]
-): StateUpdateMessage[] {
+function dropCommands(initialMessages, commandType: string) {
   const messages: StateUpdateMessage[] = [];
   for (const message of initialMessages) {
     if (message.type === "REMOTE_REVISION") {
       messages.push({
         ...message,
-        // @ts-ignore
-        commands: message.commands.filter((command) => command.type !== "SORT_CELLS"),
+        commands: message.commands.filter((command) => command.type !== commandType),
       });
     } else {
       messages.push(message);

--- a/src/model.ts
+++ b/src/model.ts
@@ -266,7 +266,10 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
 
   private onRemoteRevisionReceived({ commands }: { commands: CoreCommand[] }) {
     for (let command of commands) {
+      const previousStatus = this.status;
+      this.status = Status.RunningCore;
       this.dispatchToHandlers(this.uiPlugins, command);
+      this.status = previousStatus;
     }
     this.finalize();
   }
@@ -404,7 +407,10 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
       case Status.Finalizing:
         throw new Error(_lt("Cannot dispatch commands in the finalize state"));
       case Status.RunningCore:
-        throw new Error("A UI plugin cannot dispatch while handling a core command");
+        if (isCoreCommand(command)) {
+          throw new Error(`A UI plugin cannot dispatch ${type} while handling a core command`);
+        }
+        this.dispatchToHandlers(this.handlers, command);
     }
     return DispatchResult.Success;
   };

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -162,7 +162,6 @@ export const coreTypes = new Set<CoreCommandTypes>([
   "SET_FORMATTING",
   "CLEAR_FORMATTING",
   "SET_BORDER",
-  "SET_DECIMAL",
 
   /** CHART */
   "CREATE_CHART",
@@ -860,7 +859,6 @@ export type CoreCommand =
   | UpdateCellPositionCommand
   | ClearCellCommand
   | DeleteContentCommand
-  | SetDecimalCommand
 
   /** GRID SHAPE */
   | AddColumnsRowsCommand
@@ -959,6 +957,7 @@ export type LocalCommand =
   | ReplaceSearchCommand
   | ReplaceAllSearchCommand
   | SortCommand
+  | SetDecimalCommand
   | ResizeViewportCommand
   | RefreshChartCommand
   | SumSelectionCommand

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -355,6 +355,38 @@ describe("Collaborative local history", () => {
     expect(getCellContent(model, "A3")).toBe("3");
   });
 
+  test("Initial set decimal command is dropped", () => {
+    const initialMessages: StateUpdateMessage[] = [
+      {
+        type: "REMOTE_REVISION",
+        version: MESSAGE_VERSION,
+        nextRevisionId: "1",
+        clientId: "bob",
+        commands: [
+          {
+            // @ts-ignore SET_DECIMAL was a core command (see commit message)
+            type: "SET_DECIMAL",
+            target: target("A1"),
+            sheetId: "sheet1",
+            step: 1,
+          },
+        ],
+        serverRevisionId: "initial_revision",
+      },
+    ];
+    const data = {
+      revisionId: "initial_revision",
+      sheets: [
+        {
+          id: "sheet1",
+          cells: { A1: { content: "1" } },
+        },
+      ],
+    };
+    const model = new Model(data, {}, initialMessages);
+    expect(getCell(model, "A1")?.format).toBeUndefined();
+  });
+
   test("Undo/redo your own change only", () => {
     setCellContent(alice, "A1", "hello in A1");
     setCellContent(bob, "B2", "hello in B2");


### PR DESCRIPTION
Steps to reproduce
------------------

- set a number in one cell
- for that cell, hit the "Increase decimal places" button in the toolbar
  (which dispatches a `SET_DECIMAL` command)

=> now every time you open the spreadsheet, a new revision is dispatched,
leading to an enormous amount of initial revisions over time and thousand
of initial RPC requests.
Another consequence is to prevent any snapshot from happening, meaning
the issue will never disappear.

Why does it happen?
-------------------

Once upon a time, `"SET_DECIMAL"` was a core command (https://github.com/odoo/o-spreadsheet/commit/92ca319c8d001fd5e19d03fc1e531b3a8b30f1df).
That means some of those commands are in the initial revisions replayed
when opening the spreadsheet.

When `"SET_DECIMAL"` is replayed, it's handled by `FormatPlugin` **which
is a UI plugin!**
The plugin dispatches a `"SET_FORMATTING"` command as part of `"SET_DECIMAL"`
handling.
Since this `"SET_FORMATTING"` command is a core command coming from a UI
plugin => it's considered as a new revision which is dispatched to the
server.

The same `"SET_DECIMAL"` command is replayed again and again every time
the spreadsheet is open. Hence more and more revisions with
`"SET_FORMATTING"` are created.

Why thousands of requests?
--------------------------
When opening the spreadsheet, you'll see potentially thousands of
requests sending the revision to the server.
It will do one request per initial revision *after* the `"SET_DECIMAL"`
(including all useless previous `"SET_FORMATTING"`! This
adds one request every time you open the spreadsheet).
That's because the `"SET_FORMATTING"` is first dispatched with `"SET_DECIMAL"`
base revisionId (which is not the last). When following initial revisions
are treated, it retries to send the revision (with the new base revision
id).
Every attempt it refused by the server because the base revision id
doesn't match the last server revision id. That is until the very last
attempt which has the correct current server revision id.
Note that all those requests are performed synchronously.

Why no snapshot?
----------------
The snapshot will never be accepted by the server because replaying
commands and the snapshot are executed synchronously.
That means they are both based on the same `serverRevisionId`.

Since the `"SET_FORMATTING"` is first, it's accepted by the server and
the snapshot's `serverRevisionId` is outdated by the time the request
arrives at the server.

opw : [2951236](https://www.odoo.com/web#id=2951236&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
opw : [3045623](https://www.odoo.com/web#id=3045623&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo