### PR TITLE
[FIX] menu: fix positioning of sub menus

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -220,7 +220,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
   openSubMenu(menu: FullMenuItem, menuIndex: number) {
     const y = this.subMenuVerticalPosition(menuIndex);
     this.subMenu.position = {
-      x: this.position.x + MENU_WIDTH,
+      x: this.position.x + this.props.depth * MENU_WIDTH,
       y: y - (this.subMenu.scrollOffset || 0),
     };
     this.subMenu.menuItems = getMenuChildren(menu, this.env).filter(

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -68,8 +68,8 @@ function getMenuPosition() {
   return { left, top: top };
 }
 
-function getSubMenuPosition() {
-  const { left, top } = getElPosition(fixture.querySelectorAll(".o-menu")[1]);
+function getSubMenuPosition(depth = 1) {
+  const { left, top } = getElPosition(fixture.querySelectorAll(".o-menu")[depth]);
   return { left, top: top };
 }
 
@@ -90,8 +90,8 @@ function getMenuSize() {
   return getSize(menuItems.length);
 }
 
-function getSubMenuSize() {
-  const menu = fixture.querySelectorAll(".o-menu")[1];
+function getSubMenuSize(depth = 1) {
+  const menu = fixture.querySelectorAll(".o-menu")[depth];
   const menuItems = menu!.querySelectorAll(".o-menu-item");
   return getSize(menuItems.length);
 }
@@ -767,6 +767,37 @@ describe("Standalone context menu tests", () => {
       expect(rootTop).toBe(clickY - rootHeight);
       expect(top).toBe(clickY - height);
       expect(left).toBe(clickX + width);
+    });
+
+    test("multi depth menu is properly placed on the screen", async () => {
+      const subMenus: FullMenuItem[] = [
+        createFullMenuItem("root", {
+          name: "root",
+          sequence: 1,
+          children: [
+            () => [
+              createFullMenuItem("subMenu", {
+                name: "subMenu",
+                sequence: 1,
+                children: [
+                  createFullMenuItem("subSubMenu", {
+                    name: "subSubMenu",
+                    sequence: 1,
+                    action() {},
+                  }),
+                ],
+              }),
+            ],
+          ],
+        }),
+      ];
+      const [clickX] = await renderContextMenu(100, 100, { menuItems: subMenus });
+      await simulateClick("div[data-name='root']");
+      await simulateClick("div[data-name='subMenu']");
+      const { left: secondSubLeft } = getSubMenuPosition(2);
+      const { width: subMenuWidth } = getSubMenuSize();
+      const { width: rootWidth } = getMenuSize();
+      expect(secondSubLeft).toBe(clickX + rootWidth + subMenuWidth);
     });
   });
 });


### PR DESCRIPTION
Following the refactoring of popover, the structure of component `Menu` did not properly compute the positioning of sub menus; it would not account for the depth of the submenu and all of them would be placed (horizontally) as if they were the first sub menu.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo