### PR TITLE
[IMP] tests:  add a triggerWheelEvent/triggerKeyDown helper

### DIFF
--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
   ({ model, fixture } = await mountSpreadsheet());
 
   // start composition
-  await keyDown("Enter");
+  await keyDown({ key: "Enter" });
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
 });
 
@@ -107,7 +107,7 @@ describe("Functions autocomplete", () => {
 
     test("=S+TAB complete the function --> =SUM(␣", async () => {
       await typeInComposerGrid("=S");
-      await keyDown("Tab");
+      await keyDown({ key: "Tab" });
       expect(composerEl.textContent).toBe("=SUM(");
       expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
       expect(cehMock.selectionState.position).toBe(5);
@@ -115,7 +115,7 @@ describe("Functions autocomplete", () => {
 
     test("=S+ENTER complete the function --> =SUM(␣", async () => {
       await typeInComposerGrid("=S");
-      await keyDown("Enter");
+      await keyDown({ key: "Enter" });
       expect(composerEl.textContent).toBe("=SUM(");
       expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
       expect(cehMock.selectionState.position).toBe(5);
@@ -128,7 +128,7 @@ describe("Functions autocomplete", () => {
 
     test("=SX+ENTER does not autocomplete anything and moves to the cell down", async () => {
       await typeInComposerGrid("=SX");
-      await keyDown("Tab");
+      await keyDown({ key: "Tab" });
       expect(getCellText(model, "A1")).toBe("=SX");
     });
 
@@ -137,7 +137,7 @@ describe("Functions autocomplete", () => {
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SUM");
-      await keyDown("ArrowUp");
+      await keyDown({ key: "ArrowUp" });
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SZZ");
@@ -148,11 +148,11 @@ describe("Functions autocomplete", () => {
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SUM");
-      await keyDown("ArrowDown");
+      await keyDown({ key: "ArrowDown" });
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SZZ");
-      await keyDown("ArrowUp");
+      await keyDown({ key: "ArrowUp" });
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SUM");
@@ -163,11 +163,11 @@ describe("Functions autocomplete", () => {
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SUM");
-      await keyDown("ArrowDown");
+      await keyDown({ key: "ArrowDown" });
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SZZ");
-      await keyDown("ArrowDown");
+      await keyDown({ key: "ArrowDown" });
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SUM");
@@ -272,19 +272,19 @@ describe("Functions autocomplete", () => {
     });
     test("= and CTRL+Space show autocomplete", async () => {
       await typeInComposerGrid("=");
-      await keyUp(" ", { ctrlKey: true });
+      await keyUp({ key: " ", ctrlKey: true });
       //TODO Need a second nextTick to wait the re-render of SelectionInput (onMounted => uuid assignation). But why not before ?
       await nextTick();
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(3);
-      await keyDown("Tab");
+      await keyDown({ key: "Tab" });
       expect(composerEl.textContent).toBe("=IF(");
       expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
       expect(cehMock.selectionState.position).toBe(4);
     });
     test("= and CTRL+Space & DOWN move to next autocomplete", async () => {
       await typeInComposerGrid("=");
-      await keyUp(" ", { ctrlKey: true });
-      await keyDown("ArrowDown");
+      await keyUp({ key: " ", ctrlKey: true });
+      await keyDown({ key: "ArrowDown" });
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SUM");
@@ -321,17 +321,16 @@ describe("Autocomplete parenthesis", () => {
 
   test("=sum(1,2 + enter adds closing parenthesis", async () => {
     await typeInComposerGrid("=sum(1,2");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellText(model, "A1")).toBe("=sum(1,2)");
   });
 
   test("=sum(1,2) + enter + edit sum does not add parenthesis", async () => {
     await typeInComposerGrid("=sum(1,2)");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     selectCell(model, "A1");
     //edit A1
-    await keyDown("Enter");
-    composerEl = fixture.querySelector(".o-grid div.o-composer")!;
+    await keyDown({ key: "Enter" });
 
     model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 1, end: 4 });
     await nextTick();
@@ -361,13 +360,13 @@ describe("Autocomplete parenthesis", () => {
 
   test("=sum(sum(1,2 + enter add 2 closing parenthesis", async () => {
     await typeInComposerGrid("=sum(sum(1,2");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellText(model, "A1")).toBe("=sum(sum(1,2))");
   });
 
   test("=sum(sum(1,2) + enter add 1 closing parenthesis", async () => {
     await typeInComposerGrid("=sum(sum(1,2");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellText(model, "A1")).toBe("=sum(sum(1,2))");
   });
 
@@ -379,13 +378,13 @@ describe("Autocomplete parenthesis", () => {
 
   test('=sum("((((((((") + enter should not complete the parenthesis in the string', async () => {
     await typeInComposerGrid('=sum("((((((((")');
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellText(model, "A1")).toBe('=sum("((((((((")');
   });
 
   test("=s + tab should allow to select a ref", async () => {
     await typeInComposerGrid("=s");
-    await keyDown("Tab");
+    await keyDown({ key: "Tab" });
     expect(model.getters.getEditionMode()).toBe("selecting");
   });
 });

--- a/tests/components/autofill.test.ts
+++ b/tests/components/autofill.test.ts
@@ -3,7 +3,12 @@ import { Spreadsheet } from "../../src";
 import { DEFAULT_CELL_WIDTH, HEADER_HEIGHT, HEADER_WIDTH } from "../../src/constants";
 import { Model } from "../../src/model";
 import { setCellContent, setSelection, setViewportOffset } from "../test_helpers/commands_helpers";
-import { clickCell, edgeScrollDelay, triggerMouseEvent } from "../test_helpers/dom_helper";
+import {
+  clickCell,
+  edgeScrollDelay,
+  triggerMouseEvent,
+  triggerWheelEvent,
+} from "../test_helpers/dom_helper";
 import {
   getStylePropertyInPx,
   mountSpreadsheet,
@@ -100,13 +105,7 @@ describe("Autofill component", () => {
     const sheetId = model.getters.getActiveSheetId();
     const x = HEADER_WIDTH + model.getters.getColDimensions(sheetId, 1)!.end + 20;
     const y = model.getters.getRowDimensions(sheetId, 0)!.start + 20;
-    fixture.querySelector(".o-grid")!.dispatchEvent(
-      new WheelEvent("wheel", {
-        clientX: x,
-        clientY: y,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(".o-grid", { clientX: x, clientY: y });
     await nextTick();
     expect(fixture.querySelector(".o-autofill")).not.toBeNull();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toMatchInlineSnapshot(`

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -22,6 +22,7 @@ import {
   keyDown,
   simulateClick,
   triggerMouseEvent,
+  triggerWheelEvent,
 } from "../test_helpers/dom_helper";
 import { mockUuidV4To, mountComponent, nextTick } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
@@ -432,9 +433,9 @@ describe("BottomBar component", () => {
 
     test("Can scroll on the list of sheets", async () => {
       expect(sheetListEl.scrollLeft).toBe(0);
-      sheetListEl.dispatchEvent(new WheelEvent("wheel", { deltaY: 100 }));
+      triggerWheelEvent(sheetListEl, { deltaY: 100 });
       expect(sheetListEl.scrollLeft).toBe(50);
-      sheetListEl.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
+      triggerWheelEvent(sheetListEl, { deltaY: -100 });
       expect(sheetListEl.scrollLeft).toBe(0);
     });
 

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -277,7 +277,7 @@ describe("BottomBar component", () => {
       triggerMouseEvent(sheetName, "dblclick");
       await nextTick();
       sheetName.textContent = "New name";
-      await keyDown("Enter");
+      await keyDown({ key: "Enter" });
       expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toEqual("New name");
     });
 
@@ -295,7 +295,7 @@ describe("BottomBar component", () => {
       triggerMouseEvent(sheetName, "dblclick");
       await nextTick();
       sheetName.textContent = "New name";
-      await keyDown("Escape");
+      await keyDown({ key: "Escape" });
       expect(sheetName.textContent).toEqual("Sheet1");
       expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toEqual("Sheet1");
     });
@@ -305,7 +305,7 @@ describe("BottomBar component", () => {
       triggerMouseEvent(sheetName, "dblclick");
       await nextTick();
       sheetName.textContent = "";
-      await keyDown("Enter");
+      await keyDown({ key: "Enter" });
       expect(raiseError).toHaveBeenCalled();
     });
 
@@ -316,7 +316,7 @@ describe("BottomBar component", () => {
       await nextTick();
       sheetName.textContent = "ThisIsASheet";
       expect(window.getSelection()?.toString()).toEqual("");
-      await keyDown("Enter");
+      await keyDown({ key: "Enter" });
       expect(raiseError).toHaveBeenCalled();
       expect(window.getSelection()?.toString()).toEqual("ThisIsASheet");
       expect(document.activeElement).toEqual(sheetName);

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -118,12 +118,12 @@ async function typeInComposer(text: string, fromScratch: boolean = true) {
 
 async function moveToStart() {
   // TODO: remove keyup at refactoring of content editable helper
-  keyDown("Home");
-  keyUp("Home");
+  keyDown({ key: "Home" });
+  keyUp({ key: "Home" });
 }
 async function moveToEnd() {
-  await keyDown("End");
-  await keyUp("End");
+  await keyDown({ key: "End" });
+  await keyUp({ key: "End" });
 }
 
 beforeEach(async () => {
@@ -154,7 +154,7 @@ describe("ranges and highlights", () => {
 
   test("=Key DOWN in A1, should select and highlight A2", async () => {
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowDown" });
     expect(composerEl.textContent).toBe("=A2");
   });
 
@@ -162,82 +162,82 @@ describe("ranges and highlights", () => {
     composerEl = await typeInComposer("=");
     expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
     expect(cehMock.selectionState.position).toBe(1);
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowDown" });
     expect(composerEl.textContent).toBe("=A2");
     composerEl = await typeInComposer("+", false);
     expect(composerEl.textContent).toBe("=A2+");
     expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
     expect(cehMock.selectionState.position).toBe(4);
     expect(model.getters.getEditionMode()).toBe("selecting");
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowDown" });
     expect(composerEl.textContent).toBe("=A2+A2");
   });
 
   test("=Key DOWN+DOWN in A1, should select and highlight A3", async () => {
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowDown");
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowDown" });
+    await keyDown({ key: "ArrowDown" });
     expect(composerEl.textContent).toBe("=A3");
   });
 
   test("=Key RIGHT in A1, should select and highlight B1", async () => {
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowRight");
+    await keyDown({ key: "ArrowRight" });
     expect(composerEl.textContent).toBe("=B1");
   });
 
   test("=Key RIGHT twice selects C1", async () => {
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowRight");
-    await keyUp("ArrowRight");
+    await keyDown({ key: "ArrowRight" });
+    await keyUp({ key: "ArrowRight" });
     expect(composerEl.textContent).toBe("=B1");
-    await keyDown("ArrowRight");
-    await keyUp("ArrowRight");
+    await keyDown({ key: "ArrowRight" });
+    await keyUp({ key: "ArrowRight" });
     expect(composerEl.textContent).toBe("=C1");
   });
 
   test("=Key UP in B2, should select and highlight B1", async () => {
     selectCell(model, "B2");
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowUp");
+    await keyDown({ key: "ArrowUp" });
     expect(composerEl.textContent).toBe("=B1");
   });
 
   test("=Key LEFT in B2, should select and highlight A2", async () => {
     selectCell(model, "B2");
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowLeft");
+    await keyDown({ key: "ArrowLeft" });
     expect(composerEl.textContent).toBe("=A2");
   });
 
   test("=Key DOWN and UP in B2, should select and highlight B2", async () => {
     selectCell(model, "B2");
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowDown");
-    await keyDown("ArrowUp");
+    await keyDown({ key: "ArrowDown" });
+    await keyDown({ key: "ArrowUp" });
     expect(composerEl.textContent).toBe("=B2");
   });
 
   test("=key UP 2 times and key DOWN in B2, should select and highlight B2", async () => {
     selectCell(model, "B2");
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowUp");
-    await keyDown("ArrowUp");
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowUp" });
+    await keyDown({ key: "ArrowUp" });
+    await keyDown({ key: "ArrowDown" });
     expect(composerEl.textContent).toBe("=B2");
   });
 
   test("While selecting a ref, Shift+UP/DOWN/LEFT/RIGHT extend the range selection and updates the composer", async () => {
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowDown" });
     expect(composerEl.textContent).toBe("=A2");
-    await keyDown("ArrowDown", { shiftKey: true });
+    await keyDown({ key: "ArrowDown", shiftKey: true });
     expect(composerEl.textContent).toBe("=A2:A3");
-    await keyDown("ArrowRight", { shiftKey: true });
+    await keyDown({ key: "ArrowRight", shiftKey: true });
     expect(composerEl.textContent).toBe("=A2:B3");
-    await keyDown("ArrowUp", { shiftKey: true });
+    await keyDown({ key: "ArrowUp", shiftKey: true });
     expect(composerEl.textContent).toBe("=A2:B2");
-    await keyDown("ArrowLeft", { shiftKey: true });
+    await keyDown({ key: "ArrowLeft", shiftKey: true });
     expect(composerEl.textContent).toBe("=A2");
   });
 
@@ -248,11 +248,11 @@ describe("ranges and highlights", () => {
     merge(model, "B2:C3");
     selectCell(model, "C1");
     composerEl = await typeInComposer("=");
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowDown" });
     expect(composerEl.textContent).toBe("=B2");
     expect(getHighlights(model)).toHaveLength(1);
     expect(getHighlights(model)[0].zone).toMatchObject(toZone("B2:C3"));
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowDown" });
     expect(composerEl.textContent).toBe("=C4");
   });
 
@@ -263,8 +263,8 @@ describe("ranges and highlights", () => {
     expect(composerEl.textContent).toBe("=B2:B10");
     expect(getHighlights(model)).toHaveLength(1);
     expect(getHighlights(model)[0].zone).toMatchObject(toZone("B2:B10"));
-    await keyDown("Escape");
-    await keyUp("Escape");
+    await keyDown({ key: "Escape" });
+    await keyUp({ key: "Escape" });
     composerEl = await typeInComposer("=B2:B3");
     expect(composerEl.textContent).toBe("=B2:B3");
     expect(getHighlights(model)).toHaveLength(1);
@@ -467,14 +467,14 @@ describe("composer", () => {
     selectCell(model, "C8");
     await nextTick();
     expect(composerEl.textContent).toBe("=C8");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(model.getters.getEditionMode()).toBe("inactive");
     expect(getCellText(model, "A1")).toBe("=C8");
   });
 
   test("full rows/cols ranges are correctly displayed", async () => {
     composerEl = await typeInComposer("=SUM(A:A)");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellText(model, "A1")).toBe("=SUM(A:A)");
   });
 
@@ -485,43 +485,37 @@ describe("composer", () => {
   });
 
   test("typing incorrect formula then enter exits the edit mode and moves to the next cell down", async () => {
-    await typeInComposer("=qsdf");
-    await keyDown("Enter");
+    composerEl = await typeInComposer("=qsdf");
+    await keyDown({ key: "Enter" });
     expect(getCellText(model, "A1")).toBe("=qsdf");
     expect(getEvaluatedCell(model, "A1").value).toBe("#BAD_EXPR");
   });
 
   test("typing text then enter exits the edit mode and moves to the next cell down", async () => {
-    await startComposition();
+    composerEl = await startComposition();
     await typeInComposer("qsdf");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellContent(model, "A1")).toBe("qsdf");
     expect(getEvaluatedCell(model, "A1").value).toBe("qsdf");
   });
 
   test("keyup event triggered after edition end", async () => {
-    const composerEl = await startComposition("d");
+    await startComposition("d");
     expect(model.getters.getEditionMode()).toBe("editing");
     // Enter is pressed really fast while another character is pressed such that
     // the character keyup event happens after the Enter
-    composerEl.dispatchEvent(
-      new KeyboardEvent("keydown", Object.assign({ key: "Enter", bubbles: true }))
-    );
-    composerEl.dispatchEvent(
-      new KeyboardEvent("keyup", Object.assign({ key: "Enter", bubbles: true }))
-    );
-    composerEl.dispatchEvent(
-      new KeyboardEvent("keyup", Object.assign({ key: "d", bubbles: true }))
-    );
+    keyDown({ key: "Enter" });
+    keyUp({ key: "Enter" });
+    keyUp({ key: "d" });
     await nextTick();
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
 
   test("edit link cell changes the label", async () => {
     setCellContent(model, "A1", "[label](http://odoo.com)");
-    await startComposition();
+    composerEl = await startComposition();
     await typeInComposer(" updated");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     const link = getEvaluatedCell(model, "A1").link;
     expect(link?.label).toBe("label updated");
     expect(link?.url).toBe("http://odoo.com");
@@ -716,19 +710,19 @@ describe("composer", () => {
   });
 
   test("Home key sets cursor at the beginning", async () => {
-    await typeInComposer("Hello");
+    composerEl = await typeInComposer("Hello");
     expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });
-    await keyDown("Home");
-    await keyUp("Home");
+    await keyDown({ key: "Home" });
+    await keyUp({ key: "Home" });
     expect(model.getters.getComposerSelection()).toEqual({ start: 0, end: 0 });
   });
 
   test("End key sets cursor at the end", async () => {
-    await typeInComposer("Hello");
+    composerEl = await typeInComposer("Hello");
     model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 0, end: 0 });
     await nextTick();
-    await keyDown("End");
-    await keyUp("End");
+    await keyDown({ key: "End" });
+    await keyUp({ key: "End" });
     expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });
   });
 
@@ -740,33 +734,34 @@ describe("composer", () => {
     expect(model.getters.getEditionMode()).toBe("editing");
     expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });
     for (let _ in [1, 2, 3]) {
-      await keyDown("ArrowLeft");
+      await keyDown({ key: "ArrowLeft" });
     }
-    await keyUp("ArrowLeft");
+    await keyUp({ key: "ArrowLeft" });
     expect(model.getters.getComposerSelection()).toEqual({ start: 2, end: 2 });
     for (let _ in [1, 2]) {
-      await keyDown("ArrowRight");
+      await keyDown({ key: "ArrowRight" });
     }
-    await keyUp("ArrowRight");
+    await keyUp({ key: "ArrowRight" });
 
     expect(model.getters.getComposerSelection()).toEqual({ start: 4, end: 4 });
   });
 
   test("Move cursor while in edit mode with empty cell", async () => {
-    await typeInComposer("Hello");
+    composerEl = await typeInComposer("Hello");
     expect(model.getters.getEditionMode()).toBe("editing");
     expect(model.getters.getComposerSelection()).toEqual({ start: 5, end: 5 });
-    await keyDown("ArrowLeft");
+    await keyDown({ key: "ArrowLeft" });
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
 
   test("Select a right-to-left range with the keyboard", async () => {
     setCellContent(model, "A1", "Hello");
+    composerEl = fixture.querySelector<HTMLElement>("div.o-composer")!;
     await simulateClick("div.o-composer");
     await moveToEnd();
     const { end } = model.getters.getComposerSelection();
-    await keyDown("ArrowLeft", { shiftKey: true });
-    await keyUp("ArrowLeft", { shiftKey: true });
+    await keyDown({ key: "ArrowLeft", shiftKey: true });
+    await keyUp({ key: "ArrowLeft", shiftKey: true });
     expect(model.getters.getComposerSelection()).toEqual({
       start: end,
       end: end - 1,
@@ -780,18 +775,18 @@ describe("composer", () => {
     await moveToEnd();
     model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 0, end: 0 });
     await nextTick();
-    await keyDown("ArrowRight", { shiftKey: true });
-    await keyUp("ArrowRight", { shiftKey: true });
+    await keyDown({ key: "ArrowRight", shiftKey: true });
+    await keyUp({ key: "ArrowRight", shiftKey: true });
     expect(model.getters.getComposerSelection()).toEqual({ start: 0, end: 1 });
   });
 
   test("Select a left-to-right range with the keyboard in an empty cell", async () => {
-    await typeInComposer("Hello");
+    composerEl = await typeInComposer("Hello");
     expect(model.getters.getEditionMode()).toBe("editing");
     model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 0, end: 0 });
     await nextTick();
-    await keyDown("ArrowRight", { shiftKey: true });
-    await keyUp("ArrowRight", { shiftKey: true });
+    await keyDown({ key: "ArrowRight", shiftKey: true });
+    await keyUp({ key: "ArrowRight", shiftKey: true });
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
 
@@ -806,11 +801,11 @@ describe("composer", () => {
     // type '=' in C8
     selectCell(model, "C8");
     await nextTick();
-    await typeInComposer("=");
+    composerEl = await typeInComposer("=");
     expect(model.getters.getEditionMode()).toBe("selecting");
 
     // stop editing with enter
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellText(model, "C8")).toBe("=");
     expect(getEvaluatedCell(model, "C8").value).toBe("#BAD_EXPR");
     expect(getSelectionAnchorCellXc(model)).toBe("C9");
@@ -834,26 +829,26 @@ describe("composer", () => {
     test("f4 shortcut on cell symbol", async () => {
       composerEl = await typeInComposer("=A1");
       model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 1, end: 1 });
-      await keyDown("F4");
+      await keyDown({ key: "F4" });
       expect(model.getters.getCurrentContent()).toBe("=$A$1");
-      await keyDown("F4");
+      await keyDown({ key: "F4" });
       expect(model.getters.getCurrentContent()).toBe("=A$1");
-      await keyDown("F4");
+      await keyDown({ key: "F4" });
       expect(model.getters.getCurrentContent()).toBe("=$A1");
-      await keyDown("F4");
+      await keyDown({ key: "F4" });
       expect(model.getters.getCurrentContent()).toBe("=A1");
     });
   });
 
   test("Can go to a new line in the composer with alt + enter or ctrl + enter", async () => {
-    await typeInComposer("A");
+    composerEl = await typeInComposer("A");
     expect(model.getters.getComposerSelection()).toEqual({ start: 1, end: 1 });
 
-    await keyDown("Enter", { bubbles: true, altKey: true });
+    await keyDown({ key: "Enter", altKey: true });
     expect(model.getters.getComposerSelection()).toEqual({ start: 2, end: 2 });
     expect(model.getters.getCurrentContent()).toEqual("A\n");
 
-    await keyDown("Enter", { bubbles: true, ctrlKey: true });
+    await keyDown({ key: "Enter", ctrlKey: true });
     expect(model.getters.getComposerSelection()).toEqual({ start: 3, end: 3 });
     expect(model.getters.getCurrentContent()).toEqual("A\n\n");
 
@@ -861,7 +856,7 @@ describe("composer", () => {
     expect(model.getters.getComposerSelection()).toEqual({ start: 4, end: 4 });
     expect(model.getters.getCurrentContent()).toEqual("A\n\nC");
 
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellContent(model, "A1")).toEqual("A\n\nC");
   });
 });
@@ -934,7 +929,7 @@ describe("composer highlights color", () => {
     expect(getHighlights(model).length).toBe(2);
     expect(getHighlights(model)[0].color).toBe(colors[0]);
     expect(getHighlights(model)[1].color).toBe(colors[1]);
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
 
     await startComposition();
     expect(getHighlights(model).length).toBe(2);

--- a/tests/components/composer_integration.test.ts
+++ b/tests/components/composer_integration.test.ts
@@ -76,7 +76,7 @@ describe("Composer interactions", () => {
   });
 
   test("type in grid composer adds text to topbar composer", async () => {
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     const gridComposer = document.querySelector(".o-grid .o-composer");
     const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer");
     expect(document.activeElement).toBe(gridComposer);
@@ -134,7 +134,7 @@ describe("Composer interactions", () => {
   });
 
   test("autocomplete disappear when grid composer is blurred", async () => {
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer")!;
     await typeInComposerGrid("=SU");
     expect(fixture.querySelector(".o-grid .o-autocomplete-dropdown")).not.toBeNull();
@@ -143,7 +143,7 @@ describe("Composer interactions", () => {
   });
 
   test("focus top bar composer does not resize grid composer when autocomplete is displayed", async () => {
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     const topBarComposer = document.querySelector(".o-spreadsheet-topbar .o-composer")!;
     const gridComposerContainer = document.querySelector(".o-grid-composer")! as HTMLElement;
     const spy = jest.spyOn(gridComposerContainer.style, "width", "set");
@@ -292,23 +292,23 @@ describe("Composer interactions", () => {
     let composerEl: Element;
     composerEl = await startComposition("a");
     expect(composerEl.textContent).toBe("a");
-    await keyDown("ArrowRight");
+    await keyDown({ key: "ArrowRight" });
     expect(getCellText(model, "A1")).toBe("a");
     expect(getActivePosition(model)).toBe("B1");
 
     composerEl = await startComposition("b");
     expect(composerEl.textContent).toBe("b");
-    await keyDown("ArrowRight");
+    await keyDown({ key: "ArrowRight" });
     expect(getCellText(model, "B1")).toBe("b");
     expect(getActivePosition(model)).toBe("C1");
 
-    await keyDown("ArrowLeft");
+    await keyDown({ key: "ArrowLeft" });
     expect(getActivePosition(model)).toBe("B1");
-    await keyDown("ArrowLeft");
+    await keyDown({ key: "ArrowLeft" });
     expect(getActivePosition(model)).toBe("A1");
     composerEl = await startComposition("c");
     expect(composerEl.textContent).toBe("c");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellText(model, "B1")).toBe("b");
     expect(getCellText(model, "A1")).toBe("c");
   });
@@ -319,7 +319,7 @@ describe("Composer interactions", () => {
     await typeInComposerGrid(`"`);
     await typeInComposerGrid(`"`);
     expect(composerEl.textContent).toBe(`=""`);
-    await keyDown("ArrowLeft");
+    await keyDown({ key: "ArrowLeft" });
     expect(model.getters.getEditionMode()).not.toBe("inactive");
   });
 
@@ -327,23 +327,23 @@ describe("Composer interactions", () => {
     let composerEl: Element;
     composerEl = await startComposition("a");
     expect(composerEl.textContent).toBe("a");
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowDown" });
     expect(getCellText(model, "A1")).toBe("a");
     expect(getActivePosition(model)).toBe("A2");
 
     composerEl = await startComposition("b");
     expect(composerEl.textContent).toBe("b");
-    await keyDown("ArrowDown");
+    await keyDown({ key: "ArrowDown" });
     expect(getCellText(model, "A2")).toBe("b");
     expect(getActivePosition(model)).toBe("A3");
 
-    await keyDown("ArrowUp");
+    await keyDown({ key: "ArrowUp" });
     expect(getActivePosition(model)).toBe("A2");
-    await keyDown("ArrowUp");
+    await keyDown({ key: "ArrowUp" });
     expect(getActivePosition(model)).toBe("A1");
     composerEl = await startComposition("c");
     expect(composerEl.textContent).toBe("c");
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(getCellText(model, "A2")).toBe("b");
     expect(getCellText(model, "A1")).toBe("c");
   });
@@ -370,7 +370,7 @@ describe("Composer interactions", () => {
   });
 
   test("typing CTRL+C in grid does not type C in the cell", async () => {
-    await keyDown("c", { ctrlKey: true });
+    await keyDown({ key: "c", ctrlKey: true });
     expect(model.getters.getCurrentContent()).toBe("");
   });
 
@@ -383,7 +383,7 @@ describe("Composer interactions", () => {
     )!;
     expect(topbarComposerElement.textContent).toBe("I am Tabouret");
     await simulateClick(topbarComposerElement);
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(topbarComposerElement.textContent).toBe("wooplaburg");
   });
 
@@ -395,7 +395,7 @@ describe("Composer interactions", () => {
     )!;
     expect(topbarComposerElement.textContent).toBe("I am Tabouret");
     await simulateClick(topbarComposerElement); // gain focus on topbar composer
-    await keyDown("ArrowLeft");
+    await keyDown({ key: "ArrowLeft" });
     await simulateClick(".o-grid-overlay", 300, 200); // focus another Cell (i.e. C8)
     expect(topbarComposerElement.textContent).toBe("");
   });

--- a/tests/components/composer_integration.test.ts
+++ b/tests/components/composer_integration.test.ts
@@ -25,6 +25,7 @@ import {
   rightClickCell,
   selectColumnByClicking,
   simulateClick,
+  triggerWheelEvent,
 } from "../test_helpers/dom_helper";
 import {
   getActivePosition,
@@ -171,9 +172,7 @@ describe("Composer interactions", () => {
     const { top, bottom, left, right } = model.getters.getActiveMainViewport();
     await typeInComposerTopBar("=");
     // scroll
-    fixture
-      .querySelector(".o-grid")!
-      .dispatchEvent(new WheelEvent("wheel", { deltaY: 3 * DEFAULT_CELL_HEIGHT }));
+    triggerWheelEvent(".o-grid", { deltaY: 3 * DEFAULT_CELL_HEIGHT });
     await nextTick();
     const scrolledViewport = model.getters.getActiveMainViewport();
     expect(scrolledViewport).toMatchObject({

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -16,6 +16,7 @@ import {
   rightClickCell,
   simulateClick,
   triggerMouseEvent,
+  triggerTouchEvent,
 } from "../test_helpers/dom_helper";
 import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 
@@ -25,7 +26,6 @@ import {
   mountComponent,
   mountSpreadsheet,
   nextTick,
-  Touch,
 } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
@@ -364,35 +364,10 @@ describe("Context Menu integration tests", () => {
     const menu = fixture.querySelector(".o-menu")!;
 
     // start move at (310, 210) touch position
-    menu.dispatchEvent(
-      new TouchEvent("touchstart", {
-        bubbles: true,
-        cancelable: true,
-        touches: [
-          new Touch({
-            clientX: 310,
-            clientY: 210,
-            identifier: 1,
-            target: menu,
-          }),
-        ],
-      })
-    );
+    triggerTouchEvent(menu, "touchstart", { clientX: 310, clientY: 210, identifier: 1 });
+
     // move down;
-    menu.dispatchEvent(
-      new TouchEvent("touchmove", {
-        bubbles: true,
-        cancelable: true,
-        touches: [
-          new Touch({
-            clientX: 310,
-            clientY: 180,
-            identifier: 2,
-            target: menu,
-          }),
-        ],
-      })
-    );
+    triggerTouchEvent(menu, "touchstart", { clientX: 310, clientY: 180, identifier: 1 });
 
     await nextTick();
     // grid always at (0, 0) scroll position

--- a/tests/components/dashboard_grid.test.ts
+++ b/tests/components/dashboard_grid.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../src/constants";
 import { Model } from "../../src/model";
 import { createFilter, selectCell, setCellContent } from "../test_helpers/commands_helpers";
-import { simulateClick } from "../test_helpers/dom_helper";
+import { keyDown, simulateClick } from "../test_helpers/dom_helper";
 import { getSelectionAnchorCellXc } from "../test_helpers/getters_helpers";
 import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 
@@ -42,9 +42,7 @@ describe("Grid component in dashboard mode", () => {
     model.updateMode("dashboard");
     await nextTick();
     expect(getSelectionAnchorCellXc(model)).toBe("A1");
-    document.activeElement!.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
-    );
+    keyDown({ key: "ArrowRight" });
     expect(getSelectionAnchorCellXc(model)).not.toBe("B1");
   });
 

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -31,6 +31,7 @@ import {
   getElStyle,
   simulateClick,
   triggerMouseEvent,
+  triggerWheelEvent,
 } from "../test_helpers/dom_helper";
 import { getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
@@ -170,7 +171,7 @@ describe("figures", () => {
   test("Add a figure on sheet2, scroll down on sheet 1, switch to sheet 2, the figure should be displayed", async () => {
     createSheet(model, { sheetId: "42", position: 1 });
     createFigure(model, {}, "42");
-    fixture.querySelector(".o-grid")!.dispatchEvent(new WheelEvent("wheel", { deltaX: 1500 }));
+    triggerWheelEvent(".o-grid", { deltaX: 1500 });
     fixture.querySelector(".o-scrollbar.vertical")!.dispatchEvent(new Event("scroll"));
     await nextTick();
     activateSheet(model, "42");
@@ -374,9 +375,7 @@ describe("figures", () => {
         const figureEl = fixture.querySelector(".o-figure")!;
 
         triggerMouseEvent(figureEl, "mousedown");
-        figureEl.dispatchEvent(
-          new WheelEvent("wheel", { deltaY: wheelY, deltaX: wheelX, bubbles: true })
-        );
+        triggerWheelEvent(figureEl, { deltaY: wheelY, deltaX: wheelX });
         triggerMouseEvent(figureEl, "mouseup");
         await nextTick();
 
@@ -450,7 +449,7 @@ describe("figures", () => {
     createFigure(model);
     model.dispatch("SELECT_FIGURE", { id: "someuuid" });
     await nextTick();
-    fixture.querySelector(".o-grid")!.dispatchEvent(new WheelEvent("wheel", { deltaX: 1500 }));
+    triggerWheelEvent(".o-grid", { deltaY: 1500 });
     fixture.querySelector(".o-scrollbar.vertical")!.dispatchEvent(new Event("scroll"));
     expect(model.getters.getSelectedFigureId()).toEqual("someuuid");
   });

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -29,6 +29,8 @@ import {
 import {
   dragElement,
   getElStyle,
+  keyDown,
+  keyUp,
   simulateClick,
   triggerMouseEvent,
   triggerWheelEvent,
@@ -149,8 +151,7 @@ describe("figures", () => {
     const figure = fixture.querySelector(".o-figure")!;
     await simulateClick(".o-figure");
     expect(document.activeElement).toBe(figure);
-    figure.dispatchEvent(new KeyboardEvent("keydown", { key: "Delete" }));
-    await nextTick();
+    await keyDown({ key: "Delete" });
     expect(fixture.querySelector(".o-figure")).toBeNull();
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid>input"));
   });
@@ -160,10 +161,9 @@ describe("figures", () => {
     setCellContent(model, "A1", "content");
     selectCell(model, "A1");
     await nextTick();
-    const figure = fixture.querySelector(".o-figure")!;
+    fixture.querySelector(".o-figure")!;
     await simulateClick(".o-figure");
-    figure.dispatchEvent(new KeyboardEvent("keydown", { key: "Delete", bubbles: true }));
-    await nextTick();
+    await keyDown({ key: "Delete" });
     expect(fixture.querySelector(".o-figure")).toBeNull();
     expect(getCellContent(model, "A1")).toBe("content");
   });
@@ -184,41 +184,27 @@ describe("figures", () => {
     let figure = model.getters.getFigure(sheetId, "someuuid");
     expect(figure).toMatchObject({ id: "someuuid", x: 1, y: 1 });
     await nextTick();
-    const figureContainer = fixture.querySelector(".o-figure")!;
+    fixture.querySelector(".o-figure")!;
     await simulateClick(".o-figure");
     await nextTick();
     const selectedFigure = model.getters.getSelectedFigureId();
     expect(selectedFigure).toBe("someuuid");
     //down
-    figureContainer.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
-    );
-    figureContainer.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
-    );
-    await nextTick();
+    keyDown({ key: "ArrowDown" });
+    await keyDown({ key: "ArrowDown" });
     figure = model.getters.getFigure(sheetId, "someuuid");
     expect(figure).toMatchObject({ id: "someuuid", x: 1, y: 3 });
     //right
-    figureContainer.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
-    );
-    figureContainer.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
-    );
-    await nextTick();
+    keyDown({ key: "ArrowRight" });
+    await keyDown({ key: "ArrowRight" });
     figure = model.getters.getFigure(sheetId, "someuuid");
     expect(figure).toMatchObject({ id: "someuuid", x: 3, y: 3 });
     //left
-    figureContainer.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true })
-    );
-    await nextTick();
+    await keyDown({ key: "ArrowLeft" });
     figure = model.getters.getFigure(sheetId, "someuuid");
     expect(figure).toMatchObject({ id: "someuuid", x: 2, y: 3 });
     //up
-    figureContainer.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
-    await nextTick();
+    await keyDown({ key: "ArrowUp" });
     figure = model.getters.getFigure(sheetId, "someuuid");
     expect(figure).toMatchObject({ id: "someuuid", x: 2, y: 2 });
   });
@@ -251,9 +237,7 @@ describe("figures", () => {
     await nextTick();
     setCellContent(model, "A1", "hello");
     await simulateClick(".o-figure");
-    fixture
-      .querySelector(".o-figure")
-      ?.dispatchEvent(new KeyboardEvent("keydown", { key: "z", ctrlKey: true, bubbles: true }));
+    keyDown({ key: "z", ctrlKey: true });
     expect(getCellText(model, "A1")).toBe("");
   });
 
@@ -603,13 +587,9 @@ describe("figures", () => {
       test("Selecting a figure and hitting Ctrl does not unselect it", async () => {
         await simulateClick(".o-figure");
         expect(model.getters.getSelectedFigureId()).toBe(figureId);
-        document.activeElement!.dispatchEvent(
-          new KeyboardEvent("keydown", { key: "Control", bubbles: true })
-        );
+        keyDown({ key: "Control" });
         expect(model.getters.getSelectedFigureId()).toBe(figureId);
-        document.activeElement!.dispatchEvent(
-          new KeyboardEvent("keyup", { key: "Control", bubbles: true })
-        );
+        keyUp({ key: "Control" });
         expect(model.getters.getSelectedFigureId()).toBe(figureId);
       });
     }

--- a/tests/components/filter_menu.test.ts
+++ b/tests/components/filter_menu.test.ts
@@ -7,7 +7,7 @@ import {
   setFormat,
   updateFilter,
 } from "../test_helpers/commands_helpers";
-import { keyDown, simulateClick } from "../test_helpers/dom_helper";
+import { focusAndKeyDown, keyDown, simulateClick } from "../test_helpers/dom_helper";
 import { getCellsObject, mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
 
 async function openFilterMenu() {
@@ -190,7 +190,7 @@ describe("Filter menu component", () => {
     test("Hitting esc key correctly closes the filter menu", async () => {
       await openFilterMenu();
       expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(1);
-      await keyDown("Escape");
+      await keyDown({ key: "Escape" });
       expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(0);
     });
 
@@ -228,35 +228,26 @@ describe("Filter menu component", () => {
 
       test("Can use up/down arrow keys to select items", async () => {
         await openFilterMenu();
-        const searchInput = fixture.querySelector(".o-filter-menu input") as HTMLInputElement;
 
-        searchInput.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
-        await nextTick();
+        await focusAndKeyDown(".o-filter-menu input", { key: "ArrowDown" });
         const listItems = fixture.querySelectorAll(".o-filter-menu-value");
         expect(listItems[0].classList.contains("selected")).toBeTruthy();
 
-        searchInput.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
-        await nextTick();
+        await keyDown({ key: "ArrowDown" });
         expect(listItems[1].classList.contains("selected")).toBeTruthy();
 
-        searchInput.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
-        await nextTick();
+        await keyDown({ key: "ArrowUp" });
         expect(listItems[0].classList.contains("selected")).toBeTruthy();
       });
 
       test("Can press enter to select/unselect items", async () => {
         await openFilterMenu();
-        const searchInput = fixture.querySelector(".o-filter-menu input") as HTMLInputElement;
 
-        searchInput.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
-        await nextTick();
-
-        searchInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
-        await nextTick();
+        await focusAndKeyDown(".o-filter-menu input", { key: "ArrowDown" });
+        await keyDown({ key: "Enter" });
         expect(getFilterMenuValues()[0].isChecked).toBeFalsy();
 
-        searchInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
-        await nextTick();
+        await keyDown({ key: "Enter" });
         expect(getFilterMenuValues()[0].isChecked).toBeTruthy();
       });
     });

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -1,6 +1,6 @@
 import { Model, Spreadsheet } from "../../src";
 import { setCellContent } from "../test_helpers/commands_helpers";
-import { click, setInputValueAndTrigger } from "../test_helpers/dom_helper";
+import { click, focusAndKeyDown, setInputValueAndTrigger } from "../test_helpers/dom_helper";
 import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
@@ -118,10 +118,7 @@ describe("find and replace sidePanel component", () => {
 
     test("Going to next with Enter key", async () => {
       setInputValueAndTrigger(selectors.inputSearch, "1", "input");
-      document
-        .querySelector(selectors.inputSearch)!
-        .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
-      await nextTick();
+      await focusAndKeyDown(selectors.inputSearch, { key: "Enter" });
       expect(dispatch).toHaveBeenCalledWith("SELECT_SEARCH_NEXT_MATCH");
     });
 
@@ -278,10 +275,7 @@ describe("find and replace sidePanel component", () => {
       setInputValueAndTrigger(selectors.inputSearch, "hell", "input");
       setInputValueAndTrigger(selectors.inputReplace, "kikou", "input");
       const dispatch = spyDispatch(parent);
-      document
-        .querySelector(selectors.inputReplace)!
-        .dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
-      await nextTick();
+      await focusAndKeyDown(selectors.inputReplace, { key: "Enter" });
       expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "kikou" });
     });
   });

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -1,9 +1,9 @@
 import { arg, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
+import { keyDown, keyUp } from "../test_helpers/dom_helper";
 import {
   clearFunctions,
   mountSpreadsheet,
-  nextTick,
   restoreDefaultFunctions,
   typeInComposerGrid,
 } from "../test_helpers/helpers";
@@ -19,8 +19,7 @@ beforeEach(async () => {
   ({ model, fixture } = await mountSpreadsheet());
 
   // start composition
-  document.querySelector(".o-grid")!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
-  await nextTick();
+  await keyDown({ key: "Enter" });
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
 });
 
@@ -196,10 +195,8 @@ describe("formula assistant", () => {
     test("use arrowKey when selection in a function should not display formula assistant", async () => {
       await typeInComposerGrid("=FUNC1(1,");
       expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
-      composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
-      await nextTick();
-      composerEl.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowRight", bubbles: true }));
-      await nextTick();
+      await keyDown({ key: "ArrowRight" });
+      await keyUp({ key: "ArrowRight" });
       expect(model.getters.getCurrentContent()).toBe("=FUNC1(1,B1");
       expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(0);
     });

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -45,6 +45,7 @@ import {
   rightClickCell,
   simulateClick,
   triggerMouseEvent,
+  triggerWheelEvent,
 } from "../test_helpers/dom_helper";
 import {
   getActiveSheetFullScrollInfo,
@@ -973,14 +974,7 @@ describe("Grid component", () => {
 
   describe("Grid Scroll", () => {
     async function scrollGrid(args: { deltaY?: number; shiftKey?: boolean }) {
-      fixture.querySelector(".o-grid")!.dispatchEvent(
-        new WheelEvent("wheel", {
-          deltaY: args.deltaY || 0,
-          shiftKey: args.shiftKey,
-          deltaMode: 0,
-          bubbles: true,
-        })
-      );
+      triggerWheelEvent(".o-grid", { deltaY: args.deltaY || 0, shiftKey: args.shiftKey });
       await nextTick();
     }
 
@@ -1227,8 +1221,7 @@ describe("error tooltip", () => {
   test("Wheel events on error tooltip are scrolling the grid", async () => {
     setCellContent(model, "C1", "=0/0");
     await hoverCell(model, "C1", 400);
-    const ev = new WheelEvent("wheel", { deltaY: 300, deltaX: 300, deltaMode: 0, bubbles: true });
-    document.querySelector(".o-error-tooltip")!.dispatchEvent(ev);
+    triggerWheelEvent(".o-error-tooltip", { deltaY: 300, deltaX: 300 });
     await nextTick();
     expect(getVerticalScroll()).toBe(300);
     expect(getHorizontalScroll()).toBe(300);
@@ -1241,7 +1234,7 @@ describe("Events on Grid update viewport correctly", () => {
   });
 
   test("Vertical scroll", async () => {
-    fixture.querySelector(".o-grid")!.dispatchEvent(new WheelEvent("wheel", { deltaY: 1200 }));
+    triggerWheelEvent(".o-grid", { deltaY: 1200 });
     await nextTick();
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 52,
@@ -1257,9 +1250,7 @@ describe("Events on Grid update viewport correctly", () => {
     });
   });
   test("Horizontal scroll", async () => {
-    fixture
-      .querySelector(".o-grid")!
-      .dispatchEvent(new WheelEvent("wheel", { deltaY: 200, shiftKey: true }));
+    triggerWheelEvent(".o-grid", { deltaY: 200, shiftKey: true });
     await nextTick();
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 0,
@@ -1299,16 +1290,8 @@ describe("Events on Grid update viewport correctly", () => {
   });
   test("Move selection horizontally (left to right) through pane division resets the scroll", async () => {
     freezeColumns(model, 3);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: 4 * DEFAULT_CELL_WIDTH,
-        shiftKey: true,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_WIDTH, shiftKey: true });
+
     await clickCell(model, "C1");
     expect(model.getters.getActiveMainViewport().left).toEqual(7);
     expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(4 * DEFAULT_CELL_WIDTH);
@@ -1322,16 +1305,7 @@ describe("Events on Grid update viewport correctly", () => {
 
   test("Move selection horizontally (right to left) through pane division does not reset the scroll", async () => {
     freezeColumns(model, 3);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: 4 * DEFAULT_CELL_WIDTH,
-        shiftKey: true,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_WIDTH, shiftKey: true });
     await clickCell(model, "H1");
     expect(model.getters.getActiveMainViewport().left).toEqual(7);
     expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(4 * DEFAULT_CELL_WIDTH);
@@ -1341,16 +1315,7 @@ describe("Events on Grid update viewport correctly", () => {
     expect(model.getters.getSelectedZone()).toEqual(toZone("G1"));
     expect(model.getters.getActiveMainViewport().left).toEqual(6);
     expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(3 * DEFAULT_CELL_WIDTH);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: -4 * DEFAULT_CELL_WIDTH,
-        shiftKey: true,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: -4 * DEFAULT_CELL_WIDTH, shiftKey: true });
     await clickCell(model, "D1");
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowLeft", shiftKey: false, bubbles: true })
@@ -1362,16 +1327,7 @@ describe("Events on Grid update viewport correctly", () => {
 
   test("Move selection vertically (top to bottom) through pane division resets the scroll", async () => {
     freezeRows(model, 3);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: 4 * DEFAULT_CELL_HEIGHT,
-        shiftKey: false,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_HEIGHT });
     await clickCell(model, "A3");
     expect(model.getters.getActiveMainViewport().top).toEqual(7);
     expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(4 * DEFAULT_CELL_HEIGHT);
@@ -1385,16 +1341,7 @@ describe("Events on Grid update viewport correctly", () => {
 
   test("Move selection vertically (bottom to to) through pane division does not reset the scroll", async () => {
     freezeRows(model, 3);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: 4 * DEFAULT_CELL_HEIGHT,
-        shiftKey: false,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_HEIGHT });
     await clickCell(model, "A8");
     expect(model.getters.getActiveMainViewport().top).toEqual(7);
     expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(4 * DEFAULT_CELL_HEIGHT);
@@ -1404,16 +1351,7 @@ describe("Events on Grid update viewport correctly", () => {
     expect(model.getters.getSelectedZone()).toEqual(toZone("A7"));
     expect(model.getters.getActiveMainViewport().top).toEqual(6);
     expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(3 * DEFAULT_CELL_HEIGHT);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: -4 * DEFAULT_CELL_HEIGHT,
-        shiftKey: false,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: -4 * DEFAULT_CELL_HEIGHT });
     await clickCell(model, "A4");
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowUp", shiftKey: false, bubbles: true })
@@ -1449,16 +1387,7 @@ describe("Events on Grid update viewport correctly", () => {
 
   test("Alter selection horizontally (left to right) through pane division resets the scroll", async () => {
     freezeColumns(model, 3);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: 4 * DEFAULT_CELL_WIDTH,
-        shiftKey: true,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_WIDTH, shiftKey: true });
     await clickCell(model, "C1");
     expect(model.getters.getActiveMainViewport().left).toEqual(7);
     expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(4 * DEFAULT_CELL_WIDTH);
@@ -1472,16 +1401,7 @@ describe("Events on Grid update viewport correctly", () => {
 
   test("Alter selection horizontally (right to left) through pane division does not reset the scroll", async () => {
     freezeColumns(model, 3);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: 4 * DEFAULT_CELL_WIDTH,
-        shiftKey: true,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_WIDTH, shiftKey: true });
     await clickCell(model, "H1");
     expect(model.getters.getActiveMainViewport().left).toEqual(7);
     expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(4 * DEFAULT_CELL_WIDTH);
@@ -1491,16 +1411,7 @@ describe("Events on Grid update viewport correctly", () => {
     expect(model.getters.getSelectedZone()).toEqual(toZone("G1:H1"));
     expect(model.getters.getActiveMainViewport().left).toEqual(6);
     expect(model.getters.getActiveSheetScrollInfo().scrollX).toEqual(3 * DEFAULT_CELL_WIDTH);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: -4 * DEFAULT_CELL_WIDTH,
-        shiftKey: true,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: -4 * DEFAULT_CELL_WIDTH, shiftKey: true });
     await clickCell(model, "D1");
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowLeft", shiftKey: true, bubbles: true })
@@ -1512,16 +1423,7 @@ describe("Events on Grid update viewport correctly", () => {
 
   test("Alter selection vertically (top to bottom) through pane division resets the scroll", async () => {
     freezeRows(model, 3);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: 4 * DEFAULT_CELL_HEIGHT,
-        shiftKey: false,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_HEIGHT });
     await clickCell(model, "A3");
     expect(model.getters.getActiveMainViewport().top).toEqual(7);
     expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(4 * DEFAULT_CELL_HEIGHT);
@@ -1535,16 +1437,7 @@ describe("Events on Grid update viewport correctly", () => {
 
   test("Alter selection vertically (bottom to to) through pane division does not reset the scroll", async () => {
     freezeRows(model, 3);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: 4 * DEFAULT_CELL_HEIGHT,
-        shiftKey: false,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: 4 * DEFAULT_CELL_HEIGHT });
     await clickCell(model, "A8");
     expect(model.getters.getActiveMainViewport().top).toEqual(7);
     expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(4 * DEFAULT_CELL_HEIGHT);
@@ -1554,16 +1447,7 @@ describe("Events on Grid update viewport correctly", () => {
     expect(model.getters.getSelectedZone()).toEqual(toZone("A7:A8"));
     expect(model.getters.getActiveMainViewport().top).toEqual(6);
     expect(model.getters.getActiveSheetScrollInfo().scrollY).toEqual(3 * DEFAULT_CELL_HEIGHT);
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the left
-      new WheelEvent("wheel", {
-        deltaX: 0,
-        deltaY: -4 * DEFAULT_CELL_HEIGHT,
-        shiftKey: false,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: -4 * DEFAULT_CELL_HEIGHT });
     await clickCell(model, "A4");
     document.activeElement!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowUp", shiftKey: true, bubbles: true })
@@ -1577,16 +1461,7 @@ describe("Events on Grid update viewport correctly", () => {
     await simulateClick(".o-grid-overlay"); // gain focus on grid element
     const { width } = model.getters.getMainViewportRect();
     const { width: viewportWidth } = model.getters.getSheetViewDimensionWithHeaders();
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaY: width - viewportWidth,
-        deltaX: 0,
-        shiftKey: true,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, { deltaY: width - viewportWidth, shiftKey: true });
     const viewport = model.getters.getActiveMainViewport();
     selectCell(model, "Y1");
     await nextTick();
@@ -1621,16 +1496,10 @@ describe("Events on Grid update viewport correctly", () => {
     await simulateClick(".o-grid-overlay"); // gain focus on grid element
     const { width } = model.getters.getMainViewportRect();
     const { width: viewportWidth } = model.getters.getSheetViewDimensionWithHeaders();
-    document.activeElement!.dispatchEvent(
-      // scroll completely to the right
-      new WheelEvent("wheel", {
-        deltaY: width - viewportWidth + HEADER_WIDTH,
-        deltaX: 0,
-        shiftKey: true,
-        deltaMode: 0,
-        bubbles: true,
-      })
-    );
+    triggerWheelEvent(document.activeElement!, {
+      deltaY: width - viewportWidth + HEADER_WIDTH,
+      shiftKey: true,
+    });
     const viewport = model.getters.getActiveMainViewport();
     expect(model.getters.getActiveMainViewport()).toMatchObject(viewport);
     await clickCell(model, "Y1", { shiftKey: true });

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -45,6 +45,7 @@ import {
   rightClickCell,
   simulateClick,
   triggerMouseEvent,
+  triggerTouchEvent,
   triggerWheelEvent,
 } from "../test_helpers/dom_helper";
 import {
@@ -61,7 +62,6 @@ import {
   mountSpreadsheet,
   nextTick,
   target,
-  Touch,
   typeInComposerGrid,
 } from "../test_helpers/helpers";
 import { FileStore } from "../__mocks__/mock_file_store";
@@ -144,45 +144,12 @@ describe("Grid component", () => {
     const grid = fixture.querySelector(".o-grid-overlay")!;
     expect(getHorizontalScroll()).toBe(0);
     expect(getVerticalScroll()).toBe(0);
-    grid.dispatchEvent(
-      new TouchEvent("touchstart", {
-        touches: [
-          new Touch({
-            clientX: 150,
-            clientY: 150,
-            identifier: 1,
-            target: grid,
-          }),
-        ],
-      })
-    );
-    grid.dispatchEvent(
-      new TouchEvent("touchmove", {
-        touches: [
-          new Touch({
-            clientX: 100,
-            clientY: 120,
-            identifier: 2,
-            target: grid,
-          }),
-        ],
-      })
-    );
+    triggerTouchEvent(grid, "touchstart", { clientX: 150, clientY: 150, identifier: 1 });
+    triggerTouchEvent(grid, "touchmove", { clientX: 100, clientY: 120, identifier: 2 });
     await nextTick();
     expect(getHorizontalScroll()).toBe(50);
     expect(getVerticalScroll()).toBe(30);
-    grid.dispatchEvent(
-      new TouchEvent("touchmove", {
-        touches: [
-          new Touch({
-            clientX: 80,
-            clientY: 100,
-            identifier: 2,
-            target: grid,
-          }),
-        ],
-      })
-    );
+    triggerTouchEvent(grid, "touchmove", { clientX: 80, clientY: 100, identifier: 2 });
     await nextTick();
     expect(getHorizontalScroll()).toBe(70);
     expect(getVerticalScroll()).toBe(50);
@@ -195,65 +162,15 @@ describe("Grid component", () => {
     const mockCallback = jest.fn(() => {});
     fixture.addEventListener("touchmove", mockCallback);
 
-    grid.dispatchEvent(
-      new TouchEvent("touchstart", {
-        touches: [
-          new Touch({
-            clientX: 0,
-            clientY: 150,
-            identifier: 1,
-            target: grid,
-          }),
-        ],
-      })
-    );
+    triggerTouchEvent(grid, "touchstart", { clientX: 0, clientY: 150, identifier: 1 });
     // move down; we are at the top: ev not prevented
-    grid.dispatchEvent(
-      new TouchEvent("touchmove", {
-        cancelable: true,
-        bubbles: true,
-        touches: [
-          new Touch({
-            clientX: 0,
-            clientY: 120,
-            identifier: 2,
-            target: grid,
-          }),
-        ],
-      })
-    );
+    triggerTouchEvent(grid, "touchmove", { clientX: 0, clientY: 120, identifier: 2 });
     expect(mockCallback).toBeCalledTimes(1);
     // move up:; we are not at the top: ev prevented
-    grid.dispatchEvent(
-      new TouchEvent("touchmove", {
-        cancelable: true,
-        bubbles: true,
-        touches: [
-          new Touch({
-            clientX: 0,
-            clientY: 150,
-            identifier: 3,
-            target: grid,
-          }),
-        ],
-      })
-    );
+    triggerTouchEvent(grid, "touchmove", { clientX: 0, clientY: 150, identifier: 3 });
     expect(mockCallback).toBeCalledTimes(1);
     // move up again but we are at the stop: ev not prevented
-    grid.dispatchEvent(
-      new TouchEvent("touchmove", {
-        cancelable: true,
-        bubbles: true,
-        touches: [
-          new Touch({
-            clientX: 0,
-            clientY: 150,
-            identifier: 4,
-            target: grid,
-          }),
-        ],
-      })
-    );
+    triggerTouchEvent(grid, "touchmove", { clientX: 0, clientY: 150, identifier: 4 });
     expect(mockCallback).toBeCalledTimes(2);
   });
 

--- a/tests/components/link/link_editor.test.ts
+++ b/tests/components/link/link_editor.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../test_helpers/commands_helpers";
 import {
   clickCell,
+  keyDown,
   rightClickCell,
   setInputValueAndTrigger,
   simulateClick,
@@ -232,22 +233,19 @@ describe("link editor component", () => {
     async (input) => {
       await openLinkEditor(model, "A1");
 
-      input().dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-      await nextTick();
+      await keyDown({ key: "Enter" });
       expect(fixture.querySelector(".o-link-editor")).toBeTruthy();
       expect(getCell(model, "A1")).toBeUndefined();
 
       setInputValueAndTrigger(labelInput(), "my label", "input");
       await nextTick();
-      input().dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-      await nextTick();
+      await keyDown({ key: "Enter" });
       expect(fixture.querySelector(".o-link-editor")).toBeTruthy();
       expect(getCell(model, "A1")).toBeUndefined();
 
       setInputValueAndTrigger(urlInput(), "https://url.com", "input");
       await nextTick();
-      input().dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-      await nextTick();
+      await keyDown({ key: "Enter" });
       expect(fixture.querySelector(".o-link-editor")).toBeFalsy();
       expect(getCell(model, "A1")).toBeDefined();
     }

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -139,7 +139,7 @@ describe("Selection Input", () => {
     await createSelectionInput({ onConfirmed });
     expect(fixture.querySelector(".o-focused")).toBeTruthy();
     expect(isConfirmed).toBeFalsy();
-    await keyDown("Enter");
+    await keyDown({ key: "Enter" });
     expect(fixture.querySelector(".o-focused")).toBeFalsy();
     expect(onConfirmed).toHaveBeenCalled();
     expect(isConfirmed).toBeTruthy();
@@ -276,13 +276,11 @@ describe("Selection Input", () => {
     focus(0);
     await nextTick();
     expect(document.activeElement).toBe(selectionInputEl);
-    selectionInputEl.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
-    await nextTick();
+    await keyDown({ key: "ArrowLeft" });
     expect(document.activeElement).toBe(selectionInputEl);
     expect(selectionInputEl?.value).toEqual("B2");
-    selectionInputEl.dispatchEvent(new KeyboardEvent("keydown", { key: "F2" }));
-    selectionInputEl.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
-    await nextTick();
+    keyDown({ key: "F2" });
+    await keyDown({ key: "ArrowLeft" });
     expect(document.activeElement).toBe(selectionInputEl);
     expect(selectionInputEl?.value).toEqual("B2");
   });
@@ -390,8 +388,8 @@ describe("Selection Input", () => {
     let input = fixture.querySelector(".o-selection-input input") as HTMLInputElement;
     await simulateClick(input);
     expect(input.value).toBe("A1");
-    await keyDown("Control");
-    await keyUp("Control");
+    await keyDown({ key: "Control" });
+    await keyUp({ key: "Control" });
     await clickCell(model, "A2");
     expect(fixture.querySelectorAll(".o-selection-input input")).toHaveLength(1);
     input = fixture.querySelector(".o-selection-input input") as HTMLInputElement;

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -17,6 +17,7 @@ import {
   clickCell,
   getElComputedStyle,
   hoverCell,
+  keyDown,
   rightClickCell,
   simulateClick,
 } from "../test_helpers/dom_helper";
@@ -132,30 +133,18 @@ describe("Simple Spreadsheet Component", () => {
   test("can open/close search with ctrl+h", async () => {
     ({ model, parent, fixture } = await mountSpreadsheet());
     await nextTick();
-    document.activeElement!.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "H", ctrlKey: true, bubbles: true })
-    );
-    await nextTick();
+    await keyDown({ key: "H", ctrlKey: true });
     expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
-    document.activeElement!.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "H", ctrlKey: true, bubbles: true })
-    );
-    await nextTick();
+    await keyDown({ key: "H", ctrlKey: true });
     expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
   });
 
   test("can open/close search with ctrl+f", async () => {
     ({ model, parent, fixture } = await mountSpreadsheet());
-    document.activeElement!.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "F", ctrlKey: true, bubbles: true })
-    );
-    await nextTick();
+    await keyDown({ key: "F", ctrlKey: true });
     expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
     await nextTick();
-    document.activeElement!.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "F", ctrlKey: true, bubbles: true })
-    );
-    await nextTick();
+    await keyDown({ key: "F", ctrlKey: true });
     expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
   });
 
@@ -210,13 +199,13 @@ describe("Simple Spreadsheet Component", () => {
   test("Keydown is ineffective in dashboard mode", async () => {
     ({ model, parent, fixture } = await mountSpreadsheet());
     const spreadsheetKeyDown = jest.spyOn(parent, "onKeydown");
-    const spreadsheetDiv = fixture.querySelector(".o-spreadsheet")!;
-    spreadsheetDiv.dispatchEvent(new KeyboardEvent("keydown", { key: "H", ctrlKey: true }));
+    // const spreadsheetDiv = fixture.querySelector(".o-spreadsheet")!;
+    keyDown({ key: "H", ctrlKey: true });
     expect(spreadsheetKeyDown).toHaveBeenCalled();
     jest.clearAllMocks();
     model.updateMode("dashboard");
     await nextTick();
-    spreadsheetDiv.dispatchEvent(new KeyboardEvent("keydown", { key: "H", ctrlKey: true }));
+    keyDown({ key: "H", ctrlKey: true });
     expect(spreadsheetKeyDown).not.toHaveBeenCalled();
   });
 

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -155,8 +155,23 @@ export function triggerWheelEvent(
   }
 ) {
   const ev = new WheelEvent("wheel", { bubbles: true, ...extra });
+  dispatchEvent(selector, ev);
+}
+
+export function triggerKeyboardEvent(
+  selector: string | EventTarget,
+  type: "keydown" | "keyup",
+  eventArgs: KeyboardEventInit
+) {
+  const ev = new KeyboardEvent(type, { bubbles: true, cancelable: true, ...eventArgs });
+  dispatchEvent(selector, ev);
+}
+
+function dispatchEvent(selector: string | EventTarget, ev: Event) {
   if (typeof selector === "string") {
-    document.querySelector(selector)!.dispatchEvent(ev);
+    const el = document.querySelector(selector);
+    if (!el) throw new Error(`"${selector}" does not match any element.`);
+    el.dispatchEvent(ev);
   } else {
     selector.dispatchEvent(ev);
   }
@@ -189,17 +204,33 @@ export function setCheckboxValueAndTrigger(
  *
  * This comment is meant to leave a trace of this change in case some issues were to arise again.
  */
-export async function keyDown(key: string, options: any = {}): Promise<void> {
-  document.activeElement!.dispatchEvent(
-    new KeyboardEvent("keydown", Object.assign({ key, bubbles: true, cancelable: true }, options))
-  );
+export async function keyDown(eventArgs: KeyboardEventInit): Promise<void> {
+  triggerKeyboardEvent(document.activeElement!, "keydown", eventArgs);
   return await nextTick();
 }
 
-export async function keyUp(key: string, options: any = {}): Promise<void> {
-  document.activeElement!.dispatchEvent(
-    new KeyboardEvent("keyup", Object.assign({ key, bubbles: true, cancelable: true }, options))
-  );
+export async function keyUp(eventArgs: KeyboardEventInit): Promise<void> {
+  triggerKeyboardEvent(document.activeElement!, "keyup", eventArgs);
+  return await nextTick();
+}
+
+export async function focusAndKeyDown(
+  selector: DOMTarget,
+  eventArgs: KeyboardEventInit
+): Promise<void> {
+  const target = getTarget(selector);
+  (target as HTMLElement).focus?.();
+  triggerKeyboardEvent(target, "keydown", eventArgs);
+  return await nextTick();
+}
+
+export async function focusAndKeyUp(
+  selector: DOMTarget,
+  eventArgs: KeyboardEventInit
+): Promise<void> {
+  const target = getTarget(selector);
+  (target as HTMLElement).focus?.();
+  triggerKeyboardEvent(target, "keyup", eventArgs);
   return await nextTick();
 }
 

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -287,3 +287,67 @@ export async function dragElement(
 export function edgeScrollDelay(scrollDistance: Pixel, iterations: number) {
   return scrollDelay(Math.abs(Math.round(scrollDistance))) * (iterations + 1) - MIN_DELAY / 2;
 }
+
+/**
+ * The Touch API is defined in typescript ^3.7.7 and implemented in most major browsers, but isn't implemented in JSDOM.
+ * This implementation is used in test to easily trigger TouchEvents.
+ * (TouchEvent is supported by almost all major browsers.)
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/API/Touch
+ */
+export class Touch {
+  readonly altitudeAngle: number;
+  readonly azimuthAngle: number;
+  readonly clientX: number;
+  readonly clientY: number;
+  readonly force: number;
+  readonly identifier: number;
+  readonly pageX: number;
+  readonly pageY: number;
+  readonly radiusX: number;
+  readonly radiusY: number;
+  readonly rotationAngle: number;
+  readonly screenX: number;
+  readonly screenY: number;
+  readonly target: EventTarget;
+  readonly touchType: TouchType;
+  constructor(touchInitDict: TouchInit) {
+    this.identifier = touchInitDict.identifier;
+    this.target = touchInitDict.target;
+    this.altitudeAngle = touchInitDict.altitudeAngle || 0;
+    this.azimuthAngle = touchInitDict.azimuthAngle || 0;
+    this.clientX = touchInitDict.clientX || 0;
+    this.clientY = touchInitDict.clientY || 0;
+    this.force = touchInitDict.force || 0;
+    this.pageX = touchInitDict.pageX || 0;
+    this.pageY = touchInitDict.pageY || 0;
+    this.radiusX = touchInitDict.radiusX || 0;
+    this.radiusY = touchInitDict.radiusY || 0;
+    this.rotationAngle = touchInitDict.rotationAngle || 0;
+    this.screenX = touchInitDict.screenX || 0;
+    this.screenY = touchInitDict.screenY || 0;
+    this.touchType = touchInitDict.touchType || "direct";
+  }
+}
+
+export function triggerTouchEvent(
+  selector: string | EventTarget,
+  type: "touchstart" | "touchend" | "touchmove",
+  extra: Partial<Touch>
+) {
+  const target = typeof selector === "string" ? document.querySelector(selector) : selector;
+  if (!target) throw new Error(`"${selector}" does not match any element.`);
+
+  const ev = new TouchEvent(type, {
+    cancelable: true,
+    bubbles: true,
+    touches: [
+      new Touch({
+        identifier: 1,
+        target: target,
+        ...extra,
+      }),
+    ],
+  });
+  target.dispatchEvent(ev);
+}

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -130,7 +130,7 @@ export function triggerMouseEvent(
   offsetX?: number,
   offsetY?: number,
   extra: MouseEventInit = { bubbles: true }
-): void {
+) {
   const ev = new MouseEvent(type, {
     // this is only correct if we assume the target is positioned
     // at the very top left corner of the screen
@@ -143,6 +143,23 @@ export function triggerMouseEvent(
   (ev as any).offsetY = offsetY;
   const target = getTarget(selector);
   target.dispatchEvent(ev);
+}
+
+export function triggerWheelEvent(
+  selector: string | EventTarget,
+  extra: WheelEventInit = {
+    bubbles: true,
+    deltaMode: WheelEvent.DOM_DELTA_PIXEL, // = 0
+    deltaX: 0,
+    deltaY: 0,
+  }
+) {
+  const ev = new WheelEvent("wheel", { bubbles: true, ...extra });
+  if (typeof selector === "string") {
+    document.querySelector(selector)!.dispatchEvent(ev);
+  } else {
+    selector.dispatchEvent(ev);
+  }
 }
 
 export function setInputValueAndTrigger(

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -469,48 +469,6 @@ export function textContentAll(cssSelector: string): string[] {
 }
 
 /**
- * The Touch API is currently experimental (mid 2020).
- * This implementation is used in test to easily trigger TouchEvents.
- * (TouchEvent is not experimental and supported by all major browsers.)
- *
- * https://developer.mozilla.org/en-US/docs/Web/API/Touch
- */
-export class Touch {
-  readonly altitudeAngle: number;
-  readonly azimuthAngle: number;
-  readonly clientX: number;
-  readonly clientY: number;
-  readonly force: number;
-  readonly identifier: number;
-  readonly pageX: number;
-  readonly pageY: number;
-  readonly radiusX: number;
-  readonly radiusY: number;
-  readonly rotationAngle: number;
-  readonly screenX: number;
-  readonly screenY: number;
-  readonly target: EventTarget;
-  readonly touchType: TouchType;
-  constructor(touchInitDict: TouchInit) {
-    this.identifier = touchInitDict.identifier;
-    this.target = touchInitDict.target;
-    this.altitudeAngle = touchInitDict.altitudeAngle || 0;
-    this.azimuthAngle = touchInitDict.azimuthAngle || 0;
-    this.clientX = touchInitDict.clientX || 0;
-    this.clientY = touchInitDict.clientY || 0;
-    this.force = touchInitDict.force || 0;
-    this.pageX = touchInitDict.pageX || 0;
-    this.pageY = touchInitDict.pageY || 0;
-    this.radiusX = touchInitDict.radiusX || 0;
-    this.radiusY = touchInitDict.radiusY || 0;
-    this.rotationAngle = touchInitDict.rotationAngle || 0;
-    this.screenX = touchInitDict.screenX || 0;
-    this.screenY = touchInitDict.screenY || 0;
-    this.touchType = touchInitDict.touchType || "direct";
-  }
-}
-
-/**
  * Return XLSX export with prettified XML files.
  */
 export async function exportPrettifiedXlsx(model: Model): Promise<XLSXExport> {


### PR DESCRIPTION
The helper shorten the tests and ensure that all the wheelEvents bubbles and have a deltaMode set.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3302326](https://www.odoo.com/web#id=3302326&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo