### PR TITLE
[FIX] Edition: Reference loop should not alter sheetname of the refer…

### DIFF
--- a/src/helpers/reference_type.ts
+++ b/src/helpers/reference_type.ts
@@ -1,5 +1,6 @@
 // Helper file for the reference types in Xcs (the $ symbol, eg. A$1)
 import { Token } from "../formulas";
+import { getComposerSheetName } from "./misc";
 import { splitReference } from "./references";
 
 type FixedReferenceType = "col" | "row" | "colrow" | "none";
@@ -16,7 +17,7 @@ export function loopThroughReferenceType(token: Readonly<Token>): Token {
   const { xc, sheetName } = splitReference(token.value);
   const [left, right] = xc.split(":") as [string, string | undefined];
 
-  const sheetRef = sheetName ? `${sheetName}!` : "";
+  const sheetRef = sheetName ? `${getComposerSheetName(sheetName)}!` : "";
   const updatedLeft = getTokenNextReferenceType(left);
   const updatedRight = right ? `:${getTokenNextReferenceType(right)}` : "";
   return { ...token, value: sheetRef + updatedLeft + updatedRight };

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -1,4 +1,4 @@
-import { toCartesian, toZone } from "../../src/helpers";
+import { getComposerSheetName, toCartesian, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types";
 import {
@@ -790,5 +790,20 @@ describe("edition", () => {
     model.dispatch("STOP_EDITION");
 
     expect(spyNotify).toHaveBeenCalled();
+  });
+
+  test.each(["sheet2", "sheet 2"])("Loop references on references with sheet name", (sheetName) => {
+    const model = new Model({});
+    createSheet(model, { name: sheetName });
+    const composerSheetName = getComposerSheetName(sheetName);
+    model.dispatch("START_EDITION", { text: `=${composerSheetName}!A1` });
+    model.dispatch("CYCLE_EDITION_REFERENCES");
+    expect(model.getters.getCurrentContent()).toBe(`=${composerSheetName}!$A$1`);
+    model.dispatch("CYCLE_EDITION_REFERENCES");
+    expect(model.getters.getCurrentContent()).toBe(`=${composerSheetName}!A$1`);
+    model.dispatch("CYCLE_EDITION_REFERENCES");
+    expect(model.getters.getCurrentContent()).toBe(`=${composerSheetName}!$A1`);
+    model.dispatch("CYCLE_EDITION_REFERENCES");
+    expect(model.getters.getCurrentContent()).toBe(`=${composerSheetName}!A1`);
   });
 });


### PR DESCRIPTION
…ence

How to reproduce:
- create a sheet with a name requiring quotes like `I am a sheetName`
- in a composer, write a reference pointing towards that sheet: `='I am a sheetName'!A1`
- Loop the reference with key `F4`

=> the composer now contains `I am a sheetName!$A$1` and is not recognized as a valid reference anymore.

Task 3165719

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo