### PR TITLE
[REF] edition: force consistency in the plugin state

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -624,7 +624,7 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     const highlights = this.env.model.getters.getHighlights();
     const refSheet = sheetName
       ? this.env.model.getters.getSheetIdByName(sheetName)
-      : this.env.model.getters.getCurrentEditedCell().sheetId;
+      : this.env.model.getters.getCurrentEditedCell()?.sheetId;
 
     const highlight = highlights.find((highlight) => {
       if (highlight.sheetId !== refSheet) return false;

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -101,7 +101,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
       const rect = this.env.model.getters.getVisibleRect(zone);
       if (
         !deepEquals(rect, this.rect) ||
-        sheetId !== this.env.model.getters.getCurrentEditedCell().sheetId
+        sheetId !== this.env.model.getters.getCurrentEditedCell()?.sheetId
       ) {
         this.isCellReferenceVisible = true;
       }
@@ -113,7 +113,10 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get cellReference(): string {
-    const { col, row, sheetId } = this.env.model.getters.getCurrentEditedCell();
+    if (this.env.model.getters.getEditionMode() === "inactive") {
+      return "";
+    }
+    const { col, row, sheetId } = this.env.model.getters.getCurrentEditedCell()!;
     const prefixSheet = sheetId !== this.env.model.getters.getActiveSheetId();
     return `${
       prefixSheet ? getCanonicalSheetName(this.env.model.getters.getSheetName(sheetId)) + "!" : ""

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -171,7 +171,7 @@ interface SidePanelState {
 }
 
 interface ComposerState {
-  topBarFocus: Exclude<ComposerFocusType, "cellFocus">;
+  topBarFocus: ComposerFocusType;
   gridFocusMode: ComposerFocusType;
 }
 

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -268,7 +268,9 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
 
 TopBar.props = {
   onClick: Function,
-  focusComposer: String,
+  focusComposer: {
+    validate: (value: string) => ["inactive", "cellFocus", "contentFocus"].includes(value),
+  },
   onComposerContentFocused: Function,
   dropdownMaxHeight: Number,
 };

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1163,6 +1163,7 @@ export const enum CommandResult {
   NoActiveSheet,
   InvalidLocale,
   AlreadyInPaintingFormatMode,
+  WrongEditionMode,
 }
 
 export interface CommandHandler<T> {

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -263,7 +263,7 @@ describe("ranges and highlights", () => {
       expect(composerEl.textContent).toBe("=SUM(C3, B2)");
     });
 
-    test("the first range doesn't change if other highlight transit by the first range state ", async () => {
+    test("the first range doesn't change if other highlight transit by the first range state", async () => {
       composerEl = await typeInComposer("=SUM(B2, B1)");
       model.dispatch("START_CHANGE_HIGHLIGHT", {
         zone: toZone("B1"),

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -504,7 +504,7 @@ describe("Selection Input", () => {
       expect(inputs[1].value).toBe("B2");
     });
 
-    test("the first range doesn't change if other highlight transit by the first range state ", async () => {
+    test("the first range doesn't change if other highlight transit by the first range state", async () => {
       const { model, fixture } = await createSelectionInput({ initialRanges: ["B2", "B1"] });
       focus(0);
       model.dispatch("START_CHANGE_HIGHLIGHT", {

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -443,7 +443,6 @@ describe("TopBar component", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
     await mountParent(model);
-
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
     await click(fixture, '.o-menu-item-button[title="Vertical align"]');
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -85,10 +85,10 @@ describe("edition", () => {
     const sheet1 = model.getters.getSheetIds()[0];
     model.dispatch("START_EDITION", { text: "=" });
     expect(model.getters.getEditionMode()).toBe("selecting");
-    expect(model.getters.getCurrentEditedCell().sheetId).toBe(sheet1);
+    expect(model.getters.getCurrentEditedCell()?.sheetId).toBe(sheet1);
     createSheet(model, { activate: true, sheetId: "42" });
     expect(model.getters.getEditionMode()).toBe("selecting");
-    expect(model.getters.getCurrentEditedCell().sheetId).toBe(sheet1);
+    expect(model.getters.getCurrentEditedCell()?.sheetId).toBe(sheet1);
     model.dispatch("STOP_EDITION");
     expect(model.getters.getActiveSheetId()).toBe(sheet1);
     expect(getCellText(model, "A1")).toBe("=");
@@ -147,6 +147,7 @@ describe("edition", () => {
 
   test("setting content sets selection at the end by default", () => {
     const model = new Model();
+    model.dispatch("START_EDITION");
     expect(model.getters.getComposerSelection()).toEqual({
       start: 0,
       end: 0,
@@ -166,6 +167,7 @@ describe("edition", () => {
       start: 0,
       end: 0,
     });
+    model.dispatch("START_EDITION");
     model.dispatch("SET_CURRENT_CONTENT", {
       content: "hello",
       selection: { start: 2, end: 4 },
@@ -182,6 +184,7 @@ describe("edition", () => {
       start: 0,
       end: 0,
     });
+    model.dispatch("START_EDITION");
     const result = model.dispatch("SET_CURRENT_CONTENT", {
       content: "hello",
       selection: { start: 4, end: 0 },
@@ -195,6 +198,7 @@ describe("edition", () => {
       start: 0,
       end: 0,
     });
+    model.dispatch("START_EDITION");
     const result = model.dispatch("SET_CURRENT_CONTENT", {
       content: "hello",
       selection: { start: 1, end: 6 },
@@ -224,6 +228,7 @@ describe("edition", () => {
       start: 0,
       end: 0,
     });
+    model.dispatch("START_EDITION");
     model.dispatch("SET_CURRENT_CONTENT", {
       content: "hello",
     });
@@ -239,6 +244,7 @@ describe("edition", () => {
 
   test("Allow setting right-to-left selection", () => {
     const model = new Model();
+    model.dispatch("START_EDITION");
     model.dispatch("SET_CURRENT_CONTENT", {
       content: "hello",
     });
@@ -252,6 +258,7 @@ describe("edition", () => {
 
   test("setting selection out of content is invalid", () => {
     const model = new Model();
+    model.dispatch("START_EDITION");
     expect(model.getters.getCurrentContent()).toHaveLength(0);
     expect(
       model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", {


### PR DESCRIPTION
## Description:

[REF] edition: force consistency in the plugin state
The plugin internal state is globally inconsistent. Some values are
properly resetted when start/stopping the edition, some are not.
Furthermore, functions are designed such that we need to call fucntions
in a very specific order in order not to crash [1].

This commit forces a stronger typing in the plugin.

[1] https://github.com/odoo/o-spreadsheet/pull/1739#discussion_r1041233112

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo