### PR TITLE
[FIX] data filter: icon not centered

### DIFF
--- a/src/components/filters/filter_icon/filter_icon.ts
+++ b/src/components/filters/filter_icon/filter_icon.ts
@@ -1,5 +1,5 @@
 import * as owl from "@odoo/owl";
-import { FILTERS_COLOR, ICON_EDGE_LENGTH } from "../../../constants";
+import { FILTERS_COLOR, FILTER_ICON_EDGE_LENGTH } from "../../../constants";
 import { DOMCoordinates, SpreadsheetEnv } from "../../../types";
 import { css } from "../../helpers/css";
 
@@ -12,8 +12,8 @@ const CSS = css/* scss */ `
     display: flex;
     align-items: center;
     justify-content: center;
-    width: ${ICON_EDGE_LENGTH}px;
-    height: ${ICON_EDGE_LENGTH}px;
+    width: ${FILTER_ICON_EDGE_LENGTH}px;
+    height: ${FILTER_ICON_EDGE_LENGTH}px;
 
     svg {
       path {

--- a/src/components/filters/filter_icons_overlay/fitler_icons_overlay.ts
+++ b/src/components/filters/filter_icons_overlay/fitler_icons_overlay.ts
@@ -1,5 +1,5 @@
 import * as owl from "@odoo/owl";
-import { FILTER_ICON_MARGIN, ICON_EDGE_LENGTH } from "../../../constants";
+import { FILTER_ICON_EDGE_LENGTH, FILTER_ICON_MARGIN } from "../../../constants";
 import { DOMCoordinates, HeaderIndex, Position, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
 import { FilterIcon } from "../filter_icon/filter_icon";
@@ -35,10 +35,10 @@ export class FilterIconsOverlay extends Component<Props, SpreadsheetChildEnv> {
     const colDims = this.env.model.getters.getColDimensionsInViewport(sheetId, position.col);
 
     // TODO : change this offset when we support vertical cell align
-    const centeringOffset = (rowDims.size - ICON_EDGE_LENGTH) / 2;
+    const centeringOffset = Math.floor((rowDims.size - FILTER_ICON_EDGE_LENGTH) / 2);
     return {
-      x: colDims.end - ICON_EDGE_LENGTH + this.props.gridPosition.x - FILTER_ICON_MARGIN,
-      y: rowDims.end - ICON_EDGE_LENGTH + this.props.gridPosition.y - centeringOffset,
+      x: colDims.end - FILTER_ICON_EDGE_LENGTH + this.props.gridPosition.x - FILTER_ICON_MARGIN - 1, // -1 for cell border
+      y: rowDims.end - FILTER_ICON_EDGE_LENGTH + this.props.gridPosition.y - centeringOffset,
     };
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -125,6 +125,7 @@ export const CF_ICON_EDGE_LENGTH = 15;
 export const PADDING_AUTORESIZE_VERTICAL = 3;
 export const PADDING_AUTORESIZE_HORIZONTAL = MIN_CELL_TEXT_MARGIN;
 export const FILTER_ICON_MARGIN = 2;
+export const FILTER_ICON_EDGE_LENGTH = 17;
 
 // Menus
 export const MENU_WIDTH = 250;

--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -9,6 +9,7 @@ import {
   CELL_BORDER_COLOR,
   DEFAULT_FONT,
   FILTERS_COLOR,
+  FILTER_ICON_EDGE_LENGTH,
   FILTER_ICON_MARGIN,
   HEADER_BORDER_COLOR,
   HEADER_FONT_SIZE,
@@ -561,7 +562,7 @@ export class RendererPlugin extends UIPlugin {
 
     /** Filter Header */
     box.isFilterHeader = this.getters.isFilterHeader(sheetId, col, row);
-    const headerIconWidth = box.isFilterHeader ? ICON_EDGE_LENGTH + FILTER_ICON_MARGIN : 0;
+    const headerIconWidth = box.isFilterHeader ? FILTER_ICON_EDGE_LENGTH + FILTER_ICON_MARGIN : 0;
 
     /** Content */
     const text = this.getters.getCellText(cell, showFormula);

--- a/tests/components/dashboard_grid.test.ts
+++ b/tests/components/dashboard_grid.test.ts
@@ -3,8 +3,8 @@ import { Spreadsheet } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
+  FILTER_ICON_EDGE_LENGTH,
   FILTER_ICON_MARGIN,
-  ICON_EDGE_LENGTH,
 } from "../../src/constants";
 import { Model } from "../../src/model";
 import { createFilter, setCellContent } from "../test_helpers/commands_helpers";
@@ -63,10 +63,10 @@ describe("Grid component in dashboard mode", () => {
     await nextTick();
     const icons = fixture.querySelectorAll(".o-filter-icon");
     expect(icons).toHaveLength(2);
-    const centerIngOffset = (DEFAULT_CELL_HEIGHT - ICON_EDGE_LENGTH) / 2;
-    const top = `${DEFAULT_CELL_HEIGHT * 2 - ICON_EDGE_LENGTH - centerIngOffset}px`;
-    const leftA = `${DEFAULT_CELL_WIDTH * 2 - ICON_EDGE_LENGTH - FILTER_ICON_MARGIN}px`;
-    const leftB = `${DEFAULT_CELL_WIDTH * 3 - ICON_EDGE_LENGTH - FILTER_ICON_MARGIN}px`;
+    const centerIngOffset = (DEFAULT_CELL_HEIGHT - FILTER_ICON_EDGE_LENGTH) / 2;
+    const top = `${DEFAULT_CELL_HEIGHT * 2 - FILTER_ICON_EDGE_LENGTH - centerIngOffset}px`;
+    const leftA = `${DEFAULT_CELL_WIDTH * 2 - FILTER_ICON_EDGE_LENGTH - FILTER_ICON_MARGIN - 1}px`;
+    const leftB = `${DEFAULT_CELL_WIDTH * 3 - FILTER_ICON_EDGE_LENGTH - FILTER_ICON_MARGIN - 1}px`;
     expect((icons[0] as HTMLElement).style["_values"]).toEqual({ top, left: leftA });
     expect((icons[1] as HTMLElement).style["_values"]).toEqual({ top, left: leftB });
   });

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -5,10 +5,10 @@ import {
   BACKGROUND_GRAY_COLOR,
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
+  FILTER_ICON_EDGE_LENGTH,
   FILTER_ICON_MARGIN,
   HEADER_HEIGHT,
   HEADER_WIDTH,
-  ICON_EDGE_LENGTH,
   MESSAGE_VERSION,
   SCROLLBAR_WIDTH,
 } from "../../src/constants";
@@ -629,15 +629,15 @@ describe("Grid component", () => {
 
       const icons = fixture.querySelectorAll(".o-filter-icon");
       expect(icons).toHaveLength(2);
-      const centerIngOffset = (DEFAULT_CELL_HEIGHT - ICON_EDGE_LENGTH) / 2;
+      const centerIngOffset = (DEFAULT_CELL_HEIGHT - FILTER_ICON_EDGE_LENGTH) / 2;
       const top = `${
-        DEFAULT_CELL_HEIGHT * 2 - ICON_EDGE_LENGTH + HEADER_HEIGHT - centerIngOffset
+        DEFAULT_CELL_HEIGHT * 2 - FILTER_ICON_EDGE_LENGTH + HEADER_HEIGHT - centerIngOffset
       }px`;
       const leftA = `${
-        DEFAULT_CELL_WIDTH * 2 - ICON_EDGE_LENGTH + HEADER_WIDTH - FILTER_ICON_MARGIN
+        DEFAULT_CELL_WIDTH * 2 - FILTER_ICON_EDGE_LENGTH + HEADER_WIDTH - FILTER_ICON_MARGIN - 1
       }px`;
       const leftB = `${
-        DEFAULT_CELL_WIDTH * 3 - ICON_EDGE_LENGTH + HEADER_WIDTH - FILTER_ICON_MARGIN
+        DEFAULT_CELL_WIDTH * 3 - FILTER_ICON_EDGE_LENGTH + HEADER_WIDTH - FILTER_ICON_MARGIN - 1
       }px`;
       expect((icons[0] as HTMLElement).style["_values"]).toEqual({ top, left: leftA });
       expect((icons[1] as HTMLElement).style["_values"]).toEqual({ top, left: leftB });


### PR DESCRIPTION
## Description

The SVG Icon of data filter is not centered. That's because we try to center a svg of 15px inside a div of 18px.

Odoo task ID : [3101155](https://www.odoo.com/web#id=3101155&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo