### PR TITLE
[FIX] Top_bar: composer helper menu close

### DIFF
--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -379,6 +379,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
     this.state.menuState.parentMenu = menu;
     this.isSelectingMenu = true;
     this.openedEl = ev.target as HTMLElement;
+    this.env.model.dispatch("STOP_EDITION");
   }
 
   closeMenus() {

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -339,6 +339,15 @@ describe("Composer interactions", () => {
     fixture.remove();
     app.destroy();
   });
+
+  test("The composer helper should be closed on toggle topbar context menu", async () => {
+    await typeInComposerGrid("=sum(");
+    expect(parent.model.getters.getEditionMode()).not.toBe("inactive");
+    expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(1);
+    await simulateClick(".o-topbar-topleft .o-topbar-menu");
+    expect(parent.model.getters.getEditionMode()).toBe("inactive");
+    expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(0);
+  });
 });
 
 describe("Composer / selectionInput interactions", () => {

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -832,3 +832,13 @@ describe("Topbar - menu item resizing with viewport", () => {
     app.destroy();
   });
 });
+
+test("The composer helper should be closed on toggle topbar context menu", async () => {
+  const { parent } = await mountSpreadsheet(fixture);
+  await typeInComposerTopBar("=sum(");
+  expect(parent.model.getters.getEditionMode()).not.toBe("inactive");
+  expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(1);
+  await simulateClick(".o-topbar-topleft .o-topbar-menu");
+  expect(parent.model.getters.getEditionMode()).toBe("inactive");
+  expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(0);
+});


### PR DESCRIPTION
## Description:

Fixed composer helper menu not being closed on clicking topbar menu, resulting to refocus the composer.

Odoo task ID : [3076218](https://www.odoo.com/web#id=3076218&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo