### PR TITLE
[IMP] components: prevent mouse event defaults on drag-and-drop

### DIFF
--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -9,23 +9,32 @@ export function startDnd(
   onMouseUp: EventFn,
   onMouseDown: EventFn = () => {}
 ) {
+  const _onMouseDown = (ev: MouseEvent) => {
+    ev.preventDefault();
+    onMouseDown(ev);
+  };
+  const _onMouseMove = (ev: MouseEvent) => {
+    ev.preventDefault();
+    onMouseMove(ev);
+  };
   const _onMouseUp = (ev: MouseEvent) => {
+    ev.preventDefault();
     onMouseUp(ev);
 
-    window.removeEventListener("mousedown", onMouseDown);
+    window.removeEventListener("mousedown", _onMouseDown);
     window.removeEventListener("mouseup", _onMouseUp);
     window.removeEventListener("dragstart", _onDragStart);
-    window.removeEventListener("mousemove", onMouseMove);
-    window.removeEventListener("wheel", onMouseMove);
+    window.removeEventListener("mousemove", _onMouseMove);
+    window.removeEventListener("wheel", _onMouseMove);
   };
   function _onDragStart(ev: DragEvent) {
     ev.preventDefault();
   }
-  window.addEventListener("mousedown", onMouseDown);
+  window.addEventListener("mousedown", _onMouseDown);
   window.addEventListener("mouseup", _onMouseUp);
   window.addEventListener("dragstart", _onDragStart);
-  window.addEventListener("mousemove", onMouseMove);
-  window.addEventListener("wheel", onMouseMove);
+  window.addEventListener("mousemove", _onMouseMove);
+  window.addEventListener("wheel", _onMouseMove);
 }
 
 /**


### PR DESCRIPTION
The default behaviours of the mouse events could have a side effect because it would affect the document active element. For instance, when selecting the cells of a formulas (i.e. while editing a cell), the mouse move events would select the text inside the composer as it it is still the active element at that moment.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo