### PR TITLE
[IMP] Function: add `hidden` tag to hide functions

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -407,12 +407,14 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
 
   showAutocomplete(searchTerm: string) {
     this.autoCompleteState.showProvider = true;
-    let values = Object.entries(functionRegistry.content).map(([text, { description }]) => {
-      return {
-        text,
-        description,
-      };
-    });
+    let values = Object.entries(functionRegistry.content)
+      .filter(([_, { hidden }]) => !hidden)
+      .map(([text, { description }]) => {
+        return {
+          text,
+          description,
+        };
+      });
     if (searchTerm) {
       values = fuzzyLookup(searchTerm, values, (t) => t.text);
     } else {

--- a/src/functions/arguments.ts
+++ b/src/functions/arguments.ts
@@ -110,6 +110,7 @@ export function addMetaInfoFromArg(addDescr: AddFunctionDescription): FunctionDe
   descr.maxArgPossible = repeatingArg ? Infinity : countArg;
   descr.nbrArgRepeating = repeatingArg;
   descr.getArgToFocus = argTargeting(countArg, repeatingArg);
+  descr.hidden = addDescr.hidden || false;
 
   return descr;
 }

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -36,6 +36,7 @@ export interface AddFunctionDescription {
   args: ArgDefinition[];
   returns: [ArgType];
   isExported?: boolean;
+  hidden?: boolean;
 }
 
 export interface FunctionDescription extends AddFunctionDescription {

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -73,6 +73,13 @@ describe("Functions autocomplete", () => {
       compute: () => 1,
       returns: ["ANY"],
     });
+    functionRegistry.add("HIDDEN", {
+      description: "do something",
+      args: args(``),
+      compute: () => 1,
+      returns: ["ANY"],
+      hidden: true,
+    });
   });
 
   afterAll(() => {
@@ -82,6 +89,13 @@ describe("Functions autocomplete", () => {
   describe("autocomplete", () => {
     test("= do not show autocomplete", async () => {
       await typeInComposerGrid("=");
+      const activeElement = document.activeElement;
+      expect(activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
+    });
+
+    test("=HI do not show autocomplete when entering hidden function names", async () => {
+      await typeInComposerGrid("=HI");
       const activeElement = document.activeElement;
       expect(activeElement).toBe(composerEl);
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);


### PR DESCRIPTION
## Description:

This PR adds the tag `hidden` to hide some functions to users, so users will not have the chance to see their existences.

Odoo task ID : [3102309](https://www.odoo.com/web#id=3102309&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo