### PR TITLE
[IMP] css: use cssPropertiesToCss helper everywhere

### DIFF
--- a/src/components/collaborative_client_tag/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.ts
@@ -1,7 +1,7 @@
 import { Component } from "@odoo/owl";
 import { DEFAULT_FONT_SIZE } from "../../constants";
 import { HeaderIndex, SpreadsheetChildEnv } from "../../types";
-import { css } from "../helpers/css";
+import { css, cssPropertiesToCss } from "../helpers/css";
 
 interface ClientTagProps {
   active: boolean;
@@ -33,11 +33,14 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
       right: col,
       bottom: row,
     });
-    return `bottom: ${height - y + 15}px;left: ${
-      x - 1
-    }px;border: 1px solid ${color};background-color: ${color};${
-      this.props.active ? "opacity:1 !important" : ""
-    }`;
+
+    return cssPropertiesToCss({
+      bottom: `${height - y + 15}px`,
+      left: `${x - 1}px`,
+      border: `1px solid ${color}`,
+      "background-color": color,
+      opacity: this.props.active ? "opacity:1 !important" : undefined,
+    });
   }
 }
 

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -10,7 +10,7 @@ import { hslaToRGBA, isColorValid, rgbaToHex } from "../../helpers";
 import { chartFontColor } from "../../helpers/figures/charts";
 import { Color } from "../../types";
 import { SpreadsheetChildEnv } from "../../types/env";
-import { css } from "../helpers/css";
+import { css, cssPropertiesToCss } from "../helpers/css";
 
 const PICKER_PADDING = 6;
 
@@ -263,9 +263,12 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
 
   get magnifyingGlassStyle() {
     const { display, background, left, top } = this.state.style;
-    return `display:${display};${
-      display === "block" ? `background-color:${background};left:${left};top:${top};` : ""
-    }`;
+    return cssPropertiesToCss({
+      display,
+      "background-color": display === "block" ? background : undefined,
+      left,
+      top,
+    });
   }
 }
 

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -10,8 +10,14 @@ import {
   zoneToDimension,
 } from "../../../helpers/index";
 import { ComposerSelection } from "../../../plugins/ui_stateful/edition";
-import { DOMDimension, FunctionDescription, Rect, SpreadsheetChildEnv } from "../../../types/index";
-import { css } from "../../helpers/css";
+import {
+  CSSProperties,
+  DOMDimension,
+  FunctionDescription,
+  Rect,
+  SpreadsheetChildEnv,
+} from "../../../types/index";
+import { css, cssPropertiesToCss } from "../../helpers/css";
 import { getElementScrollTop, setElementScrollTop } from "../../helpers/dom_helpers";
 import { updateSelectionWithArrowKeys } from "../../helpers/selection_helpers";
 import { TextValueProvider } from "../autocomplete_dropdown/autocomplete_dropdown";
@@ -158,21 +164,20 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
     if (this.props.delimitation && this.props.rect) {
       const { x: cellX, y: cellY, height: cellHeight } = this.props.rect;
       const remainingHeight = this.props.delimitation.height - (cellY + cellHeight);
-      let assistantStyle = "";
+      let assistantStyle: CSSProperties = {};
       if (cellY > remainingHeight) {
         // render top
-        assistantStyle += `
-          top: -3px;
-          transform: translate(0, -100%);
-        `;
+        assistantStyle.top = `$-3px`;
+        assistantStyle.transform = `translate(0, -100%)`;
       }
       if (cellX + ASSISTANT_WIDTH > this.props.delimitation.width) {
         // render left
-        assistantStyle += `right:0px;`;
+        assistantStyle.right = `0px`;
       }
-      return (assistantStyle += `width:${ASSISTANT_WIDTH}px;`);
+      assistantStyle.width = `${ASSISTANT_WIDTH}px`;
+      return cssPropertiesToCss(assistantStyle);
     }
-    return `width:${ASSISTANT_WIDTH}px;`;
+    return cssPropertiesToCss({ width: `${ASSISTANT_WIDTH}px` });
   }
 
   // we can't allow input events to be triggered while we remove and add back the content of the composer in processContent

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -5,7 +5,7 @@ import { deepEquals, getComposerSheetName, positionToZone, toXC } from "../../..
 import { ComposerSelection } from "../../../plugins/ui_stateful/edition";
 import { DOMDimension, Rect, Ref, SpreadsheetChildEnv, Zone } from "../../../types/index";
 import { getTextDecoration } from "../../helpers";
-import { css } from "../../helpers/css";
+import { css, cssPropertiesToCss } from "../../helpers/css";
 import { Composer } from "../composer/composer";
 import { ZoneDimension } from "./../../../types/misc";
 
@@ -117,10 +117,10 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
 
   get cellReferenceStyle(): string {
     const { x: left, y: top } = this.rect;
-    return `
-      left: ${left - COMPOSER_BORDER_WIDTH}px;
-      top: ${top - GRID_CELL_REFERENCE_TOP_OFFSET}px;
-    `;
+    return cssPropertiesToCss({
+      left: `${left - COMPOSER_BORDER_WIDTH}px`,
+      top: `${top - GRID_CELL_REFERENCE_TOP_OFFSET}px`,
+    });
   }
 
   get containerStyle(): string {
@@ -155,33 +155,33 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
      *
      * The +-1 are there to include cell borders in the composer sizing/positioning
      */
-    return `
-      left: ${left - 1}px;
-      top: ${top}px;
+    return cssPropertiesToCss({
+      left: `${left - 1}px`,
+      top: `${top}px`,
 
-      min-width: ${width + 1}px;
-      min-height: ${height + 1}px;
+      "min-width": `${width + 1}px`,
+      "min-height": `${height + 1}px`,
 
-      background: ${background};
-      color: ${color};
+      background,
+      color,
 
-      font-size: ${fontSizeMap[fontSize]}px;
-      font-weight: ${fontWeight};
-      font-style: ${fontStyle};
-      text-decoration: ${textDecoration};
+      "font-size": `${fontSizeMap[fontSize]}px`,
+      "font-weight": String(fontWeight),
+      "font-style": fontStyle,
+      "text-decoration": textDecoration,
 
-      text-align: ${textAlign};
-    `;
+      "text-align": textAlign,
+    });
   }
 
   get composerStyle(): string {
     const maxHeight = this.props.gridDims.height - this.rect.y;
     const maxWidth = this.props.gridDims.width - this.rect.x;
 
-    return `
-      max-width : ${maxWidth}px;
-      max-height : ${maxHeight}px;
-    `;
+    return cssPropertiesToCss({
+      "max-width": `${maxWidth}px`,
+      "max-height": `${maxHeight}px`,
+    });
   }
 }
 

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -13,7 +13,7 @@ import {
 } from "../../types/index";
 import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
-import { css } from "../helpers/css";
+import { css, cssPropertiesToCss } from "../helpers/css";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
 import { useAbsolutePosition } from "../helpers/position_hook";
 import { useWheelHandler } from "../helpers/wheel_hook";
@@ -77,25 +77,23 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
     const sheetId = this.env.model.getters.getActiveSheetId();
     const { right } = this.env.model.getters.getSheetZone(sheetId);
     const { end } = this.env.model.getters.getColDimensions(sheetId, right);
-    return `
-      max-width: ${end}px;
-    `;
+    return cssPropertiesToCss({ "max-width": `${end}px` });
   }
 
   get gridOverlayDimensions() {
-    return `
-      height: 100%;
-      width: 100%
-    `;
+    return cssPropertiesToCss({
+      height: "100%",
+      width: "100%",
+    });
   }
 
   getCellClickableStyle(coordinates: Rect) {
-    return `
-      top: ${coordinates.y}px;
-      left: ${coordinates.x}px;
-      width: ${coordinates.width}px;
-      height: ${coordinates.height}px;
-    `;
+    return cssPropertiesToCss({
+      top: `${coordinates.y}px`,
+      left: `${coordinates.x}px`,
+      width: `${coordinates.width}px`,
+      height: `${coordinates.height}px`,
+    });
   }
 
   /**

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -155,16 +155,14 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get chartStyle() {
-    return `
-      padding:${this.chartPadding}px;
-      background:${this.backgroundColor};
-    `;
+    return cssPropertiesToCss({
+      padding: `${this.chartPadding}px`,
+      background: this.backgroundColor,
+    });
   }
 
   get chartContentStyle() {
-    return `
-      height:${this.getDrawableHeight()}px;
-    `;
+    return cssPropertiesToCss({ height: `${this.getDrawableHeight()}px` });
   }
 
   get chartPadding() {

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -5,8 +5,8 @@ import {
   SELECTION_BORDER_COLOR,
 } from "../../../constants";
 import { figureRegistry } from "../../../registries/index";
-import { Figure, Pixel, SpreadsheetChildEnv, UID } from "../../../types/index";
-import { css } from "../../helpers/css";
+import { CSSProperties, Figure, Pixel, SpreadsheetChildEnv, UID } from "../../../types/index";
+import { css, cssPropertiesToCss } from "../../helpers/css";
 import { gridOverlayPosition } from "../../helpers/dom_helpers";
 import { startDnd } from "../../helpers/drag_and_drop";
 
@@ -243,12 +243,12 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     const top = figureY >= y ? y : 0;
     const height = viewHeight - top;
 
-    return `
-      left: ${left}px;
-      top: ${top}px;
-      width: ${width}px;
-      height: ${height}px
-    `;
+    return cssPropertiesToCss({
+      left: `${left}px`,
+      top: `${top}px`,
+      width: `${width}px`,
+      height: `${height}px`,
+    });
   }
 
   get inverseViewportPositionStyle(): string {
@@ -259,10 +259,10 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     const left = figureX >= x ? -(x + offsetX) : 0;
     const top = figureY >= y ? -(y + offsetY) : 0;
 
-    return `
-      left: ${left}px;
-      top: ${top}px;
-    `;
+    return cssPropertiesToCss({
+      left: `${left}px`,
+      top: `${top}px`,
+    });
   }
 
   private getBorderWidth(): Pixel {
@@ -275,34 +275,34 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
 
   get wrapperStyle() {
     const { x, y, width, height } = this.displayedFigure;
-    return (
-      `top:${y}px;` +
-      `left:${x}px;` +
-      `width:${width}px;` +
-      `height:${height}px;` +
-      `z-index: ${ComponentsImportance.Figure + (this.isSelected ? 1 : 0)}`
-    );
+    return cssPropertiesToCss({
+      left: `${x}px`,
+      top: `${y}px`,
+      width: `${width}px`,
+      height: `${height}px`,
+      "z-index": String(ComponentsImportance.Figure + (this.isSelected ? 1 : 0)),
+    });
   }
 
-  getResizerPosition(resizer: ResizeAnchor) {
+  getResizerPosition(resizer: ResizeAnchor): string {
     const anchorCenteringOffset = (ANCHOR_SIZE - ACTIVE_BORDER_WIDTH) / 2;
-    let style = "";
+    let style: CSSProperties = {};
     if (resizer.includes("top")) {
-      style += `top: ${-anchorCenteringOffset}px;`;
+      style.top = `${-anchorCenteringOffset}px`;
     } else if (resizer.includes("bottom")) {
-      style += `bottom: ${-anchorCenteringOffset}px;`;
+      style.bottom = `${-anchorCenteringOffset}px;`;
     } else {
-      style += ` bottom: calc(50% - ${anchorCenteringOffset}px);`;
+      style.bottom = `calc(50% - ${anchorCenteringOffset}px)`;
     }
 
     if (resizer.includes("left")) {
-      style += `left: ${-anchorCenteringOffset}px;`;
+      style.left = `${-anchorCenteringOffset}px;`;
     } else if (resizer.includes("right")) {
-      style += `right: ${-anchorCenteringOffset}px;`;
+      style.right += `${-anchorCenteringOffset}px;`;
     } else {
-      style += ` right: calc(50% - ${anchorCenteringOffset}px);`;
+      style.right += ` calc(50% - ${anchorCenteringOffset}px);`;
     }
-    return style;
+    return cssPropertiesToCss(style);
   }
 
   resize(dirX: number, dirY: number, ev: MouseEvent) {

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -42,6 +42,7 @@ import { FilterIconsOverlay } from "../filters/filter_icons_overlay/fitler_icons
 import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
 import { HeadersOverlay } from "../headers_overlay/headers_overlay";
+import { cssPropertiesToCss } from "../helpers";
 import { dragAndDropBeyondTheViewport } from "../helpers/drag_and_drop";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
 import { useAbsolutePosition } from "../helpers/position_hook";
@@ -146,12 +147,12 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get gridOverlayDimensions() {
-    return `
-      top: ${HEADER_HEIGHT}px;
-      left: ${HEADER_WIDTH}px;
-      height: calc(100% - ${HEADER_HEIGHT + SCROLLBAR_WIDTH}px);
-      width: calc(100% - ${HEADER_WIDTH + SCROLLBAR_WIDTH}px);
-    `;
+    return cssPropertiesToCss({
+      top: `${HEADER_HEIGHT}px`,
+      left: `${HEADER_WIDTH}px`,
+      height: `calc(100% - ${HEADER_HEIGHT + SCROLLBAR_WIDTH}px)`,
+      width: `calc(100% - ${HEADER_WIDTH + SCROLLBAR_WIDTH}px)`,
+    });
   }
 
   onClosePopover() {

--- a/src/components/helpers/css.ts
+++ b/src/components/helpers/css.ts
@@ -136,13 +136,13 @@ export function cellTextStyleToCss(style: Style | undefined): CSSProperties {
   return attributes;
 }
 
-export function cssPropertiesToCss(attributes: CSSProperties, newLine = true): string {
-  const separator = newLine ? "\n" : "";
+export function cssPropertiesToCss(attributes: CSSProperties): string {
   const str = Object.entries(attributes)
-    .map(([attName, attValue]) => `${attName}: ${attValue};`)
-    .join(separator);
+    .filter(([attName, attValue]) => attValue !== undefined)
+    .map(([attName, attValue]) => `${attName}:${attValue};`)
+    .join(" ");
 
-  return str ? "\n" + str + "\n" : "";
+  return str;
 }
 
 export function getElementMargins(el: Element) {

--- a/src/components/highlight/border/border.ts
+++ b/src/components/highlight/border/border.ts
@@ -1,6 +1,6 @@
 import { Component } from "@odoo/owl";
 import { Pixel, SpreadsheetChildEnv, Zone } from "../../../types";
-import { css } from "../../helpers/css";
+import { css, cssPropertiesToCss } from "../../helpers/css";
 
 css/* scss */ `
   .o-border {
@@ -47,12 +47,12 @@ export class Border extends Component<Props, SpreadsheetChildEnv> {
     const widthValue = isHorizontal ? right - left : lineWidth;
     const heightValue = isVertical ? bottom - top : lineWidth;
 
-    return `
-        left:${leftValue}px;
-        top:${topValue}px;
-        width:${widthValue}px;
-        height:${heightValue}px;
-    `;
+    return cssPropertiesToCss({
+      left: `${leftValue}px`,
+      top: `${topValue}px`,
+      width: `${widthValue}px`,
+      height: `${heightValue}px`,
+    });
   }
 
   onMouseDown(ev: MouseEvent) {

--- a/src/components/highlight/corner/corner.ts
+++ b/src/components/highlight/corner/corner.ts
@@ -1,7 +1,7 @@
 import { Component } from "@odoo/owl";
 import { AUTOFILL_EDGE_LENGTH } from "../../../constants";
 import { SpreadsheetChildEnv, Zone } from "../../../types";
-import { css } from "../../helpers/css";
+import { css, cssPropertiesToCss } from "../../helpers/css";
 
 css/* scss */ `
   .o-corner {
@@ -62,11 +62,11 @@ export class Corner extends Component<Props, SpreadsheetChildEnv> {
     const leftValue = this.isLeft ? rect.x : rect.x + rect.width;
     const topValue = this.isTop ? rect.y : rect.y + rect.height;
 
-    return `
-      left:${leftValue - AUTOFILL_EDGE_LENGTH / 2}px;
-      top:${topValue - AUTOFILL_EDGE_LENGTH / 2}px;
-      background-color:${this.props.color};
-    `;
+    return cssPropertiesToCss({
+      left: `${leftValue - AUTOFILL_EDGE_LENGTH / 2}px`,
+      top: `${topValue - AUTOFILL_EDGE_LENGTH / 2}px`,
+      backgroundColor: this.props.color,
+    });
   }
 
   onMouseDown(ev: MouseEvent) {

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -19,7 +19,7 @@ import {
 } from "../../../types";
 import { ColorPicker } from "../../color_picker/color_picker";
 import { getTextDecoration } from "../../helpers";
-import { css } from "../../helpers/css";
+import { css, cssPropertiesToCss } from "../../helpers/css";
 import { ICONS, ICON_SETS } from "../../icons/icons";
 import { IconPicker } from "../../icon_picker/icon_picker";
 import { SelectionInput } from "../../selection_input/selection_input";
@@ -402,16 +402,13 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
 
   getStyle(rule: SingleColorRules | ColorScaleRule): string {
     if (rule.type === "CellIsRule") {
-      const fontWeight = rule.style.bold ? "bold" : "normal";
-      const fontDecoration = getTextDecoration(rule.style);
-      const fontStyle = rule.style.italic ? "italic" : "normal";
-      const color = rule.style.textColor || "none";
-      const backgroundColor = rule.style.fillColor || "none";
-      return `font-weight:${fontWeight};
-               text-decoration:${fontDecoration};
-               font-style:${fontStyle};
-               color:${color};
-               background-color:${backgroundColor};`;
+      return cssPropertiesToCss({
+        "font-weight": rule.style.bold ? "bold" : "normal",
+        "text-decoration": getTextDecoration(rule.style),
+        "font-style": rule.style.italic ? "italic" : "normal",
+        color: rule.style.textColor || "none",
+        "background-color": rule.style.fillColor || "none",
+      });
     } else if (rule.type === "ColorScaleRule") {
       const minColor = colorNumberString(rule.minimum.color);
       const midColor = rule.midpoint ? colorNumberString(rule.midpoint.color) : null;

--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -498,7 +498,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
     for (const row of this.cells) {
       htmlTable += "<tr>";
       for (const cell of row) {
-        const cssStyle = cssPropertiesToCss(cellStyleToCss(cell.style), false);
+        const cssStyle = cssPropertiesToCss(cellStyleToCss(cell.style));
         const cellText = this.getters.getCellText(cell.position);
         htmlTable += `<td style="${cssStyle}">` + xmlEscape(cellText) + "</td>";
       }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -296,7 +296,7 @@ export interface Cloneable<T> {
   clone: (args?: Partial<T>) => T;
 }
 
-export type CSSProperties<P extends string = string> = Record<P, string>;
+export type CSSProperties<P extends string = string> = Record<P, string | undefined>;
 
 export interface SortOptions {
   /** If true sort the headers of the range along with the rest */

--- a/tests/components/__snapshots__/composer.test.ts.snap
+++ b/tests/components/__snapshots__/composer.test.ts.snap
@@ -3,23 +3,7 @@
 exports[`composer grid composer basic style Grid composer snapshot 1`] = `
 <div
   class="o-grid-composer"
-  style="
-      left: 47px;
-      top: 26px;
-
-      min-width: 97px;
-      min-height: 24px;
-
-      background: #ffffff;
-      color: #000000;
-
-      font-size: 13px;
-      font-weight: 500;
-      font-style: normal;
-      text-decoration: none;
-
-      text-align: left;
-    "
+  style="left:47px; top:26px; min-width:97px; min-height:24px; background:#ffffff; color:#000000; font-size:13px; font-weight:500; font-style:normal; text-decoration:none; text-align:left;"
 >
   <div
     class="o-composer-container w-100 h-100"
@@ -28,10 +12,7 @@ exports[`composer grid composer basic style Grid composer snapshot 1`] = `
       class="o-composer w-100 text-start"
       contenteditable="true"
       spellcheck="false"
-      style="
-      max-width : 985px;
-      max-height : 985px;
-    "
+      style="max-width:985px; max-height:985px;"
       tabindex="1"
     >
       A

--- a/tests/components/__snapshots__/conditional_formatting.test.ts.snap
+++ b/tests/components/__snapshots__/conditional_formatting.test.ts.snap
@@ -34,11 +34,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
             
             <div
               class="o-cf-preview-image"
-              style="font-weight:normal;
-               text-decoration:none;
-               font-style:normal;
-               color:none;
-               background-color:#FF0000;"
+              style="font-weight:normal; text-decoration:none; font-style:normal; color:none; background-color:#FF0000;"
             >
               123
             </div>

--- a/tests/components/__snapshots__/dashboard_grid.test.ts.snap
+++ b/tests/components/__snapshots__/dashboard_grid.test.ts.snap
@@ -7,16 +7,11 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
 >
   <div
     class="mx-auto h-100 position-relative"
-    style="
-      max-width: 2496px;
-    "
+    style="max-width:2496px;"
   >
     <div
       class="o-grid-overlay overflow-hidden"
-      style="
-      height: 100%;
-      width: 100%
-    "
+      style="height:100%; width:100%;"
     >
       <div>
         
@@ -37,35 +32,19 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
   
   <div
     class="o-scrollbar vertical"
-    style="
-top: 0px;
-right: 0px;
-width: 15px;
-bottom: 0px;
-"
+    style="top:0px; right:0px; width:15px; bottom:0px;"
   >
     <div
-      style="
-width: 1px;
-height: 2328px;
-"
+      style="width:1px; height:2328px;"
     />
   </div>
   
   <div
     class="o-scrollbar horizontal"
-    style="
-left: 0px;
-bottom: 0px;
-height: 15px;
-right: 0px;
-"
+    style="left:0px; bottom:0px; height:15px; right:0px;"
   >
     <div
-      style="
-width: 2592px;
-height: 1px;
-"
+      style="width:2592px; height:1px;"
     />
   </div>
   

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -7,12 +7,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
 >
   <div
     class="o-grid-overlay overflow-hidden"
-    style="
-      top: 26px;
-      left: 48px;
-      height: calc(100% - 41px);
-      width: calc(100% - 63px);
-    "
+    style="top:26px; left:48px; height:calc(100% - 41px); width:calc(100% - 63px);"
   >
     <div>
       
@@ -79,35 +74,19 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   <div
     class="o-scrollbar vertical"
-    style="
-top: 26px;
-right: 0px;
-width: 15px;
-bottom: 0px;
-"
+    style="top:26px; right:0px; width:15px; bottom:0px;"
   >
     <div
-      style="
-width: 1px;
-height: 2328px;
-"
+      style="width:1px; height:2328px;"
     />
   </div>
   
   <div
     class="o-scrollbar horizontal"
-    style="
-left: 48px;
-bottom: 0px;
-height: 15px;
-right: 0px;
-"
+    style="left:48px; bottom:0px; height:15px; right:0px;"
   >
     <div
-      style="
-width: 2592px;
-height: 1px;
-"
+      style="width:2592px; height:1px;"
     />
   </div>
   

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -43,45 +43,29 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
     
     <div
       class="o-scorecard w-100 h-100"
-      style="
-      padding:10.72px;
-      background:#FFFFFF;
-    "
+      style="padding:10.72px; background:#FFFFFF;"
     >
       <div
         class="o-title-text"
-        style="
-font-size: 18px;
-display: inline-block;
-color: #757575;
-"
+        style="font-size:18px; display:inline-block; color:#757575;"
       >
         hello
       </div>
       
       <div
         class="o-scorecard-content"
-        style="
-      height:291.96px;
-    "
+        style="height:291.96px;"
       >
         <div
           class="o-key-text"
-          style="
-font-size: 69.24101876395092px;
-display: inline-block;
-color: #000000;
-"
+          style="font-size:69.24101876395092px; display:inline-block; color:#000000;"
         >
           2
         </div>
         
         <div
           class="o-baseline-text"
-          style="
-font-size: 37.28362548828126px;
-display: inline-block;
-"
+          style="font-size:37.28362548828126px; display:inline-block;"
         >
           <svg
             class="o-cf-icon arrow-up"
@@ -99,22 +83,14 @@ display: inline-block;
           
           <span
             class="o-baseline-text-value"
-            style="
-font-size: 37.28362548828126px;
-display: inline-block;
-color: #00A04A;
-"
+            style="font-size:37.28362548828126px; display:inline-block; color:#00A04A;"
           >
             1
           </span>
           
           <span
             class="o-baseline-text-description"
-            style="
-font-size: 33.55526293945314px;
-display: inline-block;
-color: #757575;
-"
+            style="font-size:33.55526293945314px; display:inline-block; color:#757575;"
           >
              description
           </span>
@@ -171,45 +147,29 @@ exports[`Scorecard charts scorecard text is resized while figure is resized 1`] 
     
     <div
       class="o-scorecard w-100 h-100"
-      style="
-      padding:4.72px;
-      background:#FFFFFF;
-    "
+      style="padding:4.72px; background:#FFFFFF;"
     >
       <div
         class="o-title-text"
-        style="
-font-size: 18px;
-display: inline-block;
-color: #757575;
-"
+        style="font-size:18px; display:inline-block; color:#757575;"
       >
         hello
       </div>
       
       <div
         class="o-scorecard-content"
-        style="
-      height:103.96000000000001px;
-    "
+        style="height:103.96000000000001px;"
       >
         <div
           class="o-key-text"
-          style="
-font-size: 30.46703915550596px;
-display: inline-block;
-color: #000000;
-"
+          style="font-size:30.46703915550596px; display:inline-block; color:#000000;"
         >
           2
         </div>
         
         <div
           class="o-baseline-text"
-          style="
-font-size: 16.405328776041667px;
-display: inline-block;
-"
+          style="font-size:16.405328776041667px; display:inline-block;"
         >
           <svg
             class="o-cf-icon arrow-up"
@@ -227,22 +187,14 @@ display: inline-block;
           
           <span
             class="o-baseline-text-value"
-            style="
-font-size: 16.405328776041667px;
-display: inline-block;
-color: #00A04A;
-"
+            style="font-size:16.405328776041667px; display:inline-block; color:#00A04A;"
           >
             1
           </span>
           
           <span
             class="o-baseline-text-description"
-            style="
-font-size: 14.764795898437502px;
-display: inline-block;
-color: #757575;
-"
+            style="font-size:14.764795898437502px; display:inline-block; color:#757575;"
           >
              description
           </span>

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -392,10 +392,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       </div>
       <div
         class="o-topbar-composer bg-white"
-        style="
-border-color: #E0E2E4;
-border-right: none;
-"
+        style="border-color:#E0E2E4; border-right:none;"
       >
         <div
           class="o-composer-container w-100 h-100"
@@ -404,12 +401,7 @@ border-right: none;
             class="o-composer w-100 text-start"
             contenteditable="true"
             spellcheck="false"
-            style="
-padding: 5px 0px 5px 8px;
-max-height: 100px;
-line-height: 24px;
-height: 34px;
-"
+            style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
             tabindex="1"
           />
           
@@ -424,12 +416,7 @@ height: 34px;
   >
     <div
       class="o-grid-overlay overflow-hidden"
-      style="
-      top: 26px;
-      left: 48px;
-      height: calc(100% - 41px);
-      width: calc(100% - 63px);
-    "
+      style="top:26px; left:48px; height:calc(100% - 41px); width:calc(100% - 63px);"
     >
       <div>
         
@@ -496,35 +483,19 @@ height: 34px;
     
     <div
       class="o-scrollbar vertical"
-      style="
-top: 26px;
-right: 0px;
-width: 15px;
-bottom: 0px;
-"
+      style="top:26px; right:0px; width:15px; bottom:0px;"
     >
       <div
-        style="
-width: 1px;
-height: 2328px;
-"
+        style="width:1px; height:2328px;"
       />
     </div>
     
     <div
       class="o-scrollbar horizontal"
-      style="
-left: 48px;
-bottom: 0px;
-height: 15px;
-right: 0px;
-"
+      style="left:48px; bottom:0px; height:15px; right:0px;"
     >
       <div
-        style="
-width: 2592px;
-height: 1px;
-"
+        style="width:2592px; height:1px;"
       />
     </div>
     
@@ -541,12 +512,7 @@ height: 1px;
     >
       <div
         class="position-absolute"
-        style="
-top: 0px;
-left: 0px;
-width: 0px;
-height: 0px;
-"
+        style="top:0px; left:0px; width:0px; height:0px;"
       >
         
       </div>
@@ -571,12 +537,7 @@ height: 0px;
     >
       <div
         class="position-absolute"
-        style="
-top: 0px;
-left: 0px;
-width: 0px;
-height: 0px;
-"
+        style="top:0px; left:0px; width:0px; height:0px;"
       >
         
       </div>
@@ -623,12 +584,7 @@ height: 0px;
         >
           <div
             class="position-absolute"
-            style="
-top: 0px;
-left: 0px;
-width: 0px;
-height: 0px;
-"
+            style="top:0px; left:0px; width:0px; height:0px;"
           >
             
           </div>

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -504,9 +504,7 @@ exports[`TopBar component can set cell format 1`] = `
         </div>
         <div
           class="o-topbar-composer bg-white"
-          style="
-border-color: #3266ca;
-"
+          style="border-color:#3266ca;"
         >
           <div
             class="o-composer-container w-100 h-100"
@@ -515,12 +513,7 @@ border-color: #3266ca;
               class="o-composer w-100 text-start"
               contenteditable="true"
               spellcheck="false"
-              style="
-padding: 5px 0px 5px 8px;
-max-height: 100px;
-line-height: 24px;
-height: fit-content;
-"
+              style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:fit-content;"
               tabindex="1"
             />
             
@@ -920,9 +913,7 @@ exports[`TopBar component simple rendering 1`] = `
     </div>
     <div
       class="o-topbar-composer bg-white"
-      style="
-border-color: #3266ca;
-"
+      style="border-color:#3266ca;"
     >
       <div
         class="o-composer-container w-100 h-100"
@@ -931,12 +922,7 @@ border-color: #3266ca;
           class="o-composer w-100 text-start"
           contenteditable="true"
           spellcheck="false"
-          style="
-padding: 5px 0px 5px 8px;
-max-height: 100px;
-line-height: 24px;
-height: fit-content;
-"
+          style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:fit-content;"
           tabindex="1"
         />
         

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -521,8 +521,8 @@ describe("clipboard", () => {
         .replace(/\n/g, "")
         .match(/<td style="(.*?)">.*?<\/td>/)![1];
 
-      expect(firstCellStyle).toContain("font-weight: bold;");
-      expect(firstCellStyle).toContain("background: #123456;");
+      expect(firstCellStyle).toContain("font-weight:bold;");
+      expect(firstCellStyle).toContain("background:#123456;");
     });
 
     test("Copied cells have their content escaped", async () => {


### PR DESCRIPTION
This commit replace the old way of generating css strings by hand/with string concatenation with the helper cssPropertiesToCss.

This have 2 main advantages:

1) It makes the code slightly more readable
2) We avoid inserting strings with newlines directly into the DOM, which makes the DOM way easier to inspect.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo