### PR TITLE
[IMP] Grid Composer: add cell reference when scrolling

### DIFF
--- a/src/components/composer/grid_composer/grid_composer.xml
+++ b/src/components/composer/grid_composer/grid_composer.xml
@@ -1,5 +1,11 @@
 <templates>
   <t t-name="o-spreadsheet-GridComposer" owl="1">
+    <div
+      class="o-cell-reference"
+      t-if="shouldDisplayCellReference"
+      t-att-style="cellReferenceStyle"
+      t-esc="cellReference"
+    />
     <div class="o-grid-composer" t-att-style="containerStyle" t-ref="gridComposer">
       <Composer
         focus="props.focus"

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -60,6 +60,7 @@ export class EditionPlugin extends UIPlugin {
     "getCurrentTokens",
     "getTokenAtCursor",
     "getComposerHighlights",
+    "getCurrentEditedCell",
   ] as const;
 
   private col: HeaderIndex = 0;
@@ -262,6 +263,14 @@ export class EditionPlugin extends UIPlugin {
     };
   }
 
+  getCurrentEditedCell(): CellPosition {
+    return {
+      sheetId: this.sheetId,
+      col: this.col,
+      row: this.row,
+    };
+  }
+
   isSelectingForComposer(): boolean {
     return this.mode === "selecting";
   }
@@ -403,8 +412,7 @@ export class EditionPlugin extends UIPlugin {
       selection = selection || { start: str.length, end: str.length };
       str = `${str}%`;
     }
-    const sheetId = this.getters.getActiveSheetId();
-    const { col, row } = this.getters.getActivePosition();
+    const { col, row, sheetId } = this.getters.getActivePosition();
     this.col = col;
     this.sheetId = sheetId;
     this.row = row;


### PR DESCRIPTION
With this revision, the cell reference is displayed when scrolling in order to help the user to know where he is in the grid.

Task-id 3096000

