### PR TITLE
[FIX] Evaluation: break laziness

### DIFF
--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -259,6 +259,19 @@ describe("evaluateCells", () => {
     expect(evaluation.value).toBe(value);
   });
 
+  test("formula returns the first error of its dependencies", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=sum(A2:A3)");
+    setCellContent(model, "A2", "=1/0"); // bad evaluation
+    setCellContent(model, "A3", "=qsd"); // bad expression
+    const cellA1 = getCell(model, "A1")?.evaluated as InvalidEvaluation;
+    const cellA2 = getCell(model, "A2")?.evaluated as InvalidEvaluation;
+    expect(cellA1.type).toBe(CellValueType.error);
+    expect(cellA2.type).toBe(CellValueType.error);
+    expect(cellA1.error.message).toBe(cellA2.error.message);
+    expect(cellA1.value).toBe(cellA2.value);
+  });
+
   test("range", () => {
     const model = new Model();
     setCellContent(model, "D4", "42");


### PR DESCRIPTION
The lazy evaluation is posing problems when trying to evaluate asynchronous
functions. More specifically, asynchronous formula are handled by first
starting the async computaiton and throwing an error. This error will be caught
by the evaluation engine and the cell will be marked as "ERROR" until the async
computation requests a new evaluation.

If a formula depends on the result of several asynchronous formula, the
evaluation engine will try to evaluate the dependencies one by one, each time
catching an error and stopping the evaluation.

This will force the asynchronous formula to be evaluated one by one, preventing
them from being evaluated in batch.

FIX
===
 We propose here to drop the "early fail" when fetching the dependencies
of a formula, which stops at the first caught error. This way, the first asynchronous
function will not prevent the following from being evaluated as well,
which will allow to batch them together at the next execution tick.

As soon as we catch an error, we continue the evaluation but still raise
it afterwards to conserve the current functional behavior.

Task 3165458

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo