### PR TITLE
[IMP] Grid: hit ESC to clean clipboard selection

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -153,7 +153,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onClosePopover() {
-    this.closeOpenedPopover();
+    if (this.env.model.getters.hasOpenedPopover()) {
+      this.closeOpenedPopover();
+    }
     this.focus();
   }
 
@@ -185,6 +187,16 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         sheetId: this.env.model.getters.getActiveSheetId(),
         target: this.env.model.getters.getSelectedZones(),
       });
+    },
+    ESCAPE: () => {
+      /** TODO: Clean once we introduce proper focus on sub components. Grid should not have to handle all this logic */
+      if (this.env.model.getters.hasOpenedPopover()) {
+        this.closeOpenedPopover();
+      } else if (this.menuState.isOpen) {
+        this.closeMenu();
+      } else {
+        this.env.model.dispatch("CLEAN_CLIPBOARD_HIGHLIGHT");
+      }
     },
     "CTRL+A": () => this.env.model.selection.loopSelection(),
     "CTRL+Z": () => this.env.model.dispatch("REQUEST_UNDO"),
@@ -361,7 +373,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       this.env.model.dispatch("PREPARE_SELECTION_INPUT_EXPANSION");
     }
 
-    this.closeOpenedPopover();
+    if (this.env.model.getters.hasOpenedPopover()) {
+      this.closeOpenedPopover();
+    }
     if (this.env.model.getters.getEditionMode() === "editing") {
       this.env.model.dispatch("STOP_EDITION");
     }
@@ -413,7 +427,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   processArrows(ev: KeyboardEvent) {
     ev.preventDefault();
     ev.stopPropagation();
-    this.closeOpenedPopover();
+    if (this.env.model.getters.hasOpenedPopover()) {
+      this.closeOpenedPopover();
+    }
 
     updateSelectionWithArrowKeys(ev, this.env.model.selection);
 
@@ -495,7 +511,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   }
 
   toggleContextMenu(type: ContextMenuType, x: Pixel, y: Pixel) {
-    this.closeOpenedPopover();
+    if (this.env.model.getters.hasOpenedPopover()) {
+      this.closeOpenedPopover();
+    }
     this.menuState.isOpen = true;
     this.menuState.position = { x, y };
     this.menuState.menuItems = registries[type]

--- a/src/plugins/ui_feature/cell_popovers.ts
+++ b/src/plugins/ui_feature/cell_popovers.ts
@@ -12,7 +12,11 @@ import { UIPlugin } from "../ui_plugin";
  * Plugin managing the display of components next to cells.
  */
 export class CellPopoverPlugin extends UIPlugin {
-  static getters = ["getCellPopover", "getPersistentPopoverTypeAtPosition"] as const;
+  static getters = [
+    "getCellPopover",
+    "getPersistentPopoverTypeAtPosition",
+    "hasOpenedPopover",
+  ] as const;
 
   private persistentPopover?: CellPosition & { type: CellPopoverType };
 
@@ -82,6 +86,10 @@ export class CellPopoverPlugin extends UIPlugin {
           ...popover,
           anchorRect: this.computePopoverAnchorRect(position),
         };
+  }
+
+  hasOpenedPopover() {
+    return this.persistentPopover !== undefined;
   }
 
   getPersistentPopoverTypeAtPosition({ col, row }: Position): CellPopoverType | undefined {

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -86,6 +86,9 @@ export class ClipboardPlugin extends UIPlugin {
         }
         this.status = "invisible";
         break;
+      case "CLEAN_CLIPBOARD_HIGHLIGHT":
+        this.status = "invisible";
+        break;
       case "DELETE_CELL": {
         const { cut, paste } = this.getDeleteCellsTargets(cmd.zone, cmd.shiftDimension);
         const state = this.getClipboardStateForCopyCells(cut, "CUT");

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -501,6 +501,10 @@ export interface PasteCommand {
   pasteOption?: ClipboardPasteOptions;
 }
 
+export interface CleanClipBoardHighlightCommand {
+  type: "CLEAN_CLIPBOARD_HIGHLIGHT";
+}
+
 export interface AutoFillCellCommand {
   type: "AUTOFILL_CELL";
   originCol: number;
@@ -959,6 +963,7 @@ export type LocalCommand =
   | CopyCommand
   | CutCommand
   | PasteCommand
+  | CleanClipBoardHighlightCommand
   | AutoFillCellCommand
   | PasteFromOSClipboardCommand
   | ActivatePaintFormatCommand

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -7,7 +7,12 @@ import { createFullMenuItem, FullMenuItem } from "../../src/registries";
 import { cellMenuRegistry } from "../../src/registries/menus/cell_menu_registry";
 import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { setCellContent } from "../test_helpers/commands_helpers";
-import { rightClickCell, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
+import {
+  keyDown,
+  rightClickCell,
+  simulateClick,
+  triggerMouseEvent,
+} from "../test_helpers/dom_helper";
 import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import {
   getStylePropertyInPx,
@@ -234,6 +239,14 @@ describe("Standalone context menu tests", () => {
       expect(fixture.querySelector(".o-menu")).toBeTruthy();
 
       await simulateClick(".o-grid-overlay", 50, 50);
+      expect(fixture.querySelector(".o-menu")).toBeFalsy();
+    });
+
+    test("right click on a cell, then hitting esc key closes a context menu", async () => {
+      await rightClickCell(model, "C8");
+      expect(fixture.querySelector(".o-menu")).toBeTruthy();
+
+      await keyDown("Escape");
       expect(fixture.querySelector(".o-menu")).toBeFalsy();
     });
 

--- a/tests/components/filter_menu.test.ts
+++ b/tests/components/filter_menu.test.ts
@@ -8,7 +8,7 @@ import {
   setFormat,
   updateFilter,
 } from "../test_helpers/commands_helpers";
-import { simulateClick } from "../test_helpers/dom_helper";
+import { keyDown, simulateClick } from "../test_helpers/dom_helper";
 import {
   getCellsObject,
   makeTestFixture,
@@ -199,6 +199,13 @@ describe("Filter menu component", () => {
         { value: "1", isChecked: true },
         { value: "2", isChecked: true },
       ]);
+    });
+
+    test("Hitting esc key correctly closes the filter menu", async () => {
+      await openFilterMenu();
+      expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(1);
+      await keyDown("Escape");
+      expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(0);
     });
 
     describe("Search bar", () => {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -1,13 +1,13 @@
 import { toCartesian, toZone, zoneToXc } from "../../src/helpers";
 import { ClipboardCellsState } from "../../src/helpers/clipboard/clipboard_cells_state";
 import { Model } from "../../src/model";
-import { ClipboardPlugin } from "../../src/plugins/ui_stateful/clipboard";
-import { CommandResult, Zone } from "../../src/types/index";
+import { CommandResult } from "../../src/types/index";
 import {
   activateSheet,
   addCellToSelection,
   addColumns,
   addRows,
+  cleanClipBoardHighlight,
   copy,
   createSheet,
   createSheetWithName,
@@ -30,17 +30,11 @@ import {
   getCellContent,
   getCellError,
   getCellText,
+  getClipboardVisibleZones,
   getEvaluatedCell,
   getStyle,
 } from "../test_helpers/getters_helpers";
-import { createEqualCF, getGrid, getPlugin, target, toRangesData } from "../test_helpers/helpers";
-
-function getClipboardVisibleZones(model: Model): Zone[] {
-  const clipboardPlugin = getPlugin(model, ClipboardPlugin);
-  return clipboardPlugin["status"] === "visible"
-    ? (clipboardPlugin["state"]! as ClipboardCellsState)["zones"]
-    : [];
-}
+import { createEqualCF, getGrid, target, toRangesData } from "../test_helpers/helpers";
 
 describe("clipboard", () => {
   test("can copy and paste a cell", () => {
@@ -86,6 +80,24 @@ describe("clipboard", () => {
     paste(model, "D3");
 
     expect(getCell(model, "D3")).toBeUndefined();
+  });
+
+  test("can clean the clipboard visible zones (copy)", () => {
+    const model = new Model();
+    setCellContent(model, "B2", "b2");
+    copy(model, "B2");
+    expect(getClipboardVisibleZones(model).length).toBe(1);
+    cleanClipBoardHighlight(model);
+    expect(getClipboardVisibleZones(model).length).toBe(0);
+  });
+
+  test("can clean the clipboard visible zones (cut)", () => {
+    const model = new Model();
+    setCellContent(model, "B2", "b2");
+    cut(model, "B2");
+    expect(getClipboardVisibleZones(model).length).toBe(1);
+    cleanClipBoardHighlight(model);
+    expect(getClipboardVisibleZones(model).length).toBe(0);
   });
 
   test("cut command will cut the selection if no target were given", () => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -274,6 +274,13 @@ export function pasteFromOSClipboard(model: Model, range: string, content: strin
 }
 
 /**
+ * Clean clipboard highlight selection.
+ */
+export function cleanClipBoardHighlight(model: Model): DispatchResult {
+  return model.dispatch("CLEAN_CLIPBOARD_HIGHLIGHT");
+}
+
+/**
  * Add columns
  */
 export function addColumns(

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -21,8 +21,12 @@ export async function simulateClick(
   }
   triggerMouseEvent(selector, "mousedown", x, y, extra);
   if (target !== document.activeElement) {
-    (document.activeElement as HTMLElement | null)?.blur();
-    target.focus();
+    const oldActiveEl = document.activeElement;
+    (document.activeElement as HTMLElement | null)?.dispatchEvent(
+      new FocusEvent("blur", { relatedTarget: target })
+    );
+
+    target.dispatchEvent(new FocusEvent("focus", { relatedTarget: oldActiveEl }));
   }
   triggerMouseEvent(selector, "mouseup", x, y, extra);
   triggerMouseEvent(selector, "click", x, y, extra);

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -1,5 +1,7 @@
+import { ClipboardCellsState } from "../../src/helpers/clipboard/clipboard_cells_state";
 import { toCartesian, toXC } from "../../src/helpers/index";
 import { Model } from "../../src/model";
+import { ClipboardPlugin } from "../../src/plugins/ui_stateful";
 import {
   Border,
   Cell,
@@ -10,8 +12,10 @@ import {
   Merge,
   Style,
   UID,
+  Zone,
 } from "../../src/types";
 import { setSelection } from "./commands_helpers";
+import { getPlugin } from "./helpers";
 
 /**
  * Get the active XC
@@ -165,4 +169,11 @@ export function getFilter(
 ) {
   const { col, row } = toCartesian(xc);
   return model.getters.getFilter({ sheetId, col, row });
+}
+
+export function getClipboardVisibleZones(model: Model): Zone[] {
+  const clipboardPlugin = getPlugin(model, ClipboardPlugin);
+  return clipboardPlugin["status"] === "visible"
+    ? (clipboardPlugin["state"]! as ClipboardCellsState)["zones"]
+    : [];
 }


### PR DESCRIPTION
## Description:

Now if there is a clipboard selection and we don't copy/paste in the spreadsheet, the clipboard selection will stay. 

This PR makes hitting ESC key to clean clipboard highlight selection possible. The idea of implementation is basically to add a new command to clean the selection in the clipboard, and add a keyboard event handler in `grid`, which dispatch the new command. 

To copy GSheets behaviors, if a popover or context menu is opened at the same time with a clipboard highlight selection, hitting ESC key will first close the popover/cell context menu without cleaning the clipboard selection. After that, hitting ESC again will clean the clipboard selection. 
The top bar/bottom bar menus are not handled. 

Odoo task ID : [2714347](https://www.odoo.com/web#id=2714347&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo