### PR TITLE
[REF] tests: introduce click helper

### DIFF
--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -2,7 +2,7 @@ import { App } from "@odoo/owl";
 import { args, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import { selectCell } from "../test_helpers/commands_helpers";
-import { clickCell, keyDown, keyUp, simulateClick } from "../test_helpers/dom_helper";
+import { click, clickCell, keyDown, keyUp, simulateClick } from "../test_helpers/dom_helper";
 import { getCellText } from "../test_helpers/getters_helpers";
 import {
   clearFunctions,
@@ -197,10 +197,7 @@ describe("Functions autocomplete", () => {
 
     test("click on a autocomplete does the autocomplete", async () => {
       await typeInComposerGrid("=S");
-      fixture
-        .querySelector(".o-autocomplete-dropdown")!
-        .children[1].dispatchEvent(new MouseEvent("click"));
-      await nextTick();
+      await click(fixture, ".o-autocomplete-dropdown > div:nth-child(2)");
       expect(composerEl.textContent).toBe("=SZZ(");
       expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
       expect(cehMock.selectionState.position).toBe(5);
@@ -229,10 +226,7 @@ describe("Functions autocomplete", () => {
 
     test("click on a autocomplete with multi-line topbar composer does the autocomplete", async () => {
       await typeInComposerTopBar("=\nS");
-      fixture
-        .querySelector(".o-autocomplete-dropdown")!
-        .children[1].dispatchEvent(new MouseEvent("click"));
-      await nextTick();
+      await click(fixture, ".o-autocomplete-dropdown > div:nth-child(2)");
       expect(composerEl.textContent).toBe("=\nSZZ(");
       expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
       expect(cehMock.selectionState.position).toBe(6);
@@ -258,8 +252,7 @@ describe("Functions autocomplete", () => {
       await nextTick();
       expect(document.activeElement).toEqual(activeElement);
 
-      dropDownEl.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      await nextTick();
+      await click(dropDownEl);
       expect(document.activeElement).toEqual(activeElement);
     });
   });

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -10,7 +10,7 @@ import {
   selectCell,
   setCellContent,
 } from "../test_helpers/commands_helpers";
-import { keyDown, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
+import { click, keyDown, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { makeTestEnv, makeTestFixture, mockUuidV4To, nextTick } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
@@ -66,7 +66,7 @@ describe("BottomBar component", () => {
     const dispatch = jest.spyOn(model, "dispatch");
     mockUuidV4To(model, 42);
     const activeSheetId = model.getters.getActiveSheetId();
-    triggerMouseEvent(".o-add-sheet", "click");
+    await click(fixture, ".o-add-sheet");
     expect(dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
       name: "Sheet2",
       sheetId: "42",
@@ -84,7 +84,7 @@ describe("BottomBar component", () => {
     const { app } = await mountBottomBar(model);
     const dispatch = jest.spyOn(model, "dispatch");
     expect(model.getters.getSheetIds().map(model.getters.getSheetName)).toEqual(["Sheet2"]);
-    triggerMouseEvent(".o-add-sheet", "click");
+    await click(fixture, ".o-add-sheet");
     expect(dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
       sheetId: expect.any(String),
       name: "Sheet1",
@@ -96,7 +96,7 @@ describe("BottomBar component", () => {
   test("Can activate a sheet", async () => {
     const { app, parent } = await mountBottomBar();
     const dispatch = jest.spyOn(parent.props.model, "dispatch");
-    triggerMouseEvent(".o-sheet", "click");
+    await click(fixture, ".o-sheet");
     const sheetIdFrom = parent.props.model.getters.getActiveSheetId();
     const sheetIdTo = sheetIdFrom;
     expect(dispatch).toHaveBeenCalledWith("ACTIVATE_SHEET", {
@@ -120,8 +120,7 @@ describe("BottomBar component", () => {
     const { app } = await mountBottomBar();
 
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    triggerMouseEvent(".o-sheet-icon", "click");
-    await nextTick();
+    await click(fixture, ".o-sheet-icon");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     app.destroy();
   });
@@ -130,11 +129,9 @@ describe("BottomBar component", () => {
     const { app } = await mountBottomBar();
 
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    triggerMouseEvent(".o-sheet-icon", "click");
-    await nextTick();
+    await click(fixture, ".o-sheet-icon");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
-    triggerMouseEvent(".o-sheet-icon", "click");
-    await nextTick();
+    await click(fixture, ".o-sheet-icon");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     app.destroy();
   });
@@ -144,13 +141,11 @@ describe("BottomBar component", () => {
 
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
 
-    triggerMouseEvent(".o-sheet-item.o-list-sheets", "click");
-    await nextTick();
+    await click(fixture, ".o-sheet-item.o-list-sheets");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Sheet1");
 
-    triggerMouseEvent(".o-sheet-icon", "click");
-    await nextTick();
+    await click(fixture, ".o-sheet-icon");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Duplicate");
     app.destroy();
@@ -164,7 +159,7 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheetId = model.getters.getActiveSheetId();
-    triggerMouseEvent(".o-menu-item[data-name='move_right'", "click");
+    await click(fixture, ".o-menu-item[data-name='move_right'");
     expect(dispatch).toHaveBeenCalledWith("MOVE_SHEET", {
       sheetId,
       direction: "right",
@@ -181,7 +176,7 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-sheet[data-id='42']", "contextmenu");
     await nextTick();
     const sheetId = model.getters.getActiveSheetId();
-    triggerMouseEvent(".o-menu-item[data-name='move_left'", "click");
+    await click(fixture, ".o-menu-item[data-name='move_left'");
     expect(dispatch).toHaveBeenCalledWith("MOVE_SHEET", {
       sheetId,
       direction: "left",
@@ -198,7 +193,7 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheetId = model.getters.getActiveSheetId();
-    triggerMouseEvent(".o-menu-item[data-name='hide_sheet']", "click");
+    await click(fixture, ".o-menu-item[data-name='hide_sheet']");
     expect(dispatch).toHaveBeenCalledWith("HIDE_SHEET", {
       sheetId,
     });
@@ -255,8 +250,7 @@ describe("BottomBar component", () => {
     test("Rename sheet with context menu makes sheet name editable and give it the focus", async () => {
       triggerMouseEvent(".o-sheet", "contextmenu");
       await nextTick();
-      triggerMouseEvent(".o-menu-item[data-name='rename'", "click");
-      await nextTick();
+      await click(fixture, ".o-menu-item[data-name='rename'");
       const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
       expect(sheetName.getAttribute("contenteditable")).toEqual("true");
       expect(document.activeElement).toEqual(sheetName);
@@ -328,7 +322,7 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheet = model.getters.getActiveSheetId();
-    triggerMouseEvent(".o-menu-item[data-name='duplicate'", "click");
+    await click(fixture, ".o-menu-item[data-name='duplicate'");
     expect(dispatch).toHaveBeenCalledWith("DUPLICATE_SHEET", {
       sheetId: sheet,
       sheetIdTo: "123",
@@ -346,7 +340,7 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheetId = model.getters.getActiveSheetId();
-    triggerMouseEvent(".o-menu-item[data-name='delete'", "click");
+    await click(fixture, ".o-menu-item[data-name='delete'");
     expect(dispatch).toHaveBeenCalledWith("DELETE_SHEET", { sheetId });
     app.destroy();
   });
@@ -364,8 +358,7 @@ describe("BottomBar component", () => {
     const { app } = await mountBottomBar();
 
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    triggerMouseEvent(".o-list-sheets", "click");
-    await nextTick();
+    await click(fixture, ".o-list-sheets");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     app.destroy();
   });
@@ -375,8 +368,7 @@ describe("BottomBar component", () => {
     const sheet = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42" });
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    triggerMouseEvent(".o-list-sheets", "click");
-    await nextTick();
+    await click(fixture, ".o-list-sheets");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     const sheets = fixture.querySelectorAll(".o-menu-item");
     expect(sheets.length).toBe(2);
@@ -391,9 +383,8 @@ describe("BottomBar component", () => {
     const sheet = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42" });
 
-    triggerMouseEvent(".o-list-sheets", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item[data-name='42'", "click");
+    await click(fixture, ".o-list-sheets");
+    await click(fixture, ".o-menu-item[data-name='42'");
     expect(dispatch).toHaveBeenCalledWith("ACTIVATE_SHEET", {
       sheetIdFrom: sheet,
       sheetIdTo: "42",
@@ -585,8 +576,7 @@ describe("BottomBar component", () => {
     selectCell(model, "A2");
     await nextTick();
 
-    triggerMouseEvent(".o-selection-statistic", "click");
-    await nextTick();
+    await click(fixture, ".o-selection-statistic");
     expect(fixture.querySelector(".o-menu")).toMatchSnapshot();
     app.destroy();
   });
@@ -599,10 +589,8 @@ describe("BottomBar component", () => {
 
     expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Sum: 24");
 
-    triggerMouseEvent(".o-selection-statistic", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item[data-name='Count Numbers'", "click");
-    await nextTick();
+    await click(fixture, ".o-selection-statistic");
+    await click(fixture, ".o-menu-item[data-name='Count Numbers'");
     expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Count Numbers: 1");
     app.destroy();
   });

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../test_helpers/commands_helpers";
 import { TEST_CHART_DATA } from "../test_helpers/constants";
 import {
+  click,
   setInputValueAndTrigger,
   simulateClick,
   triggerMouseEvent,
@@ -210,8 +211,7 @@ describe("figures", () => {
       const dispatch = spyDispatch(parent);
       switch (chartType) {
         case "basicChart":
-          const hasTitle = dataSeries.querySelector("input[type=checkbox]") as HTMLInputElement;
-          triggerMouseEvent(hasTitle, "click");
+          await click(dataSeries!.querySelector("input[type=checkbox]")!);
           expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
             id: chartId,
             sheetId,
@@ -363,8 +363,7 @@ describe("figures", () => {
     setInputValueAndTrigger(chartType, "pie", "change");
     await nextTick();
     setInputValueAndTrigger(dataSeriesValues, "B2:B5", "change");
-    triggerMouseEvent(hasTitle, "click");
-    await nextTick();
+    await click(hasTitle);
     // dataSetsHaveTitle is not propagated
     expect((mockChartData.data! as any).datasets[0].data).toEqual([
       "first column dataset",
@@ -425,7 +424,7 @@ describe("figures", () => {
           expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeTruthy();
 
           if (selectMethod === "click") {
-            await simulateClick(figures[1] as HTMLElement);
+            await simulateClick(figures[1]);
           } else {
             model.dispatch("SELECT_FIGURE", { id: "secondChartId" });
           }

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -20,7 +20,7 @@ import {
   selectCell,
   setCellContent,
 } from "../test_helpers/commands_helpers";
-import { keyDown, keyUp, simulateClick } from "../test_helpers/dom_helper";
+import { click, keyDown, keyUp, simulateClick } from "../test_helpers/dom_helper";
 import {
   getCellContent,
   getCellText,
@@ -495,8 +495,7 @@ describe("composer", () => {
 
   test("clicking on the composer while typing text (not formula) does not duplicates text", async () => {
     composerEl = await typeInComposer("a");
-    composerEl.dispatchEvent(new MouseEvent("click"));
-    await nextTick();
+    await click(composerEl);
     expect(composerEl.textContent).toBe("a");
   });
 
@@ -814,8 +813,7 @@ describe("composer", () => {
   test("clicking on the composer while in selecting mode should put the composer in edition mode", async () => {
     composerEl = await typeInComposer("=");
     expect(model.getters.getEditionMode()).toBe("selecting");
-    composerEl.dispatchEvent(new MouseEvent("click"));
-    await nextTick();
+    await click(composerEl);
     expect(model.getters.getEditionMode()).toBe("editing");
   });
 

--- a/tests/components/composer_integration.test.ts
+++ b/tests/components/composer_integration.test.ts
@@ -18,6 +18,7 @@ import {
   setCellContent,
 } from "../test_helpers/commands_helpers";
 import {
+  click,
   clickCell,
   getElComputedStyle,
   gridMouseEvent,
@@ -25,7 +26,6 @@ import {
   rightClickCell,
   selectColumnByClicking,
   simulateClick,
-  triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import {
   getActivePosition,
@@ -92,8 +92,7 @@ describe("Composer interactions", () => {
   });
 
   test("type in topbar composer adds text to grid composer", async () => {
-    triggerMouseEvent(".o-spreadsheet-topbar .o-composer", "click");
-    await nextTick();
+    await click(fixture, ".o-spreadsheet-topbar .o-composer");
     const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer");
     const gridComposer = document.querySelector(".o-grid .o-composer");
     expect(topBarComposer).not.toBeNull();
@@ -105,8 +104,7 @@ describe("Composer interactions", () => {
   });
 
   test("start typing in topbar composer then continue in grid composer", async () => {
-    triggerMouseEvent(".o-spreadsheet-topbar .o-composer", "click");
-    await nextTick();
+    await click(fixture, ".o-spreadsheet-topbar .o-composer");
     const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer");
     const gridComposer = document.querySelector(".o-grid .o-composer");
 
@@ -116,8 +114,7 @@ describe("Composer interactions", () => {
     expect(gridComposer!.textContent).toBe("from topbar");
 
     // Focus grid composer and type
-    triggerMouseEvent(".o-grid .o-composer", "click");
-    await nextTick();
+    await click(fixture, ".o-grid .o-composer");
     await typeInComposerGrid("from grid");
     expect(topBarComposer!.textContent).toBe("from topbarfrom grid");
     expect(gridComposer!.textContent).toBe("from topbarfrom grid");
@@ -138,7 +135,7 @@ describe("Composer interactions", () => {
     const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer")!;
     expect(topBarComposer.textContent).toBe("10/10/2021");
     // Focus top bar composer
-    triggerMouseEvent(topBarComposer, "click");
+    await click(topBarComposer);
     expect(topBarComposer!.textContent).toBe("10/10/2021");
   });
 
@@ -147,8 +144,7 @@ describe("Composer interactions", () => {
     const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer")!;
     await typeInComposerGrid("=SU");
     expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).not.toBeNull();
-    triggerMouseEvent(topBarComposer, "click");
-    await nextTick();
+    await click(topBarComposer);
     expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).toBeNull();
   });
 
@@ -159,15 +155,13 @@ describe("Composer interactions", () => {
     const spy = jest.spyOn(gridComposerContainer.style, "width", "set");
     await typeInComposerGrid("=SU");
     await nextTick();
-    topBarComposer.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(topBarComposer);
     expect(document.activeElement).toBe(topBarComposer);
     expect(spy).not.toHaveBeenCalled();
   });
 
   test("selecting ranges multiple times in topbar bar does not resize grid composer", async () => {
-    triggerMouseEvent(".o-spreadsheet-topbar .o-composer", "click");
-    await nextTick();
+    await click(fixture, ".o-spreadsheet-topbar .o-composer");
     const gridComposerContainer = document.querySelector(".o-grid-composer")! as HTMLElement;
     // Type in top bar composer
     await typeInComposerTopBar("=");

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -10,7 +10,7 @@ import {
   paste,
   setSelection,
 } from "../test_helpers/commands_helpers";
-import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_helper";
+import { click, setInputValueAndTrigger } from "../test_helpers/dom_helper";
 import {
   createColorScale,
   createEqualCF,
@@ -155,8 +155,7 @@ describe("UI of conditional formats", () => {
       // TODO VSC: see how we can test the gradient background image
     });
     test("can edit an existing CellIsRule", async () => {
-      triggerMouseEvent(document.querySelectorAll(selectors.listPreview)[0], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.listPreview)[0]);
       await nextTick();
 
       // change every value
@@ -165,15 +164,14 @@ describe("UI of conditional formats", () => {
       setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
       setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3", "input");
 
-      triggerMouseEvent(selectors.ruleEditor.editor.bold, "click");
-      triggerMouseEvent(selectors.ruleEditor.editor.italic, "click");
-      triggerMouseEvent(selectors.ruleEditor.editor.underline, "click");
-      triggerMouseEvent(selectors.ruleEditor.editor.strikethrough, "click");
+      await click(fixture, selectors.ruleEditor.editor.bold);
+      await click(fixture, selectors.ruleEditor.editor.italic);
+      await click(fixture, selectors.ruleEditor.editor.underline);
+      await click(fixture, selectors.ruleEditor.editor.strikethrough);
 
       const dispatch = spyDispatch(parent);
       //  click save
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
 
       const sheetId = model.getters.getActiveSheetId();
       expect(dispatch).toHaveBeenNthCalledWith(1, "ADD_CONDITIONAL_FORMAT", {
@@ -216,8 +214,7 @@ describe("UI of conditional formats", () => {
       });
       // let the sidePanel reload the CF values
       await nextTick();
-      triggerMouseEvent(document.querySelectorAll(selectors.listPreview)[0], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.listPreview)[0]);
       await nextTick();
 
       const previewLine = document.querySelector(".o-cf-preview-line")! as HTMLDivElement;
@@ -246,23 +243,19 @@ describe("UI of conditional formats", () => {
     });
 
     test("can edit an existing ColorScaleRule", async () => {
-      triggerMouseEvent(document.querySelectorAll(selectors.listPreview)[1], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.listPreview)[1]);
       await nextTick();
       // change every value
       setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
 
-      triggerMouseEvent(selectors.colorScaleEditor.minColor, "click");
-      await nextTick();
-      triggerMouseEvent(selectors.colorScaleEditor.colorPickerBlue, "click");
-      triggerMouseEvent(selectors.colorScaleEditor.maxColor, "click");
-      await nextTick();
-      triggerMouseEvent(selectors.colorScaleEditor.colorPickerYellow, "click");
+      await click(fixture, selectors.colorScaleEditor.minColor);
+      await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
+      await click(fixture, selectors.colorScaleEditor.maxColor);
+      await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
 
       const dispatch = spyDispatch(parent);
       //  click save
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
 
       const sheetId = model.getters.getActiveSheetId();
       expect(dispatch).toHaveBeenNthCalledWith(1, "ADD_CONDITIONAL_FORMAT", {
@@ -288,37 +281,24 @@ describe("UI of conditional formats", () => {
     });
 
     test("toggle color-picker", async () => {
-      triggerMouseEvent(document.querySelectorAll(selectors.listPreview)[0], "click");
-      await nextTick();
-      triggerMouseEvent(
-        document.querySelectorAll(selectors.ruleEditor.editor.colorDropdown)[0],
-        "click"
-      );
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.listPreview)[0]);
+      await click(fixture.querySelectorAll(selectors.ruleEditor.editor.colorDropdown)[0]);
       expect(fixture.querySelector(".o-color-picker")).toBeTruthy();
-      triggerMouseEvent(
-        document.querySelectorAll(selectors.ruleEditor.editor.colorDropdown)[0],
-        "click"
-      );
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.ruleEditor.editor.colorDropdown)[0]);
       expect(fixture.querySelector(".o-color-picker")).toBeFalsy();
     });
 
     test("color-picker closes when click elsewhere", async () => {
-      triggerMouseEvent(document.querySelectorAll(selectors.listPreview)[0], "click");
-      await nextTick();
-      triggerMouseEvent(selectors.ruleEditor.editor.colorDropdown, "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.listPreview)[0]);
+      await click(fixture.querySelectorAll(selectors.ruleEditor.editor.colorDropdown)[0]);
       expect(fixture.querySelector(".o-color-picker")).toBeTruthy();
-      triggerMouseEvent(".o-cf-preview-line", "click");
-      await nextTick();
+      await click(fixture, ".o-cf-preview-line");
       expect(fixture.querySelector(".o-color-picker")).toBeFalsy();
     });
 
     test("can create a new CellIsRule", async () => {
       mockUuidV4To(model, "42");
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
       await nextTick();
 
       // change every value
@@ -327,15 +307,14 @@ describe("UI of conditional formats", () => {
       await nextTick();
       setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3", "input");
 
-      triggerMouseEvent(selectors.ruleEditor.editor.bold, "click");
-      triggerMouseEvent(selectors.ruleEditor.editor.italic, "click");
-      triggerMouseEvent(selectors.ruleEditor.editor.underline, "click");
-      triggerMouseEvent(selectors.ruleEditor.editor.strikethrough, "click");
+      await click(fixture, selectors.ruleEditor.editor.bold);
+      await click(fixture, selectors.ruleEditor.editor.italic);
+      await click(fixture, selectors.ruleEditor.editor.underline);
+      await click(fixture, selectors.ruleEditor.editor.strikethrough);
 
       const dispatch = spyDispatch(parent);
       //  click save
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
       const sheetId = model.getters.getActiveSheetId();
       expect(dispatch).toHaveBeenNthCalledWith(1, "ADD_CONDITIONAL_FORMAT", {
         cf: {
@@ -359,16 +338,14 @@ describe("UI of conditional formats", () => {
     });
 
     test("cannot create a new CF with invalid range", async () => {
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
       await nextTick();
 
       setInputValueAndTrigger(selectors.ruleEditor.range, "hello", "change");
 
       const dispatch = spyDispatch(parent);
       //  click save
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
       expect(dispatch).not.toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT");
       const errorString = document.querySelector(selectors.error);
       expect(errorString!.textContent).toBe("The range is invalid");
@@ -387,8 +364,7 @@ describe("UI of conditional formats", () => {
     test("can delete Rule", async () => {
       const dispatch = spyDispatch(parent);
       const previews = document.querySelectorAll(selectors.listPreview);
-      triggerMouseEvent(previews[0].querySelector(selectors.buttonDelete), "click");
-      await nextTick();
+      await click(previews[0], selectors.buttonDelete);
       expect(dispatch).toHaveBeenCalledWith("REMOVE_CONDITIONAL_FORMAT", {
         id: "1",
         sheetId: model.getters.getActiveSheetId(),
@@ -402,8 +378,7 @@ describe("UI of conditional formats", () => {
       expect(document.querySelector(selectors.cfReorder.buttonUp)).toBeFalsy();
       expect(document.querySelector(selectors.cfReorder.buttonDown)).toBeFalsy();
 
-      triggerMouseEvent(selectors.buttonReoder, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonReoder);
 
       expect(document.querySelector(selectors.buttonExitReorder)).toBeTruthy();
       // Minus one because top rule has no up button, bottom rule no down button
@@ -414,8 +389,7 @@ describe("UI of conditional formats", () => {
         previews.length - 1
       );
 
-      triggerMouseEvent(selectors.buttonExitReorder, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonExitReorder);
 
       expect(document.querySelector(selectors.buttonExitReorder)).toBeFalsy();
       expect(document.querySelector(selectors.cfReorder.buttonUp)).toBeFalsy();
@@ -425,41 +399,33 @@ describe("UI of conditional formats", () => {
     test("can reorder CF rules with up/down buttons", async () => {
       const sheetId = model.getters.getActiveSheetId();
 
-      triggerMouseEvent(selectors.buttonReoder, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonReoder);
 
       let previews = document.querySelectorAll(selectors.listPreview);
-      triggerMouseEvent(previews[0].querySelector(selectors.cfReorder.buttonDown), "click");
-      await nextTick();
+      await click(previews[0], selectors.cfReorder.buttonDown);
       expect(model.getters.getConditionalFormats(sheetId)[0].id).toEqual("2");
 
       previews = document.querySelectorAll(selectors.listPreview);
-      triggerMouseEvent(previews[1].querySelector(selectors.cfReorder.buttonUp), "click");
-      await nextTick();
+      await click(previews[1], selectors.cfReorder.buttonUp);
       expect(model.getters.getConditionalFormats(sheetId)[0].id).toEqual("1");
     });
   });
 
   test("can create a new ColorScaleRule with cell values", async () => {
     mockUuidV4To(model, "43");
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
-    triggerMouseEvent(selectors.colorScaleEditor.minColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerBlue, "click");
-    triggerMouseEvent(selectors.colorScaleEditor.maxColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerYellow, "click");
+    await click(fixture, selectors.colorScaleEditor.minColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
+    await click(fixture, selectors.colorScaleEditor.maxColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
 
     const dispatch = spyDispatch(parent);
     //  click save
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
 
     expect(dispatch).toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT", {
       cf: {
@@ -483,32 +449,27 @@ describe("UI of conditional formats", () => {
 
   test("can create a new ColorScaleRule with fixed values", async () => {
     mockUuidV4To(model, "44");
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
 
-    triggerMouseEvent(selectors.colorScaleEditor.minColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerBlue, "click");
+    await click(fixture, selectors.colorScaleEditor.minColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
     setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
     await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10", "input");
-    triggerMouseEvent(selectors.colorScaleEditor.maxColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerYellow, "click");
+    await click(fixture, selectors.colorScaleEditor.maxColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
     setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
     await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "20", "input");
 
     const dispatch = spyDispatch(parent);
     //  click save
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
 
     const sheetId = model.getters.getActiveSheetId();
     expect(dispatch).toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT", {
@@ -535,32 +496,27 @@ describe("UI of conditional formats", () => {
 
   test("can create a new ColorScaleRule with percent values", async () => {
     mockUuidV4To(model, "44");
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
 
-    triggerMouseEvent(selectors.colorScaleEditor.minColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerBlue, "click");
+    await click(fixture, selectors.colorScaleEditor.minColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
     setInputValueAndTrigger(selectors.colorScaleEditor.minType, "percentage", "change");
     await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10", "input");
-    triggerMouseEvent(selectors.colorScaleEditor.maxColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerYellow, "click");
+    await click(fixture, selectors.colorScaleEditor.maxColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
     setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "percentage", "change");
     await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "90", "input");
 
     const dispatch = spyDispatch(parent);
     //  click save
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
 
     const sheetId = model.getters.getActiveSheetId();
     expect(dispatch).toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT", {
@@ -587,32 +543,27 @@ describe("UI of conditional formats", () => {
 
   test("can create a new ColorScaleRule with percentile values", async () => {
     mockUuidV4To(model, "44");
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
 
-    triggerMouseEvent(selectors.colorScaleEditor.minColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerBlue, "click");
+    await click(fixture, selectors.colorScaleEditor.minColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
     setInputValueAndTrigger(selectors.colorScaleEditor.minType, "percentile", "change");
     await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10", "input");
-    triggerMouseEvent(selectors.colorScaleEditor.maxColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerYellow, "click");
+    await click(fixture, selectors.colorScaleEditor.maxColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
     setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "percentile", "change");
     await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "90", "input");
 
     const dispatch = spyDispatch(parent);
     //  click save
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
 
     const sheetId = model.getters.getActiveSheetId();
     expect(dispatch).toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT", {
@@ -639,40 +590,34 @@ describe("UI of conditional formats", () => {
 
   test("can create a new ColorScaleRule with a midpoint", async () => {
     mockUuidV4To(model, "44");
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
 
-    triggerMouseEvent(selectors.colorScaleEditor.minColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerBlue, "click");
+    await click(fixture, selectors.colorScaleEditor.minColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
     setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
     await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "0", "input");
 
     setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number", "change");
     await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.midColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerOrange, "click");
+    await click(fixture, selectors.colorScaleEditor.midColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerOrange);
     setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "50", "input");
 
-    triggerMouseEvent(selectors.colorScaleEditor.maxColor, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.colorScaleEditor.colorPickerYellow, "click");
+    await click(fixture, selectors.colorScaleEditor.maxColor);
+    await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
     setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
     await nextTick();
     setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "100", "input");
 
     const dispatch = spyDispatch(parent);
     //  click save
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
 
     const sheetId = model.getters.getActiveSheetId();
     expect(dispatch).toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT", {
@@ -703,13 +648,11 @@ describe("UI of conditional formats", () => {
   });
 
   test("Make a multiple selection, open CF panel, create a rule => Should create one line per selection", async () => {
-    triggerMouseEvent(selectors.closePanel, "click");
-    await nextTick();
+    await click(fixture, selectors.closePanel);
     setSelection(model, ["B2", "C3"]);
     parent.env.openSidePanel("ConditionalFormatting");
     await nextTick();
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
     await nextTick();
     const ranges = document.querySelectorAll(selectors.ruleEditor.range);
     expect(ranges).toHaveLength(2);
@@ -719,8 +662,7 @@ describe("UI of conditional formats", () => {
 
   test("Open CF panel, make a multiple selection, open CF panel, create a rule => Should create one line per selection", async () => {
     setSelection(model, ["B2", "C3"]);
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
     const ranges = document.querySelectorAll(selectors.ruleEditor.range);
     expect(ranges).toHaveLength(2);
     expect(ranges[0]["value"]).toBe("B2");
@@ -729,7 +671,7 @@ describe("UI of conditional formats", () => {
 
   test("switching sheet resets CF Editor to list", async () => {
     const sheetId = model.getters.getActiveSheetId();
-    triggerMouseEvent(selectors.closePanel, "click");
+    await click(fixture, selectors.closePanel);
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("2", { bold: true, fillColor: "#ff0000" }, "99"),
       ranges: toRangesData(sheetId, "A1:A2"),
@@ -748,23 +690,19 @@ describe("UI of conditional formats", () => {
     expect(fixture.querySelector(selectors.listPreview)).toBeDefined();
   });
   test("error if range is empty", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
     await nextTick();
     setInputValueAndTrigger(selectors.ruleEditor.range, "", "change");
     await nextTick();
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect(errorMessages()).toEqual(["A range needs to be defined"]);
     expect(fixture.querySelector(selectors.ruleEditor.range)?.className).toContain("o-invalid");
   });
 
   test("will not dispatch if minvalue > maxvalue", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
@@ -778,8 +716,7 @@ describe("UI of conditional formats", () => {
 
     expect(errorMessages()).toHaveLength(0);
 
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
 
     expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toHaveLength(0);
     expect(errorMessages()).toEqual(["Minimum must be smaller then Maximum"]);
@@ -795,11 +732,9 @@ describe("UI of conditional formats", () => {
   });
 
   test("will show error if minvalue > midvalue", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
@@ -819,8 +754,7 @@ describe("UI of conditional formats", () => {
     expect(errorMessages()).toHaveLength(0);
 
     //  click save
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
 
     expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toHaveLength(0);
     expect(errorMessages()).toEqual([
@@ -840,11 +774,9 @@ describe("UI of conditional formats", () => {
   });
 
   test("will show error if midvalue > maxvalue", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
@@ -861,8 +793,7 @@ describe("UI of conditional formats", () => {
     expect(errorMessages()).toHaveLength(0);
 
     //  click save
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
 
     expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toHaveLength(0);
     expect(errorMessages()).toEqual(["Midpoint must be smaller then Maximum"]);
@@ -880,11 +811,9 @@ describe("UI of conditional formats", () => {
   test.each(["", "aaaa", "=SUM(1, 2)"])(
     "will display error if wrong minValue",
     async (invalidValue) => {
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
 
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
       // change every value
       setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
@@ -899,8 +828,7 @@ describe("UI of conditional formats", () => {
 
       expect(errorMessages()).toHaveLength(0);
 
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
       expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toHaveLength(0);
       expect(errorMessages()).toEqual(["The minpoint must be a number"]);
       expect(fixture.querySelector(selectors.colorScaleEditor.minValue)?.className).toContain(
@@ -918,11 +846,9 @@ describe("UI of conditional formats", () => {
   test.each(["", "aaaa", "=SUM(1, 2)"])(
     "will display error if wrong midValue",
     async (invalidValue) => {
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
 
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
       // change every value
       setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
@@ -938,8 +864,7 @@ describe("UI of conditional formats", () => {
 
       expect(errorMessages()).toHaveLength(0);
 
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
       expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toHaveLength(0);
       expect(errorMessages()).toEqual(["The midpoint must be a number"]);
       expect(fixture.querySelector(selectors.colorScaleEditor.minValue)?.className).not.toContain(
@@ -957,11 +882,9 @@ describe("UI of conditional formats", () => {
   test.each(["", "aaaa", "=SUM(1, 2)"])(
     "will display error if wrong maxValue",
     async (invalidValue) => {
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
 
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
       // change every value
       setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
@@ -976,8 +899,7 @@ describe("UI of conditional formats", () => {
 
       expect(errorMessages()).toHaveLength(0);
 
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
       expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toHaveLength(0);
       expect(errorMessages()).toEqual(["The maxpoint must be a number"]);
       expect(fixture.querySelector(selectors.colorScaleEditor.minValue)?.className).not.toContain(
@@ -993,11 +915,9 @@ describe("UI of conditional formats", () => {
   );
 
   test("will display error if there is an invalid formula for the min", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
@@ -1012,8 +932,7 @@ describe("UI of conditional formats", () => {
 
     expect(errorMessages()).toHaveLength(0);
 
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toHaveLength(0);
     expect(errorMessages()).toEqual(["Invalid Minpoint formula"]);
     expect(fixture.querySelector(selectors.colorScaleEditor.minValue)?.className).toContain(
@@ -1028,11 +947,9 @@ describe("UI of conditional formats", () => {
   });
 
   test("will display error if there is an invalid formula for the mid", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
@@ -1048,8 +965,7 @@ describe("UI of conditional formats", () => {
 
     expect(errorMessages()).toHaveLength(0);
 
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toHaveLength(0);
     expect(errorMessages()).toEqual(["Invalid Midpoint formula"]);
     expect(fixture.querySelector(selectors.colorScaleEditor.minValue)?.className).not.toContain(
@@ -1064,54 +980,44 @@ describe("UI of conditional formats", () => {
   });
 
   test("single color missing a single value", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
     setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "GreaterThan", "change");
     expect(fixture.querySelector(".o-invalid")).toBeNull();
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect(fixture.querySelector(".o-invalid")).not.toBeNull();
     expect(errorMessages()).toEqual(["The argument is missing. Please provide a value"]);
   });
 
   test("single color missing two values", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
     setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "Between", "change");
     expect(fixture.querySelector(".o-invalid")).toBeNull();
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect([...fixture.querySelectorAll(".o-invalid")]).toHaveLength(2);
     expect(errorMessages()).toEqual([
       "The argument is missing. Please provide a value",
       "The second argument is missing. Please provide a value",
     ]);
     setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "25", "input");
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect([...fixture.querySelectorAll(".o-invalid")]).toHaveLength(1);
     expect(errorMessages()).toEqual(["The second argument is missing. Please provide a value"]);
   });
 
   test("changing rule type resets errors", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
     setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "GreaterThan", "change");
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect(errorMessages()).not.toHaveLength(0);
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
     expect(errorMessages()).toHaveLength(0);
     expect([...fixture.querySelectorAll(".o-invalid")]).toHaveLength(0);
   });
 
   test("will display error if there is an invalid formula for the max", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
     setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
@@ -1126,50 +1032,37 @@ describe("UI of conditional formats", () => {
 
     expect(errorMessages()).toHaveLength(0);
 
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect(model.getters.getConditionalFormats(model.getters.getActiveSheetId())).toHaveLength(0);
     expect(errorMessages()).toEqual(["Invalid Maxpoint formula"]);
   });
 
   describe("Icon set CF", () => {
     test("can select the Icon set tab", async () => {
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
 
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
       expect(
         document.querySelector(selectors.ruleEditor.editor.iconSetRule.container)
       ).toBeDefined();
     });
 
     test("can apply different iconSet", async () => {
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
 
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
       let icons = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.icons);
       expect(icons[0].classList.value).toBe("o-cf-icon arrow-up");
       expect(icons[1].classList.value).toBe("o-cf-icon arrow-right");
       expect(icons[2].classList.value).toBe("o-cf-icon arrow-down");
 
-      triggerMouseEvent(
-        document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.iconsets)[1],
-        "click"
-      );
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.iconsets)[1]);
       icons = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.icons);
       expect(icons[0].classList.value).toBe("o-cf-icon smile");
       expect(icons[1].classList.value).toBe("o-cf-icon meh");
       expect(icons[2].classList.value).toBe("o-cf-icon frown");
 
-      triggerMouseEvent(
-        document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.iconsets)[2],
-        "click"
-      );
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.iconsets)[2]);
       icons = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.icons);
       expect(icons[0].classList.value).toBe("o-cf-icon green-dot");
       expect(icons[1].classList.value).toBe("o-cf-icon yellow-dot");
@@ -1177,19 +1070,16 @@ describe("UI of conditional formats", () => {
     });
 
     test("inverse checkbox will inverse icons", async () => {
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
 
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
 
       let icons = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.icons);
       expect(icons[0].classList.value).toBe("o-cf-icon arrow-up");
       expect(icons[1].classList.value).toBe("o-cf-icon arrow-right");
       expect(icons[2].classList.value).toBe("o-cf-icon arrow-down");
 
-      triggerMouseEvent(selectors.ruleEditor.editor.iconSetRule.reverse, "click");
-      await nextTick();
+      await click(fixture, selectors.ruleEditor.editor.iconSetRule.reverse);
       icons = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.icons);
       expect(icons[2].classList.value).toBe("o-cf-icon arrow-up");
       expect(icons[1].classList.value).toBe("o-cf-icon arrow-right");
@@ -1198,19 +1088,16 @@ describe("UI of conditional formats", () => {
 
     test("can create a new IconsetRule", async () => {
       mockUuidV4To(model, "44");
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
 
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
 
       // change every value
       setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
 
       const dispatch = spyDispatch(parent);
       //  click save
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
 
       const sheetId = model.getters.getActiveSheetId();
       expect(dispatch).toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT", {
@@ -1242,11 +1129,9 @@ describe("UI of conditional formats", () => {
 
     test("can change inputs", async () => {
       mockUuidV4To(model, "44");
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
 
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
       const rows = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.rows);
       const typeinflectionLower = rows[1].querySelectorAll("select")[1];
       const operatorinflectionLower = rows[1].querySelectorAll("select")[0];
@@ -1271,8 +1156,7 @@ describe("UI of conditional formats", () => {
 
       const dispatch = spyDispatch(parent);
       //  click save
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
 
       const sheetId = model.getters.getActiveSheetId();
       expect(dispatch).toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT", {
@@ -1309,25 +1193,20 @@ describe("UI of conditional formats", () => {
     [2, { lower: "dotNeutral", middle: "arrowNeutral", upper: "arrowGood" }],
   ])("can change each icon individually", async (iconIndex, expectedIcons) => {
     mockUuidV4To(model, "44");
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
 
     const row = document.querySelectorAll(".o-inflection tr")[1 + iconIndex]; // +1 for the <table> headers
     const iconElement = row.querySelectorAll("div")[0];
-    triggerMouseEvent(iconElement, "click");
-    await nextTick();
+    await click(iconElement);
 
     const newIcon = document.querySelectorAll(".o-icon-picker-item")[7];
-    triggerMouseEvent(newIcon, "click");
-    await nextTick();
+    await click(newIcon);
 
     const dispatch = spyDispatch(parent);
     //  click save
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
 
     const sheetId = model.getters.getActiveSheetId();
     expect(dispatch).toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT", {
@@ -1360,16 +1239,13 @@ describe("UI of conditional formats", () => {
   ])(
     "Show right lowerInflection point error message (Command result: %s , Message: %s)",
     async (error: CommandResult, errorMessage: string) => {
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
 
       const cfPlugin = getPlugin(parent.props.model, ConditionalFormatPlugin);
       cfPlugin.allowDispatch = jest.fn(() => error);
 
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
       const rows = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.rows);
       const inputInflectionLower = rows[1].querySelectorAll("input")[0];
       const inputInflectionUpper = rows[2].querySelectorAll("input")[0];
@@ -1384,17 +1260,14 @@ describe("UI of conditional formats", () => {
   ])(
     "Show right upperInflection point error message (Command result: %s , Message: %s)",
     async (error: CommandResult, errorMessage: string) => {
-      triggerMouseEvent(selectors.buttonAdd, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonAdd);
 
-      triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-      await nextTick();
+      await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
 
       const cfPlugin = getPlugin(parent.props.model, ConditionalFormatPlugin);
       cfPlugin.allowDispatch = jest.fn(() => error);
 
-      triggerMouseEvent(selectors.buttonSave, "click");
-      await nextTick();
+      await click(fixture, selectors.buttonSave);
       const rows = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.rows);
       const inputInflectionLower = rows[1].querySelectorAll("input")[0];
       const inputInflectionUpper = rows[2].querySelectorAll("input")[0];
@@ -1405,23 +1278,19 @@ describe("UI of conditional formats", () => {
   );
 
   test("display both inflection point errors", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
     const rows = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.rows);
     const inputInflectionLower = rows[1].querySelectorAll("input")[0];
     const inputInflectionUpper = rows[2].querySelectorAll("input")[0];
     setInputValueAndTrigger(inputInflectionLower, "hello", "input");
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect(inputInflectionLower.classList).toContain("o-invalid");
     expect(inputInflectionUpper.classList).not.toContain("o-invalid");
     expect(errorMessages()).toEqual(["The first value must be a number"]);
 
     setInputValueAndTrigger(inputInflectionUpper, "hello", "input");
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect(inputInflectionLower.classList).toContain("o-invalid");
     expect(inputInflectionUpper.classList).toContain("o-invalid");
     expect(errorMessages()).toEqual([
@@ -1431,10 +1300,8 @@ describe("UI of conditional formats", () => {
   });
 
   test("lower point bigger than upper displays both input as invalid", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[2], "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
     const rows = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.rows);
     const inputInflectionLower = rows[1].querySelectorAll("input")[0];
     const inputInflectionUpper = rows[2].querySelectorAll("input")[0];
@@ -1442,8 +1309,7 @@ describe("UI of conditional formats", () => {
     await nextTick();
     setInputValueAndTrigger(inputInflectionLower, "1", "input");
     await nextTick();
-    triggerMouseEvent(selectors.buttonSave, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonSave);
     expect(inputInflectionLower.classList).toContain("o-invalid");
     expect(inputInflectionUpper.classList).toContain("o-invalid");
     expect(errorMessages()).toEqual([
@@ -1452,8 +1318,7 @@ describe("UI of conditional formats", () => {
   });
 
   test("Configuration is locally saved when switching cf type", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
 
     setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
     await nextTick();
@@ -1465,11 +1330,9 @@ describe("UI of conditional formats", () => {
       ).value
     ).toBe("BeginsWith");
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[1], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
-    triggerMouseEvent(document.querySelectorAll(selectors.cfTabSelector)[0], "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(selectors.cfTabSelector)[0]);
     expect(
       (
         document.querySelector(
@@ -1480,16 +1343,13 @@ describe("UI of conditional formats", () => {
   });
 
   test("switching to list resets the rules to their default value", async () => {
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonAdd);
     setInputValueAndTrigger(selectors.ruleEditor.range, "B5:C7", "change");
     setInputValueAndTrigger(selectors.ruleEditor.range, "B5:C7", "input");
     setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
     await nextTick();
-    triggerMouseEvent(selectors.buttonCancel, "click");
-    await nextTick();
-    triggerMouseEvent(selectors.buttonAdd, "click");
-    await nextTick();
+    await click(fixture, selectors.buttonCancel);
+    await click(fixture, selectors.buttonAdd);
     expect((document.querySelector(selectors.ruleEditor.range) as HTMLInputElement).value).toBe(
       "A1"
     );

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -9,6 +9,7 @@ import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { MockClipboard } from "../test_helpers/clipboard";
 import { setCellContent } from "../test_helpers/commands_helpers";
 import {
+  click,
   keyDown,
   rightClickCell,
   simulateClick,
@@ -299,24 +300,20 @@ describe("Standalone context menu tests", () => {
     test("close contextmenu when clicking on menubar", async () => {
       await rightClickCell(model, "B1");
       expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
-      triggerMouseEvent(".o-topbar-topleft", "click");
-      await nextTick();
+      await click(fixture, ".o-topbar-topleft");
       expect(fixture.querySelector(".o-menu")).toBeFalsy();
     });
 
     test("close contextmenu when clicking on menubar item", async () => {
       await rightClickCell(model, "B1");
       expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
-      triggerMouseEvent(".o-topbar-menu[data-id='insert']", "click");
-      await nextTick();
+      await click(fixture, ".o-topbar-menu[data-id='insert']");
       expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeFalsy();
     });
     test("close contextmenu when clicking on tools bar", async () => {
       await rightClickCell(model, "B1");
       expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeTruthy();
-      const fontSizeTool = fixture.querySelector('.o-tool[title="Font Size"]')!;
-      triggerMouseEvent(fontSizeTool, "click");
-      await nextTick();
+      await click(fixture, '.o-tool[title="Font Size"]');
       expect(fixture.querySelector(".o-menu .o-menu-item[data-name='cut']")).toBeFalsy();
     });
 

--- a/tests/components/custom_currency_side_panel.test.ts
+++ b/tests/components/custom_currency_side_panel.test.ts
@@ -3,7 +3,7 @@ import { Model, Spreadsheet } from "../../src";
 import { currenciesRegistry } from "../../src/registries/currencies_registry";
 import { Currency } from "../../src/types/currency";
 import { setSelection } from "../test_helpers/commands_helpers";
-import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_helper";
+import { click, setInputValueAndTrigger } from "../test_helpers/dom_helper";
 import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 jest.useFakeTimers();
@@ -76,8 +76,7 @@ describe("custom currency sidePanel component", () => {
     // -------------------------------------------------------------------------
     test("Can close the custom currency side panel", async () => {
       expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
-      triggerMouseEvent(document.querySelector(selectors.closeSidepanel), "click");
-      await nextTick();
+      await click(fixture, selectors.closeSidepanel);
       expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
     });
 
@@ -204,8 +203,7 @@ describe("custom currency sidePanel component", () => {
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         false
       );
-      triggerMouseEvent(document.querySelector(selectors.applyFormat), "click");
-      await nextTick();
+      await click(fixture, selectors.applyFormat);
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         true
       );
@@ -217,8 +215,7 @@ describe("custom currency sidePanel component", () => {
       );
       setInputValueAndTrigger(selectors.inputSymbol, "€", "input");
       await nextTick();
-      triggerMouseEvent(document.querySelector(selectors.applyFormat), "click");
-      await nextTick();
+      await click(fixture, selectors.applyFormat);
       setSelection(model, ["A1", "A2"]);
 
       await nextTick();
@@ -233,8 +230,7 @@ describe("custom currency sidePanel component", () => {
       await nextTick();
       setInputValueAndTrigger(selectors.formatProposals, "1", "change");
       await nextTick();
-      triggerMouseEvent(document.querySelector(selectors.applyFormat), "click");
-      await nextTick();
+      await click(fixture, selectors.applyFormat);
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         true
       );
@@ -255,8 +251,7 @@ describe("custom currency sidePanel component", () => {
     test("not disable formatProposals/applyFormat if apply proposal and select other currency", async () => {
       setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
       await nextTick();
-      triggerMouseEvent(document.querySelector(selectors.applyFormat), "click");
-      await nextTick();
+      await click(fixture, selectors.applyFormat);
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         true
       );
@@ -358,8 +353,7 @@ describe("custom currency sidePanel component", () => {
       await nextTick();
       setInputValueAndTrigger(selectors.formatProposals, proposalIndex, "change");
       await nextTick();
-      triggerMouseEvent(document.querySelector(selectors.applyFormat), "click");
-      await nextTick();
+      await click(fixture, selectors.applyFormat);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: parent.env.model.getters.getActiveSheetId(),
         target: parent.env.model.getters.getSelectedZones(),
@@ -391,8 +385,7 @@ describe("custom currency sidePanel component", () => {
           await nextTick();
           setInputValueAndTrigger(selectors.formatProposals, concernedIndex, "change");
           await nextTick();
-          triggerMouseEvent(document.querySelector(selectors.applyFormat), "click");
-          await nextTick();
+          await click(fixture, selectors.applyFormat);
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: parent.env.model.getters.getActiveSheetId(),
             target: parent.env.model.getters.getSelectedZones(),
@@ -426,8 +419,7 @@ describe("custom currency sidePanel component", () => {
           await nextTick();
           setInputValueAndTrigger(selectors.formatProposals, concernedIndex, "change");
           await nextTick();
-          triggerMouseEvent(document.querySelector(selectors.applyFormat), "click");
-          await nextTick();
+          await click(fixture, selectors.applyFormat);
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: parent.env.model.getters.getActiveSheetId(),
             target: parent.env.model.getters.getSelectedZones(),
@@ -449,8 +441,7 @@ describe("custom currency sidePanel component", () => {
           await nextTick();
           setInputValueAndTrigger(selectors.formatProposals, concernedIndex, "change");
           await nextTick();
-          triggerMouseEvent(document.querySelector(selectors.applyFormat), "click");
-          await nextTick();
+          await click(fixture, selectors.applyFormat);
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: parent.env.model.getters.getActiveSheetId(),
             target: parent.env.model.getters.getSelectedZones(),
@@ -479,8 +470,7 @@ describe("custom currency sidePanel component", () => {
           await nextTick();
           setInputValueAndTrigger(selectors.formatProposals, concernedIndex, "change");
           await nextTick();
-          triggerMouseEvent(document.querySelector(selectors.applyFormat), "click");
-          await nextTick();
+          await click(fixture, selectors.applyFormat);
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: parent.env.model.getters.getActiveSheetId(),
             target: parent.env.model.getters.getSelectedZones(),

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -1,7 +1,7 @@
 import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import { setCellContent } from "../test_helpers/commands_helpers";
-import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_helper";
+import { click, setInputValueAndTrigger } from "../test_helpers/dom_helper";
 import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
@@ -48,8 +48,7 @@ describe("find and replace sidePanel component", () => {
   describe("Sidepanel", () => {
     test("Can close the find and replace side panel", async () => {
       expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
-      triggerMouseEvent(document.querySelector(selectors.closeSidepanel), "click");
-      await nextTick();
+      await click(fixture, selectors.closeSidepanel);
       expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
     });
 
@@ -113,8 +112,7 @@ describe("find and replace sidePanel component", () => {
 
     test("clicking on next", async () => {
       setInputValueAndTrigger(selectors.inputSearch, "1", "input");
-      triggerMouseEvent(document.querySelector(selectors.nextButton), "click");
-      await nextTick();
+      await click(fixture, selectors.nextButton);
       expect(dispatch).toHaveBeenCalledWith("SELECT_SEARCH_NEXT_MATCH");
     });
 
@@ -129,8 +127,7 @@ describe("find and replace sidePanel component", () => {
 
     test("clicking on previous", async () => {
       setInputValueAndTrigger(selectors.inputSearch, "1", "input");
-      triggerMouseEvent(document.querySelector(selectors.previousButton), "click");
-      await nextTick();
+      await click(fixture, selectors.previousButton);
       expect(dispatch).toHaveBeenCalledWith("SELECT_SEARCH_PREVIOUS_MATCH");
     });
 
@@ -191,8 +188,7 @@ describe("find and replace sidePanel component", () => {
       const dispatch = spyDispatch(parent);
 
       setInputValueAndTrigger(selectors.inputSearch, "Hell", "input");
-      triggerMouseEvent(document.querySelector(selectors.checkBoxMatchingCase), "click");
-      await nextTick();
+      await click(fixture, selectors.checkBoxMatchingCase);
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
         searchOptions: { exactMatch: false, matchCase: true, searchFormulas: false },
         toSearch: "Hell",
@@ -203,8 +199,7 @@ describe("find and replace sidePanel component", () => {
       const dispatch = spyDispatch(parent);
 
       setInputValueAndTrigger(selectors.inputSearch, "Hell", "input");
-      triggerMouseEvent(document.querySelector(selectors.checkBoxExactMatch), "click");
-      await nextTick();
+      await click(fixture, selectors.checkBoxExactMatch);
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
         searchOptions: { exactMatch: true, matchCase: false, searchFormulas: false },
         toSearch: "Hell",
@@ -215,8 +210,7 @@ describe("find and replace sidePanel component", () => {
       const dispatch = spyDispatch(parent);
 
       setInputValueAndTrigger(selectors.inputSearch, "Hell", "input");
-      triggerMouseEvent(document.querySelector(selectors.checkBoxSearchFormulas), "click");
-      await nextTick();
+      await click(fixture, selectors.checkBoxSearchFormulas);
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
         searchOptions: { exactMatch: false, matchCase: false, searchFormulas: true },
         toSearch: "Hell",
@@ -224,16 +218,13 @@ describe("find and replace sidePanel component", () => {
     });
 
     test("search in formulas shows formulas", async () => {
-      triggerMouseEvent(document.querySelector(selectors.checkBoxSearchFormulas), "click");
-      await nextTick();
+      await click(document.querySelector(selectors.checkBoxSearchFormulas)!);
       expect(model.getters.shouldShowFormulas()).toBe(true);
     });
 
     test("search in formulas should not show formula after closing the sidepanel", async () => {
-      triggerMouseEvent(document.querySelector(selectors.checkBoxSearchFormulas), "click");
-      await nextTick();
-      triggerMouseEvent(document.querySelector(selectors.closeSidepanel), "click");
-      await nextTick();
+      await click(fixture, selectors.checkBoxSearchFormulas);
+      await click(fixture, selectors.closeSidepanel);
       expect(model.getters.shouldShowFormulas()).toBe(false);
     });
   });
@@ -242,18 +233,16 @@ describe("find and replace sidePanel component", () => {
       setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "hello", "input");
       setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "kikou", "input");
       const dispatch = spyDispatch(parent);
-      triggerMouseEvent(document.querySelector(selectors.replaceButton), "click");
-      await nextTick();
+      await click(fixture, selectors.replaceButton);
       expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "kikou" });
     });
 
     test("Can replace a value in a formula", async () => {
       setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "2", "input");
-      triggerMouseEvent(document.querySelector(selectors.checkBoxSearchFormulas), "click");
+      await click(fixture, selectors.checkBoxSearchFormulas);
       setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "4", "input");
       const dispatch = spyDispatch(parent);
-      triggerMouseEvent(document.querySelector(selectors.replaceButton), "click");
-      await nextTick();
+      await click(fixture, selectors.replaceButton);
       expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "4" });
     });
 
@@ -261,8 +250,7 @@ describe("find and replace sidePanel component", () => {
       setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "4", "input");
       setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "2", "input");
       const dispatch = spyDispatch(parent);
-      triggerMouseEvent(document.querySelector(selectors.replaceButton), "click");
-      await nextTick();
+      await click(fixture, selectors.replaceButton);
       expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "2" });
     });
 
@@ -270,8 +258,7 @@ describe("find and replace sidePanel component", () => {
       setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "hell", "input");
       setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "kikou", "input");
       const dispatch = spyDispatch(parent);
-      triggerMouseEvent(document.querySelector(selectors.replaceAllButton), "click");
-      await nextTick();
+      await click(fixture, selectors.replaceAllButton);
       expect(dispatch).toHaveBeenCalledWith("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
     });
 

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -13,11 +13,11 @@ import {
   setCellContent,
 } from "../test_helpers/commands_helpers";
 import {
+  click,
   clickCell,
   getElComputedStyle,
   rightClickCell,
   simulateClick,
-  triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
 import {
@@ -60,8 +60,7 @@ describe("Simple Spreadsheet Component", () => {
 
   test("focus is properly set, initially and after switching sheet", async () => {
     expect(document.activeElement!.tagName).toEqual("INPUT");
-    document.querySelector(".o-add-sheet")!.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(fixture, ".o-add-sheet");
     expect(document.querySelectorAll(".o-sheet").length).toBe(2);
     expect(document.activeElement!.tagName).toEqual("INPUT");
     await simulateClick(document.querySelectorAll(".o-sheet")[1]);
@@ -174,8 +173,7 @@ describe("Simple Spreadsheet Component", () => {
     const gridComposerZIndex = getZIndex("div.o-grid-composer");
     const highlighZIndex = getZIndex(".o-highlight");
 
-    triggerMouseEvent(".o-tool.o-dropdown-button.o-with-color", "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(".o-tool.o-dropdown-button.o-with-color")[0]);
     const colorPickerZIndex = getZIndex("div.o-color-picker");
 
     createChart(model, {}, "thisIsAnId");

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -16,7 +16,7 @@ import {
   setCellContent,
   setSelection,
 } from "../test_helpers/commands_helpers";
-import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
+import { click, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getBorder, getCell, getStyle } from "../test_helpers/getters_helpers";
 import {
   getFigureIds,
@@ -101,14 +101,10 @@ describe("TopBar component", () => {
     const { app } = await mountParent(model);
 
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
-    fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(fixture, ".o-tool[title='Borders']");
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
     expect(fixture.querySelectorAll(".o-line-item").length).not.toBe(0);
-    fixture
-      .querySelector('.o-tool[title="Horizontal align"] span')!
-      .dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(fixture, ".o-tool[title='Horizontal align'] span");
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
     expect(fixture.querySelectorAll(".o-color-line").length).toBe(0);
     app.destroy();
@@ -178,8 +174,7 @@ describe("TopBar component", () => {
     expect(redoTool.classList.contains("o-disabled")).toBeTruthy();
     expect(getCell(model, "A1")!.style).toBeDefined();
 
-    undoTool.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(undoTool);
     expect(undoTool.classList.contains("o-disabled")).toBeTruthy();
     expect(redoTool.classList.contains("o-disabled")).toBeFalsy();
 
@@ -193,8 +188,7 @@ describe("TopBar component", () => {
 
     expect(paintFormatTool.classList.contains("active")).toBeFalsy();
 
-    paintFormatTool.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(paintFormatTool);
 
     expect(paintFormatTool.classList.contains("active")).toBeTruthy();
     app.destroy();
@@ -259,7 +253,7 @@ describe("TopBar component", () => {
     expect(getBorder(model, "B1")).toBeDefined();
     const { app } = await mountParent(model);
     const clearFormatTool = fixture.querySelector('.o-tool[title="Clear Format"]')!;
-    clearFormatTool.dispatchEvent(new Event("click"));
+    await click(clearFormatTool);
     expect(getCell(model, "B1")).toBeUndefined();
     app.destroy();
   });
@@ -268,13 +262,9 @@ describe("TopBar component", () => {
     const { app, model } = await mountParent();
     expect(getCell(model, "A1")).toBeUndefined();
     const formatTool = fixture.querySelector('.o-tool[title="More formats"]')!;
-    formatTool.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(formatTool);
     expect(fixture).toMatchSnapshot();
-    fixture
-      .querySelector('[data-format="percent"]')!
-      .dispatchEvent(new Event("click", { bubbles: true }));
-    await nextTick();
+    await click(fixture, `[data-format="percent"]`);
     expect(getCell(model, "A1")!.format).toEqual("0.00%");
     app.destroy();
   });
@@ -283,10 +273,8 @@ describe("TopBar component", () => {
     const { app, model } = await mountParent();
     const fontSizeTool = fixture.querySelector('.o-tool[title="Font Size"]')!;
     expect(fontSizeTool.textContent!.trim()).toBe(DEFAULT_FONT_SIZE.toString());
-    fontSizeTool.dispatchEvent(new Event("click"));
-    await nextTick();
-    fixture.querySelector('[data-size="8"]')!.dispatchEvent(new Event("click", { bubbles: true }));
-    await nextTick();
+    await click(fontSizeTool);
+    await click(fixture, "[data-size='8']");
     expect(fontSizeTool.textContent!.trim()).toBe("8");
     expect(getStyle(model, "A1").fontSize).toBe(8);
     app.destroy();
@@ -298,17 +286,14 @@ describe("TopBar component", () => {
     ["align-right", { align: "right" }],
   ])("can set horizontal alignment with the toolbar", async (iconClass, expectedStyle) => {
     const { app, model } = await mountParent();
-    const alignTool = fixture.querySelector('.o-tool[title="Horizontal align"]')!;
-    alignTool.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(fixture, ".o-tool[title='Horizontal align']");
 
     const alignButtons = fixture.querySelectorAll("div.o-dropdown-item")!;
     const button = [...alignButtons].find((element) =>
       element.children[0]!.classList.contains(iconClass)
     )!;
 
-    button.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(button);
     expect(model.getters.getCurrentStyle()).toEqual(expectedStyle);
     app.destroy();
   });
@@ -341,11 +326,9 @@ describe("TopBar component", () => {
     const { app } = await mountParent(model);
 
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
-    fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(fixture, '.o-tool[title="Borders"]');
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
-    fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
-    await nextTick();
+    await click(fixture, '.o-tool[title="Borders"]');
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
     app.destroy();
   });
@@ -356,24 +339,21 @@ describe("TopBar component", () => {
     const items = topbarMenuRegistry.getMenuItems();
     const number = items.filter((item) => item.children(parent.env).length !== 0).length;
     expect(fixture.querySelectorAll(".o-topbar-menu")).toHaveLength(number);
-    triggerMouseEvent(".o-topbar-menu[data-id='file']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='file']");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     const file = getNode(["file"], topbarMenuRegistry);
     const numberChild = file
       .children(parent.env)
       .filter((item) => item.children.length !== 0 || item.action).length;
     expect(fixture.querySelectorAll(".o-menu-item")).toHaveLength(numberChild);
-    triggerMouseEvent(".o-spreadsheet-topbar", "click");
-    await nextTick();
+    await click(fixture, ".o-spreadsheet-topbar");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     app.destroy();
   });
 
   test("Can open a Topbar menu with mousemove", async () => {
     const { app, parent } = await mountParent();
-    triggerMouseEvent(".o-topbar-menu[data-id='file']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='file']");
     const file = getNode(["file"], topbarMenuRegistry);
     let numberChild = file
       .children(parent.env)
@@ -405,10 +385,8 @@ describe("TopBar component", () => {
       },
     });
     const { app } = await mountParent();
-    triggerMouseEvent(".o-topbar-menu[data-id='test']", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='test']");
+    await click(fixture, ".o-menu-item");
     expect(fixture.querySelectorAll(".o-menu-dropdown-content")).toHaveLength(0);
     expect(number).toBe(1);
     topbarMenuRegistry.content = menuDefinitions;
@@ -420,12 +398,10 @@ describe("TopBar component", () => {
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     const menuItem = fixture.querySelector(".o-topbar-menu[data-id='edit']");
     expect(menuItem?.classList).not.toContain("o-topbar-menu-active");
-    triggerMouseEvent(menuItem, "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='edit']");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     expect(menuItem?.classList).toContain("o-topbar-menu-active");
-    triggerMouseEvent(".o-menu-item", "click");
-    await nextTick();
+    await click(fixture.querySelectorAll(".o-menu-item")[0]);
     expect(menuItem?.classList).not.toContain("o-topbar-menu-active");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     app.destroy();
@@ -481,8 +457,7 @@ describe("TopBar component", () => {
     model.updateMode("readonly");
     await nextTick();
     expect(fixture.querySelectorAll(".o-readonly-toolbar")).toHaveLength(1);
-    triggerMouseEvent(".o-topbar-menu[data-id='insert']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='insert']");
     const insertMenuItems = fixture.querySelectorAll(".o-menu div.o-menu-item");
     expect([...insertMenuItems].every((item) => item.classList.contains("disabled"))).toBeTruthy();
     app.destroy();
@@ -581,10 +556,8 @@ test("Can show/hide a TopBarComponent based on condition", async () => {
 describe("TopBar - Custom currency", () => {
   test("can open custom currency sidepanel from tool", async () => {
     const { app } = await mountSpreadsheet(fixture);
-    triggerMouseEvent(".o-tool[title='More formats']", "click");
-    await nextTick();
-    triggerMouseEvent(".o-format-tool div[data-custom='custom_currency']", "click");
-    await nextTick();
+    await click(fixture, ".o-tool[title='More formats']");
+    await click(fixture, ".o-format-tool div[data-custom='custom_currency']");
     expect(fixture.querySelector(".o-custom-currency")).toBeTruthy();
     app.destroy();
   });
@@ -605,10 +578,8 @@ describe("Format", () => {
     expect(getCell(model, "A1")?.style).toEqual({ fillColor: "#000000" });
     expect(getCell(model, "B2")?.style).toEqual({ fillColor: "#000000" });
     expect(getCell(model, "B3")?.style).toEqual({ fillColor: "#000000" });
-    triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item[data-name='format_clearFormat']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='format']");
+    await click(fixture, ".o-menu-item[data-name='format_clearFormat']");
     expect(getCell(model, "A1")?.style).toBeUndefined();
     expect(getCell(model, "B2")?.style).toBeUndefined();
     expect(getCell(model, "B3")?.style).toBeUndefined();
@@ -619,10 +590,8 @@ describe("Format", () => {
 describe("TopBar - CF", () => {
   test("open sidepanel with no CF in selected zone", async () => {
     const { app } = await mountSpreadsheet(fixture);
-    triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item[data-name='format_cf']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='format']");
+    await click(fixture, ".o-menu-item[data-name='format_cf']");
     expect(
       fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-cf .o-cf-preview-list")
     ).toBeTruthy();
@@ -653,10 +622,8 @@ describe("TopBar - CF", () => {
     });
     setSelection(model, ["A1:K11"]);
 
-    triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item[data-name='format_cf']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='format']");
+    await click(fixture, ".o-menu-item[data-name='format_cf']");
     expect(
       fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-cf .o-cf-preview-list")
     ).toBeFalsy();
@@ -702,10 +669,8 @@ describe("TopBar - CF", () => {
     });
     setSelection(model, ["A1:K11"]);
 
-    triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item[data-name='format_cf']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='format']");
+    await click(fixture, ".o-menu-item[data-name='format_cf']");
     expect(
       fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-cf .o-cf-preview-list")
     ).toBeTruthy();
@@ -735,10 +700,8 @@ describe("TopBar - CF", () => {
       ranges: toRangesData(sheetId, cfRule1.ranges.join(",")),
     });
     setSelection(model, ["A1:A11"]);
-    triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item[data-name='format_cf']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='format']");
+    await click(fixture, ".o-menu-item[data-name='format_cf']");
     expect(
       fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-cf .o-cf-preview-list")
     ).toBeFalsy();
@@ -747,10 +710,8 @@ describe("TopBar - CF", () => {
     ).toBeTruthy();
 
     setSelection(model, ["F6"]);
-    triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item[data-name='format_cf']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='format']");
+    await click(fixture, ".o-menu-item[data-name='format_cf']");
     expect(
       fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-cf .o-cf-preview-list")
     ).toBeTruthy();
@@ -763,28 +724,19 @@ describe("TopBar - CF", () => {
 describe("Topbar - View", () => {
   test("Setting show formula from topbar should retain its state even it's changed via f&r side panel upon closing", async () => {
     const { app, parent, model } = await mountSpreadsheet(fixture);
-    triggerMouseEvent(".o-topbar-menu[data-id='view']", "click");
-    await nextTick();
-    triggerMouseEvent(".o-menu-item[data-name='view_formulas']", "click");
-    await nextTick();
+    await click(fixture, ".o-topbar-menu[data-id='view']");
+    await click(fixture, ".o-menu-item[data-name='view_formulas']");
     expect(model.getters.shouldShowFormulas()).toBe(true);
     parent.env.openSidePanel("FindAndReplace");
     await nextTick();
     expect(model.getters.shouldShowFormulas()).toBe(true);
     await nextTick();
-    triggerMouseEvent(
-      document.querySelector(
-        ".o-sidePanel .o-sidePanelBody .o-find-and-replace .o-section:nth-child(1) .o-far-item:nth-child(3) input"
-      ),
-      "click"
+    await click(
+      fixture,
+      ".o-sidePanel .o-sidePanelBody .o-find-and-replace .o-section:nth-child(1) .o-far-item:nth-child(3) input"
     );
-    await nextTick();
     expect(model.getters.shouldShowFormulas()).toBe(false);
-    triggerMouseEvent(
-      document.querySelector(".o-sidePanel .o-sidePanelHeader .o-sidePanelClose"),
-      "click"
-    );
-    await nextTick();
+    await click(fixture, ".o-sidePanel .o-sidePanelHeader .o-sidePanelClose");
     expect(model.getters.shouldShowFormulas()).toBe(true);
     app.destroy();
   });

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -33,6 +33,28 @@ export async function simulateClick(
   await nextTick();
 }
 
+function findElement(el: Element, selector: string): Element {
+  let target = el;
+  if (selector) {
+    const els = el.querySelectorAll(selector);
+    if (els.length === 0) {
+      throw new Error(`No element found (selector: ${selector})`);
+    }
+    if (els.length > 1) {
+      throw new Error(`Found ${els.length} elements, instead of 1 (selector: ${selector})`);
+    }
+    target = els[0];
+  }
+  return target;
+}
+
+export async function click(el: Element, selector: string = "") {
+  const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+  const target = findElement(el, selector);
+  target.dispatchEvent(event);
+  await nextTick();
+}
+
 /**
  * Simulate hovering a cell for a given amount of time.
  * Don't forget to use `jest.useFakeTimers();` when using


### PR DESCRIPTION
Before this revision, we were using different ways to click on elements (dispatching an event by hand, using our helper `triggerMouseEvent`). When the event was dispatched by hand, we were not always using the `bubbles` option, which could lead to some issues.

This revision introduces a new helper `click` that allow us to easily click on an element. It uses the `MouseEvent` constructor and correctly set the `bubbles` option to `true`.

Task-id 3165489

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo