### PR TITLE
[REM/IMP] css: remove unused classes and improved a bit the css

### DIFF
--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
@@ -14,15 +14,10 @@ css/* scss */ `
     }
 
     & > div {
-      display: flex;
-      flex-direction: column;
       padding: 1px 0 5px 5px;
       .o-autocomplete-description {
-        padding: 0 0 0 5px;
+        padding-left: 5px;
         font-size: 11px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
     }
   }

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -1,13 +1,17 @@
 <templates>
   <t t-name="o-spreadsheet-TextValueProvider" owl="1">
-    <div t-att-class="{'o-autocomplete-dropdown':props.values.length}">
+    <div
+      t-att-class="{
+          'o-autocomplete-dropdown':props.values.length,
+          'shadow':props.values.length}">
       <t t-foreach="props.values" t-as="v" t-key="v.text">
         <div
+          class="d-flex flex-column"
           t-att-class="{'o-autocomplete-value-focus': props.selectedIndex === v_index}"
           t-on-click="() => this.props.onValueSelected(v.text)">
           <div class="o-autocomplete-value" t-esc="v.text"/>
           <div
-            class="o-autocomplete-description"
+            class="o-autocomplete-description text-truncate"
             t-esc="v.description"
             t-if="props.selectedIndex === v_index"
           />

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -91,11 +91,6 @@ css/* scss */ `
       margin: 1px 4px;
       pointer-events: none;
     }
-
-    .o-autocomplete-dropdown,
-    .o-formula-assistant-container {
-      box-shadow: 0 1px 4px 3px rgba(60, 64, 67, 0.15);
-    }
   }
 `;
 

--- a/src/components/composer/formula_assistant/formula_assistant.ts
+++ b/src/components/composer/formula_assistant/formula_assistant.ts
@@ -8,21 +8,12 @@ import { css } from "../../helpers/css";
 
 css/* scss */ `
   .o-formula-assistant {
-    white-space: normal;
-    background-color: #fff;
     .o-formula-assistant-head {
       background-color: #f2f2f2;
       padding: 10px;
     }
     .o-formula-assistant-core {
-      padding: 0px 0px 10px 0px;
-      margin: 10px;
       border-bottom: 1px solid gray;
-    }
-    .o-formula-assistant-arg {
-      padding: 0px 10px 10px 10px;
-      display: flex;
-      flex-direction: column;
     }
     .o-formula-assistant-arg-description {
       font-size: 85%;
@@ -40,18 +31,6 @@ css/* scss */ `
     .o-formula-assistant-gray {
       color: gray;
     }
-  }
-  .o-formula-assistant-container {
-    user-select: none;
-  }
-  .o-formula-assistant-event-none {
-    pointer-events: none;
-  }
-  .o-formula-assistant-event-auto {
-    pointer-events: auto;
-  }
-  .o-formula-assistant-transparency {
-    opacity: 0.3;
   }
 `;
 

--- a/src/components/composer/formula_assistant/formula_assistant.xml
+++ b/src/components/composer/formula_assistant/formula_assistant.xml
@@ -1,17 +1,17 @@
 <templates>
   <t t-name="o-spreadsheet-FunctionDescriptionProvider" owl="1">
     <div
-      class="o-formula-assistant-container"
+      class="o-formula-assistant-container user-select-none shadow"
       t-att-class="{
-          'o-formula-assistant-event-none': assistantState.allowCellSelectionBehind,
-          'o-formula-assistant-event-auto': !assistantState.allowCellSelectionBehind
+          'pe-none': assistantState.allowCellSelectionBehind,
+          'pe-auto': !assistantState.allowCellSelectionBehind
           }">
       <t t-set="context" t-value="getContext()"/>
       <div
-        class="o-formula-assistant"
+        class="o-formula-assistant bg-white"
         t-if="context.functionName"
         t-on-mousemove="onMouseMove"
-        t-att-class="{'o-formula-assistant-transparency': assistantState.allowCellSelectionBehind}">
+        t-att-class="{'opacity-25': assistantState.allowCellSelectionBehind}">
         <div class="o-formula-assistant-head">
           <span t-esc="context.functionName"/>
           (
@@ -29,14 +29,14 @@
           )
         </div>
 
-        <div class="o-formula-assistant-core">
+        <div class="o-formula-assistant-core pb-3 m-3">
           <div class="o-formula-assistant-gray">ABOUT</div>
           <div t-esc="context.functionDescription.description"/>
         </div>
 
         <t t-foreach="context.functionDescription.args" t-as="arg" t-key="arg.name">
           <div
-            class="o-formula-assistant-arg"
+            class="o-formula-assistant-arg p-3 pt-0 display-flex flex-column"
             t-att-class="{
                 'o-formula-assistant-gray': context.argToFocus >= '0',
                 'o-formula-assistant-focus': context.argToFocus === arg_index,

--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -66,15 +66,6 @@ const CSS = css/* scss */ `
       overflow-y: auto;
       border: 1px solid #949494;
 
-      .o-filter-menu-value {
-        padding: 4px;
-        line-height: 20px;
-        height: 28px;
-        .o-filter-menu-value-checked {
-          width: 20px;
-        }
-      }
-
       .o-filter-menu-no-values {
         color: #949494;
         font-style: italic;

--- a/src/components/filters/filter_menu_item/filter_menu_value_item.ts
+++ b/src/components/filters/filter_menu_item/filter_menu_value_item.ts
@@ -1,5 +1,6 @@
 import { Component, onWillPatch, useRef } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../types";
+import { css } from "../../helpers";
 
 interface Props {
   value: string;
@@ -9,6 +10,17 @@ interface Props {
   onMouseMove: () => void;
   scrolledTo: "top" | "bottom" | undefined;
 }
+
+css/*SCSS*/ `
+  .o-filter-menu-value {
+    padding: 4px;
+    line-height: 20px;
+    height: 28px;
+    .o-filter-menu-value-checked {
+      width: 20px;
+    }
+  }
+`;
 
 export class FilterMenuValueItem extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterMenuValueItem";

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -8,16 +8,6 @@ import { ColorPickerWidget } from "./../../../color_picker/color_picker_widget";
 
 css/* scss */ `
   .o-gauge-color-set {
-    .o-gauge-color-set-color-button {
-      display: inline-block;
-      border: 1px solid #dadce0;
-      border-radius: 4px;
-      cursor: pointer;
-      padding: 1px 2px;
-    }
-    .o-gauge-color-set-color-button:hover {
-      background-color: rgba(0, 0, 0, 0.08);
-    }
     table {
       table-layout: fixed;
       margin-top: 2%;

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -133,16 +133,6 @@ css/* scss */ `
     }
 
     .o-inflection {
-      .o-inflection-icon-button {
-        display: inline-block;
-        border: 1px solid #dadce0;
-        border-radius: 4px;
-        cursor: pointer;
-        padding: 1px 2px;
-      }
-      .o-inflection-icon-button:hover {
-        background-color: rgba(0, 0, 0, 0.08);
-      }
       table {
         table-layout: fixed;
         margin-top: 2%;
@@ -151,21 +141,6 @@ css/* scss */ `
         font-size: 12px;
         line-height: 18px;
         width: 100%;
-      }
-      th.o-inflection-iconset-icons {
-        width: 8%;
-      }
-      th.o-inflection-iconset-text {
-        width: 28%;
-      }
-      th.o-inflection-iconset-operator {
-        width: 14%;
-      }
-      th.o-inflection-iconset-type {
-        width: 28%;
-      }
-      th.o-inflection-iconset-value {
-        width: 26%;
       }
       input,
       select {
@@ -190,13 +165,6 @@ css/* scss */ `
 
         &:hover {
           background-color: rgba(0, 0, 0, 0.08);
-        }
-      }
-
-      .o-border {
-        .o-line-item {
-          padding: 4px;
-          margin: 1px;
         }
       }
     }

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -296,17 +296,6 @@ css/* scss */ `
           }
         }
       }
-
-      /* Cell Content */
-      .o-toolbar-cell-content {
-        font-size: 12px;
-        font-weight: 500;
-        padding: 0 12px;
-        margin: 0;
-        line-height: 34px;
-        white-space: nowrap;
-        user-select: text;
-      }
     }
   }
 `;

--- a/tests/components/__snapshots__/autocomplete_dropdown.test.ts.snap
+++ b/tests/components/__snapshots__/autocomplete_dropdown.test.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
 <div
-  class="o-autocomplete-dropdown"
+  class="o-autocomplete-dropdown shadow"
 >
   <div
-    class="o-autocomplete-value-focus"
+    class="d-flex flex-column o-autocomplete-value-focus"
   >
     <div
       class="o-autocomplete-value"
@@ -13,13 +13,15 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
       SUM
     </div>
     <div
-      class="o-autocomplete-description"
+      class="o-autocomplete-description text-truncate"
     >
       do sum
     </div>
     
   </div>
-  <div>
+  <div
+    class="d-flex flex-column"
+  >
     <div
       class="o-autocomplete-value"
     >
@@ -37,10 +39,10 @@ exports[`composer Assistant render above the cell when not enough place below 1`
   style="top:-3px; transform:translate(0, -100%); right:0px; width:300px;"
 >
   <div
-    class="o-autocomplete-dropdown"
+    class="o-autocomplete-dropdown shadow"
   >
     <div
-      class="o-autocomplete-value-focus"
+      class="d-flex flex-column o-autocomplete-value-focus"
     >
       <div
         class="o-autocomplete-value"
@@ -48,13 +50,15 @@ exports[`composer Assistant render above the cell when not enough place below 1`
         SECOND
       </div>
       <div
-        class="o-autocomplete-description"
+        class="o-autocomplete-description text-truncate"
       >
         Minute component of a specific time.
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -62,7 +66,9 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -70,7 +76,9 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -78,7 +86,9 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -86,7 +96,9 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -94,7 +106,9 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -102,7 +116,9 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -110,7 +126,9 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -118,7 +136,9 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -139,10 +159,10 @@ exports[`composer Assistant render below the cell by default 1`] = `
   style="top:-3px; transform:translate(0, -100%); right:0px; width:300px;"
 >
   <div
-    class="o-autocomplete-dropdown"
+    class="o-autocomplete-dropdown shadow"
   >
     <div
-      class="o-autocomplete-value-focus"
+      class="d-flex flex-column o-autocomplete-value-focus"
     >
       <div
         class="o-autocomplete-value"
@@ -150,13 +170,15 @@ exports[`composer Assistant render below the cell by default 1`] = `
         SECOND
       </div>
       <div
-        class="o-autocomplete-description"
+        class="o-autocomplete-description text-truncate"
       >
         Minute component of a specific time.
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -164,7 +186,9 @@ exports[`composer Assistant render below the cell by default 1`] = `
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -172,7 +196,9 @@ exports[`composer Assistant render below the cell by default 1`] = `
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -180,7 +206,9 @@ exports[`composer Assistant render below the cell by default 1`] = `
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -188,7 +216,9 @@ exports[`composer Assistant render below the cell by default 1`] = `
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -196,7 +226,9 @@ exports[`composer Assistant render below the cell by default 1`] = `
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -204,7 +236,9 @@ exports[`composer Assistant render below the cell by default 1`] = `
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -212,7 +246,9 @@ exports[`composer Assistant render below the cell by default 1`] = `
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >
@@ -220,7 +256,9 @@ exports[`composer Assistant render below the cell by default 1`] = `
       </div>
       
     </div>
-    <div>
+    <div
+      class="d-flex flex-column"
+    >
       <div
         class="o-autocomplete-value"
       >

--- a/tests/components/__snapshots__/formula_assistant.test.ts.snap
+++ b/tests/components/__snapshots__/formula_assistant.test.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`formula assistant appearance simple snapshot with =FUNC1( 1`] = `
 <div
-  class="o-formula-assistant-container o-formula-assistant-event-auto"
+  class="o-formula-assistant-container user-select-none shadow pe-auto"
 >
   <div
-    class="o-formula-assistant"
+    class="o-formula-assistant bg-white"
   >
     <div
       class="o-formula-assistant-head"
@@ -45,7 +45,7 @@ exports[`formula assistant appearance simple snapshot with =FUNC1( 1`] = `
        ) 
     </div>
     <div
-      class="o-formula-assistant-core"
+      class="o-formula-assistant-core pb-3 m-3"
     >
       <div
         class="o-formula-assistant-gray"
@@ -57,7 +57,7 @@ exports[`formula assistant appearance simple snapshot with =FUNC1( 1`] = `
       </div>
     </div>
     <div
-      class="o-formula-assistant-arg o-formula-assistant-gray o-formula-assistant-focus"
+      class="o-formula-assistant-arg p-3 pt-0 display-flex flex-column o-formula-assistant-gray o-formula-assistant-focus"
     >
       <div>
         <span>
@@ -74,7 +74,7 @@ exports[`formula assistant appearance simple snapshot with =FUNC1( 1`] = `
       </div>
     </div>
     <div
-      class="o-formula-assistant-arg o-formula-assistant-gray"
+      class="o-formula-assistant-arg p-3 pt-0 display-flex flex-column o-formula-assistant-gray"
     >
       <div>
         <span>


### PR DESCRIPTION
This commit improved a bit the css by:

- removing unused css classes
- moving css rules defined in parent component but that were only used in the child
- use bootstrap the css of the formula assistant and autocomplete dropdown

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo