### PR TITLE
[FIX] FigureContainer: Do not update figure when not dragged

### DIFF
--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -249,6 +249,9 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
       this.dnd.y = Math.max(dndInitialY + deltaY, minY);
     };
     const onMouseUp = (ev: MouseEvent) => {
+      if (!this.dnd.figId) {
+        return;
+      }
       let { x, y } = this.screenCoordinatesToInternal(this.dnd);
       this.dnd.figId = undefined;
       this.env.model.dispatch("UPDATE_FIGURE", { sheetId, id: figure.id, x, y });
@@ -283,6 +286,9 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
     };
 
     const onMouseUp = (ev: MouseEvent) => {
+      if (!this.dnd.figId) {
+        return;
+      }
       this.dnd.figId = undefined;
       let { x, y } = this.screenCoordinatesToInternal(this.dnd);
       const update: Partial<Figure> = { x, y };

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -269,6 +269,23 @@ describe("figures", () => {
     expect(model.getters.getFigure(sheetId, figureId)).toMatchObject(expectedSize);
   });
 
+  test("clicking the sheet without dragging it does not update the figure", async () => {
+    const spyDispatch = jest.spyOn(model, "dispatch");
+    createFigure(model);
+    await nextTick();
+    await simulateClick(".o-figure");
+    expect(spyDispatch).not.toHaveBeenLastCalledWith("UPDATE_FIGURE", expect.anything());
+  });
+
+  test("clicking the resizers without dragging it does not update the figure", async () => {
+    const spyDispatch = jest.spyOn(model, "dispatch");
+    createFigure(model);
+    await nextTick();
+    await simulateClick(".o-figure");
+    await simulateClick(".o-fig-anchor.o-top");
+    expect(spyDispatch).not.toHaveBeenLastCalledWith("UPDATE_FIGURE", expect.anything());
+  });
+
   describe("Move a figure with drag & drop ", () => {
     test("Can move a figure with drag & drop", async () => {
       createFigure(model, { id: "someuuid", x: 200, y: 100 });


### PR DESCRIPTION
Following 29fbbdd9, we now properly support the drag and dropping of figures while moving them through frozen panes and while scrolling. This was made possible by putting the active figure in a dedicated container and apply some coordinate tranformation at drag & drop.

Unfortunately, we apply the "drop" callback even if the figure was not dragged (e.g. we apply `mouseUp` even without `mouseMove`) and with the coordinate transformation it would lead to strange results.

e.g.
- Setup a sheet with frozen panes.
- put a figure in the bottom right pane
- scroll the viewport such taht the figure is partially visible
- select the figure (only a click) -> the figure has now been moved in the frozen pane

This revision ensures that we only update the figure when a `mouseMove` occured priorly.

task 3169099

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo