### PR TITLE
[IMP] chart: format Y values

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -70,6 +70,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
     } else {
       this.chart!.data.datasets = undefined;
     }
+    this.chart!.config.options!.tooltips = chartData.options?.tooltips;
     this.chart!.config.options!.legend = chartData.options?.legend;
     this.chart!.config.options!.scales = chartData.options?.scales;
     this.chart!.update({ duration: 0 });

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -12,6 +12,7 @@ import {
   Color,
   CommandResult,
   CoreGetters,
+  Format,
   Getters,
   Range,
   RemoveColumnsRowsCommand,
@@ -45,6 +46,7 @@ import {
 import {
   aggregateDataForLabels,
   filterEmptyDataPoints,
+  getChartDatasetFormat,
   getChartDatasetValues,
   getChartLabelValues,
   getDefaultChartJsRuntime,
@@ -183,9 +185,18 @@ export class PieChart extends AbstractChart {
   }
 }
 
-function getPieConfiguration(chart: PieChart, labels: string[]): ChartConfiguration {
+function getPieConfiguration(
+  chart: PieChart,
+  labels: string[],
+  dataSetFormat: Format | undefined
+): ChartConfiguration {
   const fontColor = chartFontColor(chart.background);
-  const config: ChartConfiguration = getDefaultChartJsRuntime(chart, labels, fontColor);
+  const config: ChartConfiguration = getDefaultChartJsRuntime(
+    chart,
+    labels,
+    fontColor,
+    dataSetFormat
+  );
   const legend: ChartLegendOptions = {
     labels: { fontColor },
   };
@@ -198,12 +209,11 @@ function getPieConfiguration(chart: PieChart, labels: string[]): ChartConfigurat
   config.options!.layout = {
     padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
   };
-  config.options!.tooltips = {
-    callbacks: {
-      title: function (tooltipItems: ChartTooltipItem[], data: ChartData) {
-        return data.datasets![tooltipItems[0]!.datasetIndex!].label!;
-      },
-    },
+  config.options!.tooltips!.callbacks!.title = function (
+    tooltipItems: ChartTooltipItem[],
+    data: ChartData
+  ) {
+    return data.datasets![tooltipItems[0]!.datasetIndex!].label!;
   };
   return config;
 }
@@ -228,7 +238,8 @@ export function createPieChartRuntime(chart: PieChart, getters: Getters): PieCha
   if (chart.aggregated) {
     ({ labels, dataSetsValues } = aggregateDataForLabels(labels, dataSetsValues));
   }
-  const config = getPieConfiguration(chart, labels);
+  const dataSetFormat = getChartDatasetFormat(getters, chart.dataSets);
+  const config = getPieConfiguration(chart, labels, dataSetFormat);
   const colors = new ChartColors();
   for (let { label, data } of dataSetsValues) {
     const backgroundColor = getPieColors(colors, dataSetsValues);

--- a/src/plugins/ui_core_views/evaluation.ts
+++ b/src/plugins/ui_core_views/evaluation.ts
@@ -53,6 +53,7 @@ export class EvaluationPlugin extends UIPlugin {
     "evaluateFormula",
     "getRangeFormattedValues",
     "getRangeValues",
+    "getRangeFormats",
     "getEvaluatedCell",
     "getEvaluatedCells",
     "getColEvaluatedCells",
@@ -138,6 +139,15 @@ export class EvaluationPlugin extends UIPlugin {
     const sheet = this.getters.tryGetSheet(range.sheetId);
     if (sheet === undefined) return [];
     return this.getters.getEvaluatedCellsInZone(sheet.id, range.zone).map((cell) => cell.value);
+  }
+
+  /**
+   * Return the format of each cell in the range.
+   */
+  getRangeFormats(range: Range): (Format | undefined)[] {
+    const sheet = this.getters.tryGetSheet(range.sheetId);
+    if (sheet === undefined) return [];
+    return this.getters.getEvaluatedCellsInZone(sheet.id, range.zone).map((cell) => cell.format);
   }
 
   getEvaluatedCell({ sheetId, col, row }: CellPosition): EvaluatedCell {

--- a/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
@@ -93,6 +93,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#FFFFFF",
             },
           },
@@ -104,6 +105,12 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+          "title": [Function],
+        },
       },
     },
     "type": "line",
@@ -211,6 +218,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -222,6 +230,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
     },
     "type": "line",
@@ -322,6 +335,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -333,6 +347,12 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+          "title": [Function],
+        },
       },
     },
     "type": "line",
@@ -411,6 +431,7 @@ Object {
             "stacked": true,
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -422,6 +443,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
     },
     "type": "bar",
@@ -502,6 +528,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -513,6 +540,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
     },
     "type": "line",
@@ -610,6 +642,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -621,6 +654,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
     },
     "type": "line",
@@ -718,6 +756,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -729,6 +768,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
     },
     "type": "line",
@@ -799,6 +843,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -810,6 +855,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
     },
     "type": "line",
@@ -907,6 +957,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -918,6 +969,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
     },
     "type": "line",
@@ -1015,6 +1071,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -1026,6 +1083,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
     },
     "type": "line",
@@ -1123,6 +1185,7 @@ Object {
             "position": "left",
             "ticks": Object {
               "beginAtZero": true,
+              "callback": [Function],
               "fontColor": "#000000",
             },
           },
@@ -1134,6 +1197,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "test",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
     },
     "type": "line",

--- a/tests/plugins/chart/__snapshots__/gauge_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/gauge_chart.test.ts.snap
@@ -64,6 +64,11 @@ Object {
         "fontStyle": "normal",
         "text": "Title",
       },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
+      },
       "valueLabel": Object {
         "backgroundColor": "#000000",
         "borderRadius": 5,
@@ -148,6 +153,11 @@ Object {
         "fontSize": 22,
         "fontStyle": "normal",
         "text": "",
+      },
+      "tooltips": Object {
+        "callbacks": Object {
+          "label": [Function],
+        },
       },
       "valueLabel": Object {
         "backgroundColor": "#000000",


### PR DESCRIPTION
## Description

This commit format the Y values displayed in ChartJS for the Y axis and the hover tooltip. The values are formatted with either:

- The first format found in the dataset that isn't a date format (date formats don't make sense for Y values)
-A default format with thousand separator if no format was found in the
dataset

Odoo task ID : [3035260](https://www.odoo.com/web#id=3035260&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo