### PR TITLE
[IMP] composer: fuzzy search to autocomplete

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -2,7 +2,7 @@ import { Component, onMounted, onPatched, onWillUnmount, useRef, useState } from
 import { ComponentsImportance, SELECTION_BORDER_COLOR } from "../../../constants";
 import { EnrichedToken } from "../../../formulas/index";
 import { functionRegistry } from "../../../functions/index";
-import { isEqual, rangeReference, zoneToDimension } from "../../../helpers/index";
+import { fuzzyLookup, isEqual, rangeReference, zoneToDimension } from "../../../helpers/index";
 import { ComposerSelection, SelectionIndicator } from "../../../plugins/ui_stateful/edition";
 import { DOMDimension, FunctionDescription, Rect, SpreadsheetChildEnv } from "../../../types/index";
 import { css } from "../../helpers/css";
@@ -376,10 +376,12 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
         description,
       };
     });
-
-    values = values
-      .filter((t) => t.text.toUpperCase().startsWith(searchTerm.toUpperCase()))
-      .sort((l, r) => (l.text < r.text ? -1 : l.text > r.text ? 1 : 0));
+    if (searchTerm) {
+      values = fuzzyLookup(searchTerm, values, (t) => t.text);
+    } else {
+      // alphabetical order
+      values = values.sort((a, b) => a.text.localeCompare(b.text));
+    }
     this.autoCompleteState.values = values.slice(0, 10);
     this.autoCompleteState.selectedIndex = 0;
   }

--- a/src/helpers/search.ts
+++ b/src/helpers/search.ts
@@ -38,7 +38,7 @@ export function fuzzyMatch(pattern: string, str: string) {
  * higher score first). An higher score means that the match is better. For
  * example, consecutive letters are considered a better match.
  */
-export function fuzzyLookup<T>(pattern: string, list: T[], fn: (t: T) => string) {
+export function fuzzyLookup<T>(pattern: string, list: T[], fn: (t: T) => string): T[] {
   const results: { score: number; elem: T }[] = [];
   list.forEach((data) => {
     const score = fuzzyMatch(pattern, fn(data));

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -195,6 +195,25 @@ describe("Functions autocomplete", () => {
       expect(document.activeElement).toBe(composerEl);
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
     });
+
+    test("autocomplete fuzzy search", async () => {
+      for (const f of ["TEST_FUZZY", "FUZZY", "FUZZY_TEST", "TEST_FUZZY_TEST"]) {
+        functionRegistry.add(f, {
+          description: "",
+          args: args(``),
+          compute: () => 1,
+          returns: ["ANY"],
+        });
+      }
+      await typeInComposerGrid("=FUZZY");
+      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(4);
+      expect(fixture.querySelectorAll(".o-autocomplete-value")[0].textContent).toBe("FUZZY");
+      expect(fixture.querySelectorAll(".o-autocomplete-value")[1].textContent).toBe("FUZZY_TEST");
+      expect(fixture.querySelectorAll(".o-autocomplete-value")[2].textContent).toBe("TEST_FUZZY");
+      expect(fixture.querySelectorAll(".o-autocomplete-value")[3].textContent).toBe(
+        "TEST_FUZZY_TEST"
+      );
+    });
   });
 
   describe("autocomplete functions SUM IF", () => {


### PR DESCRIPTION
Currently, the autocomplete dropdown is only based on the start of the function name.
If you type "=DIS", the autocomplete only shows "DISC", even if there are other functions containing "DIS".

Now, the same search will show "DISC" and "PRICEDISC" and "YIELDDISC".

Task 3133012

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo