### PR TITLE
[FIX] Cell/clipboard: Fix last cell deletion

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -80,6 +80,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   allowDispatch(cmd: CoreCommand): CommandResult {
     switch (cmd.type) {
       case "UPDATE_CELL":
+      case "CLEAR_CELL":
         return this.checkCellOutOfSheet(cmd.sheetId, cmd.col, cmd.row);
       default:
         return CommandResult.Success;

--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -1,6 +1,6 @@
 import { SELECTION_BORDER_COLOR } from "../../constants";
 import { formatValue } from "../../helpers/cells/index";
-import { clip, overlap } from "../../helpers/index";
+import { clip, isZoneValid, overlap, positions } from "../../helpers/index";
 import { Mode } from "../../model";
 import { _lt } from "../../translation";
 import {
@@ -99,6 +99,12 @@ export class ClipboardPlugin extends UIPlugin {
         break;
       case "DELETE_CELL": {
         const { cut, paste } = this.getDeleteCellsTargets(cmd.zone, cmd.shiftDimension);
+        if (!isZoneValid(cut[0])) {
+          for (const [col, row] of positions(cmd.zone)) {
+            this.dispatch("CLEAR_CELL", { col, row, sheetId: this.getters.getActiveSheetId() });
+          }
+          break;
+        }
         const state = this.getClipboardState(cut, "CUT");
         if (cmd.interactive) {
           this.interactivePaste(state, paste, cmd);

--- a/tests/plugins/cell.test.ts
+++ b/tests/plugins/cell.test.ts
@@ -51,6 +51,17 @@ describe("getCellText", () => {
     });
     expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
   });
+
+  test("clear cell outside of sheet", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const result = model.dispatch("CLEAR_CELL", {
+      sheetId,
+      col: 9999,
+      row: 9999,
+    });
+    expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
+  });
 });
 
 describe("link cell", () => {

--- a/tests/plugins/grid_manipulation.test.ts
+++ b/tests/plugins/grid_manipulation.test.ts
@@ -1938,6 +1938,17 @@ describe("Delete cell", () => {
     });
     testUndoRedo(model, expect, "DELETE_CELL", { zone: toZone("A1"), dimension: "ROW" });
   });
+
+  test.each(["up", "left"] as const)("can delete the last cell of the grid", (direction) => {
+    const sheetId = model.getters.getActiveSheetId();
+    const col = model.getters.getNumberCols(sheetId) - 1;
+    const row = model.getters.getNumberRows(sheetId) - 1;
+    const xc = toXC(col, row);
+    model.dispatch("UPDATE_CELL", { sheetId, col, row, content: "test", style: { bold: true } });
+    deleteCells(model, xc, direction);
+    const cell = getCell(model, xc);
+    expect(cell).toBeUndefined();
+  });
 });
 
 describe("Insert cell", () => {


### PR DESCRIPTION
A user could not delete a cell a shift up (resp. left) on the last row (resp. column) of a sheet.

This revision fixes this issue and also adds a missing allowDispatch for command `CLEAR_CELL` which is subject to the same limitations as `UPDATE_CELL`.

Task 3166109

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3166109](https://www.odoo.com/web#id=3166109&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo