### PR TITLE
[IMP] history: add the possibility to repeat commands at redo

### DIFF
--- a/src/collaborative/revisions.ts
+++ b/src/collaborative/revisions.ts
@@ -1,4 +1,4 @@
-import { ClientId, CoreCommand, HistoryChange, RevisionData, UID } from "../types";
+import { ClientId, Command, CoreCommand, HistoryChange, RevisionData, UID } from "../types";
 
 export class Revision implements RevisionData {
   public readonly id: UID;
@@ -19,6 +19,7 @@ export class Revision implements RevisionData {
     id: UID,
     clientId: ClientId,
     commands: readonly CoreCommand[],
+    readonly rootCommand?: Command | "SNAPSHOT" | "REMOTE" | undefined,
     changes?: readonly HistoryChange[]
   ) {
     this.id = id;

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -204,6 +204,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     "CTRL+A": () => this.env.model.selection.loopSelection(),
     "CTRL+Z": () => this.env.model.dispatch("REQUEST_UNDO"),
     "CTRL+Y": () => this.env.model.dispatch("REQUEST_REDO"),
+    F4: () => this.env.model.dispatch("REQUEST_REDO"),
     "CTRL+B": () =>
       this.env.model.dispatch("SET_FORMATTING", {
         sheetId: this.env.model.getters.getActiveSheetId(),

--- a/src/history/factory.ts
+++ b/src/history/factory.ts
@@ -23,20 +23,22 @@ export function buildRevisionLog(
       revision.setChanges(changes);
     },
     (revision: Revision) => revertChanges([revision]),
-    (id: UID) => new Revision(id, "empty", [], []),
+    (id: UID) => new Revision(id, "empty", []),
     {
       with: (revision: Revision) => (toTransform: Revision) => {
         return new Revision(
           toTransform.id,
           toTransform.clientId,
-          transformAll(toTransform.commands, revision.commands)
+          transformAll(toTransform.commands, revision.commands),
+          toTransform.rootCommand
         );
       },
       without: (revision: Revision) => (toTransform: Revision) => {
         return new Revision(
           toTransform.id,
           toTransform.clientId,
-          transformAll(toTransform.commands, revision.commands.map(inverseCommand).flat())
+          transformAll(toTransform.commands, revision.commands.map(inverseCommand).flat()),
+          toTransform.rootCommand
         );
       },
     }

--- a/src/history/repeat_commands/repeat_commands_generic.ts
+++ b/src/history/repeat_commands/repeat_commands_generic.ts
@@ -1,0 +1,30 @@
+import { deepCopy } from "../../helpers";
+import { Command, Getters } from "../../types";
+
+export const genericRepeatsTransforms = [
+  repeatSheetDependantCommand,
+  repeatTargetDependantCommand,
+  repeatPositionDependantCommand,
+];
+
+export function repeatSheetDependantCommand<T extends Command>(getters: Getters, command: T): T {
+  if (!("sheetId" in command)) return command;
+
+  return { ...deepCopy(command), sheetId: getters.getActiveSheetId() };
+}
+
+export function repeatTargetDependantCommand<T extends Command>(getters: Getters, command: T): T {
+  if (!("target" in command) || !Array.isArray(command.target)) return command;
+
+  return {
+    ...deepCopy(command),
+    target: getters.getSelectedZones(),
+  };
+}
+
+export function repeatPositionDependantCommand<T extends Command>(getters: Getters, command: T): T {
+  if (!("row" in command) || !("col" in command)) return command;
+
+  const { col, row } = getters.getActivePosition();
+  return { ...deepCopy(command), col, row };
+}

--- a/src/history/repeat_commands/repeat_commands_specific.ts
+++ b/src/history/repeat_commands/repeat_commands_specific.ts
@@ -1,0 +1,147 @@
+import { deepCopy, range, UuidGenerator } from "../../helpers";
+import { Getters } from "../../types";
+import {
+  AddColumnsRowsCommand,
+  AutoresizeColumnsCommand,
+  AutoresizeRowsCommand,
+  CreateChartCommand,
+  CreateFigureCommand,
+  CreateImageOverCommand,
+  CreateSheetCommand,
+  DeleteCellCommand,
+  HideColumnsRowsCommand,
+  InsertCellCommand,
+  PasteCommand,
+  RemoveColumnsRowsCommand,
+  RepeatPasteCommand,
+  ResizeColumnsRowsCommand,
+  SortCommand,
+} from "./../../types/commands";
+import { repeatSheetDependantCommand } from "./repeat_commands_generic";
+
+const uuidGenerator = new UuidGenerator();
+
+export function repeatCreateChartCommand(
+  getters: Getters,
+  cmd: CreateChartCommand
+): CreateChartCommand {
+  return {
+    ...repeatSheetDependantCommand(getters, cmd),
+    id: uuidGenerator.uuidv4(),
+  };
+}
+
+export function repeatCreateImageCommand(
+  getters: Getters,
+  cmd: CreateImageOverCommand
+): CreateImageOverCommand {
+  return {
+    ...repeatSheetDependantCommand(getters, cmd),
+    figureId: uuidGenerator.uuidv4(),
+  };
+}
+
+export function repeatCreateFigureCommand(
+  getters: Getters,
+  cmd: CreateFigureCommand
+): CreateFigureCommand {
+  const newCmd = repeatSheetDependantCommand(getters, cmd);
+  newCmd.figure.id = uuidGenerator.uuidv4();
+  return newCmd;
+}
+
+export function repeatCreateSheetCommand(
+  getters: Getters,
+  cmd: CreateSheetCommand
+): CreateSheetCommand {
+  const newCmd = deepCopy(cmd);
+  newCmd.sheetId = uuidGenerator.uuidv4();
+
+  const sheetName = cmd.name || getters.getSheet(getters.getActiveSheetId()).name;
+  // Extract the prefix of the sheet name (everything before the number at the end of the name)
+  const namePrefix = sheetName.match(/(.+?)\d*$/)?.[1] || sheetName;
+
+  newCmd.name = getters.getNextSheetName(namePrefix);
+
+  return newCmd;
+}
+
+export function repeatAddColumnsRowsCommand(
+  getters: Getters,
+  cmd: AddColumnsRowsCommand
+): AddColumnsRowsCommand {
+  const currentPosition = getters.getActivePosition();
+  return {
+    ...repeatSheetDependantCommand(getters, cmd),
+    base: cmd.dimension === "COL" ? currentPosition.col : currentPosition.row,
+  };
+}
+
+export function repeatHeaderElementCommand<
+  T extends RemoveColumnsRowsCommand | HideColumnsRowsCommand | ResizeColumnsRowsCommand
+>(getters: Getters, cmd: T): T {
+  const currentSelection = getters.getSelectedZone();
+  return {
+    ...repeatSheetDependantCommand(getters, cmd),
+    elements:
+      cmd.dimension === "COL"
+        ? range(currentSelection.left, currentSelection.right + 1)
+        : range(currentSelection.top, currentSelection.bottom + 1),
+  };
+}
+
+export function repeatInsertOrDeleteCellCommand<T extends InsertCellCommand | DeleteCellCommand>(
+  getters: Getters,
+  cmd: T
+): T {
+  const currentSelection = getters.getSelectedZone();
+  return {
+    ...deepCopy(cmd),
+    zone: currentSelection,
+  };
+}
+
+export function repeatAutoResizeCommand<T extends AutoresizeColumnsCommand | AutoresizeRowsCommand>(
+  getters: Getters,
+  cmd: T
+): T {
+  const newCmd = deepCopy(cmd);
+  const currentSelection = getters.getSelectedZone();
+  const { top, bottom, left, right } = currentSelection;
+  if ("cols" in newCmd) {
+    newCmd.cols = range(left, right + 1);
+  } else if ("rows" in newCmd) {
+    newCmd.rows = range(top, bottom + 1);
+  }
+  return newCmd;
+}
+
+export function repeatSortCellsCommand(getters: Getters, cmd: SortCommand): SortCommand {
+  const currentSelection = getters.getSelectedZone();
+
+  return {
+    ...repeatSheetDependantCommand(getters, cmd),
+    col: currentSelection.left,
+    row: currentSelection.top,
+    zone: currentSelection,
+  };
+}
+
+export function repeatPasteCommand(getters: Getters, cmd: PasteCommand): RepeatPasteCommand {
+  /**
+   * Note : we have to store the state of the clipboard in the clipboard plugin, and introduce a
+   * new command REPEAT_PASTE to be able to repeat the paste command.
+   *
+   * We cannot re-dispatch a paste, because the content of the clipboard may have changed in between.
+   *
+   * And we cannot adapt the sub-commands of the paste command, because they are dependant on the state of the sheet,
+   * and may change based on the paste location. A simple example is that paste create new col/rows for the clipboard
+   * content to fit the sheet. So there will be ADD_COL_ROW_COMMANDS in the sub-commands in the history, but repeating
+   * paste might not need them. Or they could only needed for the repeated paste, not for the original.
+   */
+  return {
+    type: "REPEAT_PASTE",
+    pasteOption: deepCopy(cmd.pasteOption),
+    target: getters.getSelectedZones(),
+  };
+}

--- a/src/history/repeat_commands/repeat_revision.ts
+++ b/src/history/repeat_commands/repeat_revision.ts
@@ -1,0 +1,36 @@
+import { Revision } from "../../collaborative/revisions";
+import {
+  repeatCommandTransformRegistry,
+  repeatCoreCommand,
+  repeatLocalCommand,
+  repeatLocalCommandTransformRegistry,
+} from "../../registries/repeat_commands_registry";
+import { CoreCommand, Getters } from "../../types";
+import { Command, isCoreCommand } from "../../types/commands";
+
+export function canRepeatRevision(revision: Revision | undefined): boolean {
+  if (!revision || !revision.rootCommand || typeof revision.rootCommand !== "object") {
+    return false;
+  }
+
+  if (isCoreCommand(revision.rootCommand)) {
+    return repeatCommandTransformRegistry.contains(revision.rootCommand.type);
+  }
+
+  return repeatLocalCommandTransformRegistry.contains(revision.rootCommand.type);
+}
+
+export function repeatRevision(
+  revision: Revision,
+  getters: Getters
+): CoreCommand[] | Command | undefined {
+  if (!revision.rootCommand || typeof revision.rootCommand !== "object") {
+    return undefined;
+  }
+
+  if (isCoreCommand(revision.rootCommand)) {
+    return repeatCoreCommand(getters, revision.rootCommand);
+  }
+
+  return repeatLocalCommand(getters, revision.rootCommand, revision.commands);
+}

--- a/src/history/selective_history.ts
+++ b/src/history/selective_history.ts
@@ -103,6 +103,15 @@ export class SelectiveHistory<T = unknown> {
     this.tree.drop(operationId);
   }
 
+  getRevertedExecution(): T[] {
+    const data: T[] = [];
+    const operations = this.tree.revertedExecution(this.HEAD_BRANCH);
+    for (const { operation } of operations) {
+      data.push(operation.data);
+    }
+    return data;
+  }
+
   /**
    * Revert the state as it was *before* the given operation was executed.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,11 @@ import {
   topbarComponentRegistry,
   topbarMenuRegistry,
 } from "./registries/index";
+import {
+  genericRepeat,
+  repeatCommandTransformRegistry,
+  repeatLocalCommandTransformRegistry,
+} from "./registries/repeat_commands_registry";
 import { FunctionDescription } from "./types";
 import { CellErrorLevel, EvaluationError } from "./types/errors";
 
@@ -159,6 +164,8 @@ export const registries = {
   urlRegistry,
   cellPopoverRegistry,
   numberFormatMenuRegistry,
+  repeatLocalCommandTransformRegistry,
+  repeatCommandTransformRegistry,
 };
 export const helpers = {
   arg,
@@ -187,6 +194,7 @@ export const helpers = {
   positionToZone,
   isDefined,
   lazy,
+  genericRepeat,
 };
 
 export const links = {

--- a/src/model.ts
+++ b/src/model.ts
@@ -28,6 +28,7 @@ import {
 import { StateObserver } from "./state_observer";
 import { _lt } from "./translation";
 import { StateUpdateMessage, TransportService } from "./types/collaborative/transport_service";
+import { CommandTypes } from "./types/commands";
 import { FileStore } from "./types/files";
 import {
   canExecuteInReadonly,
@@ -471,7 +472,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
    *    component)
    * 2. This allows us to define its type by using the interface CommandDispatcher
    */
-  dispatch: CommandDispatcher["dispatch"] = (type: string, payload?: any) => {
+  dispatch: CommandDispatcher["dispatch"] = (type: CommandTypes, payload?: any) => {
     const command: Command = { ...payload, type };
     let status: Status = this.status;
     if (this.getters.isReadonly() && !canExecuteInReadonly(command)) {
@@ -494,7 +495,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
           this.dispatchToHandlers(this.handlers, command);
           this.finalize();
         });
-        this.session.save(commands, changes);
+        this.session.save(command, commands, changes);
         this.status = Status.Ready;
         this.trigger("update");
         break;

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -36,6 +36,7 @@ import {
   SortPlugin,
   UIOptionsPlugin,
 } from "./ui_feature";
+import { HistoryPlugin } from "./ui_feature/local_history";
 import { UIPluginConstructor } from "./ui_plugin";
 import { ClipboardPlugin, EditionPlugin, GridSelectionPlugin } from "./ui_stateful";
 
@@ -66,7 +67,8 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("automatic_sum", AutomaticSumPlugin)
   .add("format", FormatPlugin)
   .add("cell_popovers", CellPopoverPlugin)
-  .add("selection_multiuser", SelectionMultiUserPlugin);
+  .add("selection_multiuser", SelectionMultiUserPlugin)
+  .add("history", HistoryPlugin);
 
 // Plugins which have a state, but which should not be shared in collaborative
 export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -1,3 +1,4 @@
+import { Session } from "../collaborative/session";
 import { ModelConfig } from "../model";
 import { SelectionStreamProcessor } from "../selection_stream/selection_stream_processor";
 import { StateObserver } from "../state_observer";
@@ -22,6 +23,7 @@ export interface UIPluginConfig {
   readonly uiActions: UIActions;
   readonly custom: ModelConfig["custom"];
   readonly lazyEvaluation: boolean;
+  readonly session: Session;
 }
 
 export interface UIPluginConstructor {

--- a/src/registries/repeat_commands_registry.ts
+++ b/src/registries/repeat_commands_registry.ts
@@ -1,0 +1,124 @@
+import { deepCopy, isDefined } from "../helpers";
+import { genericRepeatsTransforms } from "../history/repeat_commands/repeat_commands_generic";
+import {
+  repeatAddColumnsRowsCommand,
+  repeatAutoResizeCommand,
+  repeatCreateChartCommand,
+  repeatCreateFigureCommand,
+  repeatCreateImageCommand,
+  repeatCreateSheetCommand,
+  repeatHeaderElementCommand,
+  repeatInsertOrDeleteCellCommand,
+  repeatPasteCommand,
+  repeatSortCellsCommand,
+} from "../history/repeat_commands/repeat_commands_specific";
+import { CoreCommand, Getters } from "../types";
+import { Command, LocalCommand } from "./../types/commands";
+import { Registry } from "./registry";
+
+type RepeatTransform = (getters: Getters, cmd: CoreCommand) => CoreCommand | undefined;
+
+type LocalRepeatTransform = (
+  getters: Getters,
+  cmd: LocalCommand,
+  childCommands: readonly CoreCommand[]
+) => CoreCommand[] | LocalCommand | undefined;
+
+/**
+ *  Registry containing all the command that can be repeated on redo, and function to transform them
+ *  to the current state of the model.
+ *
+ * If the transform function is undefined, the command will be transformed using generic transformations.
+ * (change the sheetId, the row, the col, the target, the ranges, to the current active sheet & selection)
+ *
+ */
+export const repeatCommandTransformRegistry = new Registry<RepeatTransform>();
+
+repeatCommandTransformRegistry.add("UPDATE_CELL", genericRepeat);
+repeatCommandTransformRegistry.add("CLEAR_CELL", genericRepeat);
+repeatCommandTransformRegistry.add("DELETE_CONTENT", genericRepeat);
+
+repeatCommandTransformRegistry.add("ADD_MERGE", genericRepeat);
+repeatCommandTransformRegistry.add("REMOVE_MERGE", genericRepeat);
+
+repeatCommandTransformRegistry.add("SET_FORMATTING", genericRepeat);
+repeatCommandTransformRegistry.add("CLEAR_FORMATTING", genericRepeat);
+repeatCommandTransformRegistry.add("SET_BORDER", genericRepeat);
+
+repeatCommandTransformRegistry.add("CREATE_FILTER_TABLE", genericRepeat);
+repeatCommandTransformRegistry.add("REMOVE_FILTER_TABLE", genericRepeat);
+
+repeatCommandTransformRegistry.add("HIDE_SHEET", genericRepeat);
+
+repeatCommandTransformRegistry.add("ADD_COLUMNS_ROWS", repeatAddColumnsRowsCommand);
+repeatCommandTransformRegistry.add("REMOVE_COLUMNS_ROWS", repeatHeaderElementCommand);
+repeatCommandTransformRegistry.add("HIDE_COLUMNS_ROWS", repeatHeaderElementCommand);
+repeatCommandTransformRegistry.add("RESIZE_COLUMNS_ROWS", repeatHeaderElementCommand);
+
+repeatCommandTransformRegistry.add("CREATE_SHEET", repeatCreateSheetCommand);
+
+repeatCommandTransformRegistry.add("CREATE_FIGURE", repeatCreateFigureCommand);
+repeatCommandTransformRegistry.add("CREATE_CHART", repeatCreateChartCommand);
+repeatCommandTransformRegistry.add("CREATE_IMAGE", repeatCreateImageCommand);
+
+export const repeatLocalCommandTransformRegistry = new Registry<LocalRepeatTransform>();
+repeatLocalCommandTransformRegistry.add("STOP_EDITION", repeatLocalCommandChildren);
+repeatLocalCommandTransformRegistry.add("PASTE", repeatPasteCommand);
+repeatLocalCommandTransformRegistry.add("INSERT_CELL", repeatInsertOrDeleteCellCommand);
+repeatLocalCommandTransformRegistry.add("DELETE_CELL", repeatInsertOrDeleteCellCommand);
+repeatLocalCommandTransformRegistry.add("AUTORESIZE_COLUMNS", repeatAutoResizeCommand);
+repeatLocalCommandTransformRegistry.add("AUTORESIZE_ROWS", repeatAutoResizeCommand);
+repeatLocalCommandTransformRegistry.add("SORT_CELLS", repeatSortCellsCommand);
+repeatLocalCommandTransformRegistry.add("SUM_SELECTION", genericRepeat);
+repeatLocalCommandTransformRegistry.add("SET_DECIMAL", genericRepeat);
+
+export function genericRepeat<T extends Command>(getters: Getters, command: T): T {
+  let transformedCommand = deepCopy(command);
+
+  for (const repeatTransform of genericRepeatsTransforms) {
+    transformedCommand = repeatTransform(getters, transformedCommand);
+  }
+
+  return transformedCommand;
+}
+
+export function repeatCoreCommand(
+  getters: Getters,
+  command: CoreCommand | undefined
+): CoreCommand | undefined {
+  if (!command) {
+    return undefined;
+  }
+
+  const isRepeatable = repeatCommandTransformRegistry.contains(command.type);
+  if (!isRepeatable) {
+    return undefined;
+  }
+
+  const transform = repeatCommandTransformRegistry.get(command.type);
+  return transform(getters, command);
+}
+
+export function repeatLocalCommand(
+  getters: Getters,
+  command: LocalCommand,
+  childCommands: readonly CoreCommand[]
+): CoreCommand[] | LocalCommand | undefined {
+  const isRepeatable = repeatLocalCommandTransformRegistry.contains(command.type);
+  if (!isRepeatable) {
+    return undefined;
+  }
+
+  const repeatTransform = repeatLocalCommandTransformRegistry.get(command.type);
+  return repeatTransform(getters, command, childCommands);
+}
+
+export function repeatLocalCommandChildren<T extends LocalCommand>(
+  getters: Getters,
+  cmd: T,
+  childCommands: readonly CoreCommand[]
+): CoreCommand[] | undefined {
+  return childCommands
+    .map((childCommand) => repeatCoreCommand(getters, childCommand))
+    .filter(isDefined);
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -502,6 +502,12 @@ export interface PasteCommand {
   pasteOption?: ClipboardPasteOptions;
 }
 
+export interface RepeatPasteCommand {
+  type: "REPEAT_PASTE";
+  target: Zone[];
+  pasteOption?: ClipboardPasteOptions;
+}
+
 export interface CleanClipBoardHighlightCommand {
   type: "CLEAN_CLIPBOARD_HIGHLIGHT";
 }
@@ -634,11 +640,8 @@ export interface DeleteContentCommand {
   target: Zone[];
 }
 
-export interface ClearCellCommand {
+export interface ClearCellCommand extends PositionDependentCommand {
   type: "CLEAR_CELL";
-  sheetId: UID;
-  col: HeaderIndex;
-  row: HeaderIndex;
 }
 
 export interface UndoCommand {
@@ -964,6 +967,7 @@ export type LocalCommand =
   | CopyCommand
   | CutCommand
   | PasteCommand
+  | RepeatPasteCommand
   | CleanClipBoardHighlightCommand
   | AutoFillCellCommand
   | PasteFromOSClipboardCommand

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -1,5 +1,4 @@
 import { Session } from "../collaborative/session";
-import { LocalHistory } from "../history/local_history";
 import { BordersPlugin } from "../plugins/core/borders";
 import { CellPlugin } from "../plugins/core/cell";
 import { ChartPlugin } from "../plugins/core/chart";
@@ -24,6 +23,7 @@ import { CellPopoverPlugin } from "../plugins/ui_feature/cell_popovers";
 import { FindAndReplacePlugin } from "../plugins/ui_feature/find_and_replace";
 import { HeaderVisibilityUIPlugin } from "../plugins/ui_feature/header_visibility_ui";
 import { HighlightPlugin } from "../plugins/ui_feature/highlight";
+import { HistoryPlugin } from "../plugins/ui_feature/local_history";
 import { RendererPlugin } from "../plugins/ui_feature/renderer";
 import { SelectionInputsManagerPlugin } from "../plugins/ui_feature/selection_inputs_manager";
 import { SelectionMultiUserPlugin } from "../plugins/ui_feature/selection_multiuser";
@@ -84,10 +84,7 @@ type ConditionalFormatGetters = Pick<
   ConditionalFormatPlugin,
   GetterNames<typeof ConditionalFormatPlugin>
 >;
-type LocalHistoryGetters = {
-  canUndo: LocalHistory["canUndo"];
-  canRedo: LocalHistory["canRedo"];
-};
+type LocalHistoryGetters = Pick<HistoryPlugin, GetterNames<typeof HistoryPlugin>>;
 type FiltersGetters = Pick<FiltersPlugin, GetterNames<typeof FiltersPlugin>>;
 
 export type CoreGetters = SheetGetters &

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -314,7 +314,10 @@ describe("Grid component", () => {
       expect(getSelectionAnchorCellXc(model)).toBe("A1");
     });
 
-    test("can undo/redo with keyboard", async () => {
+    test.each([
+      { key: "F4", ctrlKey: false },
+      { key: "Y", ctrlKey: true },
+    ])("can undo/redo with keyboard CTRL+Z/%s", async (redoKey) => {
       model.dispatch("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
         target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
@@ -327,7 +330,7 @@ describe("Grid component", () => {
       expect(getCell(model, "A1")).toBeUndefined();
       await nextTick();
       document.activeElement!.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "y", ctrlKey: true, bubbles: true })
+        new KeyboardEvent("keydown", { ...redoKey, bubbles: true })
       );
       expect(getCell(model, "A1")!.style).toBeDefined();
     });

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -177,11 +177,16 @@ describe("TopBar component", () => {
 
     expect(undoTool.classList.contains("o-disabled")).toBeTruthy();
     expect(redoTool.classList.contains("o-disabled")).toBeTruthy();
+
+    setSelection(model, ["A2"]); // non repeatable command
+    await nextTick();
+    expect(undoTool.classList.contains("o-disabled")).toBeTruthy();
+    expect(redoTool.classList.contains("o-disabled")).toBeTruthy();
+
     setStyle(model, "A1", { bold: true });
     await nextTick();
-
     expect(undoTool.classList.contains("o-disabled")).toBeFalsy();
-    expect(redoTool.classList.contains("o-disabled")).toBeTruthy();
+    expect(redoTool.classList.contains("o-disabled")).toBeFalsy();
     expect(getCell(model, "A1")!.style).toBeDefined();
 
     await click(undoTool);

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -515,21 +515,17 @@ describe("history", () => {
     const model = new Model();
 
     expect(model.getters.canUndo()).toBe(false);
-    expect(model.getters.canRedo()).toBe(false);
 
     setCellContent(model, "A1", "abc");
     expect(model.getters.canUndo()).toBe(true);
-    expect(model.getters.canRedo()).toBe(false);
 
     undo(model);
     expect(getCell(model, "A1")).toBeUndefined();
     expect(model.getters.canUndo()).toBe(false);
-    expect(model.getters.canRedo()).toBe(true);
 
     redo(model);
     expect(getCellContent(model, "A1")).toBe("abc");
     expect(model.getters.canUndo()).toBe(true);
-    expect(model.getters.canRedo()).toBe(false);
   });
 
   test("can undo and redo a cell update", () => {
@@ -538,24 +534,20 @@ describe("history", () => {
     });
 
     expect(model.getters.canUndo()).toBe(false);
-    expect(model.getters.canRedo()).toBe(false);
 
     model.dispatch("START_EDITION", { text: "abc" });
     model.dispatch("STOP_EDITION");
 
     expect(getCellContent(model, "A1")).toBe("abc");
     expect(model.getters.canUndo()).toBe(true);
-    expect(model.getters.canRedo()).toBe(false);
 
     undo(model);
     expect(getCellContent(model, "A1")).toBe("1");
     expect(model.getters.canUndo()).toBe(false);
-    expect(model.getters.canRedo()).toBe(true);
 
     redo(model);
     expect(getCellContent(model, "A1")).toBe("abc");
     expect(model.getters.canUndo()).toBe(true);
-    expect(model.getters.canRedo()).toBe(false);
   });
 
   test("can undo and redo a delete cell operation", () => {

--- a/tests/plugins/history.test.ts
+++ b/tests/plugins/history.test.ts
@@ -7,6 +7,7 @@ import { CommandResult, UpdateCellCommand } from "../../src/types/commands";
 import {
   activateSheet,
   createSheet,
+  freezeRows,
   redo,
   selectCell,
   setCellContent,
@@ -194,21 +195,21 @@ describe("Model history", () => {
     expect(getCellContent(model, "A2")).toBe("5");
   });
 
-  test("redo stack is nuked when new operation is performed", () => {
+  test("Cannot redo when when the redo stack is empty", () => {
     const model = new Model();
-    setCellContent(model, "A2", "3");
+    expect(model.getters.canRedo()).toBeFalsy();
+  });
 
-    expect(getCellContent(model, "A2")).toBe("3");
+  test("Cannot redo when when the redo stack is empty and last command is not repeatable", () => {
+    const model = new Model();
+    freezeRows(model, 2);
+    expect(model.getters.canRedo()).toBeFalsy();
+  });
 
-    undo(model);
-    expect(getCell(model, "A2")).toBeUndefined();
-
-    expect(model.getters.canUndo()).toBe(false);
-    expect(model.getters.canRedo()).toBe(true);
-
-    setCellContent(model, "A4", "5");
-    expect(model.getters.canUndo()).toBe(true);
-    expect(model.getters.canRedo()).toBe(false);
+  test("Can redo when when the redo stack is empty and last command is repeatable", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "5");
+    expect(model.getters.canRedo()).toBeTruthy();
   });
 
   test("two identical changes do not count as two undo steps", () => {

--- a/tests/plugins/repeat_commands.test.ts
+++ b/tests/plugins/repeat_commands.test.ts
@@ -1,0 +1,492 @@
+import { Model } from "../../src";
+import {
+  repeatCommandTransformRegistry,
+  repeatCoreCommand,
+  repeatLocalCommandTransformRegistry,
+} from "../../src/registries/repeat_commands_registry";
+import { CoreCommand, Dimension, UID } from "../../src/types";
+import {
+  AddColumnsRowsCommand,
+  CreateChartCommand,
+  CreateFigureCommand,
+  CreateImageOverCommand,
+  CreateSheetCommand,
+  HideColumnsRowsCommand,
+  RemoveColumnsRowsCommand,
+  ResizeColumnsRowsCommand,
+} from "../../src/types/commands";
+import {
+  activateSheet,
+  copy,
+  createFilter,
+  createSheet,
+  deleteCells,
+  insertCells,
+  paste,
+  redo,
+  resizeColumns,
+  resizeRows,
+  setCellContent,
+  setSelection,
+  setStyle,
+  sort,
+  undo,
+} from "../test_helpers/commands_helpers";
+import {
+  getCell,
+  getCellContent,
+  getEvaluatedCell,
+  getStyle,
+} from "../test_helpers/getters_helpers";
+import { target, toRangesData } from "../test_helpers/helpers";
+import { DEFAULT_CELL_HEIGHT } from "./../../src/constants";
+import { TEST_COMMANDS } from "./../test_helpers/constants";
+
+let model: Model;
+let sheetId: UID;
+
+beforeEach(() => {
+  model = new Model();
+  sheetId = model.getters.getActiveSheetId();
+});
+
+describe("Repeat commands basics", () => {
+  test("Repeatable core command list", () => {
+    const repeatableCommands = [
+      "UPDATE_CELL",
+      "CLEAR_CELL",
+      "DELETE_CONTENT",
+      "ADD_MERGE",
+      "REMOVE_MERGE",
+      "SET_FORMATTING",
+      "CLEAR_FORMATTING",
+      "SET_BORDER",
+      "CREATE_FILTER_TABLE",
+      "REMOVE_FILTER_TABLE",
+      "ADD_COLUMNS_ROWS",
+      "REMOVE_COLUMNS_ROWS",
+      "HIDE_COLUMNS_ROWS",
+      "CREATE_SHEET",
+      "CREATE_FIGURE",
+      "CREATE_CHART",
+      "CREATE_IMAGE",
+      "HIDE_SHEET",
+      "RESIZE_COLUMNS_ROWS",
+    ].sort();
+    const registryKeys = repeatCommandTransformRegistry.getKeys().sort();
+    expect(repeatableCommands).toEqual(registryKeys);
+  });
+
+  test("Repeatable local command list", () => {
+    const repeatableCommands = [
+      "STOP_EDITION",
+      "PASTE",
+      "INSERT_CELL",
+      "DELETE_CELL",
+      "AUTORESIZE_COLUMNS",
+      "AUTORESIZE_ROWS",
+      "SORT_CELLS",
+      "SUM_SELECTION",
+      "SET_DECIMAL",
+    ].sort();
+    const registryKeys = repeatLocalCommandTransformRegistry.getKeys().sort();
+    expect(repeatableCommands).toEqual(registryKeys);
+  });
+
+  test("Can repeat a command", () => {
+    setCellContent(model, "A1", "hello");
+    setSelection(model, ["B2"]);
+    redo(model);
+    expect(getCellContent(model, "B2")).toBe("hello");
+  });
+
+  test("Can undo repeated command", () => {
+    setCellContent(model, "A1", "hello");
+    setSelection(model, ["B2"]);
+    redo(model);
+    expect(getCellContent(model, "B2")).toBe("hello");
+
+    undo(model);
+    expect(getCellContent(model, "B2")).toBe("");
+  });
+
+  test("Can undo => redo => repeat command", () => {
+    setCellContent(model, "A1", "hello");
+    undo(model);
+    expect(getCellContent(model, "A1")).toBe("");
+
+    redo(model);
+    expect(getCellContent(model, "A1")).toBe("hello");
+
+    setSelection(model, ["B2"]);
+    redo(model);
+    expect(getCellContent(model, "B2")).toBe("hello");
+  });
+});
+
+describe("Repeat command transform generics", () => {
+  test.each([
+    TEST_COMMANDS.UPDATE_CELL,
+    TEST_COMMANDS.CLEAR_CELL,
+    TEST_COMMANDS.DELETE_CONTENT,
+    TEST_COMMANDS.ADD_MERGE,
+    TEST_COMMANDS.REMOVE_MERGE,
+    TEST_COMMANDS.SET_FORMATTING,
+    TEST_COMMANDS.CLEAR_FORMATTING,
+    TEST_COMMANDS.SET_BORDER,
+    TEST_COMMANDS.CREATE_FILTER_TABLE,
+    TEST_COMMANDS.REMOVE_FILTER_TABLE,
+    TEST_COMMANDS.HIDE_SHEET,
+  ])("Sheet dependant command are adapted to current sheet %s", (command: CoreCommand) => {
+    createSheet(model, { sheetId: "42" });
+    activateSheet(model, "42");
+    const transformed = repeatCoreCommand(model.getters, command);
+    expect(transformed?.sheetId).toEqual("42");
+  });
+
+  test.each([TEST_COMMANDS.UPDATE_CELL, TEST_COMMANDS.CLEAR_CELL, TEST_COMMANDS.SET_BORDER])(
+    "Position dependant commands are adapted to current selection %s",
+    (cmd: CoreCommand) => {
+      setSelection(model, ["B2:C4"]);
+      const transformed = repeatCoreCommand(model.getters, cmd);
+      expect(transformed).toMatchObject({ col: 1, row: 1 });
+    }
+  );
+
+  test.each([
+    TEST_COMMANDS.ADD_MERGE,
+    TEST_COMMANDS.REMOVE_MERGE,
+    TEST_COMMANDS.CREATE_FILTER_TABLE,
+    TEST_COMMANDS.REMOVE_FILTER_TABLE,
+    TEST_COMMANDS.SET_FORMATTING,
+    TEST_COMMANDS.CLEAR_FORMATTING,
+  ])(
+    "Target dependant commands have target equal to current current selection",
+    (command: CoreCommand) => {
+      setSelection(model, ["B2:C4"]);
+      const transformed = repeatCoreCommand(model.getters, command);
+      expect(transformed).toMatchObject({ target: target("B2:C4") });
+    }
+  );
+
+  test("Commands not in repeatCommandRegistry aren't repeated", () => {
+    const command = { type: "RANDOM_COMMAND", col: 0, row: 0, sheetId } as unknown as CoreCommand;
+    const transformed = repeatCoreCommand(model.getters, command);
+    expect(transformed).toBeUndefined();
+  });
+});
+
+describe("Repeat command transform specifics", () => {
+  test("Create Chart transform", () => {
+    const command: CreateChartCommand = {
+      ...TEST_COMMANDS.CREATE_CHART,
+      type: "CREATE_CHART",
+      id: "chartId",
+      sheetId,
+    };
+    createSheet(model, { sheetId: "42" });
+    activateSheet(model, "42");
+    const transformed = repeatCoreCommand(model.getters, command);
+    expect(transformed).toEqual({
+      ...command,
+      id: expect.not.stringMatching("chartId"),
+      sheetId: "42",
+    });
+  });
+
+  test("Create image transform", () => {
+    const command: CreateImageOverCommand = {
+      ...TEST_COMMANDS.CREATE_IMAGE,
+      sheetId,
+      figureId: "figureId",
+    };
+    createSheet(model, { sheetId: "42" });
+    activateSheet(model, "42");
+    const transformed = repeatCoreCommand(model.getters, command);
+    expect(transformed).toEqual({
+      ...command,
+      figureId: expect.not.stringMatching("figureId"),
+      sheetId: "42",
+    });
+  });
+
+  test("Create figure transform", () => {
+    const command: CreateFigureCommand = {
+      ...TEST_COMMANDS.CREATE_FIGURE,
+      sheetId,
+    };
+    createSheet(model, { sheetId: "42" });
+    activateSheet(model, "42");
+    const transformed = repeatCoreCommand(model.getters, command);
+
+    expect(transformed).toEqual({
+      ...command,
+      sheetId: "42",
+      figure: {
+        ...command.figure,
+        id: expect.not.stringMatching(command.figure.id),
+      },
+    });
+  });
+
+  test("Create sheet transform", () => {
+    createSheet(model, { sheetId: "sheetId", name: "sheetName" });
+    let command: CreateSheetCommand = {
+      ...TEST_COMMANDS.CREATE_SHEET,
+      sheetId: "sheetId",
+      name: "sheetName",
+    };
+    const repeated = repeatCoreCommand(model.getters, command) as CreateSheetCommand;
+    expect(repeated).toEqual({
+      ...command,
+      sheetId: expect.not.stringMatching("sheetId"),
+      name: "sheetName1",
+    });
+    model.dispatch("CREATE_SHEET", { ...repeated });
+
+    expect(repeatCoreCommand(model.getters, repeated)).toEqual({
+      ...command,
+      sheetId: expect.not.stringMatching("sheetId"),
+      name: "sheetName2",
+    });
+  });
+
+  test.each([
+    { dim: "COL", selection: "C1:D4", newBase: 2 },
+    { dim: "ROW", selection: "A5", newBase: 4 },
+  ])("Repeat add col/row command %s", (args) => {
+    createSheet(model, { sheetId: "42" });
+    const command: AddColumnsRowsCommand = {
+      ...TEST_COMMANDS.ADD_COLUMNS_ROWS,
+      dimension: args.dim as Dimension,
+      sheetId,
+      base: 0,
+    };
+    activateSheet(model, "42");
+    setSelection(model, [args.selection]);
+    const transformed = repeatCoreCommand(model.getters, command);
+    expect(transformed).toEqual({
+      ...command,
+      base: args.newBase,
+      sheetId: "42",
+    });
+  });
+
+  test.each([
+    { cmd: "REMOVE_COLUMNS_ROWS" as const, dim: "COL", selection: "C1:D4", expected: [2, 3] },
+    { cmd: "REMOVE_COLUMNS_ROWS" as const, dim: "ROW", selection: "A5", expected: [4] },
+    { cmd: "HIDE_COLUMNS_ROWS" as const, dim: "COL", selection: "A5", expected: [0] },
+    { cmd: "HIDE_COLUMNS_ROWS" as const, dim: "ROW", selection: "C1:D3", expected: [0, 1, 2] },
+  ])("Repeat delete/hide col/row command %s", (args) => {
+    createSheet(model, { sheetId: "42" });
+    const command: RemoveColumnsRowsCommand | HideColumnsRowsCommand = {
+      type: args.cmd,
+      dimension: args.dim as Dimension,
+      sheetId,
+      elements: [0, 1],
+    };
+    activateSheet(model, "42");
+    setSelection(model, [args.selection]);
+    const transformed = repeatCoreCommand(model.getters, command);
+    expect(transformed).toEqual({
+      ...command,
+      elements: args.expected,
+      sheetId: "42",
+    });
+  });
+
+  test.each([
+    { dim: "COL", selection: "C1:D4", affectedHeader: [2, 3] },
+    { dim: "ROW", selection: "A5", affectedHeader: [4] },
+  ])("Repeat resize col/row command %s", (args) => {
+    createSheet(model, { sheetId: "42" });
+    const command: ResizeColumnsRowsCommand = {
+      ...TEST_COMMANDS.RESIZE_COLUMNS_ROWS,
+      dimension: args.dim as Dimension,
+      sheetId,
+    };
+    activateSheet(model, "42");
+    setSelection(model, [args.selection]);
+    const transformed = repeatCoreCommand(model.getters, command);
+    expect(transformed).toEqual({
+      ...command,
+      elements: args.affectedHeader,
+      sheetId: "42",
+    });
+  });
+});
+
+describe("Repeat local commands", () => {
+  test("Repeat Paste", () => {
+    setCellContent(model, "A1", "A1");
+    setCellContent(model, "A2", "A2");
+    setStyle(model, "A2", { fillColor: "red" });
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      ...TEST_COMMANDS.ADD_CONDITIONAL_FORMAT,
+      ranges: toRangesData(sheetId, "A1:A2"),
+    });
+    createFilter(model, "A1:A2");
+
+    setSelection(model, ["A1:A2"]);
+    copy(model);
+    paste(model, "B1");
+
+    setSelection(model, ["C1"]);
+    redo(model);
+    expect(getCellContent(model, "C1")).toEqual("A1");
+    expect(getCellContent(model, "C2")).toEqual("A2");
+    expect(getStyle(model, "C2")).toEqual({ fillColor: "red" });
+    expect(model.getters.isFilterHeader({ sheetId, col: 2, row: 0 })).toEqual(true);
+    expect(model.getters.getRulesByCell(sheetId, 2, 0)).toBeTruthy();
+  });
+
+  test("Repeat Paste format only", () => {
+    setCellContent(model, "A1", "A1");
+    setStyle(model, "A1", { fillColor: "red" });
+
+    setSelection(model, ["A1"]);
+    copy(model);
+    paste(model, "B1", "onlyFormat");
+
+    setSelection(model, ["C1"]);
+    redo(model);
+    expect(getCellContent(model, "C1")).toEqual("");
+    expect(getStyle(model, "C1")).toEqual({ fillColor: "red" });
+  });
+
+  test("Local commands can be repeated multiple times", () => {
+    setCellContent(model, "A1", "A1");
+    setSelection(model, ["A1"]);
+    copy(model);
+    paste(model, "B1");
+
+    setSelection(model, ["C1"]);
+    redo(model);
+    expect(getCellContent(model, "C1")).toEqual("A1");
+
+    setSelection(model, ["C3"]);
+    redo(model);
+    expect(getCellContent(model, "C3")).toEqual("A1");
+  });
+
+  test("Repeat insert cell", () => {
+    setCellContent(model, "A3", "A3");
+    setCellContent(model, "B3", "B3");
+    setCellContent(model, "C3", "C3");
+
+    insertCells(model, "A1:A2", "down");
+
+    setSelection(model, ["B1"]);
+    redo(model);
+    expect(getCellContent(model, "B3")).toEqual("");
+    expect(getCellContent(model, "B4")).toEqual("B3");
+
+    setSelection(model, ["C1:C2"]);
+    redo(model);
+    expect(getCellContent(model, "C3")).toEqual("");
+    expect(getCellContent(model, "C5")).toEqual("C3");
+  });
+
+  test("Repeat delete cell", () => {
+    setCellContent(model, "A3", "A3");
+    setCellContent(model, "B3", "B3");
+    setCellContent(model, "C3", "C3");
+
+    deleteCells(model, "A1:A2", "up");
+
+    setSelection(model, ["B1"]);
+    redo(model);
+    expect(getCellContent(model, "B3")).toEqual("");
+    expect(getCellContent(model, "B2")).toEqual("B3");
+
+    setSelection(model, ["C1:C2"]);
+    redo(model);
+    expect(getCellContent(model, "C3")).toEqual("");
+    expect(getCellContent(model, "C1")).toEqual("C3");
+  });
+
+  test("Repeat stop edition", () => {
+    model.dispatch("START_EDITION");
+    model.dispatch("SET_CURRENT_CONTENT", { content: "kikou" });
+    model.dispatch("STOP_EDITION");
+    expect(getCellContent(model, "A1")).toEqual("kikou");
+
+    setSelection(model, ["B1"]);
+    redo(model);
+    expect(getCellContent(model, "B1")).toEqual("kikou");
+  });
+
+  test("Repeat set decimal", () => {
+    setSelection(model, ["A1"]);
+    setCellContent(model, "A1", "1");
+    model.dispatch("SET_DECIMAL", { target: target("A1"), step: 1, sheetId });
+    expect(getEvaluatedCell(model, "A1").formattedValue).toEqual("1.0");
+
+    redo(model);
+    expect(getEvaluatedCell(model, "A1").formattedValue).toEqual("1.00");
+  });
+
+  test("Repeat autoresize rows", () => {
+    resizeRows(model, [0, 2, 3], 100);
+    model.dispatch("AUTORESIZE_ROWS", {
+      sheetId,
+      rows: [0],
+    });
+    expect(model.getters.getRowSize(sheetId, 0)).toEqual(DEFAULT_CELL_HEIGHT);
+
+    setSelection(model, ["A3:A4"]);
+    redo(model);
+    expect(model.getters.getRowSize(sheetId, 2)).toEqual(DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getRowSize(sheetId, 3)).toEqual(DEFAULT_CELL_HEIGHT);
+  });
+
+  test("Repeat autoresize columns", () => {
+    setCellContent(model, "A1", "A1");
+    setCellContent(model, "C1", "C1");
+    setCellContent(model, "D1", "D1");
+    resizeColumns(model, ["A", "C", "D"], 50);
+    model.dispatch("AUTORESIZE_COLUMNS", {
+      sheetId,
+      cols: [0],
+    });
+    expect(model.getters.getColSize(sheetId, 0)).toEqual(34);
+
+    setSelection(model, ["C1:D1"]);
+    redo(model);
+    expect(model.getters.getColSize(sheetId, 2)).toEqual(34);
+    expect(model.getters.getColSize(sheetId, 3)).toEqual(34);
+  });
+
+  test("Repeat sort cells", () => {
+    createSheet(model, { sheetId: "42" });
+    setCellContent(model, "A1", "A1", "42");
+    setCellContent(model, "A2", "A2", "42");
+    setCellContent(model, "A3", "A3", "42");
+
+    sort(model, {
+      sheetId,
+      zone: "C2:C3",
+      anchor: "C2",
+      direction: "descending",
+    });
+
+    activateSheet(model, "42");
+    setSelection(model, ["A1:A3"]);
+    redo(model);
+    expect(getCellContent(model, "A1")).toEqual("A3");
+    expect(getCellContent(model, "A2")).toEqual("A2");
+    expect(getCellContent(model, "A3")).toEqual("A1");
+  });
+
+  test("Repeat sum selection", () => {
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+
+    setSelection(model, ["B1:B2"]);
+    model.dispatch("SUM_SELECTION");
+
+    setSelection(model, ["A1:A2"]);
+    redo(model);
+    expect(getCell(model, "A3")?.content).toEqual("=SUM(A1:A2)");
+  });
+});

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -1,4 +1,6 @@
-import { BACKGROUND_CHART_COLOR } from "../../src/constants";
+import { BACKGROUND_CHART_COLOR, DEFAULT_BORDER_DESC } from "../../src/constants";
+import { CoreCommand, CoreCommandTypes } from "../../src/types";
+import { target, toRangesData } from "./helpers";
 
 export const TEST_CHART_DATA = {
   basicChart: {
@@ -43,3 +45,140 @@ export const TEST_CHART_DATA = {
     },
   },
 };
+
+type CommandMapping = {
+  [key in CoreCommandTypes]: Extract<CoreCommand, { type: key }>;
+};
+
+// TODO : use this in ot_*.test.ts files. should be at least -400 lines of code
+const TEST_COMMANDS_PARTIAL: Partial<CommandMapping> = {
+  UPDATE_CELL: {
+    type: "UPDATE_CELL",
+    col: 0,
+    row: 0,
+    content: "hello",
+    sheetId: "sheetId",
+  },
+  CLEAR_CELL: {
+    type: "CLEAR_CELL",
+    col: 0,
+    row: 0,
+    sheetId: "sheetId",
+  },
+  DELETE_CONTENT: {
+    type: "DELETE_CONTENT",
+    target: target("A1"),
+    sheetId: "sheetId",
+  },
+  ADD_MERGE: {
+    type: "ADD_MERGE",
+    target: target("A1:A2"),
+    sheetId: "sheetId",
+  },
+  REMOVE_MERGE: {
+    type: "REMOVE_MERGE",
+    target: target("A1:A2"),
+    sheetId: "sheetId",
+  },
+  SET_FORMATTING: {
+    type: "SET_FORMATTING",
+    target: target("A1"),
+    style: { bold: true },
+    sheetId: "sheetId",
+  },
+  CLEAR_FORMATTING: {
+    type: "CLEAR_FORMATTING",
+    target: target("A1"),
+    sheetId: "sheetId",
+  },
+  SET_BORDER: {
+    type: "SET_BORDER",
+    col: 0,
+    row: 0,
+    border: { top: DEFAULT_BORDER_DESC },
+    sheetId: "sheetId",
+  },
+  CREATE_FILTER_TABLE: {
+    type: "CREATE_FILTER_TABLE",
+    target: target("A1"),
+    sheetId: "sheetId",
+  },
+  REMOVE_FILTER_TABLE: {
+    type: "REMOVE_FILTER_TABLE",
+    target: target("A1"),
+    sheetId: "sheetId",
+  },
+  HIDE_SHEET: {
+    type: "HIDE_SHEET",
+    sheetId: "sheetId",
+  },
+  CREATE_SHEET: {
+    type: "CREATE_SHEET",
+    sheetId: "newSheetId",
+    name: "newSheetName",
+    position: 0,
+  },
+  DUPLICATE_SHEET: {
+    type: "DUPLICATE_SHEET",
+    sheetId: "sheetId",
+    sheetIdTo: "duplicateSheetId",
+  },
+  ADD_CONDITIONAL_FORMAT: {
+    type: "ADD_CONDITIONAL_FORMAT",
+    ranges: toRangesData("sheetId", "A1"),
+    cf: {
+      id: "cfId",
+      rule: {
+        values: ["1"],
+        operator: "Equal",
+        type: "CellIsRule",
+        style: { fillColor: "#FF0000" },
+      },
+    },
+    sheetId: "sheetId",
+  },
+  CREATE_FIGURE: {
+    type: "CREATE_FIGURE",
+    figure: {
+      id: "figureId",
+      tag: "tag",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+    },
+    sheetId: "sheetId",
+  },
+  CREATE_CHART: {
+    type: "CREATE_CHART",
+    definition: TEST_CHART_DATA.basicChart,
+    position: { x: 0, y: 0 },
+    size: { width: 200, height: 200 },
+    id: "figureId",
+    sheetId: "sheetId",
+  },
+  CREATE_IMAGE: {
+    type: "CREATE_IMAGE",
+    position: { x: 0, y: 0 },
+    size: { width: 200, height: 200 },
+    definition: { path: "/image/1", size: { width: 200, height: 200 } },
+    sheetId: "sheetId",
+    figureId: "figureId",
+  },
+  RESIZE_COLUMNS_ROWS: {
+    type: "RESIZE_COLUMNS_ROWS",
+    dimension: "ROW",
+    elements: [0],
+    size: 100,
+    sheetId: "sheetId",
+  },
+  ADD_COLUMNS_ROWS: {
+    type: "ADD_COLUMNS_ROWS",
+    position: "after",
+    dimension: "ROW",
+    base: 0,
+    quantity: 1,
+    sheetId: "sheetId",
+  },
+};
+export const TEST_COMMANDS = TEST_COMMANDS_PARTIAL as CommandMapping;


### PR DESCRIPTION
## Description:

Now if we do a redo and the redo stack is empty, we will try the redo
the last played command if possible. The list of repeatable commands
is in defined in the repeat_commands_registry.ts file.

Repeated commands are transformed to match the current selection/sheet.
To be able to repeat local commands, the "root" command of a revision
was added to the history.

Odoo task ID : [2508693](https://www.odoo.com/web#id=2508693&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo