### PR TITLE
[FIX] popover: adjusted z-index for popover and grid composer

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -103,7 +103,7 @@ const CSS = css/* scss */ `
     padding: 0;
     margin: 0;
     border: 0;
-    z-index: 5;
+    z-index: 6;
     flex-grow: 1;
     max-height: inherit;
     .o-composer {

--- a/src/components/error_tooltip.ts
+++ b/src/components/error_tooltip.ts
@@ -15,6 +15,10 @@ const CSS = css/* scss */ `
     border-left: 3px solid red;
     padding: 10px;
   }
+
+  .o-popover:has(.o-error-tooltip) {
+    z-index: 4 !important;
+  }
 `;
 
 export interface ErrorToolTipProps {

--- a/src/components/popover.ts
+++ b/src/components/popover.ts
@@ -7,7 +7,7 @@ const { xml } = tags;
 
 const TEMPLATE = xml/* xml */ `
   <Portal target="'.o-spreadsheet'">
-    <div t-att-style="style">
+    <div class="o-popover" t-att-style="style">
       <t t-slot="default"/>
     </div>
   </Portal>

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -56,6 +56,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
 
 exports[`error tooltip can display error tooltip 1`] = `
 <div
+  class="o-popover"
   style="
       position: absolute;
       z-index: 5;


### PR DESCRIPTION
## Description:

Currently error tooltip is overlapping composer assistant when one tries to
modify arguments within the grid composer.  It arises because of a conflict in
the z-index values between the popover and grid composer components.

To resolve this problem, the z-index of the popover component was reduced.
Now, the popover is behind the grid composer and allows user to view composer
assistant properly.

Odoo task ID : [3211697](https://www.odoo.com/web#id=3211697&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo