### PR TITLE
[FIX] config: Fix the action version extractor

### DIFF
--- a/tools/parse_message.js
+++ b/tools/parse_message.js
@@ -1,29 +1,31 @@
-
 /**
  * This script is used to parse the a commit message and extract the release version as well as the changelog
- * in the form of the commit body. It is therefore the responsability of the developer that creates the release
+ * in the form of the commit body. It is therefore the responsibility of the developer that creates the release
  * commit to properly document the changes in the commit message.
- * 
+ *
  * The commit message should follow the following format:
  * - the first line should contain the version number in the form of (saas-)<major>.<minor>.<patch>
  * - each subsequent line should contain a tag in the form of [TAG]
- * 
+ *
  * Note that every line that does not match the above format will be ignored.
- * 
- * 
- * The script is used in the release workflow andd as such, relies on the GitHub API to retrieve the commit message.
+ *
+ *
+ * The script is used in the release workflow and as such, relies on the GitHub API to retrieve the commit message.
  * It uses @action/core and @action/github in order to access to the workflow commands
  * and octokit REST client to interact with the GitHub API.
- * 
+ *
  * See https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action
  *     https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action#adding-actions-toolkit-packages
- * 
+ *
  * This script and the parent workflow can be tested locally by using the test environment provided here:
  * https://github.com/nektos/act
-*/
+ */
 
 const core = require("@actions/core");
 const github = require("@actions/github");
+const path = require("path");
+
+const package = require(path.join(__dirname, "../package.json"));
 
 function trim(array) {
   while (["", "\n"].includes(array[0])) {
@@ -33,24 +35,23 @@ function trim(array) {
     array.pop();
   }
 }
-
 const COMMIT_REGEX = /\[[A-Z]{3}\]/;
-const RELEASE_REGEX = /(?:saas-)?\d+\.\d+\.\d+/;
 
 /** wrap in try catch for early exit */
 try {
   /** @type {String} */
   const commit_message = github.context.payload.head_commit.message;
   let lines = commit_message.split("\n");
+  //pop title
   const title = lines.shift();
-
-  let version = title.match(RELEASE_REGEX);
-  // throw if no version
-  version = version[0];
 
   // purge non commit lines
   const commitLines = lines.filter((line) => !!line.match(COMMIT_REGEX));
   trim(commitLines);
+
+  // find version
+  const version = package.version;
+  
   console.log(
     JSON.stringify({
       title,


### PR DESCRIPTION
the tool 'parse_message' was using an incorrect regex to capture the version of the release. It specifically pose problem with the master release for which the `alpha` tag was not considered, implying that 2 consecutive master release would have the same tag, which crashes and ultimately prevent further steps of the github action, like the publication on NPM.

We can rather rely on the information of the package.json file since it's properly updated.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo