### PR TITLE
[FIX] Range: prevent crash with sheetname containing an exclamation mark 

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -303,7 +303,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     let sheetName = "";
     let prefixSheet = false;
     if (sheetXC.includes("!")) {
-      [sheetName, sheetXC] = sheetXC.split("!");
+      [sheetXC, sheetName] = sheetXC.split("!").reverse();
       if (sheetName) {
         prefixSheet = true;
       }

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -89,6 +89,7 @@ describe("range plugin", () => {
       sheets: [
         { id: "s1", name: "s1", rows: 10, cols: 10 },
         { id: "s2", name: "s 2", rows: 10, cols: 10 },
+        { id: "s1!!", name: "s1!!", rows: 10, cols: 10 },
       ],
     });
     m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["B2:D4"] });
@@ -432,6 +433,20 @@ describe("range plugin", () => {
         renameSheet(m, "s1", name);
         const range = m.getters.getRangeFromSheetXC("s1", "A1");
         expect(m.getters.getRangeString(range, "tao")).toBe(`'${name}'!A1`);
+      }
+    );
+
+    test.each([
+      ["s1!!!A1:A9", "'s1!!'!A1:A9"],
+      // TODO: the output is incorrect - should be fixed in task 3112299
+      // ["'s1!!'!A1:A9", "'!A1:A9"],
+      ["s1!!!A1:s1!!!A9", "'s1!!'!A9"],
+      ["s1!!!A1:s1!!!A9", "'s1!!'!A9"],
+    ])(
+      "xc with more than one exclamation mark does not throw error",
+      (rangeString, expectedString) => {
+        const range = m.getters.getRangeFromSheetXC("s1!!", rangeString);
+        expect(m.getters.getRangeString(range)).toBe(expectedString);
       }
     );
   });


### PR DESCRIPTION
## Description:

This commit addresses an issue in the range plugin that would crash when
handling sheetnames containing an exclamation mark (e.g. `'sheet!1'!A1:A2`)
There were 2 main symptoms:
1. when using such references in a selection input, an error would be thrown
during the processing
2. when writing a reference in a formulu through the composer

In both cases, it would cause the app to crash entirely.

Note that this commit only prevents the crash from happening but testing
these ranges highlighted that we do not properly handle exclamation
marks inside a sheetName. This will be addressed in  task 3112299

Odoo task ID : [3100211](https://www.odoo.com/web#id=3100211&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo