### PR TITLE
[REF] figure: unify chart and image menus

### DIFF
--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -4,6 +4,7 @@
       <div
         class="o-figure w-100 h-100"
         t-on-mousedown.stop="(ev) => this.onMouseDown(ev)"
+        t-on-contextmenu.prevent.stop="onContextMenu"
         t-ref="figure"
         t-att-style="props.style"
         tabindex="0"
@@ -15,6 +16,21 @@
           onFigureDeleted="props.onFigureDeleted"
           figure="props.figure"
         />
+        <div class="o-figure-menu position-absolute m-2" t-if="!env.isDashboard()">
+          <div
+            class="o-figure-menu-item"
+            t-on-click="showMenu"
+            t-ref="menuButton"
+            t-on-contextmenu.prevent.stop="showMenu">
+            <t t-call="o-spreadsheet-Icon.LIST"/>
+          </div>
+          <Menu
+            t-if="menuState.isOpen"
+            position="menuState.position"
+            menuItems="menuState.menuItems"
+            onClose="() => this.menuState.isOpen=false"
+          />
+        </div>
       </div>
       <div class="o-figure-border w-100 h-100 position-absolute pe-none" t-att-style="borderStyle"/>
       <t t-if="isSelected">

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -1,12 +1,7 @@
-import { Component, useRef, useState } from "@odoo/owl";
-import { MENU_WIDTH } from "../../../constants";
+import { Component } from "@odoo/owl";
 import { chartComponentRegistry } from "../../../registries/chart_types";
-import { MenuItemRegistry } from "../../../registries/menu_items_registry";
-import { _lt } from "../../../translation";
-import { ChartType, DOMCoordinates, Figure, SpreadsheetChildEnv } from "../../../types";
+import { ChartType, Figure, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
-import { useAbsoluteBoundingRect } from "../../helpers/position_hook";
-import { Menu, MenuState } from "../../menu/menu";
 
 // -----------------------------------------------------------------------------
 // STYLE
@@ -28,82 +23,10 @@ interface Props {
 
 export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartFigure";
-  static components = { Menu };
-  private menuState: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
-
-  private chartContainerRef = useRef("chartContainer");
-  private menuButtonRef = useRef("menuButton");
-  private menuButtonRect = useAbsoluteBoundingRect(this.menuButtonRef);
-  private position: DOMCoordinates = useAbsoluteBoundingRect(this.chartContainerRef);
-
-  private getMenuItemRegistry(): MenuItemRegistry {
-    const registry = new MenuItemRegistry();
-    registry.add("edit", {
-      name: _lt("Edit"),
-      sequence: 1,
-      action: () => {
-        this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
-        this.env.openSidePanel("ChartPanel");
-      },
-    });
-    registry.add("copy", {
-      name: _lt("Copy"),
-      sequence: 2,
-      action: async () => {
-        this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
-        this.env.model.dispatch("COPY");
-        await this.env.clipboard.write(this.env.model.getters.getClipboardContent());
-      },
-    });
-    registry.add("cut", {
-      name: _lt("Cut"),
-      sequence: 3,
-      action: async () => {
-        this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
-        this.env.model.dispatch("CUT");
-        await this.env.clipboard.write(this.env.model.getters.getClipboardContent());
-      },
-    });
-    registry.add("delete", {
-      name: _lt("Delete"),
-      sequence: 10,
-      action: () => {
-        this.env.model.dispatch("DELETE_FIGURE", {
-          sheetId: this.env.model.getters.getActiveSheetId(),
-          id: this.props.figure.id,
-        });
-        this.props.onFigureDeleted();
-      },
-    });
-    return registry;
-  }
+  static components = {};
 
   get chartType(): ChartType {
     return this.env.model.getters.getChartType(this.props.figure.id);
-  }
-
-  onContextMenu(ev: MouseEvent) {
-    const position = {
-      x: this.position.x + ev.offsetX,
-      y: this.position.y + ev.offsetY,
-    };
-    this.openContextMenu(position);
-  }
-
-  showMenu() {
-    const { x, y, width } = this.menuButtonRect;
-    const menuPosition = {
-      x: x >= MENU_WIDTH ? x - MENU_WIDTH : x + width,
-      y: y,
-    };
-    this.openContextMenu(menuPosition);
-  }
-
-  private openContextMenu(position: DOMCoordinates) {
-    const registry = this.getMenuItemRegistry();
-    this.menuState.isOpen = true;
-    this.menuState.menuItems = registry.getMenuItems();
-    this.menuState.position = position;
   }
 
   get chartComponent(): new (...args: any) => Component {

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -1,29 +1,10 @@
 <templates>
   <t t-name="o-spreadsheet-ChartFigure" owl="1">
-    <div
-      class="o-chart-container w-100 h-100"
-      t-ref="chartContainer"
-      t-on-contextmenu.prevent.stop="(ev) => !env.isDashboard() and this.onContextMenu(ev)">
-      <div class="o-figure-menu" t-if="!env.isDashboard()">
-        <div
-          class="o-figure-menu-item"
-          t-on-click="showMenu"
-          t-ref="menuButton"
-          t-on-contextmenu.prevent.stop="showMenu">
-          <t t-call="o-spreadsheet-Icon.LIST"/>
-        </div>
-      </div>
+    <div class="o-chart-container w-100 h-100">
       <t
         t-component="chartComponent"
         figure="this.props.figure"
         t-key="this.props.figure.id + '-' + chartType"
-      />
-
-      <Menu
-        t-if="menuState.isOpen"
-        position="menuState.position"
-        menuItems="menuState.menuItems"
-        onClose="() => this.menuState.isOpen=false"
       />
     </div>
   </t>

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -1,11 +1,5 @@
-import { Component, useRef, useState } from "@odoo/owl";
-import { MENU_WIDTH } from "../../../constants";
-import { getMaxFigureSize } from "../../../helpers/figures/figure/figure";
-import { createMenu } from "../../../registries/menu_items_registry";
-import { _lt } from "../../../translation";
-import { DOMCoordinates, Figure, SpreadsheetChildEnv, UID } from "../../../types";
-import { useAbsoluteBoundingRect } from "../../helpers/position_hook";
-import { Menu, MenuState } from "../../menu/menu";
+import { Component } from "@odoo/owl";
+import { Figure, SpreadsheetChildEnv, UID } from "../../../types";
 
 interface Props {
   figure: Figure;
@@ -14,86 +8,7 @@ interface Props {
 
 export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ImageFigure";
-  static components = { Menu };
-  private menuState: Pick<MenuState, "isOpen" | "position"> = useState({
-    isOpen: false,
-    position: null,
-  });
-
-  private imageContainerRef = useRef("o-image");
-  private menuButtonRef = useRef("menuButton");
-  private menuButtonRect = useAbsoluteBoundingRect(this.menuButtonRef);
-  private position: DOMCoordinates = useAbsoluteBoundingRect(this.imageContainerRef);
-
-  readonly menuItems = createMenu([
-    {
-      id: "copy",
-      name: _lt("Copy"),
-      description: "Ctrl+C",
-      action: async () => {
-        this.env.model.dispatch("SELECT_FIGURE", { id: this.figureId });
-        this.env.model.dispatch("COPY");
-        await this.env.clipboard.write(this.env.model.getters.getClipboardContent());
-      },
-    },
-    {
-      id: "cut",
-      name: _lt("Cut"),
-      description: "Ctrl+X",
-      action: async () => {
-        this.env.model.dispatch("SELECT_FIGURE", { id: this.figureId });
-        this.env.model.dispatch("CUT");
-        await this.env.clipboard.write(this.env.model.getters.getClipboardContent());
-      },
-    },
-    {
-      id: "reset_size",
-      name: _lt("Reset size"),
-      action: () => {
-        const size = this.env.model.getters.getImageSize(this.figureId);
-        const { height, width } = getMaxFigureSize(this.env.model.getters, size);
-        this.env.model.dispatch("UPDATE_FIGURE", {
-          sheetId: this.env.model.getters.getActiveSheetId(),
-          id: this.figureId,
-          height,
-          width,
-        });
-      },
-    },
-    {
-      id: "delete",
-      name: _lt("Delete image"),
-      description: "delete",
-      action: () => {
-        this.env.model.dispatch("DELETE_FIGURE", {
-          sheetId: this.env.model.getters.getActiveSheetId(),
-          id: this.figureId,
-        });
-      },
-    },
-  ]);
-
-  onContextMenu(ev: MouseEvent) {
-    const position = {
-      x: this.position.x + ev.offsetX,
-      y: this.position.y + ev.offsetY,
-    };
-    this.openContextMenu(position);
-  }
-
-  showMenu() {
-    const { x, y, width } = this.menuButtonRect;
-    const menuPosition = {
-      x: x >= MENU_WIDTH ? x - MENU_WIDTH : x + width,
-      y: y,
-    };
-    this.openContextMenu(menuPosition);
-  }
-
-  private openContextMenu(position: DOMCoordinates) {
-    this.menuState.isOpen = true;
-    this.menuState.position = position;
-  }
+  static components = {};
 
   // ---------------------------------------------------------------------------
   // Getters

--- a/src/components/figures/figure_image/figure_image.xml
+++ b/src/components/figures/figure_image/figure_image.xml
@@ -1,25 +1,5 @@
 <templates>
   <t t-name="o-spreadsheet-ImageFigure" owl="1">
-    <div class="o-figure-menu" t-if="!env.isDashboard()">
-      <div
-        class="o-figure-menu-item"
-        t-on-click="showMenu"
-        t-ref="menuButton"
-        t-on-contextmenu.prevent.stop="showMenu">
-        <t t-call="o-spreadsheet-Icon.LIST"/>
-      </div>
-    </div>
-    <img
-      t-ref="o-image"
-      t-att-src="getImagePath"
-      class="w-100 h-100"
-      t-on-contextmenu.prevent.stop="(ev) => !env.isDashboard() and this.onContextMenu(ev)"
-    />
-    <Menu
-      t-if="menuState.isOpen"
-      position="menuState.position"
-      menuItems="menuItems"
-      onClose="() => this.menuState.isOpen=false"
-    />
+    <img t-att-src="getImagePath" class="w-100 h-100"/>
   </t>
 </templates>

--- a/src/registries/figure_registry.ts
+++ b/src/registries/figure_registry.ts
@@ -1,5 +1,9 @@
 import { ChartFigure } from "../components/figures/figure_chart/figure_chart";
 import { ImageFigure } from "../components/figures/figure_image/figure_image";
+import { getMaxFigureSize } from "../helpers/figures/figure/figure";
+import { _lt } from "../translation";
+import { SpreadsheetChildEnv, UID } from "../types";
+import { createMenu, MenuItem, MenuItemSpec } from "./menu_items_registry";
 import { Registry } from "./registry";
 
 //------------------------------------------------------------------------------
@@ -15,6 +19,7 @@ import { Registry } from "./registry";
 
 export interface FigureContent {
   Component: any;
+  menuBuilder: (figureId: UID, onFigureDeleted: () => void, env: SpreadsheetChildEnv) => MenuItem[];
   SidePanelComponent?: string;
   keepRatio?: boolean;
   minFigSize?: number;
@@ -22,10 +27,112 @@ export interface FigureContent {
 }
 
 export const figureRegistry = new Registry<FigureContent>();
-figureRegistry.add("chart", { Component: ChartFigure, SidePanelComponent: "ChartPanel" });
+figureRegistry.add("chart", {
+  Component: ChartFigure,
+  SidePanelComponent: "ChartPanel",
+  menuBuilder: getChartMenu,
+});
 figureRegistry.add("image", {
   Component: ImageFigure,
   keepRatio: true,
   minFigSize: 20,
   borderWidth: 0,
+  menuBuilder: getImageMenuRegistry,
 });
+
+function getChartMenu(
+  figureId: UID,
+  onFigureDeleted: () => void,
+  env: SpreadsheetChildEnv
+): MenuItem[] {
+  const menuItemSpecs: MenuItemSpec[] = [
+    {
+      id: "edit",
+      name: _lt("Edit"),
+      sequence: 1,
+      action: () => {
+        env.model.dispatch("SELECT_FIGURE", { id: figureId });
+        env.openSidePanel("ChartPanel");
+      },
+    },
+    getCopyMenuItem(figureId, env),
+    getCutMenuItem(figureId, env),
+    getDeleteMenuItem(figureId, onFigureDeleted, env),
+  ];
+  return createMenu(menuItemSpecs);
+}
+
+function getImageMenuRegistry(
+  figureId: UID,
+  onFigureDeleted: () => void,
+  env: SpreadsheetChildEnv
+): MenuItem[] {
+  const menuItemSpecs: MenuItemSpec[] = [
+    getCopyMenuItem(figureId, env),
+    getCutMenuItem(figureId, env),
+    {
+      id: "reset_size",
+      name: _lt("Reset size"),
+      sequence: 4,
+      action: () => {
+        const size = env.model.getters.getImageSize(figureId);
+        const { height, width } = getMaxFigureSize(env.model.getters, size);
+        env.model.dispatch("UPDATE_FIGURE", {
+          sheetId: env.model.getters.getActiveSheetId(),
+          id: figureId,
+          height,
+          width,
+        });
+      },
+    },
+    getDeleteMenuItem(figureId, onFigureDeleted, env),
+  ];
+  return createMenu(menuItemSpecs);
+}
+
+function getCopyMenuItem(figureId: UID, env: SpreadsheetChildEnv): MenuItemSpec {
+  return {
+    id: "copy",
+    name: _lt("Copy"),
+    sequence: 2,
+    description: "Ctrl+C",
+    action: async () => {
+      env.model.dispatch("SELECT_FIGURE", { id: figureId });
+      env.model.dispatch("COPY");
+      await env.clipboard.write(env.model.getters.getClipboardContent());
+    },
+  };
+}
+
+function getCutMenuItem(figureId: UID, env: SpreadsheetChildEnv): MenuItemSpec {
+  return {
+    id: "cut",
+    name: _lt("Cut"),
+    sequence: 3,
+    description: "Ctrl+X",
+    action: async () => {
+      env.model.dispatch("SELECT_FIGURE", { id: figureId });
+      env.model.dispatch("CUT");
+      await env.clipboard.write(env.model.getters.getClipboardContent());
+    },
+  };
+}
+
+function getDeleteMenuItem(
+  figureId: UID,
+  onFigureDeleted: () => void,
+  env: SpreadsheetChildEnv
+): MenuItemSpec {
+  return {
+    id: "delete",
+    name: _lt("Delete"),
+    sequence: 10,
+    action: () => {
+      env.model.dispatch("DELETE_FIGURE", {
+        sheetId: env.model.getters.getActiveSheetId(),
+        id: figureId,
+      });
+      onFigureDeleted();
+    },
+  };
+}

--- a/tests/components/__snapshots__/figure.test.ts.snap
+++ b/tests/components/__snapshots__/figure.test.ts.snap
@@ -15,6 +15,40 @@ exports[`figures selected figure snapshot 1`] = `
     >
       coucou
     </div>
+    
+    <div
+      class="o-figure-menu position-absolute m-2"
+    >
+      <div
+        class="o-figure-menu-item"
+      >
+        <svg
+          class="o-icon"
+          viewBox="0 0 384 384"
+        >
+          <rect
+            height="42.667"
+            width="384"
+            x="0"
+            y="277.333"
+          />
+          <rect
+            height="42.667"
+            width="384"
+            x="0"
+            y="170.667"
+          />
+          <rect
+            height="42.667"
+            width="384"
+            x="0"
+            y="64"
+          />
+        </svg>
+      </div>
+      
+    </div>
+    
   </div>
   <div
     class="o-figure-border w-100 h-100 position-absolute pe-none"

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -10,38 +10,6 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
     class="o-chart-container w-100 h-100"
   >
     <div
-      class="o-figure-menu"
-    >
-      <div
-        class="o-figure-menu-item"
-      >
-        <svg
-          class="o-icon"
-          viewBox="0 0 384 384"
-        >
-          <rect
-            height="42.667"
-            width="384"
-            x="0"
-            y="277.333"
-          />
-          <rect
-            height="42.667"
-            width="384"
-            x="0"
-            y="170.667"
-          />
-          <rect
-            height="42.667"
-            width="384"
-            x="0"
-            y="64"
-          />
-        </svg>
-      </div>
-    </div>
-    
-    <div
       class="o-scorecard w-100 h-100"
       style="padding:10.72px; background:#FFFFFF;"
     >
@@ -98,9 +66,41 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
         
       </div>
     </div>
-    
+  </div>
+  
+  <div
+    class="o-figure-menu position-absolute m-2"
+  >
+    <div
+      class="o-figure-menu-item"
+    >
+      <svg
+        class="o-icon"
+        viewBox="0 0 384 384"
+      >
+        <rect
+          height="42.667"
+          width="384"
+          x="0"
+          y="277.333"
+        />
+        <rect
+          height="42.667"
+          width="384"
+          x="0"
+          y="170.667"
+        />
+        <rect
+          height="42.667"
+          width="384"
+          x="0"
+          y="64"
+        />
+      </svg>
+    </div>
     
   </div>
+  
 </div>
 `;
 
@@ -113,38 +113,6 @@ exports[`Scorecard charts scorecard text is resized while figure is resized 1`] 
   <div
     class="o-chart-container w-100 h-100"
   >
-    <div
-      class="o-figure-menu"
-    >
-      <div
-        class="o-figure-menu-item"
-      >
-        <svg
-          class="o-icon"
-          viewBox="0 0 384 384"
-        >
-          <rect
-            height="42.667"
-            width="384"
-            x="0"
-            y="277.333"
-          />
-          <rect
-            height="42.667"
-            width="384"
-            x="0"
-            y="170.667"
-          />
-          <rect
-            height="42.667"
-            width="384"
-            x="0"
-            y="64"
-          />
-        </svg>
-      </div>
-    </div>
-    
     <div
       class="o-scorecard w-100 h-100"
       style="padding:4.72px; background:#FFFFFF;"
@@ -202,8 +170,40 @@ exports[`Scorecard charts scorecard text is resized while figure is resized 1`] 
         
       </div>
     </div>
-    
+  </div>
+  
+  <div
+    class="o-figure-menu position-absolute m-2"
+  >
+    <div
+      class="o-figure-menu-item"
+    >
+      <svg
+        class="o-icon"
+        viewBox="0 0 384 384"
+      >
+        <rect
+          height="42.667"
+          width="384"
+          x="0"
+          y="277.333"
+        />
+        <rect
+          height="42.667"
+          width="384"
+          x="0"
+          y="170.667"
+        />
+        <rect
+          height="42.667"
+          width="384"
+          x="0"
+          y="64"
+        />
+      </svg>
+    </div>
     
   </div>
+  
 </div>
 `;

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/constants";
 import { figureRegistry } from "../../src/registries";
 import { CreateFigureCommand, Figure, SpreadsheetChildEnv, UID } from "../../src/types";
+
 import {
   activateSheet,
   addColumns,
@@ -104,7 +105,10 @@ mockGetBoundingClientRect({
 });
 
 beforeAll(() => {
-  figureRegistry.add("text", { Component: TextFigure });
+  figureRegistry.add("text", {
+    Component: TextFigure,
+    menuBuilder: () => [],
+  });
 });
 afterAll(() => {
   figureRegistry.remove("text");


### PR DESCRIPTION
## Description:

Before this commit, the chart and image menus were handled separately in `figure_chart.ts` and `figure_image.ts`. This led to a lot of duplicated code since they both do 80% the same thing.

Now the figure menu is handled in `figure.ts`, and a `menuRegistryBuilder` was added to `figureRegistry`.

Odoo task ID : [3199007](https://www.odoo.com/web#id=3199007&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo