### PR TITLE
[IMP] rollup: improve argument handling of rollup.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "serve": "live-server --open=demo",
     "dev": "npm-run-all  build --parallel serve \"build:* -- --watch\"",
     "build:js": "tsc --module es6 --incremental",
-    "build:bundle": "rollup -c -m dev",
+    "build:bundle": "rollup -c -m --configDev",
     "build": "npm run build:js && npm run build:bundle",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,14 +34,14 @@ function getConfigForFormat(format, minified = false) {
   };
 }
 
-let output = [];
-let input = "";
-let plugins = [];
-let config = {};
+export default (commandLineArgs) => {
+  let output = [];
+  let input = "";
+  let plugins = [];
+  let config = {};
 
-switch (process.argv[4]) {
-  // Only build iife version to improve speed
-  case "dev":
+  if (commandLineArgs.configDev) {
+    // Only build iife version to improve speed
     input = "build/js/index.js";
     output = [
       {
@@ -59,8 +59,7 @@ switch (process.argv[4]) {
       output,
       plugins,
     };
-    break;
-  default:
+  } else {
     input = "src/index.ts";
     output = [
       getConfigForFormat("esm"),
@@ -82,7 +81,7 @@ switch (process.argv[4]) {
         plugins: [dts()],
       },
     ];
-    break;
-}
+  }
 
-export default config;
+  return config;
+};


### PR DESCRIPTION
Currently we use `process.argv[4]` to decide if we use rollup for dev or release mode. This is not very robust and can break if we add more arguments to rollup, or arguments in a different order.

Use the official way of passing arguments with rollup instead, which pass all arguments prefixed by `config` to the config file.

https://rollupjs.org/command-line-interface/#configuration-files

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo