### PR TITLE
[FIX] collaborative: check active sheet exists

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -321,7 +321,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     for (let command of commands) {
       const previousStatus = this.status;
       this.status = Status.RunningCore;
-      this.dispatchToHandlers(this.allUIPlugins, command);
+      this.dispatchToHandlers(this.statefulUIPlugins, command);
       this.status = previousStatus;
     }
     this.finalize();

--- a/src/plugins/ui_core_views/sheetview.ts
+++ b/src/plugins/ui_core_views/sheetview.ts
@@ -617,6 +617,9 @@ export class SheetViewPlugin extends UIPlugin {
   }
 
   private resetViewports(sheetId: UID) {
+    if (!this.getters.tryGetSheet(sheetId)) {
+      return;
+    }
     const { xSplit, ySplit } = this.getters.getPaneDivisions(sheetId);
     const nCols = this.getters.getNumberCols(sheetId);
     const nRows = this.getters.getNumberRows(sheetId);


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo