### PR TITLE
[FIX] figure resizer: fix CSS

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -290,17 +290,17 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     if (resizer.includes("top")) {
       style.top = `${-anchorCenteringOffset}px`;
     } else if (resizer.includes("bottom")) {
-      style.bottom = `${-anchorCenteringOffset}px;`;
+      style.bottom = `${-anchorCenteringOffset}px`;
     } else {
       style.bottom = `calc(50% - ${anchorCenteringOffset}px)`;
     }
 
     if (resizer.includes("left")) {
-      style.left = `${-anchorCenteringOffset}px;`;
+      style.left = `${-anchorCenteringOffset}px`;
     } else if (resizer.includes("right")) {
-      style.right += `${-anchorCenteringOffset}px;`;
+      style.right = `${-anchorCenteringOffset}px`;
     } else {
-      style.right += ` calc(50% - ${anchorCenteringOffset}px);`;
+      style.right = `calc(50% - ${anchorCenteringOffset}px)`;
     }
     return cssPropertiesToCss(style);
   }

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-FigureComponent" owl="1">
     <div
-      class="position-absolute pe-none"
+      class="o-figure-parent position-absolute pe-none"
       t-att-class="{'overflow-hidden': !dnd.isActive}"
       t-att-style="containerStyle">
       <div

--- a/tests/components/__snapshots__/figure.test.ts.snap
+++ b/tests/components/__snapshots__/figure.test.ts.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`figures selected figure snapshot 1`] = `
+<div
+  class="o-figure-parent position-absolute pe-none overflow-hidden"
+  style="left:0px; top:0px; width:2592px; height:2328px;"
+>
+  <div
+    class="o-figure-viewport-inverse w-0 h-0 overflow-visible position-absolute"
+    style="left:0px; top:0px;"
+  >
+    <div
+      class="o-figure-wrapper pe-auto"
+      style="left:1px; top:1px; width:100px; height:100px; z-index:11;"
+    >
+      <div
+        class="o-figure w-100 h-100"
+        style="border-width: 1px;"
+        tabindex="0"
+      >
+        <div
+          class="o-fig-text"
+        >
+          coucou
+        </div>
+      </div>
+      <div
+        class="w-100 h-100 o-active-figure-border position-absolute pe-none"
+      />
+      <div
+        class="o-fig-resizer o-top"
+        style="top:-3px; right:calc(50% - 3px);"
+      />
+      <div
+        class="o-fig-resizer o-topRight"
+        style="top:-3px; right:-3px;"
+      />
+      <div
+        class="o-fig-resizer o-right"
+        style="bottom:calc(50% - 3px); right:-3px;"
+      />
+      <div
+        class="o-fig-resizer o-bottomRight"
+        style="bottom:-3px; right:-3px;"
+      />
+      <div
+        class="o-fig-resizer o-bottom"
+        style="bottom:-3px; right:calc(50% - 3px);"
+      />
+      <div
+        class="o-fig-resizer o-bottomLeft"
+        style="bottom:-3px; left:-3px;"
+      />
+      <div
+        class="o-fig-resizer o-left"
+        style="bottom:calc(50% - 3px); left:-3px;"
+      />
+      <div
+        class="o-fig-resizer o-topLeft"
+        style="top:-3px; left:-3px;"
+      />
+      
+    </div>
+  </div>
+</div>
+`;

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -223,6 +223,13 @@ describe("figures", () => {
     expect(anchors).toHaveLength(8);
   });
 
+  test("selected figure snapshot", async () => {
+    createFigure(model);
+    model.dispatch("SELECT_FIGURE", { id: "someuuid" });
+    await nextTick();
+    expect(fixture.querySelector(".o-figure-parent")).toMatchSnapshot();
+  });
+
   test("Can undo/redo with a figure focused", async () => {
     createFigure(model);
     await nextTick();


### PR DESCRIPTION
3710b7df changed the way css strings were generated, but some mistakes were made.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo