### PR TITLE
[FIX] chart: menu not displayed for small chart positioned left

### DIFF
--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -5,7 +5,7 @@ import { MenuItemRegistry } from "../../../registries/menu_items_registry";
 import { _lt } from "../../../translation";
 import { ChartType, DOMCoordinates, Figure, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
-import { useAbsolutePosition } from "../../helpers/position_hook";
+import { useAbsolutePosition, useBoundingRect } from "../../helpers/position_hook";
 import { Menu, MenuState } from "../../menu/menu";
 
 // -----------------------------------------------------------------------------
@@ -31,7 +31,7 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
 
   private chartContainerRef = useRef("chartContainer");
   private menuButtonRef = useRef("menuButton");
-  private menuButtonPosition = useAbsolutePosition(this.menuButtonRef);
+  private menuButtonRect = useBoundingRect(this.menuButtonRef);
   private position = useAbsolutePosition(this.chartContainerRef);
 
   private getMenuItemRegistry(): MenuItemRegistry {
@@ -89,11 +89,12 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   }
 
   showMenu() {
-    const position = {
-      x: this.menuButtonPosition.x - MENU_WIDTH,
-      y: this.menuButtonPosition.y,
+    const { x, y, width } = this.menuButtonRect;
+    const menuPosition = {
+      x: x >= MENU_WIDTH ? x - MENU_WIDTH : x + width,
+      y: y,
     };
-    this.openContextMenu(position);
+    this.openContextMenu(menuPosition);
   }
 
   private openContextMenu(position: DOMCoordinates) {

--- a/src/components/helpers/position_hook.ts
+++ b/src/components/helpers/position_hook.ts
@@ -44,14 +44,37 @@ export function useAbsolutePosition(ref: Ref): DOMCoordinates {
       return;
     }
     const { top, left } = el.getBoundingClientRect();
-    if (left !== position.x || top !== position.y) {
-      position.x = left;
-      position.y = top;
-    }
+    position.x = left;
+    position.y = top;
   }
   onMounted(updateElPosition);
   onPatched(updateElPosition);
   return position;
+}
+
+/**
+ * Return the component (or ref's component) BoundingRect, relative
+ * to the upper left corner of the screen (<body> element).
+ *
+ * Note: when used with a <Portal/> component, it will
+ * return the portal position, not the teleported position.
+ */
+export function useBoundingRect(ref: Ref): Rect {
+  const rect = useState({ x: 0, y: 0, width: 0, height: 0 });
+  function updateElRect() {
+    const el = ref.el;
+    if (el === null) {
+      return;
+    }
+    const { top, left, width, height } = el.getBoundingClientRect();
+    rect.x = left;
+    rect.y = top;
+    rect.width = width;
+    rect.height = height;
+  }
+  onMounted(updateElRect);
+  onPatched(updateElRect);
+  return rect;
 }
 
 /**

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1,7 +1,7 @@
 import { App } from "@odoo/owl";
 import { CommandResult, Model, Spreadsheet } from "../../src";
 import { ChartTerms } from "../../src/components/translations_terms";
-import { BACKGROUND_CHART_COLOR } from "../../src/constants";
+import { BACKGROUND_CHART_COLOR, MENU_WIDTH } from "../../src/constants";
 import { toHex, toZone } from "../../src/helpers";
 import { ChartDefinition } from "../../src/types";
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
@@ -138,6 +138,38 @@ describe("figures", () => {
       await nextTick();
       expect(fixture.querySelector(".o-figure")).not.toBeNull();
       expect(fixture.querySelector(".o-figure-menu-item")).toBeNull();
+    }
+  );
+
+  test.each(["basicChart", "scorecard", "gauge"])(
+    "chart menu position is correct when clicking on menu button",
+    async (chartType: string) => {
+      mockGetBoundingClientRect({
+        "o-spreadsheet": () => ({ top: 25, left: 25, height: 1000, width: 1000 }),
+        "o-figure-menu-item": () => ({ top: 500, left: 500 }),
+      });
+      createTestChart(chartType);
+      await nextTick();
+      await simulateClick(".o-figure-menu-item");
+      const menuPopover = fixture.querySelector<HTMLElement>(".o-popover")!;
+      expect(menuPopover.style.top).toBe(`${500 - 25}px`); // 25 : spreadsheet offset
+      expect(menuPopover.style.left).toBe(`${500 - 25 - MENU_WIDTH}px`);
+    }
+  );
+
+  test.each(["basicChart", "scorecard", "gauge"])(
+    "chart menu position is correct menu button position < MENU_WIDTH",
+    async (chartType: string) => {
+      mockGetBoundingClientRect({
+        "o-spreadsheet": () => ({ top: 25, left: 25, height: 1000, width: 1000 }),
+        "o-figure-menu-item": () => ({ top: 500, left: MENU_WIDTH - 50, width: 32 }),
+      });
+      createTestChart(chartType);
+      await nextTick();
+      await simulateClick(".o-figure-menu-item");
+      const menuPopover = fixture.querySelector<HTMLElement>(".o-popover")!;
+      expect(menuPopover.style.top).toBe(`${500 - 25}px`); // 25 : spreadsheet offset
+      expect(menuPopover.style.left).toBe(`${MENU_WIDTH - 50 - 25 + 32}px`);
     }
   );
 


### PR DESCRIPTION
## Description

Before this commit, the menu was not displayed for small chart positioned left of the screen. This was because if the menu button X was smaller than MENU_WIDTH, we gave a negative X as position ot the popover, thus not displaying it.

Odoo task ID : [3177176](https://www.odoo.com/web#id=3177176&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo