### PR TITLE
[IMP] Autofill: alphanumeric values

### DIFF
--- a/src/registries/autofill_modifiers.ts
+++ b/src/registries/autofill_modifiers.ts
@@ -9,6 +9,7 @@ import {
   Getters,
   IncrementModifier,
 } from "../types/index";
+import { AlphanumericIncrementModifier } from "./../types/autofill";
 import { Registry } from "./registry";
 
 /**
@@ -19,6 +20,23 @@ import { Registry } from "./registry";
 export const autofillModifiersRegistry = new Registry<AutofillModifierImplementation>();
 
 autofillModifiersRegistry
+  .add("ALPHANUMERIC_INCREMENT_MODIFIER", {
+    apply: (rule: AlphanumericIncrementModifier, data: AutofillData) => {
+      rule.current += rule.increment;
+      const content = `${rule.prefix}${rule.current
+        .toString()
+        .padStart(rule.numberPostfixLength || 0, "0")}`;
+      return {
+        cellData: {
+          border: data.border,
+          style: data.cell && data.cell.style,
+          format: data.cell && data.cell.format,
+          content,
+        },
+        tooltip: { props: { content } },
+      };
+    },
+  })
   .add("INCREMENT_MODIFIER", {
     apply: (rule: IncrementModifier, data: AutofillData) => {
       rule.current += rule.increment;

--- a/src/types/autofill.ts
+++ b/src/types/autofill.ts
@@ -18,6 +18,14 @@ export interface IncrementModifier {
   current: number;
 }
 
+export interface AlphanumericIncrementModifier {
+  type: "ALPHANUMERIC_INCREMENT_MODIFIER";
+  increment: number;
+  current: number;
+  prefix: string;
+  numberPostfixLength: number; // the length of the number post fix string, e.g. "0001" is four but "1" is one
+}
+
 export interface CopyModifier {
   type: "COPY_MODIFIER";
 }
@@ -28,7 +36,11 @@ export interface FormulaModifier {
   current: number;
 }
 
-export type AutofillModifier = IncrementModifier | CopyModifier | FormulaModifier;
+export type AutofillModifier =
+  | IncrementModifier
+  | AlphanumericIncrementModifier
+  | CopyModifier
+  | FormulaModifier;
 
 export interface Tooltip {
   props: any;

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -331,6 +331,40 @@ describe("Autofill", () => {
       expect(getCellContent(model, "A4")).toBe("test");
     });
 
+    describe("Autofill alphanumeric values", () => {
+      test("same prefix", () => {
+        setCellContent(model, "A1", "prefix1");
+        setCellContent(model, "A2", "prefix4");
+        autofill("A1:A2", "A4");
+        expect(getCellContent(model, "A3")).toBe("prefix7");
+        expect(getCellContent(model, "A4")).toBe("prefix10");
+      });
+
+      test("different prefix", () => {
+        setCellContent(model, "A1", "prefixa1");
+        setCellContent(model, "A2", "prefixb10");
+        autofill("A1:A2", "A4");
+        expect(getCellContent(model, "A3")).toBe("prefixa2");
+        expect(getCellContent(model, "A4")).toBe("prefixb11");
+      });
+
+      test("padding zeros of number at the end", () => {
+        setCellContent(model, "A1", "prefix005");
+        setCellContent(model, "A2", "prefix007");
+        autofill("A1:A2", "A4");
+        expect(getCellContent(model, "A3")).toBe("prefix009");
+        expect(getCellContent(model, "A4")).toBe("prefix011");
+      });
+
+      test("prefix with numbers", () => {
+        setCellContent(model, "A1", "prefix123and5");
+        setCellContent(model, "A2", "prefix123and7");
+        autofill("A1:A2", "A4");
+        expect(getCellContent(model, "A3")).toBe("prefix123and9");
+        expect(getCellContent(model, "A4")).toBe("prefix123and11");
+      });
+    });
+
     test.each([
       ["=A1", "=#REF"],
       ["=SUM(A1:B1)", "=SUM(#REF)"],


### PR DESCRIPTION
## Description:

This PR implements the autofill functionality of alphanumeric values (e.g. prefix1). The idea is to use regular expressions to identify the string part and the number part, and reuse some existing logic to calculate the number.

Odoo task ID : [2569019](https://www.odoo.com/web#id=2569019&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo