### PR TITLE
[FIX] top_bar: respond menu upon scaling viewport

### DIFF
--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -7,9 +7,9 @@ import {
 } from "../../constants";
 import { hslaToRGBA, isColorValid, rgbaToHex } from "../../helpers";
 import { chartFontColor } from "../../helpers/charts";
-import { Color } from "../../types";
+import { Color, Pixel } from "../../types";
 import { SpreadsheetChildEnv } from "../../types/env";
-import { css } from "../helpers/css";
+import { css, cssPropertiesToCss } from "../helpers/css";
 
 const PICKER_PADDING = 6;
 
@@ -35,8 +35,9 @@ css/* scss */ `
     z-index: ${ComponentsImportance.ColorPicker};
     box-shadow: 1px 2px 5px 2px rgba(51, 51, 51, 0.15);
     background-color: white;
-    padding: ${PICKER_PADDING}px 0px;
     line-height: 1.2;
+    overflow-y: auto;
+    overflow-x: hidden;
     width: ${GRADIENT_WIDTH + 2 * PICKER_PADDING}px;
 
     .o-color-picker-section-name {
@@ -176,6 +177,7 @@ function computeCustomColor(ev: MouseEvent) {
 }
 
 export interface ColorPickerProps {
+  maxHeight: Pixel;
   dropdownDirection?: "left" | "right" | "center";
   onColorPicked: (color: Color) => void;
   currentColor: Color;
@@ -208,6 +210,14 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
       top: "0",
     },
   });
+
+  get dropdownStyle() {
+    const height = this.props.maxHeight;
+    return cssPropertiesToCss({
+      padding: height <= 0 ? "0px" : `${PICKER_PADDING}px 0px`,
+      "max-height": `${height}px`,
+    });
+  }
 
   onColorClick(color: Color) {
     if (color) {

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -1,6 +1,9 @@
 <templates>
   <t t-name="o-spreadsheet-ColorPicker" owl="1">
-    <div class="o-color-picker" t-att-class="props.dropdownDirection || 'right'">
+    <div
+      class="o-color-picker"
+      t-att-class="props.dropdownDirection || 'right'"
+      t-att-style="dropdownStyle">
       <div class="o-color-picker-section-name">Standard</div>
       <div class="colors-grid">
         <div

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -47,9 +47,12 @@ export class Popover extends Component<Props, SpreadsheetChildEnv> {
     // within our control and to avoid leaking into external DOM
     const horizontalPosition = `left:${this.horizontalPosition() - this.spreadsheetPosition.x}`;
     const verticalPosition = `top:${this.verticalPosition() - this.spreadsheetPosition.y}`;
-    const height = `max-height:${
+    const maxHeight = Math.max(
+      0,
       this.viewportDimension.height - BOTTOMBAR_HEIGHT - SCROLLBAR_WIDTH
-    }`;
+    );
+    const height = `max-height:${maxHeight}`;
+    const shadow = maxHeight !== 0 ? "box-shadow: 1px 2px 5px 2px rgb(51 51 51 / 15%);" : "";
     return `
       position: absolute;
       z-index: ${ComponentsImportance.Popover};
@@ -59,7 +62,7 @@ export class Popover extends Component<Props, SpreadsheetChildEnv> {
       width:${this.props.childWidth}px;
       overflow-y: auto;
       overflow-x: hidden;
-      box-shadow: 1px 2px 5px 2px rgb(51 51 51 / 15%);
+      ${shadow}
     `;
   }
 

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -21,7 +21,7 @@ import {
 import { Model } from "../../model";
 import { ComposerSelection } from "../../plugins/ui/edition";
 import { _lt } from "../../translation";
-import { SpreadsheetChildEnv, WorkbookData } from "../../types";
+import { Pixel, SpreadsheetChildEnv, WorkbookData } from "../../types";
 import { NotifyUIEvent } from "../../types/ui";
 import { BottomBar } from "../bottom_bar/bottom_bar";
 import { SpreadsheetDashboard } from "../dashboard/dashboard";
@@ -339,5 +339,10 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     } else if (content) {
       this.model.dispatch("SET_CURRENT_CONTENT", { content, selection });
     }
+  }
+
+  get gridHeight(): Pixel {
+    const { height } = this.env.model.getters.getSheetViewDimension();
+    return height;
   }
 }

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -12,6 +12,7 @@
           onClick="() => this.focusGrid()"
           onComposerContentFocused="(selection) => this.onTopBarComposerFocused(selection)"
           focusComposer="focusTopBarComposer"
+          dropdownMaxHeight="gridHeight"
         />
         <Grid
           sidePanelIsOpen="sidePanel.isOpen"

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -18,6 +18,7 @@ import { FullMenuItem } from "../../registries/menu_items_registry";
 import {
   Align,
   BorderCommand,
+  Pixel,
   SetDecimalStep,
   SpreadsheetChildEnv,
   Style,
@@ -84,6 +85,7 @@ interface Props {
   onClick: () => void;
   focusComposer: Omit<ComposerFocusType, "cellFocus">;
   onComposerContentFocused: (selection: ComposerSelection) => void;
+  dropdownMaxHeight: Pixel;
 }
 
 // -----------------------------------------------------------------------------
@@ -224,6 +226,8 @@ css/* scss */ `
             position: absolute;
             top: calc(100% + 5px);
             left: 0;
+            overflow-y: auto;
+            overflow-x: hidden;
             z-index: ${ComponentsImportance.Dropdown};
             box-shadow: 1px 2px 5px 2px rgba(51, 51, 51, 0.15);
             background-color: white;
@@ -291,6 +295,10 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   customFormats = CUSTOM_FORMATS;
   currentFormatName = "automatic";
   fontSizes = fontSizes;
+
+  get dropdownStyle() {
+    return `max-height:${this.props.dropdownMaxHeight}px`;
+  }
 
   style: Style = {};
   state: State = useState({

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -91,6 +91,7 @@
             </div>
             <div
               class="o-dropdown-content o-text-options  o-format-tool "
+              t-att-style="dropdownStyle"
               t-if="state.activeTool === 'formatTool'"
               t-on-click="setFormat">
               <t t-foreach="commonFormats" t-as="commonFormat" t-key="commonFormat.name">
@@ -119,6 +120,7 @@
             </div>
             <div
               class="o-dropdown-content o-text-options "
+              t-att-style="dropdownStyle"
               t-if="state.activeTool === 'fontSizeTool'"
               t-on-click="setSize">
               <t t-foreach="fontSizes" t-as="font" t-key="font_index">
@@ -160,6 +162,7 @@
               onColorPicked="(color) => this.setColor('textColor', color)"
               currentColor="textColor"
               t-key="textColor"
+              maxHeight="this.props.dropdownMaxHeight"
             />
           </div>
           <div class="o-divider"/>
@@ -175,6 +178,7 @@
               onColorPicked="(color) => this.setColor('fillColor', color)"
               currentColor="fillColor"
               t-key="fillColor"
+              maxHeight="this.props.dropdownMaxHeight"
             />
           </div>
           <div
@@ -186,6 +190,7 @@
             </span>
             <div
               class="o-dropdown-content o-border-dropdown"
+              t-att-style="dropdownStyle"
               t-if="state.activeTool === 'borderTool'">
               <div class="o-dropdown-line">
                 <span class="o-line-item" t-on-click="(ev) => this.setBorder('all', ev)">
@@ -247,7 +252,10 @@
               </t>
               <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
             </span>
-            <div t-if="state.activeTool === 'alignTool'" class="o-dropdown-content">
+            <div
+              t-if="state.activeTool === 'alignTool'"
+              class="o-dropdown-content"
+              t-att-style="dropdownStyle">
               <div class="o-dropdown-item" t-on-click="(ev) => this.toggleAlign('left', ev)">
                 <t t-call="o-spreadsheet-Icon.ALIGN_LEFT"/>
               </div>

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -168,6 +168,7 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             <div
               class="o-dropdown-content o-text-options  o-format-tool "
+              style="max-height:1000px"
             >
               <div
                 class="active"

--- a/tests/components/color_picker.test.ts
+++ b/tests/components/color_picker.test.ts
@@ -31,6 +31,7 @@ async function mountColorPicker(
       dropdownDirection: props.dropdownDirection,
       onColorPicked: props.onColorPicked || (() => {}),
       currentColor: props.currentColor || "#000000",
+      maxHeight: props.maxHeight || 1000,
     },
     env: {
       model,

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -6,7 +6,7 @@ import { Model } from "../../src/model";
 import { topbarComponentRegistry } from "../../src/registries";
 import { getMenuChildren } from "../../src/registries/menus/helpers";
 import { topbarMenuRegistry } from "../../src/registries/menus/topbar_menu_registry";
-import { ConditionalFormat, Style } from "../../src/types";
+import { ConditionalFormat, Pixel, Style } from "../../src/types";
 import { OWL_TEMPLATES } from "../setup/jest.setup";
 import {
   addCellToSelection,
@@ -16,7 +16,7 @@ import {
   setCellContent,
   setSelection,
 } from "../test_helpers/commands_helpers";
-import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
+import { getElComputedStyle, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getBorder, getCell } from "../test_helpers/getters_helpers";
 import {
   makeTestFixture,
@@ -38,7 +38,7 @@ const t = (s: string): string => s;
 class Parent extends Component {
   static template = xml/* xml */ `
     <div class="o-spreadsheet">
-      <TopBar focusComposer="state.focusComposer" onClick="() => {}"/>
+      <TopBar focusComposer="state.focusComposer" dropdownMaxHeight="gridHeight" onClick="() => {}"/>
     </div>
   `;
   static components = { TopBar };
@@ -57,6 +57,11 @@ class Parent extends Component {
     this.state.focusComposer = this.props.focusComposer || false;
     onMounted(() => this.props.model.on("update", this, this.render));
     onWillUnmount(() => this.props.model.off("update", this));
+  }
+
+  get gridHeight(): Pixel {
+    const { height } = this.env.model.getters.getSheetViewDimension();
+    return height;
   }
 
   setFocusComposer(isFocused: boolean) {
@@ -768,6 +773,62 @@ describe("Topbar - View", () => {
     );
     await nextTick();
     expect(model.getters.shouldShowFormulas()).toBe(true);
+    app.destroy();
+  });
+});
+
+describe("Topbar - menu item resizing with viewport", () => {
+  test("font size dropdown in top bar is resized with screen size change", async () => {
+    const model = new Model();
+    const { app } = await mountParent(model);
+    triggerMouseEvent('.o-tool[title="Font Size"]', "click");
+    await nextTick();
+    let height = getElComputedStyle(".o-dropdown-content.o-text-options", "maxHeight");
+    expect(parseInt(height)).toBe(
+      model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
+    );
+    model.dispatch("RESIZE_SHEETVIEW", { width: 300, height: 100 });
+    await nextTick();
+    height = getElComputedStyle(".o-dropdown-content.o-text-options", "maxHeight");
+    expect(parseInt(height)).toBe(
+      model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
+    );
+    app.destroy();
+  });
+
+  test("color picker of fill color in top bar is resized with screen size change", async () => {
+    const model = new Model();
+    const { app } = await mountParent(model);
+    triggerMouseEvent('.o-tool[title="Fill Color"]', "click");
+    await nextTick();
+    let height = getElComputedStyle(".o-color-picker.right", "maxHeight");
+    expect(parseInt(height)).toBe(
+      model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
+    );
+    model.dispatch("RESIZE_SHEETVIEW", { width: 300, height: 100 });
+    await nextTick();
+    height = getElComputedStyle(".o-color-picker.right", "maxHeight");
+    expect(parseInt(height)).toBe(
+      model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
+    );
+    app.destroy();
+  });
+
+  test("color picker of text color in top bar is resized with screen size change", async () => {
+    const model = new Model();
+    const { app } = await mountParent(model);
+    triggerMouseEvent('.o-tool[title="Text Color"]', "click");
+    await nextTick();
+    let height = getElComputedStyle(".o-color-picker.right", "maxHeight");
+    expect(parseInt(height)).toBe(
+      model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
+    );
+    model.dispatch("RESIZE_SHEETVIEW", { width: 300, height: 100 });
+    await nextTick();
+    height = getElComputedStyle(".o-color-picker.right", "maxHeight");
+    expect(parseInt(height)).toBe(
+      model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
+    );
     app.destroy();
   });
 });


### PR DESCRIPTION
## Description:

Earlier, if we open drop down menu from top bar with a viewport less in height than needed by the menu, menu scales out from the viewport. In order to solve this issue, applying maxHeight and overflow CSS on drop down menu does the trick.

Odoo task ID : [3127234](https://www.odoo.com/web#id=3127234&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo