### PR TITLE
[FIX] registry: introduce contains method

### DIFF
--- a/src/registries/inverse_command_registry.ts
+++ b/src/registries/inverse_command_registry.ts
@@ -34,9 +34,7 @@ export const inverseCommandRegistry = new Registry<InverseFunction>()
   .add("UNHIDE_COLUMNS_ROWS", inverseUnhideColumnsRows);
 
 for (const cmd of coreTypes.values()) {
-  try {
-    inverseCommandRegistry.get(cmd);
-  } catch (_) {
+  if (!inverseCommandRegistry.contains(cmd)) {
     inverseCommandRegistry.add(cmd, identity);
   }
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -44,6 +44,13 @@ export class Registry<T> {
   }
 
   /**
+   * Check if the key is already in the registry
+   */
+  contains(key: string): boolean {
+    return key in this.content;
+  }
+
+  /**
    * Get a list of all elements in the registry
    */
   getAll(): T[] {


### PR DESCRIPTION
Before this revision, the registry did not provide a proper way to check if a key was present in the registry. The only way to do it was to access the registry and catch the error if the key was not present, which is not very convenient, especially when running a code with break on exception.

This revision introduces a `contains` method on the registry, which returns a boolean indicating if the key is present in the registry.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo