### PR TITLE
[FIX] menu: use capture for events

### DIFF
--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -3,7 +3,7 @@ import { BACKGROUND_GRAY_COLOR, BOTTOMBAR_HEIGHT, HEADER_WIDTH } from "../../con
 import { formatValue } from "../../helpers/format";
 import { interactiveRenameSheet } from "../../helpers/ui/sheet_interactive";
 import { MenuItemRegistry, sheetMenuRegistry } from "../../registries/index";
-import { Pixel, SpreadsheetChildEnv, UID } from "../../types";
+import { MenuMouseEvent, Pixel, SpreadsheetChildEnv, UID } from "../../types";
 import { css } from "../helpers/css";
 import { Menu, MenuState } from "../menu/menu";
 
@@ -106,13 +106,22 @@ interface Props {
   onClick: () => void;
 }
 
+interface BottomBarMenuState extends MenuState {
+  menuId: UID | undefined;
+}
+
 export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BottomBar";
   static components = { Menu };
 
   private bottomBarRef = useRef("bottomBar");
 
-  menuState: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
+  menuState = useState<BottomBarMenuState>({
+    isOpen: false,
+    menuId: undefined,
+    position: null,
+    menuItems: [],
+  });
   selectedStatisticFn: string = "";
 
   setup() {
@@ -178,32 +187,34 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
     interactiveRenameSheet(this.env, sheetId);
   }
 
-  openContextMenu(x: Pixel, y: Pixel, registry: MenuItemRegistry) {
+  openContextMenu(x: Pixel, y: Pixel, registry: MenuItemRegistry, menuId?: UID) {
     this.menuState.isOpen = true;
     this.menuState.menuItems = registry.getAll().filter((x) => x.isVisible(this.env));
     this.menuState.position = { x, y };
+    this.menuState.menuId = menuId;
   }
 
-  onIconClick(sheet: string, ev: MouseEvent) {
-    if (this.env.model.getters.getActiveSheetId() !== sheet) {
-      this.activateSheet(sheet);
+  onIconClick(sheetId: UID, ev: MenuMouseEvent) {
+    if (this.env.model.getters.getActiveSheetId() !== sheetId) {
+      this.activateSheet(sheetId);
     }
-    if (this.menuState.isOpen) {
+    if (ev.closedMenuId === sheetId) {
       this.menuState.isOpen = false;
+      this.menuState.menuId = undefined;
     } else {
       const target = (ev.currentTarget as HTMLElement).parentElement as HTMLElement;
       const { top, left } = target.getBoundingClientRect();
-      this.openContextMenu(left, top, sheetMenuRegistry);
+      this.openContextMenu(left, top, sheetMenuRegistry, sheetId);
     }
   }
 
-  onContextMenu(sheet: string, ev: MouseEvent) {
-    if (this.env.model.getters.getActiveSheetId() !== sheet) {
-      this.activateSheet(sheet);
+  onContextMenu(sheetId: UID, ev: MouseEvent) {
+    if (this.env.model.getters.getActiveSheetId() !== sheetId) {
+      this.activateSheet(sheetId);
     }
     const target = ev.currentTarget as HTMLElement;
     const { top, left } = target.getBoundingClientRect();
-    this.openContextMenu(left, top, sheetMenuRegistry);
+    this.openContextMenu(left, top, sheetMenuRegistry, sheetId);
   }
 
   getSelectedStatistic() {

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -27,7 +27,7 @@
               t-esc="sheet.name"
               t-on-dblclick="(ev) => this.onDblClick(sheet.id, ev)"
             />
-            <span class="o-sheet-icon" t-on-click.stop="(ev) => this.onIconClick(sheet.id, ev)">
+            <span class="o-sheet-icon" t-on-click="(ev) => this.onIconClick(sheet.id, ev)">
               <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
             </span>
           </div>
@@ -50,6 +50,7 @@
         position="menuState.position"
         menuItems="menuState.menuItems"
         onClose="() => this.menuState.isOpen=false"
+        menuId="menuState.menuId"
       />
     </div>
   </t>

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -12,7 +12,7 @@
         t-on-mousedown="onMousedown"
         t-on-input="onInput"
         t-on-keyup="onKeyup"
-        t-on-click.stop="onClick"
+        t-on-click="onClick"
         t-on-blur="onBlur"
         t-on-paste.stop=""
         t-on-compositionstart="onCompositionStart"

--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -14,3 +14,7 @@ export function gridOverlayPosition() {
   }
   throw new Error("Can't find spreadsheet position");
 }
+
+export function getOpenedMenus(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(".o-spreadsheet .o-menu"));
+}

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -49,6 +49,7 @@
         depth="props.depth + 1"
         onMenuClicked="props.onMenuClicked"
         onClose="() => this.close()"
+        menuId="props.menuId"
       />
     </Popover>
   </t>

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -298,3 +298,7 @@ export interface SortOptions {
   /** If true treat empty cells as "0" instead of undefined */
   emptyCellAsZero?: boolean;
 }
+
+export interface MenuMouseEvent extends MouseEvent {
+  closedMenuId?: UID;
+}

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -142,6 +142,39 @@ describe("BottomBar component", () => {
     app.destroy();
   });
 
+  test("Can open context menu of a sheet with the arrow if another menu is already open", async () => {
+    const { app } = await mountTopBar();
+
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
+
+    triggerMouseEvent(".o-sheet-item.o-list-sheets", "click");
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
+    expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Sheet1");
+
+    triggerMouseEvent(".o-sheet-icon", "click");
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
+    expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Duplicate");
+    app.destroy();
+  });
+
+  test("Can open list of sheet menu if another menu is already open", async () => {
+    const { app } = await mountTopBar();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
+
+    triggerMouseEvent(".o-sheet-icon", "click");
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
+    expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Duplicate");
+
+    triggerMouseEvent(".o-sheet-item.o-list-sheets", "click");
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
+    expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Sheet1");
+    app.destroy();
+  });
+
   test("Can move right a sheet", async () => {
     const model = new Model();
     createSheet(model, { sheetId: "42" });
@@ -445,6 +478,25 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-selection-statistic", "click");
     await nextTick();
     expect(fixture.querySelector(".o-menu")).toMatchSnapshot();
+    app.destroy();
+  });
+
+  test("Can open the list of statistics if another menu is already open", async () => {
+    const model = new Model();
+    const nonMockedDispatch = model.dispatch;
+    const { app } = await mountTopBar(model);
+    model.dispatch = nonMockedDispatch;
+    setCellContent(model, "A2", "24");
+    selectCell(model, "A2");
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
+    triggerMouseEvent(".o-sheet-icon", "click");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Duplicate");
+
+    triggerMouseEvent(".o-selection-statistic", "click");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Sum: 24");
     app.destroy();
   });
 

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -16,7 +16,7 @@ import {
   setCellContent,
   setSelection,
 } from "../test_helpers/commands_helpers";
-import { triggerMouseEvent } from "../test_helpers/dom_helper";
+import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getBorder, getCell } from "../test_helpers/getters_helpers";
 import {
   makeTestFixture,
@@ -105,6 +105,23 @@ describe("TopBar component", () => {
     await nextTick();
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
     expect(fixture.querySelectorAll(".o-color-line").length).toBe(0);
+    app.destroy();
+  });
+
+  test("Menu should be closed while clicking on composer", async () => {
+    const { app } = await mountParent();
+
+    expect(fixture.querySelectorAll(".o-menu").length).toBe(0);
+    fixture
+      .querySelector(".o-topbar-menu[data-id='file']")!
+      .dispatchEvent(new Event("click", { bubbles: true }));
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-menu").length).toBe(1);
+    const topbarComposerElement = fixture.querySelector(
+      ".o-topbar-toolbar .o-composer-container div"
+    )!;
+    await simulateClick(topbarComposerElement);
+    expect(fixture.querySelectorAll(".o-menu").length).toBe(0);
     app.destroy();
   });
 


### PR DESCRIPTION
## Description

Before this, the menu were closed by a listener on the onClick of window.
This caused 2 main problems :

- on some places, we stopped the events propagation, which prevented the
menu from closing. This was the case for the topbar composer for example.

- on buttons that opened a menu we needed to add a `.stop`, because if
another menu was already open the menu would instantly close after
changing its props.

Solved this by having the externalListener of menus listen to the `capture`
phase of events. This bypass all the `.stop`, and assures that the old
menu is closed before the new one is opened for click events.

The way it is currently handled should probably be improved when we
implement a proper menu service (`querySelectorAll` on the menus and
we need to customize event payload for menu toggle to work).

Odoo task ID : [3145756](https://www.odoo.com/web#id=3145756&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo