### PR TITLE
[FIX] drag & drop: mouse outside the grid & freeze panes

### DIFF
--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -136,6 +136,15 @@ export function dragAndDropBeyondTheViewport(
       }
     }
 
+    if (!canEdgeScroll) {
+      if (rowIndex === -1) {
+        rowIndex = y < 0 ? 0 : getters.getNumberRows(sheetId) - 1;
+      }
+      if (colIndex === -1 && x < 0) {
+        colIndex = x < 0 ? 0 : getters.getNumberCols(sheetId) - 1;
+      }
+    }
+
     cbMouseMove(colIndex, rowIndex, currentEv);
     if (canEdgeScroll) {
       env.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX, offsetY });

--- a/tests/components/drag_and_drop.test.ts
+++ b/tests/components/drag_and_drop.test.ts
@@ -35,6 +35,9 @@ interface Props {
   model: Model;
 }
 
+let selectedCol: number | undefined = undefined;
+let selectedRow: number | undefined = undefined;
+
 class FakeGridComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = TEMPLATE;
 
@@ -47,7 +50,10 @@ class FakeGridComponent extends Component<Props, SpreadsheetChildEnv> {
   onMouseDown(ev: MouseEvent) {
     dragAndDropBeyondTheViewport(
       this.env,
-      () => {},
+      (col, row) => {
+        selectedCol = col;
+        selectedRow = row;
+      },
       () => {}
     );
   }
@@ -63,6 +69,7 @@ afterAll(() => {
 beforeEach(async () => {
   model = new Model();
   app = new App(FakeGridComponent, { props: { model } });
+  selectedCol = selectedRow = undefined;
   fixture = makeTestFixture();
   await app.mount(fixture);
   sheetId = model.getters.getActiveSheetId();
@@ -186,6 +193,25 @@ describe("Drag And Drop horizontal tests", () => {
       right: 17,
     });
   });
+
+  test("Drag&Drop beyond the grid: correct col value is given to the callback", async () => {
+    freezeColumns(model, 4, sheetId);
+    setViewportOffset(model, 6 * DEFAULT_CELL_WIDTH, 6 * DEFAULT_CELL_HEIGHT);
+    await nextTick();
+    const { x: offsetCorrectionX } = model.getters.getMainViewportCoordinates();
+    const x = offsetCorrectionX + DEFAULT_CELL_WIDTH;
+    triggerMouseEvent(".o-fake-grid", "mousedown", x, 0);
+    triggerMouseEvent(".o-fake-grid", "mousemove", -50, 0);
+    const advanceTimer = edgeScrollDelay(offsetCorrectionX + 50, 6);
+
+    jest.advanceTimersByTime(advanceTimer);
+    triggerMouseEvent(".o-fake-grid", "mouseup", -50, 0);
+    expect(model.getters.getActiveMainViewport()).toMatchObject({
+      left: 4,
+      right: 10,
+    });
+    expect(selectedCol).toEqual(0);
+  });
 });
 
 describe("Drag And Drop vertical tests", () => {
@@ -272,6 +298,25 @@ describe("Drag And Drop vertical tests", () => {
       top: 9,
       bottom: 48,
     });
+  });
+
+  test("Drag&Drop beyond the grid: correct row value is given to the callback", async () => {
+    freezeRows(model, 4, sheetId);
+    setViewportOffset(model, 6 * DEFAULT_CELL_WIDTH, 6 * DEFAULT_CELL_HEIGHT);
+    await nextTick();
+    const { y: offsetCorrectionY } = model.getters.getMainViewportCoordinates();
+    const y = offsetCorrectionY + DEFAULT_CELL_HEIGHT;
+    triggerMouseEvent(".o-fake-grid", "mousedown", 0, y);
+    triggerMouseEvent(".o-fake-grid", "mousemove", 0, -50);
+    const advanceTimer = edgeScrollDelay(offsetCorrectionY + 50, 6);
+
+    jest.advanceTimersByTime(advanceTimer);
+    triggerMouseEvent(".o-fake-grid", "mouseup", 0, -50);
+    expect(model.getters.getActiveMainViewport()).toMatchObject({
+      top: 4,
+      bottom: 43,
+    });
+    expect(selectedRow).toEqual(0);
   });
 });
 


### PR DESCRIPTION
## Description

When selecting a zone and edge scrolling to through a frozen pane, the selection will stop at the edge of the frozen pane if the mouse is outside the grid, instead of at the end of the col/rows.

Odoo task ID : [3159669](https://www.odoo.com/web#id=3159669&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo