### PR TITLE
[FIX] figures: copy paste through context menu not working in first try

### DIFF
--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -50,7 +50,7 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
       action: async () => {
         this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
         this.env.model.dispatch("COPY");
-        await this.env.clipboard.clear();
+        await this.env.clipboard.write(this.env.model.getters.getClipboardContent());
       },
     });
     registry.add("cut", {
@@ -59,7 +59,7 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
       action: async () => {
         this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
         this.env.model.dispatch("CUT");
-        await this.env.clipboard.clear();
+        await this.env.clipboard.write(this.env.model.getters.getClipboardContent());
       },
     });
     registry.add("delete", {

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -31,7 +31,7 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
       action: async () => {
         this.env.model.dispatch("SELECT_FIGURE", { id: this.figureId });
         this.env.model.dispatch("COPY");
-        await this.env.clipboard.clear();
+        await this.env.clipboard.write(this.env.model.getters.getClipboardContent());
       },
     });
     registry.add("cut", {
@@ -41,7 +41,7 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
       action: async () => {
         this.env.model.dispatch("SELECT_FIGURE", { id: this.figureId });
         this.env.model.dispatch("CUT");
-        await this.env.clipboard.clear();
+        await this.env.clipboard.write(this.env.model.getters.getClipboardContent());
       },
     });
     registry.add("reset_size", {

--- a/src/helpers/clipboard/navigator_clipboard_wrapper.ts
+++ b/src/helpers/clipboard/navigator_clipboard_wrapper.ts
@@ -8,7 +8,6 @@ export interface ClipboardInterface {
   write(clipboardContent: ClipboardContent): Promise<void>;
   writeText(text: string): Promise<void>;
   readText(): Promise<ClipboardReadResult>;
-  clear(): Promise<void>;
 }
 
 export function instantiateClipboard(): ClipboardInterface {
@@ -44,12 +43,6 @@ class WebClipboardWrapper implements ClipboardInterface {
       const status = permissionResult?.state === "denied" ? "permissionDenied" : "notImplemented";
       return { status };
     }
-  }
-
-  async clear(): Promise<void> {
-    try {
-      this.clipboard?.write([]);
-    } catch (e) {}
   }
 
   private getClipboardItems(content: ClipboardContent): ClipboardItems {

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -1,5 +1,5 @@
 import { App, Component, xml } from "@odoo/owl";
-import { Model } from "../../src";
+import { Model, Spreadsheet } from "../../src";
 import { ChartJsComponent } from "../../src/components/figures/chart/chartJs/chartjs";
 import { ScorecardChart } from "../../src/components/figures/chart/scorecard/chart_scorecard";
 import { MENU_WIDTH, MIN_FIG_SIZE } from "../../src/constants";
@@ -32,6 +32,7 @@ import { TEST_CHART_DATA } from "./../test_helpers/constants";
 let fixture: HTMLElement;
 let model: Model;
 let app: App;
+let parent: Spreadsheet;
 
 function createFigure(
   model: Model,
@@ -105,7 +106,7 @@ afterAll(() => {
 describe("figures", () => {
   beforeEach(async () => {
     fixture = makeTestFixture();
-    ({ app, model } = await mountSpreadsheet(fixture));
+    ({ app, model, parent } = await mountSpreadsheet(fixture));
   });
 
   afterEach(() => {
@@ -380,6 +381,12 @@ describe("figures", () => {
         await simulateClick(".o-figure");
         await simulateClick(".o-figure-menu-item");
         await simulateClick(".o-menu div[data-name='copy']");
+        const envClipBoardContent = await parent.env.clipboard.readText();
+        if (envClipBoardContent.status === "ok") {
+          expect(envClipBoardContent.content).toEqual(
+            model.getters.getClipboardContent()["text/plain"]
+          );
+        }
         paste(model, "A4");
         expect(getFigureIds(model, sheetId)).toHaveLength(2);
         const figureIds = getFigureIds(model, sheetId);
@@ -392,6 +399,12 @@ describe("figures", () => {
         await simulateClick(".o-figure");
         await simulateClick(".o-figure-menu-item");
         await simulateClick(".o-menu div[data-name='cut']");
+        const envClipBoardContent = await parent.env.clipboard.readText();
+        if (envClipBoardContent.status === "ok") {
+          expect(envClipBoardContent.content).toEqual(
+            model.getters.getClipboardContent()["text/plain"]
+          );
+        }
         paste(model, "A1");
         expect(getFigureIds(model, sheetId)).toHaveLength(1);
         const figureIds = getFigureIds(model, sheetId);

--- a/tests/test_helpers/clipboard.ts
+++ b/tests/test_helpers/clipboard.ts
@@ -18,10 +18,6 @@ export class MockClipboard implements ClipboardInterface {
   async write(content: ClipboardContent) {
     this.content = content[ClipboardMIMEType.PlainText];
   }
-
-  async clear(): Promise<void> {
-    this.content = "";
-  }
 }
 
 export class MockClipboardData {


### PR DESCRIPTION
## Description:

The problem is that when users first open a spreadsheet and use context menu to copy and paste figures directly, it doesn't work. If users use keyboard shortcuts it works as normal, and after that the context menu works well, too.

The root cause seems to be the figure content hasn't been written into the clipboard when users use context menu first. Since the top bar menu works well, I use the same idea as the copy menu item in top bar menu. The reason to not reuse `ACTIONS.COPY_ACTION`/`ACTIONS.CUT_ACTION` in figure context menu is that we need to select the figure first, otherwise context menu through right-click will target at wrong selected region. 

Odoo task ID : [3159756](https://www.odoo.com/web#id=3159756&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo