### PR TITLE
[FIX] range: show ref error after removing col/row in formulas

### DIFF
--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -65,6 +65,9 @@ export function isZoneValid(zone: Zone): boolean {
   if (isNaN(zone.bottom) || isNaN(zone.top) || isNaN(zone.left) || isNaN(zone.right)) {
     return false;
   }
+  if (zone.top < 0 || zone.left < 0 || zone.right < 0 || zone.bottom < 0) {
+    return false;
+  }
   return zone.bottom >= zone.top && zone.right >= zone.left;
 }
 

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -67,6 +67,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
               newRange = this.createAdaptedRange(newRange, dimension, changeType, -toRemove);
             } else if (range.zone[start] >= min && range.zone[end] <= max) {
               changeType = "REMOVE";
+              newRange = this.buildInvalidRange(INCORRECT_RANGE_STRING);
             } else if (range.zone[start] <= max && range.zone[end] >= max) {
               const toRemove = max - range.zone[start] + 1;
               changeType = "RESIZE";
@@ -136,10 +137,8 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
             return { changeType: "NONE" };
           }
           range = {
-            ...range,
-            zone: { ...range.zone },
+            ...this.buildInvalidRange(INCORRECT_RANGE_STRING),
             invalidSheetName: this.getters.getSheetName(cmd.sheetId),
-            sheetId: "",
           };
           return { changeType: "REMOVE", range };
         }, cmd.sheetId);

--- a/tests/formulas/formulas.test.ts
+++ b/tests/formulas/formulas.test.ts
@@ -1,6 +1,12 @@
 import { Model, normalize } from "../../src";
 import { INCORRECT_RANGE_STRING } from "../../src/constants";
-import { createSheetWithName } from "../test_helpers/commands_helpers";
+import {
+  createSheetWithName,
+  deleteColumns,
+  deleteRows,
+  setCellContent,
+} from "../test_helpers/commands_helpers";
+import { getCellContent, getCellText } from "../test_helpers/getters_helpers";
 
 function moveFormula(model: Model, formula: string, offsetX: number, offsetY: number): string {
   const sheetId = model.getters.getActiveSheetId();
@@ -98,5 +104,40 @@ describe("createAdaptedRanges", () => {
     const model = new Model();
     createSheetWithName(model, { sheetId: "42" }, "Sheet 2");
     expect(moveFormula(model, "='Sheet 2'!B2", 1, 10)).toEqual("='Sheet 2'!C12");
+  });
+});
+
+describe("Remove columns/rows that are references of formula", () => {
+  let model: Model;
+  beforeEach(() => {
+    model = new Model();
+  });
+
+  test("delete multiple columns, including the one in formula and the one before it", () => {
+    setCellContent(model, "A1", "=SUM(C1,D1)");
+    deleteColumns(model, ["B", "C"]);
+    expect(getCellContent(model, "A1")).toEqual("#ERROR");
+    expect(getCellText(model, "A1")).toEqual("=SUM(#REF,B1)");
+  });
+
+  test("delete multiple columns, including the one in formula and the one after it", () => {
+    setCellContent(model, "A1", "=SUM(C1,D1)");
+    deleteColumns(model, ["C", "D"]);
+    expect(getCellContent(model, "A1")).toEqual("#ERROR");
+    expect(getCellText(model, "A1")).toEqual("=SUM(#REF,#REF)");
+  });
+
+  test("delete multiple rows, including the one in formula and the one before it", () => {
+    setCellContent(model, "A1", "=SUM(C3,C4)");
+    deleteRows(model, [1, 2]);
+    expect(getCellContent(model, "A1")).toEqual("#ERROR");
+    expect(getCellText(model, "A1")).toEqual("=SUM(#REF,C2)");
+  });
+
+  test("delete multiple rows, including the one in formula and the one after it", () => {
+    setCellContent(model, "A1", "=SUM(C3,C4)");
+    deleteRows(model, [2, 3]);
+    expect(getCellContent(model, "A1")).toEqual("#ERROR");
+    expect(getCellText(model, "A1")).toEqual("=SUM(#REF,#REF)");
   });
 });

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -39,7 +39,7 @@ class PluginTestRange extends CorePlugin {
       const change = applyChange(range);
       switch (change.changeType) {
         case "REMOVE":
-          this.ranges.splice(i, 1);
+          this.ranges[i] = change.range;
           break;
         case "RESIZE":
         case "MOVE":
@@ -80,8 +80,8 @@ describe("range plugin", () => {
   beforeEach(() => {
     m = new Model({
       sheets: [
-        { id: "s1", name: "s1", rows: 10, cols: 10 },
-        { id: "s2", name: "s 2", rows: 10, cols: 10 },
+        { id: "s1", name: "s1" },
+        { id: "s2", name: "s 2" },
       ],
     });
     m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["B2:D4"] });
@@ -124,6 +124,59 @@ describe("range plugin", () => {
       });
     });
 
+    describe("create a range and remove multiple columns", () => {
+      beforeEach(() => {
+        m = new Model({
+          sheets: [
+            { id: "s1", name: "s1" },
+            { id: "s2", name: "s 2" },
+          ],
+        });
+        m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["C2:F5"] });
+      });
+
+      test("in the middle", () => {
+        deleteColumns(m, ["D", "E"]);
+        expect(m.getters.getUsedRanges()).toEqual(["C2:D5"]);
+      });
+
+      test("in the start", () => {
+        deleteColumns(m, ["B", "C"]);
+        expect(m.getters.getUsedRanges()).toEqual(["B2:D5"]);
+      });
+
+      test("in the end", () => {
+        deleteColumns(m, ["E", "F"]);
+        expect(m.getters.getUsedRanges()).toEqual(["C2:D5"]);
+      });
+
+      test("before the start", () => {
+        deleteColumns(m, ["A", "B"]);
+        expect(m.getters.getUsedRanges()).toEqual(["A2:D5"]);
+      });
+
+      test("after the end", () => {
+        deleteColumns(m, ["G", "H"]);
+        expect(m.getters.getUsedRanges()).toEqual(["C2:F5"]);
+      });
+
+      test("including one column before the start and the first column", () => {
+        deleteColumns(m, ["C", "B"]);
+        expect(m.getters.getUsedRanges()).toEqual(["B2:D5"]);
+      });
+
+      test("including one column after the end and the last column", () => {
+        deleteColumns(m, ["G", "F"]);
+        expect(m.getters.getUsedRanges()).toEqual(["C2:E5"]);
+      });
+
+      test("delete columns causing invalid reference will be marked as #REF", () => {
+        m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["C1"] });
+        deleteColumns(m, ["B", "C"]);
+        expect(m.getters.getUsedRanges()[1]).toEqual("#REF");
+      });
+    });
+
     describe("create a range and remove a row", () => {
       test("in the middle", () => {
         deleteRows(m, [2]);
@@ -154,6 +207,61 @@ describe("range plugin", () => {
         createSheet(m, { sheetId: "42" });
         deleteRows(m, [0], "42");
         expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
+      });
+    });
+
+    describe("create a range and remove multiple rows", () => {
+      beforeEach(() => {
+        m = new Model({
+          sheets: [
+            { id: "s1", name: "s1" },
+            { id: "s2", name: "s 2" },
+          ],
+        });
+        m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["C3:F7"] });
+      });
+
+      test("in the middle", () => {
+        deleteRows(m, [3, 4]);
+        expect(m.getters.getUsedRanges()).toEqual(["C3:F5"]);
+      });
+
+      test("in the start", () => {
+        deleteRows(m, [2, 3]);
+        expect(m.getters.getUsedRanges()).toEqual(["C3:F5"]);
+      });
+
+      test("in the end", () => {
+        deleteRows(m, [5, 6]);
+        expect(m.getters.getUsedRanges()).toEqual(["C3:F5"]);
+      });
+
+      test("including one row before start and the first row", () => {
+        deleteRows(m, [1, 2]);
+        expect(m.getters.getUsedRanges()).toEqual(["C2:F5"]);
+      });
+
+      test("including one row after end and the last row", () => {
+        deleteRows(m, [6, 7]);
+        expect(m.getters.getUsedRanges()).toEqual(["C3:F6"]);
+      });
+
+      test("before the start", () => {
+        deleteRows(m, [0, 1]);
+        expect(m.getters.getUsedRanges()).toEqual(["C1:F5"]);
+      });
+
+      test("after the end", () => {
+        deleteRows(m, [7, 8]);
+        expect(m.getters.getUsedRanges()).toEqual(["C3:F7"]);
+      });
+
+      test("delete rows causing invalid reference will be marked as #REF", () => {
+        m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["C3"] });
+        deleteRows(m, [1, 2]);
+        expect(m.getters.getUsedRanges().length).toEqual(2);
+        expect(m.getters.getUsedRanges()[0]).toEqual("C2:F5");
+        expect(m.getters.getUsedRanges()[1]).toEqual("#REF");
       });
     });
 
@@ -283,7 +391,7 @@ describe("range plugin", () => {
         m.dispatch("USE_RANGE", { rangesXC: ["A1"], sheetId: "s2" });
         expect(m.getters.getUsedRanges()).toEqual(["B2:D4", "'s 2'!A1"]);
         deleteSheet(m, "s2");
-        expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
+        expect(m.getters.getUsedRanges()).toEqual(["B2:D4", "#REF"]);
       });
     });
 
@@ -297,7 +405,7 @@ describe("range plugin", () => {
         m.dispatch("USE_RANGE", { rangesXC: ["A1"], sheetId: "s2" });
         expect(m.getters.getUsedRanges()).toEqual(["B2:D4", "'s 2'!A1"]);
         deleteSheet(m, "s2");
-        expect(m.getters.getUsedRanges()).toEqual(["B2:D4"]);
+        expect(m.getters.getUsedRanges()).toEqual(["B2:D4", "#REF"]);
       });
     });
   });

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -809,7 +809,7 @@ describe("sheets", () => {
     const sheet2 = model.getters.getActiveSheetId();
     setCellContent(model, "A1", "42");
     model.dispatch("DELETE_SHEET", { sheetId: sheet2 });
-    expect(getCellText(model, "A1")).toBe("=NEW_NAME!A1");
+    expect(getCellText(model, "A1")).toBe("=#REF");
     expect(getCell(model, "A1")?.evaluated.value).toBe("#ERROR");
     undo(model);
     activateSheet(model, sheet1);


### PR DESCRIPTION
## Description:

Previouly after we remove cols/rows that are used in formulas, the formula will not show error reminding invalid references, but keep the previous range and give the wrong results.

This PR fixes this problem. After deleting rows/cols the formulas refer to removed ones will show errors. It's done by change `newRange` when removing into an invalid range. 

The tests are co-authored with Adrien Minne (@hokolomopo).

Odoo task ID : [2719611](https://www.odoo.com/web#id=2719611&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo