### PR TITLE
[FIX] grid_overlay: properly detect grid overlay resize

### DIFF
--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -1,4 +1,4 @@
-import { Component, onMounted, onWillUnmount, useEffect, useRef } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, useRef } from "@odoo/owl";
 import {
   DOMCoordinates,
   DOMDimension,
@@ -164,14 +164,15 @@ export class GridOverlay extends Component<Props> {
   setup() {
     this.gridOverlay = useRef("gridOverlay");
     useCellHovered(this.env, this.gridOverlay, this.props.onCellHovered);
-    useEffect(
-      () =>
-        this.props.onGridResized({
-          height: this.gridOverlayEl.clientHeight,
-          width: this.gridOverlayEl.clientWidth,
-        }),
-      () => [this.gridOverlayEl.clientHeight, this.gridOverlayEl.clientWidth]
-    );
+    const resizeObserver = new ResizeObserver(() => {
+      this.props.onGridResized({
+        height: this.gridOverlayEl.clientHeight,
+        width: this.gridOverlayEl.clientWidth,
+      });
+    });
+    onMounted(() => {
+      resizeObserver.observe(this.gridOverlayEl);
+    });
     useTouchMove(this.gridOverlay, this.props.onGridMoved, () => {
       const { offsetScrollbarY } = this.env.model.getters.getActiveSheetScrollInfo();
       return offsetScrollbarY > 0;

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -1285,8 +1285,9 @@ describe("Events on Grid update viewport correctly", () => {
     // mock a resizing of the grid DOM element. can occur if resizing the browser or opening the sidePanel
     jest.spyOn(HTMLDivElement.prototype, "clientWidth", "get").mockImplementation(() => 800);
     jest.spyOn(HTMLDivElement.prototype, "clientHeight", "get").mockImplementation(() => 650);
-    // force a rerendering to pass through patched() of the Grid component.
-    parent.render(true);
+    // force a triggering of all resizeObservers to ensure the grid is resized
+    //@ts-ignore
+    window.resizers.resize();
     await nextTick();
 
     expect(model.getters.getSheetViewDimension()).toMatchObject({
@@ -1313,11 +1314,6 @@ describe("Events on Grid update viewport correctly", () => {
     expect(model.getters.getActiveMainViewport()).toMatchObject(viewport);
     await clickCell(model, "Y1", { shiftKey: true });
     expect(model.getters.getActiveMainViewport()).toMatchObject(viewport);
-  });
-
-  test("resize event handler is removed", () => {
-    app.destroy();
-    window.dispatchEvent(new Event("resize"));
   });
 });
 

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -75,6 +75,9 @@ async function createScorecardChart(
   createScorecardChartHelper(model, data, chartId, sheetId);
   await nextTick();
   // second tick required for the useEffect to be effective
+  // force a triggering of all resizeObservers to ensure the chart is resized
+  //@ts-ignore
+  window.resizers.resize();
   await nextTick();
 }
 
@@ -89,6 +92,9 @@ async function updateScorecardChartSize(width: number, height: number) {
   });
   figureRect.width = width;
   figureRect.height = height;
+  // force a triggering of all resizeObservers to ensure the chart is resized
+  //@ts-ignore
+  window.resizers.resize();
   await nextTick();
 }
 
@@ -159,6 +165,10 @@ describe("Scorecard charts", () => {
     await dragElement(".o-fig-resizer.o-topLeft", 300, 200);
     expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("236px");
     expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("135px");
+    // force a triggering of all resizeObservers to ensure the grid is resized
+    //@ts-ignore
+    window.resizers.resize();
+    await nextTick();
     expect(getChartElement()).toMatchSnapshot();
   });
 

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -7,6 +7,7 @@ import "./jest_extend";
 import "./resize_observer.mock";
 
 export let OWL_TEMPLATES: Document;
+
 beforeAll(async () => {
   OWL_TEMPLATES = await getParsedOwlTemplateBundle();
 });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -64,8 +64,6 @@ Scheduler.requestAnimationFrame = function (callback: FrameRequestCallback) {
 };
 
 export async function nextTick(): Promise<void> {
-  //@ts-ignore
-  window.resizers.resize();
   await new Promise((resolve) => realTimeSetTimeout(resolve));
   await new Promise((resolve) => Scheduler.requestAnimationFrame(resolve));
 }


### PR DESCRIPTION
## Description:

Before https://github.com/odoo/o-spreadsheet/commit/be10c88968538135d197e2ded1603777a23f9e2d, the opening/closing of the side panel would update the
props of `GridOverlay`, which in turn would trigger the useEffect that
updated the plugin sheetview size. Unfortunately, the aforementioned
commit removed that props, which means `GridOverlay` was no longer
patched.

This commit proposes to rather rely on the web API `ResizeObserver`
whose role is to report the change of size of any observed `Element`.
This will act as an external listener, hence we don't need for
`GridOverlay` to be rendered in order to acknowledge its change of size
in the browser.

Task 3125767

Odoo task ID : [3125767](https://www.odoo.com/web#id=3125767&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo