### PR TITLE
[FIX] font_size_editor: add props definition

### DIFF
--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -103,3 +103,8 @@ export class FontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 }
+
+FontSizeEditor.props = {
+  onToggle: Function,
+  dropdownStyle: String,
+};


### PR DESCRIPTION
Before this revision, props were not defined on FontSizeEditor component. This caused a warning in the console when using the component.

Task-id 3196333

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3196333](https://www.odoo.com/web#id=3196333&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo