### PR TITLE
[FIX] charts: Fix chart duplicated ids

### DIFF
--- a/src/components/figures/chart.ts
+++ b/src/components/figures/chart.ts
@@ -75,7 +75,10 @@ export class ChartFigure extends Component<Props, SpreadsheetEnv> {
 
   mounted() {
     const figure = this.props.figure;
-    const chartData = this.env.getters.getChartRuntime(figure.id);
+    const chartData = this.env.getters.getChartRuntime(
+      this.env.getters.getActiveSheetId(),
+      figure.id
+    );
     if (chartData) {
       this.createChart(chartData);
     }
@@ -83,7 +86,8 @@ export class ChartFigure extends Component<Props, SpreadsheetEnv> {
 
   patched() {
     const figure = this.props.figure;
-    const chartData = this.env.getters.getChartRuntime(figure.id);
+    const sheetId = this.env.getters.getActiveSheetId();
+    const chartData = this.env.getters.getChartRuntime(sheetId, figure.id);
     if (chartData) {
       if (chartData.type !== this.chart!.config.type) {
         // Updating a chart type requires to update its options accordingly, if feasible at all.
@@ -106,7 +110,7 @@ export class ChartFigure extends Component<Props, SpreadsheetEnv> {
     } else {
       this.chart && this.chart.destroy();
     }
-    const def = this.env.getters.getChartDefinition(figure.id);
+    const def = this.env.getters.getChartDefinition(sheetId, figure.id);
     if (def) {
       this.state.background = def.background;
     }
@@ -116,7 +120,10 @@ export class ChartFigure extends Component<Props, SpreadsheetEnv> {
     const canvas = this.canvas.el as HTMLCanvasElement;
     const ctx = canvas.getContext("2d")!;
     this.chart = new window.Chart(ctx, chartData);
-    const def = this.env.getters.getChartDefinition(this.props.figure.id);
+    const def = this.env.getters.getChartDefinition(
+      this.env.getters.getActiveSheetId(),
+      this.props.figure.id
+    );
     if (def) {
       this.state.background = def.background;
     }
@@ -127,7 +134,11 @@ export class ChartFigure extends Component<Props, SpreadsheetEnv> {
     registry.add("edit", {
       name: _lt("Edit"),
       sequence: 1,
-      action: () => this.env.openSidePanel("ChartPanel", { figure: this.props.figure }),
+      action: () =>
+        this.env.openSidePanel("ChartPanel", {
+          sheetId: this.env.getters.getActiveSheetId(),
+          figure: this.props.figure,
+        }),
     });
     registry.add("delete", {
       name: _lt("Delete"),
@@ -138,7 +149,10 @@ export class ChartFigure extends Component<Props, SpreadsheetEnv> {
           id: this.props.figure.id,
         });
         if (this.props.sidePanelIsOpen) {
-          this.env.toggleSidePanel("ChartPanel", { figure: this.props.figure });
+          this.env.toggleSidePanel("ChartPanel", {
+            sheetId: this.env.getters.getActiveSheetId(),
+            figure: this.props.figure,
+          });
         }
         this.trigger("figure-deleted");
       },
@@ -148,6 +162,7 @@ export class ChartFigure extends Component<Props, SpreadsheetEnv> {
       sequence: 11,
       action: () => {
         this.env.dispatch("REFRESH_CHART", {
+          sheetId: this.env.getters.getActiveSheetId(),
           id: this.props.figure.id,
         });
       },

--- a/src/components/figures/container.ts
+++ b/src/components/figures/container.ts
@@ -251,7 +251,10 @@ export class FiguresContainer extends Component<{ sidePanelIsOpen: Boolean }, Sp
       return;
     }
     if (this.props.sidePanelIsOpen) {
-      this.env.openSidePanel("ChartPanel", { figure });
+      this.env.openSidePanel("ChartPanel", {
+        sheetId: this.env.getters.getActiveSheetId(),
+        figure,
+      });
     }
     const initialX = ev.clientX;
     const initialY = ev.clientY;

--- a/src/components/side_panel/chart_panel.ts
+++ b/src/components/side_panel/chart_panel.ts
@@ -7,6 +7,7 @@ import {
   DispatchResult,
   Figure,
   SpreadsheetEnv,
+  UID,
 } from "../../types/index";
 import { ColorPicker } from "../color_picker";
 import * as icons from "../icons";
@@ -150,6 +151,7 @@ const STYLE = css/* scss */ `
 `;
 
 interface Props {
+  sheetId: UID;
   figure: Figure;
 }
 
@@ -170,7 +172,7 @@ export class ChartPanel extends Component<Props, SpreadsheetEnv> {
   private state: ChartPanelState = useState(this.initialState(this.props.figure));
 
   async willUpdateProps(nextProps: Props) {
-    if (!this.getters.getChartDefinition(nextProps.figure.id)) {
+    if (!this.getters.getChartDefinition(nextProps.sheetId, nextProps.figure.id)) {
       this.trigger("close-side-panel");
       return;
     }
@@ -240,7 +242,7 @@ export class ChartPanel extends Component<Props, SpreadsheetEnv> {
   private updateChart(definition: ChartUIDefinitionUpdate): DispatchResult {
     return this.env.dispatch("UPDATE_CHART", {
       id: this.props.figure.id,
-      sheetId: this.getters.getActiveSheetId(),
+      sheetId: this.props.sheetId,
       definition,
     });
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,6 +76,7 @@ export const DEFAULT_REVISION_ID = "START_REVISION";
 
 // Chart
 export const MAX_CHAR_LABEL = 20;
+export const FIGURE_ID_SPLITTER = "??";
 
 export const DEBOUNCE_TIME = 200;
 

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -1,5 +1,11 @@
 import { FIGURE_ID_SPLITTER, INCORRECT_RANGE_STRING } from "../../constants";
-import { deepCopy, rangeReference, zoneToDimension, zoneToXc } from "../../helpers/index";
+import {
+  deepCopy,
+  isDefined,
+  rangeReference,
+  zoneToDimension,
+  zoneToXc,
+} from "../../helpers/index";
 import {
   ApplyRangeChange,
   ChartDefinition,
@@ -29,23 +35,30 @@ import { CorePlugin } from "../core_plugin";
  * */
 
 interface ChartState {
-  readonly chartFigures: Record<UID, ChartDefinition | undefined>;
+  readonly chartFigures: { [sheetId: UID]: Record<UID, ChartDefinition | undefined> | undefined };
 }
 
 export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
-  static getters = ["getChartDefinition", "getChartDefinitionUI", "getChartsIdBySheet"];
-  readonly chartFigures: Record<UID, ChartDefinition> = {};
+  static getters = ["getChartDefinition", "getChartDefinitionUI", "getChartDefinitionsBySheet"];
+  readonly chartFigures: ChartState["chartFigures"] = {};
 
   adaptRanges(applyChange: ApplyRangeChange) {
-    for (let [chartId, chart] of Object.entries(this.chartFigures)) {
-      if (chart) {
-        this.adaptDataSetRanges(chart, chartId, applyChange);
-        this.adaptLabelRanges(chart, chartId, applyChange);
+    for (const sheetId of Object.keys(this.chartFigures)) {
+      for (const [chartId, chart] of Object.entries(this.chartFigures[sheetId] || {})) {
+        if (chart) {
+          this.adaptDataSetRanges(sheetId, chart, chartId, applyChange);
+          this.adaptLabelRanges(sheetId, chart, chartId, applyChange);
+        }
       }
     }
   }
 
-  private adaptDataSetRanges(chart: ChartDefinition, chartId: UID, applyChange: ApplyRangeChange) {
+  private adaptDataSetRanges(
+    sheetId: UID,
+    chart: ChartDefinition,
+    chartId: UID,
+    applyChange: ApplyRangeChange
+  ) {
     for (let ds of chart.dataSets) {
       if (ds.labelCell) {
         const labelCellChange = applyChange(ds.labelCell);
@@ -53,6 +66,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
           case "REMOVE":
             this.history.update(
               "chartFigures",
+              sheetId,
               chartId,
               "dataSets",
               chart.dataSets.indexOf(ds),
@@ -65,6 +79,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
           case "CHANGE":
             this.history.update(
               "chartFigures",
+              sheetId,
               chartId,
               "dataSets",
               chart.dataSets.indexOf(ds),
@@ -77,7 +92,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
       switch (dataRangeChange.changeType) {
         case "REMOVE":
           const newDataSets = chart.dataSets.filter((dataset) => dataset !== ds);
-          this.history.update("chartFigures", chartId, "dataSets", newDataSets);
+          this.history.update("chartFigures", sheetId, chartId, "dataSets", newDataSets);
           break;
         case "RESIZE":
         case "MOVE":
@@ -89,6 +104,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
           ) {
             this.history.update(
               "chartFigures",
+              sheetId,
               chartId,
               "dataSets",
               chart.dataSets.indexOf(ds),
@@ -97,23 +113,34 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
             );
           } else {
             const newDataSets = chart.dataSets.filter((dataset) => dataset !== ds);
-            this.history.update("chartFigures", chartId, "dataSets", newDataSets);
+            this.history.update("chartFigures", sheetId, chartId, "dataSets", newDataSets);
           }
           break;
       }
     }
   }
-  private adaptLabelRanges(chart: ChartDefinition, chartId: UID, applyChange: ApplyRangeChange) {
+  private adaptLabelRanges(
+    sheetId: UID,
+    chart: ChartDefinition,
+    chartId: UID,
+    applyChange: ApplyRangeChange
+  ) {
     if (chart.labelRange) {
       const labelRangeChange = applyChange(chart.labelRange);
       switch (labelRangeChange.changeType) {
         case "REMOVE":
-          this.history.update("chartFigures", chartId, "labelRange", undefined);
+          this.history.update("chartFigures", sheetId, chartId, "labelRange", undefined);
           break;
         case "RESIZE":
         case "MOVE":
         case "CHANGE":
-          this.history.update("chartFigures", chartId, "labelRange", labelRangeChange.range);
+          this.history.update(
+            "chartFigures",
+            sheetId,
+            chartId,
+            "labelRange",
+            labelRangeChange.range
+          );
           break;
       }
     }
@@ -153,7 +180,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
         });
         break;
       case "UPDATE_CHART": {
-        this.updateChartDefinition(cmd.id, cmd.definition);
+        this.updateChartDefinition(cmd.sheetId, cmd.id, cmd.definition);
         break;
       }
       case "DUPLICATE_SHEET": {
@@ -164,7 +191,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
             const duplicatedFigureId = `${cmd.sheetIdTo}${FIGURE_ID_SPLITTER}${figureIdBase}`;
 
             const chartDefinition = {
-              ...deepCopy(this.chartFigures[fig.id]),
+              ...deepCopy(this.chartFigures[cmd.sheetId]![fig.id]!),
               id: duplicatedFigureId,
             };
             chartDefinition.sheetId = cmd.sheetIdTo;
@@ -194,14 +221,10 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
         break;
       }
       case "DELETE_FIGURE":
-        this.history.update("chartFigures", cmd.id, undefined);
+        this.history.update("chartFigures", cmd.sheetId, cmd.id, undefined);
         break;
       case "DELETE_SHEET":
-        for (let id of Object.keys(this.chartFigures)) {
-          if (this.chartFigures[id]?.sheetId === cmd.sheetId) {
-            this.history.update("chartFigures", id, undefined);
-          }
-        }
+        this.history.update("chartFigures", cmd.sheetId, undefined);
         break;
     }
   }
@@ -210,22 +233,23 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   // Getters
   // ---------------------------------------------------------------------------
 
-  getChartDefinition(figureId: UID): ChartDefinition | undefined {
-    return this.chartFigures[figureId];
+  getChartDefinition(sheetId: UID, figureId: UID): ChartDefinition | undefined {
+    return this.chartFigures[sheetId]?.[figureId];
   }
 
-  getChartsIdBySheet(sheetId: UID) {
-    return Object.entries(this.chartFigures)
-      .filter((chart) => {
-        return chart[1].sheetId === sheetId;
-      })
-      .map((chart) => chart[0]);
+  getChartDefinitionsBySheet(sheetId: UID) {
+    return Object.values(this.chartFigures[sheetId] || {}).filter(isDefined);
   }
 
-  getChartDefinitionUI(sheetId: UID, figureId: UID): ChartUIDefinition {
-    const data: ChartDefinition = this.chartFigures[figureId];
+  getChartDefinitionUI(
+    sheetId: UID,
+    figureId: UID,
+    forceSheetName: boolean = false
+  ): ChartUIDefinition {
+    const data: ChartDefinition = this.chartFigures[sheetId]![figureId]!;
+    const rangeSheetId = forceSheetName ? "forceSheetReference" : sheetId;
     const dataSets: string[] = data.dataSets
-      .map((ds: DataSet) => (ds ? this.getters.getRangeString(ds.dataRange, sheetId) : ""))
+      .map((ds: DataSet) => (ds ? this.getters.getRangeString(ds.dataRange, rangeSheetId) : ""))
       .filter((ds) => {
         return ds !== ""; // && range !== INCORRECT_RANGE_STRING ? show incorrect #ref ?
       });
@@ -233,7 +257,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
       title: data && data.title ? data.title : "",
       dataSets,
       labelRange: data.labelRange
-        ? this.getters.getRangeString(data.labelRange, sheetId)
+        ? this.getters.getRangeString(data.labelRange, rangeSheetId)
         : undefined,
       type: data ? data.type : "bar",
       dataSetsHaveTitle:
@@ -246,12 +270,12 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   }
 
   private getChartDefinitionExcel(sheetId: UID, figureId: UID): ExcelChartDefinition {
-    const data: ChartDefinition = this.chartFigures[figureId];
+    const data: ChartDefinition = this.chartFigures[sheetId]![figureId]!;
     const dataSets: ExcelChartDataset[] = data.dataSets
       .map((ds: DataSet) => this.toExcelDataset(ds))
       .filter((ds) => ds.range !== ""); // && range !== INCORRECT_RANGE_STRING ? show incorrect #ref ?
     return {
-      ...this.getChartDefinitionUI("forceSheetReference", figureId),
+      ...this.getChartDefinitionUI(sheetId, figureId, true),
       backgroundColor: data.background,
       dataSets,
     };
@@ -289,15 +313,17 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   import(data: WorkbookData) {
     for (let sheet of data.sheets) {
       if (sheet.figures) {
+        const charts = {};
         for (let figure of sheet.figures) {
           if (figure.tag === "chart") {
             const figureData: ChartUIDefinition = {
               ...figure.data,
             };
-            this.chartFigures[figure.id] = this.createChartDefinition(figureData, sheet.id);
+            charts[figure.id] = this.createChartDefinition(figureData, sheet.id);
             delete figure.data;
           }
         }
+        this.chartFigures[sheet.id] = charts;
       }
     }
   }
@@ -352,44 +378,45 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
    * Update the chart definition linked to the given id with the attributes
    * given in the partial UI definition
    */
-  private updateChartDefinition(id: UID, definition: ChartUIDefinitionUpdate) {
-    const chart = this.chartFigures[id];
+  private updateChartDefinition(sheetId: UID, id: UID, definition: ChartUIDefinitionUpdate) {
+    const chart = this.chartFigures[sheetId]![id];
     if (!chart) {
       throw new Error(`There is no chart with the given id: ${id}`);
     }
     if (definition.title !== undefined) {
-      this.history.update("chartFigures", id, "title", definition.title);
+      this.history.update("chartFigures", sheetId, id, "title", definition.title);
     }
     if (definition.type) {
-      this.history.update("chartFigures", id, "type", definition.type);
+      this.history.update("chartFigures", sheetId, id, "type", definition.type);
     }
     if (definition.dataSets) {
       const dataSetsHaveTitle = !!definition.dataSetsHaveTitle;
       const dataSets = this.createDataSets(definition.dataSets, chart.sheetId, dataSetsHaveTitle);
-      this.history.update("chartFigures", id, "dataSets", dataSets);
+      this.history.update("chartFigures", sheetId, id, "dataSets", dataSets);
     }
     if (definition.labelRange !== undefined) {
       const labelRange = definition.labelRange
         ? this.getters.getRangeFromSheetXC(chart.sheetId, definition.labelRange)
         : undefined;
-      this.history.update("chartFigures", id, "labelRange", labelRange);
+      this.history.update("chartFigures", sheetId, id, "labelRange", labelRange);
     }
     if (definition.background) {
-      this.history.update("chartFigures", id, "background", definition.background);
+      this.history.update("chartFigures", sheetId, id, "background", definition.background);
     }
     if (definition.verticalAxisPosition) {
       this.history.update(
         "chartFigures",
+        sheetId,
         id,
         "verticalAxisPosition",
         definition.verticalAxisPosition
       );
     }
     if (definition.legendPosition) {
-      this.history.update("chartFigures", id, "legendPosition", definition.legendPosition);
+      this.history.update("chartFigures", sheetId, id, "legendPosition", definition.legendPosition);
     }
     if (definition.stackedBar !== undefined) {
-      this.history.update("chartFigures", id, "stackedBar", definition.stackedBar);
+      this.history.update("chartFigures", sheetId, id, "stackedBar", definition.stackedBar);
     }
   }
 
@@ -460,7 +487,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
       sheetId,
       figure,
     });
-    this.history.update("chartFigures", figure.id, data);
+    this.history.update("chartFigures", sheetId, figure.id, data);
   }
 
   private createDataSet(sheetId: UID, fullZone: Zone, titleZone: Zone | undefined): DataSet {

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -153,8 +153,17 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   allowDispatch(cmd: Command) {
     const success: CommandResult = CommandResult.Success;
     switch (cmd.type) {
-      case "UPDATE_CHART":
       case "CREATE_CHART":
+        return this.checkValidations(
+          cmd,
+          this.chainValidations(
+            this.checkChartDuplicate,
+            this.checkEmptyDataset,
+            this.checkDataset
+          ),
+          this.checkLabelRange
+        );
+      case "UPDATE_CHART":
         return this.checkValidations(
           cmd,
           this.chainValidations(this.checkEmptyDataset, this.checkDataset),
@@ -530,5 +539,12 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
     }
     const invalidLabels = !rangeReference.test(cmd.definition.labelRange || "");
     return invalidLabels ? CommandResult.InvalidLabelRange : CommandResult.Success;
+  }
+
+  private checkChartDuplicate(cmd: CreateChartCommand): CommandResult {
+    if (this.chartFigures[cmd.sheetId]?.[cmd.id]) {
+      return CommandResult.DuplicatedChartId;
+    }
+    return CommandResult.Success;
   }
 }

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -1,4 +1,4 @@
-import { INCORRECT_RANGE_STRING } from "../../constants";
+import { FIGURE_ID_SPLITTER, INCORRECT_RANGE_STRING } from "../../constants";
 import { deepCopy, rangeReference, zoneToDimension, zoneToXc } from "../../helpers/index";
 import {
   ApplyRangeChange,
@@ -30,13 +30,11 @@ import { CorePlugin } from "../core_plugin";
 
 interface ChartState {
   readonly chartFigures: Record<UID, ChartDefinition | undefined>;
-  readonly nextId: number;
 }
 
 export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   static getters = ["getChartDefinition", "getChartDefinitionUI", "getChartsIdBySheet"];
   readonly chartFigures: Record<UID, ChartDefinition> = {};
-  readonly nextId = 1;
 
   adaptRanges(applyChange: ApplyRangeChange) {
     for (let [chartId, chart] of Object.entries(this.chartFigures)) {
@@ -162,9 +160,13 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
         const sheetFiguresFrom = this.getters.getFigures(cmd.sheetId);
         for (const fig of sheetFiguresFrom) {
           if (fig.tag === "chart") {
-            const id = this.nextId.toString();
-            this.history.update("nextId", this.nextId + 1);
-            const chartDefinition = { ...deepCopy(this.chartFigures[fig.id]), id };
+            const figureIdBase = fig.id.split(FIGURE_ID_SPLITTER).pop();
+            const duplicatedFigureId = `${cmd.sheetIdTo}${FIGURE_ID_SPLITTER}${figureIdBase}`;
+
+            const chartDefinition = {
+              ...deepCopy(this.chartFigures[fig.id]),
+              id: duplicatedFigureId,
+            };
             chartDefinition.sheetId = cmd.sheetIdTo;
             chartDefinition.dataSets.forEach((dataset) => {
               if (dataset.dataRange.sheetId === cmd.sheetId) {
@@ -179,7 +181,7 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
             }
 
             const figure: Figure = {
-              id: id,
+              id: duplicatedFigureId,
               x: fig.x,
               y: fig.y,
               height: fig.height,
@@ -289,7 +291,6 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
       if (sheet.figures) {
         for (let figure of sheet.figures) {
           if (figure.tag === "chart") {
-            this.history.update("nextId", this.nextId + 1);
             const figureData: ChartUIDefinition = {
               ...figure.data,
             };

--- a/src/plugins/core/figures.ts
+++ b/src/plugins/core/figures.ts
@@ -23,7 +23,7 @@ export class FigurePlugin extends CorePlugin<FigureState> implements FigureState
   allowDispatch(cmd: CoreCommand) {
     switch (cmd.type) {
       case "CREATE_FIGURE":
-        return this.checkFigureDuplicate(cmd.figure.id);
+        return this.checkFigureDuplicate(cmd.sheetId, cmd.figure.id);
       case "UPDATE_FIGURE":
       case "DELETE_FIGURE":
         return this.checkFigureExists(cmd.sheetId, cmd.id);
@@ -95,8 +95,8 @@ export class FigurePlugin extends CorePlugin<FigureState> implements FigureState
     return CommandResult.Success;
   }
 
-  private checkFigureDuplicate(figureId: UID): CommandResult {
-    if (Object.values(this.figures).find((sheet) => sheet?.[figureId])) {
+  private checkFigureDuplicate(sheetId: UID, figureId: UID): CommandResult {
+    if (this.figures[sheetId]?.[figureId]) {
       return CommandResult.DuplicatedFigureId;
     }
     return CommandResult.Success;

--- a/src/plugins/core/figures.ts
+++ b/src/plugins/core/figures.ts
@@ -10,14 +10,12 @@ import {
 import { CorePlugin } from "../core_plugin";
 
 interface FigureState {
-  readonly figures: { [sheet: string]: Record<UID, Figure | undefined> | undefined };
+  readonly figures: { [sheet: UID]: Record<UID, Figure | undefined> | undefined };
 }
 
 export class FigurePlugin extends CorePlugin<FigureState> implements FigureState {
   static getters = ["getFigures", "getFigure"];
-  readonly figures: {
-    [sheet: string]: Record<UID, Figure | undefined> | undefined;
-  } = {};
+  readonly figures: FigureState["figures"] = {};
   // ---------------------------------------------------------------------------
   // Command Handling
   // ---------------------------------------------------------------------------

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -556,7 +556,7 @@ export const CREATE_CHART = (env: SpreadsheetEnv) => {
     },
   });
   const figure = env.getters.getFigure(sheetId, id);
-  env.openSidePanel("ChartPanel", { figure });
+  env.openSidePanel("ChartPanel", { sheetId, figure });
 };
 
 //------------------------------------------------------------------------------

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1068,6 +1068,7 @@ export const enum CommandResult {
   InvalidViewportSize,
   FigureDoesNotExist,
   DuplicatedFigureId,
+  DuplicatedChartId,
 }
 
 export interface CommandHandler<T> {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -367,7 +367,7 @@ export interface UpdateChartCommand extends BaseCommand, SheetDependentCommand {
   definition: ChartUIDefinitionUpdate;
 }
 
-export interface RefreshChartCommand extends BaseCommand {
+export interface RefreshChartCommand extends BaseCommand, SheetDependentCommand {
   type: "REFRESH_CHART";
   id: UID;
 }

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -91,7 +91,7 @@ export interface CoreGetters {
   getCellBorder: BordersPlugin["getCellBorder"];
 
   getChartDefinition: ChartPlugin["getChartDefinition"];
-  getChartsIdBySheet: ChartPlugin["getChartsIdBySheet"];
+  getChartDefinitionsBySheet: ChartPlugin["getChartDefinitionsBySheet"];
   getChartDefinitionUI: ChartPlugin["getChartDefinitionUI"];
 
   getRangeString: RangeAdapter["getRangeString"];

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -1220,16 +1220,17 @@ Object {
         <c:plotArea>
             <!-- how the chart element is placed on the chart -->
             <c:layout/>
-            <c:barChart>
-                <c:barDir val=\\"col\\"/>
-                <c:grouping val=\\"clustered\\"/>
-                <c:overlap val=\\"-20\\"/>
-                <c:gapWidth val=\\"70\\"/>
+            <c:lineChart>
                 <!-- each data marker in the series does not have a different color -->
                 <c:varyColors val=\\"0\\"/>
                 <c:ser>
                     <c:idx val=\\"0\\"/>
                     <c:order val=\\"0\\"/>
+                    <c:smooth val=\\"0\\"/>
+                    <c:marker>
+                        <c:symbol val=\\"circle\\"/>
+                        <c:size val=\\"5\\"/>
+                    </c:marker>
                     <c:tx>
                         <c:strRef>
                             <c:f>
@@ -1238,13 +1239,11 @@ Object {
                         </c:strRef>
                     </c:tx>
                     <c:spPr>
-                        <a:solidFill>
-                            <a:srgbClr val=\\"1F77B4\\"/>
-                        </a:solidFill>
-                        <a:ln cmpd=\\"sng\\">
+                        <a:ln cmpd=\\"sng\\" w=\\"23813\\">
                             <a:solidFill>
                                 <a:srgbClr val=\\"1F77B4\\"/>
                             </a:solidFill>
+                            <a:prstDash val=\\"solid\\"/>
                         </a:ln>
                     </c:spPr>
                     <c:cat>
@@ -1268,6 +1267,11 @@ Object {
                 <c:ser>
                     <c:idx val=\\"1\\"/>
                     <c:order val=\\"1\\"/>
+                    <c:smooth val=\\"0\\"/>
+                    <c:marker>
+                        <c:symbol val=\\"circle\\"/>
+                        <c:size val=\\"5\\"/>
+                    </c:marker>
                     <c:tx>
                         <c:strRef>
                             <c:f>
@@ -1276,13 +1280,11 @@ Object {
                         </c:strRef>
                     </c:tx>
                     <c:spPr>
-                        <a:solidFill>
-                            <a:srgbClr val=\\"FF7F0E\\"/>
-                        </a:solidFill>
-                        <a:ln cmpd=\\"sng\\">
+                        <a:ln cmpd=\\"sng\\" w=\\"23813\\">
                             <a:solidFill>
                                 <a:srgbClr val=\\"FF7F0E\\"/>
                             </a:solidFill>
+                            <a:prstDash val=\\"solid\\"/>
                         </a:ln>
                     </c:spPr>
                     <c:cat>
@@ -1305,7 +1307,7 @@ Object {
                 </c:ser>
                 <c:axId val=\\"17781237\\"/>
                 <c:axId val=\\"88853993\\"/>
-            </c:barChart>
+            </c:lineChart>
             <c:catAx>
                 <c:axId val=\\"17781237\\"/>
                 <c:crossAx val=\\"88853993\\"/>

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -2207,6 +2207,290 @@ Object {
         <c:plotArea>
             <!-- how the chart element is placed on the chart -->
             <c:layout/>
+            <c:lineChart>
+                <!-- each data marker in the series does not have a different color -->
+                <c:varyColors val=\\"0\\"/>
+                <c:ser>
+                    <c:idx val=\\"0\\"/>
+                    <c:order val=\\"0\\"/>
+                    <c:smooth val=\\"0\\"/>
+                    <c:marker>
+                        <c:symbol val=\\"circle\\"/>
+                        <c:size val=\\"5\\"/>
+                    </c:marker>
+                    <c:tx>
+                        <c:strRef>
+                            <c:f>
+                                Sheet1!B1
+                            </c:f>
+                        </c:strRef>
+                    </c:tx>
+                    <c:spPr>
+                        <a:ln cmpd=\\"sng\\" w=\\"23813\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"1F77B4\\"/>
+                            </a:solidFill>
+                            <a:prstDash val=\\"solid\\"/>
+                        </a:ln>
+                    </c:spPr>
+                    <c:cat>
+                        <c:strRef>
+                            <c:f>
+                                Sheet1!A2:A4
+                            </c:f>
+                        </c:strRef>
+                    </c:cat>
+                    <!-- x-coordinate values -->
+                    <c:val>
+                        <!-- x-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!B2:B4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:val>
+                </c:ser>
+                <c:ser>
+                    <c:idx val=\\"1\\"/>
+                    <c:order val=\\"1\\"/>
+                    <c:smooth val=\\"0\\"/>
+                    <c:marker>
+                        <c:symbol val=\\"circle\\"/>
+                        <c:size val=\\"5\\"/>
+                    </c:marker>
+                    <c:tx>
+                        <c:strRef>
+                            <c:f>
+                                Sheet1!C1
+                            </c:f>
+                        </c:strRef>
+                    </c:tx>
+                    <c:spPr>
+                        <a:ln cmpd=\\"sng\\" w=\\"23813\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"FF7F0E\\"/>
+                            </a:solidFill>
+                            <a:prstDash val=\\"solid\\"/>
+                        </a:ln>
+                    </c:spPr>
+                    <c:cat>
+                        <c:strRef>
+                            <c:f>
+                                Sheet1!A2:A4
+                            </c:f>
+                        </c:strRef>
+                    </c:cat>
+                    <!-- x-coordinate values -->
+                    <c:val>
+                        <!-- x-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!C2:C4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:val>
+                </c:ser>
+                <c:axId val=\\"17781237\\"/>
+                <c:axId val=\\"88853993\\"/>
+            </c:lineChart>
+            <c:catAx>
+                <c:axId val=\\"17781237\\"/>
+                <c:crossAx val=\\"88853993\\"/>
+                <!-- reference to the other axe of the chart -->
+                <c:delete val=\\"0\\"/>
+                <!-- by default, axis are not displayed -->
+                <c:scaling>
+                    <c:orientation val=\\"minMax\\"/>
+                </c:scaling>
+                <c:axPos val=\\"b\\"/>
+                <c:majorGridlines>
+                    <c:spPr>
+                        <a:ln cmpd=\\"sng\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"B7B7B7\\"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                </c:majorGridlines>
+                <c:majorTickMark val=\\"out\\"/>
+                <c:minorTickMark val=\\"none\\"/>
+                <c:numFmt formatCode=\\"General\\" sourceLinked=\\"1\\"/>
+                <c:title>
+                    <c:tx>
+                        <c:rich>
+                            <a:bodyPr/>
+                            <a:lstStyle/>
+                            <a:p>
+                                <a:pPr lvl=\\"0\\">
+                                    <a:defRPr b=\\"0\\">
+                                        <a:solidFill>
+                                            <a:srgbClr val=\\"000000\\"/>
+                                        </a:solidFill>
+                                        <a:latin typeface=\\"+mn-lt\\"/>
+                                    </a:defRPr>
+                                </a:pPr>
+                                <a:r>
+                                    <!-- Runs -->
+                                    <a:rPr sz=\\"2200\\"/>
+                                    <a:t/>
+                                </a:r>
+                            </a:p>
+                        </c:rich>
+                    </c:tx>
+                </c:title>
+                <c:txPr>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl=\\"0\\">
+                            <a:defRPr b=\\"0\\" i=\\"0\\" sz=\\"1000\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"000000\\"/>
+                                </a:solidFill>
+                                <a:latin typeface=\\"+mn-lt\\"/>
+                            </a:defRPr>
+                        </a:pPr>
+                    </a:p>
+                </c:txPr>
+            </c:catAx>
+            <!-- <tickLblPos/> omitted -->
+            <c:valAx>
+                <c:axId val=\\"88853993\\"/>
+                <c:crossAx val=\\"17781237\\"/>
+                <!-- reference to the other axe of the chart -->
+                <c:delete val=\\"0\\"/>
+                <!-- by default, axis are not displayed -->
+                <c:scaling>
+                    <c:orientation val=\\"minMax\\"/>
+                </c:scaling>
+                <c:axPos val=\\"l\\"/>
+                <c:majorGridlines>
+                    <c:spPr>
+                        <a:ln cmpd=\\"sng\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"B7B7B7\\"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                </c:majorGridlines>
+                <c:majorTickMark val=\\"out\\"/>
+                <c:minorTickMark val=\\"none\\"/>
+                <c:numFmt formatCode=\\"General\\" sourceLinked=\\"1\\"/>
+                <c:title>
+                    <c:tx>
+                        <c:rich>
+                            <a:bodyPr/>
+                            <a:lstStyle/>
+                            <a:p>
+                                <a:pPr lvl=\\"0\\">
+                                    <a:defRPr b=\\"0\\">
+                                        <a:solidFill>
+                                            <a:srgbClr val=\\"000000\\"/>
+                                        </a:solidFill>
+                                        <a:latin typeface=\\"+mn-lt\\"/>
+                                    </a:defRPr>
+                                </a:pPr>
+                                <a:r>
+                                    <!-- Runs -->
+                                    <a:rPr sz=\\"2200\\"/>
+                                    <a:t/>
+                                </a:r>
+                            </a:p>
+                        </c:rich>
+                    </c:tx>
+                </c:title>
+                <c:txPr>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl=\\"0\\">
+                            <a:defRPr b=\\"0\\" i=\\"0\\" sz=\\"1000\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"000000\\"/>
+                                </a:solidFill>
+                                <a:latin typeface=\\"+mn-lt\\"/>
+                            </a:defRPr>
+                        </a:pPr>
+                    </a:p>
+                </c:txPr>
+            </c:valAx>
+            <!-- <tickLblPos/> omitted -->
+            <c:spPr>
+                <a:solidFill>
+                    <a:srgbClr val=\\"FFFFFF\\"/>
+                </a:solidFill>
+            </c:spPr>
+        </c:plotArea>
+        <c:legend>
+            <c:legendPos val=\\"t\\"/>
+            <c:overlay val=\\"0\\"/>
+            <c:txPr>
+                <a:bodyPr/>
+                <a:lstStyle/>
+                <a:p>
+                    <a:pPr lvl=\\"0\\">
+                        <a:defRPr b=\\"0\\" i=\\"0\\" sz=\\"1000\\">
+                            <a:solidFill>
+                                <a:srgbClr val=\\"000000\\"/>
+                            </a:solidFill>
+                            <a:latin typeface=\\"+mn-lt\\"/>
+                        </a:defRPr>
+                    </a:pPr>
+                </a:p>
+            </c:txPr>
+        </c:legend>
+    </c:chart>
+</c:chartSpace>",
+      "contentType": "chart",
+      "path": "xl/charts/chart1.xml",
+    },
+    Object {
+      "content": "<c:chartSpace xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
+    <c:roundedCorners val=\\"0\\"/>
+    <!-- <manualLayout/> to manually position the chart in the figure container -->
+    <c:spPr>
+        <a:solidFill>
+            <a:srgbClr val=\\"FFFFFF\\"/>
+        </a:solidFill>
+        <a:ln cmpd=\\"sng\\">
+            <a:solidFill>
+                <a:srgbClr val=\\"000000\\"/>
+            </a:solidFill>
+        </a:ln>
+    </c:spPr>
+    <c:chart>
+        <c:title>
+            <c:tx>
+                <c:rich>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl=\\"0\\">
+                            <a:defRPr b=\\"0\\">
+                                <a:solidFill>
+                                    <a:srgbClr val=\\"000000\\"/>
+                                </a:solidFill>
+                                <a:latin typeface=\\"+mn-lt\\"/>
+                            </a:defRPr>
+                        </a:pPr>
+                        <a:r>
+                            <!-- Runs -->
+                            <a:rPr sz=\\"2200\\"/>
+                            <a:t>
+                                test
+                            </a:t>
+                        </a:r>
+                    </a:p>
+                </c:rich>
+            </c:tx>
+            <c:overlay val=\\"0\\"/>
+        </c:title>
+        <c:autoTitleDeleted val=\\"0\\"/>
+        <c:plotArea>
+            <!-- how the chart element is placed on the chart -->
+            <c:layout/>
             <c:barChart>
                 <c:barDir val=\\"col\\"/>
                 <c:grouping val=\\"clustered\\"/>
@@ -2442,7 +2726,7 @@ Object {
     </c:chart>
 </c:chartSpace>",
       "contentType": "chart",
-      "path": "xl/charts/chart1.xml",
+      "path": "xl/charts/chart2.xml",
     },
     Object {
       "content": "<xdr:wsDr xmlns:xdr=\\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
@@ -2487,6 +2771,52 @@ Object {
             <a:graphic>
                 <a:graphicData uri=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
                     <c:chart r:id=\\"rId1\\"/>
+                </a:graphicData>
+            </a:graphic>
+        </xdr:graphicFrame>
+        <xdr:clientData fLocksWithSheet=\\"0\\"/>
+    </xdr:twoCellAnchor>
+    <xdr:twoCellAnchor>
+        <xdr:from>
+            <xdr:col>
+                0
+            </xdr:col>
+            <xdr:colOff>
+                9525
+            </xdr:colOff>
+            <xdr:row>
+                0
+            </xdr:row>
+            <xdr:rowOff>
+                9525
+            </xdr:rowOff>
+        </xdr:from>
+        <xdr:to>
+            <xdr:col>
+                5
+            </xdr:col>
+            <xdr:colOff>
+                542925
+            </xdr:colOff>
+            <xdr:row>
+                14
+            </xdr:row>
+            <xdr:rowOff>
+                133350
+            </xdr:rowOff>
+        </xdr:to>
+        <xdr:graphicFrame>
+            <xdr:nvGraphicFramePr>
+                <xdr:cNvPr id=\\"2\\" name=\\"Chart 2\\" title=\\"Chart\\"/>
+                <xdr:cNvGraphicFramePr/>
+            </xdr:nvGraphicFramePr>
+            <xdr:xfrm>
+                <a:off x=\\"0\\" y=\\"0\\"/>
+                <a:ext cx=\\"0\\" cy=\\"0\\"/>
+            </xdr:xfrm>
+            <a:graphic>
+                <a:graphicData uri=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
+                    <c:chart r:id=\\"rId2\\"/>
                 </a:graphicData>
             </a:graphic>
         </xdr:graphicFrame>
@@ -2708,6 +3038,7 @@ Object {
     Object {
       "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
     <Relationship Id=\\"rId1\\" Target=\\"../charts/chart1.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\\"/>
+    <Relationship Id=\\"rId2\\" Target=\\"../charts/chart2.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\\"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -2725,6 +3056,7 @@ Object {
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\\" PartName=\\"/xl/charts/chart1.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\\" PartName=\\"/xl/charts/chart2.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.drawing+xml\\" PartName=\\"/xl/drawings/drawing0.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\\" PartName=\\"/xl/worksheets/sheet0.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\\" PartName=\\"/xl/styles.xml\\"/>

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -138,7 +138,8 @@ describe("figures", () => {
   });
 
   test("Click on Delete button will delete the chart", async () => {
-    expect(model.getters.getChartDefinition("someuuid")).toMatchObject({
+    const sheetId = model.getters.getActiveSheetId();
+    expect(model.getters.getChartDefinition(sheetId, "someuuid")).toMatchObject({
       dataSets: [
         {
           dataRange: {
@@ -182,7 +183,7 @@ describe("figures", () => {
     const deleteButton = fixture.querySelectorAll(".o-menu-item")[1];
     expect(deleteButton.textContent).toBe("Delete");
     await simulateClick(".o-menu div[data-name='delete']");
-    expect(model.getters.getChartRuntime("someuuid")).toBeUndefined();
+    expect(model.getters.getChartRuntime(sheetId, "someuuid")).toBeUndefined();
   });
 
   test("Click on Edit button will prefill sidepanel", async () => {
@@ -284,20 +285,22 @@ describe("figures", () => {
     const model = parent.model;
     const sheetId = model.getters.getActiveSheetId();
     const figure = model.getters.getFigure(sheetId, chartId);
-    expect(parent.model.getters.getChartDefinition(chartId)?.labelRange).not.toBeUndefined();
-    parent.env.openSidePanel("ChartPanel", { figure });
+    expect(
+      parent.model.getters.getChartDefinition(sheetId, chartId)?.labelRange
+    ).not.toBeUndefined();
+    parent.env.openSidePanel("ChartPanel", { sheetId, figure });
     await nextTick();
     await simulateClick(".o-data-labels input");
     setInputValueAndTrigger(".o-data-labels input", "", "change");
     await simulateClick(".o-data-labels .o-selection-ok");
-    expect(parent.model.getters.getChartDefinition(chartId)?.labelRange).toBeUndefined();
+    expect(parent.model.getters.getChartDefinition(sheetId, chartId)?.labelRange).toBeUndefined();
   });
 
   test("empty dataset and invalid label range display both errors", async () => {
     const model = parent.model;
     const sheetId = model.getters.getActiveSheetId();
     const figure = model.getters.getFigure(sheetId, chartId);
-    parent.env.openSidePanel("ChartPanel", { figure });
+    parent.env.openSidePanel("ChartPanel", { sheetId, figure });
     await nextTick();
 
     // empty dataset
@@ -341,6 +344,7 @@ describe("figures", () => {
   });
 
   test("deleting chart will close sidePanel", async () => {
+    const sheetId = model.getters.getActiveSheetId();
     expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
     await simulateClick(".o-figure");
     await simulateClick(".o-chart-menu");
@@ -350,7 +354,7 @@ describe("figures", () => {
     await simulateClick(".o-figure");
     await simulateClick(".o-chart-menu");
     await simulateClick(".o-menu div[data-name='delete']");
-    expect(model.getters.getChartRuntime("someuuid")).toBeUndefined();
+    expect(model.getters.getChartRuntime(sheetId, "someuuid")).toBeUndefined();
     await nextTick();
     expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
   });
@@ -368,6 +372,7 @@ describe("figures", () => {
     await simulateClick(".o-menu div[data-name='refresh']");
     expect(parent.env.dispatch).toHaveBeenCalledWith("REFRESH_CHART", {
       id: "someuuid",
+      sheetId: model.getters.getActiveSheetId(),
     });
   });
 
@@ -529,7 +534,7 @@ describe("charts with multiple sheets", () => {
   test("delete sheet containing chart data does not crash", async () => {
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("Sheet1");
     model.dispatch("DELETE_SHEET", { sheetId: model.getters.getActiveSheetId() });
-    const runtimeChart = model.getters.getChartRuntime("1");
+    const runtimeChart = model.getters.getChartRuntime("Sheet2", "1");
     expect(runtimeChart).toBeDefined();
     await nextTick();
     expect(fixture.querySelector(".o-chart-container")).toBeDefined();

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -75,7 +75,7 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    expect(model.getters.getChartDefinition("1")).toMatchObject({
+    expect(model.getters.getChartDefinition(sheetId, "1")).toMatchObject({
       dataSets: [
         {
           dataRange: {
@@ -112,7 +112,7 @@ describe("datasource tests", function () {
       title: "test",
       type: "line",
     });
-    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+    expect(model.getters.getChartRuntime(sheetId, "1")).toMatchSnapshot();
   });
 
   test("create chart with rectangle dataset", () => {
@@ -126,7 +126,7 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    expect(model.getters.getChartDefinition("1")).toMatchObject({
+    expect(model.getters.getChartDefinition(sheetId, "1")).toMatchObject({
       dataSets: [
         {
           dataRange: {
@@ -163,7 +163,7 @@ describe("datasource tests", function () {
       title: "test",
       type: "line",
     });
-    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+    expect(model.getters.getChartRuntime(sheetId, "1")).toMatchSnapshot();
   });
 
   test("create chart with column datasets without series title", () => {
@@ -178,7 +178,7 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    expect(model.getters.getChartDefinition("1")).toMatchObject({
+    expect(model.getters.getChartDefinition(sheetId, "1")).toMatchObject({
       dataSets: [
         {
           dataRange: {
@@ -206,7 +206,7 @@ describe("datasource tests", function () {
       title: "test",
       type: "line",
     });
-    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+    expect(model.getters.getChartRuntime(sheetId, "1")).toMatchSnapshot();
   });
 
   test("create chart with row datasets", () => {
@@ -220,7 +220,7 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    expect(model.getters.getChartDefinition("1")).toMatchObject({
+    expect(model.getters.getChartDefinition(sheetId, "1")).toMatchObject({
       dataSets: [
         {
           dataRange: {
@@ -256,7 +256,7 @@ describe("datasource tests", function () {
       title: "test",
       type: "line",
     });
-    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+    expect(model.getters.getChartRuntime(sheetId, "1")).toMatchSnapshot();
   });
 
   test("create chart with row datasets without series title", () => {
@@ -271,7 +271,7 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    expect(model.getters.getChartDefinition("1")).toMatchObject({
+    expect(model.getters.getChartDefinition(sheetId, "1")).toMatchObject({
       dataSets: [
         {
           dataRange: {
@@ -299,7 +299,7 @@ describe("datasource tests", function () {
       title: "test",
       type: "line",
     });
-    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+    expect(model.getters.getChartRuntime(sheetId, "1")).toMatchSnapshot();
   });
 
   test("create chart with only the dataset title (no data)", () => {
@@ -313,7 +313,7 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    expect(model.getters.getChartDefinition("1")).toMatchObject({
+    expect(model.getters.getChartDefinition(sheetId, "1")).toMatchObject({
       dataSets: [],
       labelRange: {
         prefixSheet: true,
@@ -324,7 +324,7 @@ describe("datasource tests", function () {
       title: "test",
       type: "line",
     });
-    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+    expect(model.getters.getChartRuntime(sheetId, "1")).toMatchSnapshot();
   });
 
   test("create chart with a dataset of one cell (no title)", () => {
@@ -339,7 +339,7 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    expect(model.getters.getChartDefinition("1")).toMatchObject({
+    expect(model.getters.getChartDefinition(sheetId, "1")).toMatchObject({
       dataSets: [
         {
           dataRange: {
@@ -359,10 +359,11 @@ describe("datasource tests", function () {
       title: "test",
       type: "line",
     });
-    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+    expect(model.getters.getChartRuntime(sheetId, "1")).toMatchSnapshot();
   });
 
   test("create a chart with stacked bar", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -373,10 +374,11 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    expect(model.getters.getChartRuntime("1")).toMatchSnapshot();
+    expect(model.getters.getChartRuntime(sheetId, "1")).toMatchSnapshot();
   });
 
   test("ranges in definition change automatically", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -387,7 +389,7 @@ describe("datasource tests", function () {
       "1"
     );
     addColumns(model, "before", "A", 2);
-    const chart = model.getters.getChartDefinition("1")!;
+    const chart = model.getters.getChartDefinition(sheetId, "1")!;
     expect(chart.dataSets[0].dataRange.zone).toStrictEqual(toZone("D1:D4"));
     expect(chart.dataSets[0].labelCell!.zone).toStrictEqual(toZone("D1:D1"));
     expect(chart.dataSets[1].dataRange.zone).toStrictEqual(toZone("E1:E4"));
@@ -396,24 +398,26 @@ describe("datasource tests", function () {
   });
 
   test("pie chart tooltip title display the correct dataset", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       { dataSets: ["B7:B8"], dataSetsHaveTitle: true, labelRange: "B7", type: "pie" },
       "1"
     );
-    const title = model.getters.getChartRuntime("1")!.options!.tooltips!.callbacks!.title!;
+    const title = model.getters.getChartRuntime(sheetId, "1")!.options!.tooltips!.callbacks!.title!;
     const chartData = { datasets: [{ label: "dataset 1" }, { label: "dataset 2" }] };
     expect(title([{ datasetIndex: 0 }], chartData)).toBe("dataset 1");
     expect(title([{ datasetIndex: 1 }], chartData)).toBe("dataset 2");
   });
 
   test.each(["bar", "line"] as const)("chart %s tooltip title is not dynamic", (chartType) => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       { dataSets: ["B7:B8"], dataSetsHaveTitle: true, labelRange: "B7", type: chartType },
       "1"
     );
-    const title = model.getters.getChartRuntime("1")?.options?.tooltips?.callbacks?.title;
+    const title = model.getters.getChartRuntime(sheetId, "1")?.options?.tooltips?.callbacks?.title;
     expect(title).toBeUndefined();
   });
 
@@ -431,13 +435,14 @@ describe("datasource tests", function () {
     const exportedData = model.exportData();
     const newModel = new Model(exportedData);
     expect(newModel.getters.getVisibleFigures(sheetId)).toHaveLength(1);
-    expect(newModel.getters.getChartRuntime("1")).toBeTruthy();
+    expect(newModel.getters.getChartRuntime(sheetId, "1")).toBeTruthy();
     newModel.dispatch("DELETE_FIGURE", { sheetId: model.getters.getActiveSheetId(), id: "1" });
     expect(newModel.getters.getVisibleFigures(sheetId)).toHaveLength(0);
-    expect(newModel.getters.getChartRuntime("1")).toBeUndefined();
+    expect(newModel.getters.getChartRuntime(sheetId, "1")).toBeUndefined();
   });
 
   test("update dataset of imported chart", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -448,10 +453,10 @@ describe("datasource tests", function () {
       "1"
     );
     const newModel = new Model(model.exportData());
-    let chart = newModel.getters.getChartRuntime("1")!;
+    let chart = newModel.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     setCellContent(newModel, "B2", "99");
-    chart = newModel.getters.getChartRuntime("1")!;
+    chart = newModel.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([99, 11, 12]);
   });
 
@@ -466,7 +471,7 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    let chart = model.getters.getChartRuntime("1")!;
+    let chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     expect(chart.type).toEqual("line");
     updateChart(model, "1", {
@@ -476,8 +481,8 @@ describe("datasource tests", function () {
       type: "bar",
       title: "hello1",
     });
-    chart = model.getters.getChartRuntime("1")!;
-    expect(model.getters.getChartDefinition("1")).toMatchObject({
+    chart = model.getters.getChartRuntime(sheetId, "1")!;
+    expect(model.getters.getChartDefinition(sheetId, "1")).toMatchObject({
       dataSets: [
         {
           dataRange: {
@@ -519,6 +524,7 @@ describe("datasource tests", function () {
   });
 
   test("remove labels from existing chart", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -529,7 +535,7 @@ describe("datasource tests", function () {
       "1"
     );
     updateChart(model, "1", { labelRange: null });
-    expect(model.getters.getChartDefinition("1")?.labelRange).toBeUndefined();
+    expect(model.getters.getChartDefinition(sheetId, "1")?.labelRange).toBeUndefined();
   });
 
   test("deleting a random sheet does not affect a chart", () => {
@@ -569,6 +575,7 @@ describe("datasource tests", function () {
   });
 
   test("delete a data source column", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -579,13 +586,14 @@ describe("datasource tests", function () {
       "1"
     );
     deleteColumns(model, ["B"]);
-    const chart = model.getters.getChartRuntime("1")!;
+    const chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([20, 19, 18]);
     expect(chart.data!.datasets![1]).toBe(undefined);
     expect(chart.data!.labels).toEqual(["P1", "P2", "P3"]);
   });
 
   test("delete a data set labels column", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -597,14 +605,15 @@ describe("datasource tests", function () {
     );
     deleteColumns(model, ["A"]);
     // dataset in col B becomes labels in col A
-    expect(model.getters.getChartRuntime("1")!.data!.labels).toEqual(["0", "1", "2"]);
-    const chart = model.getters.getChartRuntime("1")!;
+    expect(model.getters.getChartRuntime(sheetId, "1")!.data!.labels).toEqual(["0", "1", "2"]);
+    const chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     expect(chart.data!.datasets![1].data).toEqual([20, 19, 18]);
     expect(chart.data!.labels).toEqual(["0", "1", "2"]);
   });
 
   test("delete last row of dataset", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -616,13 +625,14 @@ describe("datasource tests", function () {
       "1"
     );
     deleteRows(model, [4]);
-    const chart = model.getters.getChartRuntime("1")!;
+    const chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     expect(chart.data!.datasets![1].data).toEqual([20, 19, 18]);
     expect(chart.data!.labels).toEqual(["P1", "P2", "P3"]);
   });
 
   test("delete last col of dataset", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -634,13 +644,14 @@ describe("datasource tests", function () {
       "1"
     );
     deleteColumns(model, ["C"]);
-    const chart = model.getters.getChartRuntime("1")!;
+    const chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12, 13]);
     expect(chart.data!.datasets![1]).toBeUndefined();
     expect(chart.data!.labels).toEqual(["P1", "P2", "P3", "P4"]);
   });
 
   test("add row in dataset", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -652,7 +663,7 @@ describe("datasource tests", function () {
       "1"
     );
     addRows(model, "before", 2, 1);
-    const chart = model.getters.getChartRuntime("1")!;
+    const chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([10, undefined, 11, 12, 13]);
     expect(chart.data!.datasets![1].data).toEqual([20, undefined, 19, 18, 17]);
     expect(chart.data!.labels).toEqual(["P1", "", "P2", "P3", "P4"]);
@@ -677,6 +688,7 @@ describe("datasource tests", function () {
   });
 
   test("delete all the dataset except for the title", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -688,13 +700,14 @@ describe("datasource tests", function () {
       "1"
     );
     deleteRows(model, [1, 2, 3, 4]);
-    const chart = model.getters.getChartRuntime("1")!;
+    const chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([]);
     expect(chart.data!.datasets![1].data).toEqual([]);
     expect(chart.data!.labels).toEqual([]);
   });
 
   test("update dataset cell updates chart runtime", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -704,12 +717,12 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    let chart = model.getters.getChartRuntime("1")!;
+    let chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     expect(chart.data!.datasets![0].label).toEqual("first column dataset");
     setCellContent(model, "B2", "99");
     setCellContent(model, "B1", "new dataset label");
-    chart = model.getters.getChartRuntime("1")!;
+    chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([99, 11, 12]);
     expect(chart.data!.datasets![0].label).toEqual("new dataset label");
   });
@@ -773,8 +786,8 @@ describe("datasource tests", function () {
       },
       "1"
     );
-    const chart = model.getters.getChartRuntime("1")!;
-    expect(model.getters.getChartDefinition("1")).toMatchObject({
+    const chart = model.getters.getChartRuntime(sheetId, "1")!;
+    expect(model.getters.getChartDefinition(sheetId, "1")).toMatchObject({
       dataSets: [
         {
           dataRange: {
@@ -889,6 +902,7 @@ describe("datasource tests", function () {
     ]);
   });
   test("extend data source to new values manually", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -902,11 +916,12 @@ describe("datasource tests", function () {
       labelRange: "Sheet1!A2:A5",
       dataSetsHaveTitle: true,
     });
-    const chart = model.getters.getChartRuntime("1")!;
+    const chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12, 13]);
     expect(chart.data!.datasets![1].data).toEqual([20, 19, 18, 17]);
   });
   test("extend data set labels to new values manually", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -919,7 +934,7 @@ describe("datasource tests", function () {
       dataSets: ["Sheet1!B1:B5", "Sheet1!C1:C5"],
       labelRange: "Sheet1!A2:A5",
     });
-    const chart = model.getters.getChartRuntime("1")!;
+    const chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.data!.labels).toEqual(["P1", "P2", "P3", "P4"]);
   });
 
@@ -935,9 +950,9 @@ describe("datasource tests", function () {
       "1",
       "2"
     );
-    expect(model.getters.getChartRuntime("1")).not.toBeUndefined();
+    expect(model.getters.getChartRuntime("2", "1")).not.toBeUndefined();
     model.dispatch("DELETE_SHEET", { sheetId: "2" });
-    expect(model.getters.getChartRuntime("1")).toBeUndefined();
+    expect(model.getters.getChartRuntime("2", "1")).toBeUndefined();
   });
 
   test("Chart is copied on sheet duplication", () => {
@@ -959,7 +974,10 @@ describe("datasource tests", function () {
 
     expect(model.getters.getFigures(secondSheetId)).toHaveLength(1);
     const duplicatedFigure = model.getters.getFigures(secondSheetId)[0];
-    const duplicatedChartDefinition = model.getters.getChartDefinition(duplicatedFigure.id);
+    const duplicatedChartDefinition = model.getters.getChartDefinition(
+      secondSheetId,
+      duplicatedFigure.id
+    );
     const expectedDuplicatedChartDefinition = {
       dataSets: [
         {
@@ -982,7 +1000,7 @@ describe("datasource tests", function () {
     deleteSheet(model, firstSheetId);
     expect(model.getters.getSheets()).toHaveLength(1);
     expect(model.getters.getFigures(secondSheetId)).toEqual([duplicatedFigure]);
-    expect(model.getters.getChartDefinition(duplicatedFigure.id)).toMatchObject(
+    expect(model.getters.getChartDefinition(secondSheetId, duplicatedFigure.id)).toMatchObject(
       expectedDuplicatedChartDefinition
     );
   });
@@ -1019,17 +1037,17 @@ describe("datasource tests", function () {
     expect(figuresSh2.length).toEqual(1);
     expect(figuresSh3.length).toEqual(1);
 
-    expect(newModel.getters.getChartsIdBySheet(firstSheetId).length).toEqual(1);
-    expect(newModel.getters.getChartsIdBySheet(secondSheetId).length).toEqual(1);
-    expect(newModel.getters.getChartsIdBySheet(thirdSheetId).length).toEqual(1);
+    expect(newModel.getters.getChartDefinitionsBySheet(firstSheetId).length).toEqual(1);
+    expect(newModel.getters.getChartDefinitionsBySheet(secondSheetId).length).toEqual(1);
+    expect(newModel.getters.getChartDefinitionsBySheet(thirdSheetId).length).toEqual(1);
 
     expect(figuresSh1[0].id).toEqual("myChart");
     expect(figuresSh2[0].id).toEqual(secondSheetId + FIGURE_ID_SPLITTER + "myChart");
     expect(figuresSh3[0].id).toEqual(thirdSheetId + FIGURE_ID_SPLITTER + "myChart");
 
-    const chartSh1 = newModel.getters.getChartDefinition(figuresSh1[0].id);
-    const chartSh2 = newModel.getters.getChartDefinition(figuresSh2[0].id);
-    const chartSh3 = newModel.getters.getChartDefinition(figuresSh3[0].id);
+    const chartSh1 = newModel.getters.getChartDefinition(firstSheetId, figuresSh1[0].id);
+    const chartSh2 = newModel.getters.getChartDefinition(secondSheetId, figuresSh2[0].id);
+    const chartSh3 = newModel.getters.getChartDefinition(thirdSheetId, figuresSh3[0].id);
 
     expect(chartSh1?.sheetId).toBe(firstSheetId);
     expect(chartSh2?.sheetId).toBe(secondSheetId);
@@ -1059,7 +1077,10 @@ describe("datasource tests", function () {
       sheetId: firstSheetId,
     });
     const duplicatedFigure = model.getters.getFigures(thirdSheetId)[0];
-    const duplicatedChartDefinition = model.getters.getChartDefinition(duplicatedFigure.id);
+    const duplicatedChartDefinition = model.getters.getChartDefinition(
+      thirdSheetId,
+      duplicatedFigure.id
+    );
     expect(duplicatedChartDefinition).toMatchObject({
       dataSets: [
         {
@@ -1094,6 +1115,7 @@ describe("datasource tests", function () {
 
 describe("title", function () {
   test("change title manually", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -1103,15 +1125,16 @@ describe("title", function () {
       },
       "1"
     );
-    let chart = model.getters.getChartRuntime("1")!;
+    let chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.options!.title!.text).toEqual("title");
 
     updateChart(model, "1", { title: "newTitle" });
-    chart = model.getters.getChartRuntime("1")!;
+    chart = model.getters.getChartRuntime(sheetId, "1")!;
     expect(chart.options!.title!.text).toEqual("newTitle");
   });
 
   test("Title is not displayed if empty", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -1121,15 +1144,16 @@ describe("title", function () {
       },
       "1"
     );
-    expect(model.getters.getChartRuntime("1")?.options?.title?.display).toBe(true);
+    expect(model.getters.getChartRuntime(sheetId, "1")?.options?.title?.display).toBe(true);
     updateChart(model, "1", { title: "" });
-    expect(model.getters.getChartRuntime("1")?.options?.title?.display).toBe(false);
+    expect(model.getters.getChartRuntime(sheetId, "1")?.options?.title?.display).toBe(false);
   });
 });
 
 describe("multiple sheets", function () {
   test("create a chart with data from another sheet", () => {
-    createSheet(model, { sheetId: "42", activate: true });
+    const newSheetId = "42";
+    createSheet(model, { sheetId: newSheetId, activate: true });
     createChart(
       model,
       {
@@ -1138,8 +1162,8 @@ describe("multiple sheets", function () {
       },
       "1"
     );
-    const chart = model.getters.getChartRuntime("1")!;
-    const chartDefinition = model.getters.getChartDefinition("1");
+    const chart = model.getters.getChartRuntime(newSheetId, "1")!;
+    const chartDefinition = model.getters.getChartDefinition(newSheetId, "1");
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     expect(chart.data!.datasets![1].data).toEqual([20, 19, 18]);
     expect(chartDefinition).toMatchObject({
@@ -1170,11 +1194,12 @@ describe("multiple sheets", function () {
           },
         },
       ],
-      sheetId: "42",
+      sheetId: newSheetId,
     });
   });
   test("create a chart with dataset label from another sheet", () => {
-    createSheet(model, { sheetId: "42", activate: true });
+    const newSheetId = "42";
+    createSheet(model, { sheetId: newSheetId, activate: true });
     createChart(
       model,
       {
@@ -1183,8 +1208,8 @@ describe("multiple sheets", function () {
       },
       "1"
     );
-    const chart = model.getters.getChartRuntime("1")!;
-    const chartDefinition = model.getters.getChartDefinition("1");
+    const chart = model.getters.getChartRuntime(newSheetId, "1")!;
+    const chartDefinition = model.getters.getChartDefinition(newSheetId, "1");
     expect(chart.data!.labels).toEqual(["P1", "P2", "P3"]);
     expect(chartDefinition).toMatchObject({
       labelRange: {
@@ -1192,9 +1217,10 @@ describe("multiple sheets", function () {
         sheetId: "Sheet1",
         zone: toZone("A2:A4"),
       },
-      sheetId: "42",
+      sheetId: newSheetId,
     });
   });
+
   test("change source data then activate the chart sheet (it should be up-to-date)", () => {
     createSheet(model, { sheetId: "42", activate: true });
     createChart(
@@ -1213,7 +1239,7 @@ describe("multiple sheets", function () {
       content: "99",
     });
     model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: "Sheet1", sheetIdTo: "42" });
-    const chart = model.getters.getChartRuntime("28")!;
+    const chart = model.getters.getChartRuntime("42", "28")!;
     expect(chart.data!.datasets![0].data).toEqual([99, 11, 12]);
   });
   test("change dataset label then activate the chart sheet (it should be up-to-date)", () => {
@@ -1234,11 +1260,12 @@ describe("multiple sheets", function () {
       content: "miam",
     });
     model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: "Sheet1", sheetIdTo: "42" });
-    const chart = model.getters.getChartRuntime("28")!;
+    const chart = model.getters.getChartRuntime("42", "28")!;
     expect(chart.data!.labels).toEqual(["P1", "miam", "P3"]);
   });
   test("create a chart with data from another sheet", () => {
-    createSheet(model, { sheetId: "42", activate: true });
+    const newSheetId = "42";
+    createSheet(model, { sheetId: newSheetId, activate: true });
     createChart(
       model,
       {
@@ -1247,8 +1274,8 @@ describe("multiple sheets", function () {
       },
       "28"
     );
-    const chart = model.getters.getChartRuntime("28")!;
-    const chartDefinition = model.getters.getChartDefinition("28");
+    const chart = model.getters.getChartRuntime(newSheetId, "28")!;
+    const chartDefinition = model.getters.getChartDefinition(newSheetId, "28");
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     expect(chart.data!.datasets![1].data).toEqual([20, 19, 18]);
     expect(chartDefinition).toMatchObject({
@@ -1279,7 +1306,7 @@ describe("multiple sheets", function () {
           },
         },
       ],
-      sheetId: "42",
+      sheetId: newSheetId,
     });
   });
   describe("multiple sheets with formulas", function () {
@@ -1323,21 +1350,22 @@ describe("multiple sheets", function () {
       });
     });
     test("new model with chart with formulas from another sheet (not evaluated yet)", () => {
-      const chart = model.getters.getChartRuntime("1")!;
+      const chart = model.getters.getChartRuntime(model.getters.getActiveSheetId(), "1")!;
       expect(chart.data!.datasets![0].data).toEqual([2, 4]);
     });
     test("refresh chart to update it with new data", () => {
+      const sheetId = model.getters.getActiveSheetId();
       model.dispatch("UPDATE_CELL", {
         sheetId: "Sheet2",
         col: 0,
         row: 0,
         content: "=Sheet1!B1*3",
       });
-      let chart = model.getters.getChartRuntime("1")!;
+      let chart = model.getters.getChartRuntime(sheetId, "1")!;
       expect(chart.data!.datasets![0].data).toEqual(["Loading...", 4]); // data has not been updated :(
 
-      model.dispatch("REFRESH_CHART", { id: "1" });
-      chart = model.getters.getChartRuntime("1")!;
+      model.dispatch("REFRESH_CHART", { sheetId, id: "1" });
+      chart = model.getters.getChartRuntime(sheetId, "1")!;
       expect(chart.data!.datasets![0].data).toEqual([3, 4]);
 
       model.dispatch("UPDATE_CELL", {
@@ -1346,18 +1374,19 @@ describe("multiple sheets", function () {
         row: 1,
         content: "5",
       });
-      chart = model.getters.getChartRuntime("1")!;
+      chart = model.getters.getChartRuntime(sheetId, "1")!;
       expect(chart.data!.datasets![0].data).toEqual([3, 4]); // data has not been updated :(
 
-      model.dispatch("REFRESH_CHART", { id: "1" });
-      chart = model.getters.getChartRuntime("1")!;
+      model.dispatch("REFRESH_CHART", { sheetId, id: "1" });
+      chart = model.getters.getChartRuntime(sheetId, "1")!;
       expect(chart.data!.datasets![0].data).toEqual([3, 10]);
     });
   });
 
   test("export with chart data from a sheet that was deleted, than import data does not crash", () => {
     const originSheet = model.getters.getActiveSheetId();
-    createSheet(model, { sheetId: "42", activate: true });
+    const newSheetId = "42";
+    createSheet(model, { sheetId: newSheetId, activate: true });
     createChart(
       model,
       {
@@ -1369,7 +1398,7 @@ describe("multiple sheets", function () {
     model.dispatch("DELETE_SHEET", { sheetId: originSheet });
     const exportedData = model.exportData();
     const newModel = new Model(exportedData);
-    const chart = newModel.getters.getChartRuntime("28")!;
+    const chart = newModel.getters.getChartRuntime(newSheetId, "28")!;
     expect(chart).toBeDefined();
   });
 });
@@ -1385,6 +1414,7 @@ describe("undo/redo", () => {
     expect(model).toExport(after);
   });
   test("undo/redo chart dataset rebuild the chart runtime", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(
       model,
       {
@@ -1394,16 +1424,16 @@ describe("undo/redo", () => {
       },
       "27"
     );
-    let chart = model.getters.getChartRuntime("27")!;
+    let chart = model.getters.getChartRuntime(sheetId, "27")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     setCellContent(model, "B2", "99");
-    chart = model.getters.getChartRuntime("27")!;
+    chart = model.getters.getChartRuntime(sheetId, "27")!;
     expect(chart.data!.datasets![0].data).toEqual([99, 11, 12]);
     undo(model);
-    chart = model.getters.getChartRuntime("27")!;
+    chart = model.getters.getChartRuntime(sheetId, "27")!;
     expect(chart.data!.datasets![0].data).toEqual([10, 11, 12]);
     redo(model);
-    chart = model.getters.getChartRuntime("27")!;
+    chart = model.getters.getChartRuntime(sheetId, "27")!;
     expect(chart.data!.datasets![0].data).toEqual([99, 11, 12]);
   });
 });
@@ -1421,34 +1451,36 @@ describe("Chart without labels", () => {
   };
 
   test("The legend is not displayed when there is only one dataSet and no label", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(model, defaultChart, "42");
-    expect(model.getters.getChartRuntime("42")?.options?.legend?.display).toBe(false);
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.legend?.display).toBe(false);
 
     createChart(model, { ...defaultChart, dataSets: ["A1:A2", "A3:A4"] }, "43");
-    expect(model.getters.getChartRuntime("43")?.options?.legend?.display).toBeUndefined();
+    expect(model.getters.getChartRuntime(sheetId, "43")?.options?.legend?.display).toBeUndefined();
 
     createChart(model, { ...defaultChart, labelRange: "B1:B2" }, "44");
-    expect(model.getters.getChartRuntime("44")?.options?.legend?.display).toBeUndefined();
+    expect(model.getters.getChartRuntime(sheetId, "44")?.options?.legend?.display).toBeUndefined();
   });
 
   test("Labels are empty if there is only one dataSet and no label", () => {
+    const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
     createChart(model, defaultChart, "42");
-    expect(model.getters.getChartRuntime("42")?.data?.labels).toEqual(["", ""]);
+    expect(model.getters.getChartRuntime(sheetId, "42")?.data?.labels).toEqual(["", ""]);
 
     createChart(model, { ...defaultChart, dataSets: ["A1:A2", "A3:A4"] }, "43");
-    expect(model.getters.getChartRuntime("43")?.data?.datasets![0].label).toEqual(
+    expect(model.getters.getChartRuntime(sheetId, "43")?.data?.datasets![0].label).toEqual(
       `${chartTerms.Series.toString()} 1`
     );
-    expect(model.getters.getChartRuntime("43")?.data?.datasets![1].label).toEqual(
+    expect(model.getters.getChartRuntime(sheetId, "43")?.data?.datasets![1].label).toEqual(
       `${chartTerms.Series.toString()} 2`
     );
 
     setCellContent(model, "B1", "B1");
     setCellContent(model, "B2", "B2");
     createChart(model, { ...defaultChart, labelRange: "B1:B2" }, "44");
-    expect(model.getters.getChartRuntime("44")?.data?.labels).toEqual(["B1", "B2"]);
+    expect(model.getters.getChartRuntime(sheetId, "44")?.data?.labels).toEqual(["B1", "B2"]);
   });
 });
 
@@ -1466,17 +1498,18 @@ describe("Chart design configuration", () => {
   };
 
   test("Legend position", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(model, defaultChart, "42");
-    expect(model.getters.getChartRuntime("42")?.options?.legend?.position).toBe("top");
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.legend?.position).toBe("top");
 
     updateChart(model, "42", { legendPosition: "left" });
-    expect(model.getters.getChartRuntime("42")?.options?.legend?.position).toBe("left");
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.legend?.position).toBe("left");
 
     updateChart(model, "42", { legendPosition: "right" });
-    expect(model.getters.getChartRuntime("42")?.options?.legend?.position).toBe("right");
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.legend?.position).toBe("right");
 
     updateChart(model, "42", { legendPosition: "bottom" });
-    expect(model.getters.getChartRuntime("42")?.options?.legend?.position).toBe("bottom");
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.legend?.position).toBe("bottom");
   });
 
   test("Background is correctly updated", () => {
@@ -1492,33 +1525,59 @@ describe("Chart design configuration", () => {
   });
 
   test("Stacked bar", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(model, defaultChart, "42");
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.xAxes![0].stacked).toBeUndefined();
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.yAxes![0].stacked).toBeUndefined();
+    expect(
+      model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.xAxes![0].stacked
+    ).toBeUndefined();
+    expect(
+      model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.yAxes![0].stacked
+    ).toBeUndefined();
 
     updateChart(model, "42", { stackedBar: true });
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.xAxes![0].stacked).toBe(true);
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.yAxes![0].stacked).toBe(true);
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.xAxes![0].stacked).toBe(
+      true
+    );
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.yAxes![0].stacked).toBe(
+      true
+    );
 
     updateChart(model, "42", { type: "line" });
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.xAxes![0].stacked).toBeUndefined();
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.yAxes![0].stacked).toBeUndefined();
+    expect(
+      model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.xAxes![0].stacked
+    ).toBeUndefined();
+    expect(
+      model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.yAxes![0].stacked
+    ).toBeUndefined();
 
     updateChart(model, "42", { type: "bar" });
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.xAxes![0].stacked).toBe(true);
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.yAxes![0].stacked).toBe(true);
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.xAxes![0].stacked).toBe(
+      true
+    );
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.yAxes![0].stacked).toBe(
+      true
+    );
 
     updateChart(model, "42", { stackedBar: false });
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.xAxes![0].stacked).toBeUndefined();
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.yAxes![0].stacked).toBeUndefined();
+    expect(
+      model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.xAxes![0].stacked
+    ).toBeUndefined();
+    expect(
+      model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.yAxes![0].stacked
+    ).toBeUndefined();
   });
 
   test("Vertical axis position", () => {
+    const sheetId = model.getters.getActiveSheetId();
     createChart(model, defaultChart, "42");
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.yAxes![0].position).toBe("left");
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.yAxes![0].position).toBe(
+      "left"
+    );
 
     updateChart(model, "42", { verticalAxisPosition: "right" });
-    expect(model.getters.getChartRuntime("42")?.options?.scales?.yAxes![0].position).toBe("right");
+    expect(model.getters.getChartRuntime(sheetId, "42")?.options?.scales?.yAxes![0].position).toBe(
+      "right"
+    );
   });
 });
 
@@ -1537,10 +1596,13 @@ describe("Chart evaluation", () => {
       },
       "1"
     );
-    expect(model.getters.getChartRuntime("1")!.data!.datasets![0]!.data![0]).toBeNull();
+    const sheetId = model.getters.getActiveSheetId();
+    expect(model.getters.getChartRuntime(sheetId, "1")!.data!.datasets![0]!.data![0]).toBeNull();
     setCellContent(model, "C3", "1");
-    expect(model.getters.getChartRuntime("1")!.data!.datasets![0]!.data![0]).toBe(1);
+    expect(model.getters.getChartRuntime(sheetId, "1")!.data!.datasets![0]!.data![0]).toBe(1);
     deleteColumns(model, ["C"]);
-    expect(model.getters.getChartRuntime("1")!.data!.datasets![0]!.data![0]).toBe("#ERROR");
+    expect(model.getters.getChartRuntime(sheetId, "1")!.data!.datasets![0]!.data![0]).toBe(
+      "#ERROR"
+    );
   });
 });

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -740,6 +740,43 @@ describe("datasource tests", function () {
     expect(result).toBeCancelledBecause(CommandResult.InvalidDataSet);
   });
 
+  test("cannot duplicate chart ids on the same sheet", () => {
+    const model = new Model();
+    const cmd1 = createChart(
+      model,
+      {
+        dataSets: ["Sheet1!B1:B4"],
+        labelRange: "Sheet1!A2:A4",
+        type: "line",
+      },
+      "1"
+    );
+    expect(cmd1).toBeSuccessfullyDispatched();
+
+    const cmd2 = createChart(
+      model,
+      {
+        dataSets: ["Sheet1!C1:C4"],
+        labelRange: "Sheet1!A2:A4",
+        type: "bar",
+      },
+      "1"
+    );
+    expect(cmd2).toBeCancelledBecause(CommandResult.DuplicatedChartId);
+    createSheet(model, { sheetId: "42" });
+    const cmd3 = createChart(
+      model,
+      {
+        dataSets: ["Sheet1!C1:C4"],
+        labelRange: "Sheet1!A2:A4",
+        type: "bar",
+      },
+      "1",
+      "42"
+    );
+    expect(cmd3).toBeSuccessfullyDispatched();
+  });
+
   test("chart is focused after creation and update", () => {
     const chartId = "1234";
     createChart(

--- a/tests/plugins/chart.test.ts
+++ b/tests/plugins/chart.test.ts
@@ -1,5 +1,6 @@
 import { Model } from "../../src";
 import { chartTerms } from "../../src/components/side_panel/translations_terms";
+import { FIGURE_ID_SPLITTER } from "../../src/constants";
 import { toZone } from "../../src/helpers/zones";
 import { ChartUIDefinition, CommandResult } from "../../src/types";
 import {
@@ -996,6 +997,7 @@ describe("datasource tests", function () {
         dataSets: ["B1:B4", "C1:C4"],
         labelRange: "A2:A4",
       },
+      "myChart",
       firstSheetId
     );
     model.dispatch("DUPLICATE_SHEET", {
@@ -1020,6 +1022,10 @@ describe("datasource tests", function () {
     expect(newModel.getters.getChartsIdBySheet(firstSheetId).length).toEqual(1);
     expect(newModel.getters.getChartsIdBySheet(secondSheetId).length).toEqual(1);
     expect(newModel.getters.getChartsIdBySheet(thirdSheetId).length).toEqual(1);
+
+    expect(figuresSh1[0].id).toEqual("myChart");
+    expect(figuresSh2[0].id).toEqual(secondSheetId + FIGURE_ID_SPLITTER + "myChart");
+    expect(figuresSh3[0].id).toEqual(thirdSheetId + FIGURE_ID_SPLITTER + "myChart");
 
     const chartSh1 = newModel.getters.getChartDefinition(figuresSh1[0].id);
     const chartSh2 = newModel.getters.getChartDefinition(figuresSh2[0].id);

--- a/tests/plugins/figures.test.ts
+++ b/tests/plugins/figures.test.ts
@@ -328,7 +328,7 @@ describe("figure plugin", () => {
     expect(model.getters.getActiveCell()?.evaluated.value).toBeUndefined();
   });
 
-  test("cannot duplicate figure ids", () => {
+  test("cannot duplicate figure ids on the same sheet", () => {
     const model = new Model();
     const figure = {
       id: "someuuid",
@@ -346,9 +346,15 @@ describe("figure plugin", () => {
     createSheet(model, { sheetId: "42" });
 
     const cmd2 = model.dispatch("CREATE_FIGURE", {
-      sheetId: "42",
+      sheetId: model.getters.getActiveSheetId(),
       figure,
     });
     expect(cmd2).toBeCancelledBecause(CommandResult.DuplicatedFigureId);
+
+    const cmd3 = model.dispatch("CREATE_FIGURE", {
+      sheetId: "42",
+      figure,
+    });
+    expect(cmd3).toBeSuccessfullyDispatched();
   });
 });

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -726,7 +726,7 @@ describe("Test XLSX export", () => {
           labelRange: "Sheet1!A2:A4",
           type: "bar",
         },
-        "1"
+        "2"
       );
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });


### PR DESCRIPTION
## [FIX] chart: Prevent destructed charts on duplicated sheet

The fix introduced in commit https://github.com/odoo/o-spreadsheet/commit/bb2d957c2e027dacd160e39f16ecc142c6486412 was incorrect when setting the
value of `ChartPlugin.nextId` when importing the data.
It only counted the occurences of existing charts without testing against
the values of the existing id. This could still lead to duplicates.

E.g.
- Create 2 charts with id "aa" and "bb"
- Duplicate sheet -> creates a figure & chart with ids "1" and "2"
- Delete the charts "aa", "bb" and "1"
- snapshot & reload data

When reloading the data after the import,  `ChartPlugin.nextId` will
ahve a value of "2". This means that duplicating the first sheet would
create another chart with id "2".

This commit replaces the `nextId` strategy and replaces it by prefixing
the ids of the charts of the previous sheet by the id of the new sheet.

e.g.
- create a sheet `myFirstSheet`
- create chart with id `myChartId`
- duplicate the sheet to a sheet with the id `myNewSheet`
the chart id in the new sheet will be `myNewSheet??myChartId`[1]

- duplicate `myNewSheet` to `myThirdSheet`
The chart id in the new sheet will be `myThirdSheet??myChartId`

[1] as the question mark is a forbidden character in the sheet names.

description of this task, what is implemented and why it is implemented that way.


## [FIX] charts: Fix chart duplicated ids

The fix proposed in https://github.com/odoo/o-spreadsheet/commit/bb2d957c2e027dacd160e39f16ecc142c6486412 unfortunately didn't solve the situation
for users that already had duplicated chart ids. The main problem taking
its roots in the duplicated chart id accross different sheets, this
commit changes the chart plugin data structure to match the one of igure
plugin. I.e. a mapping of chart ids per sheet. This solution requires
no data modification and will prevent collisions



## [FIX] figure,chart: Prevent destructive creation

The fix introduced in commit https://github.com/odoo/o-spreadsheet/commit/bb2d957c2e027dacd160e39f16ecc142c6486412 was incorect as The allowDispatch
set on figures is utterly useless as we never dispatch the 'CREATE_FIGURE'
command from outside the plugin, it's always dispatched by `ChartPlugin`ATM.

This commit fixes the allowdispatch method in `FigurePlugin` for the form
but also introduces its equivalent in `ChartPlugin`.


Odoo task ID : [3141532](https://www.odoo.com/web#id=3141532&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo
- [ ] 