### PR TITLE
[FIX] functions, find & replace: escape regex special characters

### DIFF
--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from "../helpers";
 import { _lt } from "../translation";
 import { AddFunctionDescription, Argument, ArgValue } from "../types";
 import { args } from "./arguments";
@@ -312,7 +313,7 @@ export const SUBSTITUTE: AddFunctionDescription = {
     }
 
     const _replaceWith = toString(replaceWith);
-    const reg = new RegExp(_searchFor, "g");
+    const reg = new RegExp(escapeRegExp(_searchFor), "g");
     if (_occurrenceNumber === 0) {
       return _textToSearch.replace(reg, _replaceWith);
     }

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -20,6 +20,14 @@ export function stringify(obj: any): string {
 }
 
 /**
+ * Escapes a string to use as a literal string in a RegExp.
+ * @url https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+ */
+export function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Deep copy arrays, plain objects and primitive values.
  * Throws an error for other types such as class instances.
  * Sparse arrays remain sparse.

--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from "../../helpers";
 import { Cell, Command, GridRenderingContext, LAYERS, UID } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
@@ -129,7 +130,7 @@ export class FindAndReplacePlugin extends UIPlugin {
    * the value toSearch
    */
   private updateRegex() {
-    let searchValue = this.toSearch;
+    let searchValue = escapeRegExp(this.toSearch);
     const flags = !this.searchOptions.matchCase ? "i" : "";
     if (this.searchOptions.exactMatch) {
       searchValue = `^${searchValue}$`;

--- a/tests/functions/module_text.test.ts
+++ b/tests/functions/module_text.test.ts
@@ -446,6 +446,10 @@ describe("SUBSTITUTE formula", () => {
     expect(evaluateCell("A1", { A1: '=SUBSTITUTE("AAAA", "", "B")' })).toBe("AAAA");
   });
 
+  test("functional tests on argument with regexp characters", () => {
+    expect(evaluateCell("A1", { A1: '=SUBSTITUTE("(hello)", "(" , ")")' })).toBe(")hello)");
+  });
+
   test("functional tests on cell arguments", () => {
     expect(
       evaluateCell("A1", {

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -35,6 +35,13 @@ describe("basic search", () => {
     expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
   });
 
+  test("search with a regexp characters", () => {
+    setCellContent(model, "A1", "hello (world).*");
+    model.dispatch("UPDATE_SEARCH", { toSearch: "(world", searchOptions });
+    const matches = model.getters.getSearchMatches();
+    expect(matches).toStrictEqual([{ col: 0, row: 0, selected: true }]);
+  });
+
   test("Update search automatically select the first match", () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "2", searchOptions });
     expect(model.getters.getSelection().zones).toEqual([toZone("A6")]);


### PR DESCRIPTION
With this commit special characters are escaped when building the regex.

Task 3117126

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3117126](https://www.odoo.com/web#id=3117126&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo