### PR TITLE
[FIX] bottom_bar_sheet: fix innerHTML security issue

### DIFF
--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -175,12 +175,12 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
     this.props.openContextMenu(this.contextMenuRegistry, ev);
   }
 
-  private getInputContent(): string | undefined {
-    return this.sheetNameRef.el?.innerHTML;
+  private getInputContent(): string | undefined | null {
+    return this.sheetNameRef.el?.textContent;
   }
 
   private setInputContent(content: string) {
-    if (this.sheetNameRef.el) this.sheetNameRef.el.innerHTML = content;
+    if (this.sheetNameRef.el) this.sheetNameRef.el.textContent = content;
   }
 
   get contextMenuRegistry() {

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -273,7 +273,7 @@ describe("BottomBar component", () => {
       const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
       triggerMouseEvent(sheetName, "dblclick");
       await nextTick();
-      sheetName.innerHTML = "New name";
+      sheetName.textContent = "New name";
       await keyDown("Enter");
       expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toEqual("New name");
     });
@@ -282,7 +282,7 @@ describe("BottomBar component", () => {
       const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
       triggerMouseEvent(sheetName, "dblclick");
       await nextTick();
-      sheetName.innerHTML = "New name";
+      sheetName.textContent = "New name";
       sheetName.blur();
       expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toEqual("New name");
     });
@@ -291,9 +291,9 @@ describe("BottomBar component", () => {
       const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
       triggerMouseEvent(sheetName, "dblclick");
       await nextTick();
-      sheetName.innerHTML = "New name";
+      sheetName.textContent = "New name";
       await keyDown("Escape");
-      expect(sheetName.innerHTML).toEqual("Sheet1");
+      expect(sheetName.textContent).toEqual("Sheet1");
       expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toEqual("Sheet1");
     });
 
@@ -301,7 +301,7 @@ describe("BottomBar component", () => {
       const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
       triggerMouseEvent(sheetName, "dblclick");
       await nextTick();
-      sheetName.innerHTML = "";
+      sheetName.textContent = "";
       await keyDown("Enter");
       expect(raiseError).toHaveBeenCalled();
     });
@@ -311,7 +311,7 @@ describe("BottomBar component", () => {
       const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
       triggerMouseEvent(sheetName, "dblclick");
       await nextTick();
-      sheetName.innerHTML = "ThisIsASheet";
+      sheetName.textContent = "ThisIsASheet";
       expect(window.getSelection()?.toString()).toEqual("");
       await keyDown("Enter");
       expect(raiseError).toHaveBeenCalled();


### PR DESCRIPTION
9c5f0ebc used `.innerHTML` to set the content of a div, which may be a security risk. This commit replaces it with `.textContent`.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo