### PR TITLE
[IMP] selection_input: consistent range colors

### DIFF
--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -26,12 +26,6 @@ export function colorNumberString(color: number): Color {
   return toHex(color.toString(16).padStart(6, "0"));
 }
 
-let colorIndex = 0;
-export function getNextColor() {
-  colorIndex = ++colorIndex % colors.length;
-  return colors[colorIndex];
-}
-
 /**
  * Converts any CSS color value to a standardized hex6 value.
  * Accepts: hex3, hex6, hex8 and rgb (rgba is not supported)

--- a/src/plugins/ui_feature/selection_input.ts
+++ b/src/plugins/ui_feature/selection_input.ts
@@ -1,4 +1,4 @@
-import { getComposerSheetName, getNextColor, positionToZone, zoneToXc } from "../../helpers/index";
+import { colors, getComposerSheetName, positionToZone, zoneToXc } from "../../helpers/index";
 import { StreamCallbacks } from "../../selection_stream/event_stream";
 import { SelectionEvent } from "../../types/event_stream";
 import { Command, CommandResult, Highlight, LAYERS, UID } from "../../types/index";
@@ -185,7 +185,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
       ...values.map((xc, i) => ({
         xc,
         id: (this.ranges.length + i + 1).toString(),
-        color: getNextColor(),
+        color: colors[(this.ranges.length + i) % colors.length],
       }))
     );
   }

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -644,4 +644,18 @@ describe("selection input plugin", () => {
     model.dispatch("CHANGE_RANGE", { id, rangeId: idOfRange(model, id, 0), value: "1:1" });
     expect(model.getters.getSelectionInput(id)[0].xc).toBe("1:1");
   });
+
+  test("consistent range colors upon refocusing multiple times", () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, initialRanges: ["B1:B5", "C1:C5"] });
+    model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
+    const [initialFirstColor, initalSecondColor] = model.getters
+      .getSelectionInput(id)
+      .map((i) => i.color);
+    model.dispatch("DISABLE_SELECTION_INPUT", { id });
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, initialRanges: ["B1:B5", "C1:C5"] });
+    model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
+    const [newFirstColor, newSecondColor] = model.getters.getSelectionInput(id).map((i) => i.color);
+    expect(initialFirstColor).toBe(newFirstColor);
+    expect(initalSecondColor).toBe(newSecondColor);
+  });
 });


### PR DESCRIPTION
## Description:

Current behaviour of range colors upon being focused in selection input is it shows different colors every time the sidepanel is opened while range is being focused.

To bring a consistency on these colors, simply an index parameter is passed in getNextColor method in order to remove the global variable that is maintained for color index.

Odoo task ID : [2877044](https://www.odoo.com/web#id=2877044&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo