### PR TITLE
[FIX] chart: Remove forwardport comments

### DIFF
--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -97,7 +97,6 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
       ...(this.getChartDefinition() as T),
       ...updateDefinition,
     };
-    // TODORAR add a putain de test - c'est faux de nouveau ...
     return this.env.model.dispatch("UPDATE_CHART", {
       definition,
       id: this.figureId,
@@ -111,7 +110,6 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
       throw new Error("Chart not defined.");
     }
     const definition = getChartDefinitionFromContextCreation(context, type);
-    // TODORAR add a putain de test - c'est faux de nouveau ...
     this.env.model.dispatch("UPDATE_CHART", {
       definition,
       id: this.figureId,

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -139,9 +139,6 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
   }
 
   getChartIds(sheetId: UID) {
-    // TODORAR refaire ce shit truc
-    // on veut un  truc du genre Object.keys(this.charts[sheetId] || {} a mon avis
-    // return (Object.values(this.charts[sheetId] || {}).filter(isDefined) as AbstractChart[]).map((chart) => chart.id);
     return Object.keys(this.charts[sheetId] || {});
   }
 

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -10,6 +10,7 @@ import {
   createChart,
   createGaugeChart,
   createScorecardChart,
+  createSheet,
   paste,
   setStyle,
   updateChart,
@@ -543,6 +544,34 @@ describe("figures", () => {
     ]);
     expect(mockChartData.type).toBe("pie");
     expect((mockChartData.options!.title as any).text).toBe("hello");
+  });
+
+  test("updating a chart from another sheet does not change it s sheetId", async () => {
+    createTestChart("basicChart");
+    await nextTick();
+
+    expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
+    await simulateClick(".o-figure");
+    await simulateClick(".o-chart-menu-item");
+    await simulateClick(".o-menu div[data-name='edit']");
+
+    createSheet(model, { sheetId: "42", activate: true });
+    await nextTick();
+    const chartType = fixture.querySelectorAll(".o-input")[0] as HTMLSelectElement;
+    setInputValueAndTrigger(chartType, "pie", "change");
+    await nextTick();
+
+    expect(model.getters.getChart(sheetId, chartId)?.sheetId).toBe(sheetId);
+
+    const dataSeries = fixture.querySelectorAll(
+      ".o-sidePanel .o-sidePanelBody .o-chart .o-data-series"
+    )[0] as HTMLInputElement;
+    const dataSeriesValues = dataSeries.querySelector("input");
+    const hasTitle = dataSeries.querySelector("input[type=checkbox]") as HTMLInputElement;
+    setInputValueAndTrigger(dataSeriesValues, "B2:B5", "change");
+    triggerMouseEvent(hasTitle, "click");
+    await nextTick();
+    expect(model.getters.getChart(sheetId, chartId)?.sheetId).toBe(sheetId);
   });
 
   test.each(["basicChart", "scorecard", "gauge"])(


### PR DESCRIPTION
In a haste to close a tiresome forward port, I forgot to address some of the `TODO` comments I left myself...

Task: 3210689

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3210689](https://www.odoo.com/web#id=3210689&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo