### PR TITLE
[FIX] renderer: overflowing cell in Y have wrong clipRect

### DIFF
--- a/src/plugins/ui_feature/renderer.ts
+++ b/src/plugins/ui_feature/renderer.ts
@@ -182,16 +182,17 @@ export class RendererPlugin extends UIPlugin {
         let width: number;
         const y = box.y + thinLineWidth / 2;
         const height = box.height - thinLineWidth;
+        const clipWidth = Math.min(box.clipRect?.width || Infinity, box.content.width);
         if (align === "left") {
           x = box.x + thinLineWidth / 2;
-          width = (box.clipRect?.width || box.content.width) - 2 * thinLineWidth;
+          width = clipWidth - 2 * thinLineWidth;
         } else if (align === "right") {
           x = box.x + box.width - thinLineWidth / 2;
-          width = -(box.clipRect?.width || box.content.width) + 2 * thinLineWidth;
+          width = -clipWidth + 2 * thinLineWidth;
         } else {
           x =
             (box.clipRect?.x || box.x + box.width / 2 - box.content.width / 2) + thinLineWidth / 2;
-          width = (box.clipRect?.width || box.content.width) - 2 * thinLineWidth;
+          width = clipWidth - 2 * thinLineWidth;
         }
         ctx.fillStyle = "#ffffff";
         ctx.fillRect(x, y, width, height);
@@ -685,6 +686,7 @@ export class RendererPlugin extends UIPlugin {
         height,
       };
     }
+
     return box;
   }
 


### PR DESCRIPTION
## Description

Following https://github.com/odoo/o-spreadsheet/commit/3ce6151f4d7d09c6033f8f902918ed530e7ffd95, the separator between cells isn't displayed anymore
when the cell is overflowing. But the clipRect of a cell overflowing
in Y was spanning from the cell until the next non-empty cell, making
all the separators between them disappear, even if there was no

content there.
Odoo task ID : [3096929](https://www.odoo.com/web#id=3096929&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo