### PR TITLE
[FIX] headers: fix rounding error in header size

### DIFF
--- a/src/plugins/core/header_size.ts
+++ b/src/plugins/core/header_size.ts
@@ -141,10 +141,10 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
   }
 
   private getHeaderSize(sheetId: UID, dimension: Dimension, index: HeaderIndex): Pixel {
-    return (
+    return Math.round(
       this.sizes[sheetId]?.[dimension][index]?.manualSize ||
-      this.sizes[sheetId]?.[dimension][index]?.computedSize() ||
-      this.getDefaultHeaderSize(dimension)
+        this.sizes[sheetId]?.[dimension][index]?.computedSize() ||
+        this.getDefaultHeaderSize(dimension)
     );
   }
 

--- a/tests/plugins/resizing.test.ts
+++ b/tests/plugins/resizing.test.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_CELL_WIDTH } from "../../src/constants";
-import { getDefaultCellHeight, toXC } from "../../src/helpers";
+import { getDefaultCellHeight as getDefaultCellHeightHelper, toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
-import { CommandResult, Sheet } from "../../src/types";
+import { CommandResult, Sheet, Style } from "../../src/types";
 import {
   activateSheet,
   addColumns,
@@ -22,6 +22,10 @@ import {
   unMerge,
 } from "../test_helpers/commands_helpers";
 import { DEFAULT_CELL_HEIGHT } from "./../../src/constants";
+
+function getDefaultCellHeight(style: Style | undefined, numberOfLines?: number) {
+  return Math.round(getDefaultCellHeightHelper(style, numberOfLines));
+}
 
 describe("Model resizer", () => {
   test("Can resize one column, undo, then redo", async () => {
@@ -501,5 +505,14 @@ describe("Model resizer", () => {
 
       expect(model.getters.getRowSize(sheet.id, 0)).toBe(getDefaultCellHeight({ fontSize: 18 }));
     });
+  });
+
+  test("Header sizes are rounded to avoid issues in further computations with floating number precision", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    resizeColumns(model, ["A"], 26.4);
+    resizeRows(model, [0], 26.6);
+    expect(model.getters.getColSize(sheetId, 0)).toBe(26);
+    expect(model.getters.getRowSize(sheetId, 0)).toBe(27);
   });
 });

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -507,20 +507,14 @@ describe("Viewport of Simple sheet", () => {
     });
     resizeRows(model, [...Array(numberRows).keys()], DEFAULT_CELL_HEIGHT / 2);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
-      top: 15,
-      bottom: 99,
-      left: 0,
-      right: 10,
-    });
-    expect(model.getters.getActiveMainViewport()).toMatchObject({
-      top: 15,
+      top: 19,
       bottom: 99,
       left: 0,
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
       offsetX: 0,
-      offsetY: (DEFAULT_CELL_HEIGHT / 2) * 15,
+      offsetY: Math.round(DEFAULT_CELL_HEIGHT / 2) * 19,
     });
   });
 


### PR DESCRIPTION
## Description

There were rounding issues of JS that caused the code of the sheetView to go in an infinite loop. We will now round all the header size returned by the getters of the header size plugin to avoid this issue.

An example where the problem occurred :
 - col 1;2;3 with size 83.52;199.94;89.64
 - 2 frozen columns
 - try to go to the right with the arrow keys => infinite loop when reaching the end of the viewPort.

Odoo task ID : [3076079](https://www.odoo.com/web#id=3076079&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo