### PR TITLE
[FIX] chart: add dimensions to canvas

### DIFF
--- a/src/components/figures/chart.ts
+++ b/src/components/figures/chart.ts
@@ -16,7 +16,7 @@ const { useRef } = hooks;
 const TEMPLATE = xml/* xml */ `
 <div class="o-chart-container">
   <div class="o-chart-menu" t-on-click="showMenu">${LIST}</div>
-  <canvas t-att-style="canvasStyle" t-ref="graphContainer"/>
+  <canvas class="w-100 h-100" t-att-style="canvasStyle" t-ref="graphContainer"/>
   <Menu t-if="menuState.isOpen"
     position="menuState.position"
     menuItems="menuState.menuItems"

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -255,6 +255,31 @@ describe("figures", () => {
     });
   });
 
+  test("can edit chart background color", async () => {
+    const chartId = "someuuid";
+    const sheetId = model.getters.getActiveSheetId();
+    await simulateClick(".o-figure");
+    await simulateClick(".o-chart-menu");
+    await simulateClick(".o-menu div[data-name='edit']");
+
+    parent.env.dispatch = jest.fn((command) => DispatchResult.Success);
+    await simulateClick(".o-panel .inactive");
+    await simulateClick(".o-with-color-picker span");
+    expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-color-picker")).toBeTruthy();
+    await simulateClick(
+      ".o-color-picker .o-color-picker-line .o-color-picker-line-item[data-color='#00ffff']"
+    );
+    expect(parent.env.dispatch).toHaveBeenCalledWith("UPDATE_CHART", {
+      id: chartId,
+      sheetId,
+      definition: {
+        background: "#00ffff",
+      },
+    });
+    expect(fixture.querySelector(".o-chart-container canvas")!.classList).toContain("w-100");
+    expect(fixture.querySelector(".o-chart-container canvas")!.classList).toContain("h-100");
+  });
+
   test("remove labels", async () => {
     const model = parent.model;
     const sheetId = model.getters.getActiveSheetId();


### PR DESCRIPTION
## Description:

This PR adds dimensions to chart canvas. It fixes the problem when changing chart background color, the dimensions of chart will temporarily change and be out of the figure. 

Odoo task ID : [3167230](https://www.odoo.com/web#id=3167230&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo