### PR TITLE
[FIX] topbar: colorPicker maximum height props

### DIFF
--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -33,6 +33,7 @@ css/* scss */ `
     position: absolute;
     top: calc(100% + 5px);
     z-index: ${ComponentsImportance.ColorPicker};
+    padding: ${PICKER_PADDING}px 0px;
     box-shadow: 1px 2px 5px 2px rgba(51, 51, 51, 0.15);
     background-color: white;
     line-height: 1.2;
@@ -177,7 +178,7 @@ function computeCustomColor(ev: MouseEvent) {
 }
 
 export interface ColorPickerProps {
-  maxHeight: Pixel;
+  maxHeight?: Pixel;
   dropdownDirection?: "left" | "right" | "center";
   onColorPicked: (color: Color) => void;
   currentColor: Color;
@@ -211,11 +212,13 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
     },
   });
 
-  get dropdownStyle() {
-    const height = this.props.maxHeight;
+  get colorPickerStyle(): string {
+    if (this.props.maxHeight === undefined) return "";
+    if (this.props.maxHeight <= 0) {
+      return cssPropertiesToCss({ display: "none" });
+    }
     return cssPropertiesToCss({
-      padding: height <= 0 ? "0px" : `${PICKER_PADDING}px 0px`,
-      "max-height": `${height}px`,
+      "max-height": `${this.props.maxHeight}px`,
     });
   }
 

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -3,7 +3,7 @@
     <div
       class="o-color-picker"
       t-att-class="props.dropdownDirection || 'right'"
-      t-att-style="dropdownStyle">
+      t-att-style="colorPickerStyle">
       <div class="o-color-picker-section-name">Standard</div>
       <div class="colors-grid">
         <div

--- a/tests/components/color_picker.test.ts
+++ b/tests/components/color_picker.test.ts
@@ -31,7 +31,7 @@ async function mountColorPicker(
       dropdownDirection: props.dropdownDirection,
       onColorPicked: props.onColorPicked || (() => {}),
       currentColor: props.currentColor || "#000000",
-      maxHeight: props.maxHeight || 1000,
+      maxHeight: props.maxHeight !== undefined ? props.maxHeight : 1000,
     },
     env: {
       model,
@@ -170,5 +170,11 @@ describe("Color Picker buttons", () => {
     await simulateClick(".o-color-picker-toggler");
     const inputCodeEl = fixture.querySelector(".o-custom-input-preview input") as HTMLInputElement;
     expect(inputCodeEl.value).toBe("");
+  });
+
+  test("color picker disappears when maxHeight is 0", async () => {
+    await mountColorPicker({ currentColor: "#45818e", maxHeight: 0 });
+    const picker = fixture.querySelector<HTMLElement>(".o-color-picker")!;
+    expect(picker.style["display"]).toEqual("none");
   });
 });


### PR DESCRIPTION
6b2629c2 fixed problems in the topbar dropdowns & colorPickers when there was not enough space to display them, but it was a bit bugged for the color picker, it's props maxHeight was badly handled when it was undefined.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo