### PR TITLE
Master tool bar add "vertical align" and "text wrapping" buttons

### DIFF
--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -168,13 +168,29 @@
       <polygon points="5.5 9 12.5 9 9 12.5"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.TEXT_WRAPPING" owl="1">
-    <svg class="o-icon">
+  <t t-name="o-spreadsheet-Icon.WRAPPING_OVERFLOW" owl="1">
+    <svg class="o-icon wrapping-overflow" width="20" height="20">
+      <rect x="2" y="2" width="2" height="14"/>
+      <rect x="9" y="2" width="2" height="4"/>
+      <rect x="9" y="12" width="2" height="4"/>
+      <polygon points="13 8 6 8 6 10 13 10 13 12 16 9 13 6"/>
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.WRAPPING_WRAP" owl="1">
+    <svg class="o-icon wrapping-wrap" width="20" height="20">
+      <rect x="2" y="2" width="2" height="14"/>
+      <rect x="14" y="2" width="2" height="14"/>
       <path
-        fill="#000000"
-        d="M14,0 L0,0 L0,2 L14,2 L14,0 Z M0,12 L4,12 L4,10 L0,10 L0,12 Z M11.5,5 L0,5 L0,7 L11.75,7 C12.58,7 13.25,7.67 13.25,8.5 C13.25,9.33 12.58,10 11.75,10 L9,10 L9,8 L6,11 L9,14 L9,12 L11.5,12 C13.43,12 15,10.43 15,8.5 C15,6.57 13.43,5 11.5,5 Z"
-        transform="translate(2 3)"
+        d="M6,5 L6,7 L9.75,7 C10.5,7 11.25,7.67 11.25,8.5 C11.25,9.25 10.5,10 9.75,10 L8,10 L8,12 L9.5,12 C11.5,12 13,10.5 13,8.5 C13,6.5 11.5,5 9.5,5 L6,5 Z"
       />
+      <polygon points="8 10 8 8 5 11 8 14 8 12"/>
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.WRAPPING_CLIP" owl="1">
+    <svg class="o-icon wrapping-clip" width="20" height="20">
+      <rect x="2" y="2" width="2" height="14"/>
+      <rect x="14" y="2" width="2" height="14"/>
+      <rect x="6" y="8" width="8" height="2"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BORDERS" owl="1">

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -147,13 +147,25 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.ALIGN_TOP" owl="1">
+    <svg class="o-icon align-top" width="20" height="20">
+      <rect x="3" y="2" width="12" height="2"/>
+      <rect x="8" y="9" width="2" height="7"/>
+      <polygon points="5.5 9 12.5 9 9 5.5"/>
+    </svg>
+  </t>
   <t t-name="o-spreadsheet-Icon.ALIGN_MIDDLE" owl="1">
-    <svg class="o-icon">
-      <path
-        fill="#000000"
-        d="M9.5,3 L7,3 L7,0 L5,0 L5,3 L2.5,3 L6,6.5 L9.5,3 L9.5,3 Z M0,8 L0,10 L12,10 L12,8 L0,8 L0,8 Z M2.5,15 L5,15 L5,18 L7,18 L7,15 L9.5,15 L6,11.5 L2.5,15 L2.5,15 Z"
-        transform="translate(3)"
-      />
+    <svg class="o-icon align-middle" width="20" height="20">
+      <polygon points="12.5 3 10 3 10 0 8 0 8 3 5.5 3 9 6.5"/>
+      <polygon points="5.5 15 8 15 8 18 10 18 10 15 12.5 15 9 11.5"/>
+      <rect x="3" y="8" width="12" height="2"/>
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.ALIGN_BOTTOM" owl="1">
+    <svg class="o-icon align-bottom" width="20" height="20">
+      <rect x="3" y="14" width="12" height="2"/>
+      <rect x="8" y="2" width="2" height="7"/>
+      <polygon points="5.5 9 12.5 9 9 12.5"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.TEXT_WRAPPING" owl="1">

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -28,6 +28,7 @@ import {
   SpreadsheetChildEnv,
   Style,
   VerticalAlign,
+  Wrapping,
 } from "../../types/index";
 import { ColorPicker } from "../color_picker/color_picker";
 import { TopBarComposer } from "../composer/top_bar_composer/top_bar_composer";
@@ -397,6 +398,11 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
 
   toggleVerticalAlign(verticalAlign: VerticalAlign) {
     setStyle(this.env, { verticalAlign });
+    this.onClick();
+  }
+
+  toggleTextWrapping(wrapping: Wrapping) {
+    setStyle(this.env, { wrapping });
     this.onClick();
   }
 

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -27,6 +27,7 @@ import {
   SetDecimalStep,
   SpreadsheetChildEnv,
   Style,
+  VerticalAlign,
 } from "../../types/index";
 import { ColorPicker } from "../color_picker/color_picker";
 import { TopBarComposer } from "../composer/top_bar_composer/top_bar_composer";
@@ -389,8 +390,13 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
     setFormatter(this.env, value);
   }
 
-  toggleAlign(align: Align) {
-    setStyle(this.env, { ["align"]: align });
+  toggleHorizontalAlign(align: Align) {
+    setStyle(this.env, { align });
+    this.onClick();
+  }
+
+  toggleVerticalAlign(verticalAlign: VerticalAlign) {
+    setStyle(this.env, { verticalAlign });
     this.onClick();
   }
 

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -327,6 +327,45 @@
                 </div>
               </div>
             </div>
+            <div class="o-dropdown">
+              <div
+                class="o-tool o-dropdown-button"
+                title="Text wrapping"
+                t-on-click="(ev) => this.toggleDropdownTool('textWrappingTool', ev)">
+                <span>
+                  <t t-if="style.wrapping === 'wrap'">
+                    <t t-call="o-spreadsheet-Icon.WRAPPING_WRAP"/>
+                  </t>
+                  <t t-elif="style.wrapping === 'clip'">
+                    <t t-call="o-spreadsheet-Icon.WRAPPING_CLIP"/>
+                  </t>
+                  <t t-else="">
+                    <t t-call="o-spreadsheet-Icon.WRAPPING_OVERFLOW"/>
+                  </t>
+                  <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
+                </span>
+              </div>
+              <div
+                t-if="state.activeTool === 'textWrappingTool'"
+                class="o-dropdown-content"
+                t-on-click.stop="">
+                <div
+                  class="o-dropdown-item o-dropdown-align-item"
+                  t-on-click="() => this.toggleTextWrapping('overflow')">
+                  <t t-call="o-spreadsheet-Icon.WRAPPING_OVERFLOW"/>
+                </div>
+                <div
+                  class="o-dropdown-item o-dropdown-align-item"
+                  t-on-click="() => this.toggleTextWrapping('wrap')">
+                  <t t-call="o-spreadsheet-Icon.WRAPPING_WRAP"/>
+                </div>
+                <div
+                  class="o-dropdown-item o-dropdown-align-item"
+                  t-on-click="() => this.toggleTextWrapping('clip')">
+                  <t t-call="o-spreadsheet-Icon.WRAPPING_CLIP"/>
+                </div>
+              </div>
+            </div>
             <div class="o-divider"/>
             <div
               t-if="selectionContainsFilter"

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -253,7 +253,7 @@
               <div
                 class="o-tool o-dropdown-button"
                 title="Horizontal align"
-                t-on-click="(ev) => this.toggleDropdownTool('alignTool', ev)">
+                t-on-click="(ev) => this.toggleDropdownTool('horizontalAlignTool', ev)">
                 <span>
                   <t t-if="style.align === 'right'">
                     <t t-call="o-spreadsheet-Icon.ALIGN_RIGHT"/>
@@ -268,23 +268,62 @@
                 </span>
               </div>
               <div
-                t-if="state.activeTool === 'alignTool'"
+                t-if="state.activeTool === 'horizontalAlignTool'"
                 class="o-dropdown-content"
                 t-on-click.stop="">
                 <div
                   class="o-dropdown-item o-dropdown-align-item"
-                  t-on-click="(ev) => this.toggleAlign('left', ev)">
+                  t-on-click="() => this.toggleHorizontalAlign('left')">
                   <t t-call="o-spreadsheet-Icon.ALIGN_LEFT"/>
                 </div>
                 <div
                   class="o-dropdown-item o-dropdown-align-item"
-                  t-on-click="(ev) => this.toggleAlign('center', ev)">
+                  t-on-click="() => this.toggleHorizontalAlign('center')">
                   <t t-call="o-spreadsheet-Icon.ALIGN_CENTER"/>
                 </div>
                 <div
                   class="o-dropdown-item o-dropdown-align-item"
-                  t-on-click="(ev) => this.toggleAlign('right', ev)">
+                  t-on-click="() => this.toggleHorizontalAlign('right')">
                   <t t-call="o-spreadsheet-Icon.ALIGN_RIGHT"/>
+                </div>
+              </div>
+            </div>
+            <div class="o-dropdown">
+              <div
+                class="o-tool o-dropdown-button"
+                title="Vertical align"
+                t-on-click="(ev) => this.toggleDropdownTool('verticalAlignTool', ev)">
+                <span>
+                  <t t-if="style.verticalAlign === 'top'">
+                    <t t-call="o-spreadsheet-Icon.ALIGN_TOP"/>
+                  </t>
+                  <t t-elif="style.verticalAlign === 'bottom'">
+                    <t t-call="o-spreadsheet-Icon.ALIGN_BOTTOM"/>
+                  </t>
+                  <t t-else="">
+                    <t t-call="o-spreadsheet-Icon.ALIGN_MIDDLE"/>
+                  </t>
+                  <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
+                </span>
+              </div>
+              <div
+                t-if="state.activeTool === 'verticalAlignTool'"
+                class="o-dropdown-content"
+                t-on-click.stop="">
+                <div
+                  class="o-dropdown-item o-dropdown-align-item"
+                  t-on-click="() => this.toggleVerticalAlign('top')">
+                  <t t-call="o-spreadsheet-Icon.ALIGN_TOP"/>
+                </div>
+                <div
+                  class="o-dropdown-item o-dropdown-align-item"
+                  t-on-click="() => this.toggleVerticalAlign('middle')">
+                  <t t-call="o-spreadsheet-Icon.ALIGN_MIDDLE"/>
+                </div>
+                <div
+                  class="o-dropdown-item o-dropdown-align-item"
+                  t-on-click="() => this.toggleVerticalAlign('bottom')">
+                  <t t-call="o-spreadsheet-Icon.ALIGN_BOTTOM"/>
                 </div>
               </div>
             </div>

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -409,6 +409,58 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
             
           </div>
           <div
+            class="o-dropdown"
+          >
+            <div
+              class="o-tool o-dropdown-button"
+              title="Text wrapping"
+            >
+              <span>
+                
+                
+                <svg
+                  class="o-icon wrapping-overflow"
+                  height="20"
+                  width="20"
+                >
+                  <rect
+                    height="14"
+                    width="2"
+                    x="2"
+                    y="2"
+                  />
+                  <rect
+                    height="4"
+                    width="2"
+                    x="9"
+                    y="2"
+                  />
+                  <rect
+                    height="4"
+                    width="2"
+                    x="9"
+                    y="12"
+                  />
+                  <polygon
+                    points="13 8 6 8 6 10 13 10 13 12 16 9 13 6"
+                  />
+                </svg>
+                
+                <svg
+                  class="o-icon"
+                >
+                  <polygon
+                    fill="#000000"
+                    points="0 0 4 4 8 0"
+                    transform="translate(5 7)"
+                  />
+                </svg>
+                
+              </span>
+            </div>
+            
+          </div>
+          <div
             class="o-divider"
           />
           

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -366,6 +366,49 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
             
           </div>
           <div
+            class="o-dropdown"
+          >
+            <div
+              class="o-tool o-dropdown-button"
+              title="Vertical align"
+            >
+              <span>
+                
+                
+                <svg
+                  class="o-icon align-middle"
+                  height="20"
+                  width="20"
+                >
+                  <polygon
+                    points="12.5 3 10 3 10 0 8 0 8 3 5.5 3 9 6.5"
+                  />
+                  <polygon
+                    points="5.5 15 8 15 8 18 10 18 10 15 12.5 15 9 11.5"
+                  />
+                  <rect
+                    height="2"
+                    width="12"
+                    x="3"
+                    y="8"
+                  />
+                </svg>
+                
+                <svg
+                  class="o-icon"
+                >
+                  <polygon
+                    fill="#000000"
+                    points="0 0 4 4 8 0"
+                    transform="translate(5 7)"
+                  />
+                </svg>
+                
+              </span>
+            </div>
+            
+          </div>
+          <div
             class="o-divider"
           />
           

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -521,6 +521,58 @@ exports[`TopBar component can set cell format 1`] = `
               
             </div>
             <div
+              class="o-dropdown"
+            >
+              <div
+                class="o-tool o-dropdown-button"
+                title="Text wrapping"
+              >
+                <span>
+                  
+                  
+                  <svg
+                    class="o-icon wrapping-overflow"
+                    height="20"
+                    width="20"
+                  >
+                    <rect
+                      height="14"
+                      width="2"
+                      x="2"
+                      y="2"
+                    />
+                    <rect
+                      height="4"
+                      width="2"
+                      x="9"
+                      y="2"
+                    />
+                    <rect
+                      height="4"
+                      width="2"
+                      x="9"
+                      y="12"
+                    />
+                    <polygon
+                      points="13 8 6 8 6 10 13 10 13 12 16 9 13 6"
+                    />
+                  </svg>
+                  
+                  <svg
+                    class="o-icon"
+                  >
+                    <polygon
+                      fill="#000000"
+                      points="0 0 4 4 8 0"
+                      transform="translate(5 7)"
+                    />
+                  </svg>
+                  
+                </span>
+              </div>
+              
+            </div>
+            <div
               class="o-divider"
             />
             
@@ -955,6 +1007,58 @@ exports[`TopBar component simple rendering 1`] = `
                   width="12"
                   x="3"
                   y="8"
+                />
+              </svg>
+              
+              <svg
+                class="o-icon"
+              >
+                <polygon
+                  fill="#000000"
+                  points="0 0 4 4 8 0"
+                  transform="translate(5 7)"
+                />
+              </svg>
+              
+            </span>
+          </div>
+          
+        </div>
+        <div
+          class="o-dropdown"
+        >
+          <div
+            class="o-tool o-dropdown-button"
+            title="Text wrapping"
+          >
+            <span>
+              
+              
+              <svg
+                class="o-icon wrapping-overflow"
+                height="20"
+                width="20"
+              >
+                <rect
+                  height="14"
+                  width="2"
+                  x="2"
+                  y="2"
+                />
+                <rect
+                  height="4"
+                  width="2"
+                  x="9"
+                  y="2"
+                />
+                <rect
+                  height="4"
+                  width="2"
+                  x="9"
+                  y="12"
+                />
+                <polygon
+                  points="13 8 6 8 6 10 13 10 13 12 16 9 13 6"
                 />
               </svg>
               

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -478,6 +478,49 @@ exports[`TopBar component can set cell format 1`] = `
               
             </div>
             <div
+              class="o-dropdown"
+            >
+              <div
+                class="o-tool o-dropdown-button"
+                title="Vertical align"
+              >
+                <span>
+                  
+                  
+                  <svg
+                    class="o-icon align-middle"
+                    height="20"
+                    width="20"
+                  >
+                    <polygon
+                      points="12.5 3 10 3 10 0 8 0 8 3 5.5 3 9 6.5"
+                    />
+                    <polygon
+                      points="5.5 15 8 15 8 18 10 18 10 15 12.5 15 9 11.5"
+                    />
+                    <rect
+                      height="2"
+                      width="12"
+                      x="3"
+                      y="8"
+                    />
+                  </svg>
+                  
+                  <svg
+                    class="o-icon"
+                  >
+                    <polygon
+                      fill="#000000"
+                      points="0 0 4 4 8 0"
+                      transform="translate(5 7)"
+                    />
+                  </svg>
+                  
+                </span>
+              </div>
+              
+            </div>
+            <div
               class="o-divider"
             />
             
@@ -869,6 +912,49 @@ exports[`TopBar component simple rendering 1`] = `
                   d="M0,14 L10,14 L10,12 L0,12 L0,14 Z M10,4 L0,4 L0,6 L10,6 L10,4 Z M0,0 L0,2 L14,2 L14,0 L0,0 Z M0,10 L14,10 L14,8 L0,8 L0,10 Z"
                   fill="#000000"
                   transform="translate(2 2)"
+                />
+              </svg>
+              
+              <svg
+                class="o-icon"
+              >
+                <polygon
+                  fill="#000000"
+                  points="0 0 4 4 8 0"
+                  transform="translate(5 7)"
+                />
+              </svg>
+              
+            </span>
+          </div>
+          
+        </div>
+        <div
+          class="o-dropdown"
+        >
+          <div
+            class="o-tool o-dropdown-button"
+            title="Vertical align"
+          >
+            <span>
+              
+              
+              <svg
+                class="o-icon align-middle"
+                height="20"
+                width="20"
+              >
+                <polygon
+                  points="12.5 3 10 3 10 0 8 0 8 3 5.5 3 9 6.5"
+                />
+                <polygon
+                  points="5.5 15 8 15 8 18 10 18 10 15 12.5 15 9 11.5"
+                />
+                <rect
+                  height="2"
+                  width="12"
+                  x="3"
+                  y="8"
                 />
               </svg>
               

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -352,6 +352,42 @@ describe("TopBar component", () => {
     );
   });
 
+  describe("text wrapping", () => {
+    test.each([
+      ["wrapping-overflow", { wrapping: "overflow" }],
+      ["wrapping-wrap", { wrapping: "wrap" }],
+      ["wrapping-clip", { wrapping: "clip" }],
+    ])("can set the wrapping state '%s' with the toolbar", async (iconClass, expectedStyle) => {
+      const { app, model } = await mountParent();
+      await click(fixture, ".o-tool[title='Text wrapping']");
+      const alignButtons = fixture.querySelectorAll("div.o-dropdown-item")!;
+      const button = [...alignButtons].find((element) =>
+        element.children[0]!.classList.contains(iconClass)
+      )!;
+      await click(button);
+      expect(model.getters.getCurrentStyle()).toEqual(expectedStyle);
+      app.destroy();
+    });
+    test.each([
+      ["text", {}, "wrapping-overflow"],
+      ["0", {}, "wrapping-overflow"],
+      ["0", { wrapping: "overflow" }, "wrapping-overflow"],
+      ["0", { wrapping: "wrap" }, "wrapping-wrap"],
+      ["0", { wrapping: "clip" }, "wrapping-clip"],
+    ])(
+      "wrapping icon in top bar matches the selected cell (content: %s, style: %s)",
+      async (content, style, expectedIconClass) => {
+        const model = new Model();
+        setCellContent(model, "A1", content);
+        setStyle(model, "A1", style as Style);
+        const { app } = await mountParent(model);
+        const wrapTool = fixture.querySelector('.o-tool[title="Text wrapping"]')!;
+        expect(wrapTool.querySelector("svg")!.classList).toContain(expectedIconClass);
+        app.destroy();
+      }
+    );
+  });
+
   test("opening, then closing same menu", async () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
@@ -517,6 +553,7 @@ describe("TopBar component", () => {
   test.each([
     ["Horizontal align", ".o-dropdown-content"],
     ["Vertical align", ".o-dropdown-content"],
+    ["Text wrapping", ".o-dropdown-content"],
     ["Borders", ".o-dropdown-content"],
     ["Font Size", ".o-dropdown-content"],
     ["Fill Color", ".o-color-picker"],

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -2,7 +2,6 @@ import { App, Component, onMounted, onWillUnmount, useState, xml } from "@odoo/o
 import { ComposerFocusType } from "../../src/components/spreadsheet/spreadsheet";
 import { TopBar } from "../../src/components/top_bar/top_bar";
 import { DEFAULT_FONT_SIZE } from "../../src/constants";
-import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { topbarComponentRegistry } from "../../src/registries";
 import { topbarMenuRegistry } from "../../src/registries/menus/topbar_menu_registry";
@@ -15,6 +14,7 @@ import {
   setAnchorCorner,
   setCellContent,
   setSelection,
+  setStyle,
 } from "../test_helpers/commands_helpers";
 import { click, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getBorder, getCell, getStyle } from "../test_helpers/getters_helpers";
@@ -25,7 +25,6 @@ import {
   makeTestFixture,
   mountSpreadsheet,
   nextTick,
-  target,
   toRangesData,
   typeInComposerTopBar,
 } from "../test_helpers/helpers";
@@ -162,12 +161,7 @@ describe("TopBar component", () => {
 
     expect(undoTool.classList.contains("o-disabled")).toBeTruthy();
     expect(redoTool.classList.contains("o-disabled")).toBeTruthy();
-
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
-      style: { bold: true },
-    });
+    setStyle(model, "A1", { bold: true });
     await nextTick();
 
     expect(undoTool.classList.contains("o-disabled")).toBeFalsy();
@@ -280,45 +274,83 @@ describe("TopBar component", () => {
     app.destroy();
   });
 
-  test.each([
-    ["align-left", { align: "left" }],
-    ["align-center", { align: "center" }],
-    ["align-right", { align: "right" }],
-  ])("can set horizontal alignment with the toolbar", async (iconClass, expectedStyle) => {
-    const { app, model } = await mountParent();
-    await click(fixture, ".o-tool[title='Horizontal align']");
-
-    const alignButtons = fixture.querySelectorAll("div.o-dropdown-item")!;
-    const button = [...alignButtons].find((element) =>
-      element.children[0]!.classList.contains(iconClass)
-    )!;
-
-    await click(button);
-    expect(model.getters.getCurrentStyle()).toEqual(expectedStyle);
-    app.destroy();
+  describe("horizontal align", () => {
+    test.each([
+      ["align-left", { align: "left" }],
+      ["align-center", { align: "center" }],
+      ["align-right", { align: "right" }],
+    ])(
+      "can set horizontal alignment with the toolbar (iconClass: %s)",
+      async (iconClass, expectedStyle) => {
+        const { app, model } = await mountParent();
+        await click(fixture, ".o-tool[title='Horizontal align']");
+        const alignButtons = fixture.querySelectorAll("div.o-dropdown-item")!;
+        const button = [...alignButtons].find((element) =>
+          element.children[0]!.classList.contains(iconClass)
+        )!;
+        await click(button);
+        expect(model.getters.getCurrentStyle()).toEqual(expectedStyle);
+        app.destroy();
+      }
+    );
+    test.each([
+      ["text", {}, "align-left"],
+      ["0", {}, "align-right"],
+      ["0", { align: "left" }, "align-left"],
+      ["0", { align: "center" }, "align-center"],
+      ["0", { align: "right" }, "align-right"],
+    ])(
+      "alignment icon in top bar matches the selected cell (content: %s, style: %s)",
+      async (content, style, expectedIconClass) => {
+        const model = new Model();
+        setCellContent(model, "A1", content);
+        setStyle(model, "A1", style as Style);
+        const { app } = await mountParent(model);
+        const alignTool = fixture.querySelector('.o-tool[title="Horizontal align"]')!;
+        expect(alignTool.querySelector("svg")!.classList).toContain(expectedIconClass);
+        app.destroy();
+      }
+    );
   });
-  test.each([
-    ["text", {}, "align-left"],
-    ["0", {}, "align-right"],
-    ["0", { align: "left" }, "align-left"],
-    ["0", { align: "center" }, "align-center"],
-    ["0", { align: "right" }, "align-right"],
-  ])(
-    "alignment icon in top bar match the selected cell",
-    async (content, style, expectedIconClass) => {
-      const model = new Model();
-      setCellContent(model, "A1", content);
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
-        style: style as Style,
-      });
-      const { app } = await mountParent(model);
-      const alignTool = fixture.querySelector('.o-tool[title="Horizontal align"]')!;
-      expect(alignTool.querySelector("svg")!.classList).toContain(expectedIconClass);
-      app.destroy();
-    }
-  );
+
+  describe("vertical align", () => {
+    test.each([
+      ["align-top", { verticalAlign: "top" }],
+      ["align-middle", { verticalAlign: "middle" }],
+      ["align-bottom", { verticalAlign: "bottom" }],
+    ])(
+      "can set vertical alignment with the toolbar (iconClass: %s)",
+      async (iconClass, expectedStyle) => {
+        const { app, model } = await mountParent();
+        await click(fixture, ".o-tool[title='Vertical align']");
+        const alignButtons = fixture.querySelectorAll("div.o-dropdown-item")!;
+        const button = [...alignButtons].find((element) =>
+          element.children[0]!.classList.contains(iconClass)
+        )!;
+        await click(button);
+        expect(model.getters.getCurrentStyle()).toEqual(expectedStyle);
+        app.destroy();
+      }
+    );
+    test.each([
+      ["text", {}, "align-middle"],
+      ["0", {}, "align-middle"],
+      ["0", { verticalAlign: "top" }, "align-top"],
+      ["0", { verticalAlign: "middle" }, "align-middle"],
+      ["0", { verticalAlign: "bottom" }, "align-bottom"],
+    ])(
+      "alignment icon in top bar matches the selected cell (content: %s, style: %s)",
+      async (content, style, expectedIconClass) => {
+        const model = new Model();
+        setCellContent(model, "A1", content);
+        setStyle(model, "A1", style as Style);
+        const { app } = await mountParent(model);
+        const alignTool = fixture.querySelector('.o-tool[title="Vertical align"]')!;
+        expect(alignTool.querySelector("svg")!.classList).toContain(expectedIconClass);
+        app.destroy();
+      }
+    );
+  });
 
   test("opening, then closing same menu", async () => {
     const model = new Model();
@@ -484,6 +516,7 @@ describe("TopBar component", () => {
 
   test.each([
     ["Horizontal align", ".o-dropdown-content"],
+    ["Vertical align", ".o-dropdown-content"],
     ["Borders", ".o-dropdown-content"],
     ["Font Size", ".o-dropdown-content"],
     ["Fill Color", ".o-color-picker"],
@@ -566,12 +599,7 @@ describe("TopBar - Custom currency", () => {
 describe("Format", () => {
   test("can clear format", async () => {
     const { app, model } = await mountSpreadsheet(fixture);
-    const sheetId = model.getters.getActiveSheetId();
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1, B2:B3"),
-      style: { fillColor: "#000000" },
-    });
+    setStyle(model, "A1, B2:B3", { fillColor: "#000000" });
     selectCell(model, "A1");
     addCellToSelection(model, "B2");
     setAnchorCorner(model, "B3");


### PR DESCRIPTION
## [IMP] top bar: add 'vertical alignment' options

Vertical alignment is a feature that is already
present in spreadsheet but its shortcut isn't
present in the toolbar. This commit adds it.

## [IMP] top bar: add 'text wrapping' options

Text wrapping is a feature that is already
present in spreadsheet but its shortcut isn't
present in the toolbar. This commit adds it.

Odoo task ID : [3047949](https://www.odoo.com/web#id=3047949&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo