### PR TITLE
[IMP] model: allow to run evaluation in non lazy mode

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -90,6 +90,7 @@ export interface ModelConfig {
   client: Client;
   snapshotRequested: boolean;
   notifyUI: (payload: NotifyUIEvent) => void;
+  lazyEvaluation: boolean;
 }
 
 const enum Status {
@@ -362,6 +363,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       moveClient: () => {},
       snapshotRequested: false,
       notifyUI: (payload: NotifyUIEvent) => this.trigger("notify-ui", payload),
+      lazyEvaluation: "lazyEvaluation" in config ? config.lazyEvaluation! : true,
     };
   }
 
@@ -385,6 +387,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       moveClient: this.session.move.bind(this.session),
       external: this.config.external,
       uiActions: this.config,
+      lazyEvaluation: this.config.lazyEvaluation,
     };
   }
 

--- a/src/plugins/ui_core_views/evaluation.ts
+++ b/src/plugins/ui_core_views/evaluation.ts
@@ -68,10 +68,12 @@ export class EvaluationPlugin extends UIPlugin {
       | undefined;
   } = {};
   private readonly evalContext: EvalContext;
+  private readonly lazyEvaluation: boolean;
 
   constructor(config: UIPluginConfig) {
     super(config);
     this.evalContext = config.external;
+    this.lazyEvaluation = config.lazyEvaluation;
   }
 
   // ---------------------------------------------------------------------------
@@ -186,6 +188,9 @@ export class EvaluationPlugin extends UIPlugin {
       this.evaluatedCells[sheetId]![col] = {};
     }
     this.evaluatedCells[sheetId]![col]![row] = evaluatedCell;
+    if (!this.lazyEvaluation) {
+      this.evaluatedCells[sheetId]![col]![row]!();
+    }
   }
 
   private *getAllCells(): Iterable<Cell> {

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -21,6 +21,7 @@ export interface UIPluginConfig {
   readonly moveClient: (position: ClientPosition) => void;
   readonly uiActions: UIActions;
   readonly external: ModelConfig["external"];
+  readonly lazyEvaluation: boolean;
 }
 
 export interface UIPluginConstructor {

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -1220,4 +1220,40 @@ describe("evaluate formula getter", () => {
     expect((getEvaluatedCell(model, "A1") as ErrorCell).error.message).toBe("Error2");
     functionRegistry.remove("GETVALUE");
   });
+
+  test("Cell are directly evaluated in non-lazy mode", () => {
+    let evaluated = false;
+    const model = new Model({}, { lazyEvaluation: false });
+    functionRegistry.add("FN", {
+      description: "",
+      compute: () => {
+        evaluated = true;
+        return true;
+      },
+      args: args(``),
+      returns: ["ANY"],
+    });
+    setCellContent(model, "A1", "=FN()");
+    expect(evaluated).toBe(true);
+    functionRegistry.remove("FN");
+  });
+
+  test("Cell are lazily evaluated in lazy mode (default mode)", () => {
+    let evaluated = false;
+    const model = new Model();
+    functionRegistry.add("FN", {
+      description: "",
+      compute: () => {
+        evaluated = true;
+        return true;
+      },
+      args: args(``),
+      returns: ["ANY"],
+    });
+    setCellContent(model, "A1", "=FN()");
+    expect(evaluated).toBe(false);
+    getCellContent(model, "A1");
+    expect(evaluated).toBe(true);
+    functionRegistry.remove("FN");
+  });
 });


### PR DESCRIPTION
With this revision, we allow to run the evaluation in non lazy mode. It's useful when we want to trigger the evaluation of all cells, for example when we want to export the data which contains formulas which trigger async calls.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo