### PR TITLE
[FIX] chart: default background behaviour and colorPicker: wrong selection on reset

### DIFF
--- a/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
@@ -6,7 +6,7 @@
         <div class="o-with-color-picker">
           Select a color...
           <span
-            t-attf-style="border-color:{{props.definition.background}}"
+            t-att-style="props.definition.background ? `border-color: ${props.definition.background}` : 'border-bottom-style: hidden'"
             t-on-click.stop="toggleColorPicker">
             <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
           </span>

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
@@ -7,7 +7,7 @@
           Select a color...
           <span
             title="Background Color"
-            t-attf-style="border-color:{{props.definition.background}}"
+            t-att-style="props.definition.background ? `border-color: ${props.definition.background}` : 'border-bottom-style: hidden'"
             t-on-click.stop="() => this.toggleMenu('backgroundColor', ev)">
             <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
           </span>

--- a/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
@@ -6,7 +6,7 @@
         <div class="o-with-color-picker">
           Select a color...
           <span
-            t-attf-style="border-color:{{props.definition.background}}"
+            t-att-style="props.definition.background ? `border-color: ${props.definition.background}` : 'border-bottom-style: hidden'"
             t-on-click.stop="toggleColorPicker">
             <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
           </span>

--- a/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
@@ -6,7 +6,7 @@
         <div class="o-with-color-picker">
           Select a color...
           <span
-            t-attf-style="border-color:{{props.definition.background}}"
+            t-att-style="props.definition.background ? `border-color: ${props.definition.background}` : 'border-bottom-style: hidden'"
             t-on-click.stop="toggleColorPicker">
             <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
           </span>

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
@@ -7,7 +7,7 @@
           Select a color...
           <span
             title="Background Color"
-            t-attf-style="border-color:{{props.definition.background}}"
+            t-att-style="props.definition.background ? `border-color: ${props.definition.background}` : 'border-bottom-style: hidden'"
             t-on-click.stop="() => this.openColorPicker('backgroundColor')">
             <t t-call="o-spreadsheet-Icon.FILL_COLOR"/>
           </span>

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -1,8 +1,4 @@
-import {
-  BACKGROUND_CHART_COLOR,
-  DEFAULT_FIGURE_HEIGHT,
-  DEFAULT_FIGURE_WIDTH,
-} from "../../constants";
+import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../../constants";
 import { areZonesContinuous, numberToLetters, zoneToXc } from "../../helpers/index";
 import { interactiveSortSelection } from "../../helpers/sort";
 import { interactiveCut } from "../../helpers/ui/cut_interactive";
@@ -623,7 +619,6 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
       dataSets,
       labelRange,
       type: "bar",
-      background: BACKGROUND_CHART_COLOR,
       stacked: false,
       dataSetsHaveTitle,
       verticalAxisPosition: "left",

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -11,6 +11,7 @@ import {
   createGaugeChart,
   createScorecardChart,
   paste,
+  setStyle,
   updateChart,
 } from "../test_helpers/commands_helpers";
 import {
@@ -1221,5 +1222,35 @@ describe("charts with multiple sheets", () => {
     expect(runtimeChart).toBeDefined();
     await nextTick();
     expect(fixture.querySelector(".o-chart-container")).not.toBeNull();
+  });
+});
+
+describe("Default background on runtime tests", () => {
+  beforeEach(async () => {
+    fixture = makeTestFixture();
+    ({ app, parent } = await mountSpreadsheet(fixture, { model: new Model() }));
+    model = parent.model;
+    await nextTick();
+  });
+  afterEach(() => {
+    app.destroy();
+  });
+  test("Creating a 'basicChart' without background should have default background on runtime", async () => {
+    createChart(model, { dataSets: ["A1"] }, "1", sheetId);
+    expect(model.getters.getChartDefinition("1")?.background).toBeUndefined();
+    expect(model.getters.getChartRuntime("1").background).toBe(BACKGROUND_CHART_COLOR);
+  });
+  test("Creating a 'basicChart' without background and updating its type should have default background on runtime", async () => {
+    createChart(model, { dataSets: ["A1"] }, "1", sheetId);
+    updateChart(model, "1", { type: "line" }, sheetId);
+    expect(model.getters.getChartDefinition("1")?.background).toBeUndefined();
+    expect(model.getters.getChartRuntime("1").background).toBe(BACKGROUND_CHART_COLOR);
+  });
+  test("Creating a 'basicChart' on a single cell with style and converting into scorecard should have cell background as chart background", () => {
+    setStyle(model, "A1", { fillColor: "#FA0000" }, sheetId);
+    createChart(model, { dataSets: ["A1"] }, "1", sheetId);
+    updateChart(model, "1", { type: "scorecard", keyValue: "A1" }, sheetId);
+    expect(model.getters.getChartDefinition("1")?.background).toBeUndefined();
+    expect(model.getters.getChartRuntime("1").background).toBe("#FA0000");
   });
 });

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -14,7 +14,6 @@ import {
 import { getMenuChildren } from "../src/registries/menus/helpers";
 import { SpreadsheetChildEnv } from "../src/types";
 import {
-  BACKGROUND_CHART_COLOR,
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
   DEFAULT_FIGURE_HEIGHT,
@@ -1120,7 +1119,6 @@ describe("Menu Item actions", () => {
         sheetId: model.getters.getActiveSheetId(),
         definition: {
           dataSets: ["A1"],
-          background: BACKGROUND_CHART_COLOR,
           dataSetsHaveTitle: false,
           labelRange: undefined,
           legendPosition: "none",

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -1,4 +1,3 @@
-import { BACKGROUND_CHART_COLOR } from "../../src/constants";
 import { isInside, lettersToNumber, toCartesian, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import {
@@ -109,7 +108,7 @@ export function createChart(
       dataSetsHaveTitle: data.dataSetsHaveTitle !== undefined ? data.dataSetsHaveTitle : true,
       labelRange: data.labelRange,
       type: data.type || "bar",
-      background: data.background || BACKGROUND_CHART_COLOR,
+      background: data.background,
       verticalAxisPosition: ("verticalAxisPosition" in data && data.verticalAxisPosition) || "left",
       legendPosition: data.legendPosition || "top",
       stacked: ("stacked" in data && data.stacked) || false,


### PR DESCRIPTION
## Description:

1. Chart default background was forced to be set on default white colour on it's context, now the chart is set to show default colour only on runtime but carry no specified background colour in it's context unless specified.
2. ColorPicker was picking black colour when set to reset / when no colour was specified, now it simply hides the colour bar if no colour is specified.

Odoo task ID : [3095538](https://www.odoo.com/web#id=3095538&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo