### PR TITLE
[FIX] selection input: dynamic highlights

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -1,4 +1,12 @@
-import { Component, onMounted, onPatched, onWillUnmount, useState } from "@odoo/owl";
+import {
+  Component,
+  onMounted,
+  onPatched,
+  onWillUnmount,
+  useEffect,
+  useRef,
+  useState,
+} from "@odoo/owl";
 import { SELECTION_BORDER_COLOR } from "../../constants";
 import { UuidGenerator } from "../../helpers/index";
 import { RangeInputValue } from "../../plugins/ui_feature/selection_input";
@@ -93,6 +101,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     isMissing: false,
     mode: "select-range",
   });
+  private focusedInput = useRef("focusedInput");
 
   get ranges(): SelectionRange[] {
     const existingSelectionRange = this.env.model.getters.getSelectionInput(this.id);
@@ -124,6 +133,10 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
   }
 
   setup() {
+    useEffect(
+      () => this.focusedInput.el?.focus(),
+      () => [this.focusedInput.el]
+    );
     onMounted(() => this.enableNewSelectionInput());
     onWillUnmount(async () => this.disableNewSelectionInput());
     onPatched(() => this.checkChange());
@@ -170,6 +183,9 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
         ev.preventDefault();
         updateSelectionWithArrowKeys(ev, this.env.model.selection);
       }
+    } else if (ev.key === "Enter") {
+      const target = ev.target as HTMLInputElement;
+      target.blur();
     }
   }
 
@@ -199,7 +215,6 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
       rangeId,
       value: target.value,
     });
-    target.blur();
     this.triggerChange();
   }
 

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -10,7 +10,7 @@
         <input
           type="text"
           spellcheck="false"
-          t-on-change="(ev) => this.onInputChanged(range.id, ev)"
+          t-on-input="(ev) => this.onInputChanged(range.id, ev)"
           t-on-focus="() => this.focus(range.id)"
           t-on-keydown="onKeydown"
           t-att-value="range.xc"
@@ -22,6 +22,7 @@
             'o-invalid': isInvalid || !range.isValidRange,
             'text-decoration-underline': range.isFocused and state.mode === 'select-range'
           }"
+          t-ref="{{range.isFocused ? 'focused' : 'unfocused'}}Input"
         />
         <button
           class="o-btn o-remove-selection"

--- a/src/plugins/ui_feature/selection_input.ts
+++ b/src/plugins/ui_feature/selection_input.ts
@@ -83,7 +83,8 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
           this.focus(index);
         }
         if (index !== null) {
-          const values = cmd.value.split(",").map((reference) => reference.trim());
+          const valueWithoutLeadingComma = cmd.value.replace(/^,+/, "");
+          const values = valueWithoutLeadingComma.split(",").map((reference) => reference.trim());
           this.setRange(index, values);
         }
         break;
@@ -181,13 +182,14 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
    * Insert new inputs after the given index.
    */
   private insertNewRange(index: number, values: string[]) {
+    const currentMaxId = Math.max(0, ...this.ranges.map((range) => Number(range.id)));
     this.ranges.splice(
       index,
       0,
       ...values.map((xc, i) => ({
         xc,
-        id: (this.ranges.length + i + 1).toString(),
-        color: colors[(this.ranges.length + i) % colors.length],
+        id: (currentMaxId + i + 1).toString(),
+        color: colors[(currentMaxId + 1 + i) % colors.length],
       }))
     );
   }

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -216,7 +216,7 @@ describe("figures", () => {
           });
           break;
         case "scorecard":
-          setInputValueAndTrigger(dataSeriesValues, "B2:B4", "change");
+          setInputValueAndTrigger(dataSeriesValues, "B2:B4", "input");
           expect(dispatch).toHaveBeenLastCalledWith("CHANGE_RANGE", {
             value: "B2:B4",
             id: expect.anything(),
@@ -334,7 +334,7 @@ describe("figures", () => {
       parent.env.openSidePanel("ChartPanel");
       await nextTick();
       await simulateClick(domClass + " input");
-      setInputValueAndTrigger(domClass + " input", "", "change");
+      setInputValueAndTrigger(domClass + " input", "", "input");
       await nextTick();
       await simulateClick(domClass + " .o-selection-ok");
       expect(
@@ -462,7 +462,7 @@ describe("figures", () => {
     await simulateClick(".o-menu div[data-name='edit']");
     await simulateClick(".o-data-series .o-add-selection");
     const element = document.querySelectorAll(".o-data-series input")[1];
-    setInputValueAndTrigger(element, "C1:C4", "change");
+    setInputValueAndTrigger(element, "C1:C4", "input");
     await nextTick();
     await simulateClick(".o-data-series .o-selection-ok");
     expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
@@ -491,7 +491,7 @@ describe("figures", () => {
         await simulateClick(".o-menu div[data-name='edit']");
 
         await simulateClick(".o-data-labels input");
-        setInputValueAndTrigger(".o-data-labels input", "", "change");
+        setInputValueAndTrigger(".o-data-labels input", "", "input");
         await nextTick();
         await simulateClick(".o-data-labels .o-selection-ok");
 
@@ -517,7 +517,7 @@ describe("figures", () => {
         await simulateClick(".o-figure-menu-item");
         await simulateClick(".o-menu div[data-name='edit']");
         await simulateClick(".o-data-series input");
-        setInputValueAndTrigger(".o-data-series input", "This is not valid", "change");
+        setInputValueAndTrigger(".o-data-series input", "This is not valid", "input");
         await nextTick();
         await simulateClick(".o-data-series .o-selection-ok");
         expect(errorMessages()).toEqual(
@@ -539,7 +539,7 @@ describe("figures", () => {
         await simulateClick(".o-figure-menu-item");
         await simulateClick(".o-menu div[data-name='edit']");
         await simulateClick(".o-data-labels input");
-        setInputValueAndTrigger(".o-data-labels input", "this is not valid", "change");
+        setInputValueAndTrigger(".o-data-labels input", "this is not valid", "input");
         await nextTick();
         await simulateClick(".o-data-labels .o-selection-ok");
         expect(errorMessages()).toEqual(
@@ -643,7 +643,7 @@ describe("figures", () => {
 
       // empty dataset/key value
       await simulateClick(".o-data-series input");
-      setInputValueAndTrigger(".o-data-series input", "", "change");
+      setInputValueAndTrigger(".o-data-series input", "", "input");
       await nextTick();
       await simulateClick(".o-data-series .o-selection-ok");
       expect(document.querySelector(".o-data-series input")?.classList).toContain("o-invalid");
@@ -651,7 +651,7 @@ describe("figures", () => {
 
       // invalid labels/baseline
       await simulateClick(".o-data-labels input");
-      setInputValueAndTrigger(".o-data-labels input", "Invalid Label Range", "change");
+      setInputValueAndTrigger(".o-data-labels input", "Invalid Label Range", "input");
       await simulateClick(".o-data-labels .o-selection-ok");
       expect(document.querySelector(".o-data-series input")?.classList).toContain("o-invalid");
       expect(document.querySelector(".o-data-labels input")?.classList).toContain("o-invalid");

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -237,7 +237,7 @@ describe("UI of conditional formats", () => {
       await click(fixture.querySelectorAll(selectors.listPreview)[1]);
       await nextTick();
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
 
       await click(fixture, selectors.colorScaleEditor.minColor);
       await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
@@ -293,7 +293,7 @@ describe("UI of conditional formats", () => {
       await nextTick();
 
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "A1:A3", "change");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "A1:A3", "input");
       setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
       await nextTick();
       setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3", "input");
@@ -332,7 +332,7 @@ describe("UI of conditional formats", () => {
       await click(fixture, selectors.buttonAdd);
       await nextTick();
 
-      setInputValueAndTrigger(selectors.ruleEditor.range, "hello", "change");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "hello", "input");
 
       const dispatch = spyDispatch(parent);
       //  click save
@@ -408,7 +408,7 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
     await click(fixture, selectors.colorScaleEditor.maxColor);
@@ -445,7 +445,7 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
 
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
@@ -492,7 +492,7 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
 
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
@@ -539,7 +539,7 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
 
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
@@ -586,7 +586,7 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
 
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
@@ -683,7 +683,7 @@ describe("UI of conditional formats", () => {
   test("error if range is empty", async () => {
     await click(fixture, selectors.buttonAdd);
     await nextTick();
-    setInputValueAndTrigger(selectors.ruleEditor.range, "", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "", "input");
     await nextTick();
     await click(fixture, selectors.buttonSave);
     expect(errorMessages()).toEqual(["A range needs to be defined"]);
@@ -1084,7 +1084,7 @@ describe("UI of conditional formats", () => {
       await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
 
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
 
       const dispatch = spyDispatch(parent);
       //  click save

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -400,8 +400,14 @@ describe("selection input plugin", () => {
 
   test("trailing commas and spaces are removed", () => {
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
-    model.dispatch("CHANGE_RANGE", { id, rangeId: idOfRange(model, id, 0), value: " ,C2, " });
+    model.dispatch("CHANGE_RANGE", { id, rangeId: idOfRange(model, id, 0), value: "C2, " });
     expect(model.getters.getSelectionInputValue(id)).toStrictEqual(["C2"]);
+  });
+
+  test("leading commas and spaces are removed", () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
+    model.dispatch("CHANGE_RANGE", { id, rangeId: idOfRange(model, id, 0), value: " ,C2,B3" });
+    expect(model.getters.getSelectionInputValue(id)).toStrictEqual(["C2", "B3"]);
   });
 
   test("new state does not keep previous range focus", () => {


### PR DESCRIPTION
## Description:

This PR fixes the problem of flashing highlight when confirming a selection input. 
The solution is to make the selection input range update dynamically so the highlight can show instantly.

This PR also fixes a bug of possible duplicate range ids in selection input plugin. 
This PR also prevents the leading commas to create a new range input. The trailing comma will still lead to a new range, and the focus will also be transferred into this new range. 

Odoo task ID : [2884221](https://www.odoo.com/web#id=2884221&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo