### PR TITLE
[IMP] XLSX: support `oneCellAnchor` when importing

### DIFF
--- a/src/types/figure.ts
+++ b/src/types/figure.ts
@@ -14,4 +14,9 @@ export interface FigureSize {
   height: Pixel;
 }
 
+export interface ExcelFigureSize {
+  cx: number;
+  cy: number;
+}
+
 export type ResizeDirection = -1 | 0 | 1;

--- a/src/types/xlsx.ts
+++ b/src/types/xlsx.ts
@@ -1,5 +1,6 @@
 import { Alias, ExcelChartDefinition, Format, PaneDivision } from ".";
 import { ExcelImage } from "../types/image";
+import { ExcelFigureSize } from "./figure";
 
 /**
  * Most of the times we tried to create Objects that matched quite closely with the data in the XLSX files.
@@ -520,6 +521,7 @@ export interface XLSXFigureSize {
 export interface XLSXFigure {
   anchors: XLSXFigureAnchor[];
   data: ExcelChartDefinition | ExcelImage;
+  figureSize?: ExcelFigureSize;
 }
 
 export const XLSX_CHART_TYPES = [

--- a/src/xlsx/conversion/figure_conversion.ts
+++ b/src/xlsx/conversion/figure_conversion.ts
@@ -9,6 +9,7 @@ import { ChartDefinition, ExcelChartDefinition, FigureData } from "../../types";
 import { ExcelImage } from "../../types/image";
 import { XLSXFigure, XLSXWorksheet } from "../../types/xlsx";
 import { convertEMUToDotValue, getColPosition, getRowPosition } from "../helpers/content_helpers";
+import { XLSXFigureAnchor } from "./../../types/xlsx";
 import { convertColor } from "./color_conversion";
 
 export function convertFigures(sheetData: XLSXWorksheet): FigureData<any>[] {
@@ -23,27 +24,26 @@ function convertFigure(
   id: string,
   sheetData: XLSXWorksheet
 ): FigureData<any> | undefined {
-  const x1 =
-    getColPosition(figure.anchors[0].col, sheetData) +
-    convertEMUToDotValue(figure.anchors[0].colOffset);
-  const x2 =
-    getColPosition(figure.anchors[1].col, sheetData) +
-    convertEMUToDotValue(figure.anchors[1].colOffset);
-
-  const y1 =
-    getRowPosition(figure.anchors[0].row, sheetData) +
-    convertEMUToDotValue(figure.anchors[0].rowOffset);
-  const y2 =
-    getRowPosition(figure.anchors[1].row, sheetData) +
-    convertEMUToDotValue(figure.anchors[1].rowOffset);
-
+  let x1: number, y1: number;
+  let height: number, width: number;
+  if (figure.anchors.length === 1) {
+    // one cell anchor
+    ({ x: x1, y: y1 } = getPositionFromAnchor(figure.anchors[0], sheetData));
+    width = convertEMUToDotValue(figure.figureSize!.cx);
+    height = convertEMUToDotValue(figure.figureSize!.cy);
+  } else {
+    ({ x: x1, y: y1 } = getPositionFromAnchor(figure.anchors[0], sheetData));
+    const { x: x2, y: y2 } = getPositionFromAnchor(figure.anchors[1], sheetData);
+    width = x2 - x1;
+    height = y2 - y1;
+  }
   const figureData = { id, x: x1, y: y1 };
 
   if (isChartData(figure.data)) {
     return {
       ...figureData,
-      width: x2 - x1,
-      height: y2 - y1,
+      width,
+      height,
       tag: "chart",
       data: convertChartData(figure.data),
     };
@@ -117,4 +117,17 @@ function convertExcelRangeToSheetXC(range: string, dataSetsHaveTitle: boolean): 
   }
   const dataXC = zoneToXc(zone);
   return sheetName + dataXC;
+}
+
+function getPositionFromAnchor(
+  anchor: XLSXFigureAnchor,
+  sheetData: XLSXWorksheet
+): {
+  x: number;
+  y: number;
+} {
+  return {
+    x: getColPosition(anchor.col, sheetData) + convertEMUToDotValue(anchor.colOffset),
+    y: getRowPosition(anchor.row, sheetData) + convertEMUToDotValue(anchor.rowOffset),
+  };
 }

--- a/src/xlsx/extraction/figure_extractor.ts
+++ b/src/xlsx/extraction/figure_extractor.ts
@@ -1,4 +1,4 @@
-import { ExcelChartDefinition } from "../../types";
+import { ExcelChartDefinition, ExcelFigureSize } from "../../types";
 import { ExcelImage } from "../../types/image";
 import { XLSXFigure, XLSXFigureAnchor } from "../../types/xlsx";
 import { IMAGE_EXTENSION_TO_MIMETYPE_MAPPING } from "../conversion";
@@ -6,15 +6,16 @@ import { removeTagEscapedNamespaces } from "../helpers/xml_helpers";
 import { XlsxBaseExtractor } from "./base_extractor";
 import { XlsxChartExtractor } from "./chart_extractor";
 
+const ONE_CELL_ANCHOR = "oneCellAnchor";
+const TWO_CELL_ANCHOR = "twoCellAnchor";
+
 export class XlsxFigureExtractor extends XlsxBaseExtractor {
   extractFigures(): XLSXFigure[] {
     return this.mapOnElements(
       { parent: this.rootFile.file.xml, query: "xdr:wsDr", children: true },
       (figureElement): XLSXFigure => {
         const anchorType = removeTagEscapedNamespaces(figureElement.tagName);
-        if (anchorType !== "twoCellAnchor") {
-          throw new Error("Only twoCellAnchor are supported for xlsx drawings.");
-        }
+        const anchors = this.extractFigureAnchorsByType(figureElement, anchorType);
 
         const chartElement = this.querySelector(figureElement, "c:chart");
         const imageElement = this.querySelector(figureElement, "a:blip");
@@ -23,14 +24,43 @@ export class XlsxFigureExtractor extends XlsxBaseExtractor {
         }
 
         return {
-          anchors: [
-            this.extractFigureAnchor("xdr:from", figureElement),
-            this.extractFigureAnchor("xdr:to", figureElement),
-          ],
+          anchors,
           data: chartElement ? this.extractChart(chartElement) : this.extractImage(figureElement),
+          figureSize:
+            anchorType === ONE_CELL_ANCHOR
+              ? this.extractFigureSizeFromSizeTag(figureElement, "xdr:ext")
+              : undefined,
         };
       }
     );
+  }
+
+  private extractFigureAnchorsByType(
+    figureElement: Element,
+    anchorType: string
+  ): XLSXFigureAnchor[] {
+    switch (anchorType) {
+      case ONE_CELL_ANCHOR:
+        return [this.extractFigureAnchor("xdr:from", figureElement)];
+      case TWO_CELL_ANCHOR:
+        return [
+          this.extractFigureAnchor("xdr:from", figureElement),
+          this.extractFigureAnchor("xdr:to", figureElement),
+        ];
+      default:
+        throw new Error(`${anchorType} is not supported for xlsx drawings. `);
+    }
+  }
+
+  private extractFigureSizeFromSizeTag(figureElement: Element, sizeTag: string): ExcelFigureSize {
+    const sizeElement = this.querySelector(figureElement, sizeTag);
+    if (!sizeElement) {
+      throw new Error(`Missing size element '${sizeTag}'`);
+    }
+    return {
+      cx: this.extractAttr(sizeElement, "cx", { required: true })!.asNum(),
+      cy: this.extractAttr(sizeElement, "cy", { required: true })!.asNum(),
+    };
   }
 
   private extractFigureAnchor(anchorTag: string, figureElement: Element): XLSXFigureAnchor {
@@ -71,16 +101,17 @@ export class XlsxFigureExtractor extends XlsxBaseExtractor {
       throw new Error("Unable to extract image");
     }
 
-    const shapePropertyElement = this.querySelector(figureElement, "a:xfrm")!;
     const extension = image.fileName.split(".").at(-1);
+    const anchorType = removeTagEscapedNamespaces(figureElement.tagName);
+    const sizeElement =
+      anchorType === TWO_CELL_ANCHOR ? this.querySelector(figureElement, "a:xfrm")! : figureElement;
+    const sizeTag = anchorType === TWO_CELL_ANCHOR ? "a:ext" : "xdr:ext";
+    const size = this.extractFigureSizeFromSizeTag(sizeElement, sizeTag);
 
     return {
       imageSrc: image.imageSrc,
       mimetype: extension ? IMAGE_EXTENSION_TO_MIMETYPE_MAPPING[extension] : undefined,
-      size: {
-        cx: this.extractChildAttr(shapePropertyElement, "a:ext", "cx", { required: true })!.asNum(),
-        cy: this.extractChildAttr(shapePropertyElement, "a:ext", "cy", { required: true })!.asNum(),
-      },
+      size,
     };
   }
 }

--- a/tests/__xlsx__/xlsx_demo_data/[Content_Types].xml
+++ b/tests/__xlsx__/xlsx_demo_data/[Content_Types].xml
@@ -16,6 +16,7 @@
   <Override PartName="/xl/worksheets/sheet10.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
   <Override PartName="/xl/worksheets/sheet11.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
   <Override PartName="/xl/worksheets/sheet12.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/worksheets/sheet13.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
   <Override PartName="/xl/externalLinks/externalLink1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml"/>
   <Override PartName="/xl/pivotCache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/>
   <Override PartName="/xl/pivotCache/pivotCacheRecords1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml"/>
@@ -34,12 +35,14 @@
   <Override PartName="/xl/pivotTables/pivotTable1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml"/>
   <Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>
   <Override PartName="/xl/drawings/drawing2.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>
+  <Override PartName="/xl/drawings/drawing3.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>
   <Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/charts/style1.xml" ContentType="application/vnd.ms-office.chartstyle+xml"/>
   <Override PartName="/xl/charts/colors1.xml" ContentType="application/vnd.ms-office.chartcolorstyle+xml"/>
   <Override PartName="/xl/charts/chart2.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/charts/chart3.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/charts/chart4.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
+  <Override PartName="/xl/charts/chart5.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/calcChain.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.calcChain+xml"/>
   <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
   <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>

--- a/tests/__xlsx__/xlsx_demo_data/xl/_rels/workbook.xml.rels
+++ b/tests/__xlsx__/xlsx_demo_data/xl/_rels/workbook.xml.rels
@@ -18,4 +18,5 @@
   <Relationship Id="rId9" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet9.xml" />
   <Relationship Id="rId18" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet12.xml" />
   <Relationship Id="rId14" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml" />
+  <Relationship Id="rId19" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet13.xml" />
 </Relationships>

--- a/tests/__xlsx__/xlsx_demo_data/xl/charts/chart5.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/charts/chart5.xml
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:mv="urn:schemas-microsoft-com:mac:vml"
+  xmlns:c14="http://schemas.microsoft.com/office/drawing/2007/8/2/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:tx>
+            <c:strRef>
+              <c:f>Sheet1!$B$26</c:f>
+            </c:strRef>
+          </c:tx>
+          <c:spPr>
+            <a:solidFill>
+              <a:schemeClr val="accent1"/>
+            </a:solidFill>
+            <a:ln cmpd="sng">
+              <a:solidFill>
+                <a:srgbClr val="000000"/>
+              </a:solidFill>
+            </a:ln>
+          </c:spPr>
+          <c:cat>
+            <c:strRef>
+              <c:f>Sheet1!$A$27:$A$35</c:f>
+            </c:strRef>
+          </c:cat>
+          <c:val>
+            <c:numRef>
+              <c:f>Sheet1!$B$27:$B$35</c:f>
+              <c:numCache/>
+            </c:numRef>
+          </c:val>
+        </c:ser>
+        <c:ser>
+          <c:idx val="1"/>
+          <c:order val="1"/>
+          <c:tx>
+            <c:strRef>
+              <c:f>Sheet1!$C$26</c:f>
+            </c:strRef>
+          </c:tx>
+          <c:spPr>
+            <a:solidFill>
+              <a:schemeClr val="accent2"/>
+            </a:solidFill>
+            <a:ln cmpd="sng">
+              <a:solidFill>
+                <a:srgbClr val="000000"/>
+              </a:solidFill>
+            </a:ln>
+          </c:spPr>
+          <c:cat>
+            <c:strRef>
+              <c:f>Sheet1!$A$27:$A$35</c:f>
+            </c:strRef>
+          </c:cat>
+          <c:val>
+            <c:numRef>
+              <c:f>Sheet1!$C$27:$C$35</c:f>
+              <c:numCache/>
+            </c:numRef>
+          </c:val>
+        </c:ser>
+        <c:axId val="998664793"/>
+        <c:axId val="344680958"/>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="998664793"/>
+        <c:scaling>
+          <c:orientation val="minMax"/>
+        </c:scaling>
+        <c:delete val="0"/>
+        <c:axPos val="b"/>
+        <c:title>
+          <c:tx>
+            <c:rich>
+              <a:bodyPr/>
+              <a:lstStyle/>
+              <a:p>
+                <a:pPr lvl="0">
+                  <a:defRPr b="0">
+                    <a:solidFill>
+                      <a:srgbClr val="000000"/>
+                    </a:solidFill>
+                    <a:latin typeface="+mn-lt"/>
+                  </a:defRPr>
+                </a:pPr>
+                <a:r>
+                  <a:rPr b="0">
+                    <a:solidFill>
+                      <a:srgbClr val="000000"/>
+                    </a:solidFill>
+                    <a:latin typeface="+mn-lt"/>
+                  </a:rPr>
+                  <a:t/>
+                </a:r>
+              </a:p>
+            </c:rich>
+          </c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+        <c:numFmt formatCode="General" sourceLinked="1"/>
+        <c:majorTickMark val="none"/>
+        <c:minorTickMark val="none"/>
+        <c:spPr/>
+        <c:txPr>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr lvl="0">
+              <a:defRPr b="0">
+                <a:solidFill>
+                  <a:srgbClr val="000000"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+              </a:defRPr>
+            </a:pPr>
+          </a:p>
+        </c:txPr>
+        <c:crossAx val="344680958"/>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="344680958"/>
+        <c:scaling>
+          <c:orientation val="minMax"/>
+        </c:scaling>
+        <c:delete val="0"/>
+        <c:axPos val="l"/>
+        <c:majorGridlines>
+          <c:spPr>
+            <a:ln>
+              <a:solidFill>
+                <a:srgbClr val="B7B7B7"/>
+              </a:solidFill>
+            </a:ln>
+          </c:spPr>
+        </c:majorGridlines>
+        <c:minorGridlines>
+          <c:spPr>
+            <a:ln>
+              <a:solidFill>
+                <a:srgbClr val="CCCCCC">
+                  <a:alpha val="0"/>
+                </a:srgbClr>
+              </a:solidFill>
+            </a:ln>
+          </c:spPr>
+        </c:minorGridlines>
+        <c:title>
+          <c:tx>
+            <c:rich>
+              <a:bodyPr/>
+              <a:lstStyle/>
+              <a:p>
+                <a:pPr lvl="0">
+                  <a:defRPr b="0">
+                    <a:solidFill>
+                      <a:srgbClr val="000000"/>
+                    </a:solidFill>
+                    <a:latin typeface="+mn-lt"/>
+                  </a:defRPr>
+                </a:pPr>
+                <a:r>
+                  <a:rPr b="0">
+                    <a:solidFill>
+                      <a:srgbClr val="000000"/>
+                    </a:solidFill>
+                    <a:latin typeface="+mn-lt"/>
+                  </a:rPr>
+                  <a:t/>
+                </a:r>
+              </a:p>
+            </c:rich>
+          </c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+        <c:numFmt formatCode="General" sourceLinked="1"/>
+        <c:majorTickMark val="none"/>
+        <c:minorTickMark val="none"/>
+        <c:tickLblPos val="nextTo"/>
+        <c:spPr>
+          <a:ln/>
+        </c:spPr>
+        <c:txPr>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr lvl="0">
+              <a:defRPr b="0">
+                <a:solidFill>
+                  <a:srgbClr val="000000"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+              </a:defRPr>
+            </a:pPr>
+          </a:p>
+        </c:txPr>
+        <c:crossAx val="998664793"/>
+      </c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p>
+          <a:pPr lvl="0">
+            <a:defRPr b="0">
+              <a:solidFill>
+                <a:srgbClr val="1A1A1A"/>
+              </a:solidFill>
+              <a:latin typeface="+mn-lt"/>
+            </a:defRPr>
+          </a:pPr>
+        </a:p>
+      </c:txPr>
+    </c:legend>
+    <c:plotVisOnly val="1"/>
+  </c:chart>
+</c:chartSpace>

--- a/tests/__xlsx__/xlsx_demo_data/xl/drawings/_rels/drawing3.xml.rels
+++ b/tests/__xlsx__/xlsx_demo_data/xl/drawings/_rels/drawing3.xml.rels
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship
+    Id="rId1"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
+    Target="../charts/chart5.xml"
+  />
+  <Relationship
+    Id="rId2"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
+    Target="../media/image1.png"
+  />
+</Relationships>

--- a/tests/__xlsx__/xlsx_demo_data/xl/drawings/drawing3.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/drawings/drawing3.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xdr:wsDr
+  xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+  xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex"
+  xmlns:cx1="http://schemas.microsoft.com/office/drawing/2015/9/8/chartex"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:dgm="http://schemas.openxmlformats.org/drawingml/2006/diagram"
+  xmlns:x3Unk="http://schemas.microsoft.com/office/drawing/2010/slicer"
+  xmlns:sle15="http://schemas.microsoft.com/office/drawing/2012/slicer">
+  <xdr:oneCellAnchor>
+    <xdr:from>
+      <xdr:col>0</xdr:col>
+      <xdr:colOff>0</xdr:colOff>
+      <xdr:row>0</xdr:row>
+      <xdr:rowOff>0</xdr:rowOff>
+    </xdr:from>
+    <xdr:ext cx="5657850" cy="3495675"/>
+    <xdr:graphicFrame>
+      <xdr:nvGraphicFramePr>
+        <xdr:cNvPr id="5" name="Chart 5" title="Chart"/>
+        <xdr:cNvGraphicFramePr/>
+      </xdr:nvGraphicFramePr>
+      <xdr:xfrm>
+        <a:off x="0" y="0"/>
+        <a:ext cx="0" cy="0"/>
+      </xdr:xfrm>
+      <a:graphic>
+        <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+          <c:chart r:id="rId1"/>
+        </a:graphicData>
+      </a:graphic>
+    </xdr:graphicFrame>
+    <xdr:clientData fLocksWithSheet="0"/>
+  </xdr:oneCellAnchor>
+  <xdr:oneCellAnchor>
+    <xdr:from>
+      <xdr:col>7</xdr:col>
+      <xdr:colOff>57150</xdr:colOff>
+      <xdr:row>0</xdr:row>
+      <xdr:rowOff>0</xdr:rowOff>
+    </xdr:from>
+    <xdr:ext cx="3733800" cy="3733800"/>
+    <xdr:pic>
+      <xdr:nvPicPr>
+        <xdr:cNvPr id="0" name="image2.png" title="Image"/>
+        <xdr:cNvPicPr preferRelativeResize="0"/>
+      </xdr:nvPicPr>
+      <xdr:blipFill>
+        <a:blip cstate="print" r:embed="rId2"/>
+        <a:stretch>
+          <a:fillRect/>
+        </a:stretch>
+      </xdr:blipFill>
+      <xdr:spPr>
+        <a:prstGeom prst="rect">
+          <a:avLst/>
+        </a:prstGeom>
+        <a:noFill/>
+      </xdr:spPr>
+    </xdr:pic>
+    <xdr:clientData fLocksWithSheet="0"/>
+  </xdr:oneCellAnchor>
+</xdr:wsDr>

--- a/tests/__xlsx__/xlsx_demo_data/xl/workbook.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/workbook.xml
@@ -24,6 +24,7 @@
     <sheet name="jestHiddenSheet" sheetId="13" state="hidden" r:id="rId10"/>
     <sheet name="jestFreezePane" sheetId="14" r:id="rId11"/>
     <sheet name="jestImages" sheetId="15" r:id="rId18"/>
+    <sheet name="jestOneCellAnchor" sheetId="16" r:id="rId19"/>
   </sheets>
   <externalReferences>
     <externalReference r:id="rId12"/>

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/_rels/sheet13.xml.rels
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/_rels/sheet13.xml.rels
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship
+    Id="rId1"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing"
+    Target="../drawings/drawing3.xml"
+  />
+</Relationships>

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet13.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet13.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet
+  xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:mv="urn:schemas-microsoft-com:mac:vml"
+  xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"
+  xmlns:x15="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main"
+  xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac"
+  xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">
+  <sheetPr>
+    <outlinePr summaryBelow="0" summaryRight="0"/>
+  </sheetPr>
+  <sheetViews>
+    <sheetView workbookViewId="0"/>
+  </sheetViews>
+  <sheetFormatPr customHeight="1" defaultColWidth="14.43" defaultRowHeight="15.0"/>
+  <sheetData/>
+  <drawing r:id="rId1"/>
+</worksheet>

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -793,6 +793,31 @@ describe("Import xlsx data", () => {
     }
   );
 
+  test.each([
+    ["chart", "A1:F19"],
+    ["image", "H1:K20"],
+  ])("Can import figure %s which uses oneCellAnchor", (figureType, figureZone) => {
+    const testSheet = getWorkbookSheet("jestOneCellAnchor", convertedData)!;
+    const figZone = toZone(figureZone);
+    const figure = testSheet.figures.find((figure) => figure.tag === figureType)!;
+    expect(figure.x).toBeBetween(
+      getColPosition(figZone.left, testSheet),
+      getColPosition(figZone.left + 1, testSheet)
+    );
+    expect(figure.y).toBeBetween(
+      getRowPosition(figZone.top, testSheet),
+      getRowPosition(figZone.top + 1, testSheet)
+    );
+    expect(figure.width).toBeBetween(
+      getColPosition(figZone.right, testSheet) - getColPosition(figZone.left, testSheet),
+      getColPosition(figZone.right + 1, testSheet) - getColPosition(figZone.left, testSheet)
+    );
+    expect(figure.height).toBeBetween(
+      getRowPosition(figZone.bottom, testSheet) - getRowPosition(figZone.top, testSheet),
+      getRowPosition(figZone.bottom + 1, testSheet) - getRowPosition(figZone.top, testSheet)
+    );
+  });
+
   test("Can import images", () => {
     const testSheet = getWorkbookSheet("jestImages", convertedData)!;
     const figure = testSheet.figures.find((figure) => figure.tag === "image")!;


### PR DESCRIPTION
## Description:

`oneCellAnchor` is used in exported files for charts and images from Google Sheets. Now we support it. 

Odoo task ID : [3164410](https://www.odoo.com/web#id=3164410&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo