### PR TITLE
[FIX] bundle_xml: small fixes for script bundling the xmls

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:js": "tsc --module es6 --incremental",
     "bundle:js": "rollup -c -m dev",
     "bundle:xml": "node tools/bundle_xml/main.js",
-    "build": "npm-run-all build:js bundle:js 'bundle:xml -- --outDir build'",
+    "build": "npm-run-all build:js bundle:js \"bundle:xml -- --outDir build\"",
     "doc": "typedoc",
     "precommit": "npm run prettier && npm run doc",
     "test": "jest",

--- a/tools/bundle_xml/main.js
+++ b/tools/bundle_xml/main.js
@@ -1,6 +1,8 @@
 const bundle = require("./bundle_xml_templates");
 
-const outDirAgIndex = process.argv.findIndex((arg) => arg === "--outDir") + 1;
-const outDir = process.argv[outDirAgIndex] || "dist";
+const DEFAULT_DIR = "dist";
 
-bundle.writeOwlTemplateBundleToFile(outDir);
+const outDirFlagIndex = process.argv.findIndex((arg) => arg === "--outDir");
+const outDir = outDirFlagIndex !== -1 ? process.argv[outDirFlagIndex + 1] : DEFAULT_DIR;
+
+bundle.writeOwlTemplateBundleToFile(outDir || DEFAULT_DIR);


### PR DESCRIPTION
Two issues :
1) bundle_xml script had the wrong default value if the argument "--outDir" wasn't specified.
2) the syntax 'build:xml ...' in package.json wasn't working in windows. Replaced `'build...'` by `\"build...\"` to fix it.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo