### PR TITLE
[FIX] Reference: Support sheet names containing exclamation points

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -2,7 +2,14 @@ import * as owl from "@odoo/owl";
 import { SELECTION_BORDER_COLOR } from "../../constants";
 import { EnrichedToken } from "../../formulas/index";
 import { functionRegistry } from "../../functions/index";
-import { DEBUG, isEqual, rangeReference, toZone, zoneToDimension } from "../../helpers/index";
+import {
+  DEBUG,
+  isEqual,
+  rangeReference,
+  splitReference,
+  toZone,
+  zoneToDimension,
+} from "../../helpers/index";
 import { ComposerSelection, SelectionIndicator } from "../../plugins/ui/edition";
 import { FunctionDescription, Rect, SpreadsheetEnv } from "../../types/index";
 import { TextValueProvider } from "./autocomplete_dropdown";
@@ -480,9 +487,9 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
           break;
         case "SYMBOL":
           let value = token.value;
-          const [xc, sheet] = value.split("!").reverse() as [string, string | undefined];
+          const { xc, sheetName } = splitReference(value);
           if (rangeReference.test(xc)) {
-            result.push({ value: token.value, color: this.rangeColor(xc, sheet) || "#000" });
+            result.push({ value: token.value, color: this.rangeColor(xc, sheetName) || "#000" });
           } else if (["TRUE", "FALSE"].includes(value.toUpperCase())) {
             result.push({ value: token.value, color: NumberColor });
           } else {
@@ -546,7 +553,7 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     if (content.startsWith("=")) {
       const tokenAtCursor = this.getters.getTokenAtCursor();
       if (tokenAtCursor) {
-        const [xc] = tokenAtCursor.value.split("!").reverse();
+        const { xc } = splitReference(tokenAtCursor.value);
         if (
           tokenAtCursor.type === "FUNCTION" ||
           (tokenAtCursor.type === "SYMBOL" && !rangeReference.test(xc))

--- a/src/helpers/references.ts
+++ b/src/helpers/references.ts
@@ -6,3 +6,10 @@ export const rangeReference = new RegExp(
   /^\s*(.*!)?\$?[A-Z]{1,3}\$?[0-9]{1,7}\s*(\s*:\s*\$?[A-Z]{1,3}\$?[0-9]{1,7}\s*)?$/,
   "i"
 );
+
+export function splitReference(ref: string): { sheetName?: string; xc: string } {
+  const parts = ref.split("!");
+  const xc = parts.pop()!;
+  const sheetName = parts.join("!") || undefined;
+  return { sheetName, xc };
+}

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -6,6 +6,7 @@ import {
   isZoneValid,
   numberToLetters,
   rangeReference,
+  splitReference,
   toZoneWithoutBoundaryChanges,
 } from "../../helpers/index";
 import {
@@ -271,7 +272,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    */
   getRangeFromSheetXC(defaultSheetId: UID, sheetXC: string): Range {
     let xc = sheetXC;
-    let sheetName: string = "";
+    let sheetName: string | undefined;
     let sheetId: UID | undefined;
     let invalidSheetName: string | undefined;
     let prefixSheet: boolean = false;
@@ -279,7 +280,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       return this.buildInvalidRange(sheetXC);
     }
     if (sheetXC.includes("!")) {
-      [xc, sheetName] = sheetXC.split("!").reverse();
+      ({ xc, sheetName } = splitReference(sheetXC));
       if (sheetName) {
         sheetId = this.getters.getSheetIdByName(sheetName);
         prefixSheet = true;

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -5,6 +5,7 @@ import {
   isEqual,
   markdownLink,
   rangeReference,
+  splitReference,
   toZone,
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
@@ -176,7 +177,7 @@ export class EditionPlugin extends UIPlugin {
           .filter((token) => token.type === "SYMBOL")
           .find((token) => {
             let value = token.value;
-            const [xc, sheet] = value.split("!").reverse();
+            const { xc, sheetName: sheet } = splitReference(value);
             const sheetName = sheet || this.getters.getSheetName(this.sheet);
             const activeSheetId = this.getters.getActiveSheetId();
             return (
@@ -546,10 +547,12 @@ export class EditionPlugin extends UIPlugin {
 
     for (let token of this.currentTokens.filter((token) => token.type === "SYMBOL")) {
       let value = token.value;
-      const [xc, sheet] = value.split("!").reverse();
+      const { xc, sheetName } = splitReference(value);
       if (rangeReference.test(xc)) {
         const refSanitized =
-          (sheet ? `${sheet}!` : `${this.getters.getSheetName(this.getters.getEditionSheet())}!`) +
+          (sheetName
+            ? `${sheetName}!`
+            : `${this.getters.getSheetName(this.getters.getEditionSheet())}!`) +
           xc.replace(/\$/g, "");
 
         ranges.push(refSanitized);

--- a/src/plugins/ui/highlight.ts
+++ b/src/plugins/ui/highlight.ts
@@ -1,4 +1,4 @@
-import { isEqual, toZone, zoneToDimension } from "../../helpers/index";
+import { isEqual, splitReference, toZone, zoneToDimension } from "../../helpers/index";
 import { Mode } from "../../model";
 import { GridRenderingContext, Highlight, LAYERS } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
@@ -32,8 +32,8 @@ export class HighlightPlugin extends UIPlugin {
     const activeSheetId = this.getters.getActiveSheetId();
     const preparedHighlights: Highlight[] = [];
     for (let [r1c1, color] of ranges) {
-      const [xc, sheet] = r1c1.split("!").reverse();
-      const sheetId = sheet ? this.getters.getSheetIdByName(sheet) : activeSheetId;
+      const { xc, sheetName } = splitReference(r1c1);
+      const sheetId = sheetName ? this.getters.getSheetIdByName(sheetName) : activeSheetId;
       if (sheetId) {
         let zone = toZone(xc);
         const { height, width } = zoneToDimension(zone);

--- a/src/plugins/ui/selection_inputs.ts
+++ b/src/plugins/ui/selection_inputs.ts
@@ -2,6 +2,7 @@ import {
   getComposerSheetName,
   getNextColor,
   rangeReference,
+  splitReference,
   UuidGenerator,
   zoneToXc,
 } from "../../helpers/index";
@@ -155,14 +156,14 @@ export class SelectionInputPlugin extends UIPlugin {
     );
   }
 
-  isRangeValid(xc: string): boolean {
-    if (!xc) {
+  isRangeValid(reference: string): boolean {
+    if (!reference) {
       return false;
     }
-    const [rangeXc, sheetName] = xc.split("!").reverse();
+    const { xc, sheetName } = splitReference(reference);
     return (
-      rangeXc.match(rangeReference) !== null &&
-      (sheetName === undefined || this.getters.getSheetIdByName(sheetName) !== undefined)
+      xc.match(rangeReference) !== null &&
+      (!sheetName || this.getters.getSheetIdByName(sheetName) !== undefined)
     );
   }
 
@@ -316,7 +317,7 @@ export class SelectionInputPlugin extends UIPlugin {
    * the current active sheet.
    */
   private shouldBeHighlighted(inputSheetId: UID, reference: string): boolean {
-    const sheetName = reference.split("!").reverse()[1];
+    const { sheetName } = splitReference(reference);
     const sheetId = this.getters.getSheetIdByName(sheetName);
     const activeSheetId = this.getters.getActiveSheet().id;
     const valid = this.isRangeValid(reference);

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../test_helpers/commands_helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
-let m;
+let m; // any because we add a getter, which is not typed
 
 export interface UseRange extends BaseCommand {
   type: "USE_RANGE";
@@ -389,14 +389,17 @@ describe("range plugin", () => {
       expect(m.getters.getRangeString(undefined, "not there")).toBe(INCORRECT_RANGE_STRING);
     });
 
-    test.each(["Sheet 0", "<Sheet1>", "&Sheet2", "Sheet4;", "Sheet5🐻"])(
+    test.each(["Sheet 0", "<Sheet1>", "&Sheet2", "Sheet4;", "Sheet5🐻", "She!et2"])(
       "sheet name with special character %s",
       (name) => {
         m.dispatch("RENAME_SHEET", {
           sheetId: "s1",
           name,
         });
-        const range = m.getters.getRangeFromSheetXC("s1", "A1");
+        let range: Range;
+        range = m.getters.getRangeFromSheetXC("s1", "A1");
+        expect(m.getters.getRangeString(range, "tao")).toBe(`'${name}'!A1`);
+        range = m.getters.getRangeFromSheetXC("s1", `'${name}'!A1`);
         expect(m.getters.getRangeString(range, "tao")).toBe(`'${name}'!A1`);
       }
     );

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -552,18 +552,21 @@ describe("selection input plugin", () => {
     expect(model.getters.getSelectionInput(id)[1].xc).toBe("C5");
   });
 
-  test("highlights are set when activating another sheet", () => {
-    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
-    model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1 });
-    model.dispatch("CHANGE_RANGE", {
-      id,
-      rangeId: idOfRange(model, id, 0),
-      value: "Sheet2!B3, A1",
-    });
-    expect(highlightedZones(model)).toEqual(["A1"]);
-    activateSheet(model, "42");
-    expect(highlightedZones(model)).toEqual(["B3"]);
-  });
+  test.each(["Sheet2", "She!et2"])(
+    "highlights are set when activating another sheet",
+    (sheetName) => {
+      model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
+      model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1, name: sheetName });
+      model.dispatch("CHANGE_RANGE", {
+        id,
+        rangeId: idOfRange(model, id, 0),
+        value: `${sheetName}!B3, A1`,
+      });
+      expect(highlightedZones(model)).toEqual(["A1"]);
+      activateSheet(model, "42");
+      expect(highlightedZones(model)).toEqual(["B3"]);
+    }
+  );
 
   test("input not focused when changing sheet", () => {
     model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1 });


### PR DESCRIPTION
The previous implementation would not conserve the full sheet name when splitting the shee name from the xc in a reference. Since the same faulty code was used at several places, this commit introduces a common helper that should be used everywhere.

This will solve problems that were introduced in ulterior versions (e.g. broken xlsx import/export)

Task 3112299

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo