### PR TITLE
[FIX] filters: filter can hide all the visible rows of a sheet

### DIFF
--- a/tests/plugins/filters.test.ts
+++ b/tests/plugins/filters.test.ts
@@ -10,6 +10,7 @@ import {
   deleteColumns,
   deleteFilter,
   deleteRows,
+  hideRows,
   insertCells,
   merge,
   paste,
@@ -145,6 +146,29 @@ describe("Filters plugin", () => {
 
       expect(getFilterValues(model, sheetId)).toMatchObject([{ zone: "A1:A3", value: ["C"] }]);
       expect(getFilterValues(model, sheet2Id)).toMatchObject([{ zone: "A1:A3", value: ["D"] }]);
+    });
+
+    test("Filter is disabled if its header row is hidden by the user", () => {
+      createFilter(model, "A1:A3");
+      setCellContent(model, "A2", "28");
+      updateFilter(model, "A1", ["28"]);
+      expect(model.getters.isRowHidden(sheetId, 1)).toBe(true);
+
+      hideRows(model, [0]);
+      expect(model.getters.isRowHidden(sheetId, 1)).toBe(false);
+    });
+
+    test("Filter is disabled if its header row is hidden by another filter", () => {
+      createFilter(model, "A2:A3");
+      setCellContent(model, "A3", "15");
+      updateFilter(model, "A2", ["15"]);
+      expect(model.getters.isRowHidden(sheetId, 2)).toBe(true);
+
+      createFilter(model, "B1:B2");
+      setCellContent(model, "B2", "28");
+      updateFilter(model, "B1", ["28"]);
+      expect(model.getters.isRowHidden(sheetId, 1)).toBe(true);
+      expect(model.getters.isRowHidden(sheetId, 2)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Description

It's currently possible to use data filters to hide all the rows in a sheet,
leaving a buggy sheet with no visible rows.

Fixing this is a bit tricky, since the filtered rows are an UI concept, and
thus we cannot rely on the allowDispatch of "HIDE_COLUMNS_ROWS" to prevent
the user from hiding all the rows. Using allowDispatch isn't possible
because the filtered values (and the values of the cells) are different
from an user to another. This means that the allowDispatch could return
a success for an user, and a failure for the other, leading to a
dis-synchronized model state for the 2 user.

Fortunately we can fix this by disabling data filters whose header row is
hidden (by the user or by another filter). By construction of the filters,
it becomes impossible to hide all the rows of a sheet.

This may still becomes an issue in the future if we implement something
like filters being applied to a column header. In that case, we would need
to handle sheets with all their rows hidden.


Odoo task ID : [3205608](https://www.odoo.com/web#id=3205608&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo