### PR TITLE
[IMP] function: `hyperlink(url, label)`

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -23,6 +23,7 @@ import * as math from "./module_math";
 import * as operators from "./module_operators";
 import * as statistical from "./module_statistical";
 import * as text from "./module_text";
+import * as web from "./module_web";
 
 export { args } from "./arguments";
 
@@ -39,6 +40,7 @@ const functions: { [category: string]: { [name: string]: AddFunctionDescription 
   statistical,
   text,
   engineering,
+  web,
 };
 
 const functionNameRegex = /^[A-Z0-9\_\.]+$/;

--- a/src/functions/module_web.ts
+++ b/src/functions/module_web.ts
@@ -1,0 +1,26 @@
+import { markdownLink } from "../helpers";
+import { _lt } from "../translation";
+import { AddFunctionDescription, PrimitiveArgValue } from "../types";
+import { args } from "./arguments";
+import { toString } from "./helpers";
+
+// -----------------------------------------------------------------------------
+// HYPERLINK
+// -----------------------------------------------------------------------------
+export const HYPERLINK: AddFunctionDescription = {
+  description: _lt("Creates a hyperlink in a cell."),
+  args: args(`
+    url (string) ${_lt("The full URL of the link enclosed in quotation marks.")}
+    link_label (string, optional) ${_lt(
+      "The text to display in the cell, enclosed in quotation marks."
+    )}
+  `),
+  returns: ["STRING"],
+  compute: function (url: PrimitiveArgValue, linkLabel: PrimitiveArgValue): string {
+    const processedUrl = toString(url).trim();
+    const processedLabel = toString(linkLabel) || processedUrl;
+    if (processedUrl === "") return processedLabel;
+    return markdownLink(processedLabel, processedUrl);
+  },
+  isExported: true,
+};

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -12135,6 +12135,13 @@ Object {
                 </f>
             </c>
         </row>
+        <row r=\\"165\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A165\\" s=\\"1\\">
+                <f>
+                    HYPERLINK(\\"https://www.odoo.com\\",\\"Odoo\\")
+                </f>
+            </c>
+        </row>
     </sheetData>
 </worksheet>",
       "contentType": "sheet",
@@ -14519,6 +14526,13 @@ Object {
             <c r=\\"A164\\" s=\\"1\\">
                 <f>
                     ISERR(A162)
+                </f>
+            </c>
+        </row>
+        <row r=\\"165\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A165\\" s=\\"1\\">
+                <f>
+                    HYPERLINK(\\"https://www.odoo.com\\",\\"Odoo\\")
                 </f>
             </c>
         </row>

--- a/tests/components/link/link_editor.test.ts
+++ b/tests/components/link/link_editor.test.ts
@@ -119,6 +119,20 @@ describe("link editor component", () => {
     expect(urlInput().disabled).toBeTruthy();
   });
 
+  test("open link editor in a hyperlink formula cell with a url and a label", async () => {
+    setCellContent(model, "A1", '=HYPERLINK("url.com", "label")');
+    await openLinkEditor(model, "A1");
+    expect(labelInput().value).toBe("label");
+    expect(urlInput().value).toBe("https://url.com");
+  });
+
+  test("open link editor in a hyperlink formula cell without label", async () => {
+    setCellContent(model, "B1", '=HYPERLINK("url2.com")');
+    await openLinkEditor(model, "B1");
+    expect(labelInput().value).toBe("url2.com");
+    expect(urlInput().value).toBe("https://url2.com");
+  });
+
   test("insert link with an url and a label", async () => {
     await openLinkEditor(model, "A1");
     setInputValueAndTrigger(labelInput(), "my label", "input");
@@ -164,6 +178,14 @@ describe("link editor component", () => {
   test("remove current link", async () => {
     setCellContent(model, "A1", "[label](url.com)");
     await openLinkEditor(model, "A1");
+    expect(urlInput().value).toBe("https://url.com");
+    await simulateClick(".o-remove-url");
+    expect(urlInput().value).toBe("");
+  });
+
+  test("remove link from HYPERLINK function", async () => {
+    setCellContent(model, "B1", '=HYPERLINK("url.com", "label")');
+    await openLinkEditor(model, "B1");
     expect(urlInput().value).toBe("https://url.com");
     await simulateClick(".o-remove-url");
     expect(urlInput().value).toBe("");

--- a/tests/functions/module_web.test.ts
+++ b/tests/functions/module_web.test.ts
@@ -1,0 +1,63 @@
+import { evaluateCell, evaluateCellText } from "../test_helpers/helpers";
+
+describe("HYPERLINK formula", () => {
+  test("The evaluated result is the link", () => {
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("https://www.odoo.com", "Odoo")' })).toBe("Odoo");
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("https://www.odoo.com")' })).toBe(
+      "https://www.odoo.com"
+    );
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("invalidUrl")' })).toBe("invalidUrl");
+  });
+
+  test("The reference will be taken into account", () => {
+    expect(evaluateCell("A1", { A1: "=HYPERLINK(A2)", A2: "https://www.odoo.com" })).toBe(
+      "https://www.odoo.com"
+    );
+    expect(evaluateCell("A1", { A1: '=HYPERLINK(A2, "Odoo")', A2: "https://www.odoo.com" })).toBe(
+      "Odoo"
+    );
+    expect(
+      evaluateCell("A1", { A1: "=HYPERLINK(A2, A3)", A2: "https://www.odoo.com", A3: "Odoo" })
+    ).toBe("Odoo");
+  });
+
+  test("URL is not a string", () => {
+    expect(evaluateCell("A1", { A1: "=HYPERLINK(2)" })).toBe(2);
+    expect(evaluateCell("A1", { A1: '=HYPERLINK(2, "number")' })).toBe("number");
+
+    expect(evaluateCell("A1", { A1: "=HYPERLINK(true)" })).toBe(true);
+    expect(evaluateCell("A1", { A1: '=HYPERLINK(true, "boolean")' })).toBe("boolean");
+
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("1/31/2022")' })).toBe(44592);
+    expect(evaluateCellText("A1", { A1: '=HYPERLINK("1/31/2022")' })).toBe("1/31/2022");
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("1/31/2022", "date")' })).toBe("date");
+
+    expect(evaluateCell("A1", { A1: "=HYPERLINK()" })).toBe("#BAD_EXPR");
+  });
+
+  test("Label is not a string", () => {
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("www.odoo.com", 2)' })).toBe(2);
+
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("www.odoo.com", true)' })).toBe(true);
+    expect(evaluateCellText("A1", { A1: '=HYPERLINK("www.odoo.com", true)' })).toBe("TRUE");
+
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("www.odoo.com", "1/31/2022")' })).toBe(44592);
+    expect(evaluateCellText("A1", { A1: '=HYPERLINK("www.odoo.com", "1/31/2022")' })).toBe(
+      "1/31/2022"
+    );
+  });
+
+  test("Url which is empty or only contains whitespaces will not be converted into link, but label still shows", () => {
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("")' })).toBe("");
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("", "   ")' })).toBe("   ");
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("", "label")' })).toBe("label");
+    expect(evaluateCell("A1", { A1: '=HYPERLINK(" ")' })).toBe("");
+    expect(evaluateCell("A1", { A1: '=HYPERLINK(" ", "   ")' })).toBe("   ");
+    expect(evaluateCell("A1", { A1: '=HYPERLINK(" ", "link label")' })).toBe("link label");
+  });
+
+  test("Label which is empty or only contains whitespace will not influence the conversion to link", () => {
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("www.odoo.com", "")' })).toBe("www.odoo.com");
+    expect(evaluateCell("A1", { A1: '=HYPERLINK("www.odoo.com", "   ")' })).toBe("   ");
+  });
+});

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -284,6 +284,7 @@ const allExportableFormulasData = {
         A162: { content: "=NA()" },
         A163: { content: "=ISNA(A162)" },
         A164: { content: "=ISERR(A162)" },
+        A165: { content: '=HYPERLINK("https://www.odoo.com", "Odoo")' },
 
         // DATA
         G1: { content: "Name", style: 8 },


### PR DESCRIPTION
## Description:

This commit implements HYPERLINK() function which also exists in GSheets and Excel. 

The evaluated result is a markdown string, which will be evaluated as a link later. It behaves like inserting a link using menu, so not exactly the same as `HYPERLINK` in GSheets and Excel, which also supports something like `ftp` or `mailto`. 

Odoo task ID : [2837746](https://www.odoo.com/web#id=2837746&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo