### PR TITLE
[IMP] popover: Fix `usePopoverContainer`

### DIFF
--- a/src/components/helpers/position_hook.ts
+++ b/src/components/helpers/position_hook.ts
@@ -70,7 +70,7 @@ export function usePopoverContainer(): Rect {
     const newRect =
       "getPopoverContainerRect" in env ? env.getPopoverContainerRect() : spreadsheetRect;
     container.x = newRect.x;
-    container.y = newRect.x;
+    container.y = newRect.y;
     container.width = newRect.width;
     container.height = newRect.height;
   }


### PR DESCRIPTION
The container ordinate (vertical coordinate) was not properly set, it would cause problems when the spreadsheet was embedded, like in Odoo.

Task 3110780

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo