### PR TITLE
[FIX] Composer: select headers when composer is open

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -471,8 +471,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     const lastZone = zones[zones.length - 1];
     let type: ContextMenuType = "CELL";
     if (!isInside(col, row, lastZone)) {
-      this.env.model.dispatch("UNFOCUS_SELECTION_INPUT");
-      this.env.model.dispatch("STOP_EDITION");
+      this.env.model.selection.getBackToDefault();
       this.env.model.selection.selectCell(col, row);
     } else {
       if (this.env.model.getters.getActiveCols().has(col)) {

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -200,6 +200,9 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
       this.startMovement(ev);
       return;
     }
+    if (this.env.model.getters.getEditionMode() === "editing") {
+      this.env.model.selection.getBackToDefault();
+    }
     this.startSelection(ev, index);
   }
 

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -401,7 +401,9 @@ export class EditionPlugin extends UIPlugin {
       { cell: { col: this.col, row: this.row }, zone },
       {
         handleEvent: this.handleEvent.bind(this),
-        release: () => (this.mode = "inactive"),
+        release: () => {
+          this.stopEdition();
+        },
       }
     );
   }

--- a/src/selection_stream/event_stream.ts
+++ b/src/selection_stream/event_stream.ts
@@ -86,6 +86,17 @@ export class EventStream<Event> {
   }
 
   /**
+   * Release whichever subscription in charge and get back to the default subscription
+   */
+  getBackToDefault() {
+    if (this.mainSubscription === this.defaultSubscription) {
+      return;
+    }
+    this.mainSubscription?.callbacks.release?.();
+    this.mainSubscription = this.defaultSubscription;
+  }
+
+  /**
    * Check if you are currently the main stream consumer
    */
   isListening(owner: unknown): boolean {

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -119,6 +119,10 @@ export class SelectionStreamProcessor
     }
   }
 
+  getBackToDefault() {
+    this.stream.getBackToDefault();
+  }
+
   /**
    * Select a new anchor
    */

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -25,6 +25,7 @@ import {
   keyDown,
   keyUp,
   rightClickCell,
+  selectColumnByClicking,
   simulateClick,
 } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
@@ -1204,6 +1205,20 @@ describe("composer", () => {
     await rightClickCell(model, "C8");
     expect(model.getters.getEditionMode()).toBe("inactive");
     expect(fixture.querySelectorAll(".o-grid div.o-composer")).toHaveLength(0);
+  });
+
+  test("The composer should be closed before selecting headers", async () => {
+    await typeInComposerGrid("Hello");
+    expect(fixture.querySelectorAll(".o-grid div.o-composer")).toHaveLength(1);
+    await selectColumnByClicking(model, "C");
+    expect(fixture.querySelectorAll(".o-grid div.o-composer")).toHaveLength(0);
+  });
+
+  test("The content in the composer should be kept after selecting headers", async () => {
+    await clickCell(model, "C8");
+    await typeInComposerGrid("Hello");
+    await selectColumnByClicking(model, "C");
+    expect(getCellText(model, "C8")).toBe("Hello");
   });
 
   test("type '=', stop editing with enter, click on the modified cell --> the edition mode should be inactive", async () => {

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -20,7 +20,11 @@ import {
   setCellContent,
   undo,
 } from "../test_helpers/commands_helpers";
-import { edgeScrollDelay, triggerMouseEvent } from "../test_helpers/dom_helper";
+import {
+  edgeScrollDelay,
+  selectColumnByClicking,
+  triggerMouseEvent,
+} from "../test_helpers/dom_helper";
 import { getActiveXc, getCell } from "../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
@@ -37,19 +41,10 @@ function fillData() {
   }
 }
 
-/**
- * Select a column
- * @param letter Name of the column to click on (Starts at 'A')
- * @param extra shiftKey, ctrlKey
- */
 async function selectColumn(letter: string, extra: any = {}) {
-  const index = lettersToNumber(letter);
-  const x = model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
-  triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", x, 10);
-  await nextTick();
-  triggerMouseEvent(".o-overlay .o-col-resizer", "mousedown", x, 10, extra);
-  triggerMouseEvent(window, "mouseup", x, 10);
+  await selectColumnByClicking(model, letter, extra);
 }
+
 /**
  * Resize a column
  * @param letter Name of the column to resize (Starts at 'A')

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -1,6 +1,6 @@
 import { Model } from "../../src";
 import { HEADER_HEIGHT, HEADER_WIDTH } from "../../src/constants";
-import { MIN_DELAY, scrollDelay, toZone } from "../../src/helpers";
+import { lettersToNumber, MIN_DELAY, scrollDelay, toZone } from "../../src/helpers";
 import { Pixel } from "../../src/types";
 import { nextTick } from "./helpers";
 
@@ -152,6 +152,22 @@ export function getElComputedStyle(selector: string, style: string): string {
   const element = document.querySelector(selector);
   if (!element) throw new Error(`No element matching selector "${selector}"`);
   return window.getComputedStyle(element)[style];
+}
+
+/**
+ * Select a column
+ * @param model
+ * @param letter Name of the column to click on (Starts at 'A')
+ * @param extra shiftKey, ctrlKey
+ */
+export async function selectColumnByClicking(model: Model, letter: string, extra: any = {}) {
+  const index = lettersToNumber(letter);
+  const x = model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
+  triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", x, 10);
+  await nextTick();
+  triggerMouseEvent(".o-overlay .o-col-resizer", "mousedown", x, 10, extra);
+  triggerMouseEvent(window, "mouseup", x, 10);
+  await nextTick();
 }
 
 export async function dragElement(


### PR DESCRIPTION
## Description:

This PR fixes the usability problem that when the composer is open, the headers cannot be selected. 

Odoo task ID : [2835588](https://www.odoo.com/web#id=2835588&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo