### PR TITLE
[IMP] Autofill: support edge scrolling

### DIFF
--- a/src/components/autofill/autofill.xml
+++ b/src/components/autofill/autofill.xml
@@ -1,15 +1,15 @@
 <templates>
   <t t-name="o-spreadsheet-Autofill" owl="1">
+    <div class="o-autofill" t-att-style="style"/>
     <div
-      class="o-autofill"
+      class="o-autofill-handler"
+      t-att-style="handlerStyle"
       t-on-mousedown="onMouseDown"
-      t-att-style="style"
-      t-on-dblclick="onDblClick">
-      <div class="o-autofill-handler" t-att-style="styleHandler"/>
-      <t t-set="tooltip" t-value="getTooltip()"/>
-      <div t-if="tooltip" class="o-autofill-nextvalue" t-att-style="styleNextvalue">
-        <t t-component="tooltip.component" t-props="tooltip.props"/>
-      </div>
+      t-on-dblclick="onDblClick"
+    />
+    <t t-set="tooltip" t-value="getTooltip()"/>
+    <div t-if="tooltip" class="o-autofill-nextvalue" t-att-style="styleNextValue">
+      <t t-component="tooltip.component" t-props="tooltip.props"/>
     </div>
   </t>
 </templates>

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -322,7 +322,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     };
   }
 
-  isAutoFillActive(): boolean {
+  get isAutofillVisible(): boolean {
     const zone = this.env.model.getters.getSelectedZone();
     const rect = this.env.model.getters.getVisibleRect({
       left: zone.right,

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -57,8 +57,8 @@
         onMouseWheel.bind="onMouseWheel"
         onClosePopover.bind="onClosePopover"
       />
-      <t t-if="env.model.getters.getEditionMode() === 'inactive' and isAutoFillActive()">
-        <Autofill position="getAutofillPosition()"/>
+      <t t-if="env.model.getters.getEditionMode() === 'inactive'">
+        <Autofill position="getAutofillPosition()" isVisible="isAutofillVisible"/>
       </t>
       <t t-if="env.model.getters.getEditionMode() !== 'inactive'">
         <t t-foreach="env.model.getters.getHighlights()" t-as="highlight" t-key="highlight_index">

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -58,14 +58,13 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   <div
     class="o-autofill"
-    style="top:45px;left:140px"
-  >
-    <div
-      class="o-autofill-handler"
-      style="top:0px;left:0px;"
-    />
-    
-  </div>
+    style="top:45px; left:140px; visibility:visible;"
+  />
+  <div
+    class="o-autofill-handler"
+    style="top:45px; left:140px;"
+  />
+  
   
   
   

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -566,14 +566,13 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
     
     <div
       class="o-autofill"
-      style="top:45px;left:140px"
-    >
-      <div
-        class="o-autofill-handler"
-        style="top:0px;left:0px;"
-      />
-      
-    </div>
+      style="top:45px; left:140px; visibility:visible;"
+    />
+    <div
+      class="o-autofill-handler"
+      style="top:45px; left:140px;"
+    />
+    
     
     
     


### PR DESCRIPTION
## Description:

This commit support the edge scrolling in autofill. 
The basic idea is to reuse `dragAndDropBeyondTheViewport` function. We also need to cancel the check of whether the autofill is active (which is based on the visibility of the autofill selection) to make the tooltip and handler still available during edge scrolling. 

Odoo task ID : [2870875](https://www.odoo.com/web#id=2870875&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo