### PR TITLE
[FIX] index.ts: export helper to create empty sheet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,11 @@ import {
   toZone,
   UuidGenerator,
 } from "./helpers/index";
-import { createEmptySheet, createEmptyWorkbookData } from "./migrations/data";
+import {
+  createEmptyExcelSheet,
+  createEmptySheet,
+  createEmptyWorkbookData,
+} from "./migrations/data";
 import { corePluginRegistry, uiPluginRegistry } from "./plugins/index";
 import { clickableCellRegistry } from "./registries/cell_clickable_registry";
 import {
@@ -171,6 +175,7 @@ export const helpers = {
   markdownLink,
   createEmptyWorkbookData,
   createEmptySheet,
+  createEmptyExcelSheet,
   getDefaultChartJsRuntime,
   chartFontColor,
   getMenuChildren,

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -416,7 +416,7 @@ export function createEmptyWorkbookData(sheetName = "Sheet1"): WorkbookData {
   return data;
 }
 
-function createEmptyExcelSheet(sheetId: UID, name: string): ExcelSheetData {
+export function createEmptyExcelSheet(sheetId: UID, name: string): ExcelSheetData {
   return {
     ...(createEmptySheet(sheetId, name) as Omit<ExcelSheetData, "charts">),
     charts: [],


### PR DESCRIPTION

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3102330](https://www.odoo.com/web#id=3102330&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo