### PR TITLE
[REF/IMP] figure: refactor figure container and handle scroll

### DIFF
--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -87,10 +87,10 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
   onMouseDown(ev: MouseEvent) {
     this.state.handler = true;
     this.state.position = { left: 0, top: 0 };
-    const { offsetY, offsetX } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollY, scrollX } = this.env.model.getters.getActiveSheetScrollInfo();
     const start = {
-      left: ev.clientX + offsetX,
-      top: ev.clientY + offsetY,
+      left: ev.clientX + scrollX,
+      top: ev.clientY + scrollY,
     };
     let lastCol: HeaderIndex | undefined;
     let lastRow: HeaderIndex | undefined;
@@ -102,10 +102,10 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
 
     const onMouseMove = (ev: MouseEvent) => {
       const position = gridOverlayPosition();
-      const { offsetY, offsetX } = this.env.model.getters.getActiveSheetScrollInfo();
+      const { scrollY, scrollX } = this.env.model.getters.getActiveSheetScrollInfo();
       this.state.position = {
-        left: ev.clientX - start.left + offsetX,
-        top: ev.clientY - start.top + offsetY,
+        left: ev.clientX - start.left + scrollX,
+        top: ev.clientY - start.top + scrollY,
       };
       const col = this.env.model.getters.getColIndex(ev.clientX - position.left);
       const row = this.env.model.getters.getRowIndex(ev.clientY - position.top);

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -157,11 +157,10 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
   }
 
   private moveCanvas(deltaX: Pixel, deltaY: Pixel) {
-    const { offsetScrollbarX, offsetScrollbarY } =
-      this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetDOMScrollInfo();
     this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
-      offsetX: offsetScrollbarX + deltaX,
-      offsetY: offsetScrollbarY + deltaY,
+      offsetX: scrollX + deltaX,
+      offsetY: scrollY + deltaY,
     });
   }
 }

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -205,11 +205,11 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
 
   get inverseViewportPositionStyle(): string {
     const { x: figureX, y: figureY } = this.props.figure;
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
     const { x, y } = this.env.model.getters.getMainViewportCoordinates();
 
-    const left = figureX >= x ? -(x + offsetX) : 0;
-    const top = figureY >= y ? -(y + offsetY) : 0;
+    const left = figureX >= x ? -(x + scrollX) : 0;
+    const top = figureY >= y ? -(y + scrollY) : 0;
 
     return `
       left: ${left}px;
@@ -339,7 +339,7 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     const position = gridOverlayPosition();
     const { x: offsetCorrectionX, y: offsetCorrectionY } =
       this.env.model.getters.getMainViewportCoordinates();
-    const { offsetX, offsetY } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
     const sheetId = this.env.model.getters.getActiveSheetId();
 
     const initialX = ev.clientX - position.left;
@@ -363,14 +363,14 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
       let { x, y } = this.dnd;
       // Correct position in case of moving to/from a frozen pane
       if (this.dnd.x > offsetCorrectionX && figure.x < offsetCorrectionX) {
-        x += offsetX;
+        x += scrollX;
       } else if (this.dnd.x < offsetCorrectionX && figure.x > offsetCorrectionX) {
-        x -= offsetX;
+        x -= scrollX;
       }
       if (this.dnd.y > offsetCorrectionY && figure.y < offsetCorrectionY) {
-        y += offsetY;
+        y += scrollY;
       } else if (this.dnd.y < offsetCorrectionY && figure.y > offsetCorrectionY) {
-        y -= offsetY;
+        y -= scrollY;
       }
       this.dnd.isActive = false;
       this.env.model.dispatch("UPDATE_FIGURE", { sheetId, id: figure.id, x, y });

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -1,15 +1,12 @@
-import { Component, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, useEffect, useRef } from "@odoo/owl";
 import {
   ComponentsImportance,
   FIGURE_BORDER_COLOR,
-  MIN_FIG_SIZE,
   SELECTION_BORDER_COLOR,
 } from "../../../constants";
-import { figureRegistry } from "../../../registries/index";
-import { Figure, Pixel, SpreadsheetChildEnv, UID } from "../../../types/index";
-import { css } from "../../helpers/css";
-import { gridOverlayPosition } from "../../helpers/dom_helpers";
-import { startDnd } from "../../helpers/drag_and_drop";
+import { figureRegistry } from "../../../registries";
+import { Figure, Pixel, ResizeDirection, SpreadsheetChildEnv, UID } from "../../../types/index";
+import { css, cssPropertiesToCss } from "../../helpers/css";
 
 type ResizeAnchor =
   | "top left"
@@ -39,11 +36,6 @@ css/*SCSS*/ `
     &:focus {
       outline: none;
     }
-
-    &.o-dragging {
-      opacity: 0.9;
-      cursor: grabbing;
-    }
   }
 
   div.o-active-figure-border {
@@ -56,7 +48,7 @@ css/*SCSS*/ `
     position: absolute;
     box-sizing: content-box;
 
-    .o-fig-resizer {
+    .o-fig-anchor {
       z-index: ${ComponentsImportance.ChartAnchor};
       position: absolute;
       width: ${ANCHOR_SIZE}px;
@@ -92,148 +84,46 @@ css/*SCSS*/ `
   }
 `;
 
-interface DndState {
-  isActive: boolean;
-  x: Pixel;
-  y: Pixel;
-  width: Pixel;
-  height: Pixel;
-}
-
 interface Props {
-  sidePanelIsOpen: Boolean;
-  onFigureDeleted: () => void;
   figure: Figure;
+  style: string;
+  onFigureDeleted: () => void;
+  onMouseDown: (ev: MouseEvent) => void;
+  onClickAnchor(dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent): void;
 }
-
-/**
- * Each figure ⭐ is positioned inside a container `div` placed and sized
- * according to the split pane the figure is part of.
- * Any part of the figure outside of the container is hidden
- * thanks to its `overflow: hidden` property.
- *
- * Additionally, the figure is placed inside a "inverse viewport" `div` 🟥.
- * Its position represents the viewport position in the grid: its top/left
- * corner represents the top/left corner of the grid.
- *
- * It allows to position the figure inside this div regardless of the
- * (possibly freezed) viewports and the scrolling position.
- *
- * --: container limits
- * 🟥: inverse viewport
- * ⭐: figure top/left position
- *
- *                     container
- *                         ↓
- * |🟥--------------------------------------------
- * |  \                                          |
- * |   \                                         |
- * |    \                                        |
- * |     \          visible area                 |  no scroll
- * |      ⭐                                     |
- * |                                             |
- * |                                             |
- * -----------------------------------------------
- *
- * the scrolling of the pane is applied as an inverse offset
- * to the div which will in turn move the figure up and down
- * inside the container.
- * Hence, once the figure position is (resp. partly) out of
- * the container dimensions, it will be (resp. partly) hidden.
- *
- * The same reasoning applies to the horizontal axis.
- *
- *  🟥 ························
- *    \                       ↑
- *     \                      |
- *      \                     | inverse viewport = -1 * scroll of pane
- *       \                    |
- *        ⭐ <- not visible   |
- *                            ↓
- * -----------------------------------------------
- * |                                             |
- * |                                             |
- * |                                             |
- * |               visible area                  |
- * |                                             |
- * |                                             |
- * |                                             |
- * -----------------------------------------------
- *
- */
 
 export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FigureComponent";
   static components = {};
+  static defaultProps = {
+    onFigureDeleted: () => {},
+    onMouseDown: () => {},
+    onClickAnchor: () => {},
+  };
   figureRegistry = figureRegistry;
-
   private figureRef = useRef("figure");
-
-  dnd: DndState = useState({
-    isActive: false,
-    x: 0,
-    y: 0,
-    width: 0,
-    height: 0,
-  });
-
-  get displayedFigure(): Figure {
-    return this.dnd.isActive ? { ...this.props.figure, ...this.dnd } : this.props.figure;
-  }
 
   get isSelected(): boolean {
     return this.env.model.getters.getSelectedFigureId() === this.props.figure.id;
   }
 
-  get containerStyle(): string {
-    const { x: figureX, y: figureY } = this.props.figure;
-    const { width: viewWidth, height: viewHeight } = this.env.model.getters.getMainViewportRect();
-    const { x, y } = this.env.model.getters.getMainViewportCoordinates();
-
-    const left = figureX >= x ? x : 0;
-    const width = viewWidth - left;
-    const top = figureY >= y ? y : 0;
-    const height = viewHeight - top;
-
-    return `
-      left: ${left}px;
-      top: ${top}px;
-      width: ${width}px;
-      height: ${height}px
-    `;
-  }
-
-  get inverseViewportPositionStyle(): string {
-    const { x: figureX, y: figureY } = this.props.figure;
-    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
-    const { x, y } = this.env.model.getters.getMainViewportCoordinates();
-
-    const left = figureX >= x ? -(x + scrollX) : 0;
-    const top = figureY >= y ? -(y + scrollY) : 0;
-
-    return `
-      left: ${left}px;
-      top: ${top}px;
-    `;
-  }
-
-  private getBorderWidth() {
+  private getBorderWidth(): Pixel {
     return this.env.isDashboard() ? 0 : BORDER_WIDTH;
   }
 
   get figureStyle() {
-    return `border-width: ${this.getBorderWidth()}px;`;
+    return this.props.style + `border-width: ${this.getBorderWidth()}px;`;
   }
 
   get wrapperStyle() {
-    const { x, y, width, height } = this.displayedFigure;
-    return (
-      `top:${y}px;` +
-      `left:${x}px;` +
-      `width:${width}px;` +
-      `height:${height}px;` +
-      `z-index: ${ComponentsImportance.Figure + (this.isSelected ? 1 : 0)}`
-    );
+    const { x, y, width, height } = this.props.figure;
+    return cssPropertiesToCss({
+      left: `${x}px`,
+      top: `${y}px`,
+      width: `${width}px`,
+      height: `${height}px`,
+      "z-index": String(ComponentsImportance.Figure + (this.isSelected ? 1 : 0)),
+    });
   }
 
   getResizerPosition(resizer: ResizeAnchor) {
@@ -276,106 +166,12 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     );
   }
 
-  resize(dirX: number, dirY: number, ev: MouseEvent) {
-    const figure = this.props.figure;
-
-    ev.stopPropagation();
-    const initialX = ev.clientX;
-    const initialY = ev.clientY;
-
-    this.dnd.x = figure.x;
-    this.dnd.y = figure.y;
-    this.dnd.width = figure.width;
-    this.dnd.height = figure.height;
-
-    const onMouseMove = (ev: MouseEvent) => {
-      this.dnd.isActive = true;
-      const deltaX = Math.max(dirX * (ev.clientX - initialX), MIN_FIG_SIZE - figure.width);
-      const deltaY = Math.max(dirY * (ev.clientY - initialY), MIN_FIG_SIZE - figure.height);
-      this.dnd.width = figure.width + deltaX;
-      this.dnd.height = figure.height + deltaY;
-      if (dirX < 0) {
-        this.dnd.x = figure.x - deltaX;
-      }
-      if (dirY < 0) {
-        this.dnd.y = figure.y - deltaY;
-      }
-    };
-    const onMouseUp = (ev: MouseEvent) => {
-      this.dnd.isActive = false;
-      const update: Partial<Figure> = {
-        x: this.dnd.x,
-        y: this.dnd.y,
-      };
-      if (dirX) {
-        update.width = this.dnd.width;
-      }
-      if (dirY) {
-        update.height = this.dnd.height;
-      }
-      this.env.model.dispatch("UPDATE_FIGURE", {
-        sheetId: this.env.model.getters.getActiveSheetId(),
-        id: figure.id,
-        ...update,
-      });
-    };
-    startDnd(onMouseMove, onMouseUp);
+  clickAnchor(dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent) {
+    this.props.onClickAnchor(dirX, dirY, ev);
   }
 
   onMouseDown(ev: MouseEvent) {
-    const figure = this.props.figure;
-    if (ev.button > 0 || this.env.model.getters.isReadonly()) {
-      // not main button, probably a context menu
-      return;
-    }
-    const selectResult = this.env.model.dispatch("SELECT_FIGURE", { id: figure.id });
-    if (!selectResult.isSuccessful) {
-      return;
-    }
-    if (this.props.sidePanelIsOpen) {
-      this.env.openSidePanel("ChartPanel");
-    }
-
-    const position = gridOverlayPosition();
-    const { x: offsetCorrectionX, y: offsetCorrectionY } =
-      this.env.model.getters.getMainViewportCoordinates();
-    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
-    const sheetId = this.env.model.getters.getActiveSheetId();
-
-    const initialX = ev.clientX - position.left;
-    const initialY = ev.clientY - position.top;
-    this.dnd.x = figure.x;
-    this.dnd.y = figure.y;
-    this.dnd.width = figure.width;
-    this.dnd.height = figure.height;
-
-    const onMouseMove = (ev: MouseEvent) => {
-      this.dnd.isActive = true;
-      const newX = ev.clientX - position.left;
-      let deltaX = newX - initialX;
-      this.dnd.x = Math.max(figure.x + deltaX, 0);
-
-      const newY = ev.clientY - position.top;
-      let deltaY = newY - initialY;
-      this.dnd.y = Math.max(figure.y + deltaY, 0);
-    };
-    const onMouseUp = (ev: MouseEvent) => {
-      let { x, y } = this.dnd;
-      // Correct position in case of moving to/from a frozen pane
-      if (this.dnd.x > offsetCorrectionX && figure.x < offsetCorrectionX) {
-        x += scrollX;
-      } else if (this.dnd.x < offsetCorrectionX && figure.x > offsetCorrectionX) {
-        x -= scrollX;
-      }
-      if (this.dnd.y > offsetCorrectionY && figure.y < offsetCorrectionY) {
-        y += scrollY;
-      } else if (this.dnd.y < offsetCorrectionY && figure.y > offsetCorrectionY) {
-        y -= scrollY;
-      }
-      this.dnd.isActive = false;
-      this.env.model.dispatch("UPDATE_FIGURE", { sheetId, id: figure.id, x, y });
-    };
-    startDnd(onMouseMove, onMouseUp);
+    this.props.onMouseDown(ev);
   }
 
   onKeyDown(ev: KeyboardEvent) {
@@ -412,3 +208,11 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 }
+
+FigureComponent.props = {
+  figure: Object,
+  style: { type: String, optional: true },
+  onFigureDeleted: { type: Function, optional: true },
+  onMouseDown: { type: Function, optional: true },
+  onClickAnchor: { type: Function, optional: true },
+};

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -1,75 +1,64 @@
 <templates>
   <t t-name="o-spreadsheet-FigureComponent" owl="1">
-    <div
-      class="position-absolute pe-none"
-      t-att-class="{'overflow-hidden': !dnd.isActive}"
-      t-att-style="containerStyle">
+    <div class="o-figure-wrapper pe-auto" t-att-style="wrapperStyle">
       <div
-        class="o-figure-viewport-inverse w-0 h-0 overflow-visible position-absolute"
-        t-att-style="inverseViewportPositionStyle">
-        <div class="o-figure-wrapper pe-auto" t-att-style="wrapperStyle">
-          <div
-            class="o-figure w-100 h-100"
-            t-on-mousedown.stop="(ev) => this.onMouseDown(ev)"
-            t-att-class="{'o-dragging': dnd.isActive}"
-            t-ref="figure"
-            t-att-style="figureStyle"
-            tabindex="0"
-            t-on-keydown.stop="(ev) => this.onKeyDown(ev)"
-            t-on-keyup.stop="">
-            <t
-              t-component="figureRegistry.get(this.props.figure.tag).Component"
-              t-key="this.props.figure.id"
-              sidePanelIsOpen="props.sidePanelIsOpen"
-              onFigureDeleted="props.onFigureDeleted"
-              figure="displayedFigure"
-            />
-          </div>
-          <t t-if="isSelected">
-            <div class="w-100 h-100 o-active-figure-border position-absolute pe-none"/>
-            <div
-              class="o-fig-resizer o-top"
-              t-att-style="this.getResizerPosition('top')"
-              t-on-mousedown="(ev) => this.resize(0,-1, ev)"
-            />
-            <div
-              class="o-fig-resizer o-topRight"
-              t-att-style="this.getResizerPosition('top right')"
-              t-on-mousedown="(ev) => this.resize(1,-1, ev)"
-            />
-            <div
-              class="o-fig-resizer o-right"
-              t-att-style="this.getResizerPosition('right')"
-              t-on-mousedown="(ev) => this.resize(1,0, ev)"
-            />
-            <div
-              class="o-fig-resizer o-bottomRight"
-              t-att-style="this.getResizerPosition('bottom right')"
-              t-on-mousedown="(ev) => this.resize(1,1, ev)"
-            />
-            <div
-              class="o-fig-resizer o-bottom"
-              t-att-style="this.getResizerPosition('bottom')"
-              t-on-mousedown="(ev) => this.resize(0,1, ev)"
-            />
-            <div
-              class="o-fig-resizer o-bottomLeft"
-              t-att-style="this.getResizerPosition('bottom left')"
-              t-on-mousedown="(ev) => this.resize(-1,1, ev)"
-            />
-            <div
-              class="o-fig-resizer o-left"
-              t-att-style="this.getResizerPosition('left')"
-              t-on-mousedown="(ev) => this.resize(-1,0, ev)"
-            />
-            <div
-              class="o-fig-resizer o-topLeft"
-              t-att-style="this.getResizerPosition('top left')"
-              t-on-mousedown="(ev) => this.resize(-1,-1, ev)"
-            />
-          </t>
-        </div>
+        class="o-figure w-100 h-100"
+        t-on-mousedown.stop="(ev) => this.onMouseDown(ev)"
+        t-ref="figure"
+        t-att-style="figureStyle"
+        tabindex="0"
+        t-on-keydown.stop="(ev) => this.onKeyDown(ev)"
+        t-on-keyup.stop="">
+        <t
+          t-component="figureRegistry.get(props.figure.tag).Component"
+          t-key="props.figure.id"
+          onFigureDeleted="props.onFigureDeleted"
+          figure="props.figure"
+        />
       </div>
+      <t t-if="isSelected">
+        <div class="w-100 h-100 o-active-figure-border position-absolute pe-none"/>
+        <div
+          class="o-fig-anchor o-top"
+          t-att-style="this.getResizerPosition('top')"
+          t-on-mousedown="(ev) => this.clickAnchor(0,-1, ev)"
+        />
+        <div
+          class="o-fig-anchor o-topRight"
+          t-att-style="this.getResizerPosition('top right')"
+          t-on-mousedown="(ev) => this.clickAnchor(1,-1, ev)"
+        />
+        <div
+          class="o-fig-anchor o-right"
+          t-att-style="this.getResizerPosition('right')"
+          t-on-mousedown="(ev) => this.clickAnchor(1,0, ev)"
+        />
+        <div
+          class="o-fig-anchor o-bottomRight"
+          t-att-style="this.getResizerPosition('bottom right')"
+          t-on-mousedown="(ev) => this.clickAnchor(1,1, ev)"
+        />
+        <div
+          class="o-fig-anchor o-bottom"
+          t-att-style="this.getResizerPosition('bottom')"
+          t-on-mousedown="(ev) => this.clickAnchor(0,1, ev)"
+        />
+        <div
+          class="o-fig-anchor o-bottomLeft"
+          t-att-style="this.getResizerPosition('bottom left')"
+          t-on-mousedown="(ev) => this.clickAnchor(-1,1, ev)"
+        />
+        <div
+          class="o-fig-anchor o-left"
+          t-att-style="this.getResizerPosition('left')"
+          t-on-mousedown="(ev) => this.clickAnchor(-1,0, ev)"
+        />
+        <div
+          class="o-fig-anchor o-topLeft"
+          t-att-style="this.getResizerPosition('top left')"
+          t-on-mousedown="(ev) => this.clickAnchor(-1,-1, ev)"
+        />
+      </t>
     </div>
   </t>
 </templates>

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -1,21 +1,110 @@
-import { Component, onMounted } from "@odoo/owl";
-import { figureRegistry } from "../../../registries/index";
-import { Figure, SpreadsheetChildEnv } from "../../../types/index";
+import { Component, onMounted, useState } from "@odoo/owl";
+import { MIN_FIG_SIZE } from "../../../constants";
+import { figureRegistry } from "../../../registries";
+import {
+  DOMCoordinates,
+  Figure,
+  Pixel,
+  ResizeDirection,
+  SpreadsheetChildEnv,
+} from "../../../types/index";
+import { cssPropertiesToCss } from "../../helpers";
+import { startDnd } from "../../helpers/drag_and_drop";
 import { FigureComponent } from "../figure/figure";
 import { ChartFigure } from "../figure_chart/figure_chart";
 
+type ContainerType = "topLeft" | "topRight" | "bottomLeft" | "bottomRight" | "dnd";
+
+interface DndState {
+  figId: string | undefined;
+  x: Pixel;
+  y: Pixel;
+  width: Pixel;
+  height: Pixel;
+}
 interface Props {
   sidePanelIsOpen: Boolean;
   onFigureDeleted: () => void;
 }
 
+interface Container {
+  type: ContainerType;
+  figures: Figure[];
+  style: string;
+  inverseViewportStyle: string;
+}
+
+/**
+ * Each figure ⭐ is positioned inside a container `div` placed and sized
+ * according to the split pane the figure is part of, or a separate container for the figure
+ * currently drag & dropped. Any part of the figure outside of the container is hidden
+ * thanks to its `overflow: hidden` property.
+ *
+ * Additionally, the figure is placed inside a "inverse viewport" `div` 🟥.
+ * Its position represents the viewport position in the grid: its top/left
+ * corner represents the top/left corner of the grid.
+ *
+ * It allows to position the figure inside this div regardless of the
+ * (possibly freezed) viewports and the scrolling position.
+ *
+ * --: container limits
+ * 🟥: inverse viewport
+ * ⭐: figure top/left position
+ *
+ *                     container
+ *                         ↓
+ * |🟥--------------------------------------------
+ * |  \                                          |
+ * |   \                                         |
+ * |    \                                        |
+ * |     \          visible area                 |  no scroll
+ * |      ⭐                                     |
+ * |                                             |
+ * |                                             |
+ * -----------------------------------------------
+ *
+ * the scrolling of the pane is applied as an inverse offset
+ * to the div which will in turn move the figure up and down
+ * inside the container.
+ * Hence, once the figure position is (resp. partly) out of
+ * the container dimensions, it will be (resp. partly) hidden.
+ *
+ * The same reasoning applies to the horizontal axis.
+ *
+ *  🟥 ························
+ *    \                       ↑
+ *     \                      |
+ *      \                     | inverse viewport = -1 * scroll of pane
+ *       \                    |
+ *        ⭐ <- not visible   |
+ *                            ↓
+ * -----------------------------------------------
+ * |                                             |
+ * |                                             |
+ * |                                             |
+ * |               visible area                  |
+ * |                                             |
+ * |                                             |
+ * |                                             |
+ * -----------------------------------------------
+ *
+ * In the case the d&d figure container, the container is the same as the "topLeft" container for
+ * frozen pane (unaffected by scroll and always visible). The figure coordinates are transformed
+ * for this container at the start of the d&d, and transformed back at the end to adapt to the scroll
+ * that occurred during the drag & drop, and to position the figure on the correct pane.
+ *
+ */
 export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FiguresContainer";
   static components = { FigureComponent };
 
-  getVisibleFigures(): Figure[] {
-    return this.env.model.getters.getVisibleFigures();
-  }
+  dnd = useState<DndState>({
+    figId: undefined,
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  });
 
   setup() {
     onMounted(() => {
@@ -28,6 +117,228 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
       // new rendering
       this.render();
     });
+  }
+
+  private getVisibleFigures(): Figure[] {
+    const visibleFigures = this.env.model.getters.getVisibleFigures();
+    if (this.dnd.figId && !visibleFigures.some((figure) => figure.id === this.dnd.figId)) {
+      visibleFigures.push(
+        this.env.model.getters.getFigure(this.env.model.getters.getActiveSheetId(), this.dnd.figId)!
+      );
+    }
+    return visibleFigures;
+  }
+
+  get containers(): Container[] {
+    const visibleFigures = this.getVisibleFigures();
+    const containers: Container[] = [];
+
+    for (const containerType of [
+      "topLeft",
+      "topRight",
+      "bottomLeft",
+      "bottomRight",
+    ] as ContainerType[]) {
+      const containerFigures = visibleFigures.filter(
+        (figure) => this.getFigureContainer(figure) === containerType
+      );
+
+      if (containerFigures.length > 0) {
+        containers.push({
+          type: containerType,
+          figures: containerFigures,
+          style: this.getContainerStyle(containerType),
+          inverseViewportStyle: this.getInverseViewportPositionStyle(containerType),
+        });
+      }
+    }
+
+    if (this.dnd.figId) {
+      containers.push({
+        type: "dnd",
+        figures: [this.getDndFigure()],
+        style: this.getContainerStyle("dnd"),
+        inverseViewportStyle: this.getInverseViewportPositionStyle("dnd"),
+      });
+    }
+
+    return containers;
+  }
+
+  private getContainerStyle(container: ContainerType): string {
+    const { width: viewWidth, height: viewHeight } = this.env.model.getters.getMainViewportRect();
+    const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
+
+    const left = ["bottomRight", "topRight"].includes(container) ? viewportX : 0;
+    const width = viewWidth - left;
+    const top = ["bottomRight", "bottomLeft"].includes(container) ? viewportY : 0;
+    const height = viewHeight - top;
+
+    return cssPropertiesToCss({
+      left: `${left}px`,
+      top: `${top}px`,
+      width: `${width}px`,
+      height: `${height}px`,
+    });
+  }
+
+  private getInverseViewportPositionStyle(container: ContainerType): string {
+    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
+
+    const left = ["bottomRight", "topRight"].includes(container) ? -(viewportX + scrollX) : 0;
+    const top = ["bottomRight", "bottomLeft"].includes(container) ? -(viewportY + scrollY) : 0;
+
+    return cssPropertiesToCss({
+      left: `${left}px`,
+      top: `${top}px`,
+    });
+  }
+
+  private getFigureContainer(figure: Figure): ContainerType {
+    const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
+    if (figure.id === this.dnd.figId) {
+      return "dnd";
+    } else if (figure.x < viewportX && figure.y < viewportY) {
+      return "topLeft";
+    } else if (figure.x < viewportX) {
+      return "bottomLeft";
+    } else if (figure.y < viewportY) {
+      return "topRight";
+    } else {
+      return "bottomRight";
+    }
+  }
+
+  startDraggingFigure(figure: Figure, ev: MouseEvent) {
+    if (ev.button > 0 || this.env.model.getters.isReadonly()) {
+      // not main button, probably a context menu and no d&d in readonly mode
+      return;
+    }
+    const selectResult = this.env.model.dispatch("SELECT_FIGURE", { id: figure.id });
+    if (!selectResult.isSuccessful) {
+      return;
+    }
+
+    const sheetId = this.env.model.getters.getActiveSheetId();
+
+    const mouseInitialX = ev.clientX;
+    const mouseInitialY = ev.clientY;
+
+    const { x: dndInitialX, y: dndInitialY } = this.internalToScreenCoordinates(figure);
+    this.dnd.x = dndInitialX;
+    this.dnd.y = dndInitialY;
+    this.dnd.width = figure.width;
+    this.dnd.height = figure.height;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
+      const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+
+      const minX = viewportX ? 0 : -scrollX;
+      const minY = viewportY ? 0 : -scrollY;
+
+      this.dnd.figId = figure.id;
+
+      const newX = ev.clientX;
+      let deltaX = newX - mouseInitialX;
+      this.dnd.x = Math.max(dndInitialX + deltaX, minX);
+
+      const newY = ev.clientY;
+      let deltaY = newY - mouseInitialY;
+      this.dnd.y = Math.max(dndInitialY + deltaY, minY);
+    };
+    const onMouseUp = (ev: MouseEvent) => {
+      let { x, y } = this.screenCoordinatesToInternal(this.dnd);
+      this.dnd.figId = undefined;
+      this.env.model.dispatch("UPDATE_FIGURE", { sheetId, id: figure.id, x, y });
+    };
+    startDnd(onMouseMove, onMouseUp);
+  }
+
+  startResize(figure: Figure, dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent) {
+    ev.stopPropagation();
+    const initialX = ev.clientX;
+    const initialY = ev.clientY;
+
+    const { x: dndInitialX, y: dndInitialY } = this.internalToScreenCoordinates(figure);
+    this.dnd.x = dndInitialX;
+    this.dnd.y = dndInitialY;
+    this.dnd.width = figure.width;
+    this.dnd.height = figure.height;
+
+    let onMouseMove: (ev: MouseEvent) => void;
+    onMouseMove = (ev: MouseEvent) => {
+      this.dnd.figId = figure.id;
+      const deltaX = Math.max(dirX * (ev.clientX - initialX), MIN_FIG_SIZE - figure.width);
+      const deltaY = Math.max(dirY * (ev.clientY - initialY), MIN_FIG_SIZE - figure.height);
+      this.dnd.width = figure.width + deltaX;
+      this.dnd.height = figure.height + deltaY;
+      if (dirX < 0) {
+        this.dnd.x = dndInitialX - deltaX;
+      }
+      if (dirY < 0) {
+        this.dnd.y = dndInitialY - deltaY;
+      }
+    };
+
+    const onMouseUp = (ev: MouseEvent) => {
+      this.dnd.figId = undefined;
+      let { x, y } = this.screenCoordinatesToInternal(this.dnd);
+      const update: Partial<Figure> = { x, y };
+      if (dirX) {
+        update.width = this.dnd.width;
+      }
+      if (dirY) {
+        update.height = this.dnd.height;
+      }
+      this.env.model.dispatch("UPDATE_FIGURE", {
+        sheetId: this.env.model.getters.getActiveSheetId(),
+        id: figure.id,
+        ...update,
+      });
+    };
+    startDnd(onMouseMove, onMouseUp);
+  }
+
+  private getDndFigure(): Figure {
+    const figure = this.getVisibleFigures().find((fig) => fig.id === this.dnd.figId);
+    if (!figure) throw new Error("Dnd figure not found");
+    return {
+      ...figure,
+      x: this.dnd.x,
+      y: this.dnd.y,
+      width: this.dnd.width,
+      height: this.dnd.height,
+    };
+  }
+
+  getFigureStyle(figure: Figure): string {
+    if (figure.id !== this.dnd.figId) return "";
+    return cssPropertiesToCss({
+      opacity: "0.9",
+      cursor: "grabbing",
+    });
+  }
+
+  private internalToScreenCoordinates({ x, y }: DOMCoordinates): DOMCoordinates {
+    const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
+    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+
+    x = x < viewportX ? x : x - scrollX;
+    y = y < viewportY ? y : y - scrollY;
+
+    return { x, y };
+  }
+
+  private screenCoordinatesToInternal({ x, y }: DOMCoordinates): DOMCoordinates {
+    const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
+    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetScrollInfo();
+
+    x = viewportX && x < viewportX ? x : x + scrollX;
+    y = viewportY && y < viewportY ? y : y + scrollY;
+
+    return { x, y };
   }
 }
 

--- a/src/components/figures/figure_container/figure_container.xml
+++ b/src/components/figures/figure_container/figure_container.xml
@@ -1,12 +1,25 @@
 <templates>
   <t t-name="o-spreadsheet-FiguresContainer" owl="1">
     <div>
-      <t t-foreach="getVisibleFigures()" t-as="figure" t-key="figure.id">
-        <FigureComponent
-          sidePanelIsOpen="this.props.sidePanelIsOpen"
-          onFigureDeleted="this.props.onFigureDeleted"
-          figure="figure"
-        />
+      <t t-foreach="containers" t-as="container" t-key="container.type">
+        <div
+          class="o-figure-container position-absolute pe-none overflow-hidden"
+          t-att-style="container.style"
+          t-att-data-id="container.type + 'Container'">
+          <div
+            class="o-figure-viewport-inverse w-0 h-0 overflow-visible position-absolute"
+            t-att-style="container.inverseViewportStyle">
+            <t t-foreach="container.figures" t-as="figure" t-key="figure.id">
+              <FigureComponent
+                onFigureDeleted="this.props.onFigureDeleted"
+                figure="figure"
+                style="getFigureStyle(figure)"
+                onMouseDown="(ev) => this.startDraggingFigure(figure, ev)"
+                onClickAnchor="(dirX, dirY, ev) => this.startResize(figure, dirX, dirY, ev)"
+              />
+            </t>
+          </div>
+        </div>
       </t>
     </div>
   </t>

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -312,11 +312,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private moveCanvas(deltaX: number, deltaY: number) {
-    const { offsetScrollbarX, offsetScrollbarY } =
-      this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollX, scrollY } = this.env.model.getters.getActiveSheetDOMScrollInfo();
     this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
-      offsetX: Math.max(offsetScrollbarX + deltaX, 0),
-      offsetY: Math.max(offsetScrollbarY + deltaY, 0),
+      offsetX: Math.max(scrollX + deltaX, 0),
+      offsetY: Math.max(scrollY + deltaY, 0),
     });
   }
 

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -149,7 +149,7 @@ interface Props {
   onFigureDeleted: () => void;
 }
 
-export class GridOverlay extends Component<Props> {
+export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GridOverlay";
   static components = { FiguresContainer };
   static defaultProps = {
@@ -175,8 +175,8 @@ export class GridOverlay extends Component<Props> {
       () => [this.gridOverlayEl.clientHeight, this.gridOverlayEl.clientWidth]
     );
     useTouchMove(this.gridOverlay, this.props.onGridMoved, () => {
-      const { offsetScrollbarY } = this.env.model.getters.getActiveSheetScrollInfo();
-      return offsetScrollbarY > 0;
+      const { scrollY } = this.env.model.getters.getActiveSheetDOMScrollInfo();
+      return scrollY > 0;
     });
   }
 

--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -68,8 +68,7 @@ export function dragAndDropBeyondTheViewport(
 
     const { x: offsetCorrectionX, y: offsetCorrectionY } = getters.getMainViewportCoordinates();
     let { top, left, bottom, right } = getters.getActiveMainViewport();
-    let { offsetScrollbarX: offsetX, offsetScrollbarY: offsetY } =
-      getters.getActiveSheetScrollInfo();
+    let { scrollX, scrollY } = getters.getActiveSheetDOMScrollInfo();
     const { xSplit, ySplit } = getters.getPaneDivisions(sheetId);
     let canEdgeScroll = false;
     let timeoutDelay = MAX_DELAY;
@@ -101,7 +100,7 @@ export function dragAndDropBeyondTheViewport(
             newTarget = colIndex;
             break;
         }
-        offsetX = getters.getColDimensions(sheetId, newTarget!).start - offsetCorrectionX;
+        scrollX = getters.getColDimensions(sheetId, newTarget!).start - offsetCorrectionX;
       }
     }
 
@@ -132,13 +131,13 @@ export function dragAndDropBeyondTheViewport(
             newTarget = rowIndex;
             break;
         }
-        offsetY = env.model.getters.getRowDimensions(sheetId, newTarget!).start - offsetCorrectionY;
+        scrollY = env.model.getters.getRowDimensions(sheetId, newTarget!).start - offsetCorrectionY;
       }
     }
 
     cbMouseMove(colIndex, rowIndex, currentEv);
     if (canEdgeScroll) {
-      env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });
+      env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: scrollX, offsetY: scrollY });
       timeOutId = setTimeout(() => {
         timeOutId = null;
         onMouseMove(currentEv);

--- a/src/components/scrollbar/scrollbar_horizontal.ts
+++ b/src/components/scrollbar/scrollbar_horizontal.ts
@@ -23,7 +23,7 @@ export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
   };
 
   get offset() {
-    return this.env.model.getters.getActiveSheetScrollInfo().offsetScrollbarX;
+    return this.env.model.getters.getActiveSheetDOMScrollInfo().scrollX;
   }
 
   get width() {
@@ -48,10 +48,10 @@ export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onScroll(offset) {
-    const { offsetScrollbarY } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollY } = this.env.model.getters.getActiveSheetDOMScrollInfo();
     this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
       offsetX: offset,
-      offsetY: offsetScrollbarY, // offsetY is the same
+      offsetY: scrollY, // offsetY is the same
     });
   }
 }

--- a/src/components/scrollbar/scrollbar_vertical.ts
+++ b/src/components/scrollbar/scrollbar_vertical.ts
@@ -23,7 +23,7 @@ export class VerticalScrollBar extends Component<Props, SpreadsheetChildEnv> {
   };
 
   get offset() {
-    return this.env.model.getters.getActiveSheetScrollInfo().offsetScrollbarY;
+    return this.env.model.getters.getActiveSheetDOMScrollInfo().scrollY;
   }
 
   get height() {
@@ -48,9 +48,9 @@ export class VerticalScrollBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onScroll(offset) {
-    const { offsetScrollbarX } = this.env.model.getters.getActiveSheetScrollInfo();
+    const { scrollX } = this.env.model.getters.getActiveSheetDOMScrollInfo();
     this.env.model.dispatch("SET_VIEWPORT_OFFSET", {
-      offsetX: offsetScrollbarX, // offsetX is the same
+      offsetX: scrollX, // offsetX is the same
       offsetY: offset,
     });
   }

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -566,12 +566,12 @@ export const CREATE_CHART = (env: SpreadsheetChildEnv) => {
 
   const size = { width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
   const { x, y } = getters.getMainViewportCoordinates();
-  const { offsetX, offsetY } = getters.getActiveSheetScrollInfo();
+  const { scrollX, scrollY } = getters.getActiveSheetScrollInfo();
   const { width, height } = getters.getVisibleRect(getters.getActiveMainViewport());
 
   const position = {
-    x: x + offsetX + Math.max(0, (width - size.width) / 2),
-    y: y + offsetY + Math.max(0, (height - size.height) / 2),
+    x: x + scrollX + Math.max(0, (width - size.width) / 2),
+    y: y + scrollY + Math.max(0, (height - size.height) / 2),
   }; // Position at the center of the scrollable viewport
 
   let title = "";

--- a/src/types/figure.ts
+++ b/src/types/figure.ts
@@ -8,3 +8,10 @@ export interface Figure {
   height: Pixel;
   tag: string;
 }
+
+export interface FigureSize {
+  width: Pixel;
+  height: Pixel;
+}
+
+export type ResizeDirection = -1 | 0 | 1;

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -49,27 +49,32 @@ export interface DOMDimension {
  */
 
 export type Viewport = Zone & Alias;
+
 export interface SheetScrollInfo {
   /**
    * The offset in the X coordinate between the viewport left side and
    * the grid left side (left of column "A").
    */
-  offsetX: Pixel;
-  /**
-   * The scrollBar offset in the X coordinate, which can differ from offsetX as
-   * the former is "smooth" and the latter will "snap" from one cell coordinate to the other
-   */
-  offsetScrollbarX: Pixel;
+  scrollX: Pixel;
   /**
    * The offset in the Y coordinate between the viewport top side and
    * the grid top side (top of row "1").
    */
-  offsetY: Pixel;
+  scrollY: Pixel;
+}
+
+export interface SheetDOMScrollInfo {
+  /**
+   * The scrollBar offset in the X coordinate, which can differ from offsetX as
+   * the former is "smooth" and the latter will "snap" from one cell coordinate to the other
+   */
+  scrollX: Pixel;
+
   /**
    * The scrollBar offset in the Y coordinate, which can differ from offsetX as
    * the former is "smooth" and the latter will "snap" from one cell coordinate to the other
    */
-  offsetScrollbarY: Pixel;
+  scrollY: Pixel;
 }
 
 export interface GridRenderingContext {

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -130,8 +130,11 @@ color: #757575;
 
 exports[`Scorecard charts scorecard text is resized while figure is resized 1`] = `
 <div
-  class="o-figure w-100 h-100 o-dragging"
-  style="border-width: 1px;"
+  class="o-figure w-100 h-100"
+  style="
+opacity: 0.9;
+cursor: grabbing;
+border-width: 1px;"
   tabindex="0"
 >
   <div

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -1,11 +1,14 @@
 import { App, Component, xml } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
-import { MIN_FIG_SIZE } from "../../src/constants";
+import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH, MIN_FIG_SIZE } from "../../src/constants";
 import { figureRegistry } from "../../src/registries";
 import { CreateFigureCommand, Figure, SpreadsheetChildEnv, UID } from "../../src/types";
 import {
   activateSheet,
+  addColumns,
   createSheet,
+  freezeColumns,
+  freezeRows,
   selectCell,
   setCellContent,
 } from "../test_helpers/commands_helpers";
@@ -17,6 +20,7 @@ let fixture: HTMLElement;
 let model: Model;
 let parent: Spreadsheet;
 let app: App;
+let sheetId: UID;
 
 function createFigure(
   model: Model,
@@ -39,18 +43,17 @@ function createFigure(
 }
 
 const anchorSelectors = {
-  top: ".o-fig-resizer.o-top",
-  topRight: ".o-fig-resizer.o-topRight",
-  right: ".o-fig-resizer.o-right",
-  bottomRight: ".o-fig-resizer.o-bottomRight",
-  bottom: ".o-fig-resizer.o-bottom",
-  bottomLeft: ".o-fig-resizer.o-bottomLeft",
-  left: ".o-fig-resizer.o-left",
-  topLeft: ".o-fig-resizer.o-topLeft",
+  top: ".o-fig-anchor.o-top",
+  topRight: ".o-fig-anchor.o-topRight",
+  right: ".o-fig-anchor.o-right",
+  bottomRight: ".o-fig-anchor.o-bottomRight",
+  bottom: ".o-fig-anchor.o-bottom",
+  bottomLeft: ".o-fig-anchor.o-bottomLeft",
+  left: ".o-fig-anchor.o-left",
+  topLeft: ".o-fig-anchor.o-topLeft",
 };
 async function dragAnchor(anchor: string, dragX: number, dragY: number, mouseUp = false) {
-  const anchorElement = fixture.querySelector(anchorSelectors[anchor])!;
-  await dragElement(anchorElement, dragX, dragY, mouseUp);
+  await dragElement(anchorSelectors[anchor], dragX, dragY, mouseUp);
 }
 
 //Test Component required as we don't especially want/need to load an entire chart
@@ -79,6 +82,7 @@ describe("figures", () => {
     fixture = makeTestFixture();
     ({ app, parent } = await mountSpreadsheet(fixture));
     model = parent.model;
+    sheetId = model.getters.getActiveSheetId();
   });
 
   afterEach(() => {
@@ -192,8 +196,26 @@ describe("figures", () => {
     createFigure(model);
     model.dispatch("SELECT_FIGURE", { id: "someuuid" });
     await nextTick();
-    const anchors = fixture.querySelectorAll(".o-fig-resizer");
+    const anchors = fixture.querySelectorAll(".o-fig-anchor");
     expect(anchors).toHaveLength(8);
+  });
+
+  test.each([
+    ["top", { mouseOffsetX: 0, mouseOffsetY: -50 }, { width: 100, height: 150 }],
+    ["topRight", { mouseOffsetX: 50, mouseOffsetY: -50 }, { width: 150, height: 150 }],
+    ["right", { mouseOffsetX: 50, mouseOffsetY: 0 }, { width: 150, height: 100 }],
+    ["bottomRight", { mouseOffsetX: 50, mouseOffsetY: 50 }, { width: 150, height: 150 }],
+    ["bottom", { mouseOffsetX: 0, mouseOffsetY: 50 }, { width: 100, height: 150 }],
+    ["bottomLeft", { mouseOffsetX: -50, mouseOffsetY: 50 }, { width: 150, height: 150 }],
+    ["left", { mouseOffsetX: -50, mouseOffsetY: 0 }, { width: 150, height: 100 }],
+    ["topLeft", { mouseOffsetX: -50, mouseOffsetY: -50 }, { width: 150, height: 150 }],
+  ])("Can resize a figure through its anchors", async (anchor: string, mouseMove, expectedSize) => {
+    const figureId = "someuuid";
+    createFigure(model, { id: figureId, y: 200, x: 200, width: 100, height: 100 });
+    await nextTick();
+    await simulateClick(".o-figure");
+    await dragAnchor(anchor, mouseMove.mouseOffsetX, mouseMove.mouseOffsetY, true);
+    expect(model.getters.getFigure(sheetId, figureId)).toMatchObject(expectedSize);
   });
 
   test.each([
@@ -247,22 +269,113 @@ describe("figures", () => {
     expect(model.getters.getFigure(sheetId, figureId)).toMatchObject(expectedSize);
   });
 
-  test("Can resize a figure through its anchors", async () => {
-    const figureId = "someuuid";
-    createFigure(model, { id: figureId, y: 200 });
-    await nextTick();
-    await simulateClick(".o-figure");
-    expect(model.getters.getSelectedFigureId()).toBe(figureId);
-    expect(model.getters.getFigure(model.getters.getActiveSheetId(), figureId)!.height).toBe(100);
-    // increase height by 50 pixels from the top anchor
-    const resizeTopSelector = fixture.querySelector(".o-fig-resizer.o-top");
-    triggerMouseEvent(resizeTopSelector, "mousedown", 0, 200);
-    await nextTick();
-    triggerMouseEvent(resizeTopSelector, "mousemove", 0, 150);
-    await nextTick();
-    triggerMouseEvent(resizeTopSelector, "mouseup");
-    await nextTick();
-    expect(model.getters.getFigure(model.getters.getActiveSheetId(), figureId)!.height).toBe(150);
+  describe("Move a figure with drag & drop ", () => {
+    test("Can move a figure with drag & drop", async () => {
+      createFigure(model, { id: "someuuid", x: 200, y: 100 });
+      await nextTick();
+      await dragElement(".o-figure", 150, 100, true);
+      await nextTick();
+      expect(model.getters.getFigure(model.getters.getActiveSheetId(), "someuuid")).toMatchObject({
+        x: 350,
+        y: 200,
+      });
+    });
+
+    describe("Figure drag & drop with frozen pane", () => {
+      const cellWidth = DEFAULT_CELL_WIDTH;
+      const cellHeight = DEFAULT_CELL_HEIGHT;
+      const id = "someId";
+      const figureSelector = ".o-figure";
+      beforeEach(async () => {
+        freezeRows(model, 5);
+        freezeColumns(model, 5);
+        model.dispatch("SET_VIEWPORT_OFFSET", {
+          offsetX: 10 * cellWidth,
+          offsetY: 10 * cellHeight,
+        });
+      });
+      test("Figure in frozen rows can be dragged to main viewport", async () => {
+        createFigure(model, { id, x: 16 * cellWidth, y: 4 * cellHeight });
+        await nextTick();
+        await dragElement(figureSelector, 0, 3 * cellHeight, true);
+        expect(model.getters.getFigure(sheetId, id)).toMatchObject({
+          x: 16 * cellWidth,
+          y: 17 * cellHeight, // initial position + drag offset + scroll offset
+        });
+      });
+      test("Figure in main viewport can be dragged to frozen rows", async () => {
+        createFigure(model, { id, x: 16 * cellWidth, y: 16 * cellHeight });
+        await nextTick();
+        await dragElement(figureSelector, 0, -3 * cellHeight, true);
+        expect(model.getters.getFigure(sheetId, id)).toMatchObject({
+          x: 16 * cellWidth,
+          y: 3 * cellHeight, // initial position + drag offset - scroll offset
+        });
+      });
+      test("Dragging figure that is half hidden by frozen rows will put in on top of the freeze pane", async () => {
+        createFigure(model, { id, x: 16 * cellWidth, y: 14 * cellHeight, height: 5 * cellHeight });
+        await nextTick();
+        await dragElement(figureSelector, 1, 0, true);
+        expect(model.getters.getFigure(sheetId, id)).toMatchObject({
+          x: 16 * cellWidth + 1,
+          y: 4 * cellHeight, // initial position - scroll offset
+        });
+      });
+      test("Figure in frozen cols can be dragged to main viewport", async () => {
+        createFigure(model, { id, x: 4 * cellWidth, y: 16 * cellHeight });
+        await nextTick();
+        await dragElement(figureSelector, 3 * cellWidth, 0, true);
+        expect(model.getters.getFigure(sheetId, id)).toMatchObject({
+          x: 17 * cellWidth, // initial position + drag offset + scroll offset
+          y: 16 * cellHeight,
+        });
+      });
+      test("Figure in main viewport can be dragged to frozen cols", async () => {
+        createFigure(model, { id, x: 16 * cellWidth, y: 16 * cellHeight });
+        await nextTick();
+        await dragElement(figureSelector, -3 * cellWidth, 0, true);
+        expect(model.getters.getFigure(sheetId, id)).toMatchObject({
+          x: 3 * cellWidth, // initial position + drag offset - scroll offset
+          y: 16 * cellHeight,
+        });
+      });
+      test("Dragging figure that is half hidden by frozen cols will put in on top of the freeze pane", async () => {
+        createFigure(model, { id, x: 14 * cellWidth, y: 16 * cellHeight, width: 5 * cellWidth });
+        await nextTick();
+        await dragElement(figureSelector, 0, 1, true);
+        expect(model.getters.getFigure(sheetId, id)).toMatchObject({
+          x: 4 * cellWidth, // initial position - scroll offset
+          y: 16 * cellHeight + 1,
+        });
+      });
+    });
+
+    test.each([
+      [{ wheelX: 0, wheelY: 10 * DEFAULT_CELL_HEIGHT }],
+      [{ wheelX: 10 * DEFAULT_CELL_WIDTH, wheelY: 0 }],
+      [{ wheelX: 0, wheelY: 50 * DEFAULT_CELL_HEIGHT }], // scroll out of original viewport
+      [{ wheelX: 40 * DEFAULT_CELL_WIDTH, wheelY: 0 }], // scroll out of original viewport
+    ])(
+      "Can scroll while dragging a figure",
+      async ({ wheelX, wheelY }: { wheelX: number; wheelY: number }) => {
+        addColumns(model, "after", "A", 50);
+        createFigure(model, { id: "someuuid", x: 200, y: 100 });
+        await nextTick();
+        const figureEl = fixture.querySelector(".o-figure")!;
+
+        triggerMouseEvent(figureEl, "mousedown");
+        figureEl.dispatchEvent(
+          new WheelEvent("wheel", { deltaY: wheelY, deltaX: wheelX, bubbles: true })
+        );
+        triggerMouseEvent(figureEl, "mouseup");
+        await nextTick();
+
+        expect(model.getters.getFigure(sheetId, "someuuid")).toMatchObject({
+          x: 200 + wheelX,
+          y: 100 + wheelY,
+        });
+      }
+    );
   });
 
   test("Cannot select/move figure in readonly mode", async () => {
@@ -273,7 +386,7 @@ describe("figures", () => {
     const figure = fixture.querySelector(".o-figure")!;
     await simulateClick(".o-figure");
     expect(document.activeElement).not.toBe(figure);
-    expect(fixture.querySelector(".o-fig-resizer")).toBeNull();
+    expect(fixture.querySelector(".o-fig-anchor")).toBeNull();
 
     triggerMouseEvent(figure, "mousedown", 300, 200);
     await nextTick();

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -39,7 +39,13 @@ import {
   simulateClick,
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
-import { getActiveXc, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
+import {
+  getActiveSheetFullScrollInfo,
+  getActiveXc,
+  getCell,
+  getCellContent,
+  getCellText,
+} from "../test_helpers/getters_helpers";
 import {
   makeTestFixture,
   MockClipboard,
@@ -936,11 +942,11 @@ describe("Events on Grid update viewport correctly", () => {
       left: 0,
       right: 10,
     });
-    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetScrollbarX: 0,
-      offsetY: 1196,
-      offsetScrollbarY: 1200,
+    expect(getActiveSheetFullScrollInfo(model)).toMatchObject({
+      scrollX: 0,
+      scrollbarScrollX: 0,
+      scrollY: 1196,
+      scrollbarScrollY: 1200,
     });
   });
   test("Horizontal scroll", async () => {
@@ -954,11 +960,11 @@ describe("Events on Grid update viewport correctly", () => {
       left: 2,
       right: 12,
     });
-    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 192,
-      offsetScrollbarX: 200,
-      offsetY: 0,
-      offsetScrollbarY: 0,
+    expect(getActiveSheetFullScrollInfo(model)).toMatchObject({
+      scrollX: 192,
+      scrollbarScrollX: 200,
+      scrollY: 0,
+      scrollbarScrollY: 0,
     });
   });
   test("Move selection with keyboard", async () => {
@@ -979,9 +985,9 @@ describe("Events on Grid update viewport correctly", () => {
       left: 1,
       right: 11,
     });
-    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 96,
-      offsetScrollbarX: 96,
+    expect(getActiveSheetFullScrollInfo(model)).toMatchObject({
+      scrollX: 96,
+      scrollbarScrollX: 96,
     });
   });
   test("Move selection horizontally (left to right) through pane division resets the scroll", async () => {
@@ -998,13 +1004,13 @@ describe("Events on Grid update viewport correctly", () => {
     );
     await clickCell(model, "C1");
     expect(model.getters.getActiveMainViewport().left).toEqual(7);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(4 * DEFAULT_CELL_WIDTH);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(4 * DEFAULT_CELL_WIDTH);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", shiftKey: false, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("D1"));
     expect(model.getters.getActiveMainViewport().left).toEqual(3);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(0);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(0);
   });
 
   test("Move selection horizontally (right to left) through pane division does not reset the scroll", async () => {
@@ -1021,13 +1027,13 @@ describe("Events on Grid update viewport correctly", () => {
     );
     await clickCell(model, "H1");
     expect(model.getters.getActiveMainViewport().left).toEqual(7);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(4 * DEFAULT_CELL_WIDTH);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(4 * DEFAULT_CELL_WIDTH);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowLeft", shiftKey: false, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("G1"));
     expect(model.getters.getActiveMainViewport().left).toEqual(6);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(3 * DEFAULT_CELL_WIDTH);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(3 * DEFAULT_CELL_WIDTH);
     document.activeElement!.dispatchEvent(
       // scroll completely to the right
       new WheelEvent("wheel", {
@@ -1044,7 +1050,7 @@ describe("Events on Grid update viewport correctly", () => {
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("C1"));
     expect(model.getters.getActiveMainViewport().left).toEqual(3);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(0);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(0);
   });
 
   test("Move selection vertically (top to bottom) through pane division resets the scroll", async () => {
@@ -1061,13 +1067,13 @@ describe("Events on Grid update viewport correctly", () => {
     );
     await clickCell(model, "A3");
     expect(model.getters.getActiveMainViewport().top).toEqual(7);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(4 * DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(4 * DEFAULT_CELL_HEIGHT);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowDown", shiftKey: false, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("A4"));
     expect(model.getters.getActiveMainViewport().top).toEqual(3);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(0);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(0);
   });
 
   test("Move selection vertically (bottom to to) through pane division does not reset the scroll", async () => {
@@ -1084,13 +1090,13 @@ describe("Events on Grid update viewport correctly", () => {
     );
     await clickCell(model, "A8");
     expect(model.getters.getActiveMainViewport().top).toEqual(7);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(4 * DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(4 * DEFAULT_CELL_HEIGHT);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowUp", shiftKey: false, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("A7"));
     expect(model.getters.getActiveMainViewport().top).toEqual(6);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(3 * DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(3 * DEFAULT_CELL_HEIGHT);
     document.activeElement!.dispatchEvent(
       // scroll completely to the right
       new WheelEvent("wheel", {
@@ -1107,7 +1113,7 @@ describe("Events on Grid update viewport correctly", () => {
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("A3"));
     expect(model.getters.getActiveMainViewport().top).toEqual(3);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(0);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(0);
   });
 
   test("Alter selection with keyboard", async () => {
@@ -1128,9 +1134,9 @@ describe("Events on Grid update viewport correctly", () => {
       left: 1,
       right: 11,
     });
-    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 96,
-      offsetScrollbarX: 96,
+    expect(getActiveSheetFullScrollInfo(model)).toMatchObject({
+      scrollX: 96,
+      scrollbarScrollX: 96,
     });
   });
 
@@ -1148,13 +1154,13 @@ describe("Events on Grid update viewport correctly", () => {
     );
     await clickCell(model, "C1");
     expect(model.getters.getActiveMainViewport().left).toEqual(7);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(4 * DEFAULT_CELL_WIDTH);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(4 * DEFAULT_CELL_WIDTH);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", shiftKey: true, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("C1:D1"));
     expect(model.getters.getActiveMainViewport().left).toEqual(3);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(0);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(0);
   });
 
   test("Alter selection horizontally (right to left) through pane division does not reset the scroll", async () => {
@@ -1171,13 +1177,13 @@ describe("Events on Grid update viewport correctly", () => {
     );
     await clickCell(model, "H1");
     expect(model.getters.getActiveMainViewport().left).toEqual(7);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(4 * DEFAULT_CELL_WIDTH);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(4 * DEFAULT_CELL_WIDTH);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowLeft", shiftKey: true, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("G1:H1"));
     expect(model.getters.getActiveMainViewport().left).toEqual(6);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(3 * DEFAULT_CELL_WIDTH);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(3 * DEFAULT_CELL_WIDTH);
     document.activeElement!.dispatchEvent(
       // scroll completely to the right
       new WheelEvent("wheel", {
@@ -1194,7 +1200,7 @@ describe("Events on Grid update viewport correctly", () => {
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("C1:D1"));
     expect(model.getters.getActiveMainViewport().left).toEqual(3);
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toEqual(0);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(0);
   });
 
   test("Alter selection vertically (top to bottom) through pane division resets the scroll", async () => {
@@ -1211,13 +1217,13 @@ describe("Events on Grid update viewport correctly", () => {
     );
     await clickCell(model, "A3");
     expect(model.getters.getActiveMainViewport().top).toEqual(7);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(4 * DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(4 * DEFAULT_CELL_HEIGHT);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowDown", shiftKey: true, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("A3:A4"));
     expect(model.getters.getActiveMainViewport().top).toEqual(3);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(0);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(0);
   });
 
   test("Alter selection vertically (bottom to to) through pane division does not reset the scroll", async () => {
@@ -1234,13 +1240,13 @@ describe("Events on Grid update viewport correctly", () => {
     );
     await clickCell(model, "A8");
     expect(model.getters.getActiveMainViewport().top).toEqual(7);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(4 * DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(4 * DEFAULT_CELL_HEIGHT);
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowUp", shiftKey: true, bubbles: true })
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("A7:A8"));
     expect(model.getters.getActiveMainViewport().top).toEqual(6);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(3 * DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(3 * DEFAULT_CELL_HEIGHT);
     document.activeElement!.dispatchEvent(
       // scroll completely to the left
       new WheelEvent("wheel", {
@@ -1257,7 +1263,7 @@ describe("Events on Grid update viewport correctly", () => {
     );
     expect(model.getters.getSelectedZone()).toEqual(toZone("A3:A4"));
     expect(model.getters.getActiveMainViewport().top).toEqual(3);
-    expect(model.getters.getActiveSheetScrollInfo().offsetY).toEqual(0);
+    expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(0);
   });
 
   test("Scroll viewport then alter selection with keyboard from penultimate cell to last cell does not shift viewport", async () => {

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -158,7 +158,8 @@ describe("Scorecard charts", () => {
     // required to mock getBoundingClientRect
     figureRect.width -= 300;
     figureRect.height -= 200;
-    await dragElement(".o-fig-resizer.o-topLeft", 300, 200);
+    await dragElement(".o-fig-anchor.o-topLeft", 300, 200);
+    await nextTick(); // wait for useEffect() of scorecard
     expect(getElComputedStyle(".o-figure-wrapper", "width")).toBe("236px");
     expect(getElComputedStyle(".o-figure-wrapper", "height")).toBe("135px");
     expect(getChartElement()).toMatchSnapshot();

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -478,7 +478,7 @@ describe("Composer / selectionInput interactions", () => {
     model.dispatch("SELECT_FIGURE", { id: "thisIsAnId" });
     await nextTick();
     const figureZIndex = getZIndex(".o-figure-wrapper");
-    const figureAnchorZIndex = getZIndex(".o-fig-resizer");
+    const figureAnchorZIndex = getZIndex(".o-fig-anchor");
 
     expect(gridZIndex).toBeLessThan(highlighZIndex);
     expect(highlighZIndex).toBeLessThan(figureZIndex);

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -20,7 +20,7 @@ import {
   simulateClick,
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
-import { getCellContent } from "../test_helpers/getters_helpers";
+import { getActiveSheetFullScrollInfo, getCellContent } from "../test_helpers/getters_helpers";
 import {
   makeTestFixture,
   MockClipboard,
@@ -444,9 +444,9 @@ describe("Composer / selectionInput interactions", () => {
       top: top + 3,
       bottom: bottom + 3,
     });
-    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetY: 3 * DEFAULT_CELL_HEIGHT,
-      offsetScrollbarY: 3 * DEFAULT_CELL_HEIGHT,
+    expect(getActiveSheetFullScrollInfo(model)).toMatchObject({
+      scrollY: 3 * DEFAULT_CELL_HEIGHT,
+      scrollbarScrollY: 3 * DEFAULT_CELL_HEIGHT,
     });
     await clickCell(model, "E5");
     expect(model.getters.getSelectedZones()).toEqual([toZone("A1")]);

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -38,6 +38,7 @@ import {
   unfreezeRows,
   updateFilter,
 } from "../test_helpers/commands_helpers";
+import { getActiveSheetFullScrollInfo } from "../test_helpers/getters_helpers";
 import { getPlugin, target } from "../test_helpers/helpers";
 
 let model: Model;
@@ -75,8 +76,8 @@ describe("Viewport of Simple sheet", () => {
       right: 16,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 6 * DEFAULT_CELL_WIDTH,
-      offsetY: 0,
+      scrollX: 6 * DEFAULT_CELL_WIDTH,
+      scrollY: 0,
     });
 
     selectCell(model, "A79");
@@ -87,8 +88,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: 36 * DEFAULT_CELL_HEIGHT,
+      scrollX: 0,
+      scrollY: 36 * DEFAULT_CELL_HEIGHT,
     });
 
     // back to topleft
@@ -100,8 +101,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: 0,
+      scrollX: 0,
+      scrollY: 0,
     });
 
     selectCell(model, "U51");
@@ -112,8 +113,8 @@ describe("Viewport of Simple sheet", () => {
       right: 21,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 11 * DEFAULT_CELL_WIDTH,
-      offsetY: 8 * DEFAULT_CELL_HEIGHT,
+      scrollX: 11 * DEFAULT_CELL_WIDTH,
+      scrollY: 8 * DEFAULT_CELL_HEIGHT,
     });
   });
   test("Can Undo/Redo action that alters viewport structure (add/delete rows or cols)", () => {
@@ -127,8 +128,8 @@ describe("Viewport of Simple sheet", () => {
       bottom: 169,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 127,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 127,
     });
 
     undo(model);
@@ -139,8 +140,8 @@ describe("Viewport of Simple sheet", () => {
       bottom: 99,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 57,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 57,
     });
 
     redo(model); // should not alter offset
@@ -151,8 +152,8 @@ describe("Viewport of Simple sheet", () => {
       bottom: 100,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 57,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 57,
     });
   });
 
@@ -186,8 +187,8 @@ describe("Viewport of Simple sheet", () => {
       right: 12,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH * 2,
-      offsetY: 0,
+      scrollX: DEFAULT_CELL_WIDTH * 2,
+      scrollY: 0,
     });
 
     setViewportOffset(model, DEFAULT_CELL_WIDTH * 16, 0);
@@ -198,8 +199,8 @@ describe("Viewport of Simple sheet", () => {
       right: 25,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH * 16,
-      offsetY: 0,
+      scrollX: DEFAULT_CELL_WIDTH * 16,
+      scrollY: 0,
     });
 
     setViewportOffset(model, DEFAULT_CELL_WIDTH * 12.6, 0);
@@ -209,11 +210,11 @@ describe("Viewport of Simple sheet", () => {
       left: 12,
       right: 22,
     });
-    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH * 12,
-      offsetScrollbarX: DEFAULT_CELL_WIDTH * 12.6,
-      offsetY: 0,
-      offsetScrollbarY: 0,
+    expect(getActiveSheetFullScrollInfo(model)).toMatchObject({
+      scrollX: DEFAULT_CELL_WIDTH * 12,
+      scrollbarScrollX: DEFAULT_CELL_WIDTH * 12.6,
+      scrollY: 0,
+      scrollbarScrollY: 0,
     });
   });
 
@@ -235,8 +236,8 @@ describe("Viewport of Simple sheet", () => {
       right: 12,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH * 2,
-      offsetY: 0,
+      scrollX: DEFAULT_CELL_WIDTH * 2,
+      scrollY: 0,
     });
 
     setViewportOffset(model, DEFAULT_CELL_WIDTH * 16, 0);
@@ -255,8 +256,8 @@ describe("Viewport of Simple sheet", () => {
       right: 25,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH * 16,
-      offsetY: 0,
+      scrollX: DEFAULT_CELL_WIDTH * 16,
+      scrollY: 0,
     });
   });
 
@@ -272,8 +273,8 @@ describe("Viewport of Simple sheet", () => {
       right: 12,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH * 2,
-      offsetY: 0,
+      scrollX: DEFAULT_CELL_WIDTH * 2,
+      scrollY: 0,
     });
   });
 
@@ -286,8 +287,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 2,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 2,
     });
 
     setViewportOffset(model, 0, DEFAULT_CELL_HEIGHT * 57);
@@ -298,8 +299,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 57,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 57,
     });
 
     setViewportOffset(model, 0, DEFAULT_CELL_HEIGHT * 12.6);
@@ -309,11 +310,11 @@ describe("Viewport of Simple sheet", () => {
       left: 0,
       right: 10,
     });
-    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetScrollbarX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 12,
-      offsetScrollbarY: DEFAULT_CELL_HEIGHT * 12.6,
+    expect(getActiveSheetFullScrollInfo(model)).toMatchObject({
+      scrollX: 0,
+      scrollbarScrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 12,
+      scrollbarScrollY: DEFAULT_CELL_HEIGHT * 12.6,
     });
   });
 
@@ -329,8 +330,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 2,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 2,
     });
     expect(getSheetViewBoundaries(model)).toMatchObject({
       top: 0,
@@ -347,8 +348,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 57,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 57,
     });
     expect(getSheetViewBoundaries(model)).toMatchObject({
       top: 0,
@@ -364,11 +365,11 @@ describe("Viewport of Simple sheet", () => {
       left: 4,
       right: 10,
     });
-    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetScrollbarX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 12,
-      offsetScrollbarY: DEFAULT_CELL_HEIGHT * 12.6,
+    expect(getActiveSheetFullScrollInfo(model)).toMatchObject({
+      scrollX: 0,
+      scrollbarScrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 12,
+      scrollbarScrollY: DEFAULT_CELL_HEIGHT * 12.6,
     });
     expect(getSheetViewBoundaries(model)).toMatchObject({
       top: 0,
@@ -390,19 +391,19 @@ describe("Viewport of Simple sheet", () => {
       right: 1,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 2,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 2,
     });
   });
 
   test("cannot set offset outside of the grid", () => {
     // negative
     setViewportOffset(model, -1, -1);
-    expect(model.getters.getActiveSheetScrollInfo()).toEqual({
-      offsetScrollbarX: 0,
-      offsetScrollbarY: 0,
-      offsetX: 0,
-      offsetY: 0,
+    expect(getActiveSheetFullScrollInfo(model)).toEqual({
+      scrollbarScrollX: 0,
+      scrollbarScrollY: 0,
+      scrollX: 0,
+      scrollY: 0,
     });
 
     // too large
@@ -419,18 +420,18 @@ describe("Viewport of Simple sheet", () => {
 
     const maxOffsetX = DEFAULT_CELL_WIDTH * (nCols - 10 + 1);
     const maxOffsetY = DEFAULT_CELL_HEIGHT * (nRows - 10 + 1);
-    expect(model.getters.getActiveSheetScrollInfo()).toEqual({
-      offsetScrollbarX: maxOffsetX + 1,
-      offsetScrollbarY: maxOffsetY + 1 + 5,
-      offsetX: maxOffsetX,
-      offsetY: maxOffsetY,
+    expect(getActiveSheetFullScrollInfo(model)).toEqual({
+      scrollbarScrollX: maxOffsetX + 1,
+      scrollbarScrollY: maxOffsetY + 1 + 5,
+      scrollX: maxOffsetX,
+      scrollY: maxOffsetY,
     });
   });
 
   test("Resize (increase) columns correctly affects viewport without changing the offset", () => {
     const sheetId = model.getters.getActiveSheetId();
     setViewportOffset(model, DEFAULT_CELL_WIDTH * 2, 0);
-    const { offsetX } = model.getters.getActiveSheetScrollInfo();
+    const { scrollX } = model.getters.getActiveSheetScrollInfo();
     resizeColumns(
       model,
       range(0, model.getters.getNumberCols(sheetId)).map(numberToLetters),
@@ -443,8 +444,8 @@ describe("Viewport of Simple sheet", () => {
       right: 6,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX,
-      offsetY: 0,
+      scrollX,
+      scrollY: 0,
     });
   });
 
@@ -472,15 +473,15 @@ describe("Viewport of Simple sheet", () => {
       right: 25,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: (DEFAULT_CELL_WIDTH / 2) * 7,
-      offsetY: 0,
+      scrollX: (DEFAULT_CELL_WIDTH / 2) * 7,
+      scrollY: 0,
     });
   });
 
   test("Resize rows correctly affects viewport without changing the offset", () => {
     const numberRows = model.getters.getNumberRows(model.getters.getActiveSheetId());
     setViewportOffset(model, 0, DEFAULT_CELL_HEIGHT * 2);
-    const { offsetY } = model.getters.getActiveSheetScrollInfo();
+    const { scrollY } = model.getters.getActiveSheetScrollInfo();
     resizeRows(model, [...Array(numberRows).keys()], DEFAULT_CELL_HEIGHT * 2);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 1,
@@ -489,8 +490,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY,
+      scrollX: 0,
+      scrollY,
     });
   });
 
@@ -513,8 +514,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: Math.round(DEFAULT_CELL_HEIGHT / 2) * 19,
+      scrollX: 0,
+      scrollY: Math.round(DEFAULT_CELL_HEIGHT / 2) * 19,
     });
   });
 
@@ -527,8 +528,8 @@ describe("Viewport of Simple sheet", () => {
       right: 15,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: 0,
+      scrollX: 0,
+      scrollY: 0,
     });
   });
 
@@ -544,8 +545,8 @@ describe("Viewport of Simple sheet", () => {
       right: viewport.right,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH * 3,
-      offsetY: 0,
+      scrollX: DEFAULT_CELL_WIDTH * 3,
+      scrollY: 0,
     });
   });
   test("Hide/unhide Row from top row", () => {
@@ -557,8 +558,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: 0,
+      scrollX: 0,
+      scrollY: 0,
     });
   });
   test("Hide/unhide Rows from bottom row", () => {
@@ -573,8 +574,8 @@ describe("Viewport of Simple sheet", () => {
       right: viewport.right,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 17,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 17,
     });
   });
   test("Horizontally move position to top right then back to top left correctly affects offset", () => {
@@ -588,8 +589,8 @@ describe("Viewport of Simple sheet", () => {
       right: 11,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH,
-      offsetY: 0,
+      scrollX: DEFAULT_CELL_WIDTH,
+      scrollY: 0,
     });
     moveAnchorCell(model, "right");
     moveAnchorCell(model, "right");
@@ -600,8 +601,8 @@ describe("Viewport of Simple sheet", () => {
       right: 13,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH * 3,
-      offsetY: 0,
+      scrollX: DEFAULT_CELL_WIDTH * 3,
+      scrollY: 0,
     });
     const { left } = model.getters.getActiveMainViewport();
     selectCell(model, toXC(left, 0));
@@ -614,8 +615,8 @@ describe("Viewport of Simple sheet", () => {
       right: 11,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: DEFAULT_CELL_WIDTH,
-      offsetY: 0,
+      scrollX: DEFAULT_CELL_WIDTH,
+      scrollY: 0,
     });
   });
 
@@ -630,8 +631,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT,
     });
     moveAnchorCell(model, "down");
     moveAnchorCell(model, "down");
@@ -642,8 +643,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT * 3,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT * 3,
     });
     const { top } = model.getters.getActiveMainViewport();
     selectCell(model, toXC(0, top));
@@ -656,8 +657,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: DEFAULT_CELL_HEIGHT,
+      scrollX: 0,
+      scrollY: DEFAULT_CELL_HEIGHT,
     });
   });
 
@@ -691,8 +692,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: 0,
+      scrollX: 0,
+      scrollY: 0,
     });
     moveAnchorCell(model, "down");
     expect(model.getters.getActiveMainViewport()).toMatchObject({
@@ -702,8 +703,8 @@ describe("Viewport of Simple sheet", () => {
       right: 10,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: height + 50, // row1 + row2
+      scrollX: 0,
+      scrollY: height + 50, // row1 + row2
     });
   });
 
@@ -717,8 +718,8 @@ describe("Viewport of Simple sheet", () => {
       right: 0,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: 0,
+      scrollX: 0,
+      scrollY: 0,
     });
     moveAnchorCell(model, "right");
     expect(model.getters.getActiveMainViewport()).toMatchObject({
@@ -728,8 +729,8 @@ describe("Viewport of Simple sheet", () => {
       right: 11,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: width + 50, // colA + colB
-      offsetY: 0,
+      scrollX: width + 50, // colA + colB
+      scrollY: 0,
     });
   });
   test("Select Column while updating range does not update viewport", () => {
@@ -782,9 +783,9 @@ describe("Viewport of Simple sheet", () => {
     ({ width, height } = model.getters.getSheetViewDimensionWithHeaders());
     ({ width: gridWidth, height: gridHeight } = model.getters.getMainViewportRect());
 
-    expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetScrollbarX: gridWidth - width,
-      offsetScrollbarY: gridHeight - height,
+    expect(model.getters.getActiveSheetDOMScrollInfo()).toMatchObject({
+      scrollX: gridWidth - width,
+      scrollY: gridHeight - height,
     });
   });
 
@@ -1006,11 +1007,11 @@ describe("Multi Panes viewport", () => {
     });
     setViewportOffset(model, 0, 5 * DEFAULT_CELL_HEIGHT);
     freezeRows(model, 11);
-    expect(model.getters.getActiveSheetScrollInfo()).toEqual({
-      offsetX: 0,
-      offsetY: 0,
-      offsetScrollbarX: 0,
-      offsetScrollbarY: 0,
+    expect(getActiveSheetFullScrollInfo(model)).toEqual({
+      scrollX: 0,
+      scrollY: 0,
+      scrollbarScrollX: 0,
+      scrollbarScrollY: 0,
     });
     expect(setViewportOffset(model, 0, 5 * DEFAULT_CELL_HEIGHT)).toBeCancelledBecause(
       CommandResult.InvalidScrollingDirection
@@ -1026,11 +1027,11 @@ describe("Multi Panes viewport", () => {
     });
     setViewportOffset(model, 5 * DEFAULT_CELL_WIDTH, 0);
     freezeColumns(model, 10);
-    expect(model.getters.getActiveSheetScrollInfo()).toEqual({
-      offsetX: 0,
-      offsetY: 0,
-      offsetScrollbarX: 0,
-      offsetScrollbarY: 0,
+    expect(getActiveSheetFullScrollInfo(model)).toEqual({
+      scrollX: 0,
+      scrollY: 0,
+      scrollbarScrollX: 0,
+      scrollbarScrollY: 0,
     });
     expect(setViewportOffset(model, 5 * DEFAULT_CELL_WIDTH, 0)).toBeCancelledBecause(
       CommandResult.InvalidScrollingDirection
@@ -1069,8 +1070,8 @@ describe("multi sheet with different sizes", () => {
       right: 1,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: 0,
+      scrollX: 0,
+      scrollY: 0,
     });
     activateSheet(model, "big");
     expect(model.getters.getActiveMainViewport()).toMatchObject({
@@ -1080,8 +1081,8 @@ describe("multi sheet with different sizes", () => {
       right: 4,
     });
     expect(model.getters.getActiveSheetScrollInfo()).toMatchObject({
-      offsetX: 0,
-      offsetY: 0,
+      scrollX: 0,
+      scrollY: 0,
     });
   });
 
@@ -1231,9 +1232,9 @@ describe("shift viewport up/down", () => {
     selectCell(model, "D1");
     setViewportOffset(model, DEFAULT_CELL_WIDTH * 3, 0);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toBe(DEFAULT_CELL_WIDTH * 3);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveSheetScrollInfo().offsetX).toBe(DEFAULT_CELL_WIDTH * 3);
+    expect(model.getters.getActiveSheetScrollInfo().scrollX).toBe(DEFAULT_CELL_WIDTH * 3);
   });
 
   test("anchor cell at the viewport top is shifted", () => {

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -125,3 +125,12 @@ export function automaticSumMulti(
   setSelection(model, xcs, { anchor });
   return model.dispatch("SUM_SELECTION");
 }
+
+export function getActiveSheetFullScrollInfo(model: Model) {
+  const scrollBarScroll = model.getters.getActiveSheetDOMScrollInfo();
+  return {
+    ...model.getters.getActiveSheetScrollInfo(),
+    scrollbarScrollX: scrollBarScroll.scrollX,
+    scrollbarScrollY: scrollBarScroll.scrollY,
+  };
+}


### PR DESCRIPTION
## Description

This commit refactor the figure container and inverse viewport: now the figure don't have to create its own container and inverse viewport, but this is handled by the `FigureContainer`, that place the figures in the correct container.

There is a new container specific to the figure that is currently dragged. The container takes the full screen and is independent of the scroll of the spreadsheet. When we start the drag & drop, we transform the figure coordinates for this container, and we transform them back when we drop the figure. This allow us to not worry about the scroll and the frozen panes during the drag & drop.

Odoo task ID : [3035531](https://www.odoo.com/web#id=3035531&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo