### PR TITLE
[IMP] config: update release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         # should work with le latest stable node
         # parse-message will fail on invalid commit title/body
         run: |
-          npm i @actions/core && npm i @actions/github &&\
+          npm i @actions/core @actions/github --no-save &&\
           echo "data=$(node tools/parse_message.js)" >> $GITHUB_OUTPUT
       # generate all builds
       - name: Build
@@ -27,7 +27,7 @@ jobs:
         with:
           tag: ${{ fromJSON(steps.parse.outputs.data).version }}
           body: ${{ fromJSON(steps.parse.outputs.data).body }}
-          artifacts: "./dist/*"
+          artifacts: "./dist/*.*"
       - name: Publish
         run: npm publish
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "1.0.1",
+  "version": "14.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "1.0.1",
+      "version": "14.0.2",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "^1.4.10"


### PR DESCRIPTION
- Restore package.json before the publication (it was updated when
  installing the gh action packages)
- chain package insstall instead of calling `npm i` twice
- more control on the artifacts that we release