### PR TITLE
[FIX] bottom_bar_statistic: close context menu on change

### DIFF
--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -171,6 +171,12 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
     this.menuState.position = null;
   }
 
+  closeContextMenuWithId(menuId: UID) {
+    if (this.menuState.menuId === menuId) {
+      this.closeMenu();
+    }
+  }
+
   onWheel(ev: WheelEvent) {
     this.targetScroll = undefined;
     const target = ev.currentTarget as HTMLElement;

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -77,6 +77,7 @@
 
       <BottomBarStatistic
         openContextMenu="(x, y, registry) => this.openContextMenu(x, y, 'listSelectionStatistics', registry)"
+        closeContextMenu="() => this.closeContextMenuWithId('listSelectionStatistics')"
       />
 
       <Menu

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -583,4 +583,27 @@ describe("BottomBar component", () => {
     await click(fixture, ".o-menu-item[data-name='Count Numbers'");
     expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Count Numbers: 1");
   });
+
+  test("The list of statistics menu closes if the selection or the cell value change", async () => {
+    const { model } = await mountBottomBar();
+    // Change value of cell
+    setCellContent(model, "A1", "24");
+    await nextTick();
+    triggerMouseEvent(".o-selection-statistic", "click");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeTruthy();
+
+    setCellContent(model, "A1", "42");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeFalsy();
+
+    // Change selection
+    triggerMouseEvent(".o-selection-statistic", "click");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeTruthy();
+
+    selectCell(model, "A2");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Description:

Before this commit the context menu of the bottom bar statistic stayed
open when the selection/value of the cells of the selection was changed.
The menu should be closed in this case, because a change in selection/
value in the selection make the content of the menu invalid.

Odoo task ID : [3146086](https://www.odoo.com/web#id=3146086&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo