### PR TITLE
[IMP] figure: reposition figure upon row/col deletion

### DIFF
--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -262,6 +262,17 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
 
     const initialMousePosition = { x: ev.clientX, y: ev.clientY };
 
+    const maxDimensions = {
+      maxX: this.env.model.getters.getColDimensions(
+        sheetId,
+        this.env.model.getters.getNumberCols(sheetId) - 1
+      ).end,
+      maxY: this.env.model.getters.getRowDimensions(
+        sheetId,
+        this.env.model.getters.getNumberRows(sheetId) - 1
+      ).end,
+    };
+
     const { x, y } = internalFigureToScreen(this.env.model.getters, figure);
 
     const initialFig = { ...figure, x, y };
@@ -274,6 +285,7 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
         initialMousePosition,
         initialFig,
         this.env.model.getters.getMainViewportCoordinates(),
+        maxDimensions,
         getters.getActiveSheetScrollInfo()
       );
 

--- a/src/components/helpers/figure_drag_helper.ts
+++ b/src/components/helpers/figure_drag_helper.ts
@@ -5,17 +5,20 @@ export function dragFigureForMove(
   { x: mouseInitialX, y: mouseInitialY }: PixelPosition,
   initialFigure: Figure,
   { x: viewportX, y: viewportY }: PixelPosition,
+  { maxX, maxY }: { maxX: number; maxY: number },
   { scrollX, scrollY }: SheetScrollInfo
 ): Figure {
   const minX = viewportX ? 0 : -scrollX;
   const minY = viewportY ? 0 : -scrollY;
-
-  let deltaX = mouseX - mouseInitialX;
-  const newX = Math.max(initialFigure.x + deltaX, minX);
-  let deltaY = mouseY - mouseInitialY;
-  const newY = Math.max(initialFigure.y + deltaY, minY);
-
+  const deltaX = mouseX - mouseInitialX;
+  const newX = clamp(initialFigure.x + deltaX, minX, maxX - initialFigure.width - scrollX);
+  const deltaY = mouseY - mouseInitialY;
+  const newY = clamp(initialFigure.y + deltaY, minY, maxY - initialFigure.height - scrollY);
   return { ...initialFigure, x: newX, y: newY };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
 }
 
 export function dragFigureForResize(

--- a/src/helpers/clipboard/clipboard_figure_state.ts
+++ b/src/helpers/clipboard/clipboard_figure_state.ts
@@ -84,14 +84,19 @@ export class ClipboardFigureState implements ClipboardState {
    */
   paste(target: Zone[]) {
     const sheetId = this.getters.getActiveSheetId();
+    const { width, height } = this.copiedFigure;
+    const numCols = this.getters.getNumberCols(sheetId);
+    const numRows = this.getters.getNumberRows(sheetId);
+    const targetX = this.getters.getColDimensions(sheetId, target[0].left).start;
+    const targetY = this.getters.getRowDimensions(sheetId, target[0].top).start;
+    const maxX = this.getters.getColDimensions(sheetId, numCols - 1).end;
+    const maxY = this.getters.getRowDimensions(sheetId, numRows - 1).end;
     const position = {
-      x: this.getters.getColDimensions(sheetId, target[0].left).start,
-      y: this.getters.getRowDimensions(sheetId, target[0].top).start,
+      x: maxX < width ? 0 : Math.min(targetX, maxX - width),
+      y: maxY < height ? 0 : Math.min(targetY, maxY - height),
     };
-    const size = { height: this.copiedFigure.height, width: this.copiedFigure.width };
-
     const newId = new UuidGenerator().uuidv4();
-    this.copiedFigureContent.paste(sheetId, newId, position, size);
+    this.copiedFigureContent.paste(sheetId, newId, position, { height, width });
 
     if (this.operation === "CUT") {
       this.dispatch("DELETE_FIGURE", {

--- a/src/plugins/core/figures.ts
+++ b/src/plugins/core/figures.ts
@@ -53,6 +53,42 @@ export class FigurePlugin extends CorePlugin<FigureState> implements FigureState
       case "DELETE_FIGURE":
         this.removeFigure(cmd.id, cmd.sheetId);
         break;
+      case "REMOVE_COLUMNS_ROWS":
+        this.onRowColDelete(cmd.sheetId, cmd.dimension);
+    }
+  }
+
+  private onRowColDelete(sheetId: string, dimension: string) {
+    dimension === "ROW" ? this.onRowDeletion(sheetId) : this.onColDeletion(sheetId);
+  }
+
+  private onRowDeletion(sheetId: string) {
+    const numHeader = this.getters.getNumberRows(sheetId);
+    let gridHeight = 0;
+    for (let i = 0; i < numHeader; i++) {
+      gridHeight += this.getters.getRowSize(sheetId, i);
+    }
+    const figures = this.getters.getFigures(sheetId);
+    for (const figure of figures) {
+      const newY = Math.min(figure.y, gridHeight - figure.height);
+      if (newY !== figure.y) {
+        this.dispatch("UPDATE_FIGURE", { sheetId, id: figure.id, y: newY });
+      }
+    }
+  }
+
+  private onColDeletion(sheetId: string) {
+    const numHeader = this.getters.getNumberCols(sheetId);
+    let gridWidth = 0;
+    for (let i = 0; i < numHeader; i++) {
+      gridWidth += this.getters.getColSize(sheetId, i);
+    }
+    const figures = this.getters.getFigures(sheetId);
+    for (const figure of figures) {
+      const newX = Math.min(figure.x, gridWidth - figure.width);
+      if (newX !== figure.x) {
+        this.dispatch("UPDATE_FIGURE", { sheetId, id: figure.id, x: newX });
+      }
     }
   }
 

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -953,8 +953,14 @@ describe("figures", () => {
 
       test("No Y snap with bottom border below the viewport", async () => {
         const { height: viewportHeight } = model.getters.getMainViewportRect();
-        createFigure(model, { id: "f1", x: 0, y: 100, width: 100, height: viewportHeight });
-        createFigure(model, { id: "f2", x: 0, y: 0, width: 100, height: viewportHeight + 100 });
+        createFigure(model, { id: "f1", x: 0, y: 100, width: 100, height: 0.85 * viewportHeight });
+        createFigure(model, {
+          id: "f2",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 0.85 * viewportHeight + 100,
+        });
         await nextTick();
         await dragElement(".o-figure[data-id=f1]", { x: 0, y: 1 }, undefined, true);
         expect(model.getters.getFigure(sheetId, "f1")).toMatchObject({ x: 0, y: 101 });
@@ -962,8 +968,14 @@ describe("figures", () => {
 
       test("No X snap with right border right of the viewport", async () => {
         const { width: viewportWidth } = model.getters.getMainViewportRect();
-        createFigure(model, { id: "f1", x: 100, y: 0, width: viewportWidth, height: 100 });
-        createFigure(model, { id: "f2", x: 0, y: 0, width: viewportWidth + 100, height: 100 });
+        createFigure(model, { id: "f1", x: 100, y: 0, width: 0.85 * viewportWidth, height: 100 });
+        createFigure(model, {
+          id: "f2",
+          x: 0,
+          y: 0,
+          width: 0.85 * viewportWidth + 100,
+          height: 100,
+        });
         await nextTick();
         await dragElement(".o-figure[data-id=f1]", { x: 1, y: 0 }, undefined, true);
         expect(model.getters.getFigure(sheetId, "f1")).toMatchObject({ x: 101, y: 0 });

--- a/tests/plugins/clipboard_figure.test.ts
+++ b/tests/plugins/clipboard_figure.test.ts
@@ -128,6 +128,29 @@ describe.each(["chart", "image"])("Clipboard for %s figures", (type: string) => 
     expect(model.getters.getFigures(sheetId)).toHaveLength(0);
   });
 
+  test("Figure is copied to edge of the sheet", () => {
+    model.dispatch("UPDATE_FIGURE", {
+      sheetId,
+      id: figureId,
+      height: 256,
+      width: 257,
+    });
+    model.dispatch("SELECT_FIGURE", { id: figureId });
+    copy(model);
+    paste(model, "Z100");
+    const copiedFigure = model.getters.getFigure(sheetId, getCopiedFigureId())!;
+    const maxX = model.getters.getColDimensions(
+      sheetId,
+      model.getters.getNumberCols(sheetId) - 1
+    ).end;
+    const maxY = model.getters.getRowDimensions(
+      sheetId,
+      model.getters.getNumberRows(sheetId) - 1
+    ).end;
+    expect(copiedFigure.x).toBe(maxX - copiedFigure.width);
+    expect(copiedFigure.y).toBe(maxY - copiedFigure.height);
+  });
+
   describe("Paste command result", () => {
     test("Cannot paste with empty target", () => {
       model.dispatch("SELECT_FIGURE", { id: figureId });

--- a/tests/plugins/figures.test.ts
+++ b/tests/plugins/figures.test.ts
@@ -1,9 +1,12 @@
 import { CommandResult } from "../../src";
 import { DEFAULT_CELL_WIDTH } from "../../src/constants";
+import { numberToLetters, range } from "../../src/helpers";
 import { Model } from "../../src/model";
 import {
   activateSheet,
   createSheet,
+  deleteColumns,
+  deleteRows,
   freezeColumns,
   freezeRows,
   selectCell,
@@ -401,5 +404,69 @@ describe("figure plugin", () => {
       figure,
     });
     expect(cmd3).toBeCancelledBecause(CommandResult.DuplicatedFigureId);
+  });
+
+  test("Figure stay in grid after removing the rows and columns", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const figureId = "someuuid";
+
+    const colSize = model.getters.getColDimensions(sheetId, 1).size;
+    const rowSize = model.getters.getRowDimensions(sheetId, 1).size;
+
+    const maxX = model.getters.getColDimensions(
+      sheetId,
+      model.getters.getNumberCols(sheetId) - 1
+    ).end;
+    const maxY = model.getters.getRowDimensions(
+      sheetId,
+      model.getters.getNumberRows(sheetId) - 1
+    ).end;
+
+    const figure = {
+      id: figureId,
+      x: maxX - rowSize,
+      y: maxY - colSize,
+      tag: "hey",
+      width: 500,
+      height: 500,
+    };
+    model.dispatch("CREATE_FIGURE", {
+      sheetId,
+      figure,
+    });
+
+    deleteColumns(model, ["B"]);
+    deleteRows(model, [1]);
+    const figureAfter = model.getters.getFigure(sheetId, figureId)!;
+    expect(figureAfter.x).toBe(maxX - colSize - figureAfter.width);
+    expect(figureAfter.y).toBe(maxY - rowSize - figureAfter.height);
+  });
+
+  test("Move image at (0,0) if not enough space after removing rows and columns", async () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const figureId = "someuuid";
+    const figureDef = {
+      id: figureId,
+      x: 800,
+      y: 1200,
+      tag: "hey",
+      width: 800,
+      height: 1100,
+    };
+    model.dispatch("CREATE_FIGURE", {
+      sheetId,
+      figure: figureDef,
+    });
+
+    const figure = model.getters.getFigure(sheetId, figureId)!;
+    expect(figure.x).toBe(800);
+    expect(figure.y).toBe(1200);
+    deleteColumns(model, range(8, model.getters.getNumberCols(sheetId)).map(numberToLetters));
+    deleteRows(model, range(8, model.getters.getNumberRows(sheetId)));
+    const figureAfter = model.getters.getFigure(sheetId, figureId)!;
+    expect(figureAfter.x).toBe(0);
+    expect(figureAfter.y).toBe(0);
   });
 });


### PR DESCRIPTION
## Description:

This commit improves the positioning of the figures regarding the
structure of the sheet. Upon deletion of rows/columns[1], the figure will
be repositions to fit (as much as possible) inside the sheet grid, that
is having the figure not outside of the grid.

This commit also ensures this behaviour when copy/pasting a figure.

[1] A follow up work will address the visibility of the headers but this
requires a more in-depth refactoring which is far enough form the task
original goal to be left for later.

Task: 3171141

Odoo task ID : [3171141](https://www.odoo.com/web#id=3171141&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo