### PR TITLE
[REF] compiler: use code builder

### DIFF
--- a/src/formulas/code_builder.ts
+++ b/src/formulas/code_builder.ts
@@ -1,0 +1,106 @@
+/**
+ * Block of code that produces a value.
+ */
+export interface FunctionCode {
+  readonly returnExpression: string;
+  /**
+   * Return the same function code but wrapped in a closure.
+   */
+  wrapInClosure(): FunctionCode;
+  /**
+   * Return the same function code but with the return expression assigned to a variable.
+   */
+  assignResultToVariable(): FunctionCode;
+}
+
+export class FunctionCodeBuilder {
+  private code: string = "";
+
+  constructor(private scope: Scope = new Scope()) {}
+
+  append(...lines: (string | FunctionCode)[]) {
+    this.code += lines.map((line) => line.toString()).join("\n") + "\n";
+  }
+
+  return(expression: string): FunctionCode {
+    return new FunctionCodeImpl(this.scope, this.code, expression);
+  }
+
+  toString(): string {
+    return indentCode(this.code);
+  }
+}
+
+class FunctionCodeImpl implements FunctionCode {
+  private readonly code: string;
+  constructor(private readonly scope: Scope, code: string, readonly returnExpression: string) {
+    this.code = indentCode(code);
+  }
+
+  toString(): string {
+    return this.code;
+  }
+
+  wrapInClosure(): FunctionCode {
+    const closureName = this.scope.nextVariableName();
+    const code = new FunctionCodeBuilder(this.scope);
+    code.append(`const ${closureName} = () => {`);
+    code.append(this.code);
+    code.append(`return ${this.returnExpression};`);
+    code.append(`}`);
+    return code.return(closureName);
+  }
+
+  assignResultToVariable(): FunctionCode {
+    if (this.scope.isAlreadyDeclared(this.returnExpression)) {
+      return this;
+    }
+    const variableName = this.scope.nextVariableName();
+    const code = new FunctionCodeBuilder(this.scope);
+    code.append(this.code);
+    code.append(`const ${variableName} = ${this.returnExpression};`);
+    return code.return(variableName);
+  }
+}
+
+export class Scope {
+  private nextId = 1;
+  private declaredVariables: Set<string> = new Set();
+
+  nextVariableName(): string {
+    const name = `_${this.nextId++}`;
+    this.declaredVariables.add(name);
+    return name;
+  }
+
+  isAlreadyDeclared(name: string): boolean {
+    return this.declaredVariables.has(name);
+  }
+}
+
+/**
+ * Takes a list of strings that might be single or multiline
+ * and maps them in a list of single line strings.
+ */
+function splitLines(str: string): string[] {
+  return str
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+}
+
+function indentCode(code: string): string {
+  let result = "";
+  let indentLevel = 0;
+  const lines = splitLines(code);
+  for (const line of lines) {
+    if (line.startsWith("}")) {
+      indentLevel--;
+    }
+    result += "\t".repeat(indentLevel) + line + "\n";
+    if (line.endsWith("{")) {
+      indentLevel++;
+    }
+  }
+  return result.trim();
+}

--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -4,6 +4,7 @@ import { concat, parseNumber, removeStringQuotes } from "../helpers";
 import { _lt } from "../translation";
 import { CompiledFormula } from "../types";
 import { BadExpressionError } from "../types/errors";
+import { FunctionCode, FunctionCodeBuilder, Scope } from "./code_builder";
 import { AST, ASTFuncall, parseTokens } from "./parser";
 import { rangeTokenize } from "./range_tokenizer";
 
@@ -28,39 +29,6 @@ const UNARY_OPERATOR_MAP = {
   "-": "UMINUS",
   "+": "UPLUS",
   "%": "UNARY.PERCENT",
-};
-
-/**
- * Takes a list of strings that might be single or multiline
- * and maps them in a list of single line strings.
- */
-function splitCodeLines(codeBlocks: string[]): string[] {
-  return codeBlocks
-    .join("\n")
-    .split("\n")
-    .filter((line) => line.trim() !== "");
-}
-/**
- * Used as intermediate compilation.
- * Formula `=SUM(|0|, |1|)` gives the following code.
- * ```js
- * let _2 = range(deps[0])
- * let _3 = range(deps[1])
- * ctx.__lastFnCalled = 'SUM'
- * let _1 = ctx['SUM'](_2,_3)
- * ```
- * The result id is `_1`.
- */
-type CompiledAST = {
-  /**
-   * The result of the code is stored in this identifier.
-   * Can be a variable or a primitive value.
-   */
-  id: string;
-  /**
-   * String containing the compiled code
-   */
-  code: string;
 };
 
 interface ConstantValues {
@@ -89,7 +57,7 @@ export function compile(formula: string): CompiledFormula {
   const cacheKey = compilationCacheKey(tokens, dependencies, constantValues);
   if (!functionCache[cacheKey]) {
     const ast = parseTokens([...tokens]);
-    let nextId = 1;
+    const scope = new Scope();
 
     if (ast.type === "BIN_OPERATION" && ast.value === ":") {
       throw new BadExpressionError(_lt("Invalid formula"));
@@ -98,17 +66,16 @@ export function compile(formula: string): CompiledFormula {
       throw new BadExpressionError(_lt("Invalid formula"));
     }
     const compiledAST = compileAST(ast);
-    const code = splitCodeLines([
-      `// ${cacheKey}`,
-      compiledAST.code,
-      `return ${compiledAST.id};`,
-    ]).join("\n");
+    const code = new FunctionCodeBuilder();
+    code.append(`// ${cacheKey}`);
+    code.append(compiledAST);
+    code.append(`return ${compiledAST.returnExpression};`);
     let baseFunction = new Function(
       "deps", // the dependencies in the current formula
       "ref", // a function to access a certain dependency at a given index
       "range", // same as above, but guarantee that the result is in the form of a range
       "ctx",
-      code
+      code.toString()
     );
 
     functionCache[cacheKey] = {
@@ -123,7 +90,7 @@ export function compile(formula: string): CompiledFormula {
      * the cell value into a range. This allow the grid model to differentiate
      * between a cell value and a non cell value.
      */
-    function compileFunctionArgs(ast: ASTFuncall): CompiledAST[] {
+    function compileFunctionArgs(ast: ASTFuncall): FunctionCode[] {
       const functionDefinition = functions[ast.value.toUpperCase()];
       const currentFunctionArguments = ast.args;
 
@@ -169,7 +136,7 @@ export function compile(formula: string): CompiledFormula {
         }
       }
 
-      let listArgs: CompiledAST[] = [];
+      let compiledArgs: FunctionCode[] = [];
       for (let i = 0; i < nbrArg; i++) {
         const argPosition = functionDefinition.getArgToFocus(i + 1) - 1;
         if (0 <= argPosition && argPosition < functionDefinition.args.length) {
@@ -211,15 +178,15 @@ export function compile(formula: string): CompiledFormula {
             }
           }
 
-          const compiledAST = compileAST(currentArg, isLazy, isMeta, hasRange, {
+          const compiledAST = compileAST(currentArg, isMeta, hasRange, {
             functionName: ast.value.toUpperCase(),
             paramIndex: i + 1,
           });
-          listArgs.push(compiledAST);
+          compiledArgs.push(isLazy ? compiledAST.wrapInClosure() : compiledAST);
         }
       }
 
-      return listArgs;
+      return compiledArgs;
     }
 
     /**
@@ -227,123 +194,85 @@ export function compile(formula: string): CompiledFormula {
      * executable code for the evaluation of the cells content. It uses a cash to
      * not reevaluate identical code structures.
      *
-     * The function is sensitive to two parameters “isLazy” and “isMeta”. These
-     * parameters may vary when compiling function arguments:
-     *
-     * - isLazy: In some cases the function arguments does not need to be
-     * evaluated before entering the functions. For example the IF function might
-     * take invalid arguments that do not need to be evaluate and thus should not
-     * create an error. For this we have lazy arguments.
-     *
-     * - isMeta: In some cases the function arguments expects information on the
+     * The function is sensitive to parameter “isMeta”. This
+     * parameter may vary when compiling function arguments:
+     * isMeta: In some cases the function arguments expects information on the
      * cell/range other than the associated value(s). For example the COLUMN
      * function needs to receive as argument the coordinates of a cell rather
      * than its value. For this we have meta arguments.
      */
-
     function compileAST(
       ast: AST,
-      isLazy = false,
       isMeta = false,
       hasRange = false,
       referenceVerification: {
         functionName?: string;
         paramIndex?: number;
       } = {}
-    ): CompiledAST {
-      const codeBlocks: string[] = [];
-      let id, fnName, statement;
+    ): FunctionCode {
+      const code = new FunctionCodeBuilder(scope);
       if (ast.type !== "REFERENCE" && !(ast.type === "BIN_OPERATION" && ast.value === ":")) {
         if (isMeta) {
           throw new BadExpressionError(_lt(`Argument must be a reference to a cell or range.`));
         }
       }
       if (ast.debug) {
-        codeBlocks.push("debugger;");
+        code.append("debugger;");
       }
       switch (ast.type) {
         case "BOOLEAN":
-          if (!isLazy) {
-            return { id: `{ value: ${ast.value} }`, code: "" };
-          }
-          id = nextId++;
-          statement = `{ value: ${ast.value} }`;
-          break;
+          return code.return(`{ value: ${ast.value} }`);
         case "NUMBER":
-          id = nextId++;
-          statement = `{ value: this.constantValues.numbers[${constantValues.numbers.indexOf(
-            ast.value
-          )}] }`;
-          break;
+          return code.return(
+            `{ value: this.constantValues.numbers[${constantValues.numbers.indexOf(ast.value)}] }`
+          );
         case "STRING":
-          id = nextId++;
-          statement = `{ value: this.constantValues.strings[${constantValues.strings.indexOf(
-            ast.value
-          )}] }`;
-          break;
+          return code.return(
+            `{ value: this.constantValues.strings[${constantValues.strings.indexOf(ast.value)}] }`
+          );
         case "REFERENCE":
           const referenceIndex = dependencies.indexOf(ast.value);
-          id = nextId++;
           if (hasRange) {
-            statement = `range(deps[${referenceIndex}])`;
+            return code.return(`range(deps[${referenceIndex}])`);
           } else {
-            statement = `ref(deps[${referenceIndex}], ${isMeta ? "true" : "false"}, "${
-              referenceVerification.functionName || OPERATOR_MAP["="]
-            }",  ${referenceVerification.paramIndex})`;
+            return code.return(
+              `ref(deps[${referenceIndex}], ${isMeta ? "true" : "false"}, "${
+                referenceVerification.functionName || OPERATOR_MAP["="]
+              }",  ${referenceVerification.paramIndex})`
+            );
           }
-          break;
         case "FUNCALL":
-          id = nextId++;
-          const args = compileFunctionArgs(ast);
-          codeBlocks.push(args.map((arg) => arg.code).join("\n"));
-          fnName = ast.value.toUpperCase();
-          codeBlocks.push(`ctx.__lastFnCalled = '${fnName}';`);
-          statement = `ctx['${fnName}'](${args.map((arg) => arg.id)})`;
-          break;
+          const args = compileFunctionArgs(ast).map((arg) => arg.assignResultToVariable());
+          code.append(...args);
+          const fnName = ast.value.toUpperCase();
+          code.append(`ctx.__lastFnCalled = '${fnName}';`);
+          return code.return(`ctx['${fnName}'](${args.map((arg) => arg.returnExpression)})`);
         case "UNARY_OPERATION": {
-          id = nextId++;
-          fnName = UNARY_OPERATOR_MAP[ast.value];
-          const operand = compileAST(ast.operand, false, false, false, {
+          const fnName = UNARY_OPERATOR_MAP[ast.value];
+          const operand = compileAST(ast.operand, false, false, {
             functionName: fnName,
-          });
-          codeBlocks.push(operand.code);
-          codeBlocks.push(`ctx.__lastFnCalled = '${fnName}';`);
-          statement = `ctx['${fnName}'](${operand.id})`;
-          break;
+          }).assignResultToVariable();
+          code.append(operand);
+          code.append(`ctx.__lastFnCalled = '${fnName}';`);
+          return code.return(`ctx['${fnName}'](${operand.returnExpression})`);
         }
         case "BIN_OPERATION": {
-          id = nextId++;
-          fnName = OPERATOR_MAP[ast.value];
-          const left = compileAST(ast.left, false, false, false, {
+          const fnName = OPERATOR_MAP[ast.value];
+          const left = compileAST(ast.left, false, false, {
             functionName: fnName,
-          });
-          const right = compileAST(ast.right, false, false, false, {
+          }).assignResultToVariable();
+          const right = compileAST(ast.right, false, false, {
             functionName: fnName,
-          });
-          codeBlocks.push(left.code);
-          codeBlocks.push(right.code);
-          codeBlocks.push(`ctx.__lastFnCalled = '${fnName}';`);
-          statement = `ctx['${fnName}'](${left.id}, ${right.id})`;
-          break;
+          }).assignResultToVariable();
+          code.append(left);
+          code.append(right);
+          code.append(`ctx.__lastFnCalled = '${fnName}';`);
+          return code.return(
+            `ctx['${fnName}'](${left.returnExpression}, ${right.returnExpression})`
+          );
         }
         case "UNKNOWN":
-          if (!isLazy) {
-            return { id: "undefined", code: "" };
-          }
-          id = nextId++;
-          statement = `undefined`;
-          break;
-      }
-      if (isLazy) {
-        const lazyFunction =
-          `const _${id} = () => {\n` +
-          `\t${splitCodeLines(codeBlocks).join("\n\t")}\n` +
-          `\treturn ${statement};\n` +
-          "}";
-        return { id: `_${id}`, code: lazyFunction };
-      } else {
-        codeBlocks.push(`let _${id} = ${statement};`);
-        return { id: `_${id}`, code: codeBlocks.join("\n") };
+          return code.return("undefined");
       }
     }
   }

--- a/tests/formulas/__snapshots__/compiler.test.ts.snap
+++ b/tests/formulas/__snapshots__/compiler.test.ts.snap
@@ -4,12 +4,11 @@ exports[`compile functions with lazy arguments functions call requesting lazy pa
 "function anonymous(deps,ref,range,ctx
 ) {
 // =USELAZYARG(|N0|)
-const _2 = () => {
+const _1 = () => {
 	return { value: this.constantValues.numbers[0] };
 }
 ctx.__lastFnCalled = 'USELAZYARG';
-let _1 = ctx['USELAZYARG'](_2);
-return _1;
+return ctx['USELAZYARG'](_1);
 }"
 `;
 
@@ -17,15 +16,14 @@ exports[`compile functions with lazy arguments functions call requesting lazy pa
 "function anonymous(deps,ref,range,ctx
 ) {
 // =USELAZYARG(|N0|/|N1|)
-const _2 = () => {
-	let _3 = { value: this.constantValues.numbers[0] };
-	let _4 = { value: this.constantValues.numbers[1] };
+const _3 = () => {
+	const _1 = { value: this.constantValues.numbers[0] };
+	const _2 = { value: this.constantValues.numbers[1] };
 	ctx.__lastFnCalled = 'DIVIDE';
-	return ctx['DIVIDE'](_3, _4);
+	return ctx['DIVIDE'](_1, _2);
 }
 ctx.__lastFnCalled = 'USELAZYARG';
-let _1 = ctx['USELAZYARG'](_2);
-return _1;
+return ctx['USELAZYARG'](_3);
 }"
 `;
 
@@ -33,18 +31,17 @@ exports[`compile functions with lazy arguments functions call requesting lazy pa
 "function anonymous(deps,ref,range,ctx
 ) {
 // =USELAZYARG(|N0|/|N0|/|N1|)
-const _2 = () => {
-	let _4 = { value: this.constantValues.numbers[0] };
-	let _5 = { value: this.constantValues.numbers[0] };
+const _5 = () => {
+	const _1 = { value: this.constantValues.numbers[0] };
+	const _2 = { value: this.constantValues.numbers[0] };
 	ctx.__lastFnCalled = 'DIVIDE';
-	let _3 = ctx['DIVIDE'](_4, _5);
-	let _6 = { value: this.constantValues.numbers[1] };
+	const _3 = ctx['DIVIDE'](_1, _2);
+	const _4 = { value: this.constantValues.numbers[1] };
 	ctx.__lastFnCalled = 'DIVIDE';
-	return ctx['DIVIDE'](_3, _6);
+	return ctx['DIVIDE'](_3, _4);
 }
 ctx.__lastFnCalled = 'USELAZYARG';
-let _1 = ctx['USELAZYARG'](_2);
-return _1;
+return ctx['USELAZYARG'](_5);
 }"
 `;
 
@@ -53,15 +50,14 @@ exports[`compile functions with lazy arguments functions call requesting lazy pa
 ) {
 // =USELAZYARG(USELAZYARG(|N0|))
 const _2 = () => {
-	const _3 = () => {
+	const _1 = () => {
 		return { value: this.constantValues.numbers[0] };
 	}
 	ctx.__lastFnCalled = 'USELAZYARG';
-	return ctx['USELAZYARG'](_3);
+	return ctx['USELAZYARG'](_1);
 }
 ctx.__lastFnCalled = 'USELAZYARG';
-let _1 = ctx['USELAZYARG'](_2);
-return _1;
+return ctx['USELAZYARG'](_2);
 }"
 `;
 
@@ -69,10 +65,9 @@ exports[`compile functions with meta arguments function call requesting meta par
 "function anonymous(deps,ref,range,ctx
 ) {
 // =USEMETAARG(|0|)
-let _2 = ref(deps[0], true, \\"USEMETAARG\\",  1);
+const _1 = ref(deps[0], true, \\"USEMETAARG\\",  1);
 ctx.__lastFnCalled = 'USEMETAARG';
-let _1 = ctx['USEMETAARG'](_2);
-return _1;
+return ctx['USEMETAARG'](_1);
 }"
 `;
 
@@ -80,10 +75,9 @@ exports[`compile functions with meta arguments function call requesting meta par
 "function anonymous(deps,ref,range,ctx
 ) {
 // =USEMETAARG(|0|)
-let _2 = ref(deps[0], true, \\"USEMETAARG\\",  1);
+const _1 = ref(deps[0], true, \\"USEMETAARG\\",  1);
 ctx.__lastFnCalled = 'USEMETAARG';
-let _1 = ctx['USEMETAARG'](_2);
-return _1;
+return ctx['USEMETAARG'](_1);
 }"
 `;
 
@@ -91,10 +85,9 @@ exports[`expression compiler cells are converted to ranges if function require a
 "function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|0|)
-let _2 = range(deps[0]);
+const _1 = range(deps[0]);
 ctx.__lastFnCalled = 'SUM';
-let _1 = ctx['SUM'](_2);
-return _1;
+return ctx['SUM'](_1);
 }"
 `;
 
@@ -102,14 +95,13 @@ exports[`expression compiler expression with $ref 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|0|+|1|+|2|
-let _3 = ref(deps[0], false, \\"ADD\\",  undefined);
-let _4 = ref(deps[1], false, \\"ADD\\",  undefined);
+const _1 = ref(deps[0], false, \\"ADD\\",  undefined);
+const _2 = ref(deps[1], false, \\"ADD\\",  undefined);
 ctx.__lastFnCalled = 'ADD';
-let _2 = ctx['ADD'](_3, _4);
-let _5 = ref(deps[2], false, \\"ADD\\",  undefined);
+const _3 = ctx['ADD'](_1, _2);
+const _4 = ref(deps[2], false, \\"ADD\\",  undefined);
 ctx.__lastFnCalled = 'ADD';
-let _1 = ctx['ADD'](_2, _5);
-return _1;
+return ctx['ADD'](_3, _4);
 }"
 `;
 
@@ -117,8 +109,7 @@ exports[`expression compiler expression with references with a sheet 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|0|
-let _1 = ref(deps[0], false, \\"EQ\\",  undefined);
-return _1;
+return ref(deps[0], false, \\"EQ\\",  undefined);
 }"
 `;
 
@@ -127,11 +118,10 @@ exports[`expression compiler expressions with a debugger 1`] = `
 ) {
 // =?|0|/|N0|
 debugger;
-let _2 = ref(deps[0], false, \\"DIVIDE\\",  undefined);
-let _3 = { value: this.constantValues.numbers[0] };
+const _1 = ref(deps[0], false, \\"DIVIDE\\",  undefined);
+const _2 = { value: this.constantValues.numbers[0] };
 ctx.__lastFnCalled = 'DIVIDE';
-let _1 = ctx['DIVIDE'](_2, _3);
-return _1;
+return ctx['DIVIDE'](_1, _2);
 }"
 `;
 
@@ -139,13 +129,12 @@ exports[`expression compiler read some values and functions 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|0|+sum(|1|)
-let _2 = ref(deps[0], false, \\"ADD\\",  undefined);
-let _4 = range(deps[1]);
+const _1 = ref(deps[0], false, \\"ADD\\",  undefined);
+const _2 = range(deps[1]);
 ctx.__lastFnCalled = 'SUM';
-let _3 = ctx['SUM'](_4);
+const _3 = ctx['SUM'](_2);
 ctx.__lastFnCalled = 'ADD';
-let _1 = ctx['ADD'](_2, _3);
-return _1;
+return ctx['ADD'](_1, _3);
 }"
 `;
 
@@ -153,8 +142,7 @@ exports[`expression compiler some arithmetic expressions 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|
-let _1 = { value: this.constantValues.numbers[0] };
-return _1;
+return { value: this.constantValues.numbers[0] };
 }"
 `;
 
@@ -170,8 +158,7 @@ exports[`expression compiler some arithmetic expressions 3`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|S0|
-let _1 = { value: this.constantValues.strings[0] };
-return _1;
+return { value: this.constantValues.strings[0] };
 }"
 `;
 
@@ -179,11 +166,10 @@ exports[`expression compiler some arithmetic expressions 4`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|+|N1|
-let _2 = { value: this.constantValues.numbers[0] };
-let _3 = { value: this.constantValues.numbers[1] };
+const _1 = { value: this.constantValues.numbers[0] };
+const _2 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'ADD';
-let _1 = ctx['ADD'](_2, _3);
-return _1;
+return ctx['ADD'](_1, _2);
 }"
 `;
 
@@ -191,11 +177,10 @@ exports[`expression compiler some arithmetic expressions 5`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|*|N1|
-let _2 = { value: this.constantValues.numbers[0] };
-let _3 = { value: this.constantValues.numbers[1] };
+const _1 = { value: this.constantValues.numbers[0] };
+const _2 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'MULTIPLY';
-let _1 = ctx['MULTIPLY'](_2, _3);
-return _1;
+return ctx['MULTIPLY'](_1, _2);
 }"
 `;
 
@@ -203,11 +188,10 @@ exports[`expression compiler some arithmetic expressions 6`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|-|N1|
-let _2 = { value: this.constantValues.numbers[0] };
-let _3 = { value: this.constantValues.numbers[1] };
+const _1 = { value: this.constantValues.numbers[0] };
+const _2 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'MINUS';
-let _1 = ctx['MINUS'](_2, _3);
-return _1;
+return ctx['MINUS'](_1, _2);
 }"
 `;
 
@@ -215,11 +199,10 @@ exports[`expression compiler some arithmetic expressions 7`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|/|N1|
-let _2 = { value: this.constantValues.numbers[0] };
-let _3 = { value: this.constantValues.numbers[1] };
+const _1 = { value: this.constantValues.numbers[0] };
+const _2 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'DIVIDE';
-let _1 = ctx['DIVIDE'](_2, _3);
-return _1;
+return ctx['DIVIDE'](_1, _2);
 }"
 `;
 
@@ -227,10 +210,9 @@ exports[`expression compiler some arithmetic expressions 8`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =-|N0|
-let _2 = { value: this.constantValues.numbers[0] };
+const _1 = { value: this.constantValues.numbers[0] };
 ctx.__lastFnCalled = 'UMINUS';
-let _1 = ctx['UMINUS'](_2);
-return _1;
+return ctx['UMINUS'](_1);
 }"
 `;
 
@@ -238,19 +220,18 @@ exports[`expression compiler some arithmetic expressions 9`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =(|N0|+|N1|)*(-|N1|+|N2|)
-let _3 = { value: this.constantValues.numbers[0] };
-let _4 = { value: this.constantValues.numbers[1] };
+const _1 = { value: this.constantValues.numbers[0] };
+const _2 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'ADD';
-let _2 = ctx['ADD'](_3, _4);
-let _7 = { value: this.constantValues.numbers[1] };
+const _3 = ctx['ADD'](_1, _2);
+const _4 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'UMINUS';
-let _6 = ctx['UMINUS'](_7);
-let _8 = { value: this.constantValues.numbers[2] };
+const _5 = ctx['UMINUS'](_4);
+const _6 = { value: this.constantValues.numbers[2] };
 ctx.__lastFnCalled = 'ADD';
-let _5 = ctx['ADD'](_6, _8);
+const _7 = ctx['ADD'](_5, _6);
 ctx.__lastFnCalled = 'MULTIPLY';
-let _1 = ctx['MULTIPLY'](_2, _5);
-return _1;
+return ctx['MULTIPLY'](_3, _7);
 }"
 `;
 
@@ -258,11 +239,10 @@ exports[`expression compiler some arithmetic expressions 10`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|N0|,|N1|)
-let _2 = { value: this.constantValues.numbers[0] };
-let _3 = { value: this.constantValues.numbers[1] };
+const _1 = { value: this.constantValues.numbers[0] };
+const _2 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'SUM';
-let _1 = ctx['SUM'](_2,_3);
-return _1;
+return ctx['SUM'](_1,_2);
 }"
 `;
 
@@ -270,10 +250,10 @@ exports[`expression compiler some arithmetic expressions 11`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =sum(true,|S0|)
-let _2 = { value: this.constantValues.strings[0] };
+const _1 = { value: true };
+const _2 = { value: this.constantValues.strings[0] };
 ctx.__lastFnCalled = 'SUM';
-let _1 = ctx['SUM']({ value: true },_2);
-return _1;
+return ctx['SUM'](_1,_2);
 }"
 `;
 
@@ -281,11 +261,11 @@ exports[`expression compiler some arithmetic expressions 12`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =sum(|N0|,,|N1|)
-let _2 = { value: this.constantValues.numbers[0] };
-let _3 = { value: this.constantValues.numbers[1] };
+const _1 = { value: this.constantValues.numbers[0] };
+const _2 = undefined;
+const _3 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'SUM';
-let _1 = ctx['SUM'](_2,undefined,_3);
-return _1;
+return ctx['SUM'](_1,_2,_3);
 }"
 `;
 
@@ -293,10 +273,9 @@ exports[`expression compiler some arithmetic expressions 13`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|N0|%
-let _2 = { value: this.constantValues.numbers[0] };
+const _1 = { value: this.constantValues.numbers[0] };
 ctx.__lastFnCalled = 'UNARY.PERCENT';
-let _1 = ctx['UNARY.PERCENT'](_2);
-return _1;
+return ctx['UNARY.PERCENT'](_1);
 }"
 `;
 
@@ -304,13 +283,12 @@ exports[`expression compiler some arithmetic expressions 14`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =(|N0|+|N1|)%
-let _3 = { value: this.constantValues.numbers[0] };
-let _4 = { value: this.constantValues.numbers[1] };
+const _1 = { value: this.constantValues.numbers[0] };
+const _2 = { value: this.constantValues.numbers[1] };
 ctx.__lastFnCalled = 'ADD';
-let _2 = ctx['ADD'](_3, _4);
+const _3 = ctx['ADD'](_1, _2);
 ctx.__lastFnCalled = 'UNARY.PERCENT';
-let _1 = ctx['UNARY.PERCENT'](_2);
-return _1;
+return ctx['UNARY.PERCENT'](_3);
 }"
 `;
 
@@ -318,10 +296,9 @@ exports[`expression compiler some arithmetic expressions 15`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =|0|%
-let _2 = ref(deps[0], false, \\"UNARY.PERCENT\\",  undefined);
+const _1 = ref(deps[0], false, \\"UNARY.PERCENT\\",  undefined);
 ctx.__lastFnCalled = 'UNARY.PERCENT';
-let _1 = ctx['UNARY.PERCENT'](_2);
-return _1;
+return ctx['UNARY.PERCENT'](_1);
 }"
 `;
 
@@ -329,11 +306,10 @@ exports[`expression compiler with the same reference multiple times 1`] = `
 "function anonymous(deps,ref,range,ctx
 ) {
 // =SUM(|0|,|0|,|2|)
-let _2 = range(deps[0]);
-let _3 = range(deps[0]);
-let _4 = range(deps[2]);
+const _1 = range(deps[0]);
+const _2 = range(deps[0]);
+const _3 = range(deps[2]);
 ctx.__lastFnCalled = 'SUM';
-let _1 = ctx['SUM'](_2,_3,_4);
-return _1;
+return ctx['SUM'](_1,_2,_3);
 }"
 `;


### PR DESCRIPTION
The goal here is to have more flexibility in the way we
assign (or not) intermediate compiled AST nodes to a variable before
using it later. This prepares the ground for automatic function argument
casting.

Currently, `compileAST` function decides to assign the result or not.

Notice how `isLazy` parameter of `compileAST` is used.
One of its effect is to assign (or not) the result to a variable
for the caller to use. (how is that linked to laziness? [🧐](https://emojipedia.org/face-with-monocle/))
It should be the caller's responsibility to do it. Only the caller
knows what it will do with the result and if it makes sense or not.

This brings noise to `compileAST` with early returns and temporary
`statement` variable.

It allows to remove `isLazy` from `compileAST`'s parameters.
That makes sense because laziness only makes sense when compiling function
arguments. It is not a property of any AST node itself.
Now laziness is located in `compileFunctionArgs` only.
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo