### PR TITLE
[IMP/REF] tests: mount owl App in test mode & mount helper

### DIFF
--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { args, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import { selectCell } from "../test_helpers/commands_helpers";
@@ -6,7 +5,6 @@ import { click, clickCell, keyDown, keyUp, simulateClick } from "../test_helpers
 import { getCellText } from "../test_helpers/getters_helpers";
 import {
   clearFunctions,
-  makeTestFixture,
   mountSpreadsheet,
   nextTick,
   restoreDefaultFunctions,
@@ -21,7 +19,6 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 let model: Model;
 let composerEl: Element;
 let fixture: HTMLElement;
-let app: App;
 let cehMock: ContentEditableHelper;
 
 async function typeInComposerGrid(text: string, fromScratch: boolean = true) {
@@ -39,17 +36,11 @@ async function typeInComposerTopBar(text: string, fromScratch: boolean = true) {
 }
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, model } = await mountSpreadsheet(fixture));
+  ({ model, fixture } = await mountSpreadsheet());
 
   // start composition
   await keyDown("Enter");
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
-});
-
-afterEach(() => {
-  fixture.remove();
-  app.destroy();
 });
 
 describe("Functions autocomplete", () => {

--- a/tests/components/autofill.test.ts
+++ b/tests/components/autofill.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
@@ -9,21 +9,14 @@ import {
 import { Model } from "../../src/model";
 import { setCellContent, setSelection, setViewportOffset } from "../test_helpers/commands_helpers";
 import { clickCell, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let model: Model;
 let parent: Spreadsheet;
-let app: App;
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, parent, model } = await mountSpreadsheet(fixture));
-});
-
-afterEach(() => {
-  fixture.remove();
-  app.destroy();
+  ({ parent, model, fixture } = await mountSpreadsheet());
 });
 
 describe("Autofill component", () => {

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { CommandResult, Model, Spreadsheet } from "../../src";
 import { ChartTerms } from "../../src/components/translations_terms";
 import { BACKGROUND_CHART_COLOR } from "../../src/constants";
@@ -21,7 +20,6 @@ import {
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import {
-  makeTestFixture,
   mockChart,
   mountSpreadsheet,
   nextTick,
@@ -61,10 +59,9 @@ let chartId: string;
 let sheetId: string;
 
 let parent: Spreadsheet;
-let app: App;
+
 describe("figures", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
     mockChartData = mockChart();
     chartId = "someuuid";
     sheetId = "Sheet1";
@@ -93,15 +90,12 @@ describe("figures", () => {
         },
       ],
     };
-    ({ app, parent, model } = await mountSpreadsheet(fixture, { model: new Model(data) }));
+    ({ parent, model, fixture } = await mountSpreadsheet({ model: new Model(data) }));
     await nextTick();
     await nextTick();
     await nextTick();
   });
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
-  });
+
   test.each(["basicChart", "scorecard", "gauge"])("can export a chart %s", (chartType: string) => {
     createTestChart(chartType);
     const data = model.exportData();
@@ -942,7 +936,6 @@ describe("figures", () => {
 
 describe("charts with multiple sheets", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
     mockChartData = mockChart();
     const data = {
       sheets: [
@@ -999,13 +992,10 @@ describe("charts with multiple sheets", () => {
         },
       ],
     };
-    ({ app, parent, model } = await mountSpreadsheet(fixture, { model: new Model(data) }));
+    ({ parent, model, fixture } = await mountSpreadsheet({ model: new Model(data) }));
     await nextTick();
   });
-  afterEach(() => {
-    fixture.remove();
-    app.destroy();
-  });
+
   test("delete sheet containing chart data does not crash", async () => {
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("Sheet1");
     model.dispatch("DELETE_SHEET", { sheetId: model.getters.getActiveSheetId() });
@@ -1018,14 +1008,10 @@ describe("charts with multiple sheets", () => {
 
 describe("Default background on runtime tests", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture, { model: new Model() }));
-    model = parent.model;
+    ({ parent, fixture, model } = await mountSpreadsheet({ model: new Model() }));
     await nextTick();
   });
-  afterEach(() => {
-    app.destroy();
-  });
+
   test("Creating a 'basicChart' without background should have default background on runtime", async () => {
     createChart(model, { dataSets: ["A1"] }, "1", sheetId);
     expect(model.getters.getChartDefinition("1")?.background).toBeUndefined();

--- a/tests/components/color_picker.test.ts
+++ b/tests/components/color_picker.test.ts
@@ -1,43 +1,23 @@
-import { App } from "@odoo/owl";
 import { Model } from "../../src";
 import { ColorPicker, ColorPickerProps } from "../../src/components/color_picker/color_picker";
 import { toHex } from "../../src/helpers";
-import { SpreadsheetChildEnv } from "../../src/types";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { setStyle } from "../test_helpers/commands_helpers";
 import {
   getElComputedStyle,
   setInputValueAndTrigger,
   simulateClick,
 } from "../test_helpers/dom_helper";
-import { makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { mountComponent, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-beforeEach(async () => {
-  fixture = makeTestFixture();
-});
-
-afterEach(() => {
-  fixture.remove();
-});
-
-async function mountColorPicker(
-  props: Partial<ColorPickerProps> = {},
-  model = new Model()
-): Promise<ColorPicker> {
-  const app = new App(ColorPicker, {
-    props: {
-      dropdownDirection: props.dropdownDirection,
-      onColorPicked: props.onColorPicked || (() => {}),
-      currentColor: props.currentColor || "#000000",
-    },
-    env: {
-      model,
-    } as SpreadsheetChildEnv,
-  });
-  app.addTemplates(OWL_TEMPLATES);
-  return await app.mount(fixture);
+async function mountColorPicker(partialProps: Partial<ColorPickerProps> = {}, model = new Model()) {
+  const props = {
+    dropdownDirection: partialProps.dropdownDirection,
+    onColorPicked: partialProps.onColorPicked || (() => {}),
+    currentColor: partialProps.currentColor || "#000000",
+  };
+  ({ fixture } = await mountComponent(ColorPicker, { model, props }));
 }
 
 describe("Color Picker position tests", () => {

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, onMounted, onWillUnmount, useState, xml } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, useState, xml } from "@odoo/owl";
 import {
   Composer,
   ComposerProps,
@@ -10,7 +10,6 @@ import { colors, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { ComposerSelection } from "../../src/plugins/ui_stateful";
 import { Highlight, SpreadsheetChildEnv } from "../../src/types";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { getClipboardEvent, MockClipboardData } from "../test_helpers/clipboard";
 import {
   createSheet,
@@ -27,12 +26,7 @@ import {
   getEvaluatedCell,
   getSelectionAnchorCellXc,
 } from "../test_helpers/getters_helpers";
-import {
-  makeTestEnv,
-  makeTestFixture,
-  nextTick,
-  typeInComposerHelper,
-} from "../test_helpers/helpers";
+import { mountComponent, nextTick, typeInComposerHelper } from "../test_helpers/helpers";
 import { ContentEditableHelper } from "./__mocks__/content_editable_helper";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("./__mocks__/content_editable_helper")
@@ -40,8 +34,7 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 
 let model: Model;
 let composerEl: Element;
-let fixture: HTMLDivElement;
-let app: App;
+let fixture: HTMLElement;
 let cehMock: ContentEditableHelper;
 let parent: Parent;
 
@@ -88,19 +81,17 @@ class Parent extends Component<Props, SpreadsheetChildEnv> {
 }
 
 async function mountParent(
-  fixture: HTMLDivElement,
   model: Model = new Model(),
   composerProps: Partial<ComposerProps> = {},
   focusComposer: ComposerFocusType = "inactive"
-): Promise<{ parent: Parent; app: App; model: Model }> {
-  const env = makeTestEnv({
+): Promise<{ parent: Parent; model: Model }> {
+  let parent: Component;
+  ({ parent, fixture } = await mountComponent(Parent, {
+    props: { composerProps, focusComposer },
     model,
-  });
-  const app = new App(Parent, { props: { composerProps, focusComposer }, env });
-  app.addTemplates(OWL_TEMPLATES);
-  const parent: Parent = await app.mount(fixture);
+  }));
 
-  return { app, parent, model };
+  return { parent: parent as Parent, model };
 }
 
 function getHighlights(model: Model): Highlight[] {
@@ -136,13 +127,7 @@ async function moveToEnd() {
 }
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, model, parent } = await mountParent(fixture));
-});
-
-afterEach(() => {
-  app.destroy();
-  fixture.remove();
+  ({ model, parent } = await mountParent());
 });
 
 describe("ranges and highlights", () => {

--- a/tests/components/composer_integration.test.ts
+++ b/tests/components/composer_integration.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Model } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
@@ -34,7 +33,6 @@ import {
 } from "../test_helpers/getters_helpers";
 import {
   createEqualCF,
-  makeTestFixture,
   mountSpreadsheet,
   nextTick,
   startGridComposition,
@@ -50,7 +48,6 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 
 let fixture: HTMLElement;
 let model: Model;
-let app: App;
 let cehMock: ContentEditableHelper;
 
 async function startComposition(key?: string) {
@@ -71,16 +68,11 @@ const modelData = { sheets: [{ id: "sh1" }] };
 
 describe("Composer interactions", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, model } = await mountSpreadsheet(fixture, {
+    ({ model, fixture } = await mountSpreadsheet({
       model: new Model(modelData),
     }));
   });
 
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
-  });
   test("type in grid composer adds text to topbar composer", async () => {
     await keyDown("Enter");
     const gridComposer = document.querySelector(".o-grid .o-composer");
@@ -422,15 +414,9 @@ describe("Composer interactions", () => {
 
 describe("Grid composer", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, model } = await mountSpreadsheet(fixture, {
+    ({ model, fixture } = await mountSpreadsheet({
       model: new Model(modelData),
     }));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
   });
 
   test("Composer is closed when changing sheet while not editing a formula", async () => {

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import { toZone } from "../../src/helpers/zones";
 import { ConditionalFormatPlugin } from "../../src/plugins/core/conditional_format";
@@ -15,7 +14,6 @@ import {
   createColorScale,
   createEqualCF,
   getPlugin,
-  makeTestFixture,
   mockUuidV4To,
   mountSpreadsheet,
   nextTick,
@@ -30,18 +28,11 @@ let model: Model;
 describe("UI of conditional formats", () => {
   let fixture: HTMLElement;
   let parent: Spreadsheet;
-  let app: App;
 
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent, model } = await mountSpreadsheet(fixture));
+    ({ parent, model, fixture } = await mountSpreadsheet());
     parent.env.openSidePanel("ConditionalFormatting");
     await nextTick();
-  });
-
-  afterEach(() => {
-    fixture.remove();
-    app.destroy();
   });
 
   function errorMessages(): string[] {

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -1,11 +1,10 @@
-import { App, Component, useSubEnv, xml } from "@odoo/owl";
+import { Component, useSubEnv, xml } from "@odoo/owl";
 import { Menu } from "../../src/components/menu/menu";
 import { MENU_ITEM_HEIGHT, MENU_VERTICAL_PADDING, MENU_WIDTH } from "../../src/constants";
 import { toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { cellMenuRegistry } from "../../src/registries/menus/cell_menu_registry";
 import { createMenu, MenuItem } from "../../src/registries/menu_items_registry";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { MockClipboard } from "../test_helpers/clipboard";
 import { setCellContent } from "../test_helpers/commands_helpers";
 import {
@@ -18,7 +17,7 @@ import {
 import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import {
   getStylePropertyInPx,
-  makeTestFixture,
+  mountComponent,
   mountSpreadsheet,
   nextTick,
   Touch,
@@ -26,7 +25,6 @@ import {
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
 let fixture: HTMLElement;
-let app: App;
 let model: Model;
 
 mockGetBoundingClientRect({
@@ -106,13 +104,8 @@ describe("Standalone context menu tests", () => {
       },
       configurable: true,
     });
-    fixture = makeTestFixture();
-    ({ app, model } = await mountSpreadsheet(fixture));
-  });
 
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ model, fixture } = await mountSpreadsheet());
   });
 
   function getSelectionAnchorCellXc(model: Model): string {
@@ -135,18 +128,9 @@ describe("Standalone context menu tests", () => {
     // x, y are relative to the upper left grid corner, but the menu
     // props must take the top bar into account.
 
-    app = new App(ContextMenuParent, {
-      props: {
-        x,
-        y,
-        width,
-        height,
-        model: new Model(),
-        config: testConfig,
-      },
-    });
-    app.addTemplates(OWL_TEMPLATES);
-    parent = await app.mount(fixture);
+    const model = new Model();
+    const props = { x, y, width, height, model, config: testConfig };
+    ({ fixture } = await mountComponent(ContextMenuParent, { props, fixture, model }));
     await nextTick();
     return [x, y];
   }
@@ -797,13 +781,7 @@ describe("Standalone context menu tests", () => {
 
 describe("Context menu react to grid size changes", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, model } = await mountSpreadsheet(fixture));
-  });
-
-  afterEach(() => {
-    fixture.remove();
-    app.destroy();
+    ({ model, fixture } = await mountSpreadsheet());
   });
 
   test("Submenu is closed when grid size change make the parent menu hidden", async () => {

--- a/tests/components/custom_currency_side_panel.test.ts
+++ b/tests/components/custom_currency_side_panel.test.ts
@@ -1,10 +1,9 @@
-import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import { currenciesRegistry } from "../../src/registries/currencies_registry";
 import { Currency } from "../../src/types/currency";
 import { setSelection } from "../test_helpers/commands_helpers";
 import { click, setInputValueAndTrigger } from "../test_helpers/dom_helper";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 jest.useFakeTimers();
 
@@ -45,16 +44,14 @@ const loadCurrencies = async () => {
 
 let fixture: HTMLElement;
 let parent: Spreadsheet;
-let app: App;
 let dispatch;
 let currenciesContent: { [key: string]: Currency };
 let model: Model;
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
   currenciesContent = Object.assign({}, currenciesRegistry.content);
 
-  ({ app, parent, model } = await mountSpreadsheet(fixture, {
+  ({ parent, model, fixture } = await mountSpreadsheet({
     model: new Model({}, { external: { loadCurrencies } }),
   }));
   dispatch = spyDispatch(parent);
@@ -64,8 +61,6 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-  app.destroy();
-  fixture.remove();
   currenciesRegistry.content = currenciesContent;
 });
 
@@ -91,13 +86,10 @@ describe("custom currency sidePanel component", () => {
     test("if currencies aren't provided in spreadsheet --> remove 'available currencies' section", async () => {
       // create spreadsheet without loadCurrencies in env
       currenciesRegistry.content = {};
-      const fixture = makeTestFixture();
-      const { app, parent } = await mountSpreadsheet(fixture);
+      const { parent, fixture } = await mountSpreadsheet();
       parent.env.openSidePanel("CustomCurrency");
       await nextTick();
       expect(fixture.querySelector(selectors.availableCurrencies)).toBe(null);
-      fixture.remove();
-      app.destroy();
     });
 
     // -------------------------------------------------------------------------

--- a/tests/components/dashboard_grid.test.ts
+++ b/tests/components/dashboard_grid.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
@@ -10,12 +9,11 @@ import { Model } from "../../src/model";
 import { createFilter, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
 import { getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let parent: Spreadsheet;
 let model: Model;
-let app: App;
 
 function getEmptyClipboardEvent(type: "copy" | "paste" | "cut") {
   const event = new Event(type, { bubbles: true });
@@ -30,15 +28,8 @@ function getEmptyClipboardEvent(type: "copy" | "paste" | "cut") {
 
 describe("Grid component in dashboard mode", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ parent, fixture, model } = await mountSpreadsheet());
     await nextTick();
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
   });
 
   test("simple dashboard rendering snapshot", async () => {

--- a/tests/components/drag_and_drop.test.ts
+++ b/tests/components/drag_and_drop.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, useSubEnv, xml } from "@odoo/owl";
+import { Component, useSubEnv, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { dragAndDropBeyondTheViewport } from "../../src/components/helpers/drag_and_drop";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
@@ -14,7 +14,7 @@ import {
   setViewportOffset,
 } from "../test_helpers/commands_helpers";
 import { edgeScrollDelay, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { mountComponent, nextTick } from "../test_helpers/helpers";
 
 // As we test an isolated component, grid and gridOverlay won't exist
 jest.mock("../../src/components/helpers/dom_helpers", () => {
@@ -24,9 +24,7 @@ jest.mock("../../src/components/helpers/dom_helpers", () => {
   };
 });
 
-let fixture: HTMLElement;
 let model: Model;
-let app: App;
 let sheetId: UID;
 
 //Test Component required
@@ -73,16 +71,10 @@ afterAll(() => {
 
 beforeEach(async () => {
   model = new Model();
-  app = new App(FakeGridComponent, { props: { model } });
+  await mountComponent(FakeGridComponent, { model, props: { model } });
   selectedCol = selectedRow = undefined;
-  fixture = makeTestFixture();
-  await app.mount(fixture);
   sheetId = model.getters.getActiveSheetId();
   await nextTick();
-});
-
-afterEach(() => {
-  app.destroy();
 });
 
 describe("Drag And Drop horizontal tests", () => {

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import { ChartJsComponent } from "../../src/components/figures/chart/chartJs/chartjs";
 import { ScorecardChart } from "../../src/components/figures/chart/scorecard/chart_scorecard";
@@ -21,7 +21,6 @@ import { getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
   getFigureDefinition,
   getFigureIds,
-  makeTestFixture,
   mockChart,
   mountSpreadsheet,
   nextTick,
@@ -31,7 +30,6 @@ import { TEST_CHART_DATA } from "./../test_helpers/constants";
 
 let fixture: HTMLElement;
 let model: Model;
-let app: App;
 let parent: Spreadsheet;
 
 function createFigure(
@@ -105,12 +103,7 @@ afterAll(() => {
 
 describe("figures", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, model, parent } = await mountSpreadsheet(fixture));
-  });
-
-  afterEach(() => {
-    app.destroy();
+    ({ model, parent, fixture } = await mountSpreadsheet());
   });
 
   test("can create a figure with some data", () => {

--- a/tests/components/filter_menu.test.ts
+++ b/tests/components/filter_menu.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Model } from "../../src";
 import { UID } from "../../src/types";
 import {
@@ -9,13 +8,7 @@ import {
   updateFilter,
 } from "../test_helpers/commands_helpers";
 import { keyDown, simulateClick } from "../test_helpers/dom_helper";
-import {
-  getCellsObject,
-  makeTestFixture,
-  mountSpreadsheet,
-  nextTick,
-  target,
-} from "../test_helpers/helpers";
+import { getCellsObject, mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
 
 async function openFilterMenu() {
   await simulateClick(".o-filter-icon");
@@ -25,7 +18,6 @@ describe("Filter menu component", () => {
   let fixture: HTMLElement;
   let model: Model;
   let sheetId: UID;
-  let app: App;
 
   function getFilterMenuValues() {
     const values: { value: string; isChecked: boolean }[] = [];
@@ -40,14 +32,8 @@ describe("Filter menu component", () => {
   }
 
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, model } = await mountSpreadsheet(fixture));
+    ({ model, fixture } = await mountSpreadsheet());
     sheetId = model.getters.getActiveSheetId();
-  });
-
-  afterEach(() => {
-    fixture.remove();
-    app.destroy();
   });
 
   describe("Filter Tests", () => {

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -1,8 +1,7 @@
-import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import { setCellContent } from "../test_helpers/commands_helpers";
 import { click, setInputValueAndTrigger } from "../test_helpers/dom_helper";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
 let model: Model;
@@ -33,18 +32,13 @@ const selectors = {
 describe("find and replace sidePanel component", () => {
   let fixture: HTMLElement;
   let parent: Spreadsheet;
-  let app: App;
+
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent, model } = await mountSpreadsheet(fixture));
+    ({ parent, model, fixture } = await mountSpreadsheet());
     parent.env.openSidePanel("FindAndReplace");
     await nextTick();
   });
 
-  afterEach(() => {
-    fixture.remove();
-    app.destroy();
-  });
   describe("Sidepanel", () => {
     test("Can close the find and replace side panel", async () => {
       expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -1,9 +1,7 @@
-import { App } from "@odoo/owl";
 import { args, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import {
   clearFunctions,
-  makeTestFixture,
   mountSpreadsheet,
   nextTick,
   restoreDefaultFunctions,
@@ -16,21 +14,14 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 let model: Model;
 let composerEl: Element;
 let fixture: HTMLElement;
-let app: App;
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, model } = await mountSpreadsheet(fixture));
+  ({ model, fixture } = await mountSpreadsheet());
 
   // start composition
   document.querySelector(".o-grid")!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
   await nextTick();
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
-});
-
-afterEach(() => {
-  app.destroy();
-  fixture.remove();
 });
 
 describe("formula assistant", () => {

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Spreadsheet, TransportService } from "../../src";
 import {
   BACKGROUND_GRAY_COLOR,
@@ -49,7 +48,7 @@ import {
   getSelectionAnchorCellXc,
   getStyle,
 } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick, Touch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, Touch } from "../test_helpers/helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
 import { mockChart } from "./__mocks__/chart";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
@@ -69,27 +68,12 @@ function getHorizontalScroll(): number {
 let fixture: HTMLElement;
 let model: Model;
 let parent: Spreadsheet;
-let app: App;
 
 jest.useFakeTimers();
 
-beforeEach(async () => {
-  fixture = makeTestFixture();
-});
-
-afterEach(() => {
-  fixture.remove();
-});
-
 describe("Grid component", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent, model } = await mountSpreadsheet(fixture));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
 
   test("simple rendering snapshot", async () => {
@@ -781,14 +765,9 @@ describe("Multi User selection", () => {
   let transportService: TransportService;
   beforeEach(async () => {
     transportService = new MockTransportService();
-    fixture = makeTestFixture();
-    model = new Model({}, { transportService });
-    ({ app, parent } = await mountSpreadsheet(fixture, { model }));
-  });
 
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    model = new Model({}, { transportService });
+    ({ parent, fixture } = await mountSpreadsheet({ model }));
   });
 
   test("Do not render multi user selection with invalid sheet", async () => {
@@ -835,12 +814,11 @@ describe("Multi User selection", () => {
 describe("error tooltip", () => {
   beforeEach(async () => {
     jest.useFakeTimers();
-    ({ app, parent, model } = await mountSpreadsheet(fixture));
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
 
   afterEach(() => {
     jest.useRealTimers();
-    app.destroy();
   });
 
   test("can display error on A1", async () => {
@@ -912,13 +890,9 @@ describe("error tooltip", () => {
 
 describe("Events on Grid update viewport correctly", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent, model } = await mountSpreadsheet(fixture));
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
-  });
+
   test("Vertical scroll", async () => {
     fixture.querySelector(".o-grid")!.dispatchEvent(new WheelEvent("wheel", { deltaY: 1200 }));
     await nextTick();
@@ -1320,13 +1294,8 @@ describe("Events on Grid update viewport correctly", () => {
 describe("Edge-Scrolling on mouseMove in selection", () => {
   beforeEach(async () => {
     jest.useFakeTimers();
-    fixture = makeTestFixture();
-    ({ app, parent, model } = await mountSpreadsheet(fixture));
-  });
 
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
 
   test("Can edge-scroll horizontally", async () => {
@@ -1408,15 +1377,9 @@ describe("Copy paste keyboard shortcut", () => {
   let sheetId: string;
 
   beforeEach(async () => {
-    fixture = makeTestFixture();
     clipboardData = new MockClipboardData();
-    ({ app, parent, model } = await mountSpreadsheet(fixture));
+    ({ parent, model, fixture } = await mountSpreadsheet());
     sheetId = model.getters.getActiveSheetId();
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
   });
 
   test("Can paste from OS", async () => {

--- a/tests/components/grid_manipulation.test.ts
+++ b/tests/components/grid_manipulation.test.ts
@@ -1,11 +1,10 @@
-import { App } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { Model } from "../../src/model";
 import { selectColumn, selectRow } from "../test_helpers/commands_helpers";
 import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 
 const COLUMN_D = { x: 340, y: 10 };
 const ROW_5 = { x: 30, y: 100 };
@@ -14,16 +13,9 @@ const OUTSIDE_CM = { x: 50, y: 50 };
 let fixture: HTMLElement;
 let model: Model;
 let parent: Spreadsheet;
-let app: App;
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, parent, model } = await mountSpreadsheet(fixture));
-});
-
-afterEach(() => {
-  app.destroy();
-  fixture.remove();
+  ({ parent, model, fixture } = await mountSpreadsheet());
 });
 
 function simulateContextMenu(selector: string, coord: { x: number; y: number }) {

--- a/tests/components/highlight.test.ts
+++ b/tests/components/highlight.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, useSubEnv, xml } from "@odoo/owl";
+import { Component, useSubEnv, xml } from "@odoo/owl";
 import { Highlight } from "../../src/components/highlight/highlight/highlight";
 import {
   DEFAULT_CELL_HEIGHT,
@@ -8,11 +8,10 @@ import {
 import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { DispatchResult } from "../../src/types/commands";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { merge } from "../test_helpers/commands_helpers";
 import { edgeScrollDelay, triggerMouseEvent } from "../test_helpers/dom_helper";
 import {
-  makeTestFixture,
+  mountComponent,
   mountSpreadsheet,
   nextTick,
   startGridComposition,
@@ -100,9 +99,7 @@ async function moveToCell(el: Element, xc: string) {
 }
 
 let model: Model;
-let app: App;
 let fixture: HTMLElement;
-let parent: Parent;
 let cornerEl: Element;
 let borderEl: Element;
 
@@ -124,13 +121,14 @@ class Parent extends Component {
 }
 
 async function mountHighlight(zone: string, color: string): Promise<Parent> {
-  app = new App(Parent, { props: { zone: toZone(zone), color, model } });
-  app.addTemplates(OWL_TEMPLATES);
-  return await app.mount(fixture);
+  let parent: Component;
+  ({ fixture, parent } = await mountComponent(Parent, {
+    props: { zone: toZone(zone), color, model },
+  }));
+  return parent as Parent;
 }
 
 const genericBeforeEach = async () => {
-  fixture = makeTestFixture();
   model = new Model();
   model.dispatch("RESIZE_SHEETVIEW", {
     width: DEFAULT_SHEETVIEW_SIZE,
@@ -140,17 +138,11 @@ const genericBeforeEach = async () => {
   });
 };
 
-const genericAfterEach = () => {
-  app.destroy();
-  fixture.remove();
-};
-
 describe("Corner component", () => {
   beforeEach(genericBeforeEach);
-  afterEach(genericAfterEach);
   describe("can drag all corners", () => {
     test("start on nw corner", async () => {
-      parent = await mountHighlight("B2", "#666");
+      await mountHighlight("B2", "#666");
       cornerEl = fixture.querySelector(".o-corner-nw")!;
 
       // select B2 nw corner
@@ -166,7 +158,7 @@ describe("Corner component", () => {
     });
 
     test("start on ne corner", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       cornerEl = fixture.querySelector(".o-corner-ne")!;
 
       // select B2 ne corner
@@ -183,7 +175,7 @@ describe("Corner component", () => {
     });
 
     test("start on sw corner", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       cornerEl = fixture.querySelector(".o-corner-sw")!;
 
       // select B2 sw corner
@@ -200,7 +192,7 @@ describe("Corner component", () => {
     });
 
     test("start on se corner", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       cornerEl = fixture.querySelector(".o-corner-se")!;
 
       // select B2 se corner
@@ -218,7 +210,7 @@ describe("Corner component", () => {
   });
 
   test("do nothing if drag outside the grid", async () => {
-    parent = await mountHighlight("A1", "#666");
+    const parent = await mountHighlight("A1", "#666");
     cornerEl = fixture.querySelector(".o-corner-nw")!;
 
     // select A1 nw corner
@@ -240,7 +232,7 @@ describe("Corner component", () => {
 
   test("drag highlight corner on merged cells expands the final highlight zone", async () => {
     merge(model, "B1:C1");
-    parent = await mountHighlight("B2", "#666");
+    const parent = await mountHighlight("B2", "#666");
     cornerEl = fixture.querySelector(".o-corner-nw")!;
 
     // select B2 se corner
@@ -264,7 +256,7 @@ describe("Corner component", () => {
       elements: [0, 1],
       size: width / 2,
     });
-    parent = await mountHighlight("B1", "#666");
+    const parent = await mountHighlight("B1", "#666");
     cornerEl = fixture.querySelector(".o-corner-nw")!;
 
     // select B1 nw corner
@@ -289,7 +281,7 @@ describe("Corner component", () => {
       elements: [0, 1],
       size: height / 2,
     });
-    parent = await mountHighlight("A2", "#666");
+    const parent = await mountHighlight("A2", "#666");
     cornerEl = fixture.querySelector(".o-corner-nw")!;
 
     // select A2 nw corner
@@ -309,10 +301,9 @@ describe("Corner component", () => {
 
 describe("Border component", () => {
   beforeEach(genericBeforeEach);
-  afterEach(genericAfterEach);
   describe("can drag all borders", () => {
     test("start on top border", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       borderEl = fixture.querySelector(".o-border-n")!;
 
       // select B2 top border
@@ -329,7 +320,7 @@ describe("Border component", () => {
     });
 
     test("start on left border", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       borderEl = fixture.querySelector(".o-border-w")!;
 
       // select B2 left border
@@ -346,7 +337,7 @@ describe("Border component", () => {
     });
 
     test("start on right border", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       borderEl = fixture.querySelector(".o-border-w")!;
 
       // select B2 right border
@@ -363,7 +354,7 @@ describe("Border component", () => {
     });
 
     test("start on bottom border", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       borderEl = fixture.querySelector(".o-border-w")!;
 
       // select B2 bottom border
@@ -381,7 +372,7 @@ describe("Border component", () => {
   });
 
   test("drag the A1:B2 highlight, start on A1 top border, finish on C1 --> set C1:D2 highlight", async () => {
-    parent = await mountHighlight("A1:B2", "#666");
+    const parent = await mountHighlight("A1:B2", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select A1 top border
@@ -404,7 +395,7 @@ describe("Border component", () => {
   });
 
   test("drag the A1:B2 highlight, start on B1 top border, finish on C1 --> set B1:C2 highlight", async () => {
-    parent = await mountHighlight("A1:B2", "#666");
+    const parent = await mountHighlight("A1:B2", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select B1 top border
@@ -421,7 +412,7 @@ describe("Border component", () => {
   });
 
   test("cannot drag highlight zone if already beside limit border", async () => {
-    parent = await mountHighlight("A1:B2", "#666");
+    const parent = await mountHighlight("A1:B2", "#666");
     borderEl = fixture.querySelector(".o-border-s")!;
 
     // select B2 bottom border
@@ -437,7 +428,7 @@ describe("Border component", () => {
 
   test("drag highlight order on merged cells expands the final highlight zone", async () => {
     merge(model, "B1:C1");
-    parent = await mountHighlight("A1", "#666");
+    const parent = await mountHighlight("A1", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select A1 top border
@@ -455,7 +446,7 @@ describe("Border component", () => {
 
   test("drag highlight on merged cells expands the highlight zone", async () => {
     merge(model, "B1:C1");
-    parent = await mountHighlight("A1", "#666");
+    const parent = await mountHighlight("A1", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select A1 top border
@@ -479,7 +470,7 @@ describe("Border component", () => {
       elements: [0, 1],
       size: width / 2,
     });
-    parent = await mountHighlight("B1", "#666");
+    const parent = await mountHighlight("B1", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select B1 top border
@@ -504,7 +495,7 @@ describe("Border component", () => {
       elements: [0, 1],
       size: height / 2,
     });
-    parent = await mountHighlight("A2", "#666");
+    const parent = await mountHighlight("A2", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select A2 top border
@@ -525,17 +516,12 @@ describe("Border component", () => {
 describe("Edge-Scrolling on mouseMove of hightlights", () => {
   beforeEach(async () => {
     jest.useFakeTimers();
-    fixture = makeTestFixture();
-    ({ app, model } = await mountSpreadsheet(fixture));
+    ({ model, fixture } = await mountSpreadsheet());
     // ensure that highlights exist
     await startGridComposition();
     await typeInComposerGrid("=A1");
   });
 
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
-  });
   test("Can edge-scroll border horizontally", async () => {
     const { width } = model.getters.getSheetViewDimensionWithHeaders();
     const y = DEFAULT_CELL_HEIGHT;

--- a/tests/components/link/link_display.test.ts
+++ b/tests/components/link/link_display.test.ts
@@ -1,26 +1,18 @@
-import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../../src";
 import { buildSheetLink } from "../../../src/helpers";
 import { clearCell, createSheet, merge, setCellContent } from "../../test_helpers/commands_helpers";
 import { clickCell, hoverCell, rightClickCell, simulateClick } from "../../test_helpers/dom_helper";
 import { getCell, getEvaluatedCell } from "../../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+import { mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
 
 describe("link display component", () => {
   let fixture: HTMLElement;
   let model: Model;
-  let app: App;
   let parent: Spreadsheet;
 
   beforeEach(async () => {
     jest.useFakeTimers();
-    fixture = makeTestFixture();
-    ({ app, parent, model } = await mountSpreadsheet(fixture));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
 
   test("simple snapshot", async () => {

--- a/tests/components/link/link_editor.test.ts
+++ b/tests/components/link/link_editor.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Model } from "../../../src";
 import { buildSheetLink } from "../../../src/helpers";
 import {
@@ -14,7 +13,7 @@ import {
   simulateClick,
 } from "../../test_helpers/dom_helper";
 import { getCell, getEvaluatedCell } from "../../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+import { mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../../test_helpers/mock_helpers";
 
 mockGetBoundingClientRect({
@@ -24,7 +23,6 @@ mockGetBoundingClientRect({
 describe("link editor component", () => {
   let fixture: HTMLElement;
   let model: Model;
-  let app: App;
 
   async function openLinkEditor(model: Model, xc: string) {
     await rightClickCell(model, xc);
@@ -46,13 +44,7 @@ describe("link editor component", () => {
   }
 
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, model } = await mountSpreadsheet(fixture));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ model, fixture } = await mountSpreadsheet());
   });
 
   test("open link editor from cell context menu", async () => {

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { ColResizer, RowResizer } from "../../src/components/headers_overlay/headers_overlay";
 import {
   DEFAULT_CELL_HEIGHT,
@@ -25,11 +24,10 @@ import {
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import { getEvaluatedCell, getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let model: Model;
-let app: App;
 
 ColResizer.prototype._getMaxSize = () => 1000;
 RowResizer.prototype._getMaxSize = () => 1000;
@@ -138,7 +136,6 @@ async function dblClickRow(index: number) {
 
 describe("Resizer component", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
     const data = {
       sheets: [
         {
@@ -148,12 +145,7 @@ describe("Resizer component", () => {
       ],
     };
     model = new Model(data);
-    ({ app } = await mountSpreadsheet(fixture, { model }));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ fixture } = await mountSpreadsheet({ model }));
   });
 
   test("can click on a header to select a column", async () => {
@@ -751,14 +743,10 @@ describe("Resizer component", () => {
 describe("Edge-Scrolling on mouseMove in selection", () => {
   beforeEach(async () => {
     jest.useFakeTimers();
-    fixture = makeTestFixture();
-    ({ app, model } = await mountSpreadsheet(fixture));
+
+    ({ model, fixture } = await mountSpreadsheet());
   });
 
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
-  });
   test("Can edge-scroll horizontally", async () => {
     const { width } = model.getters.getSheetViewDimension();
     const y = DEFAULT_CELL_HEIGHT;
@@ -829,7 +817,6 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
 
 describe("move selected element(s)", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
     const data = {
       sheets: [
         {
@@ -840,12 +827,7 @@ describe("move selected element(s)", () => {
       ],
     };
     model = new Model(data);
-    ({ app } = await mountSpreadsheet(fixture, { model }));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ fixture } = await mountSpreadsheet({ model }));
   });
 
   test("select the last selected cols/rows keep all selected zone active", async () => {

--- a/tests/components/popover.test.ts
+++ b/tests/components/popover.test.ts
@@ -2,8 +2,7 @@ import { App, Component, useSubEnv, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { Popover, PopoverProps } from "../../src/components/popover/popover";
 import { Pixel, Rect } from "../../src/types";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
-import { getStylePropertyInPx, makeTestFixture } from "../test_helpers/helpers";
+import { getStylePropertyInPx, mountComponent } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
 const POPOVER_HEIGHT = 200;
@@ -51,9 +50,7 @@ async function mountTestPopover(args: MountPopoverArgs) {
     }
   }
 
-  app = new App(Parent, { props: { model } });
-  app.addTemplates(OWL_TEMPLATES);
-  await app.mount(fixture);
+  ({ fixture, app } = await mountComponent(Parent, { props: { model } }));
 }
 
 mockGetBoundingClientRect({
@@ -71,13 +68,7 @@ mockGetBoundingClientRect({
 });
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
   model = new Model();
-});
-
-afterEach(() => {
-  app?.destroy();
-  fixture.remove();
 });
 
 describe("Popover sizing", () => {

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Model } from "../../src";
 import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH } from "../../src/constants";
 import { toHex } from "../../src/helpers";
@@ -11,14 +10,12 @@ import {
 } from "../test_helpers/commands_helpers";
 import { dragElement, getElComputedStyle, simulateClick } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let model: Model;
 let chartId: string;
 let sheetId: string;
-
-let app: App;
 
 const figureRect: Rect = { x: 0, y: 0, width: 0, height: 0 };
 const defaultRect = { x: 0, y: 0, width: DEFAULT_FIGURE_WIDTH, height: DEFAULT_FIGURE_HEIGHT };
@@ -110,7 +107,6 @@ function getChartBaselineTextContent() {
 
 describe("Scorecard charts", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
     chartId = "someuuid";
     sheetId = "Sheet1";
     const data = {
@@ -131,13 +127,11 @@ describe("Scorecard charts", () => {
         },
       ],
     };
-    ({ app, model } = await mountSpreadsheet(fixture, { model: new Model(data) }));
+    ({ model, fixture } = await mountSpreadsheet({ model: new Model(data) }));
     Object.assign(figureRect, defaultRect);
   });
 
   afterEach(() => {
-    app.destroy();
-    fixture.remove();
     Object.assign(figureRect, defaultRect);
   });
 

--- a/tests/components/side_panel.test.ts
+++ b/tests/components/side_panel.test.ts
@@ -1,13 +1,12 @@
-import { App, Component, xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import { sidePanelRegistry } from "../../src/registries/index";
 import { SidePanelContent } from "../../src/registries/side_panel_registry";
 import { simulateClick } from "../test_helpers/dom_helper";
-import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let parent: Spreadsheet;
-let app: App;
 let sidePanelContent: { [key: string]: SidePanelContent };
 
 class Body extends Component<any, any> {
@@ -27,14 +26,11 @@ class Body2 extends Component<any, any> {
 }
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, parent } = await mountSpreadsheet(fixture));
+  ({ parent, fixture } = await mountSpreadsheet());
   sidePanelContent = Object.assign({}, sidePanelRegistry.content);
 });
 
 afterEach(() => {
-  app.destroy();
-  fixture.remove();
   sidePanelRegistry.content = sidePanelContent;
 });
 

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Model } from "../../src";
 import { Spreadsheet } from "../../src/components";
 import { args, functionRegistry } from "../../src/functions";
@@ -21,7 +20,6 @@ import {
 } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
 import {
-  makeTestFixture,
   mountSpreadsheet,
   nextTick,
   restoreDefaultFunctions,
@@ -38,20 +36,13 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 let fixture: HTMLElement;
 let parent: Spreadsheet;
 let model: Model;
-let app: App;
 
 describe("Simple Spreadsheet Component", () => {
   // default model and env
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, model, parent } = await mountSpreadsheet(fixture, {
+    ({ model, parent, fixture } = await mountSpreadsheet({
       model: new Model({ sheets: [{ id: "sh1" }] }),
     }));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
   });
 
   test("simple rendering snapshot", async () => {
@@ -93,7 +84,7 @@ describe("Simple Spreadsheet Component", () => {
     });
 
     test("Can use an external dependency in a function at model start", async () => {
-      await mountSpreadsheet(fixture, {
+      await mountSpreadsheet({
         model: new Model(
           {
             version: 2,
@@ -217,29 +208,23 @@ describe("Simple Spreadsheet Component", () => {
 
 test("Can instantiate a spreadsheet with a given client id-name", async () => {
   const client = { id: "alice", name: "Alice" };
-  fixture = makeTestFixture();
-  ({ app, parent, model } = await mountSpreadsheet(fixture, {
+
+  ({ parent, model, fixture } = await mountSpreadsheet({
     model: new Model({}, { client }),
   }));
   expect(model.getters.getClient()).toEqual(client);
-  app.destroy();
-  fixture.remove();
 });
 
 test("Spreadsheet detects frozen panes that exceed the limit size at start", async () => {
   const notifyUser = jest.fn();
-  fixture = makeTestFixture();
   const model = new Model({ sheets: [{ panes: { xSplit: 12, ySplit: 50 } }] });
-  ({ app, parent } = await mountSpreadsheet(fixture, { model }, { notifyUser }));
+  ({ parent, fixture } = await mountSpreadsheet({ model }, { notifyUser }));
   expect(notifyUser).toHaveBeenCalled();
-  app.destroy();
-  fixture.remove();
 });
 
 test("Warn user only once when the viewport is too small for its frozen panes", async () => {
   const notifyUser = jest.fn();
-  fixture = makeTestFixture();
-  ({ app, parent, model } = await mountSpreadsheet(fixture, undefined, { notifyUser }));
+  ({ parent, model, fixture } = await mountSpreadsheet(undefined, { notifyUser }));
   expect(notifyUser).not.toHaveBeenCalled();
   freezeRows(model, 51);
   await nextTick();
@@ -258,19 +243,13 @@ test("Warn user only once when the viewport is too small for its frozen panes", 
   freezeRows(model, 51);
   await nextTick();
   expect(notifyUser).toHaveBeenCalledTimes(2);
-  app.destroy();
-  fixture.remove();
 });
 
 test("Notify ui correctly with type notification correctly use notifyUser in the env", async () => {
   const raiseError = jest.fn();
-  fixture = makeTestFixture();
-  ({ app, model } = await mountSpreadsheet(fixture, undefined, { raiseError }));
-  await app.mount(fixture);
+  ({ model, fixture } = await mountSpreadsheet(undefined, { raiseError }));
   model["config"].notifyUI({ type: "ERROR", text: "hello" });
   expect(raiseError).toHaveBeenCalledWith("hello");
-  fixture.remove();
-  app.destroy();
 });
 
 describe("Composer / selectionInput interactions", () => {
@@ -290,15 +269,9 @@ describe("Composer / selectionInput interactions", () => {
     ],
   };
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, model, parent } = await mountSpreadsheet(fixture, {
+    ({ model, parent, fixture } = await mountSpreadsheet({
       model: new Model(modelDataCf),
     }));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
   });
 
   test("Switching from selection input to composer should update the highlihts", async () => {

--- a/tests/menu_item_insert_chart.test.ts
+++ b/tests/menu_item_insert_chart.test.ts
@@ -1,5 +1,4 @@
-import { App } from "@odoo/owl";
-import { Model, Spreadsheet } from "../src";
+import { Model } from "../src";
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
@@ -22,7 +21,6 @@ import {
 import {
   doAction,
   makeTestEnv,
-  makeTestFixture,
   mockChart,
   mountSpreadsheet,
   nextTick,
@@ -84,7 +82,6 @@ describe("Insert chart menu item", () => {
   let dispatchSpy: jest.SpyInstance;
   let defaultPayload: any;
   let model: Model;
-  let app: App;
   let env: SpreadsheetChildEnv;
   let openSidePanelSpy: jest.Mock<any, any>;
 
@@ -93,11 +90,7 @@ describe("Insert chart menu item", () => {
   }
 
   async function mountTestSpreadsheet() {
-    const fixture = makeTestFixture();
-    let parent: Spreadsheet;
-    ({ app, model, parent } = await mountSpreadsheet(fixture, { model: new Model(data) }));
-    env = parent.env;
-    model = env.model;
+    ({ model, env, model } = await mountSpreadsheet({ model: new Model(data) }));
     dispatchSpy = spyModelDispatch(model);
   }
 
@@ -128,10 +121,6 @@ describe("Insert chart menu item", () => {
         verticalAxisPosition: "left",
       },
     };
-  });
-
-  afterEach(() => {
-    app?.destroy();
   });
 
   test("Chart is inserted at correct position", () => {

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../src";
 import { fontSizes } from "../src/fonts";
 import { zoneToXc } from "../src/helpers";
@@ -25,7 +24,6 @@ import {
   getName,
   getNode,
   makeTestEnv,
-  makeTestFixture,
   mockUuidV4To,
   mountSpreadsheet,
   nextTick,
@@ -95,22 +93,14 @@ describe("Menu Item Registry", () => {
 });
 
 describe("Menu Item actions", () => {
-  let fixture: HTMLElement;
   let model: Model;
   let parent: Spreadsheet;
-  let app: App;
   let env: SpreadsheetChildEnv;
   let dispatch;
 
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent, model } = await mountSpreadsheet(fixture));
-    env = parent.env;
+    ({ parent, model, env } = await mountSpreadsheet());
     dispatch = spyDispatch(parent);
-  });
-
-  afterEach(() => {
-    app.destroy();
   });
 
   test("Edit -> undo", () => {

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -1,9 +1,6 @@
-import { App, Component, useSubEnv, xml } from "@odoo/owl";
-import { Spreadsheet } from "../../src";
 import { toCartesian, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { CommandResult } from "../../src/types/index";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import {
   addColumns,
   deleteRows,
@@ -19,7 +16,6 @@ import {
   undo,
   unMerge,
 } from "../test_helpers/commands_helpers";
-import { simulateClick } from "../test_helpers/dom_helper";
 import {
   getBorder,
   getCell,
@@ -29,14 +25,7 @@ import {
   getSelectionAnchorCellXc,
   getStyle,
 } from "../test_helpers/getters_helpers";
-import {
-  getChildFromComponent,
-  getMergeCellMap,
-  makeTestFixture,
-  nextTick,
-  target,
-  XCToMergeCellMap,
-} from "../test_helpers/helpers";
+import { getMergeCellMap, target, XCToMergeCellMap } from "../test_helpers/helpers";
 
 function getCellsXC(model: Model): string[] {
   return Object.values(model.getters.getCells(model.getters.getActiveSheetId())).map((cell) => {
@@ -308,40 +297,6 @@ describe("merges", () => {
       styles: { 1: {} },
     });
     expect(merge(model, "A1:C4")).toBeSuccessfullyDispatched();
-  });
-
-  test("merging destructively a selection ask for confirmation", async () => {
-    const askConfirmation = jest.fn();
-    class Parent extends Component<any> {
-      static template = xml/* xml */ `<Spreadsheet model="_model"/>`;
-      static components = { Spreadsheet };
-      private _model!: Model;
-      setup() {
-        this._model = new Model();
-        useSubEnv({
-          askConfirmation,
-        });
-      }
-
-      get spreadsheet(): Spreadsheet {
-        return getChildFromComponent(this, Spreadsheet);
-      }
-
-      get model(): Model {
-        return this._model;
-      }
-    }
-    const fixture = makeTestFixture();
-    const app = new App(Parent);
-    app.addTemplates(OWL_TEMPLATES);
-    const parent = await app.mount(fixture);
-    const model = parent.model;
-    setCellContent(model, "B2", "b2");
-
-    setAnchorCorner(model, "F6");
-    await nextTick();
-    await simulateClick(".o-merge-tool");
-    expect(askConfirmation).toHaveBeenCalled();
   });
 
   test("merging cells with values will do nothing if not forced", () => {

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -35,4 +35,18 @@ beforeEach(() => {
 afterEach(() => {
   //@ts-ignore
   global.resizers.removeAll();
+  executeCleanups();
 });
+
+const cleanUps: (() => void)[] = [];
+
+export function registerCleanup(cleanupFn: () => void) {
+  cleanUps.push(cleanupFn);
+}
+
+function executeCleanups() {
+  let cleanupFn: (() => void) | undefined;
+  while ((cleanupFn = cleanUps.pop())) {
+    cleanupFn();
+  }
+}


### PR DESCRIPTION
Change the parameters of the owl `App` in the test. The `App` will now
be mounted in test mode. The main purpose is to enable props validation,
which ensure that the test is close to the reality, and avoid tests
failing for unclear reasons because a props was missing (https://github.com/odoo/o-spreadsheet/commit/d4663158d7f82af870409e2508be6fa161d1921c).

The Owl test mode is equivalent to dev mode, but without warning that
the app is unsuited for production. Documentation here :
https://github.com/odoo/owl/blob/master/doc/reference/app.md#dev-mode

Also added an helper `mountComponent` and modified the existing helper
`mountSpreadsheet`. The helper now creates and returns the fixture in which
the component is mounted. They also register cleanup functions to remove
the fixture and destroy the app, so we don't have to do it manually.
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo