### PR TITLE
[IMP] remove duplicate: add the remove duplicate functionality

### DIFF
--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -1,4 +1,4 @@
-import { areZonesContinuous } from "../helpers/index";
+import { areZonesContinuous, getZoneArea } from "../helpers/index";
 import { interactiveSortSelection } from "../helpers/sort";
 import { interactiveAddFilter } from "../helpers/ui/filter_interactive";
 import { _t } from "../translation";
@@ -19,6 +19,21 @@ export const sortAscending: ActionSpec = {
     interactiveSortSelection(env, sheetId, anchor.cell, zones[0], "ascending");
   },
   icon: "o-spreadsheet-Icon.SORT_ASCENDING",
+};
+
+export const dataCleanup: ActionSpec = {
+  name: _t("Data cleanup"),
+  icon: "o-spreadsheet-Icon.DATA_CLEANUP",
+};
+
+export const removeDuplicates: ActionSpec = {
+  name: _t("Remove duplicates"),
+  execute: (env) => {
+    if (getZoneArea(env.model.getters.getSelectedZone()) === 1) {
+      env.model.selection.selectTableAroundSelection();
+    }
+    env.openSidePanel("RemoveDuplicates", {});
+  },
 };
 
 export const sortDescending: ActionSpec = {

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -738,6 +738,13 @@
       <text x="9" y="15.9" class="small-text">A</text>
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.DATA_CLEANUP">
+    <svg class="o-icon" fill="currentColor">
+      <path
+        d="m13.6 6.4-2.1-2.1c-.4-.4-1-.4-1.4 0l-8.8 8.9c-.4.4-.4 1 0 1.4l2.1 2.1c.4.4 1 .4 1.4 0l8.8-8.9c.4-.4.4-1 0-1.4M8 8.5 10.5 6l1.4 1.4-2.5 2.5m3-7 1.8.8.8 1.8.8-1.8 1.8-.8-1.8-.8L14.9.4l-.8 1.8M3.5 4l1.7.7.8 1.8.8-1.8 1.8-.8-1.8-.8-.8-1.8-.8 1.8zm13.5 7.7-1.8-.8-.8-1.8-.8 1.8-1.8.8 1.8.8.8 1.8.7-1.8"
+      />
+    </svg>
+  </t>
   <t t-name="o-spreadsheet-Icon.FILTER_ICON">
     <svg
       class="o-cf-icon filter-icon"

--- a/src/components/side_panel/remove_duplicates/remove_duplicates.ts
+++ b/src/components/side_panel/remove_duplicates/remove_duplicates.ts
@@ -1,0 +1,122 @@
+import { Component, onWillUpdateProps, useState } from "@odoo/owl";
+import { numberToLetters, zoneToDimension } from "../../../helpers";
+import { _t } from "../../../translation";
+import { HeaderIndex, SpreadsheetChildEnv } from "../../../types/index";
+import { css } from "../../helpers";
+import { RemoveDuplicateTerms } from "../../translations_terms";
+import { SidePanelErrors } from "../side_panel_errors/side_panel_errors";
+
+css/* scss */ `
+  .o-checkbox-selection {
+    height: 150px;
+  }
+`;
+
+interface Props {
+  onCloseSidePanel: () => void;
+}
+
+interface RemoveDuplicatesState {
+  hasHeader: boolean;
+  columns: { [colIndex: number]: boolean };
+}
+
+export class RemoveDuplicatesPanel extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-RemoveDuplicatesPanel";
+  static components = { SidePanelErrors };
+
+  state: RemoveDuplicatesState = useState({
+    hasHeader: false,
+    columns: {},
+  });
+
+  setup() {
+    onWillUpdateProps(() => this.updateColumns());
+  }
+
+  toggleHasHeader() {
+    this.state.hasHeader = !this.state.hasHeader;
+  }
+
+  toggleAllColumns() {
+    const newState = !this.isEveryColumnSelected;
+    for (const index in this.state.columns) {
+      this.state.columns[index] = newState;
+    }
+  }
+
+  toggleColumn(colIndex: number) {
+    this.state.columns[colIndex] = !this.state.columns[colIndex];
+  }
+
+  onRemoveDuplicates() {
+    this.env.model.dispatch("REMOVE_DUPLICATES", {
+      hasHeader: this.state.hasHeader,
+      columns: this.getColsToAnalyze(),
+    });
+  }
+
+  getColLabel(colKey: string): string {
+    const col = parseInt(colKey);
+    let colLabel = _t("Column %s", numberToLetters(col));
+    if (this.state.hasHeader) {
+      const sheetId = this.env.model.getters.getActiveSheetId();
+      const row = this.env.model.getters.getSelectedZone().top;
+      const colHeader = this.env.model.getters.getEvaluatedCell({ sheetId, col, row });
+      if (colHeader.type !== "empty") {
+        colLabel += ` - ${colHeader.value}`;
+      }
+    }
+    return colLabel;
+  }
+
+  get isEveryColumnSelected(): boolean {
+    return Object.values(this.state.columns).every((value) => value === true);
+  }
+
+  get errorMessages(): string[] {
+    const cancelledReasons = this.env.model.canDispatch("REMOVE_DUPLICATES", {
+      hasHeader: this.state.hasHeader,
+      columns: this.getColsToAnalyze(),
+    }).reasons;
+
+    const errors = new Set<string>();
+
+    for (const reason of cancelledReasons) {
+      errors.add(RemoveDuplicateTerms.Errors[reason] || RemoveDuplicateTerms.Errors.Unexpected);
+    }
+    return Array.from(errors);
+  }
+
+  get selectionStatisticalInformation(): string {
+    const dimension = zoneToDimension(this.env.model.getters.getSelectedZone());
+    return _t("%(row_count)s rows and %(column_count)s columns selected", {
+      row_count: dimension.numberOfRows,
+      column_count: dimension.numberOfCols,
+    });
+  }
+
+  get canConfirm(): boolean {
+    return this.errorMessages.length === 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private updateColumns() {
+    const zone = this.env.model.getters.getSelectedZone();
+    const oldColumns = this.state.columns;
+    const newColumns = {};
+    for (let i = zone.left; i <= zone.right; i++) {
+      newColumns[i] = i in oldColumns ? oldColumns[i] : true;
+    }
+    this.state.columns = newColumns;
+  }
+
+  private getColsToAnalyze(): HeaderIndex[] {
+    return Object.keys(this.state.columns)
+      .filter((colIndex) => this.state.columns[colIndex])
+      .map((colIndex) => parseInt(colIndex));
+  }
+}

--- a/src/components/side_panel/remove_duplicates/remove_duplicates.xml
+++ b/src/components/side_panel/remove_duplicates/remove_duplicates.xml
@@ -1,0 +1,51 @@
+<templates>
+  <t t-name="o-spreadsheet-RemoveDuplicatesPanel">
+    <div class="o-remove-duplicates">
+      <div class="o-section">
+        <div class="o-section-subtitle" t-esc="selectionStatisticalInformation"/>
+        <label class="o-checkbox">
+          <input type="checkbox" t-att-checked="state.hasHeader" t-on-change="toggleHasHeader"/>
+          Data has header row
+        </label>
+      </div>
+
+      <div class="o-section">
+        <div class="o-section-title">Columns to analyze</div>
+        <div class="o-checkbox-selection overflow-auto p-3 vh-50 border rounded">
+          <label class="o-checkbox">
+            <input
+              t-att-checked="isEveryColumnSelected"
+              t-on-change="toggleAllColumns"
+              type="checkbox"
+            />
+            Select all
+          </label>
+
+          <t t-foreach="Object.keys(state.columns)" t-as="colIndex" t-key="colIndex">
+            <label class="o-checkbox">
+              <input
+                type="checkbox"
+                t-att-checked="state.columns[colIndex]"
+                t-on-change="() => this.toggleColumn(colIndex)"
+              />
+              <t t-esc="getColLabel(colIndex)"/>
+            </label>
+          </t>
+        </div>
+      </div>
+
+      <div class="o-sidePanelButtons">
+        <button
+          class="o-sidePanelButton"
+          t-att-class="{'o-disabled': !canConfirm}"
+          t-on-click="onRemoveDuplicates">
+          Remove duplicates
+        </button>
+      </div>
+
+      <div class="o-section" t-if="errorMessages.length">
+        <SidePanelErrors messages="errorMessages" msgType="'error'"/>
+      </div>
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/side_panel_errors/side_panel_errors.xml
+++ b/src/components/side_panel/side_panel_errors/side_panel_errors.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-SidePanelErrors">
     <t t-foreach="props.messages" t-as="msg" t-key="msg">
-      <div class="d-flex align-items-center" t-att-class="divClasses">
+      <div class="d-flex align-items-center o-side-panel-error" t-att-class="divClasses">
         <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
         <span t-esc="msg"/>
       </div>

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -1,3 +1,4 @@
+import { PasteInteractiveContent } from "../helpers/ui/paste_interactive";
 import { _t } from "../translation";
 import { CommandResult } from "../types/index";
 
@@ -92,5 +93,16 @@ export const SplitToColumnsTerms = {
       "Only a selection from a single column can be split"
     ),
     [CommandResult.SplitWillOverwriteContent]: _t("Splitting will overwrite existing content"),
+  },
+};
+
+export const RemoveDuplicateTerms = {
+  Errors: {
+    Unexpected: _t("Cannot remove duplicates for an unknown reason"),
+    [CommandResult.MoreThanOneRangeSelected]: _t("Please select only one range of cells"),
+    [CommandResult.EmptyTarget]: _t("Please select a range of cells containing values."),
+    [CommandResult.NoColumnsProvided]: _t("Please select at latest one column to analyze."),
+    //TODO: Remove it when accept to copy and paste merge cells
+    [CommandResult.WillRemoveExistingMerge]: PasteInteractiveContent.willRemoveExistingMerge,
   },
 };

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -26,6 +26,7 @@ import {
   AutomaticSumPlugin,
   CellPopoverPlugin,
   CollaborativePlugin,
+  DataCleanupPlugin,
   FindAndReplacePlugin,
   FormatPlugin,
   HeaderVisibilityUIPlugin,
@@ -77,7 +78,8 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("split_to_columns", SplitToColumnsPlugin)
   .add("cell_popovers", CellPopoverPlugin)
   .add("collaborative", CollaborativePlugin)
-  .add("history", HistoryPlugin);
+  .add("history", HistoryPlugin)
+  .add("data_cleanup", DataCleanupPlugin);
 
 // Plugins which have a state, but which should not be shared in collaborative
 export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()

--- a/src/plugins/ui_feature/data_cleanup.ts
+++ b/src/plugins/ui_feature/data_cleanup.ts
@@ -1,0 +1,205 @@
+import { deepEquals, positions, range, zoneToDimension } from "../../helpers";
+import { ClipboardCellsState } from "../../helpers/clipboard/clipboard_cells_state";
+import { _t } from "../../translation";
+import {
+  Command,
+  CommandResult,
+  HeaderIndex,
+  RemoveDuplicatesCommand,
+  UID,
+  Zone,
+} from "../../types/index";
+import { UIPlugin } from "../ui_plugin";
+
+export class DataCleanupPlugin extends UIPlugin {
+  // ---------------------------------------------------------------------------
+  // Command Handling
+  // ---------------------------------------------------------------------------
+
+  allowDispatch(cmd: Command) {
+    switch (cmd.type) {
+      case "REMOVE_DUPLICATES":
+        return this.checkValidations(
+          cmd,
+          this.chainValidations(
+            this.checkSingleRangeSelected,
+            this.checkNoMergeInZone,
+            this.checkRangeContainsValues,
+            this.checkColumnsIncludedInZone
+          ),
+          this.chainValidations(this.checkNoColumnProvided, this.checkColumnsAreUnique)
+        );
+    }
+    return CommandResult.Success;
+  }
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "REMOVE_DUPLICATES":
+        this.removeDuplicates(cmd.columns, cmd.hasHeader);
+        break;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private removeDuplicates(columnsToAnalyze: HeaderIndex[], hasHeader: boolean) {
+    const sheetId = this.getters.getActiveSheetId();
+    const zone = this.getters.getSelectedZone();
+    if (hasHeader) {
+      zone.top += 1;
+    }
+
+    const uniqueRowsIndexes = this.getUniqueRowsIndexes(
+      sheetId,
+      zone.top,
+      zone.bottom,
+      columnsToAnalyze
+    );
+    const numberOfUniqueRows = uniqueRowsIndexes.length;
+
+    if (numberOfUniqueRows === zoneToDimension(zone).numberOfRows) {
+      this.notifyRowsRemovedAndRemaining(0, numberOfUniqueRows);
+      return;
+    }
+
+    const rowsToKeep: Zone[] = uniqueRowsIndexes.map((rowIndex) => ({
+      left: zone.left,
+      top: rowIndex,
+      right: zone.right,
+      bottom: rowIndex,
+    }));
+
+    const state = new ClipboardCellsState(
+      rowsToKeep,
+      "COPY",
+      this.getters,
+      this.dispatch,
+      this.selection
+    );
+
+    for (const { col, row } of positions(zone)) {
+      this.dispatch("CLEAR_CELL", { col, row, sheetId });
+    }
+
+    const zonePasted: Zone = {
+      left: zone.left,
+      top: zone.top,
+      right: zone.left,
+      bottom: zone.top,
+    };
+
+    state.paste([zonePasted]);
+
+    const remainingZone = {
+      left: zone.left,
+      top: zone.top - (hasHeader ? 1 : 0),
+      right: zone.right,
+      bottom: zone.top + numberOfUniqueRows - 1,
+    };
+
+    this.selection.selectZone({
+      cell: { col: remainingZone.left, row: remainingZone.top },
+      zone: remainingZone,
+    });
+
+    const removedRows = zone.bottom - zone.top + 1 - numberOfUniqueRows;
+    this.notifyRowsRemovedAndRemaining(removedRows, numberOfUniqueRows);
+  }
+
+  private getUniqueRowsIndexes(
+    sheetId: UID,
+    top: HeaderIndex,
+    bottom: HeaderIndex,
+    columns: HeaderIndex[]
+  ): number[] {
+    const uniqueRows = new Map<number, string>();
+
+    for (const row of range(top, bottom + 1)) {
+      const cellsValuesInRow = columns.map((col) => {
+        return this.getters.getEvaluatedCell({
+          sheetId,
+          col,
+          row,
+        }).value;
+      });
+      const isRowUnique = !Object.values(uniqueRows).some((uniqueRow) =>
+        deepEquals(uniqueRow, cellsValuesInRow)
+      );
+
+      if (isRowUnique) {
+        uniqueRows[row] = cellsValuesInRow;
+      }
+    }
+    // transform key object in number
+    return Object.keys(uniqueRows).map((key) => parseInt(key));
+  }
+
+  private notifyRowsRemovedAndRemaining(removedRows: number, remainingRows: number) {
+    this.ui.notifyUI({
+      type: "info",
+      text: _t(
+        "%s duplicate rows found and removed.\n%s unique rows remain.",
+        removedRows.toString(),
+        remainingRows.toString()
+      ),
+      sticky: false,
+    });
+  }
+
+  private checkSingleRangeSelected(): CommandResult {
+    const zones = this.getters.getSelectedZones();
+    if (zones.length !== 1) {
+      return CommandResult.MoreThanOneRangeSelected;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkNoMergeInZone(): CommandResult {
+    const sheetId = this.getters.getActiveSheetId();
+    const zone = this.getters.getSelectedZone();
+    const mergesInZone = this.getters.getMergesInZone(sheetId, zone);
+    if (mergesInZone.length > 0) {
+      return CommandResult.WillRemoveExistingMerge;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkRangeContainsValues(cmd: RemoveDuplicatesCommand): CommandResult {
+    const sheetId = this.getters.getActiveSheetId();
+    const zone = this.getters.getSelectedZone();
+    if (cmd.hasHeader) {
+      zone.top += 1;
+    }
+    const evaluatedCells = this.getters.getEvaluatedCellsInZone(sheetId, zone);
+    if (evaluatedCells.every((evaluatedCel) => evaluatedCel.type === "empty")) {
+      return CommandResult.EmptyTarget;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkNoColumnProvided(cmd: RemoveDuplicatesCommand): CommandResult {
+    if (cmd.columns.length === 0) {
+      return CommandResult.NoColumnsProvided;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkColumnsIncludedInZone(cmd: RemoveDuplicatesCommand): CommandResult {
+    const zone = this.getters.getSelectedZone();
+    const columnsToAnalyze = cmd.columns;
+    if (columnsToAnalyze.some((colIndex) => colIndex < zone.left || colIndex > zone.right)) {
+      return CommandResult.ColumnsNotIncludedInZone;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkColumnsAreUnique(cmd: RemoveDuplicatesCommand): CommandResult {
+    if (cmd.columns.length !== new Set(cmd.columns).size) {
+      return CommandResult.DuplicatesColumnsSelected;
+    }
+    return CommandResult.Success;
+  }
+}

--- a/src/plugins/ui_feature/index.ts
+++ b/src/plugins/ui_feature/index.ts
@@ -2,6 +2,7 @@ export * from "./autofill";
 export * from "./automatic_sum";
 export * from "./cell_popovers";
 export * from "./collaborative";
+export * from "./data_cleanup";
 export * from "./find_and_replace";
 export * from "./format";
 export * from "./header_visibility_ui";

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -377,6 +377,14 @@ topbarMenuRegistry
     ...ACTION_DATA.sortDescending,
     sequence: 20,
   })
+  .addChild("data_cleanup", ["data"], {
+    ...ACTION_DATA.dataCleanup,
+    sequence: 15,
+  })
+  .addChild("remove_duplicates", ["data", "data_cleanup"], {
+    ...ACTION_DATA.removeDuplicates,
+    sequence: 10,
+  })
   .addChild("split_to_columns", ["data"], {
     ...ACTION_DATA.splitToColumns,
     sequence: 20,

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -2,6 +2,7 @@ import { ChartPanel } from "../components/side_panel/chart/main_chart_panel/main
 import { ConditionalFormattingPanel } from "../components/side_panel/conditional_formatting/conditional_formatting";
 import { CustomCurrencyPanel } from "../components/side_panel/custom_currency/custom_currency";
 import { FindAndReplacePanel } from "../components/side_panel/find_and_replace/find_and_replace";
+import { RemoveDuplicatesPanel } from "../components/side_panel/remove_duplicates/remove_duplicates";
 import { SettingsPanel } from "../components/side_panel/settings/settings_panel";
 import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns_panel/split_to_columns_panel";
 import { _t } from "../translation";
@@ -47,4 +48,9 @@ sidePanelRegistry.add("SplitToColumns", {
 sidePanelRegistry.add("Settings", {
   title: _t("Spreadsheet settings"),
   Body: SettingsPanel,
+});
+
+sidePanelRegistry.add("RemoveDuplicates", {
+  title: _t("Remove duplicates"),
+  Body: RemoveDuplicatesPanel,
 });

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -496,6 +496,16 @@ export interface UpdateLocaleCommand {
   locale: Locale;
 }
 
+// ------------------------------------------------
+// DATA CLEANUP
+// ------------------------------------------------
+
+export interface RemoveDuplicatesCommand {
+  type: "REMOVE_DUPLICATES";
+  columns: HeaderIndex[];
+  hasHeader: boolean;
+}
+
 //#endregion
 
 //#region Local Commands
@@ -1022,7 +1032,8 @@ export type LocalCommand =
   | ActivateNextSheetCommand
   | ActivatePreviousSheetCommand
   | UpdateFilterCommand
-  | SplitTextIntoColumnsCommand;
+  | SplitTextIntoColumnsCommand
+  | RemoveDuplicatesCommand;
 
 export type Command = CoreCommand | LocalCommand;
 
@@ -1163,6 +1174,10 @@ export const enum CommandResult {
   NoActiveSheet = "NoActiveSheet",
   InvalidLocale = "InvalidLocale",
   AlreadyInPaintingFormatMode = "AlreadyInPaintingFormatMode",
+  MoreThanOneRangeSelected = "MoreThanOneRangeSelected",
+  NoColumnsProvided = "NoColumnsProvided",
+  ColumnsNotIncludedInZone = "ColumnsNotIncludedInZone",
+  DuplicatesColumnsSelected = "DuplicatesColumnsSelected",
 }
 
 export interface CommandHandler<T> {

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -39,7 +39,7 @@ describe("find and replace sidePanel component", () => {
       parent.env.openSidePanel("FindAndReplace");
       await nextTick();
     });
-    test("Can close the find and replace side panel", async () => {
+    test("Can close the remove duplicate side panel", async () => {
       expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
       await click(fixture, selectors.closeSidepanel);
       expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);

--- a/tests/components/remove_duplicates_side_panel.test.ts
+++ b/tests/components/remove_duplicates_side_panel.test.ts
@@ -1,0 +1,243 @@
+import { Model, Spreadsheet } from "../../src";
+import { toZone } from "../../src/helpers";
+import { click, merge, setCellContent, setSelection } from "../test_helpers";
+import { getRangeValuesAsMatrix, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+
+const selectors = {
+  closeSidepanel: ".o-sidePanel .o-sidePanelClose",
+  statisticalInformation:
+    ".o-sidePanel .o-remove-duplicates .o-section:nth-child(1) .o-section-subtitle",
+  checkBoxHasHeaderRow: ".o-sidePanel .o-remove-duplicates .o-section:nth-child(1) input",
+  checkBoxColumnsLabel: ".o-sidePanel .o-remove-duplicates .o-section:nth-child(2) label",
+  checkBoxColumnsInput: ".o-sidePanel .o-remove-duplicates .o-section:nth-child(2) input",
+  sidePanelError: ".o-side-panel-error",
+  removeDuplicateButton: ".o-sidePanel .o-remove-duplicates .o-sidePanelButton",
+};
+
+let model: Model;
+
+describe("remove duplicates", () => {
+  let fixture: HTMLElement;
+  let parent: Spreadsheet;
+
+  beforeEach(async () => {
+    ({ parent, model, fixture } = await mountSpreadsheet());
+
+    parent.env.openSidePanel("RemoveDuplicates");
+    await nextTick();
+  });
+
+  test("Can close the find and replace side panel", async () => {
+    expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
+    await click(fixture, selectors.closeSidepanel);
+    expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
+  });
+
+  test("displayed column names correspond to columns in selection", async () => {
+    setSelection(model, ["B2:C6"]);
+    await nextTick();
+    const nodeList = fixture.querySelectorAll(selectors.checkBoxColumnsLabel);
+    expect(nodeList.length).toBe(3);
+    expect(nodeList[0].textContent).toBe(" Select all ");
+    expect(nodeList[1].textContent).toBe("Column B");
+    expect(nodeList[2].textContent).toBe("Column C");
+  });
+
+  test("select 'Data has header row' change the column label if content", async () => {
+    setCellContent(model, "B2", "Bachibouzouk");
+    setCellContent(model, "C2", "Cucurbitacee");
+    setSelection(model, ["B2:D3"]);
+    await click(fixture, selectors.checkBoxHasHeaderRow);
+    const checkBox = fixture.querySelectorAll(selectors.checkBoxColumnsLabel);
+    expect(checkBox.length).toBe(4);
+    expect(checkBox[0].textContent?.trim()).toBe("Select all"); // trim because of the space added by prettier in the template
+    expect(checkBox[1].textContent).toBe("Column B - Bachibouzouk");
+    expect(checkBox[2].textContent).toBe("Column C - Cucurbitacee");
+    expect(checkBox[3].textContent).toBe("Column D");
+  });
+
+  test("display corresponding statistical information on the number of row/col selected", async () => {
+    setSelection(model, ["E3:H7"]);
+    await nextTick();
+    expect(fixture.querySelector(selectors.statisticalInformation)!.textContent).toBe(
+      "5 rows and 4 columns selected"
+    );
+  });
+
+  test("update statistical information when selection change", async () => {
+    setSelection(model, ["E3:H7"]);
+    await nextTick();
+    expect(fixture.querySelector(selectors.statisticalInformation)!.textContent).toBe(
+      "5 rows and 4 columns selected"
+    );
+
+    setSelection(model, ["A1:B2"]);
+    await nextTick();
+    expect(fixture.querySelector(selectors.statisticalInformation)!.textContent).toBe(
+      "2 rows and 2 columns selected"
+    );
+  });
+
+  test("do the remove duplicates", async () => {
+    const cells = {
+      A1: { content: "11" },
+      A2: { content: "88" },
+      A3: { content: "11" },
+      A4: { content: "88" },
+      A5: { content: "11" },
+    };
+
+    model = new Model({ sheets: [{ cells }] });
+    ({ parent, fixture } = await mountSpreadsheet({ model }));
+    parent.env.openSidePanel("RemoveDuplicates");
+    await nextTick();
+    setSelection(model, ["A1:A5"]);
+    await click(fixture, selectors.checkBoxHasHeaderRow);
+    await click(fixture, selectors.removeDuplicateButton);
+
+    expect(getRangeValuesAsMatrix(model, "A1:A5")).toEqual([[11], [88], [11], [""], [""]]);
+  });
+
+  test("checkboxes columns evolve with correct state ", async () => {
+    setCellContent(model, "A1", "Atchoum");
+    setSelection(model, ["A1:B2"]);
+    await nextTick();
+
+    let checkBoxes = fixture.querySelectorAll(selectors.checkBoxColumnsInput);
+    let checkBoxAll = checkBoxes[0];
+    let checkBoxA = checkBoxes[1];
+    let checkBoxB = checkBoxes[2];
+
+    // at the beginning --> expect all checkbox to be selected
+    expect((checkBoxAll as HTMLInputElement).checked).toBe(true);
+    expect((checkBoxA as HTMLInputElement).checked).toBe(true);
+    expect((checkBoxB as HTMLInputElement).checked).toBe(true);
+
+    // unselect "select all" --> all checkbox should be unselected
+    await click(checkBoxAll);
+    await nextTick();
+    expect((checkBoxAll as HTMLInputElement).checked).toBe(false);
+    expect((checkBoxA as HTMLInputElement).checked).toBe(false);
+    expect((checkBoxB as HTMLInputElement).checked).toBe(false);
+
+    // select A --> only A should be selected
+    await click(checkBoxA);
+    await nextTick();
+    expect((checkBoxAll as HTMLInputElement).checked).toBe(false);
+    expect((checkBoxA as HTMLInputElement).checked).toBe(true);
+    expect((checkBoxB as HTMLInputElement).checked).toBe(false);
+
+    // select B --> "select all" become selected because all checkbox are selected
+    await click(checkBoxB);
+    await nextTick();
+    expect((checkBoxAll as HTMLInputElement).checked).toBe(true);
+    expect((checkBoxA as HTMLInputElement).checked).toBe(true);
+    expect((checkBoxB as HTMLInputElement).checked).toBe(true);
+
+    // unselect A --> "select all" become unselected, still B selected
+    await click(checkBoxA);
+    await nextTick();
+    expect((checkBoxAll as HTMLInputElement).checked).toBe(false);
+    expect((checkBoxA as HTMLInputElement).checked).toBe(false);
+    expect((checkBoxB as HTMLInputElement).checked).toBe(true);
+  });
+
+  test("the state of the checkboxes of the columns is preserved when extending the selection", async () => {
+    setCellContent(model, "A1", "Atchoum");
+    setSelection(model, ["A1:B2"]);
+    await nextTick();
+
+    let checkBoxes = fixture.querySelectorAll(selectors.checkBoxColumnsInput);
+    let checkBoxAll = checkBoxes[0];
+    let checkBoxA = checkBoxes[1];
+    let checkBoxB = checkBoxes[2];
+
+    // unselect B
+    await click(checkBoxB);
+    await nextTick();
+    expect((checkBoxAll as HTMLInputElement).checked).toBe(false);
+    expect((checkBoxA as HTMLInputElement).checked).toBe(true);
+    expect((checkBoxB as HTMLInputElement).checked).toBe(false);
+
+    // extend selection to C --> keep the state of the checkboxes A and B
+    setSelection(model, ["A1:C2"]);
+    await nextTick();
+    expect((checkBoxAll as HTMLInputElement).checked).toBe(false);
+    expect((checkBoxA as HTMLInputElement).checked).toBe(true);
+    expect((checkBoxB as HTMLInputElement).checked).toBe(false);
+
+    let checkBoxC = fixture.querySelectorAll(selectors.checkBoxColumnsInput)[3];
+    expect((checkBoxC as HTMLInputElement).checked).toBe(true);
+  });
+
+  test("if no content selected --> display error message and disable ", async () => {
+    setSelection(model, ["A1:B2"]);
+    await nextTick();
+    const errors = fixture.querySelectorAll(selectors.sidePanelError);
+    expect(errors.length).toBe(1);
+    expect(errors[0].textContent).toBe("Please select a range of cells containing values.");
+    expect(fixture.querySelector(selectors.removeDuplicateButton)!.classList).toContain(
+      "o-disabled"
+    );
+  });
+
+  test("if more than one selection --> display error message and disable ", async () => {
+    setSelection(model, ["A1:B2", "C3:D4"]);
+    await nextTick();
+    const errors = fixture.querySelectorAll(selectors.sidePanelError);
+    expect(errors.length).toBe(1);
+    expect(errors[0].textContent).toBe("Please select only one range of cells");
+    expect(fixture.querySelector(selectors.removeDuplicateButton)!.classList).toContain(
+      "o-disabled"
+    );
+  });
+
+  test("if merges zone --> display error message and disable", async () => {
+    merge(model, "A1:B1");
+    merge(model, "A2:B2");
+    setSelection(model, ["A1:B2"]);
+    await nextTick();
+    const errors = fixture.querySelectorAll(selectors.sidePanelError);
+    expect(errors.length).toBe(1);
+    expect(errors[0].textContent).toBe(
+      "This operation is not possible due to a merge. Please remove the merges first than try again."
+    );
+    expect(fixture.querySelector(selectors.removeDuplicateButton)!.classList).toContain(
+      "o-disabled"
+    );
+  });
+
+  test("if no columns selected --> display error message and disable", async () => {
+    const cells = { B1: { content: "42" }, B2: { content: "42" } };
+    model = new Model({ sheets: [{ cells }] });
+    ({ parent, fixture } = await mountSpreadsheet({ model }));
+    setSelection(model, ["B1:B2"]);
+    parent.env.openSidePanel("RemoveDuplicates");
+    await nextTick();
+
+    const checkBoxSelectAll = fixture.querySelectorAll(selectors.checkBoxColumnsInput)[0]; // checkBox[0] correspond to " Select all "
+    await click(checkBoxSelectAll);
+
+    const errors = fixture.querySelectorAll(selectors.sidePanelError);
+    expect(errors.length).toBe(1);
+    expect(errors[0].textContent).toBe("Please select at latest one column to analyze.");
+    expect(fixture.querySelector(selectors.removeDuplicateButton)!.classList).toContain(
+      "o-disabled"
+    );
+  });
+});
+
+describe("remove duplicate action", () => {
+  test("expand selection to table if only one cell is selected", async () => {
+    const cells = { B1: { content: "42" }, B2: { content: "42" } };
+    const { fixture, model } = await mountSpreadsheet({
+      model: new Model({ sheets: [{ cells }] }),
+    });
+    setSelection(model, ["B2"]);
+    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='data']");
+    await click(fixture, ".o-menu-item[data-name='data_cleanup']");
+    await click(fixture, ".o-menu-item[data-name='remove_duplicates']");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("B1:B2"));
+  });
+});

--- a/tests/plugins/remove_duplicates.test.ts
+++ b/tests/plugins/remove_duplicates.test.ts
@@ -1,0 +1,267 @@
+import { CommandResult } from "../../src";
+import { toZone } from "../../src/helpers";
+import { getCell, getEvaluatedCell } from "../test_helpers";
+import { merge, selectCell, setFormat, setSelection } from "../test_helpers/commands_helpers";
+import {
+  createModelFromGrid,
+  getRangeFormatsAsMatrix,
+  getRangeValuesAsMatrix,
+} from "../test_helpers/helpers";
+
+describe("remove duplicates", () => {
+  test("can remove duplicate", () => {
+    const grid = { A2: "1", A3: "1", A4: "2", A5: "2" };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:A5"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false });
+    expect(getRangeValuesAsMatrix(model, "A2:A5")).toEqual([[1], [2], [""], [""]]);
+  });
+
+  test("selection is updated after removing duplicates", () => {
+    const grid = { A2: "1", A3: "1", A4: "2", A5: "2" };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:A5"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A2:A3"));
+  });
+
+  test("apply deletion only in selected zone", () => {
+    const grid = { A2: "1", A3: "1", A4: "2", A5: "2" };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:A4"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false });
+    expect(getRangeValuesAsMatrix(model, "A2:A5")).toEqual([[1], [2], [""], [2]]);
+  });
+
+  test("remove duplicates based on columns provided", () => {
+    // prettier-ignore
+    const grid = {
+      A2: "1", B2: "la",
+      A3: "1", B3: "la",
+      A4: "1", B4: "land",
+    };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:B4"]);
+    // provide column B to analyze
+    model.dispatch("REMOVE_DUPLICATES", { columns: [1], hasHeader: false });
+    expect(getRangeValuesAsMatrix(model, "A2:B4")).toEqual([
+      [1, "la"],
+      [1, "land"],
+      ["", ""],
+    ]);
+  });
+
+  test("if several rows considered identical are found, returns the first row found of these rows", () => {
+    // prettier-ignore
+    const grid = {
+      A2: "1", B2: "B2",
+      A3: "1", B3: "B3",
+      A4: "1", B4: "B4",
+    };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:B4"]);
+    // provide column A to analyze
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false });
+    expect(getRangeValuesAsMatrix(model, "B2:B4")).toEqual([["B2"], [""], [""]]);
+  });
+
+  test("For formula, take into account the evaluated cell value", () => {
+    const grid = {
+      A2: "42",
+      A3: "=21+21",
+    };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:A3"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false });
+
+    expect(getEvaluatedCell(model, "A2").value).toBe(42);
+    expect(getEvaluatedCell(model, "A3").value).toBe("");
+  });
+
+  test("For formula, update the references", () => {
+    const grid = {
+      A2: "1",
+      A3: "1",
+      A4: "=A2+1",
+    };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:A4"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false });
+
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
+    expect(getEvaluatedCell(model, "A3").value).toBe(1);
+    expect(getCell(model, "A3")!.content).toBe("=A1+1");
+  });
+
+  test("dont take into account the format", () => {
+    const grid = {
+      B2: "42",
+      B3: "42",
+      B4: "42",
+    };
+    const model = createModelFromGrid(grid);
+    selectCell(model, "B2");
+    setFormat(model, "0.00%");
+
+    selectCell(model, "B4");
+    setFormat(model, "#,##0[$€]");
+
+    expect(getRangeValuesAsMatrix(model, "B2:B4")).toEqual([[42], [42], [42]]);
+    expect(getRangeFormatsAsMatrix(model, "B2:B4")).toEqual([["0.00%"], [""], ["#,##0[$€]"]]);
+
+    setSelection(model, ["B2:B4"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [1], hasHeader: false });
+
+    expect(getRangeValuesAsMatrix(model, "B2:B4")).toEqual([[42], [""], [""]]);
+    expect(getRangeFormatsAsMatrix(model, "B2:B4")).toEqual([["0.00%"], [""], [""]]);
+  });
+
+  test("consider empty cell as value to compare", () => {
+    const model = createModelFromGrid({
+      A1: "24",
+      A4: "42",
+      A6: "242",
+    });
+    setSelection(model, ["A1:A6"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false });
+    expect(getRangeValuesAsMatrix(model, "A1:A6")).toEqual([[24], [""], [42], [242], [""], [""]]);
+  });
+
+  test("can remove duplicates with header", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "42", B1: "Michel Blanc",
+      A2: "24", B2: "Michel Noir",
+      A3: "42", B3: "Michel Noir",
+      A4: "24", B4: "Michel Blanc",
+    };
+
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A1:A4"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: true });
+    expect(getRangeValuesAsMatrix(model, "A1:A4")).toEqual([[42], [24], [42], [""]]);
+
+    setSelection(model, ["B1:B4"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [1], hasHeader: true });
+    expect(getRangeValuesAsMatrix(model, "B1:B4")).toEqual([
+      ["Michel Blanc"],
+      ["Michel Noir"],
+      ["Michel Blanc"],
+      [""],
+    ]);
+  });
+});
+
+describe("allow dispatch", () => {
+  test("cancel if merging zone", () => {
+    const grid = {
+      A2: "1",
+      A3: "1",
+    };
+    const model = createModelFromGrid(grid);
+    merge(model, "A1:A2");
+    setSelection(model, ["A1:A3"]);
+    expect(
+      model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false })
+    ).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
+  });
+
+  test("throw error if more than one range selected", () => {
+    const grid = {
+      A2: "1",
+      A3: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:A3", "A3:A4"]);
+    expect(
+      model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false })
+    ).toBeCancelledBecause(CommandResult.MoreThanOneRangeSelected);
+  });
+
+  test("throw error if zone doesn't contain values", () => {
+    const grid = {
+      A2: "1",
+      A3: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["D10:E11"]);
+    expect(
+      model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false })
+    ).toBeCancelledBecause(CommandResult.EmptyTarget);
+    setSelection(model, ["C9:E11"]);
+    expect(
+      model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: true })
+    ).toBeCancelledBecause(CommandResult.EmptyTarget);
+  });
+
+  test("throw error if no columns selected", () => {
+    const grid = {
+      A2: "1",
+      A3: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:A3"]);
+    expect(
+      model.dispatch("REMOVE_DUPLICATES", { columns: [], hasHeader: false })
+    ).toBeCancelledBecause(CommandResult.NoColumnsProvided);
+  });
+
+  test("throw error if columns aren't in zone", () => {
+    const grid = {
+      A2: "1",
+      A3: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A1:B2"]);
+    expect(
+      // provide column B and D to analyze
+      model.dispatch("REMOVE_DUPLICATES", { columns: [1, 3], hasHeader: false })
+    ).toBeCancelledBecause(CommandResult.ColumnsNotIncludedInZone);
+  });
+
+  test("throw error if columns are selected twice", () => {
+    const grid = {
+      A2: "1",
+      A3: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setSelection(model, ["A2:A3"]);
+    expect(
+      model.dispatch("REMOVE_DUPLICATES", { columns: [0, 0], hasHeader: false })
+    ).toBeCancelledBecause(CommandResult.DuplicatesColumnsSelected);
+  });
+});
+
+describe("notify user", () => {
+  test("notify when row removed", async () => {
+    const model = createModelFromGrid({
+      A1: "42",
+      A2: "42",
+    });
+    let notifyUserTextSpy = jest.fn();
+    jest.spyOn(model.config, "notifyUI").mockImplementation(notifyUserTextSpy);
+    setSelection(model, ["A1:A2"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false });
+    expect(notifyUserTextSpy).toHaveBeenCalledWith({
+      text: "1 duplicate rows found and removed.\n1 unique rows remain.",
+      type: "info",
+      sticky: false,
+    });
+  });
+
+  test("notify when no row removed", async () => {
+    const model = createModelFromGrid({
+      A1: "42",
+      A2: "24",
+    });
+    let notifyUserTextSpy = jest.fn();
+    jest.spyOn(model.config, "notifyUI").mockImplementation(notifyUserTextSpy);
+    setSelection(model, ["A1:A2"]);
+    model.dispatch("REMOVE_DUPLICATES", { columns: [0], hasHeader: false });
+    expect(notifyUserTextSpy).toHaveBeenCalledWith({
+      text: "0 duplicate rows found and removed.\n2 unique rows remain.",
+      type: "info",
+      sticky: false,
+    });
+  });
+});


### PR DESCRIPTION
## Description:

Add a new feature in the data menu allowing to remove duplicate
rows in the selection

Co-authored-by: Anthony Hendrickx (anhe) <anhe@odoo.com>

Odoo task ID : [2984935](https://www.odoo.com/web#id=2984935&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo