### PR TITLE
[FIX] composer: (real) support of IME

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -74,6 +74,8 @@ const TEMPLATE = xml/* xml */ `
     t-on-click.stop="onClick"
     t-on-blur="onBlur"
     t-on-paste.stop=""
+    t-on-compositionstart="onCompositionStart"
+    t-on-compositionend="onCompositionEnd"
   />
 
   <div t-if="props.focus !== 'inactive' and (autoCompleteState.showProvider or functionDescriptionState.showDescription)"
@@ -197,6 +199,7 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     argToFocus: 0,
   });
   private isKeyStillDown: boolean = false;
+  private compositionActive: boolean = false;
 
   get assistantStyle(): string {
     if (this.props.delimitation && this.props.rect) {
@@ -333,6 +336,13 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
     this.dispatch("STOP_EDITION", { cancel: true });
   }
 
+  onCompositionStart() {
+    this.compositionActive = true;
+  }
+  onCompositionEnd() {
+    this.compositionActive = false;
+  }
+
   onKeydown(ev: KeyboardEvent) {
     let handler = this.keyMapping[ev.key];
     if (handler) {
@@ -437,6 +447,9 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
   // ---------------------------------------------------------------------------
 
   private processContent() {
+    if (this.compositionActive) {
+      return;
+    }
     this.contentHelper.removeAll(); // removes the content of the composer, to be added just after
     this.shouldProcessInputEvents = false;
 


### PR DESCRIPTION
The previous attempt to support IME was only tackling a small part of the problem. Typing a character in the grid (not in an open composer) was not capturing the modified input. This specific issue was solved but it didn't tackle the main issue. Writing any character will automatically close the IME. The problem occurs because we never trust the contenteditable helper value. Each rendering, we empty it and reinstert everything, the deletion causes the IME to dissapear.

This revision skips the deletion/reinsertion in the contentEditableHelper whenever the composition is active.

This leaves one issue - when inputing a character in the grid, we open a new composer and give it focus, which obviously closes the IME. This issue needs a refactoring to be addressed - is will be done in version 16.2 or after.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo