### PR TITLE
[IMP] Header: auto-resize of row height

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -2,6 +2,7 @@
 // Miscellaneous
 //------------------------------------------------------------------------------
 import {
+  DEFAULT_CELL_HEIGHT,
   DEFAULT_FONT,
   DEFAULT_FONT_SIZE,
   DEFAULT_FONT_WEIGHT,
@@ -11,7 +12,7 @@ import {
   PADDING_AUTORESIZE_VERTICAL,
 } from "../constants";
 import { fontSizeMap } from "../fonts";
-import { ConsecutiveIndexes, Lazy, Style, UID } from "../types";
+import { Cell, ConsecutiveIndexes, Lazy, Style, UID } from "../types";
 import { Cloneable, Pixel } from "./../types/misc";
 import { parseDateTime } from "./dates";
 /**
@@ -124,10 +125,13 @@ export function computeTextLinesHeight(textLineHeight: number, numberOfLines: nu
 /**
  * Get the default height of the cell given its style.
  */
-export function getDefaultCellHeight(style: Style | undefined): Pixel {
-  // TO DO: take multi text line into account to compute the real cell height in case of wrapping cell
-  const fontSize = computeTextFontSizeInPixels(style);
-  return computeTextLinesHeight(fontSize) + 2 * PADDING_AUTORESIZE_VERTICAL;
+export function getDefaultCellHeight(cell: Cell | undefined): Pixel {
+  if (!cell || !cell.content) {
+    return DEFAULT_CELL_HEIGHT;
+  }
+  const fontSize = computeTextFontSizeInPixels(cell.style);
+  const multiLineText = cell.content.split(NEWLINE);
+  return computeTextLinesHeight(fontSize, multiLineText.length) + 2 * PADDING_AUTORESIZE_VERTICAL;
 }
 
 export function computeTextWidth(context: CanvasRenderingContext2D, text: string, style: Style) {

--- a/src/plugins/core/header_size.ts
+++ b/src/plugins/core/header_size.ts
@@ -185,7 +185,7 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
       return DEFAULT_CELL_HEIGHT;
     }
     const cell = this.getters.getCell(position);
-    return getDefaultCellHeight(cell?.style);
+    return getDefaultCellHeight(cell);
   }
 
   /**

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -997,6 +997,7 @@ describe("Multi users synchronisation", () => {
     const firstSheetId = alice.getters.getActiveSheetId();
     network.concurrent(() => {
       setStyle(bob, "A1", { fontSize: 36 });
+      setCellContent(bob, "A1", "text");
       charlie.dispatch("DUPLICATE_SHEET", {
         sheetId: firstSheetId,
         sheetIdTo: "sheet2",
@@ -1005,7 +1006,7 @@ describe("Multi users synchronisation", () => {
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getRowSize("sheet2", 0),
-      getDefaultCellHeight({ fontSize: 36 })
+      getDefaultCellHeight(getCell(alice, "A1"))
     );
   });
 });

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -868,6 +868,9 @@ describe("Viewport of Simple sheet", () => {
       top: 0,
     });
     setStyle(model, "A1:A20", { fontSize: 36 });
+    for (let i = 1; i <= 20; ++i) {
+      setCellContent(model, `A${i}`, "test"); // Requires non-empty cells. Otherwise, the fontsize is not considered when computing the row height
+    }
     expect(model.getters.getActiveMainViewport()).toEqual({
       bottom: 18,
       left: 0,


### PR DESCRIPTION
## Description:

This PR implements a simple auto-resize of row height for cells with multiline text which only takes the number of lines into consideration (no wrapping mode, etc due to performance consideration and code structure). 

This PR also fixes the auto-resize of row height for empty cells. Now the default height of empty cells will be `DEFAULT_CELL_HEIGHT` instead of the height computed from the font size. 

Odoo task ID : [3095603](https://www.odoo.com/web#id=3095603&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo