### PR TITLE
[FIX] top_bar: auto selecting adjacent cells for filter

### DIFF
--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -587,6 +587,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
     if (this.cannotCreateFilter) {
       return;
     }
+    this.env.model.selection.selectTableAroundSelection();
     const sheetId = this.env.model.getters.getActiveSheetId();
     const selection = this.env.model.getters.getSelectedZones();
     interactiveAddFilter(this.env, sheetId, selection);

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -2,6 +2,7 @@ import { Component, onMounted, onWillUnmount, useState, xml } from "@odoo/owl";
 import { ComposerFocusType } from "../../src/components/spreadsheet/spreadsheet";
 import { TopBar } from "../../src/components/top_bar/top_bar";
 import { DEFAULT_FONT_SIZE } from "../../src/constants";
+import { toZone, zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { topbarComponentRegistry } from "../../src/registries";
 import { topbarMenuRegistry } from "../../src/registries/menus/topbar_menu_registry";
@@ -21,7 +22,7 @@ import {
   simulateClick,
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
-import { getBorder, getCell, getStyle } from "../test_helpers/getters_helpers";
+import { getBorder, getCell, getFilterTable, getStyle } from "../test_helpers/getters_helpers";
 import {
   getFigureIds,
   getNode,
@@ -235,6 +236,22 @@ describe("TopBar component", () => {
       filterTool = fixture.querySelector(".o-filter-tool")!;
       expect(filterTool.querySelectorAll(".filter-icon-active").length).toEqual(1);
       expect(filterTool.querySelectorAll(".filter-icon-inactive").length).toEqual(0);
+    });
+
+    test("Adjacent cells selection while applying filter on single cell", async () => {
+      setCellContent(model, "A1", "A");
+      setCellContent(model, "A2", "A3");
+      setCellContent(model, "B2", "B");
+      setCellContent(model, "B3", "3");
+      setCellContent(model, "C3", "B4");
+      setCellContent(model, "C4", "Hello");
+      setCellContent(model, "D4", "2");
+      selectCell(model, "A1");
+      await simulateClick(".o-tool.o-filter-tool");
+      await nextTick();
+      const selection = model.getters.getSelectedZone();
+      expect(zoneToXc(selection)).toEqual("A1:D4");
+      expect(getFilterTable(model, "A1")!.zone).toEqual(toZone("A1:D4"));
     });
   });
 

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -798,6 +798,7 @@ export function createFilter(
   range: string,
   sheetId: UID = model.getters.getActiveSheetId()
 ): DispatchResult {
+  model.selection.selectTableAroundSelection();
   return model.dispatch("CREATE_FILTER_TABLE", {
     sheetId,
     target: target(range),


### PR DESCRIPTION
## Description:

Earlier, filter function is unable to identify adjacent available cells. To resolve this a new function created, which will help to identifying and updating the filterable zone by taking into consideration any adjacent available cells. Furthermore, if a specific zone has already been selected, the filter will only be applied to that specific zone.

Odoo task ID : [3128920](https://www.odoo.com/web#id=3128920&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo