### PR TITLE
[FIX] scorecard: rendering issue while resizing

### DIFF
--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,16 +1,8 @@
-import { Component, useEffect, useRef, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { DEFAULT_FONT } from "../../../../constants";
 import { getFontSizeMatchingWidth, relativeLuminance } from "../../../../helpers";
 import { chartComponentRegistry } from "../../../../registries";
-import {
-  Color,
-  DOMDimension,
-  Figure,
-  Pixel,
-  Ref,
-  SpreadsheetChildEnv,
-  Style,
-} from "../../../../types";
+import { Color, Figure, Pixel, SpreadsheetChildEnv, Style } from "../../../../types";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
 import { cellTextStyleToCss, cssPropertiesToCss } from "../../../helpers";
 import { css } from "../../../helpers/css";
@@ -93,26 +85,6 @@ interface Props {
 export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChart";
   private ctx = document.createElement("canvas").getContext("2d")!;
-  private chartRef!: Ref<HTMLDivElement>;
-
-  private state: DOMDimension = useState({ width: 0, height: 0 });
-
-  setup() {
-    this.chartRef = useRef("chart");
-    const resizeObserver = new ResizeObserver(() => {
-      const { width, height } = this.chartRef.el!.getBoundingClientRect();
-      this.state.width = width;
-      this.state.height = height;
-    });
-    useEffect(
-      () => {
-        const el = this.chartRef.el!;
-        resizeObserver.observe(el);
-        return () => resizeObserver.unobserve(el);
-      },
-      () => [this.chartRef.el]
-    );
-  }
 
   get runtime(): ScorecardChartRuntime {
     return this.env.model.getters.getChartRuntime(this.props.figure.id) as ScorecardChartRuntime;
@@ -169,12 +141,12 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get chartPadding() {
-    return this.state.width * CHART_PADDING_RATIO;
+    return this.props.figure.width * CHART_PADDING_RATIO;
   }
 
   getTextStyles() {
     // If the widest text overflows horizontally, scale it down, and apply the same scaling factors to all the other fonts.
-    const maxLineWidth = this.state.width * (1 - 2 * CHART_PADDING_RATIO);
+    const maxLineWidth = this.props.figure.width * (1 - 2 * CHART_PADDING_RATIO);
     const widestElement = this.getWidestElement();
     const baseFontSize = widestElement.getElementMaxFontSize(this.getDrawableHeight(), this);
     const fontSizeMatchingWidth = getFontSizeMatchingWidth(
@@ -230,7 +202,7 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   /** Get the height of the chart minus all the vertical paddings */
   private getDrawableHeight(): number {
     const verticalPadding = 2 * this.chartPadding;
-    let availableHeight = this.state.height - verticalPadding;
+    let availableHeight = this.props.figure.height - verticalPadding;
     availableHeight -= this.title ? TITLE_FONT_SIZE * LINE_HEIGHT : 0;
     return availableHeight;
   }

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -32,16 +32,14 @@ css/*SCSS*/ `
     width: 100%;
     height: 100%;
 
-    border: solid ${FIGURE_BORDER_COLOR};
     &:focus {
       outline: none;
     }
   }
 
-  div.o-active-figure-border {
+  div.o-figure-border {
     box-sizing: border-box;
     z-index: 1;
-    border: ${ACTIVE_BORDER_WIDTH}px solid ${SELECTION_BORDER_COLOR};
   }
 
   .o-figure-wrapper {
@@ -108,11 +106,14 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private getBorderWidth(): Pixel {
-    return this.env.isDashboard() ? 0 : BORDER_WIDTH;
+    if (this.env.isDashboard()) return 0;
+    return this.isSelected ? ACTIVE_BORDER_WIDTH : BORDER_WIDTH;
   }
 
-  get figureStyle() {
-    return this.props.style + `border-width: ${this.getBorderWidth()}px;`;
+  get borderStyle() {
+    const borderWidth = this.getBorderWidth();
+    const borderColor = this.isSelected ? SELECTION_BORDER_COLOR : FIGURE_BORDER_COLOR;
+    return `border: ${borderWidth}px solid ${borderColor};`;
   }
 
   get wrapperStyle() {

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -5,7 +5,7 @@
         class="o-figure w-100 h-100"
         t-on-mousedown.stop="(ev) => this.onMouseDown(ev)"
         t-ref="figure"
-        t-att-style="figureStyle"
+        t-att-style="props.style"
         tabindex="0"
         t-on-keydown.stop="(ev) => this.onKeyDown(ev)"
         t-on-keyup.stop="">
@@ -16,8 +16,8 @@
           figure="props.figure"
         />
       </div>
+      <div class="o-figure-border w-100 h-100 position-absolute pe-none" t-att-style="borderStyle"/>
       <t t-if="isSelected">
-        <div class="w-100 h-100 o-active-figure-border position-absolute pe-none"/>
         <div
           class="o-fig-anchor o-top"
           t-att-style="this.getResizerPosition('top')"

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -39,6 +39,8 @@ css/* scss */ `
 `;
 
 interface Props {
+  // props figure is necessary scorecards, we need the chart dimension at render to avoid having to force the
+  // style by hand in the useEffect()
   figure: Figure;
   sidePanelIsOpen: boolean;
   onFigureDeleted: () => void;

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Scorecard charts Scorecard snapshot 1`] = `
 <div
   class="o-figure w-100 h-100"
-  style="border-width: 1px;"
+  style=""
   tabindex="0"
 >
   <div
@@ -134,7 +134,7 @@ exports[`Scorecard charts scorecard text is resized while figure is resized 1`] 
   style="
 opacity: 0.9;
 cursor: grabbing;
-border-width: 1px;"
+"
   tabindex="0"
 >
   <div

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -1,6 +1,12 @@
 import { App, Component, xml } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
-import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH, MIN_FIG_SIZE } from "../../src/constants";
+import {
+  DEFAULT_CELL_HEIGHT,
+  DEFAULT_CELL_WIDTH,
+  FIGURE_BORDER_COLOR,
+  MIN_FIG_SIZE,
+  SELECTION_BORDER_COLOR,
+} from "../../src/constants";
 import { figureRegistry } from "../../src/registries";
 import { CreateFigureCommand, Figure, SpreadsheetChildEnv, UID } from "../../src/types";
 import {
@@ -12,7 +18,12 @@ import {
   selectCell,
   setCellContent,
 } from "../test_helpers/commands_helpers";
-import { dragElement, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
+import {
+  dragElement,
+  getElComputedStyle,
+  simulateClick,
+  triggerMouseEvent,
+} from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
 import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
@@ -410,17 +421,32 @@ describe("figures", () => {
     expect(figure.classList).not.toContain("o-dragging");
   });
 
-  test("Figure border disabled on dashboard mode", async () => {
-    const figureId = "someuuid";
-    createFigure(model, { id: figureId, y: 200 });
-    await nextTick();
-    let figure = fixture.querySelector(".o-figure")! as HTMLElement;
-    expect(window.getComputedStyle(figure)["border-width"]).toEqual("1px");
+  describe("Figure border", () => {
+    test("Border for figure", async () => {
+      createFigure(model);
+      await nextTick();
+      expect(getElComputedStyle(".o-figure-border", "border")).toEqual(
+        `1px solid ${FIGURE_BORDER_COLOR}`
+      );
+    });
 
-    model.updateMode("dashboard");
-    await nextTick();
-    figure = fixture.querySelector(".o-figure")! as HTMLElement;
-    expect(window.getComputedStyle(figure)["border-width"]).toEqual("0px");
+    test("Border for selected chart", async () => {
+      createFigure(model, { id: "figureId" });
+      model.dispatch("SELECT_FIGURE", { id: "figureId" });
+      await nextTick();
+      expect(getElComputedStyle(".o-figure-border", "border")).toEqual(
+        `2px solid ${SELECTION_BORDER_COLOR}`
+      );
+    });
+
+    test("No border in dashboard mode", async () => {
+      createFigure(model, { id: "figureId" });
+      await nextTick();
+      expect(getElComputedStyle(".o-figure-border", "border-width")).toEqual("1px");
+      model.updateMode("dashboard");
+      await nextTick();
+      expect(getElComputedStyle(".o-figure-border", "border-width")).toEqual("0px");
+    });
   });
 
   test("Selected figure isn't removed by scroll", async () => {

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -1,8 +1,7 @@
 import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
-import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../../src/constants";
 import { toHex } from "../../src/helpers";
-import { Rect, UID } from "../../src/types";
+import { UID } from "../../src/types";
 import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart";
 import {
   createScorecardChart as createScorecardChartHelper,
@@ -20,21 +19,6 @@ let sheetId: string;
 
 let parent: Spreadsheet;
 let app: App;
-
-const figureRect: Rect = { x: 0, y: 0, width: 0, height: 0 };
-const defaultRect = { x: 0, y: 0, width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
-
-const originalGetBoundingClientRect = HTMLDivElement.prototype.getBoundingClientRect;
-// @ts-ignore the mock should return a complete DOMRect, not only { top, left }
-jest
-  .spyOn(HTMLDivElement.prototype, "getBoundingClientRect")
-  .mockImplementation(function (this: HTMLDivElement) {
-    const isScoreCard = this.className.includes("o-scorecard");
-    if (isScoreCard) {
-      return figureRect;
-    }
-    return originalGetBoundingClientRect.call(this);
-  });
 
 function getChartElement(): HTMLElement {
   return fixture.querySelector(".o-figure")!;
@@ -71,11 +55,7 @@ async function createScorecardChart(
   chartId?: UID,
   sheetId?: UID
 ) {
-  figureRect.width = DEFAULT_FIGURE_WIDTH;
-  figureRect.height = DEFAULT_FIGURE_HEIGHT;
   createScorecardChartHelper(model, data, chartId, sheetId);
-  await nextTick();
-  // second tick required for the useEffect to be effective
   await nextTick();
 }
 
@@ -88,8 +68,6 @@ async function updateScorecardChartSize(width: number, height: number) {
     width,
     height,
   });
-  figureRect.width = width;
-  figureRect.height = height;
   await nextTick();
 }
 
@@ -127,14 +105,12 @@ describe("Scorecard charts", () => {
       ],
     };
     ({ app, parent } = await mountSpreadsheet(fixture, { model: new Model(data) }));
-    Object.assign(figureRect, defaultRect);
     model = parent.model;
   });
 
   afterEach(() => {
     app.destroy();
     fixture.remove();
-    Object.assign(figureRect, defaultRect);
   });
 
   test("Scorecard snapshot", async () => {
@@ -155,11 +131,7 @@ describe("Scorecard charts", () => {
     await simulateClick(".o-figure");
     expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("536px");
     expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("335px");
-    // required to mock getBoundingClientRect
-    figureRect.width -= 300;
-    figureRect.height -= 200;
     await dragElement(".o-fig-anchor.o-topLeft", 300, 200);
-    await nextTick(); // wait for useEffect() of scorecard
     expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("236px");
     expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("135px");
     expect(getChartElement()).toMatchSnapshot();


### PR DESCRIPTION
## Description

Since 5514296, the rendering of the scorecard was bugging a bit during resizing, the title was blinking in and out.

This was because the size of the scorecard was updated during the `useEffect()` which changed the state of the chart, thus we had to wait for the next render to have a correct value. 

In this commit we removed the borders in the `o-figure` element. This means that we can use the size of the figure props in scorecards.

The figure borders are now set in the `o-figure-border` overlay above the figure. This mean that 1px in the chart is now covered by the border, which shouldn't be a big problem.

Odoo task ID : [3130899](https://www.odoo.com/web#id=3130899&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo