### PR TITLE
[IMP] selection input: dynamic highlight followup

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -108,9 +108,9 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     const ranges = existingSelectionRange.length
       ? existingSelectionRange
       : this.props.ranges
-      ? this.props.ranges.map((xc, i) => ({
+      ? this.props.ranges.map((xc, id) => ({
           xc,
-          id: i.toString(),
+          id,
           isFocused: false,
         }))
       : [];
@@ -186,10 +186,11 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     } else if (ev.key === "Enter") {
       const target = ev.target as HTMLInputElement;
       target.blur();
+      this.confirm();
     }
   }
 
-  focus(rangeId: string) {
+  focus(rangeId: number) {
     this.state.isMissing = false;
     this.state.mode = "select-range";
     this.env.model.dispatch("FOCUS_RANGE", {
@@ -202,13 +203,13 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     this.env.model.dispatch("ADD_EMPTY_RANGE", { id: this.id });
   }
 
-  removeInput(rangeId: string) {
+  removeInput(rangeId: number) {
     this.env.model.dispatch("REMOVE_RANGE", { id: this.id, rangeId });
     this.triggerChange();
     this.props.onSelectionConfirmed?.();
   }
 
-  onInputChanged(rangeId: string, ev: InputEvent) {
+  onInputChanged(rangeId: number, ev: InputEvent) {
     const target = ev.target as HTMLInputElement;
     this.env.model.dispatch("CHANGE_RANGE", {
       id: this.id,
@@ -218,7 +219,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     this.triggerChange();
   }
 
-  disable() {
+  confirm() {
     this.env.model.dispatch("UNFOCUS_SELECTION_INPUT");
     const ranges = this.env.model.getters.getSelectionInputValue(this.id);
     if (this.props.required && ranges.length === 0) {

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -36,7 +36,7 @@
         <button class="o-btn-action o-add-selection" t-if="canAddRange" t-on-click="addEmptyInput">
           Add range
         </button>
-        <button class="o-btn-action o-selection-ok" t-if="hasFocus" t-on-click="disable">
+        <button class="o-btn-action o-selection-ok" t-if="hasFocus" t-on-click="confirm">
           Confirm
         </button>
       </div>

--- a/src/plugins/ui_feature/selection_input.ts
+++ b/src/plugins/ui_feature/selection_input.ts
@@ -11,7 +11,7 @@ import { Command, CommandResult, Highlight, LAYERS, UID } from "../../types/inde
 import { UIPlugin, UIPluginConfig } from "../ui_plugin";
 
 export interface RangeInputValue {
-  id: UID;
+  id: number;
   xc: string;
   color: string;
 }
@@ -188,8 +188,8 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
       0,
       ...values.map((xc, i) => ({
         xc,
-        id: (currentMaxId + i + 1).toString(),
-        color: colors[(currentMaxId + 1 + i) % colors.length],
+        id: currentMaxId + i + 1,
+        color: colors[(currentMaxId + i) % colors.length],
       }))
     );
   }
@@ -264,7 +264,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
    * Return the index of a range given its id
    * or `null` if the range is not found.
    */
-  getIndex(rangeId: string | null): number | null {
+  getIndex(rangeId: number | null): number | null {
     const index = this.ranges.findIndex((range) => range.id === rangeId);
     return index >= 0 ? index : null;
   }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -719,7 +719,7 @@ export interface FocusInputCommand {
   /**
    * Range to focus
    */
-  rangeId: string;
+  rangeId: number;
 }
 
 /**
@@ -740,7 +740,7 @@ export interface RemoveRangeCommand {
   /** SelectionComponent id */
   id: string;
   /** The range to be removed */
-  rangeId: string;
+  rangeId: number;
 }
 
 /**
@@ -751,7 +751,7 @@ export interface ChangeRangeCommand {
   /** SelectionComponent id */
   id: string;
   /** The range to be changed */
-  rangeId: string;
+  rangeId: number;
   /**
    * Range to set in the input. Invalid ranges are also accepted.
    * e.g. "B2:B3" or the invalid "A5:"

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -29,7 +29,7 @@ function highlightedZones(model: Model) {
     .map(zoneToXc);
 }
 
-function idOfRange(model: Model, id: string, rangeIndex: number): string {
+function idOfRange(model: Model, id: string, rangeIndex: number): number {
   return model.getters.getSelectionInput(id)[rangeIndex].id;
 }
 
@@ -663,5 +663,16 @@ describe("selection input plugin", () => {
     const [newFirstColor, newSecondColor] = model.getters.getSelectionInput(id).map((i) => i.color);
     expect(initialFirstColor).toBe(newFirstColor);
     expect(initalSecondColor).toBe(newSecondColor);
+  });
+
+  test("no duplicate range ids when creating and deleting ranges frequently", () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, initialRanges: ["B1:B5", "C1:C5"] });
+    model.dispatch("ADD_EMPTY_RANGE", { id }); // id: 3
+    model.dispatch("ADD_EMPTY_RANGE", { id }); // id: 4
+    model.dispatch("REMOVE_RANGE", { id, rangeId: idOfRange(model, id, 2) });
+    model.dispatch("ADD_EMPTY_RANGE", { id }); // id: 5
+    const selectionInput = model.getters.getSelectionInput(id);
+    expect(selectionInput.length).toEqual(4);
+    expect(selectionInput.map((input) => input.id)).toStrictEqual([1, 2, 4, 5]);
   });
 });


### PR DESCRIPTION
## Description:

This commit contains several follow-up work for the dynamic highlight task ([2884221](https://www.odoo.com/web#id=2884221&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)):
- Change range id type from UID to number
- Make hitting enter key act the same as clicking confirm button
- Change confirm button clicking cuntion name from `disable` to `confirm`
- Range id will start from 0 rather than 1
- Add tests for detecting duplicate range ids and hitting enter key

Odoo task ID : [3203266](https://www.odoo.com/web#id=3203266&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo