### PR TITLE
[FIX] composer: closing menu upon focus on composer

### DIFF
--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -12,7 +12,7 @@
         t-on-mousedown="onMousedown"
         t-on-input="onInput"
         t-on-keyup="onKeyup"
-        t-on-click.stop="onClick"
+        t-on-click="onClick"
         t-on-blur="onBlur"
         t-on-paste.stop=""
       />

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -1551,3 +1551,16 @@ describe("Copy/paste in composer", () => {
     expect(sypeDispatch).not.toBeCalledWith("PASTE", expect.any);
   });
 });
+
+test("Menu should be closed while clicking on composer", async () => {
+  expect(fixture.querySelectorAll(".o-menu").length).toBe(0);
+  fixture.querySelector(".o-topbar-menu[data-id='file']")!.dispatchEvent(new Event("click"));
+  await nextTick();
+  expect(fixture.querySelectorAll(".o-menu").length).toBe(1);
+  const topbarComposerElement = fixture.querySelector(
+    ".o-topbar-toolbar .o-composer-container div"
+  )!;
+  await simulateClick(topbarComposerElement);
+  expect(model.getters.getEditionMode()).toBe("editing");
+  expect(fixture.querySelectorAll(".o-menu").length).toBe(0);
+});


### PR DESCRIPTION
## Description:

Earlier, if top bar menu is open and followed by focusing on composer then menu won't close. In order to resolve removing the stop functionality from t-on-click at composer fixes it.

Odoo task ID : [3110759](https://www.odoo.com/web#id=3110759&cids=2&menu_id=3940&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo