### PR TITLE
[REF] port: run server on 9090 instead of 9000

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -16,7 +16,7 @@ topbarMenuRegistry.addChild("clear", ["file"], {
   name: "Clear & reload",
   sequence: 10,
   action: async (env) => {
-    await fetch("http://localhost:9000/clear");
+    await fetch("http://localhost:9090/clear");
     document.location.reload();
   },
 });
@@ -115,7 +115,7 @@ class App extends Component {
    * @returns {Promise}
    */
   async fetchHistory() {
-    const result = await fetch("http://localhost:9000");
+    const result = await fetch("http://localhost:9090");
     return result.json();
   }
 }

--- a/demo/transport.js
+++ b/demo/transport.js
@@ -14,7 +14,7 @@ export class WebsocketTransport {
    */
   connect() {
     return new Promise((resolve, reject) => {
-      const socket = new WebSocket(`ws://localhost:9000`);
+      const socket = new WebSocket(`ws://localhost:9090`);
       socket.addEventListener("open", () => {
         this.socket = socket;
         this.isConnected = true;

--- a/tools/server/main.js
+++ b/tools/server/main.js
@@ -107,6 +107,6 @@ app.ws("/", function (ws, req) {
   });
 });
 
-app.listen(9000, () => {
-  console.log("connected to :9000");
+app.listen(9090, () => {
+  console.log("connected to :9090");
 });


### PR DESCRIPTION
The port 9000 is the default php-fpm port. So a person working on php may have trouble trying to launch the spreadsheets. We move to the port 9090 to avoid the possible conflict.
