### PR TITLE
[IMP] figure: remove useless chart registry filling

### DIFF
--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -1,14 +1,12 @@
 import { Component, xml } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
-import { ChartJsComponent } from "../../src/components/figures/chart/chartJs/chartjs";
-import { ScorecardChart } from "../../src/components/figures/chart/scorecard/chart_scorecard";
 import {
   FIGURE_BORDER_COLOR,
   MENU_WIDTH,
   MIN_FIG_SIZE,
   SELECTION_BORDER_COLOR,
 } from "../../src/constants";
-import { chartComponentRegistry, figureRegistry } from "../../src/registries";
+import { figureRegistry } from "../../src/registries";
 import { CreateFigureCommand, Figure, SpreadsheetChildEnv, UID } from "../../src/types";
 
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
@@ -104,12 +102,6 @@ mockGetBoundingClientRect({
 
 beforeAll(() => {
   figureRegistry.add("text", { Component: TextFigure });
-  // TODO : remove this once #1861 is merged
-  chartComponentRegistry.add("line", ChartJsComponent);
-  chartComponentRegistry.add("bar", ChartJsComponent);
-  chartComponentRegistry.add("pie", ChartJsComponent);
-  chartComponentRegistry.add("gauge", ChartJsComponent);
-  chartComponentRegistry.add("scorecard", ScorecardChart);
 });
 afterAll(() => {
   figureRegistry.remove("text");


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo