### PR TITLE
[IMP] Chart: attach source chart id when copying charts

### DIFF
--- a/src/helpers/clipboard/clipboard_figure_state.ts
+++ b/src/helpers/clipboard/clipboard_figure_state.ts
@@ -116,6 +116,7 @@ export class ClipboardFigureState implements ClipboardState {
 
 export class ClipboardFigureChart {
   private readonly copiedChart: AbstractChart;
+  private readonly sourceChartId: string;
 
   constructor(
     private dispatch: CommandDispatcher["dispatch"],
@@ -128,6 +129,7 @@ export class ClipboardFigureChart {
       throw new Error(`No chart for the given id: ${copiedFigureId}`);
     }
     this.copiedChart = chart.copyInSheetId(sheetId);
+    this.sourceChartId = copiedFigureId;
   }
 
   paste(sheetId: UID, figureId: UID, position: { x: number; y: number }, size: FigureSize) {
@@ -137,6 +139,7 @@ export class ClipboardFigureChart {
       sheetId,
       position,
       size,
+      sourceChartId: this.sourceChartId,
       definition: copy.getDefinition(),
     });
   }

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -93,6 +93,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
                 size: { width: fig.width, height: fig.height },
                 definition: chart.getDefinition(),
                 sheetId: cmd.sheetIdTo,
+                sourceChartId: fig.id,
               });
             }
           }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -423,6 +423,7 @@ export interface CreateChartCommand extends SheetDependentCommand {
   id: UID;
   position?: { x: number; y: number };
   size?: FigureSize;
+  sourceChartId?: string;
   definition: ChartDefinition;
 }
 


### PR DESCRIPTION
## Description:

This PR adds a new field `sourceChartId` in `CREATE_CHART` command, and when pasting the new chart, the original chart id is attached with the creation command. 
It helps with the correct copying of odoo menu link, and possibly other things only existing in odoo in the future. 

Odoo task ID : [2906334](https://www.odoo.com/web#id=2906334&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo