### PR TITLE
[FIX] menus,charts: missing translations

### DIFF
--- a/src/helpers/charts/bar_chart.ts
+++ b/src/helpers/charts/bar_chart.ts
@@ -1,6 +1,7 @@
 import { ChartConfiguration, ChartDataSets, ChartLegendOptions } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../constants";
 import { chartRegistry } from "../../registries/chart_types";
+import { _lt } from "../../translation";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -56,7 +57,7 @@ chartRegistry.add("bar", {
   ) => BarChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     BarChart.getDefinitionFromContextCreation(context),
-  name: "Bar",
+  name: _lt("Bar"),
 });
 
 export class BarChart extends AbstractChart {

--- a/src/helpers/charts/gauge_chart.ts
+++ b/src/helpers/charts/gauge_chart.ts
@@ -6,6 +6,7 @@ import {
 } from "../../constants";
 import { BasePlugin } from "../../plugins/base_plugin";
 import { chartRegistry } from "../../registries/chart_types";
+import { _lt } from "../../translation";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -49,7 +50,7 @@ chartRegistry.add("gauge", {
   ) => GaugeChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     GaugeChart.getDefinitionFromContextCreation(context),
-  name: "Gauge",
+  name: _lt("Gauge"),
 });
 
 type RangeLimitsValidation = (rangeLimit: string, rangeLimitName: string) => CommandResult;

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -1,6 +1,7 @@
 import { ChartConfiguration, ChartDataSets, ChartLegendOptions } from "chart.js";
 import { BACKGROUND_CHART_COLOR, LINE_FILL_TRANSPARENCY } from "../../constants";
 import { chartRegistry } from "../../registries/chart_types";
+import { _lt } from "../../translation";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -64,7 +65,7 @@ chartRegistry.add("line", {
   ) => LineChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     LineChart.getDefinitionFromContextCreation(context),
-  name: "Line",
+  name: _lt("Line"),
 });
 
 export class LineChart extends AbstractChart {

--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -7,6 +7,7 @@ import {
 } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../constants";
 import { chartRegistry } from "../../registries/chart_types";
+import { _lt } from "../../translation";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -62,7 +63,7 @@ chartRegistry.add("pie", {
   ) => PieChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     PieChart.getDefinitionFromContextCreation(context),
-  name: "Pie",
+  name: _lt("Pie"),
 });
 
 export class PieChart extends AbstractChart {

--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -1,6 +1,6 @@
 import { transformZone } from "../../collaborative/ot/ot_helpers";
 import { chartRegistry } from "../../registries/chart_types";
-import { _t } from "../../translation";
+import { _lt, _t } from "../../translation";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -47,7 +47,7 @@ chartRegistry.add("scorecard", {
   ) => ScorecardChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     ScorecardChart.getDefinitionFromContextCreation(context),
-  name: "Scorecard",
+  name: _lt("Scorecard"),
 });
 
 function checkKeyValue(definition: ScorecardChartDefinition): CommandResult {

--- a/src/registries/menus/col_menu_registry.ts
+++ b/src/registries/menus/col_menu_registry.ts
@@ -93,7 +93,7 @@ colMenuRegistry
     separator: true,
   })
   .add("unhide_columns", {
-    name: "Unhide columns",
+    name: _lt("Unhide columns"),
     sequence: 86,
     action: ACTIONS.UNHIDE_COLUMNS_ACTION,
     isVisible: (env: SpreadsheetChildEnv) => {

--- a/src/registries/menus/row_menu_registry.ts
+++ b/src/registries/menus/row_menu_registry.ts
@@ -76,7 +76,7 @@ rowMenuRegistry
     separator: true,
   })
   .add("unhide_rows", {
-    name: "Unhide rows",
+    name: _lt("Unhide rows"),
     sequence: 86,
     action: ACTIONS.UNHIDE_ROWS_ACTION,
     isVisible: (env: SpreadsheetChildEnv) => {

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -387,17 +387,17 @@ topbarMenuRegistry
     separator: true,
   })
   .addChild("format_wrapping_overflow", ["format", "format_wrapping"], {
-    name: "Overflow",
+    name: _lt("Overflow"),
     sequence: 10,
     action: (env: SpreadsheetChildEnv) => setStyle(env, { wrapping: "overflow" }),
   })
   .addChild("format_wrapping_wrap", ["format", "format_wrapping"], {
-    name: "Wrap",
+    name: _lt("Wrap"),
     sequence: 20,
     action: (env: SpreadsheetChildEnv) => setStyle(env, { wrapping: "wrap" }),
   })
   .addChild("format_wrapping_clip", ["format", "format_wrapping"], {
-    name: "Clip",
+    name: _lt("Clip"),
     sequence: 30,
     action: (env: SpreadsheetChildEnv) => setStyle(env, { wrapping: "clip" }),
   })


### PR DESCRIPTION
There were some missing translations in the menu items as well as the chart type names.

Task 3196113

Fixes https://github.com/odoo/odoo/issues/112235

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo