### PR TITLE
[IMP] Edition: composer selection set to the saved activated sheet selection rather than reset to (0,0)

### DIFF
--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -201,10 +201,11 @@ export class EditionPlugin extends UIPlugin {
           this.resetContent();
         }
         if (cmd.sheetIdFrom !== cmd.sheetIdTo) {
+          const activePosition = this.getters.getActivePosition();
           const { col, row } = this.getters.getNextVisibleCellPosition({
             sheetId: cmd.sheetIdTo,
-            col: 0,
-            row: 0,
+            col: activePosition.col,
+            row: activePosition.row,
           });
           const zone = this.getters.expandZone(cmd.sheetIdTo, positionToZone({ col, row }));
           this.selection.resetAnchor(this, { cell: { col, row }, zone });

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -573,7 +573,7 @@ describe("edition", () => {
     expect(model.getters.getCurrentContent()).toBe("=Sheet2!A2+Sheet2!A3");
   });
 
-  test("composer selection is reset only when changing sheet", () => {
+  test("When changing sheet, composer selection is reset if there's no saved selection for activated sheet", () => {
     const model = new Model();
     createSheet(model, { sheetId: "42", name: "Sheet2" });
     selectCell(model, "D3");
@@ -586,6 +586,21 @@ describe("edition", () => {
     activateSheet(model, "42");
     moveAnchorCell(model, "down");
     expect(model.getters.getCurrentContent()).toEqual("=Sheet2!A3");
+  });
+
+  test("When changing sheet, composer selection will be set to saved selection (if any) of activated sheet", () => {
+    const model = new Model();
+    createSheet(model, { sheetId: "42", name: "Sheet2" });
+    const sheet1 = model.getters.getSheetIds()[0];
+    const sheet2 = model.getters.getSheetIds()[1];
+    selectCell(model, "B2"); // Sheet1!B2
+    activateSheet(model, sheet2);
+    selectCell(model, "D3"); // Sheet2!D3
+    activateSheet(model, sheet1);
+    model.dispatch("START_EDITION", { text: "=" });
+    activateSheet(model, sheet2);
+    moveAnchorCell(model, "down");
+    expect(model.getters.getCurrentContent()).toEqual("=Sheet2!D4");
   });
 
   test("select an empty cell, start selecting mode at the composer position", () => {


### PR DESCRIPTION
## Description:

Previously when in the composer selecting mode, after activating another sheet, no matter whether the activated sheet has saved selection (other than (0,0)) or not, the composer selection will always be reset to (0,0).

This commit makes the composer selection set to the saved activated sheet selection after activating another sheet, if there's any. Otherwise it will reset to (0,0). 

Odoo task ID : [3077701](https://www.odoo.com/web#id=3077701&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo