### PR TITLE
[FIX] drag&drop: preventDefault on passive wheel event

### DIFF
--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -34,7 +34,10 @@ export function startDnd(
   window.addEventListener("mouseup", _onMouseUp);
   window.addEventListener("dragstart", _onDragStart);
   window.addEventListener("mousemove", _onMouseMove);
-  window.addEventListener("wheel", _onMouseMove);
+  // mouse wheel on window is by default a passive event.
+  // preventDefault() is not allowed in passive event handler.
+  // https://chromestatus.com/feature/6662647093133312
+  window.addEventListener("wheel", _onMouseMove, { passive: false });
 }
 
 /**


### PR DESCRIPTION
fc253ab introduced the use of preventDefault() on the events during a drag & drop.

This is a problem for the wheel because since the event is passive by default (at least in Chrome and Firefox), the preventDefault will be ignored and a warning will be logged in the console.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo