### PR TITLE
[IMP] top_bar: added placeholder to topbar composer

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -86,6 +86,13 @@ css/* scss */ `
       }
     }
 
+    .o-composer:empty:not(:focus)::before {
+      content: attr(placeholder);
+      color: lightgrey;
+      font-style: italic;
+      margin-left: 5px;
+    }
+
     .o-composer-assistant {
       position: absolute;
       margin: 1px 4px;
@@ -106,6 +113,7 @@ export interface ComposerProps {
   rect?: Rect;
   delimitation?: DOMDimension;
   onComposerUnmounted?: () => void;
+  placeholder?: string;
 }
 
 interface ComposerState {
@@ -692,4 +700,5 @@ Composer.props = {
   rect: { type: Object, optional: true },
   delimitation: { type: Object, optional: true },
   onComposerUnmounted: { type: Function, optional: true },
+  placeholder: { type: String, optional: true },
 };

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -19,6 +19,7 @@
         t-on-paste.stop=""
         t-on-compositionstart="onCompositionStart"
         t-on-compositionend="onCompositionEnd"
+        t-att-placeholder="props.placeholder"
       />
 
       <div

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -5,6 +5,7 @@
         focus="props.focus"
         inputStyle="composerStyle"
         onComposerContentFocused="props.onComposerContentFocused"
+        placeholder="'fx'"
       />
     </div>
   </t>

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -505,6 +505,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           <div
             class="o-composer w-100 text-start"
             contenteditable="true"
+            placeholder="fx"
             spellcheck="false"
             style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
             tabindex="1"

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -618,6 +618,7 @@ exports[`TopBar component can set cell format 1`] = `
             <div
               class="o-composer w-100 text-start"
               contenteditable="true"
+              placeholder="fx"
               spellcheck="false"
               style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
               tabindex="1"
@@ -1132,6 +1133,7 @@ exports[`TopBar component simple rendering 1`] = `
         <div
           class="o-composer w-100 text-start"
           contenteditable="true"
+          placeholder="fx"
           spellcheck="false"
           style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
           tabindex="1"

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -864,4 +864,13 @@ describe("Topbar - menu item resizing with viewport", () => {
       model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
     );
   });
+
+  test("Rendering have by default placeholder in composer", async () => {
+    const model = new Model();
+    await mountParent(model);
+    const topbarComposerElement = fixture.querySelector(
+      ".o-spreadsheet-topbar .o-composer-container div"
+    )!;
+    expect(topbarComposerElement.getAttribute("placeholder")).toBe("fx");
+  });
 });


### PR DESCRIPTION
## Description:

This PR implements the feature of adding a placeholder to the top bar composer.  It disappears automatically when the user clicks inside the composer.

Odoo task ID : [3175327](https://www.odoo.com/web#id=3175327&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo