### PR TITLE
[IMP] selection: selecting row/col now add full unbounded range

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -206,6 +206,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.coreGetters.getRangeDataFromXc = this.range.getRangeDataFromXc.bind(this.range);
     this.coreGetters.getRangeDataFromZone = this.range.getRangeDataFromZone.bind(this.range);
     this.coreGetters.getRangeFromRangeData = this.range.getRangeFromRangeData.bind(this.range);
+    this.coreGetters.getRangeFromZone = this.range.getRangeFromZone.bind(this.range);
 
     this.getters = {
       isReadonly: () => this.config.mode === "readonly" || this.config.mode === "dashboard",

--- a/src/model.ts
+++ b/src/model.ts
@@ -206,7 +206,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.coreGetters.getRangeDataFromXc = this.range.getRangeDataFromXc.bind(this.range);
     this.coreGetters.getRangeDataFromZone = this.range.getRangeDataFromZone.bind(this.range);
     this.coreGetters.getRangeFromRangeData = this.range.getRangeFromRangeData.bind(this.range);
-    this.coreGetters.getSelectionRangeString = this.range.getSelectionRangeString.bind(this.range);
 
     this.getters = {
       isReadonly: () => this.config.mode === "readonly" || this.config.mode === "dashboard",

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -36,7 +36,6 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
 
   static getters = [
     "getRangeString",
-    "getSelectionRangeString",
     "getRangeFromSheetXC",
     "createAdaptedRanges",
     "getRangeDataFromXc",
@@ -319,22 +318,6 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     const rangeInterface = { prefixSheet, zone, sheetId, invalidSheetName, parts };
 
     return new RangeImpl(rangeInterface, this.getters.getSheetSize).orderZone();
-  }
-
-  /**
-   * Same as `getRangeString` but add all necessary merge to the range to make it a valid selection
-   */
-  getSelectionRangeString(range: Range, forSheetId: UID): string {
-    const rangeImpl = RangeImpl.fromRange(range, this.getters);
-    const expandedZone = this.getters.expandZone(rangeImpl.sheetId, rangeImpl.zone);
-    const expandedRange = rangeImpl.clone({
-      zone: {
-        ...expandedZone,
-        bottom: rangeImpl.isFullCol ? undefined : expandedZone.bottom,
-        right: rangeImpl.isFullRow ? undefined : expandedZone.right,
-      },
-    });
-    return this.getRangeString(expandedRange, forSheetId);
   }
 
   /**

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -24,6 +24,7 @@ import {
   RangeData,
   RangeProvider,
   UID,
+  UnboundedZone,
   Zone,
 } from "../../types/index";
 
@@ -41,6 +42,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     "getRangeDataFromXc",
     "getRangeDataFromZone",
     "getRangeFromRangeData",
+    "getRangeFromZone",
   ] as const;
 
   // ---------------------------------------------------------------------------
@@ -382,6 +384,21 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
 
   getRangeDataFromZone(sheetId: UID, zone: Zone): RangeData {
     return { _sheetId: sheetId, _zone: zone };
+  }
+
+  getRangeFromZone(sheetId: UID, zone: UnboundedZone): Range {
+    return new RangeImpl(
+      {
+        sheetId,
+        zone,
+        parts: [
+          { colFixed: false, rowFixed: false },
+          { colFixed: false, rowFixed: false },
+        ],
+        prefixSheet: false,
+      },
+      this.getters.getSheetSize
+    );
   }
 
   getRangeFromRangeData(data: RangeData): Range {

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -29,6 +29,7 @@ import {
   Sheet,
   SheetData,
   UID,
+  UnboundedZone,
   UpdateCellPositionCommand,
   WorkbookData,
   Zone,
@@ -71,6 +72,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "getPaneDivisions",
     "checkZonesExistInSheet",
     "getCommandZones",
+    "getUnboundedZone",
   ] as const;
 
   readonly sheetIdsMapName: Record<string, UID | undefined> = {};
@@ -446,6 +448,16 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
       left: 0,
       bottom: this.getNumberRows(sheetId) - 1,
       right: this.getNumberCols(sheetId) - 1,
+    };
+  }
+
+  getUnboundedZone(sheetId: UID, zone: Zone): UnboundedZone {
+    const isFullRow = zone.left === 0 && zone.right === this.getNumberCols(sheetId) - 1;
+    const isFullCol = zone.top === 0 && zone.bottom === this.getNumberRows(sheetId) - 1;
+    return {
+      ...zone,
+      right: isFullRow ? undefined : zone.right,
+      bottom: isFullCol ? undefined : zone.bottom,
     };
   }
 

--- a/src/plugins/ui_feature/selection_input.ts
+++ b/src/plugins/ui_feature/selection_input.ts
@@ -1,10 +1,4 @@
-import {
-  colors,
-  getCanonicalSheetName,
-  positionToZone,
-  splitReference,
-  zoneToXc,
-} from "../../helpers/index";
+import { colors, positionToZone, splitReference } from "../../helpers/index";
 import { StreamCallbacks } from "../../selection_stream/event_stream";
 import { SelectionEvent } from "../../types/event_stream";
 import {
@@ -81,11 +75,14 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
   }
 
   handleEvent(event: SelectionEvent) {
-    const xc = zoneToXc(event.anchor.zone);
     const inputSheetId = this.activeSheet;
     const sheetId = this.getters.getActiveSheetId();
-    const sheetName = this.getters.getSheetName(sheetId);
-    this.add([sheetId === inputSheetId ? xc : `${getCanonicalSheetName(sheetName)}!${xc}`]);
+    const zone = event.anchor.zone;
+    const range = this.getters.getRangeFromZone(
+      sheetId,
+      event.type === "HeadersSelected" ? this.getters.getUnboundedZone(sheetId, zone) : zone
+    );
+    this.add([this.getters.getSelectionRangeString(range, inputSheetId)]);
   }
 
   handle(cmd: Command) {

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -459,6 +459,20 @@ describe("ranges and highlights", () => {
       expect(composerEl.textContent).toBe("=SUM($B$1:$B$2)");
     });
   });
+
+  test("Can select full column as unbounded zone", async () => {
+    composerEl = await typeInComposer("=");
+    model.selection.selectColumn(2, "newAnchor");
+    await nextTick();
+    expect(composerEl.textContent).toBe("=C:C");
+  });
+
+  test("Can select full row as unbounded zone", async () => {
+    composerEl = await typeInComposer("=");
+    model.selection.selectRow(2, "newAnchor");
+    await nextTick();
+    expect(composerEl.textContent).toBe("=3:3");
+  });
 });
 
 describe("composer", () => {

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -2,7 +2,13 @@ import { App, Component, onMounted, onWillUnmount, useSubEnv, xml } from "@odoo/
 import { Model } from "../../src";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/actions/menu_items_actions";
 import { SelectionInput } from "../../src/components/selection_input/selection_input";
-import { activateSheet, createSheet, selectCell, undo } from "../test_helpers/commands_helpers";
+import {
+  activateSheet,
+  createSheet,
+  merge,
+  selectCell,
+  undo,
+} from "../test_helpers/commands_helpers";
 import {
   clickCell,
   keyDown,
@@ -187,6 +193,34 @@ describe("Selection Input", () => {
     expect(fixture.querySelectorAll("input")[0].getAttribute("style")).toBe(`color: ${color};`);
     expect(fixture.querySelectorAll("input")[1].value).toBe("B5");
     expect(fixture.querySelectorAll("input")[1].getAttribute("style")).toBe(`color: ${color2};`);
+  });
+
+  test("can select full column as unbounded zone by clicking on header", async () => {
+    const { model } = await createSelectionInput();
+    model.selection.selectColumn(3, "overrideSelection");
+    await nextTick();
+    expect(fixture.querySelector("input")!.value).toBe("D:D");
+  });
+
+  test("can select full row as unbounded zone by clicking on header", async () => {
+    const { model } = await createSelectionInput();
+    model.selection.selectRow(2, "overrideSelection");
+    await nextTick();
+    expect(fixture.querySelector("input")!.value).toBe("3:3");
+  });
+
+  test("can correctly select a merged zone", async () => {
+    const { model } = await createSelectionInput();
+    merge(model, "A1:B2");
+    model.selection.selectCell(0, 0);
+    await nextTick();
+    expect(fixture.querySelector("input")!.value).toBe("A1");
+    model.selection.selectZone({
+      cell: { col: 0, row: 0 },
+      zone: { top: 0, left: 0, bottom: 1, right: 1 },
+    });
+    await nextTick();
+    expect(fixture.querySelector("input")!.value).toBe("A1");
   });
 
   test("ctrl + select cell --> add new input", async () => {

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -92,10 +92,10 @@ describe("selection input plugin", () => {
     model.dispatch("PREPARE_SELECTION_INPUT_EXPANSION");
     selectCell(model, "A4");
     setAnchorCorner(model, "A3");
-    expect(model.getters.getSelectionInput(id)[0].xc).toBe("A2:A4");
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("A2");
     expect(highlightedZones(model)).toStrictEqual(["A2:A4"]);
     setAnchorCorner(model, "A2");
-    expect(model.getters.getSelectionInput(id)[0].xc).toBe("A2:A4");
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("A2");
     expect(highlightedZones(model)).toStrictEqual(["A2:A4"]);
   });
 

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -1007,4 +1007,24 @@ describe("sheets", () => {
     expect(addColumns(model, "after", "A", 0)).toBeCancelledBecause(CommandResult.InvalidQuantity);
     expect(addRows(model, "after", 0, -1)).toBeCancelledBecause(CommandResult.InvalidQuantity);
   });
+  test("GetUnboundedZone works as expected > Range without any full col/row", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
+    const sheetId = model.getters.getActiveSheetId();
+    const zone = toZone("A1:E5");
+    expect(model.getters.getUnboundedZone(sheetId, zone)).toEqual(zone);
+  });
+
+  test("GetUnboundedZone works as expected > Range with a full row", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
+    const sheetId = model.getters.getActiveSheetId();
+    const zone = toZone("A1:A10");
+    expect(model.getters.getUnboundedZone(sheetId, zone)).toEqual({ ...zone, bottom: undefined });
+  });
+
+  test("GetUnboundedZone works as expected > Range with a full col", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
+    const sheetId = model.getters.getActiveSheetId();
+    const zone = toZone("A1:J1");
+    expect(model.getters.getUnboundedZone(sheetId, zone)).toEqual({ ...zone, right: undefined });
+  });
 });


### PR DESCRIPTION
## Task Description

When selecting a range and clicking on a col/row header, the added range should be a full unbounded range (ie `A:A` or `1:1`). ATM, the resulting range is simply bounded to the maximum available cell (ie `A1:A100` or `A1:Z1`).

## Related Task
Odoo task ID : [3076514](https://www.odoo.com/web#id=3076514&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo