### PR TITLE
[FIX] bottom_bar: left/right scroll sheet arrows don't WorkbookData

### DIFF
--- a/src/components/animation/ripple.xml
+++ b/src/components/animation/ripple.xml
@@ -9,7 +9,7 @@
           <RippleEffect t-props="getRippleEffectProps(ripple.id)"/>
         </t>
       </div>
-      <div t-ref="childContainer">
+      <div class="position-relative" t-ref="childContainer">
         <t t-slot="default"/>
       </div>
     </div>

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -7,16 +7,14 @@
       t-on-contextmenu.prevent="">
       <Ripple>
         <div
-          class="o-sheet-item o-add-sheet position-relative me-2 p-1"
+          class="o-sheet-item o-add-sheet me-2 p-1"
           t-att-class="{'disabled': env.model.getters.isReadonly()}"
           t-on-click="clickAddSheet">
           <t t-call="o-spreadsheet-Icon.PLUS"/>
         </div>
       </Ripple>
       <Ripple>
-        <div
-          class="o-sheet-item o-list-sheets position-relative me-2 p-1"
-          t-on-click="clickListSheets">
+        <div class="o-sheet-item o-list-sheets me-2 p-1" t-on-click="clickListSheets">
           <t t-call="o-spreadsheet-Icon.LIST"/>
         </div>
       </Ripple>

--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-BottomBarSheet" owl="1">
     <Ripple>
       <div
-        class="o-sheet position-relative d-flex align-items-center user-select-none text-nowrap "
+        class="o-sheet d-flex align-items-center user-select-none text-nowrap "
         t-on-mousedown="(ev) => this.onMouseDown(ev)"
         t-on-contextmenu.prevent="(ev) => this.onContextMenu(ev)"
         t-ref="sheetDiv"
@@ -21,9 +21,7 @@
           t-on-keydown="(ev) => this.onKeyDown(ev)"
           t-att-contenteditable="state.isEditing.toString()"
         />
-        <span
-          class="o-sheet-icon position-relative ms-1"
-          t-on-click.stop="(ev) => this.onIconClick(ev)">
+        <span class="o-sheet-icon ms-1" t-on-click.stop="(ev) => this.onIconClick(ev)">
           <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
         </span>
       </div>

--- a/src/components/bottom_bar_statistic/bottom_bar_statistic.xml
+++ b/src/components/bottom_bar_statistic/bottom_bar_statistic.xml
@@ -3,7 +3,7 @@
     <t t-set="selectedStatistic" t-value="getSelectedStatistic()"/>
     <Ripple class="'ms-auto'" t-if="selectedStatistic !== undefined">
       <div
-        class="o-selection-statistic position-relative text-truncate user-select-none me-4 bg-white rounded shadow"
+        class="o-selection-statistic text-truncate user-select-none me-4 bg-white rounded shadow"
         t-on-click="listSelectionStatistics">
         <t t-esc="selectedStatistic"/>
         <span class="ms-2">

--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -110,9 +110,11 @@ exports[`BottomBar component simple rendering 1`] = `
     >
       
     </div>
-    <div>
+    <div
+      class="position-relative"
+    >
       <div
-        class="o-sheet-item o-add-sheet position-relative me-2 p-1"
+        class="o-sheet-item o-add-sheet me-2 p-1"
       >
         <svg
           class="o-icon"
@@ -134,9 +136,11 @@ exports[`BottomBar component simple rendering 1`] = `
     >
       
     </div>
-    <div>
+    <div
+      class="position-relative"
+    >
       <div
-        class="o-sheet-item o-list-sheets position-relative me-2 p-1"
+        class="o-sheet-item o-list-sheets me-2 p-1"
       >
         <svg
           class="o-icon"
@@ -180,9 +184,11 @@ exports[`BottomBar component simple rendering 1`] = `
         >
           
         </div>
-        <div>
+        <div
+          class="position-relative"
+        >
           <div
-            class="o-sheet position-relative d-flex align-items-center user-select-none text-nowrap active"
+            class="o-sheet d-flex align-items-center user-select-none text-nowrap active"
             data-id="Sheet1"
             style=""
             title="Sheet1"
@@ -194,7 +200,7 @@ exports[`BottomBar component simple rendering 1`] = `
               Sheet1
             </span>
             <span
-              class="o-sheet-icon position-relative ms-1"
+              class="o-sheet-icon ms-1"
             >
               <svg
                 class="o-icon"

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -619,9 +619,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       >
         
       </div>
-      <div>
+      <div
+        class="position-relative"
+      >
         <div
-          class="o-sheet-item o-add-sheet position-relative me-2 p-1"
+          class="o-sheet-item o-add-sheet me-2 p-1"
         >
           <svg
             class="o-icon"
@@ -643,9 +645,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       >
         
       </div>
-      <div>
+      <div
+        class="position-relative"
+      >
         <div
-          class="o-sheet-item o-list-sheets position-relative me-2 p-1"
+          class="o-sheet-item o-list-sheets me-2 p-1"
         >
           <svg
             class="o-icon"
@@ -689,9 +693,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           >
             
           </div>
-          <div>
+          <div
+            class="position-relative"
+          >
             <div
-              class="o-sheet position-relative d-flex align-items-center user-select-none text-nowrap active"
+              class="o-sheet d-flex align-items-center user-select-none text-nowrap active"
               data-id="sh1"
               style=""
               title="Sheet1"
@@ -703,7 +709,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
                 Sheet1
               </span>
               <span
-                class="o-sheet-icon position-relative ms-1"
+                class="o-sheet-icon ms-1"
               >
                 <svg
                   class="o-icon"


### PR DESCRIPTION
## Description

The Ripple component needs its child to be relative/absolute positioned of it to receive the click events. But the arrows weren't positioned relatively.

Changed by applying a `position-relative` class to the container in the Ripple component, rather than having to apply it to each child.

Odoo task ID : [3213533](https://www.odoo.com/web#id=3213533&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo