### PR TITLE
[IMP] Chart: use first row as headers

### DIFF
--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -3,7 +3,7 @@ import { ComponentsImportance, SELECTION_BORDER_COLOR } from "../../../constants
 import {
   deepEquals,
   fontSizeInPixels,
-  getComposerSheetName,
+  getCanonicalSheetName,
   positionToZone,
   toXC,
 } from "../../../helpers";
@@ -116,7 +116,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     const { col, row, sheetId } = this.env.model.getters.getCurrentEditedCell();
     const prefixSheet = sheetId !== this.env.model.getters.getActiveSheetId();
     return `${
-      prefixSheet ? getComposerSheetName(this.env.model.getters.getSheetName(sheetId)) + "!" : ""
+      prefixSheet ? getCanonicalSheetName(this.env.model.getters.getSheetName(sheetId)) + "!" : ""
     }${toXC(col, row)}`;
   }
 

--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
@@ -24,15 +24,6 @@
           onSelectionChanged="(ranges) => this.onDataSeriesRangesChanged(ranges)"
           onSelectionConfirmed="() => this.onDataSeriesConfirmed()"
         />
-        <label>
-          <input
-            type="checkbox"
-            t-att-checked="props.definition.dataSetsHaveTitle"
-            t-on-change="onUpdateDataSetsHaveTitle"
-            class="align-middle"
-          />
-          Data series include title
-        </label>
       </div>
       <div class="o-section o-data-labels">
         <div class="o-section-title">Categories / Labels</div>
@@ -52,6 +43,19 @@
             class="align-middle"
           />
           Aggregate
+        </label>
+      </div>
+      <div class="o-section o-use-row-as-headers" t-if="calculateHeaderPosition()">
+        <label>
+          <input
+            type="checkbox"
+            t-att-checked="props.definition.dataSetsHaveTitle"
+            t-on-change="onUpdateDataSetsHaveTitle"
+            class="align-middle"
+          />
+          Use row
+          <span t-esc="calculateHeaderPosition()"/>
+          as headers
         </label>
       </div>
       <div class="o-section o-sidepanel-error" t-if="errorMessages">

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
@@ -1,4 +1,6 @@
 import { Component, useState } from "@odoo/owl";
+import { createRange } from "../../../../helpers";
+import { createDataSets } from "../../../../helpers/figures/charts";
 import { BarChartDefinition } from "../../../../types/chart/bar_chart";
 import { LineChartDefinition } from "../../../../types/chart/line_chart";
 import { PieChartDefinition } from "../../../../types/chart/pie_chart";
@@ -92,6 +94,27 @@ export class LineBarPieConfigPanel extends Component<Props, SpreadsheetChildEnv>
     this.props.updateChart({
       aggregated: ev.target.checked,
     });
+  }
+
+  calculateHeaderPosition(): number | undefined {
+    if (this.isDatasetInvalid || this.isLabelInvalid) {
+      return undefined;
+    }
+    const getters = this.env.model.getters;
+    const sheetId = getters.getActiveSheetId();
+    const labelRange = createRange(getters, sheetId, this.labelRange);
+    const dataSets = createDataSets(
+      getters,
+      this.dataSeriesRanges,
+      sheetId,
+      this.props.definition.dataSetsHaveTitle
+    );
+    if (dataSets.length) {
+      return dataSets[0].dataRange.zone.top + 1;
+    } else if (labelRange) {
+      return labelRange.zone.top + 1;
+    }
+    return undefined;
   }
 }
 

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
@@ -10,15 +10,6 @@
           onSelectionChanged="(ranges) => this.onDataSeriesRangesChanged(ranges)"
           onSelectionConfirmed="() => this.onDataSeriesConfirmed()"
         />
-        <label>
-          <input
-            type="checkbox"
-            t-att-checked="props.definition.dataSetsHaveTitle"
-            t-on-change="onUpdateDataSetsHaveTitle"
-            class="align-middle"
-          />
-          Data series include title
-        </label>
       </div>
       <div class="o-section o-data-labels">
         <div class="o-section-title">Categories / Labels</div>
@@ -38,6 +29,19 @@
             class="align-middle"
           />
           Aggregate
+        </label>
+      </div>
+      <div class="o-section o-use-row-as-headers" t-if="calculateHeaderPosition()">
+        <label>
+          <input
+            type="checkbox"
+            t-att-checked="props.definition.dataSetsHaveTitle"
+            t-on-change="onUpdateDataSetsHaveTitle"
+            class="align-middle"
+          />
+          Use row
+          <span t-esc="calculateHeaderPosition()"/>
+          as headers
         </label>
       </div>
       <div class="o-section o-sidepanel-error" t-if="errorMessages">

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -24,15 +24,6 @@
           onSelectionChanged="(ranges) => this.onDataSeriesRangesChanged(ranges)"
           onSelectionConfirmed="() => this.onDataSeriesConfirmed()"
         />
-        <label>
-          <input
-            type="checkbox"
-            t-att-checked="props.definition.dataSetsHaveTitle"
-            t-on-change="onUpdateDataSetsHaveTitle"
-            class="align-middle"
-          />
-          Data series include title
-        </label>
       </div>
       <div class="o-section o-data-labels">
         <div class="o-section-title">Categories / Labels</div>
@@ -64,6 +55,19 @@
             Treat labels as text
           </label>
         </div>
+      </div>
+      <div class="o-section o-use-row-as-headers" t-if="calculateHeaderPosition()">
+        <label>
+          <input
+            type="checkbox"
+            t-att-checked="props.definition.dataSetsHaveTitle"
+            t-on-change="onUpdateDataSetsHaveTitle"
+            class="align-middle"
+          />
+          Use row
+          <span t-esc="calculateHeaderPosition()"/>
+          as headers
+        </label>
       </div>
       <div class="o-section o-sidepanel-error" t-if="errorMessages">
         <div t-foreach="errorMessages" t-as="error" t-key="error">

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1,4 +1,4 @@
-import { getComposerSheetName, toXC, toZone } from "../helpers/index";
+import { getCanonicalSheetName, toXC, toZone } from "../helpers/index";
 import { _lt } from "../translation";
 import {
   AddFunctionDescription,
@@ -96,7 +96,7 @@ export const ADDRESS: AddFunctionDescription = {
       cellReference = rowPart + colPart;
     }
     if (sheet !== undefined) {
-      return `${getComposerSheetName(toString(sheet))}!${cellReference}`;
+      return `${getCanonicalSheetName(toString(sheet))}!${cellReference}`;
     }
     return cellReference;
   },

--- a/src/helpers/figures/charts/chart_factory.ts
+++ b/src/helpers/figures/charts/chart_factory.ts
@@ -163,7 +163,6 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
     labelRangeXc = zoneToXc({
       ...zone,
       right: zone.left,
-      top: dataSetsHaveTitle ? zone.top + 1 : zone.top,
     });
   }
   // Only display legend for several datasets.

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -39,7 +39,9 @@ import {
   copyDataSetsWithNewSheetId,
   copyLabelRangeWithNewSheetId,
   createDataSets,
+  shouldRemoveFirstLabel,
   toExcelDataset,
+  toExcelLabelRange,
   transformChartDefinitionWithDataSetsWithZone,
   updateChartRangesWithDataSets,
 } from "./chart_common";
@@ -59,6 +61,7 @@ export class PieChart extends AbstractChart {
   readonly legendPosition: LegendPosition;
   readonly type = "pie";
   readonly aggregated?: boolean;
+  readonly dataSetsHaveTitle: boolean;
 
   constructor(definition: PieChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -72,6 +75,7 @@ export class PieChart extends AbstractChart {
     this.background = definition.background;
     this.legendPosition = definition.legendPosition;
     this.aggregated = definition.aggregated;
+    this.dataSetsHaveTitle = definition.dataSetsHaveTitle;
   }
 
   static transformDefinition(
@@ -161,12 +165,18 @@ export class PieChart extends AbstractChart {
     const dataSets: ExcelChartDataset[] = this.dataSets
       .map((ds: DataSet) => toExcelDataset(this.getters, ds))
       .filter((ds) => ds.range !== ""); // && range !== INCORRECT_RANGE_STRING ? show incorrect #ref ?
+    const labelRange = toExcelLabelRange(
+      this.getters,
+      this.labelRange,
+      shouldRemoveFirstLabel(this.labelRange, this.dataSets[0], this.dataSetsHaveTitle)
+    );
     return {
       ...this.getDefinition(),
       backgroundColor: toXlsxHexColor(this.background || BACKGROUND_CHART_COLOR),
       fontColor: toXlsxHexColor(chartFontColor(this.background)),
       verticalAxisPosition: "left", //TODO ExcelChartDefinition should be adapted, but can be done later
       dataSets,
+      labelRange,
     };
   }
 
@@ -232,6 +242,13 @@ export function createPieChartRuntime(chart: PieChart, getters: Getters): PieCha
   const labelValues = getChartLabelValues(getters, chart.dataSets, chart.labelRange);
   let labels = labelValues.formattedValues;
   let dataSetsValues = getChartDatasetValues(getters, chart.dataSets);
+  if (
+    chart.dataSetsHaveTitle &&
+    dataSetsValues[0] &&
+    labels.length > dataSetsValues[0].data.length
+  ) {
+    labels.shift();
+  }
 
   ({ labels, dataSetsValues } = filterEmptyDataPoints(labels, dataSetsValues));
 

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -106,7 +106,7 @@ export function getUnquotedSheetName(sheetName: string): string {
  * '\w' captures [0-9][a-z][A-Z] and _.
  * @param sheetName Name of the sheet
  */
-export function getComposerSheetName(sheetName: string): string {
+export function getCanonicalSheetName(sheetName: string): string {
   if (sheetName.match(/\w/g)?.length !== sheetName.length) {
     sheetName = `'${sheetName}'`;
   }

--- a/src/helpers/reference_type.ts
+++ b/src/helpers/reference_type.ts
@@ -1,6 +1,6 @@
 // Helper file for the reference types in Xcs (the $ symbol, eg. A$1)
 import { Token } from "../formulas";
-import { getComposerSheetName } from "./misc";
+import { getCanonicalSheetName } from "./misc";
 import { splitReference } from "./references";
 
 type FixedReferenceType = "col" | "row" | "colrow" | "none";
@@ -17,7 +17,7 @@ export function loopThroughReferenceType(token: Readonly<Token>): Token {
   const { xc, sheetName } = splitReference(token.value);
   const [left, right] = xc.split(":") as [string, string | undefined];
 
-  const sheetRef = sheetName ? `${getComposerSheetName(sheetName)}!` : "";
+  const sheetRef = sheetName ? `${getCanonicalSheetName(sheetName)}!` : "";
   const updatedLeft = getTokenNextReferenceType(left);
   const updatedRight = right ? `:${getTokenNextReferenceType(right)}` : "";
   return { ...token, value: sheetRef + updatedLeft + updatedRight };

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -1,7 +1,7 @@
 import { INCORRECT_RANGE_STRING } from "../../constants";
 import {
   createAdaptedZone,
-  getComposerSheetName,
+  getCanonicalSheetName,
   groupConsecutive,
   isZoneInside,
   isZoneValid,
@@ -366,7 +366,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       if (rangeImpl.invalidSheetName) {
         sheetName = rangeImpl.invalidSheetName;
       } else {
-        sheetName = getComposerSheetName(this.getters.getSheetName(rangeImpl.sheetId));
+        sheetName = getCanonicalSheetName(this.getters.getSheetName(rangeImpl.sheetId));
       }
     }
 

--- a/src/plugins/ui_feature/selection_input.ts
+++ b/src/plugins/ui_feature/selection_input.ts
@@ -1,6 +1,6 @@
 import {
   colors,
-  getComposerSheetName,
+  getCanonicalSheetName,
   positionToZone,
   splitReference,
   zoneToXc,
@@ -66,7 +66,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
     const inputSheetId = this.activeSheet;
     const sheetId = this.getters.getActiveSheetId();
     const sheetName = this.getters.getSheetName(sheetId);
-    this.add([sheetId === inputSheetId ? xc : `${getComposerSheetName(sheetName)}!${xc}`]);
+    this.add([sheetId === inputSheetId ? xc : `${getCanonicalSheetName(sheetName)}!${xc}`]);
   }
 
   handle(cmd: Command) {

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -3,7 +3,7 @@ import { POSTFIX_UNARY_OPERATORS } from "../../formulas/tokenizer";
 import {
   colors,
   concat,
-  getComposerSheetName,
+  getCanonicalSheetName,
   getZoneArea,
   isDateTimeFormat,
   isEqual,
@@ -578,7 +578,7 @@ export class EditionPlugin extends UIPlugin {
     const sheetId = this.getters.getActiveSheetId();
     let selectedXc = this.getters.zoneToXC(sheetId, zone, fixedParts);
     if (this.getters.getCurrentEditedCell().sheetId !== this.getters.getActiveSheetId()) {
-      const sheetName = getComposerSheetName(
+      const sheetName = getCanonicalSheetName(
         this.getters.getSheetName(this.getters.getActiveSheetId())
       );
       selectedXc = `${sheetName}!${selectedXc}`;

--- a/src/xlsx/extraction/chart_extractor.ts
+++ b/src/xlsx/extraction/chart_extractor.ts
@@ -31,6 +31,7 @@ export class XlsxChartExtractor extends XlsxBaseExtractor {
           dataSets: this.extractChartDatasets(
             this.querySelector(rootChartElement, `c:${chartType}`)!
           ),
+          labelRange: this.extractChildTextContent(rootChartElement, "c:ser c:cat c:f"),
           backgroundColor: this.extractChildAttr(
             rootChartElement,
             "c:chartSpace > c:spPr a:srgbClr",
@@ -63,7 +64,7 @@ export class XlsxChartExtractor extends XlsxBaseExtractor {
       { parent: chartElement, query: "c:ser" },
       (chartDataElement): ExcelChartDataset => {
         return {
-          label: this.extractChildTextContent(chartDataElement, "c:cat c:f"),
+          label: this.extractChildTextContent(chartDataElement, "c:tx c:f"),
           range: this.extractChildTextContent(chartDataElement, "c:val c:f", { required: true })!,
         };
       }

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -87,7 +87,7 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                Sheet1!A2:A5
+                                Sheet1!A3:A5
                             </c:f>
                         </c:strRef>
                     </c:cat>
@@ -125,7 +125,7 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                Sheet1!A2:A5
+                                Sheet1!A3:A5
                             </c:f>
                         </c:strRef>
                     </c:cat>
@@ -719,7 +719,7 @@ Object {
                         <!-- x-coordinate values -->
                         <c:numRef>
                             <c:f>
-                                Sheet1!C4:C12
+                                Sheet1!C2:C4
                             </c:f>
                             <c:numCache/>
                         </c:numRef>
@@ -1304,7 +1304,7 @@ Object {
                         <!-- x-coordinate values -->
                         <c:numRef>
                             <c:f>
-                                Sheet1!C4:C12
+                                Sheet1!C2:C4
                             </c:f>
                             <c:numCache/>
                         </c:numRef>
@@ -1857,7 +1857,7 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                Sheet1!A2:A4
+                                Sheet1!A3:A4
                             </c:f>
                         </c:strRef>
                     </c:cat>
@@ -1878,7 +1878,7 @@ Object {
                     <c:tx>
                         <c:strRef>
                             <c:f>
-                                Sheet1!C4
+                                Sheet1!C2
                             </c:f>
                         </c:strRef>
                     </c:tx>
@@ -1895,7 +1895,7 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                Sheet1!A2:A4
+                                Sheet1!A3:A4
                             </c:f>
                         </c:strRef>
                     </c:cat>
@@ -1904,7 +1904,7 @@ Object {
                         <!-- x-coordinate values -->
                         <c:numRef>
                             <c:f>
-                                Sheet1!C5:C12
+                                Sheet1!C3:C4
                             </c:f>
                             <c:numCache/>
                         </c:numRef>
@@ -2127,7 +2127,7 @@ Object {
                     <c:tx>
                         <c:strRef>
                             <c:f>
-                                Sheet1!C4
+                                Sheet1!C2
                             </c:f>
                         </c:strRef>
                     </c:tx>
@@ -2157,84 +2157,6 @@ Object {
                             </a:ln>
                         </c:spPr>
                     </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"2\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"AEC7E8\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"3\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"FFBB78\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"4\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"2CA02C\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"5\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"98DF8A\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"6\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"D62728\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"7\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"FF9896\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
                     <dLbls>
                         <c:showLegendKey val=\\"0\\"/>
                         <c:showVal val=\\"0\\"/>
@@ -2247,14 +2169,14 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                Sheet1!A2:A4
+                                Sheet1!A3:A4
                             </c:f>
                         </c:strRef>
                     </c:cat>
                     <c:val>
                         <c:numRef>
                             <c:f>
-                                Sheet1!C5:C12
+                                Sheet1!C3:C4
                             </c:f>
                             <c:numCache/>
                         </c:numRef>
@@ -2308,7 +2230,7 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                Sheet1!A2:A4
+                                Sheet1!A3:A4
                             </c:f>
                         </c:strRef>
                     </c:cat>
@@ -2426,7 +2348,7 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                Sheet1!A2:A4
+                                Sheet1!A3:A4
                             </c:f>
                         </c:strRef>
                     </c:cat>
@@ -2452,7 +2374,7 @@ Object {
                     <c:tx>
                         <c:strRef>
                             <c:f>
-                                Sheet1!C4
+                                Sheet1!C2
                             </c:f>
                         </c:strRef>
                     </c:tx>
@@ -2467,7 +2389,7 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                Sheet1!A2:A4
+                                Sheet1!A3:A4
                             </c:f>
                         </c:strRef>
                     </c:cat>
@@ -2476,7 +2398,7 @@ Object {
                         <!-- x-coordinate values -->
                         <c:numRef>
                             <c:f>
-                                Sheet1!C5:C12
+                                Sheet1!C3:C4
                             </c:f>
                             <c:numCache/>
                         </c:numRef>
@@ -2699,7 +2621,7 @@ Object {
                     <c:tx>
                         <c:strRef>
                             <c:f>
-                                'She!et2'!C4
+                                'She!et2'!C2
                             </c:f>
                         </c:strRef>
                     </c:tx>
@@ -2729,84 +2651,6 @@ Object {
                             </a:ln>
                         </c:spPr>
                     </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"2\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"AEC7E8\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"3\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"FFBB78\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"4\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"2CA02C\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"5\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"98DF8A\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"6\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"D62728\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
-                    <c:dPt>
-                        <c:idx val=\\"7\\"/>
-                        <c:spPr>
-                            <a:solidFill>
-                                <a:srgbClr val=\\"FF9896\\"/>
-                            </a:solidFill>
-                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
-                                <a:solidFill>
-                                    <a:srgbClr val=\\"FFFFFF\\"/>
-                                </a:solidFill>
-                            </a:ln>
-                        </c:spPr>
-                    </c:dPt>
                     <dLbls>
                         <c:showLegendKey val=\\"0\\"/>
                         <c:showVal val=\\"0\\"/>
@@ -2819,14 +2663,14 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                'She!et2'!A2:A4
+                                'She!et2'!A3:A4
                             </c:f>
                         </c:strRef>
                     </c:cat>
                     <c:val>
                         <c:numRef>
                             <c:f>
-                                'She!et2'!C5:C12
+                                'She!et2'!C3:C4
                             </c:f>
                             <c:numCache/>
                         </c:numRef>
@@ -2880,7 +2724,7 @@ Object {
                     <c:cat>
                         <c:strRef>
                             <c:f>
-                                'She!et2'!A2:A4
+                                'She!et2'!A3:A4
                             </c:f>
                         </c:strRef>
                     </c:cat>
@@ -17047,7 +16891,7 @@ Object {
                         <!-- x-coordinate values -->
                         <c:numRef>
                             <c:f>
-                                Sheet1!C4:C12
+                                Sheet1!C2:C4
                             </c:f>
                             <c:numCache/>
                         </c:numRef>

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -155,8 +155,9 @@ describe("charts", () => {
           const dataSeries = fixture.querySelectorAll(
             ".o-sidePanel .o-sidePanelBody .o-chart .o-data-series"
           )[0];
-          const hasTitle = (dataSeries.querySelector("input[type=checkbox]") as HTMLInputElement)
-            .checked;
+          const hasTitle = (
+            fixture.querySelector(".o-use-row-as-headers input[type=checkbox]") as HTMLInputElement
+          ).checked;
           const labels = fixture.querySelector(".o-data-labels");
           expect((panelChartType as HTMLSelectElement).value).toBe(TEST_CHART_DATA.basicChart.type);
           expect((dataSeries.querySelector(" .o-selection input") as HTMLInputElement).value).toBe(
@@ -219,7 +220,7 @@ describe("charts", () => {
       const dispatch = spyDispatch(parent);
       switch (chartType) {
         case "basicChart":
-          await click(dataSeries!.querySelector("input[type=checkbox]")!);
+          await click(fixture.querySelector(".o-use-row-as-headers input[type=checkbox]")!);
           expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
             id: chartId,
             sheetId,
@@ -390,7 +391,9 @@ describe("charts", () => {
       ".o-sidePanel .o-sidePanelBody .o-chart .o-data-series"
     )[0] as HTMLInputElement;
     const dataSeriesValues = dataSeries.querySelector("input");
-    const hasTitle = dataSeries.querySelector("input[type=checkbox]") as HTMLInputElement;
+    const hasTitle = fixture.querySelector(
+      ".o-use-row-as-headers input[type=checkbox]"
+    ) as HTMLInputElement;
     setInputValueAndTrigger(chartType, "pie", "change");
     await nextTick();
     setInputValueAndTrigger(dataSeriesValues, "B2:B5", "change");
@@ -427,7 +430,9 @@ describe("charts", () => {
       ".o-sidePanel .o-sidePanelBody .o-chart .o-data-series"
     )[0] as HTMLInputElement;
     const dataSeriesValues = dataSeries.querySelector("input");
-    const hasTitle = dataSeries.querySelector("input[type=checkbox]") as HTMLInputElement;
+    const hasTitle = fixture.querySelector(
+      ".o-use-row-as-headers input[type=checkbox]"
+    ) as HTMLInputElement;
     setInputValueAndTrigger(dataSeriesValues, "B2:B5", "change");
     triggerMouseEvent(hasTitle, "click");
     await nextTick();
@@ -493,8 +498,9 @@ describe("charts", () => {
           const dataSeries = fixture.querySelectorAll(
             ".o-sidePanel .o-sidePanelBody .o-chart .o-data-series"
           )[0];
-          const hasTitle = (dataSeries.querySelector("input[type=checkbox]") as HTMLInputElement)
-            .checked;
+          const hasTitle = (
+            fixture.querySelector(".o-use-row-as-headers input[type=checkbox]") as HTMLInputElement
+          ).checked;
           const labels = fixture.querySelector(".o-data-labels");
           expect((panelChartType as HTMLSelectElement).value).toBe("line");
           expect((dataSeries.querySelector(" .o-selection input") as HTMLInputElement).value).toBe(

--- a/tests/menu_item_insert_chart.test.ts
+++ b/tests/menu_item_insert_chart.test.ts
@@ -365,7 +365,7 @@ describe("Insert chart menu item", () => {
     insertChart();
     const payload = { ...defaultPayload };
     payload.definition.dataSets = ["B1:B5"];
-    payload.definition.labelRange = "A2:A5";
+    payload.definition.labelRange = "A1:A5";
     payload.definition.dataSetsHaveTitle = true;
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
   });
@@ -389,7 +389,7 @@ describe("Insert chart menu item", () => {
     payload.definition.legendPosition = "top";
     payload.definition.title = "Title1 and 3";
     payload.definition.dataSetsHaveTitle = true;
-    payload.definition.labelRange = "C2:C4";
+    payload.definition.labelRange = "C1:C4";
     payload.definition.type = "line";
     payload.definition.labelsAsText = false;
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
@@ -402,7 +402,7 @@ describe("Insert chart menu item", () => {
     payload.definition.legendPosition = "top";
     payload.definition.title = "Title1, 3 and Title2";
     payload.definition.dataSetsHaveTitle = true;
-    payload.definition.labelRange = "C2:C4";
+    payload.definition.labelRange = "C1:C4";
     payload.definition.type = "line";
     payload.definition.labelsAsText = false;
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
@@ -412,7 +412,7 @@ describe("Insert chart menu item", () => {
     insertChart();
     const payload = { ...defaultPayload };
     payload.definition.dataSets = ["B1:B5"];
-    payload.definition.labelRange = "A2:A5";
+    payload.definition.labelRange = "A1:A5";
     payload.definition.dataSetsHaveTitle = true;
     payload.definition.legendPosition = "none";
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
@@ -423,7 +423,7 @@ describe("Insert chart menu item", () => {
     const payload = { ...defaultPayload };
     payload.definition.dataSets = ["G1:I5"];
     payload.definition.dataSetsHaveTitle = true;
-    payload.definition.labelRange = "F2:F5";
+    payload.definition.labelRange = "F1:F5";
     payload.definition.legendPosition = "top";
     payload.definition.type = "line";
     payload.definition.labelsAsText = false;
@@ -459,7 +459,7 @@ describe("Insert chart menu item", () => {
     insertChart();
     const payload = { ...defaultPayload };
     payload.definition.dataSets = ["B1:H5"];
-    payload.definition.labelRange = "A2:A5";
+    payload.definition.labelRange = "A1:A5";
     payload.definition.dataSetsHaveTitle = true;
     payload.definition.legendPosition = "top";
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);

--- a/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
@@ -11,20 +11,16 @@ Object {
           "borderColor": "rgb(31,119,180)",
           "data": Array [
             Object {
-              "x": "20",
+              "x": "19",
               "y": 11,
             },
             Object {
-              "x": "19",
+              "x": "18",
               "y": 12,
             },
             Object {
-              "x": "18",
-              "y": 13,
-            },
-            Object {
               "x": "17",
-              "y": undefined,
+              "y": 13,
             },
           ],
           "fill": false,
@@ -34,7 +30,6 @@ Object {
         },
       ],
       "labels": Array [
-        "20",
         "19",
         "18",
         "17",
@@ -666,6 +661,120 @@ Object {
 }
 `;
 
+exports[`datasource tests create chart with column datasets with category title 1`] = `
+Object {
+  "background": "#FFFFFF",
+  "chartJsConfig": Object {
+    "data": Object {
+      "datasets": Array [
+        Object {
+          "backgroundColor": "#1f77b4",
+          "borderColor": "rgb(31,119,180)",
+          "data": Array [
+            10,
+            11,
+            12,
+          ],
+          "fill": false,
+          "label": "first column dataset",
+          "lineTension": 0,
+          "pointBackgroundColor": "rgb(31,119,180)",
+        },
+        Object {
+          "backgroundColor": "#ff7f0e",
+          "borderColor": "rgb(255,127,14)",
+          "data": Array [
+            20,
+            19,
+            18,
+          ],
+          "fill": false,
+          "label": "second column datase…",
+          "lineTension": 0,
+          "pointBackgroundColor": "rgb(255,127,14)",
+        },
+      ],
+      "labels": Array [
+        "P1",
+        "P2",
+        "P3",
+      ],
+    },
+    "options": Object {
+      "animation": Object {
+        "duration": 0,
+      },
+      "elements": Object {
+        "line": Object {
+          "fill": false,
+        },
+        "point": Object {
+          "hitRadius": 15,
+        },
+      },
+      "hover": Object {
+        "animationDuration": 10,
+      },
+      "layout": Object {
+        "padding": Object {
+          "bottom": 10,
+          "left": 20,
+          "right": 20,
+          "top": 10,
+        },
+      },
+      "legend": Object {
+        "labels": Object {
+          "fontColor": "#000000",
+          "generateLabels": [Function],
+        },
+        "onClick": undefined,
+        "position": "top",
+      },
+      "maintainAspectRatio": false,
+      "responsive": true,
+      "responsiveAnimationDuration": 0,
+      "scales": Object {
+        "xAxes": Array [
+          Object {
+            "ticks": Object {
+              "fontColor": "#000000",
+              "labelOffset": 2,
+              "maxRotation": 60,
+              "minRotation": 15,
+              "padding": 5,
+            },
+          },
+        ],
+        "yAxes": Array [
+          Object {
+            "position": "left",
+            "ticks": Object {
+              "beginAtZero": true,
+              "callback": [Function],
+              "fontColor": "#000000",
+            },
+          },
+        ],
+      },
+      "title": Object {
+        "display": true,
+        "fontColor": "#000000",
+        "fontSize": 22,
+        "fontStyle": "normal",
+        "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
+      },
+    },
+    "type": "line",
+  },
+}
+`;
+
 exports[`datasource tests create chart with column datasets without series title 1`] = `
 Object {
   "background": "#FFFFFF",
@@ -785,9 +894,21 @@ Object {
   "background": "#FFFFFF",
   "chartJsConfig": Object {
     "data": Object {
-      "datasets": Array [],
+      "datasets": Array [
+        Object {
+          "backgroundColor": "#1f77b4",
+          "borderColor": "rgb(31,119,180)",
+          "data": Array [
+            undefined,
+            undefined,
+          ],
+          "fill": false,
+          "label": "30",
+          "lineTension": 0,
+          "pointBackgroundColor": "rgb(31,119,180)",
+        },
+      ],
       "labels": Array [
-        "P4",
         "P5",
         "P6",
       ],
@@ -982,6 +1103,120 @@ Object {
 `;
 
 exports[`datasource tests create chart with row datasets 1`] = `
+Object {
+  "background": "#FFFFFF",
+  "chartJsConfig": Object {
+    "data": Object {
+      "datasets": Array [
+        Object {
+          "backgroundColor": "#1f77b4",
+          "borderColor": "rgb(31,119,180)",
+          "data": Array [
+            30,
+            31,
+            32,
+          ],
+          "fill": false,
+          "label": "first row dataset",
+          "lineTension": 0,
+          "pointBackgroundColor": "rgb(31,119,180)",
+        },
+        Object {
+          "backgroundColor": "#ff7f0e",
+          "borderColor": "rgb(255,127,14)",
+          "data": Array [
+            40,
+            41,
+            42,
+          ],
+          "fill": false,
+          "label": "second row dataset",
+          "lineTension": 0,
+          "pointBackgroundColor": "rgb(255,127,14)",
+        },
+      ],
+      "labels": Array [
+        "P4",
+        "P5",
+        "P6",
+      ],
+    },
+    "options": Object {
+      "animation": Object {
+        "duration": 0,
+      },
+      "elements": Object {
+        "line": Object {
+          "fill": false,
+        },
+        "point": Object {
+          "hitRadius": 15,
+        },
+      },
+      "hover": Object {
+        "animationDuration": 10,
+      },
+      "layout": Object {
+        "padding": Object {
+          "bottom": 10,
+          "left": 20,
+          "right": 20,
+          "top": 10,
+        },
+      },
+      "legend": Object {
+        "labels": Object {
+          "fontColor": "#000000",
+          "generateLabels": [Function],
+        },
+        "onClick": undefined,
+        "position": "top",
+      },
+      "maintainAspectRatio": false,
+      "responsive": true,
+      "responsiveAnimationDuration": 0,
+      "scales": Object {
+        "xAxes": Array [
+          Object {
+            "ticks": Object {
+              "fontColor": "#000000",
+              "labelOffset": 2,
+              "maxRotation": 60,
+              "minRotation": 15,
+              "padding": 5,
+            },
+          },
+        ],
+        "yAxes": Array [
+          Object {
+            "position": "left",
+            "ticks": Object {
+              "beginAtZero": true,
+              "callback": [Function],
+              "fontColor": "#000000",
+            },
+          },
+        ],
+      },
+      "title": Object {
+        "display": true,
+        "fontColor": "#000000",
+        "fontSize": 22,
+        "fontStyle": "normal",
+        "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
+      },
+    },
+    "type": "line",
+  },
+}
+`;
+
+exports[`datasource tests create chart with row datasets with category title 1`] = `
 Object {
   "background": "#FFFFFF",
   "chartJsConfig": Object {

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -132,6 +132,22 @@ describe("datasource tests", function () {
     expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
   });
 
+  test("create chart with column datasets with category title", () => {
+    createChart(
+      model,
+      {
+        dataSets: ["Sheet1!B1:B4", "Sheet1!C1:C4"],
+        labelRange: "A1:A4",
+        type: "line",
+      },
+      "1"
+    );
+    expect(
+      (model.getters.getChartRuntime("1") as LineChartRuntime).chartJsConfig.data?.labels
+    ).toEqual(["P1", "P2", "P3"]);
+    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+  });
+
   test("create chart with row datasets", () => {
     createChart(
       model,
@@ -187,6 +203,22 @@ describe("datasource tests", function () {
     expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
   });
 
+  test("create chart with row datasets with category title", () => {
+    createChart(
+      model,
+      {
+        dataSets: ["Sheet1!A8:D8", "Sheet1!A9:D9"],
+        labelRange: "A7:D7",
+        type: "line",
+      },
+      "1"
+    );
+    expect(
+      (model.getters.getChartRuntime("1") as LineChartRuntime).chartJsConfig.data?.labels
+    ).toEqual(["P4", "P5", "P6"]);
+    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+  });
+
   test("create chart with only the dataset title (no data)", () => {
     createChart(
       model,
@@ -197,12 +229,15 @@ describe("datasource tests", function () {
       },
       "1"
     );
+    const chart = model.getters.getChartRuntime("1") as LineChartRuntime;
     expect(model.getters.getChartDefinition("1")).toMatchObject({
-      dataSets: [],
       labelRange: "Sheet1!B7:D7",
       title: "test",
       type: "line",
     });
+    expect(chart.chartJsConfig.data?.datasets?.[0].data).toEqual(
+      expect.arrayContaining([undefined, undefined])
+    );
     expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
   });
 
@@ -454,7 +489,6 @@ describe("datasource tests", function () {
     expect(chart.data!.labels).toEqual(["0", "1", "2"]);
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     expect(chart.data!.datasets![1].data).toEqual([20, 19, 18]);
-    expect(chart.data!.labels).toEqual(["0", "1", "2"]);
   });
 
   test("delete last row of dataset", () => {
@@ -541,7 +575,8 @@ describe("datasource tests", function () {
     );
     deleteRows(model, [1, 2, 3, 4]);
     const chart = (model.getters.getChartRuntime("1") as LineChartRuntime).chartJsConfig;
-    expect(chart.data!.datasets).toHaveLength(0);
+    expect(chart.data!.datasets?.[0].data).toHaveLength(0);
+    expect(chart.data!.datasets?.[1].data).toHaveLength(0);
     expect(chart.data!.labels).toEqual([]);
   });
 
@@ -1504,7 +1539,7 @@ describe("Chart design configuration", () => {
     let chart: BarChartRuntime;
     setCellContent(model, "A2", "2022/03/01");
     setCellContent(model, "A3", "2022/03/02");
-    createChart(model, { labelRange: "A2:A3", dataSets: ["B2:B3"] }, "1");
+    createChart(model, { labelRange: "A2:A3", dataSets: ["B2:B3"], dataSetsHaveTitle: false }, "1");
     chart = model.getters.getChartRuntime("1") as BarChartRuntime;
     expect(chart.chartJsConfig.data!.labels).toEqual(["2022/03/01", "2022/03/02"]);
     setCellFormat(model, "A2", "m/d/yyyy");

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -1,4 +1,4 @@
-import { getComposerSheetName, toZone } from "../../src/helpers";
+import { getCanonicalSheetName, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
@@ -1007,7 +1007,7 @@ describe("edition", () => {
   test.each(["sheet2", "sheet 2"])("Loop references on references with sheet name", (sheetName) => {
     const model = new Model({});
     createSheet(model, { name: sheetName });
-    const composerSheetName = getComposerSheetName(sheetName);
+    const composerSheetName = getCanonicalSheetName(sheetName);
     model.dispatch("START_EDITION", { text: `=${composerSheetName}!A1` });
     model.dispatch("CYCLE_EDITION_REFERENCES");
     expect(model.getters.getCurrentContent()).toBe(`=${composerSheetName}!$A$1`);

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -1,5 +1,5 @@
 import { FORBIDDEN_SHEET_CHARS } from "../../src/constants";
-import { getComposerSheetName, toZone } from "../../src/helpers";
+import { getCanonicalSheetName, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
@@ -900,7 +900,7 @@ describe("sheets", () => {
     renameSheet(model, sheetId, name);
     expect(model.getters.getSheetIdByName(name)).toBe(sheetId);
     expect(model.getters.getSheetIdByName(`'${name}'`)).toBe(sheetId);
-    expect(model.getters.getSheetIdByName(getComposerSheetName(name))).toBe(sheetId);
+    expect(model.getters.getSheetIdByName(getCanonicalSheetName(name))).toBe(sheetId);
   });
 
   test("getSheetIdByName with invalid name", () => {

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -740,6 +740,30 @@ describe("Test XLSX export", () => {
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
 
+    test("exported results will not be influenced by `dataSetsHaveTitle` if the dataset contains titles and label range doesn't", async () => {
+      const model = new Model(chartData);
+      createChart(
+        model,
+        {
+          dataSets: ["Sheet1!B1:B4", "Sheet1!C1:C4"],
+          labelRange: "Sheet1!A1:A4",
+          dataSetsHaveTitle: true,
+        },
+        "1"
+      );
+      createChart(
+        model,
+        {
+          dataSets: ["Sheet1!B1:B4", "Sheet1!C1:C4"],
+          labelRange: "Sheet1!A2:A4",
+          dataSetsHaveTitle: true,
+        },
+        "2"
+      );
+      const exported = getExportedExcelData(model);
+      expect(exported.sheets[0].charts[0].data).toEqual(exported.sheets[0].charts[1].data);
+    });
+
     test("multiple charts in the same sheet", async () => {
       const model = new Model(chartData);
       createChart(
@@ -864,7 +888,7 @@ describe("Test XLSX export", () => {
       createChart(
         model,
         {
-          dataSets: ["Sheet1!B2:B4", "Sheet1!C12:C4"],
+          dataSets: ["Sheet1!B2:B4", "Sheet1!C2:C4"],
           labelRange: "Sheet1!A2:A4",
           type: "bar",
           dataSetsHaveTitle: false,
@@ -880,7 +904,7 @@ describe("Test XLSX export", () => {
       createChart(
         model,
         {
-          dataSets: ["Sheet1!B2:B4", "Sheet1!C12:C4"],
+          dataSets: ["Sheet1!B2:B4", "Sheet1!C2:C4"],
           labelRange: "Sheet1!A2:A4",
           type: "bar",
           background: "#EFEFEF",
@@ -890,7 +914,7 @@ describe("Test XLSX export", () => {
       createChart(
         model,
         {
-          dataSets: ["Sheet1!B2:B4", "Sheet1!C12:C4"],
+          dataSets: ["Sheet1!B2:B4", "Sheet1!C2:C4"],
           labelRange: "Sheet1!A2:A4",
           type: "pie",
           background: "#EEEEEE",
@@ -900,7 +924,7 @@ describe("Test XLSX export", () => {
       createChart(
         model,
         {
-          dataSets: ["Sheet1!B2:B4", "Sheet1!C12:C4"],
+          dataSets: ["Sheet1!B2:B4", "Sheet1!C2:C4"],
           labelRange: "Sheet1!A2:A4",
           type: "line",
           background: "#DDDDDD",
@@ -910,7 +934,7 @@ describe("Test XLSX export", () => {
       createChart(
         model,
         {
-          dataSets: ["She!et2!B2:B4", "She!et2!C12:C4"],
+          dataSets: ["She!et2!B2:B4", "She!et2!C2:C4"],
           labelRange: "She!et2!A2:A4",
           type: "pie",
           background: "#EEEEEE",
@@ -940,7 +964,7 @@ describe("Test XLSX export", () => {
       createChart(
         model,
         {
-          dataSets: ["Sheet1!B2:B4", "Sheet1!C12:C4"],
+          dataSets: ["Sheet1!B2:B4", "Sheet1!C2:C4"],
           labelRange: "Sheet1!A2:A4",
           type: "bar",
           dataSetsHaveTitle: false,
@@ -1033,7 +1057,7 @@ describe("Test XLSX export", () => {
     createChart(
       model,
       {
-        dataSets: ["Sheet1!B2:B4", "Sheet1!C12:C4"],
+        dataSets: ["Sheet1!B2:B4", "Sheet1!C2:C4"],
         labelRange: "Sheet1!A2:A4",
         type: "bar",
         dataSetsHaveTitle: false,

--- a/tests/xlsx_import.test.ts
+++ b/tests/xlsx_import.test.ts
@@ -718,25 +718,47 @@ describe("Import xlsx data", () => {
     expect(figure.tag).toEqual("chart");
   });
 
-  test.each([
-    ["line chart", "line", "#CECECE", "Sheet1!B27:B35 Sheet1!C27:C35"],
-    ["bar chart", "bar", "#fff", "Sheet1!B27:B35 Sheet1!C27:C35"],
-    ["pie chart", "pie", "#fff", "Sheet1!B27:B35"],
-    ["doughnut chart", "pie", "#fff", "Sheet1!B27:B35 Sheet1!C27:C35"],
-  ])("Can import charts %s", (chartTitle, chartType, chartColor, chartDataset) => {
-    const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
-    const figure = testSheet.figures.find((figure) => figure.data.title === chartTitle)!;
-    const chartData = figure.data as LineChartDefinition | PieChartDefinition | BarChartDefinition;
-    expect(chartData.title).toEqual(chartTitle);
-    expect(chartData.type).toEqual(chartType);
-    expect(standardizeColor(chartData.background!)).toEqual(standardizeColor(chartColor));
+  test.each([["bar chart", "bar", "#fff", ["Sheet1!B27:B35", "Sheet1!C27:C35"]]])(
+    "Can import charts %s without dataset titles",
+    (chartTitle, chartType, chartColor, chartDatasets) => {
+      const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
+      const figure = testSheet.figures.find((figure) => figure.data.title === chartTitle)!;
+      const chartData = figure.data as
+        | LineChartDefinition
+        | PieChartDefinition
+        | BarChartDefinition;
+      expect(chartData.title).toEqual(chartTitle);
+      expect(chartData.type).toEqual(chartType);
+      expect(standardizeColor(chartData.background!)).toEqual(standardizeColor(chartColor));
 
-    expect(chartData.labelRange).toEqual("Sheet1!A27:A35");
-    const datasets = chartDataset.split(" ");
-    for (let i = 0; i < datasets.length; i++) {
-      expect(chartData.dataSets[i]).toEqual(datasets[i]);
+      expect(chartData.labelRange).toEqual("Sheet1!A27:A35");
+      expect(chartData.dataSets).toEqual(chartDatasets);
+      expect(chartData.dataSetsHaveTitle).toBeFalsy();
     }
-  });
+  );
+
+  test.each([
+    ["line chart", "line", "#CECECE", ["Sheet1!B26:B35", "Sheet1!C26:C35"]],
+    ["pie chart", "pie", "#fff", ["Sheet1!B26:B35"]],
+    ["doughnut chart", "pie", "#fff", ["Sheet1!B26:B35", "Sheet1!C26:C35"]],
+  ])(
+    "Can import charts %s with dataset titles",
+    (chartTitle, chartType, chartColor, chartDatasets) => {
+      const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
+      const figure = testSheet.figures.find((figure) => figure.data.title === chartTitle)!;
+      const chartData = figure.data as
+        | LineChartDefinition
+        | PieChartDefinition
+        | BarChartDefinition;
+      expect(chartData.title).toEqual(chartTitle);
+      expect(chartData.type).toEqual(chartType);
+      expect(standardizeColor(chartData.background!)).toEqual(standardizeColor(chartColor));
+
+      expect(chartData.labelRange).toEqual("Sheet1!A26:A35");
+      expect(chartData.dataSets).toEqual(chartDatasets);
+      expect(chartData.dataSetsHaveTitle).toBeTruthy();
+    }
+  );
 
   describe("Misc tests", () => {
     test("Newlines characters in strings are removed", () => {


### PR DESCRIPTION
## Description:

This PR changes the current option "Datasets include title" to "Use row/col x as headers", which is more similar to the functionality in GSheets. It will exclude the first row/col in the datasets/labels when creating the chart.

Odoo task ID : [3099995](https://www.odoo.com/web#id=3099995&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo