### PR TITLE
[IMP] Menus: disable insertion via menus when separate columns/rows selected

### DIFF
--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -1,94 +1,117 @@
 import { functionRegistry } from "../functions";
-import { isDefined } from "../helpers";
+import { isConsecutive, isDefined } from "../helpers";
 import { _lt } from "../translation";
 import { ActionBuilder, ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 
 export const insertRow: ActionSpec = {
   name: ACTIONS.MENU_INSERT_ROWS_NAME,
-  isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
+  isVisible: (env) =>
+    isConsecutive(env.model.getters.getActiveRows()) &&
+    ACTIONS.IS_ONLY_ONE_RANGE(env) &&
+    env.model.getters.getActiveCols().size === 0,
   icon: "o-spreadsheet-Icon.INSERT_ROW",
 };
 
 export const rowInsertRowBefore: ActionSpec = {
   name: ACTIONS.ROW_INSERT_ROWS_BEFORE_NAME,
   execute: ACTIONS.INSERT_ROWS_BEFORE_ACTION,
+  isVisible: (env) =>
+    isConsecutive(env.model.getters.getActiveRows()) &&
+    ACTIONS.IS_ONLY_ONE_RANGE(env) &&
+    env.model.getters.getActiveCols().size === 0,
 };
 
 export const topBarInsertRowsBefore: ActionSpec = {
   ...rowInsertRowBefore,
   name: ACTIONS.MENU_INSERT_ROWS_BEFORE_NAME,
-  isVisible: (env) => env.model.getters.getActiveCols().size === 0,
 };
 
 export const cellInsertRowsBefore: ActionSpec = {
   ...rowInsertRowBefore,
   name: ACTIONS.CELL_INSERT_ROWS_BEFORE_NAME,
-  isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
   icon: "o-spreadsheet-Icon.INSERT_ROW",
 };
 
 export const rowInsertRowsAfter: ActionSpec = {
   execute: ACTIONS.INSERT_ROWS_AFTER_ACTION,
   name: ACTIONS.ROW_INSERT_ROWS_AFTER_NAME,
+  isVisible: (env) =>
+    isConsecutive(env.model.getters.getActiveRows()) &&
+    ACTIONS.IS_ONLY_ONE_RANGE(env) &&
+    env.model.getters.getActiveCols().size === 0,
 };
 
 export const topBarInsertRowsAfter: ActionSpec = {
   ...rowInsertRowsAfter,
   name: ACTIONS.MENU_INSERT_ROWS_AFTER_NAME,
-  isVisible: (env) => env.model.getters.getActiveCols().size === 0,
 };
 
 export const insertCol: ActionSpec = {
   name: ACTIONS.MENU_INSERT_COLUMNS_NAME,
-  isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
+  isVisible: (env) =>
+    isConsecutive(env.model.getters.getActiveCols()) &&
+    ACTIONS.IS_ONLY_ONE_RANGE(env) &&
+    env.model.getters.getActiveRows().size === 0,
   icon: "o-spreadsheet-Icon.INSERT_COL",
 };
 
 export const colInsertColsBefore: ActionSpec = {
   name: ACTIONS.COLUMN_INSERT_COLUMNS_BEFORE_NAME,
   execute: ACTIONS.INSERT_COLUMNS_BEFORE_ACTION,
+  isVisible: (env) =>
+    isConsecutive(env.model.getters.getActiveCols()) &&
+    ACTIONS.IS_ONLY_ONE_RANGE(env) &&
+    env.model.getters.getActiveRows().size === 0,
 };
 
 export const topBarInsertColsBefore: ActionSpec = {
   ...colInsertColsBefore,
   name: ACTIONS.MENU_INSERT_COLUMNS_BEFORE_NAME,
-  isVisible: (env) => env.model.getters.getActiveRows().size === 0,
 };
 
 export const cellInsertColsBefore: ActionSpec = {
   ...colInsertColsBefore,
   name: ACTIONS.CELL_INSERT_COLUMNS_BEFORE_NAME,
-  isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
   icon: "o-spreadsheet-Icon.INSERT_COL",
 };
 
 export const colInsertColsAfter: ActionSpec = {
   name: ACTIONS.COLUMN_INSERT_COLUMNS_AFTER_NAME,
   execute: ACTIONS.INSERT_COLUMNS_AFTER_ACTION,
+  isVisible: (env) =>
+    isConsecutive(env.model.getters.getActiveCols()) &&
+    ACTIONS.IS_ONLY_ONE_RANGE(env) &&
+    env.model.getters.getActiveRows().size === 0,
 };
 
 export const topBarInsertColsAfter: ActionSpec = {
   ...colInsertColsAfter,
   name: ACTIONS.MENU_INSERT_COLUMNS_AFTER_NAME,
   execute: ACTIONS.INSERT_COLUMNS_AFTER_ACTION,
-  isVisible: (env) => env.model.getters.getActiveRows().size === 0,
 };
 
 export const insertCell: ActionSpec = {
   name: _lt("Insert cells"),
-  isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
+  isVisible: (env) =>
+    ACTIONS.IS_ONLY_ONE_RANGE(env) &&
+    env.model.getters.getActiveCols().size === 0 &&
+    env.model.getters.getActiveRows().size === 0,
   icon: "o-spreadsheet-Icon.INSERT_CELL",
 };
 
 export const insertCellShiftDown: ActionSpec = {
   name: _lt("Insert cells and shift down"),
   execute: ACTIONS.INSERT_CELL_SHIFT_DOWN,
+  isVisible: (env) =>
+    env.model.getters.getActiveRows().size === 0 && env.model.getters.getActiveCols().size === 0,
 };
 
 export const insertCellShiftRight: ActionSpec = {
   name: _lt("Insert cells and shift right"),
   execute: ACTIONS.INSERT_CELL_SHIFT_RIGHT,
+  isVisible: (env) =>
+    env.model.getters.getActiveRows().size === 0 && env.model.getters.getActiveCols().size === 0,
 };
 
 export const insertChart: ActionSpec = {

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -310,7 +310,7 @@ export const DELETE_CELL_SHIFT_LEFT = (env: SpreadsheetChildEnv) => {
 };
 
 export const MENU_INSERT_ROWS_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getColumnsNumber(env);
+  const number = getRowsNumber(env);
   return number === 1 ? _lt("Insert row") : _lt("Insert %s rows", number.toString());
 };
 

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -536,3 +536,16 @@ export function moveItemToIndex<T>(array: T[], startIndex: number, targetIndex: 
   array.splice(targetIndex, 0, item);
   return array;
 }
+
+/**
+ * Determine if the numbers are consecutive.
+ */
+export function isConsecutive(iterable: Iterable<number>): boolean {
+  const array = Array.from(iterable).sort((a, b) => a - b); // sort numerically rather than lexicographically
+  for (let i = 1; i < array.length; i++) {
+    if (array[i] - array[i - 1] !== 1) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -574,7 +574,11 @@ export class GridSelectionPlugin extends UIPlugin {
       },
       zone: selectedZone,
     };
-    this.setSelectionMixin(anchor, [selectedZone]);
+
+    const selections = this.gridSelection.zones.map((zone) =>
+      updateSelectionOnDeletion(zone, "left", [...cmd.elements])
+    );
+    this.setSelectionMixin(anchor, selections);
   }
 
   private onRowsRemoved(cmd: RemoveColumnsRowsCommand) {
@@ -589,20 +593,29 @@ export class GridSelectionPlugin extends UIPlugin {
       },
       zone: selectedZone,
     };
-    this.setSelectionMixin(anchor, [selectedZone]);
+    const selections = this.gridSelection.zones.map((zone) =>
+      updateSelectionOnDeletion(zone, "top", [...cmd.elements])
+    );
+    this.setSelectionMixin(anchor, selections);
   }
 
   private onAddElements(cmd: AddColumnsRowsCommand) {
-    const selection = this.gridSelection.anchor.zone;
-    const zone = updateSelectionOnInsertion(
-      selection,
-      cmd.dimension === "COL" ? "left" : "top",
+    const start = cmd.dimension === "COL" ? "left" : "top";
+    const anchorZone = updateSelectionOnInsertion(
+      this.gridSelection.anchor.zone,
+      start,
       cmd.base,
       cmd.position,
       cmd.quantity
     );
-    const anchor = { cell: { col: zone.left, row: zone.top }, zone };
-    this.setSelectionMixin(anchor, [zone]);
+    const selection = this.gridSelection.zones.map((zone) =>
+      updateSelectionOnInsertion(zone, start, cmd.base, cmd.position, cmd.quantity)
+    );
+    const anchor = {
+      cell: { col: anchorZone.left, row: anchorZone.top },
+      zone: anchorZone,
+    };
+    this.setSelectionMixin(anchor, selection);
   }
 
   private onMoveElements(cmd: MoveColumnsRowsCommand) {

--- a/tests/helpers/misc.test.ts
+++ b/tests/helpers/misc.test.ts
@@ -1,5 +1,5 @@
 import { deepCopy } from "../../src/helpers";
-import { groupConsecutive, lazy, range } from "../../src/helpers/misc";
+import { groupConsecutive, isConsecutive, lazy, range } from "../../src/helpers/misc";
 
 describe("Misc", () => {
   test("range", () => {
@@ -196,5 +196,19 @@ describe("lazy", () => {
 
   test("map a non-computed lazy value to another value", () => {
     expect(lazy(5).map((n) => n + 1)()).toBe(6);
+  });
+});
+
+describe("isConsecutive", () => {
+  test("consecutive", () => {
+    expect(isConsecutive([2, 3, 1])).toBeTruthy();
+  });
+
+  test("inconsecutive", () => {
+    expect(isConsecutive([5, 1, 2])).toBeFalsy();
+  });
+
+  test("sort numerically rather than lexicographically", () => {
+    expect(isConsecutive([10, 9, 11])).toBeTruthy();
   });
 });

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -305,19 +305,19 @@ describe("Menu Item actions", () => {
   });
 
   describe("Insert -> Row above", () => {
-    const path = ["insert", "insert_row", "insert_row_before"];
+    const insertRowBeforePath = ["insert", "insert_row", "insert_row_before"];
 
     test("A selected row", () => {
-      selectRow(model, 4, "newAnchor");
-      expect(getName(path, env)).toBe("Row above");
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      selectRow(model, 4, "overrideSelection");
+      expect(getName(insertRowBeforePath, env)).toBe("Row above");
+      expect(getNode(insertRowBeforePath).isVisible(env)).toBeTruthy();
     });
 
-    test("Multiple selected rows", () => {
-      selectRow(model, 4, "newAnchor");
+    test("Multiple consecutive selected rows", () => {
+      selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getName(path, env)).toBe("2 Rows above");
-      doAction(path, env);
+      expect(getName(insertRowBeforePath, env)).toBe("2 Rows above");
+      doAction(insertRowBeforePath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
         dimension: "ROW",
@@ -325,25 +325,31 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowBeforePath).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple inconsecutive selected rows", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 6, "newAnchor");
+      expect(getNode(insertRowBeforePath).isVisible(env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
-      selectColumn(model, 4, "newAnchor");
-      expect(getNode(path).isVisible(env)).toBeFalsy();
+      selectColumn(model, 4, "overrideSelection");
+      expect(getNode(insertRowBeforePath).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
-      expect(getName(path, env)).toBe("Row above");
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getName(insertRowBeforePath, env)).toBe("Row above");
+      expect(getNode(insertRowBeforePath).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(path, env)).toBe("2 Rows above");
-      doAction(path, env);
+      expect(getName(insertRowBeforePath, env)).toBe("2 Rows above");
+      doAction(insertRowBeforePath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
         dimension: "ROW",
@@ -351,24 +357,55 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowBeforePath).isVisible(env)).toBeTruthy();
+    });
+  });
+
+  describe("Insert row above via row menu", () => {
+    const addRowBeforePath = ["add_row_before"];
+
+    test("A selected row", () => {
+      selectRow(model, 4, "overrideSelection");
+      expect(getName(addRowBeforePath, env, rowMenuRegistry)).toBe("Insert row above");
+      expect(getNode(addRowBeforePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple consecutive selected rows", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 5, "updateAnchor");
+      expect(getName(addRowBeforePath, env, rowMenuRegistry)).toBe("Insert 2 rows above");
+      doAction(addRowBeforePath, env, rowMenuRegistry);
+      expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        dimension: "ROW",
+        base: 4,
+        quantity: 2,
+        position: "before",
+      });
+      expect(getNode(addRowBeforePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple inconsecutive selected rows", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 6, "newAnchor");
+      expect(getNode(addRowBeforePath, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });
   });
 
   describe("Insert -> Row below", () => {
-    const path = ["insert", "insert_row", "insert_row_after"];
+    const insertRowAfterPath = ["insert", "insert_row", "insert_row_after"];
 
     test("A selected row", () => {
-      selectRow(model, 4, "newAnchor");
-      expect(getName(path, env)).toBe("Row below");
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      selectRow(model, 4, "overrideSelection");
+      expect(getName(insertRowAfterPath, env)).toBe("Row below");
+      expect(getNode(insertRowAfterPath).isVisible(env)).toBeTruthy();
     });
 
-    test("Multiple selected rows", () => {
-      selectRow(model, 4, "newAnchor");
+    test("Multiple consecutive selected rows", () => {
+      selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getName(path, env)).toBe("2 Rows below");
-      doAction(path, env);
+      expect(getName(insertRowAfterPath, env)).toBe("2 Rows below");
+      doAction(insertRowAfterPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
         dimension: "ROW",
@@ -376,25 +413,31 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowAfterPath).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple inconsecutive selected rows", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 6, "newAnchor");
+      expect(getNode(insertRowAfterPath).isVisible(env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
-      selectColumn(model, 4, "newAnchor");
-      expect(getNode(path).isVisible(env)).toBeFalsy();
+      selectColumn(model, 4, "overrideSelection");
+      expect(getNode(insertRowAfterPath).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
-      expect(getName(path, env)).toBe("Row below");
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getName(insertRowAfterPath, env)).toBe("Row below");
+      expect(getNode(insertRowAfterPath).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(path, env)).toBe("2 Rows below");
-      doAction(path, env);
+      expect(getName(insertRowAfterPath, env)).toBe("2 Rows below");
+      doAction(insertRowAfterPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
         dimension: "ROW",
@@ -402,24 +445,55 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowAfterPath).isVisible(env)).toBeTruthy();
+    });
+  });
+
+  describe("Insert row below via row menu", () => {
+    const addRowAfterPath = ["add_row_after"];
+
+    test("A selected row", () => {
+      selectRow(model, 4, "overrideSelection");
+      expect(getName(addRowAfterPath, env, rowMenuRegistry)).toBe("Insert row below");
+      expect(getNode(addRowAfterPath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple consecutive selected rows", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 5, "updateAnchor");
+      expect(getName(addRowAfterPath, env, rowMenuRegistry)).toBe("Insert 2 rows below");
+      doAction(addRowAfterPath, env, rowMenuRegistry);
+      expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        dimension: "ROW",
+        base: 5,
+        quantity: 2,
+        position: "after",
+      });
+      expect(getNode(addRowAfterPath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple inconsecutive selected rows", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 6, "newAnchor");
+      expect(getNode(addRowAfterPath, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });
   });
 
   describe("Insert -> Column left", () => {
-    const path = ["insert", "insert_column", "insert_column_before"];
+    const insertColBeforePath = ["insert", "insert_column", "insert_column_before"];
 
     test("A selected column", () => {
-      selectColumn(model, 4, "newAnchor");
-      expect(getName(path, env)).toBe("Column left");
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      selectColumn(model, 4, "overrideSelection");
+      expect(getName(insertColBeforePath, env)).toBe("Column left");
+      expect(getNode(insertColBeforePath).isVisible(env)).toBeTruthy();
     });
 
-    test("Multiple selected columns", () => {
-      selectColumn(model, 4, "newAnchor");
+    test("Multiple consecutive selected columns", () => {
+      selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getName(path, env)).toBe("2 Columns left");
-      doAction(path, env);
+      expect(getName(insertColBeforePath, env)).toBe("2 Columns left");
+      doAction(insertColBeforePath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
         base: 4,
@@ -427,25 +501,31 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColBeforePath).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple inconsecutive selected columns", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 6, "newAnchor");
+      expect(getNode(insertColBeforePath).isVisible(env)).toBeFalsy();
     });
 
     test("A selected row should hide the item", () => {
-      selectRow(model, 4, "newAnchor");
-      expect(getNode(path).isVisible(env)).toBeFalsy();
+      selectRow(model, 4, "overrideSelection");
+      expect(getNode(insertColBeforePath).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
-      expect(getName(path, env)).toBe("Column left");
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getName(insertColBeforePath, env)).toBe("Column left");
+      expect(getNode(insertColBeforePath).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(path, env)).toBe("2 Columns left");
-      doAction(path, env);
+      expect(getName(insertColBeforePath, env)).toBe("2 Columns left");
+      doAction(insertColBeforePath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
         base: 3,
@@ -453,24 +533,55 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColBeforePath).isVisible(env)).toBeTruthy();
+    });
+  });
+
+  describe("Insert column left via column Menu", () => {
+    const addColBeforePath = ["add_column_before"];
+
+    test("A selected column", () => {
+      selectColumn(model, 4, "overrideSelection");
+      expect(getName(addColBeforePath, env, colMenuRegistry)).toBe("Insert column left");
+      expect(getNode(addColBeforePath, colMenuRegistry).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple consecutive selected columns", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 5, "updateAnchor");
+      expect(getName(addColBeforePath, env, colMenuRegistry)).toBe("Insert 2 columns left");
+      doAction(addColBeforePath, env, colMenuRegistry);
+      expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        base: 4,
+        dimension: "COL",
+        quantity: 2,
+        position: "before",
+      });
+      expect(getNode(addColBeforePath, colMenuRegistry).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple inconsecutive selected columns", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 6, "newAnchor");
+      expect(getNode(addColBeforePath, colMenuRegistry).isVisible(env)).toBeFalsy();
     });
   });
 
   describe("Insert -> Column right", () => {
-    const path = ["insert", "insert_column", "insert_column_after"];
+    const insertColAfterPath = ["insert", "insert_column", "insert_column_after"];
 
     test("A selected column", () => {
-      selectColumn(model, 4, "newAnchor");
-      expect(getName(path, env)).toBe("Column right");
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      selectColumn(model, 4, "overrideSelection");
+      expect(getName(insertColAfterPath, env)).toBe("Column right");
+      expect(getNode(insertColAfterPath).isVisible(env)).toBeTruthy();
     });
 
-    test("Multiple selected columns", () => {
-      selectColumn(model, 4, "newAnchor");
+    test("Multiple consecutive selected columns", () => {
+      selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getName(path, env)).toBe("2 Columns right");
-      doAction(path, env);
+      expect(getName(insertColAfterPath, env)).toBe("2 Columns right");
+      doAction(insertColAfterPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
         base: 5,
@@ -478,25 +589,31 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColAfterPath).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple inconsecutive selected columns", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 6, "newAnchor");
+      expect(getNode(insertColAfterPath).isVisible(env)).toBeFalsy();
     });
 
     test("A selected row should hide the item", () => {
-      selectRow(model, 4, "newAnchor");
-      expect(getNode(path).isVisible(env)).toBeFalsy();
+      selectRow(model, 4, "overrideSelection");
+      expect(getNode(insertColAfterPath).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
-      expect(getName(path, env)).toBe("Column right");
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getName(insertColAfterPath, env)).toBe("Column right");
+      expect(getNode(insertColAfterPath).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
       selectCell(model, "D4");
       setAnchorCorner(model, "E5");
-      expect(getName(path, env)).toBe("2 Columns right");
-      doAction(path, env);
+      expect(getName(insertColAfterPath, env)).toBe("2 Columns right");
+      doAction(insertColAfterPath, env);
       expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
         base: 4,
@@ -504,7 +621,160 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(path).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColAfterPath).isVisible(env)).toBeTruthy();
+    });
+  });
+
+  describe("Insert column right via column menu", () => {
+    const addColAfterPath = ["add_column_after"];
+
+    test("A selected column", () => {
+      selectColumn(model, 4, "overrideSelection");
+      expect(getName(addColAfterPath, env, colMenuRegistry)).toBe("Insert column right");
+      expect(getNode(addColAfterPath, colMenuRegistry).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple consecutive selected columns", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 5, "updateAnchor");
+      expect(getName(addColAfterPath, env, colMenuRegistry)).toBe("Insert 2 columns right");
+      doAction(addColAfterPath, env, colMenuRegistry);
+      expect(dispatch).toHaveBeenLastCalledWith("ADD_COLUMNS_ROWS", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        base: 5,
+        dimension: "COL",
+        quantity: 2,
+        position: "after",
+      });
+      expect(getNode(addColAfterPath, colMenuRegistry).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple inconsecutive selected columns", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 6, "newAnchor");
+      expect(getNode(addColAfterPath, colMenuRegistry).isVisible(env)).toBeFalsy();
+    });
+  });
+
+  describe("Insert -> Insert cells and shift down", () => {
+    const insertCellShiftDownPath = ["insert", "insert_cell", "insert_cell_down"];
+
+    test("A selected row should hide the item", () => {
+      selectRow(model, 4, "overrideSelection");
+      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("A selected column should hide the item", () => {
+      selectColumn(model, 4, "overrideSelection");
+      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("Multiple consecutive selected columns should hide the item", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 5, "updateAnchor");
+      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("Multiple inconsecutive selected columns should hide the item", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 6, "newAnchor");
+      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("Multiple consecutive selected rows should hide the item", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 5, "updateAnchor");
+      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("Multiple inconsecutive selected rows should hide the item", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 6, "newAnchor");
+      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("A selected cell", () => {
+      selectCell(model, "D4");
+      expect(getName(insertCellShiftDownPath, env)).toBe("Shift down");
+      doAction(insertCellShiftDownPath, env);
+      expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
+        zone: env.model.getters.getSelectedZone(),
+        shiftDimension: "ROW",
+      });
+      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple selected cells", () => {
+      selectCell(model, "D4");
+      setAnchorCorner(model, "E5");
+      expect(getName(insertCellShiftDownPath, env)).toBe("Shift down");
+      doAction(insertCellShiftDownPath, env);
+      expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
+        zone: env.model.getters.getSelectedZone(),
+        shiftDimension: "ROW",
+      });
+      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeTruthy();
+    });
+  });
+
+  describe("Insert -> Insert cells and shift right", () => {
+    const insertCellShiftRightPath = ["insert", "insert_cell", "insert_cell_right"];
+
+    test("A selected row should hide the item", () => {
+      selectRow(model, 4, "overrideSelection");
+      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("A selected column should hide the item", () => {
+      selectColumn(model, 4, "overrideSelection");
+      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("Multiple consecutive selected columns should hide the item", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 5, "updateAnchor");
+      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("Multiple inconsecutive selected columns should hide the item", () => {
+      selectColumn(model, 4, "overrideSelection");
+      selectColumn(model, 6, "newAnchor");
+      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("Multiple consecutive selected rows should hide the item", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 5, "updateAnchor");
+      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("Multiple inconsecutive selected rows should hide the item", () => {
+      selectRow(model, 4, "overrideSelection");
+      selectRow(model, 6, "newAnchor");
+      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+    });
+
+    test("A selected cell", () => {
+      selectCell(model, "D4");
+      expect(getName(insertCellShiftRightPath, env)).toBe("Shift right");
+      doAction(insertCellShiftRightPath, env);
+      expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
+        zone: env.model.getters.getSelectedZone(),
+        shiftDimension: "COL",
+      });
+      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeTruthy();
+    });
+
+    test("Multiple selected cells", () => {
+      selectCell(model, "D4");
+      setAnchorCorner(model, "E5");
+      expect(getName(insertCellShiftRightPath, env)).toBe("Shift right");
+      doAction(insertCellShiftRightPath, env);
+      expect(dispatch).toHaveBeenLastCalledWith("INSERT_CELL", {
+        zone: env.model.getters.getSelectedZone(),
+        shiftDimension: "COL",
+      });
+      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeTruthy();
     });
   });
 

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -14,8 +14,10 @@ import {
   activateSheet,
   addCellToSelection,
   addColumns,
+  addRows,
   createSheet,
   deleteColumns,
+  deleteRows,
   hideColumns,
   hideRows,
   merge,
@@ -1006,5 +1008,247 @@ describe("Selection loop (ctrl + a)", () => {
       expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A1:A2");
       expect(model.getters.getActiveSheetScrollInfo()).toEqual(initialScroll);
     });
+  });
+});
+
+describe("Multiple selection updates after insertion and deletion", () => {
+  test("after inserting column before", () => {
+    const model = new Model({ sheets: [{ colNumber: 20, rowNumber: 10 }] });
+    selectColumn(model, 4, "overrideSelection"); // select E
+    selectColumn(model, 9, "newAnchor"); // select J
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 9, right: 9, top: 0, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("J1"));
+
+    addColumns(model, "before", "A", 1);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("K1"));
+    expect(selection.zones).toEqual([
+      { left: 5, right: 5, top: 0, bottom: 9 },
+      { left: 10, right: 10, top: 0, bottom: 9 },
+    ]);
+  });
+
+  test("after inserting column between", () => {
+    const model = new Model({ sheets: [{ colNumber: 20, rowNumber: 10 }] });
+    selectColumn(model, 4, "overrideSelection"); // select E
+    selectColumn(model, 9, "newAnchor"); // select J
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 9, right: 9, top: 0, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("J1"));
+
+    addColumns(model, "before", "H", 1);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("K1"));
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 10, right: 10, top: 0, bottom: 9 },
+    ]);
+  });
+
+  test("after inserting column after", () => {
+    const model = new Model({ sheets: [{ colNumber: 20, rowNumber: 10 }] });
+    selectColumn(model, 4, "overrideSelection"); // select E
+    selectColumn(model, 9, "newAnchor"); // select J
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 9, right: 9, top: 0, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("J1"));
+
+    addColumns(model, "after", "K", 1);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("J1"));
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 9, right: 9, top: 0, bottom: 9 },
+    ]);
+  });
+
+  test("after inserting row before", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 20 }] });
+    selectRow(model, 4, "overrideSelection"); // select 5
+    selectRow(model, 9, "newAnchor"); // select 10
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 9, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("A10"));
+
+    addRows(model, "before", 0, 1);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("A11"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 5, bottom: 5 },
+      { left: 0, right: 9, top: 10, bottom: 10 },
+    ]);
+  });
+
+  test("after inserting row between", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 20 }] });
+    selectRow(model, 4, "overrideSelection"); // select 5
+    selectRow(model, 9, "newAnchor"); // select 10
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 9, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("A10"));
+
+    addRows(model, "before", 6, 1);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("A11"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 10, bottom: 10 },
+    ]);
+  });
+
+  test("after inserting rows after", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 20 }] });
+    selectRow(model, 4, "overrideSelection"); // select 5
+    selectRow(model, 9, "newAnchor"); // select 10
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 9, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("A10"));
+
+    addRows(model, "after", 11, 1);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("A10"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 9, bottom: 9 },
+    ]);
+  });
+
+  test("after deleting column before", () => {
+    const model = new Model({ sheets: [{ colNumber: 20, rowNumber: 10 }] });
+    selectColumn(model, 4, "overrideSelection"); // select E
+    selectColumn(model, 9, "newAnchor"); // select J
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 9, right: 9, top: 0, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("J1"));
+
+    deleteColumns(model, ["A"]);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("I1"));
+    expect(selection.zones).toEqual([
+      { left: 3, right: 3, top: 0, bottom: 9 },
+      { left: 8, right: 8, top: 0, bottom: 9 },
+    ]);
+  });
+
+  test("after deleting column between", () => {
+    const model = new Model({ sheets: [{ colNumber: 20, rowNumber: 10 }] });
+    selectColumn(model, 4, "overrideSelection"); // select E
+    selectColumn(model, 9, "newAnchor"); // select J
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 9, right: 9, top: 0, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("J1"));
+
+    deleteColumns(model, ["H"]);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("I1"));
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 8, right: 8, top: 0, bottom: 9 },
+    ]);
+  });
+
+  test("after deleting column after", () => {
+    const model = new Model({ sheets: [{ colNumber: 20, rowNumber: 10 }] });
+    selectColumn(model, 4, "overrideSelection"); // select E
+    selectColumn(model, 9, "newAnchor"); // select J
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 9, right: 9, top: 0, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("J1"));
+
+    deleteColumns(model, ["K"]);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("J1"));
+    expect(selection.zones).toEqual([
+      { left: 4, right: 4, top: 0, bottom: 9 },
+      { left: 9, right: 9, top: 0, bottom: 9 },
+    ]);
+  });
+
+  test("after deleting row before", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 20 }] });
+    selectRow(model, 4, "overrideSelection"); // select 5
+    selectRow(model, 9, "newAnchor"); // select 10
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 9, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("A10"));
+
+    deleteRows(model, [1]);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("A9"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 3, bottom: 3 },
+      { left: 0, right: 9, top: 8, bottom: 8 },
+    ]);
+  });
+
+  test("after deleting row between", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 20 }] });
+    selectRow(model, 4, "overrideSelection"); // select 5
+    selectRow(model, 9, "newAnchor"); // select 10
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 9, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("A10"));
+
+    deleteRows(model, [6]);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("A9"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 8, bottom: 8 },
+    ]);
+  });
+
+  test("after deleting row after", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 20 }] });
+    selectRow(model, 4, "overrideSelection"); // select 5
+    selectRow(model, 9, "newAnchor"); // select 10
+    let selection = model.getters.getSelection();
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 9, bottom: 9 },
+    ]);
+    expect(selection.anchor.cell).toEqual(toCartesian("A10"));
+
+    deleteRows(model, [10]);
+    selection = model.getters.getSelection();
+    expect(selection.anchor.cell).toEqual(toCartesian("A10"));
+    expect(selection.zones).toEqual([
+      { left: 0, right: 9, top: 4, bottom: 4 },
+      { left: 0, right: 9, top: 9, bottom: 9 },
+    ]);
   });
 });


### PR DESCRIPTION
## Description:

This PR disables the insertion functionality via menus (top menu & row/col context menu) when separate cols/rows are selected. 

This PR also makes the selection after insertion kept to the previously selected columns/rows. 

Odoo task ID : [2714327](https://www.odoo.com/web#id=2714327&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo