### PR TITLE
[IMP] evaluation: allow to by pass lazy evaluation for specific funct…

### DIFF
--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -186,6 +186,9 @@ export class EvaluationPlugin extends UIPlugin {
           return handleError(error);
         }
       });
+      if (cell.compiledFormula.byPassLazyEvaluation) {
+        computedCell();
+      }
       cell.assignEvaluation(computedCell);
     }
   }

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -36,6 +36,7 @@ export interface AddFunctionDescription {
   args: ArgDefinition[];
   returns: [ArgType];
   isExported?: boolean;
+  byPassLazyEvaluation?: boolean;
 }
 
 export interface FunctionDescription extends AddFunctionDescription {

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -160,6 +160,7 @@ export interface CompiledFormula {
   execute: _CompiledFormula;
   tokens: Token[];
   dependencies: string[];
+  byPassLazyEvaluation: boolean;
 }
 
 export type Arg = MatrixArg | PrimitiveArg;

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -289,6 +289,40 @@ describe("evaluateCells", () => {
     functionRegistry.remove("RANGE.COUNT.FUNCTION");
   });
 
+  test("Formula with a function non-lazy is evaluated non-lazily", () => {
+    let evaluated = false;
+    functionRegistry.add("FUNCTION.WITHOUT.LAZY", {
+      description: "any function",
+      compute: () => {
+        evaluated = true;
+        return 42;
+      },
+      args: [],
+      returns: ["NUMBER"],
+      byPassLazyEvaluation: true,
+    });
+    const model = new Model();
+    setCellContent(model, "A1", "=FUNCTION.WITHOUT.LAZY()");
+    expect(evaluated).toBe(true);
+  });
+
+  test("Formula with a function non-lazy as argument is evaluated non-lazily", () => {
+    let evaluated = false;
+    functionRegistry.add("FUNCTION.WITHOUT.LAZY", {
+      description: "any function",
+      compute: () => {
+        evaluated = true;
+        return 42;
+      },
+      args: [],
+      returns: ["NUMBER"],
+      byPassLazyEvaluation: true,
+    });
+    const model = new Model();
+    setCellContent(model, "A1", "=SUM(1, FUNCTION.WITHOUT.LAZY())");
+    expect(evaluated).toBe(true);
+  });
+
   test("range totally outside of sheet", () => {
     const model = new Model();
     setCellContent(model, "A1", "=sum(AB1:AZ999)");


### PR DESCRIPTION
…ions

In Odoo, we have specific functions that should not be lazy evaluated, such as `ODOO.LIST` or `ODOO.LIST.HEADER`. As for a list, we do not know the number of rows, we use the evaluation to collect the maximum position of a record, and after the collection, we do only one RPC call to fetch all the records in one time. With the lazy evaluation, we would have to do one RPC call each time a list cell is shown in the viewport.

This revision allows to by pass the lazy evaluation for specific functions, by adding a `byPassLazyEvaluation` property to the function description.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo