### PR TITLE
Better IME support

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -441,26 +441,31 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
   // ---------------------------------------------------------------------------
 
   private processContent() {
-    const currentContent = this.getters.getCurrentContent();
-    const oldContent = this.oldContent || "";
-    if (!currentContent.startsWith("=") && deepEquals(oldContent, currentContent)) {
-      return;
+    // Ensure we have the focus we are expecting
+    if (this.props.focus !== "inactive") {
+      this.contentHelper.el.focus();
     }
-    this.oldContent = currentContent;
-    const content = this.getContent();
-    this.contentHelper.removeAll(); // removes the content of the composer, to be added just after
     this.shouldProcessInputEvents = false;
 
-    if (this.props.focus !== "inactive") {
-      this.contentHelper.selectRange(0, 0); // move the cursor inside the composer at 0 0.
-    }
-    if (content.length !== 0) {
-      this.contentHelper.setText(content);
-      const { start, end } = this.getters.getComposerSelection();
+    const currentContent = this.getters.getCurrentContent();
+    const oldContent = this.oldContent || "";
+    if (currentContent.startsWith("=") || !deepEquals(oldContent, currentContent)) {
+      //Need to re-render the whole content
+      this.oldContent = currentContent;
+      const content = this.getContent();
+      this.contentHelper.removeAll(); // removes the content of the composer, to be added just after
 
       if (this.props.focus !== "inactive") {
-        // Put the cursor back where it was before the rendering
-        this.contentHelper.selectRange(start, end);
+        this.contentHelper.selectRange(0, 0); // move the cursor inside the composer at 0 0.
+      }
+      if (content.length !== 0) {
+        this.contentHelper.setText(content);
+        const { start, end } = this.getters.getComposerSelection();
+
+        if (this.props.focus !== "inactive") {
+          // Put the cursor back where it was before the rendering
+          this.contentHelper.selectRange(start, end);
+        }
       }
     }
 

--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -1,9 +1,10 @@
 import { HtmlContent } from "./composer";
 
 export class ContentEditableHelper {
+  // todo make el private and expose dedicted methods
   el: HTMLElement;
-  constructor(el: HTMLElement | null) {
-    this.el = el!;
+  constructor(el: HTMLElement) {
+    this.el = el;
   }
 
   updateEl(el: HTMLElement) {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -240,3 +240,27 @@ export function isDefined<T>(argument: T | undefined): argument is T {
 }
 
 export const DEBUG: { [key: string]: any } = {};
+
+/**
+ * Compare two objects.
+ */
+export function deepEquals<T extends Object>(o1: T, o2: T): boolean {
+  if (o1 === o2) return true;
+  if ((o1 && !o2) || (o2 && !o1)) return false;
+
+  // Objects can have different keys if the values are undefined
+  const keys = new Set<string>();
+  Object.keys(o1).forEach((key) => keys.add(key));
+  Object.keys(o2).forEach((key) => keys.add(key));
+
+  for (let key of keys) {
+    if (typeof o1[key] !== typeof o2[key]) return false;
+    if (typeof o1[key] === "object") {
+      if (!deepEquals(o1[key], o2[key])) return false;
+    } else {
+      if (o1[key] !== o2[key]) return false;
+    }
+  }
+
+  return true;
+}

--- a/tests/components/__mocks__/content_editable_helper.ts
+++ b/tests/components/__mocks__/content_editable_helper.ts
@@ -24,10 +24,6 @@ export class ContentEditableHelper {
     this.colors = {};
   }
   selectRange(start: number, end: number) {
-    // TODO: find a way not to depend on selectRange to gain focus and push mockContentHelper
-    this.el!.focus();
-    // @ts-ignore
-    window.mockContentHelper = this;
     this.manualRange = true;
     this.currentState.cursorStart = start;
     this.currentState.cursorEnd = end;
@@ -94,6 +90,8 @@ export class ContentEditableHelper {
   private attachEventHandlers() {
     if (this.el === null) return;
     this.el.addEventListener("keydown", (ev: KeyboardEvent) => this.onKeyDown(this.el!, ev));
+    // @ts-ignore
+    this.el.addEventListener("focus", (ev: FocusEvent) => (window.mockContentHelper = this));
   }
 
   /**


### PR DESCRIPTION
# 2 issues

1. Starting the composition will jump from 1 input (hidden) to the other, hence closing the IME assistant
2. when editing, we purge and reinsert everything in the contenteditable helper, again closing the ime helper since the nodes were purged.

# solutions:

1. work exclusively with the gridcomposer, no additional hidden input 
2. Skip the whole reinsert everything at render on the active composer WHEN we are not writing a function and we already had focus (based on props  then)

   useEffect or equivalent to get rid of that ugly (that I introduced) onPatched in MASTER

### perso comments, not relevant at all !!! -- TO REMOVE

Why in 15.0  and not before ? 14.0 is really, really rusty .  the composer was not what it is now but the general usability is quite limited. 
The composer itself is quite steady starting 15.0 
Also - the IME reports were first issued in 15.0, with the recent rise in interest of the lib, we should definitely try to support to the largest crowd -> IME users should be able to make use of this spreadsheet as much a the next, this at least concerns japanese/chinese/korean users, which in turn could take interest in the integrations we offer with Odoo.

donc j'ai réussi a modifier le rendering du coposer de façon a pas tout détruire comme des connardds a chaque input, en tout cas ça fonctionne pour du texte mais faut aller plus loin que ça pour écrire des formules malheureusement.

Mais EN PLUS de cette connerie, en fait le fix de 1779 marque que a moitié puisque le fait d'écrire dans l'input crée un nouvel input et lui file le focus, de ce fait on perd le helper d'input method.

DONC en fait faut que le grid composer soit le focus par défaut, et non pas un input a la con en plus. et faut que cet input soit caché quand on édite pas et qu'il soit visible quand on édite. DONc gridCOposer va prendre plus d'importance.

Il faut alors trouver une combine pour pouvoir focus (genre vraiment avoir le focus au sens DOM) l'input de grid composer quand on  appelle la fonction de callback focusgrid.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo