### PR TITLE
[FIX] Reference: Support sheet names containing exclamation points

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -2,7 +2,7 @@ import { Component, onMounted, onPatched, onWillUnmount, useRef, useState } from
 import { ComponentsImportance, SELECTION_BORDER_COLOR } from "../../../constants";
 import { EnrichedToken } from "../../../formulas/index";
 import { functionRegistry } from "../../../functions/index";
-import { isEqual, rangeReference, zoneToDimension } from "../../../helpers/index";
+import { isEqual, rangeReference, splitReference, zoneToDimension } from "../../../helpers/index";
 import { ComposerSelection, SelectionIndicator } from "../../../plugins/ui/edition";
 import { DOMDimension, FunctionDescription, Rect, SpreadsheetChildEnv } from "../../../types/index";
 import { css } from "../../helpers/css";
@@ -442,8 +442,8 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
           result.push({ value: token.value, color: tokenColor[token.type] || "#000" });
           break;
         case "REFERENCE":
-          const [xc, sheet] = token.value.split("!").reverse() as [string, string | undefined];
-          result.push({ value: token.value, color: this.rangeColor(xc, sheet) || "#000" });
+          const { xc, sheetName } = splitReference(token.value);
+          result.push({ value: token.value, color: this.rangeColor(xc, sheetName) || "#000" });
           break;
         case "SYMBOL":
           let value = token.value;
@@ -512,7 +512,7 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
     if (content.startsWith("=")) {
       const tokenAtCursor = this.env.model.getters.getTokenAtCursor();
       if (tokenAtCursor) {
-        const [xc] = tokenAtCursor.value.split("!").reverse();
+        const { xc } = splitReference(tokenAtCursor.value);
         if (
           tokenAtCursor.type === "FUNCTION" ||
           (tokenAtCursor.type === "SYMBOL" && !rangeReference.test(xc))

--- a/src/helpers/reference_type.ts
+++ b/src/helpers/reference_type.ts
@@ -1,5 +1,6 @@
 // Helper file for the reference types in Xcs (the $ symbol, eg. A$1)
 import { Token } from "../formulas";
+import { splitReference } from "./references";
 
 type FixedReferenceType = "col" | "row" | "colrow" | "none";
 
@@ -12,10 +13,10 @@ type FixedReferenceType = "col" | "row" | "colrow" | "none";
  */
 export function loopThroughReferenceType(token: Readonly<Token>): Token {
   if (token.type !== "REFERENCE") return token;
-  const [range, sheet] = token.value.split("!").reverse() as [string, string | undefined];
-  const [left, right] = range.split(":") as [string, string | undefined];
+  const { xc, sheetName } = splitReference(token.value);
+  const [left, right] = xc.split(":") as [string, string | undefined];
 
-  const sheetRef = sheet ? `${sheet}!` : "";
+  const sheetRef = sheetName ? `${sheetName}!` : "";
   const updatedLeft = getTokenNextReferenceType(left);
   const updatedRight = right ? `:${getTokenNextReferenceType(right)}` : "";
   return { ...token, value: sheetRef + updatedLeft + updatedRight };

--- a/src/helpers/references.ts
+++ b/src/helpers/references.ts
@@ -1,3 +1,5 @@
+import { getUnquotedSheetName } from "./misc";
+
 /** Reference of a cell (eg. A1, $B$5) */
 export const cellReference = new RegExp(/\$?([A-Z]{1,3})\$?([0-9]{1,7})/, "i");
 
@@ -53,4 +55,11 @@ export function isColHeader(str: string): boolean {
  */
 export function isSingleCellReference(xc: string): boolean {
   return singleCellReference.test(xc);
+}
+
+export function splitReference(ref: string): { sheetName?: string; xc: string } {
+  const parts = ref.split("!");
+  const xc = parts.pop()!;
+  const sheetName = getUnquotedSheetName(parts.join("!")) || undefined;
+  return { sheetName, xc };
 }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -8,6 +8,7 @@ import {
   numberToLetters,
   RangeImpl,
   rangeReference,
+  splitReference,
   toUnboundedZone,
 } from "../../helpers/index";
 import {
@@ -300,16 +301,17 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
       );
     }
 
-    let sheetName = "";
+    let sheetName: string | undefined;
+    let xc = sheetXC;
     let prefixSheet = false;
     if (sheetXC.includes("!")) {
-      [sheetXC, sheetName] = sheetXC.split("!").reverse();
+      ({ xc, sheetName } = splitReference(sheetXC));
       if (sheetName) {
         prefixSheet = true;
       }
     }
-    const zone = toUnboundedZone(sheetXC);
-    const parts = RangeImpl.getRangeParts(sheetXC, zone);
+    const zone = toUnboundedZone(xc);
+    const parts = RangeImpl.getRangeParts(xc, zone);
     const invalidSheetName =
       sheetName && !this.getters.getSheetIdByName(sheetName) ? sheetName : undefined;
     const sheetId = this.getters.getSheetIdByName(sheetName) || defaultSheetId;

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -9,6 +9,7 @@ import {
   isNumber,
   markdownLink,
   positionToZone,
+  splitReference,
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
 } from "../../helpers/index";
@@ -158,8 +159,7 @@ export class EditionPlugin extends UIPlugin {
         const previousRefToken = this.currentTokens
           .filter((token) => token.type === "REFERENCE")
           .find((token) => {
-            let value = token.value;
-            const [xc, sheet] = value.split("!").reverse();
+            const { xc, sheetName: sheet } = splitReference(token.value);
             const sheetName = sheet || this.getters.getSheetName(this.sheetId);
             const activeSheetId = this.getters.getActiveSheetId();
             if (this.getters.getSheetName(activeSheetId) !== sheetName) {

--- a/src/plugins/ui/selection_input.ts
+++ b/src/plugins/ui/selection_input.ts
@@ -2,6 +2,7 @@ import {
   getComposerSheetName,
   getNextColor,
   positionToZone,
+  splitReference,
   UuidGenerator,
   zoneToXc,
 } from "../../helpers/index";
@@ -242,7 +243,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
       .filter((range) => this.getters.isRangeValid(range))
       .filter((reference) => this.shouldBeHighlighted(this.activeSheet, reference));
     return XCs.map((xc) => {
-      const [, sheetName] = xc.split("!").reverse();
+      const { sheetName } = splitReference(xc);
       return {
         zone: this.getters.getRangeFromSheetXC(this.activeSheet, xc).zone,
         sheetId: (sheetName && this.getters.getSheetIdByName(sheetName)) || this.activeSheet,
@@ -267,7 +268,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
    * the current active sheet.
    */
   private shouldBeHighlighted(inputSheetId: UID, reference: string): boolean {
-    const sheetName = reference.split("!").reverse()[1];
+    const { sheetName } = splitReference(reference);
     const sheetId = this.getters.getSheetIdByName(sheetName);
     const activeSheetId = this.getters.getActiveSheet().id;
     const valid = this.getters.isRangeValid(reference);

--- a/src/plugins/ui/selection_inputs_manager.ts
+++ b/src/plugins/ui/selection_inputs_manager.ts
@@ -1,4 +1,4 @@
-import { positionToZone, rangeReference } from "../../helpers/index";
+import { positionToZone, rangeReference, splitReference } from "../../helpers/index";
 import { ModelConfig } from "../../model";
 import { SelectionStreamProcessor } from "../../selection_stream/selection_stream_processor";
 import { StateObserver } from "../../state_observer";
@@ -126,14 +126,14 @@ export class SelectionInputsManagerPlugin extends UIPlugin {
     );
   }
 
-  isRangeValid(xc: string): boolean {
-    if (!xc) {
+  isRangeValid(reference: string): boolean {
+    if (!reference) {
       return false;
     }
-    const [rangeXc, sheetName] = xc.split("!").reverse();
+    const { xc, sheetName } = splitReference(reference);
     return (
-      rangeXc.match(rangeReference) !== null &&
-      (sheetName === undefined || this.getters.getSheetIdByName(sheetName) !== undefined)
+      xc.match(rangeReference) !== null &&
+      (!sheetName || this.getters.getSheetIdByName(sheetName) !== undefined)
     );
   }
 

--- a/src/xlsx/conversion/sheet_conversion.ts
+++ b/src/xlsx/conversion/sheet_conversion.ts
@@ -1,4 +1,4 @@
-import { buildSheetLink, markdownLink, toCartesian, toXC } from "../../helpers";
+import { buildSheetLink, markdownLink, splitReference, toCartesian, toXC } from "../../helpers";
 import { CellData, HeaderData, SheetData } from "../../types";
 import { XLSXCell, XLSXHyperLink, XLSXImportData, XLSXWorksheet } from "../../types/xlsx";
 import {
@@ -183,7 +183,9 @@ function convertHyperlink(
   if (!link.relTarget && !link.location) {
     warningManager.generateNotSupportedWarning(WarningTypes.BadlyFormattedHyperlink);
   }
-  const url = link.relTarget ? link.relTarget : buildSheetLink(link.location!.split("!")[0]);
+  const url = link.relTarget
+    ? link.relTarget
+    : buildSheetLink(splitReference(link.location!).sheetName!);
   return markdownLink(label, url);
 }
 

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_FONT_SIZE } from "../../constants";
-import { toUnboundedZone } from "../../helpers";
+import { splitReference, toUnboundedZone } from "../../helpers";
 import {
   BorderDescr,
   CellData,
@@ -251,16 +251,21 @@ export function convertDotValueToEMU(value: number) {
   return Math.round((value * 914400) / DPI);
 }
 
-export function getRangeSize(xc: string, defaultSheetIndex: string, data: ExcelWorkbookData) {
-  const xcSplit = xc.split("!");
+export function getRangeSize(
+  reference: string,
+  defaultSheetIndex: string,
+  data: ExcelWorkbookData
+) {
+  let xc = reference;
+  let sheetName: string | undefined = undefined;
+  ({ xc, sheetName } = splitReference(reference));
   let rangeSheetIndex: number;
-  if (xcSplit.length > 1) {
-    const index = data.sheets.findIndex((sheet) => sheet.name === xcSplit[0]);
+  if (sheetName) {
+    const index = data.sheets.findIndex((sheet) => sheet.name === sheetName);
     if (index < 0) {
-      throw new Error("Unable to find a sheet with the name " + xcSplit[0]);
+      throw new Error("Unable to find a sheet with the name " + sheetName);
     }
     rangeSheetIndex = index;
-    xc = xcSplit[1];
   } else {
     rangeSheetIndex = Number(defaultSheetIndex);
   }

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -1776,6 +1776,7 @@ Object {
       "content": "<workbook xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
     <sheets>
         <sheet state=\\"visible\\" name=\\"Sheet1\\" sheetId=\\"1\\" r:id=\\"rId1\\"/>
+        <sheet state=\\"visible\\" name=\\"She!et2\\" sheetId=\\"2\\" r:id=\\"rId2\\"/>
     </sheets>
 </workbook>",
       "contentType": "workbook",
@@ -2636,6 +2637,293 @@ Object {
       "path": "xl/charts/chart3.xml",
     },
     Object {
+      "content": "<c:chartSpace xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
+    <c:roundedCorners val=\\"0\\"/>
+    <!-- <manualLayout/> to manually position the chart in the figure container -->
+    <c:spPr>
+        <a:solidFill>
+            <a:srgbClr val=\\"EEEEEE\\"/>
+        </a:solidFill>
+        <a:ln cmpd=\\"sng\\">
+            <a:solidFill>
+                <a:srgbClr val=\\"000000\\"/>
+            </a:solidFill>
+        </a:ln>
+    </c:spPr>
+    <c:chart>
+        <c:title>
+            <c:tx>
+                <c:rich>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl=\\"0\\">
+                            <a:defRPr b=\\"0\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"000000\\"/>
+                                </a:solidFill>
+                                <a:latin typeface=\\"+mn-lt\\"/>
+                            </a:defRPr>
+                        </a:pPr>
+                        <a:r>
+                            <!-- Runs -->
+                            <a:rPr sz=\\"2200\\"/>
+                            <a:t>
+                                test
+                            </a:t>
+                        </a:r>
+                    </a:p>
+                </c:rich>
+            </c:tx>
+            <c:overlay val=\\"0\\"/>
+        </c:title>
+        <c:autoTitleDeleted val=\\"0\\"/>
+        <c:plotArea>
+            <!-- how the chart element is placed on the chart -->
+            <c:layout/>
+            <c:doughnutChart>
+                <c:varyColors val=\\"1\\"/>
+                <c:holeSize val=\\"0\\"/>
+                <dLbls>
+                    <c:showLegendKey val=\\"0\\"/>
+                    <c:showVal val=\\"0\\"/>
+                    <c:showCatName val=\\"0\\"/>
+                    <c:showSerName val=\\"0\\"/>
+                    <c:showPercent val=\\"0\\"/>
+                    <c:showBubbleSize val=\\"0\\"/>
+                    <c:showLeaderLines val=\\"0\\"/>
+                </dLbls>
+                <c:ser>
+                    <c:idx val=\\"1\\"/>
+                    <c:order val=\\"1\\"/>
+                    <c:tx>
+                        <c:strRef>
+                            <c:f>
+                                'She!et2'!C4
+                            </c:f>
+                        </c:strRef>
+                    </c:tx>
+                    <c:dPt>
+                        <c:idx val=\\"0\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"1F77B4\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <c:dPt>
+                        <c:idx val=\\"1\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"FF7F0E\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <c:dPt>
+                        <c:idx val=\\"2\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"AEC7E8\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <c:dPt>
+                        <c:idx val=\\"3\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"FFBB78\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <c:dPt>
+                        <c:idx val=\\"4\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"2CA02C\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <c:dPt>
+                        <c:idx val=\\"5\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"98DF8A\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <c:dPt>
+                        <c:idx val=\\"6\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"D62728\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <c:dPt>
+                        <c:idx val=\\"7\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"FF9896\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <dLbls>
+                        <c:showLegendKey val=\\"0\\"/>
+                        <c:showVal val=\\"0\\"/>
+                        <c:showCatName val=\\"0\\"/>
+                        <c:showSerName val=\\"0\\"/>
+                        <c:showPercent val=\\"0\\"/>
+                        <c:showBubbleSize val=\\"0\\"/>
+                        <c:showLeaderLines val=\\"1\\"/>
+                    </dLbls>
+                    <c:cat>
+                        <c:strRef>
+                            <c:f>
+                                'She!et2'!A2:A4
+                            </c:f>
+                        </c:strRef>
+                    </c:cat>
+                    <c:val>
+                        <c:numRef>
+                            <c:f>
+                                'She!et2'!C5:C12
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:val>
+                </c:ser>
+                <c:ser>
+                    <c:idx val=\\"0\\"/>
+                    <c:order val=\\"0\\"/>
+                    <c:tx>
+                        <c:strRef>
+                            <c:f>
+                                'She!et2'!B2
+                            </c:f>
+                        </c:strRef>
+                    </c:tx>
+                    <c:dPt>
+                        <c:idx val=\\"0\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"1F77B4\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <c:dPt>
+                        <c:idx val=\\"1\\"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val=\\"FF7F0E\\"/>
+                            </a:solidFill>
+                            <a:ln cmpd=\\"sng\\" w=\\"14288\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"FFFFFF\\"/>
+                                </a:solidFill>
+                            </a:ln>
+                        </c:spPr>
+                    </c:dPt>
+                    <dLbls>
+                        <c:showLegendKey val=\\"0\\"/>
+                        <c:showVal val=\\"0\\"/>
+                        <c:showCatName val=\\"0\\"/>
+                        <c:showSerName val=\\"0\\"/>
+                        <c:showPercent val=\\"0\\"/>
+                        <c:showBubbleSize val=\\"0\\"/>
+                        <c:showLeaderLines val=\\"1\\"/>
+                    </dLbls>
+                    <c:cat>
+                        <c:strRef>
+                            <c:f>
+                                'She!et2'!A2:A4
+                            </c:f>
+                        </c:strRef>
+                    </c:cat>
+                    <c:val>
+                        <c:numRef>
+                            <c:f>
+                                'She!et2'!B3:B4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:val>
+                </c:ser>
+            </c:doughnutChart>
+            <c:spPr>
+                <a:solidFill>
+                    <a:srgbClr val=\\"EEEEEE\\"/>
+                </a:solidFill>
+            </c:spPr>
+        </c:plotArea>
+        <c:legend>
+            <c:legendPos val=\\"t\\"/>
+            <c:overlay val=\\"0\\"/>
+            <c:txPr>
+                <a:bodyPr/>
+                <a:lstStyle/>
+                <a:p>
+                    <a:pPr lvl=\\"0\\">
+                        <a:defRPr b=\\"0\\" i=\\"0\\" sz=\\"1000\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"000000\\"/>
+                            </a:solidFill>
+                            <a:latin typeface=\\"+mn-lt\\"/>
+                        </a:defRPr>
+                    </a:pPr>
+                </a:p>
+            </c:txPr>
+        </c:legend>
+    </c:chart>
+</c:chartSpace>",
+      "contentType": "chart",
+      "path": "xl/charts/chart4.xml",
+    },
+    Object {
       "content": "<xdr:wsDr xmlns:xdr=\\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
     <xdr:twoCellAnchor>
         <xdr:from>
@@ -2775,6 +3063,52 @@ Object {
         </xdr:graphicFrame>
         <xdr:clientData fLocksWithSheet=\\"0\\"/>
     </xdr:twoCellAnchor>
+    <xdr:twoCellAnchor>
+        <xdr:from>
+            <xdr:col>
+                0
+            </xdr:col>
+            <xdr:colOff>
+                9525
+            </xdr:colOff>
+            <xdr:row>
+                0
+            </xdr:row>
+            <xdr:rowOff>
+                9525
+            </xdr:rowOff>
+        </xdr:from>
+        <xdr:to>
+            <xdr:col>
+                5
+            </xdr:col>
+            <xdr:colOff>
+                542925
+            </xdr:colOff>
+            <xdr:row>
+                14
+            </xdr:row>
+            <xdr:rowOff>
+                133350
+            </xdr:rowOff>
+        </xdr:to>
+        <xdr:graphicFrame>
+            <xdr:nvGraphicFramePr>
+                <xdr:cNvPr id=\\"4\\" name=\\"Chart 4\\" title=\\"Chart\\"/>
+                <xdr:cNvGraphicFramePr/>
+            </xdr:nvGraphicFramePr>
+            <xdr:xfrm>
+                <a:off x=\\"0\\" y=\\"0\\"/>
+                <a:ext cx=\\"0\\" cy=\\"0\\"/>
+            </xdr:xfrm>
+            <a:graphic>
+                <a:graphicData uri=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
+                    <c:chart r:id=\\"rId4\\"/>
+                </a:graphicData>
+            </a:graphic>
+        </xdr:graphicFrame>
+        <xdr:clientData fLocksWithSheet=\\"0\\"/>
+    </xdr:twoCellAnchor>
 </xdr:wsDr>",
       "contentType": "drawing",
       "path": "xl/drawings/drawing0.xml",
@@ -2901,6 +3235,47 @@ Object {
       "path": "xl/worksheets/sheet0.xml",
     },
     Object {
+      "content": "<worksheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <sheetViews>
+        <sheetView showGridLines=\\"1\\" workbookViewId=\\"0\\">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight=\\"17.25\\" defaultColWidth=\\"12.64\\"/>
+    <cols>
+        <col min=\\"1\\" max=\\"1\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"2\\" max=\\"2\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"3\\" max=\\"3\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"4\\" max=\\"4\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"5\\" max=\\"5\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"6\\" max=\\"6\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"7\\" max=\\"7\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"8\\" max=\\"8\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"9\\" max=\\"9\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"10\\" max=\\"10\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"11\\" max=\\"11\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"12\\" max=\\"12\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"13\\" max=\\"13\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"14\\" max=\\"14\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"15\\" max=\\"15\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"16\\" max=\\"16\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"17\\" max=\\"17\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"18\\" max=\\"18\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"19\\" max=\\"19\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"20\\" max=\\"20\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"21\\" max=\\"21\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"22\\" max=\\"22\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"23\\" max=\\"23\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"24\\" max=\\"24\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"25\\" max=\\"25\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"26\\" max=\\"26\\" width=\\"12.64\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+    </cols>
+    <sheetData>
+    </sheetData>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet1.xml",
+    },
+    Object {
       "content": "<styleSheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
     <numFmts count=\\"0\\">
     </numFmts>
@@ -2986,8 +3361,9 @@ Object {
     Object {
       "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
     <Relationship Id=\\"rId1\\" Target=\\"worksheets/sheet0.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\\"/>
-    <Relationship Id=\\"rId2\\" Target=\\"sharedStrings.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\\"/>
-    <Relationship Id=\\"rId3\\" Target=\\"styles.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\\"/>
+    <Relationship Id=\\"rId2\\" Target=\\"worksheets/sheet1.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\\"/>
+    <Relationship Id=\\"rId3\\" Target=\\"sharedStrings.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\\"/>
+    <Relationship Id=\\"rId4\\" Target=\\"styles.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\\"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/_rels/workbook.xml.rels",
@@ -2997,6 +3373,7 @@ Object {
     <Relationship Id=\\"rId1\\" Target=\\"../charts/chart1.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\\"/>
     <Relationship Id=\\"rId2\\" Target=\\"../charts/chart2.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\\"/>
     <Relationship Id=\\"rId3\\" Target=\\"../charts/chart3.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\\"/>
+    <Relationship Id=\\"rId4\\" Target=\\"../charts/chart4.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\\"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -3016,8 +3393,10 @@ Object {
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\\" PartName=\\"/xl/charts/chart1.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\\" PartName=\\"/xl/charts/chart2.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\\" PartName=\\"/xl/charts/chart3.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\\" PartName=\\"/xl/charts/chart4.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawing+xml\\" PartName=\\"/xl/drawings/drawing0.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\\" PartName=\\"/xl/worksheets/sheet0.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\\" PartName=\\"/xl/worksheets/sheet1.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\\" PartName=\\"/xl/styles.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\\" PartName=\\"/xl/sharedStrings.xml\\"/>
 </Types>",

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -438,10 +438,9 @@ describe("range plugin", () => {
 
     test.each([
       ["s1!!!A1:A9", "'s1!!'!A1:A9"],
-      // TODO: the output is incorrect - should be fixed in task 3112299
-      // ["'s1!!'!A1:A9", "'!A1:A9"],
-      ["s1!!!A1:s1!!!A9", "'s1!!'!A9"],
-      ["s1!!!A1:s1!!!A9", "'s1!!'!A9"],
+      ["'s1!!'!A1:A9", "'s1!!'!A1:A9"],
+      ["s1!!!A1:s1!!!A9", "s1!!!A1:s1!!!A9"],
+      ["s1!!!A1:s1!!!A9", "s1!!!A1:s1!!!A9"],
     ])(
       "xc with more than one exclamation mark does not throw error",
       (rangeString, expectedString) => {

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -816,6 +816,7 @@ describe("Test XLSX export", () => {
 
     test("chart font color is white with a dark background color", async () => {
       const model = new Model(chartData);
+      createSheet(model, { sheetId: "42", name: "She!et2" });
       createChart(
         model,
         {
@@ -845,6 +846,16 @@ describe("Test XLSX export", () => {
           background: "#DDDDDD",
         },
         "3"
+      );
+      createChart(
+        model,
+        {
+          dataSets: ["She!et2!B2:B4", "She!et2!C12:C4"],
+          labelRange: "She!et2!A2:A4",
+          type: "pie",
+          background: "#EEEEEE",
+        },
+        "4"
       );
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });


### PR DESCRIPTION
The previous implementation would not conserve the full sheet name when splitting the shee name from the xc in a reference. Since the same faulty code was used at several places, this commit introduces a common helper that should be used everywhere.

This will solve problems that were introduced in ulterior versions (e.g. broken xlsx import/export)

Task 3112299
fwp of #1941 

X-original-commit: ab92b9d

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo