### PR TITLE
[IMP] highlight: support unbounded zone

### DIFF
--- a/src/components/highlight/highlight/highlight.ts
+++ b/src/components/highlight/highlight/highlight.ts
@@ -1,7 +1,7 @@
 import { Component, useState } from "@odoo/owl";
 import { ComponentsImportance } from "../../../constants";
 import { clip, isEqual } from "../../../helpers";
-import { Color, Pixel, SpreadsheetChildEnv, Zone } from "../../../types";
+import { Color, HeaderIndex, Pixel, SpreadsheetChildEnv, Zone } from "../../../types";
 import { css } from "../../helpers/css";
 import { gridOverlayPosition } from "../../helpers/dom_helpers";
 import { dragAndDropBeyondTheViewport } from "../../helpers/drag_and_drop";
@@ -34,7 +34,7 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
   });
 
   onResizeHighlight(isLeft: boolean, isTop: boolean) {
-    const activeSheet = this.env.model.getters.getActiveSheet();
+    const activeSheetId = this.env.model.getters.getActiveSheetId();
 
     this.highlightState.shiftingMode = "isResizing";
     const z = this.props.zone;
@@ -46,12 +46,11 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
     let currentZone = z;
 
     this.env.model.dispatch("START_CHANGE_HIGHLIGHT", {
-      range: this.env.model.getters.getRangeDataFromZone(activeSheet.id, currentZone),
+      range: this.env.model.getters.getRangeDataFromZone(activeSheetId, currentZone),
     });
 
-    const mouseMove = (col, row) => {
+    const mouseMove = (col: HeaderIndex, row: HeaderIndex) => {
       if (lastCol !== col || lastRow !== row) {
-        const activeSheetId = this.env.model.getters.getActiveSheetId();
         lastCol = clip(
           col === -1 ? lastCol : col,
           0,
@@ -74,7 +73,10 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
 
         if (!isEqual(newZone, currentZone)) {
           this.env.model.dispatch("CHANGE_HIGHLIGHT", {
-            range: this.env.model.getters.getRangeDataFromZone(activeSheet.id, newZone),
+            range: this.env.model.getters.getRangeFromZone(
+              activeSheetId,
+              this.env.model.getters.getUnboundedZone(activeSheetId, newZone)
+            ).rangeData,
           });
           currentZone = newZone;
         }
@@ -116,7 +118,7 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
     let lastCol = initCol;
     let lastRow = initRow;
 
-    const mouseMove = (col, row) => {
+    const mouseMove = (col: HeaderIndex, row: HeaderIndex) => {
       if (lastCol !== col || lastRow !== row) {
         lastCol = col === -1 ? lastCol : col;
         lastRow = row === -1 ? lastRow : row;
@@ -131,10 +133,12 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
         };
 
         newZone = this.env.model.getters.expandZone(activeSheetId, newZone);
-
         if (!isEqual(newZone, currentZone)) {
           this.env.model.dispatch("CHANGE_HIGHLIGHT", {
-            range: this.env.model.getters.getRangeDataFromZone(activeSheetId, newZone),
+            range: this.env.model.getters.getRangeFromZone(
+              activeSheetId,
+              this.env.model.getters.getUnboundedZone(activeSheetId, newZone)
+            ).rangeData,
           });
           currentZone = newZone;
         }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -382,11 +382,11 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     return this.getters.getRangeFromSheetXC(sheetId, xc).rangeData;
   }
 
-  getRangeDataFromZone(sheetId: UID, zone: Zone): RangeData {
+  getRangeDataFromZone(sheetId: UID, zone: Zone | UnboundedZone): RangeData {
     return { _sheetId: sheetId, _zone: zone };
   }
 
-  getRangeFromZone(sheetId: UID, zone: UnboundedZone): Range {
+  getRangeFromZone(sheetId: UID, zone: Zone | UnboundedZone): Range {
     return new RangeImpl(
       {
         sheetId,

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -456,8 +456,9 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     const isFullCol = zone.top === 0 && zone.bottom === this.getNumberRows(sheetId) - 1;
     return {
       ...zone,
-      right: isFullRow ? undefined : zone.right,
       bottom: isFullCol ? undefined : zone.bottom,
+      // cannot be unbounded in the 2 dimensions at once
+      right: isFullRow && !isFullCol ? undefined : zone.right,
     };
   }
 

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -30,6 +30,7 @@ import {
   RemoveColumnsRowsCommand,
   UID,
   UnboundedZone,
+  Zone,
 } from "../../types";
 import { SelectionEvent } from "../../types/event_stream";
 import { UIPlugin } from "../ui_plugin";
@@ -170,7 +171,9 @@ export class EditionPlugin extends UIPlugin {
         }
         break;
       case "START_CHANGE_HIGHLIGHT":
+        // FIXME: thiws whole ordeal could be handled with the Selection Processor which would extend the feature to selection inputs
         this.dispatch("STOP_COMPOSER_RANGE_SELECTION");
+        // FIXME: we should check range SheetId compared to this.activeSheetId r maybe not have a sheetId in the payload ??
         const range = this.getters.getRangeFromRangeData(cmd.range);
         const previousRefToken = this.currentTokens
           .filter((token) => token.type === "REFERENCE")
@@ -556,7 +559,7 @@ export class EditionPlugin extends UIPlugin {
     }
   }
 
-  private insertSelectedRange(zone: UnboundedZone) {
+  private insertSelectedRange(zone: Zone | UnboundedZone) {
     // infer if range selected or selecting range from cursor position
     const start = Math.min(this.selectionStart, this.selectionEnd);
     const ref = this.getZoneReference(zone);
@@ -571,12 +574,12 @@ export class EditionPlugin extends UIPlugin {
   /**
    * Replace the current reference selected by the new one.
    * */
-  private replaceSelectedRanges(zone: UnboundedZone) {
+  private replaceSelectedRanges(zone: Zone | UnboundedZone) {
     const ref = this.getZoneReference(zone);
     this.replaceText(ref, this.selectionInitialStart, this.selectionEnd);
   }
 
-  private getZoneReference(zone: UnboundedZone): string {
+  private getZoneReference(zone: Zone | UnboundedZone): string {
     const inputSheetId = this.getters.getCurrentEditedCell().sheetId;
     const sheetId = this.getters.getActiveSheetId();
     const range = this.getters.getRangeFromZone(sheetId, zone);

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -15,6 +15,7 @@ export interface Range extends Cloneable<Range> {
   readonly invalidSheetName?: string;
   /** the sheet on which the range is defined */
   readonly sheetId: UID;
+  readonly rangeData: RangeData;
 }
 
 export interface RangeData {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -403,8 +403,12 @@ export function target(str: string): Zone[] {
   return str.split(",").map(zone);
 }
 
+export function toRangeData(sheetId: UID, xc: string): RangeData {
+  return { _zone: toUnboundedZone(xc), _sheetId: sheetId };
+}
+
 export function toRangesData(sheetId: UID, str: string): RangeData[] {
-  return str.split(",").map((xc) => ({ _zone: toUnboundedZone(xc), _sheetId: sheetId }));
+  return str.split(",").map((xc) => toRangeData(sheetId, xc));
 }
 
 export function createEqualCF(


### PR DESCRIPTION
## Description:

Previously when moving or resizing highlights, the unbounded property of the zone will not be kept. 

This PR uses the unbounded zone as the parameter type of the changing highlight command so this property is kept. 



Odoo task ID : [3122611](https://www.odoo.com/web#id=3122611&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo