### PR TITLE
[FIX] selection: avoid scroll when using ctrl+a loop

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -22,7 +22,10 @@ import {
   statefulUIPluginRegistry,
 } from "./plugins/index";
 import { UIPlugin, UIPluginConfig, UIPluginConstructor } from "./plugins/ui_plugin";
-import { SelectionStreamProcessor } from "./selection_stream/selection_stream_processor";
+import {
+  SelectionStreamProcessor,
+  SelectionStreamProcessorImpl,
+} from "./selection_stream/selection_stream_processor";
 import { StateObserver } from "./state_observer";
 import { _lt } from "./translation";
 import { StateUpdateMessage, TransportService } from "./types/collaborative/transport_service";
@@ -218,7 +221,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.uuidGenerator.setIsFastStrategy(true);
 
     // Initiate stream processor
-    this.selection = new SelectionStreamProcessor(this.getters);
+    this.selection = new SelectionStreamProcessorImpl(this.getters);
 
     this.corePluginConfig = this.setupCorePluginConfig();
     this.uiPluginConfig = this.setupUiPluginConfig();

--- a/src/plugins/ui_core_views/sheetview.ts
+++ b/src/plugins/ui_core_views/sheetview.ts
@@ -130,7 +130,7 @@ export class SheetViewPlugin extends UIPlugin {
   private handleEvent(event: SelectionEvent) {
     switch (event.type) {
       case "HeadersSelected":
-      case "AlterZoneCorner":
+      case "AlterZone":
         break;
       case "ZonesSelected":
         let { col, row } = findCellInNewZone(event.previousAnchor.zone, event.anchor.zone);

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -53,13 +53,13 @@ interface SelectionProcessor {
   selectTableAroundSelection(): DispatchResult;
 }
 
+export type SelectionStreamProcessor = SelectionProcessor &
+  StatefulStream<SelectionEvent, AnchorZone>;
 /**
  * Processes all selection updates (usually from user inputs) and emits an event
  * with the new selected anchor
  */
-export class SelectionStreamProcessor
-  implements SelectionProcessor, StatefulStream<SelectionEvent, AnchorZone>
-{
+export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
   private stream: EventStream<SelectionEvent>;
   /**
    * "Active" anchor used as a reference to compute new anchors

--- a/src/types/event_stream/selection_events.ts
+++ b/src/types/event_stream/selection_events.ts
@@ -14,8 +14,8 @@ export interface HeadersSelected extends SelectionEventPayload {
   type: "HeadersSelected";
 }
 
-export interface AlterZoneCorner extends SelectionEventPayload {
-  type: "AlterZoneCorner";
+export interface AlterZone extends SelectionEventPayload {
+  type: "AlterZone";
 }
 
-export type SelectionEvent = Readonly<ZonesSelected | HeadersSelected | AlterZoneCorner>;
+export type SelectionEvent = Readonly<ZonesSelected | HeadersSelected | AlterZone>;

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -1074,22 +1074,15 @@ describe("Selection loop (ctrl + a)", () => {
       model = new Model();
     });
 
-    function initModel() {
+    test("Selection loop doesn't scroll the viewport", () => {
       setCellContent(model, "A1", "a");
       setCellContent(model, "A2", "a");
-      setCellContent(model, "A3", "a");
-      setCellContent(model, "A4", "a");
-
-      selectCell(model, "A4");
+      selectCell(model, "A2");
       setViewportOffset(model, 0, DEFAULT_CELL_HEIGHT);
-    }
-
-    test("Selection loop doesn't scroll the viewport", () => {
-      initModel();
       const initialScroll = model.getters.getActiveSheetScrollInfo();
 
       model.selection.loopSelection();
-      expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A1:A4");
+      expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A1:A2");
       expect(model.getters.getActiveSheetScrollInfo()).toEqual(initialScroll);
 
       model.selection.loopSelection();
@@ -1097,16 +1090,19 @@ describe("Selection loop (ctrl + a)", () => {
       expect(model.getters.getActiveSheetScrollInfo()).toEqual(initialScroll);
 
       model.selection.loopSelection();
-      expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A4");
+      expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A2");
       expect(model.getters.getActiveSheetScrollInfo()).toEqual(initialScroll);
     });
 
     test("selectTableAroundSelection doesn't scroll the viewport", () => {
-      initModel();
+      setCellContent(model, "A1", "a");
+      setCellContent(model, "A2", "a");
+      selectCell(model, "A2");
+      setViewportOffset(model, 0, DEFAULT_CELL_HEIGHT);
       const initialScroll = model.getters.getActiveSheetScrollInfo();
 
       model.selection.selectTableAroundSelection();
-      expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A1:A4");
+      expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A1:A2");
       expect(model.getters.getActiveSheetScrollInfo()).toEqual(initialScroll);
     });
   });


### PR DESCRIPTION
## Description

When the selection is updated using the ctrl+a shortcut (or when inserting a chart), the sheet shouldn't be scrolled to try to display the new selection.

Odoo task ID : [3068981](https://www.odoo.com/web#id=3068981&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo