### PR TITLE
[FIX] components: Fix static colors for spreadsheet

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -41,6 +41,17 @@ css/* scss */ `
     position: relative;
     display: grid;
     grid-template-columns: auto 350px;
+    color: #333;
+    input {
+      background-color: white;
+    }
+    .text-muted {
+      color: grey !important;
+    }
+    button {
+      color: #333;
+    }
+
     * {
       font-family: "Roboto", "RobotoDraft", Helvetica, Arial, sans-serif;
     }


### PR DESCRIPTION
Some components had part of their style relying on bootstrap defaults. Those can be altered by changing css variables, to create a dark mode for example.

The issue is that our custom style cannot be alteredin the same way because we rely on JS variables to generate static css whereas we should rely on scss variables to use in js. Since the current implementation does not support scss variables, we force the light mode for the time being.

Task 3143440

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo