### PR TITLE
[FIX] ripple: use `window.getComputedStyle()` only in `onClick`

### DIFF
--- a/src/components/animation/ripple.ts
+++ b/src/components/animation/ripple.ts
@@ -41,6 +41,7 @@ interface RippleEffectProps
   extends Omit<Required<RippleProps>, "ignoreClickPosition" | "enabled" | "class"> {
   x: string;
   y: string;
+  style: string;
 }
 
 interface RippleDef {
@@ -108,6 +109,7 @@ RippleEffect.props = {
   offsetX: Number,
   allowOverflow: Boolean,
   onAnimationEnd: Function,
+  style: String,
 };
 
 export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
@@ -146,7 +148,7 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
     this.state.ripples.push({ rippleRect, id: this.currentId++ });
   }
 
-  getStyle(): string {
+  private getRippleStyle(): string {
     const containerEl = this.childContainer.el;
 
     if (!containerEl || containerEl.childElementCount !== 1 || !containerEl.firstElementChild) {
@@ -202,6 +204,7 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
       offsetX: this.props.offsetX || 0,
       offsetY: this.props.offsetY || 0,
       allowOverflow: this.props.allowOverflow || false,
+      style: this.getRippleStyle(),
       onAnimationEnd: () => this.removeRipple(id),
     };
   }

--- a/src/components/animation/ripple.xml
+++ b/src/components/animation/ripple.xml
@@ -4,7 +4,7 @@
       class="o-ripple-container position-relative"
       t-att-class="props.class"
       t-on-click="onClick">
-      <div class="position-absolute" t-att-style="getStyle()">
+      <div class="position-absolute w-100 h-100">
         <t t-foreach="state.ripples" t-as="ripple" t-key="ripple.id">
           <RippleEffect t-props="getRippleEffectProps(ripple.id)"/>
         </t>
@@ -17,14 +17,10 @@
 
   <t t-name="o-spreadsheet-RippleEffect" owl="1">
     <div
-      class="position-absolute h-100 w-100"
-      t-att-class="{ 'overflow-hidden': !props.allowOverflow }">
-      <div
-        class="o-ripple position-relative pe-none"
-        t-ref="ripple"
-        t-att-style="rippleStyle"
-        t-on-animationend="onAnimationEnd"
-      />
+      class="position-absolute"
+      t-att-class="{ 'overflow-hidden': !props.allowOverflow }"
+      t-att-style="props.style">
+      <div class="o-ripple position-relative pe-none" t-ref="ripple" t-att-style="rippleStyle"/>
     </div>
   </t>
 </templates>

--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -106,8 +106,7 @@ exports[`BottomBar component simple rendering 1`] = `
     class="o-ripple-container position-relative"
   >
     <div
-      class="position-absolute"
-      style=""
+      class="position-absolute w-100 h-100"
     >
       
     </div>
@@ -131,8 +130,7 @@ exports[`BottomBar component simple rendering 1`] = `
     class="o-ripple-container position-relative"
   >
     <div
-      class="position-absolute"
-      style=""
+      class="position-absolute w-100 h-100"
     >
       
     </div>
@@ -178,8 +176,7 @@ exports[`BottomBar component simple rendering 1`] = `
         class="o-ripple-container position-relative"
       >
         <div
-          class="position-absolute"
-          style=""
+          class="position-absolute w-100 h-100"
         >
           
         </div>

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -511,8 +511,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       class="o-ripple-container position-relative"
     >
       <div
-        class="position-absolute"
-        style="top:0px; left:0px; width:0px; height:0px;"
+        class="position-absolute w-100 h-100"
       >
         
       </div>
@@ -536,8 +535,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       class="o-ripple-container position-relative"
     >
       <div
-        class="position-absolute"
-        style="top:0px; left:0px; width:0px; height:0px;"
+        class="position-absolute w-100 h-100"
       >
         
       </div>
@@ -583,8 +581,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           class="o-ripple-container position-relative"
         >
           <div
-            class="position-absolute"
-            style="top:0px; left:0px; width:0px; height:0px;"
+            class="position-absolute w-100 h-100"
           >
             
           </div>


### PR DESCRIPTION
Previously, `window.getComputedStyle()` was called at each render of the `Ripple` Component, which seems fine in a browser, but really slows down JSDom and the tests.

Now it is only called when the `onClick` event is triggered, and we actually create a `RippleEffect`.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo