### PR TITLE
[FIX] Renderer: Speed up rendering

### DIFF
--- a/src/plugins/ui/renderer.ts
+++ b/src/plugins/ui/renderer.ts
@@ -43,6 +43,7 @@ import {
   HeaderIndex,
   LAYERS,
   UID,
+  Viewport,
   Zone,
 } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
@@ -525,10 +526,8 @@ export class RendererPlugin extends UIPlugin {
     return align || cell.defaultAlign;
   }
 
-  private createZoneBox(sheetId: UID, zone: Zone): Box {
-    const visibleCols = this.getters.getSheetViewVisibleCols();
-    const left = visibleCols[0];
-    const right = visibleCols[visibleCols.length - 1];
+  private createZoneBox(sheetId: UID, zone: Zone, viewport: Viewport): Box {
+    const { left, right } = viewport;
     const col: HeaderIndex = zone.left;
     const row: HeaderIndex = zone.top;
     const cell = this.getters.getCell(sheetId, col, row);
@@ -677,7 +676,9 @@ export class RendererPlugin extends UIPlugin {
         if (this.getters.isInMerge(sheetId, colNumber, rowNumber)) {
           continue;
         }
-        boxes.push(this.createZoneBox(sheetId, positionToZone({ col: colNumber, row: rowNumber })));
+        boxes.push(
+          this.createZoneBox(sheetId, positionToZone({ col: colNumber, row: rowNumber }), viewport)
+        );
       }
     }
     for (const merge of this.getters.getMerges(sheetId)) {
@@ -685,7 +686,7 @@ export class RendererPlugin extends UIPlugin {
         continue;
       }
       if (overlap(merge, viewport)) {
-        const box = this.createZoneBox(sheetId, merge);
+        const box = this.createZoneBox(sheetId, merge, viewport);
         const borderBottomRight = this.getters.getCellBorder(sheetId, merge.right, merge.bottom);
         box.border = {
           ...box.border,


### PR DESCRIPTION
The rendering process has been slower since the introduction of the frozen panes (c0c2044). One of the main reason being that we were computing the boxes sizes and positions in the past but now have to do it for multiple panes at a time. This is done by calling the getter `getVisibleRect` for each box zone. However, we were also calling `getSheetViewVisiblecols/rows` to get the viewport  boundaries for each cell, it would take between 25 and 39% of the call to `drawGrid`.

This revision ensures that we only fetch the viewport boundaries once when computing the boxes.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo