### PR TITLE
[IMP] bundle_xml: use library to parse bundle:xml arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "jszip": "^3.6.0",
         "lint-staged": "^12.1.2",
         "live-server": "^1.2.1",
+        "minimist": "^1.2.8",
         "mockdate": "^3.0.2",
         "node-watch": "^0.7.3",
         "npm-run-all": "^4.1.5",
@@ -7818,10 +7819,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -17161,9 +17165,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "mixin-deep": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@prettier/plugin-xml": "^2.0.1",
     "@rollup/plugin-node-resolve": "^11.0.1",
+    "@rollup/plugin-terser": "^0.2.0",
     "@types/chart.js": "2.9.3",
     "@types/jest": "^27.0.1",
     "@types/node": "^13.13.23",
@@ -74,6 +75,7 @@
     "jszip": "^3.6.0",
     "lint-staged": "^12.1.2",
     "live-server": "^1.2.1",
+    "minimist": "^1.2.8",
     "mockdate": "^3.0.2",
     "node-watch": "^0.7.3",
     "npm-run-all": "^4.1.5",
@@ -81,7 +83,6 @@
     "prettier-plugin-organize-imports": "^3.1.1",
     "rollup": "^2.38.5",
     "rollup-plugin-dts": "^4.2.0",
-    "@rollup/plugin-terser": "^0.2.0",
     "rollup-plugin-typescript2": "^0.34.1",
     "ts-jest": "^27.0.5",
     "typedoc": "0.23.15",

--- a/tools/bundle_xml/bundle_xml_templates.js
+++ b/tools/bundle_xml/bundle_xml_templates.js
@@ -57,9 +57,12 @@ async function createOwlTemplateBundle(files, removeRootTags) {
 /**
  * Write the xml bundle to the `dist` directory
  */
-async function writeOwlTemplateBundleToFile(dir) {
+async function writeOwlTemplateBundleToFile(dir, outro = "") {
   process.stdout.write(`Building xml template bundle in "${dir}/" ...`);
   let templateBundle = await getOwlTemplatesBundle(true);
+  if (outro) {
+    templateBundle += "<!--" + outro + "-->";
+  }
   templateBundle = prettify(templateBundle);
   writeToFile(path.join(__dirname, `../../${dir}/o_spreadsheet.xml`), templateBundle);
   process.stdout.write("done\n");

--- a/tools/bundle_xml/main.js
+++ b/tools/bundle_xml/main.js
@@ -1,8 +1,22 @@
+const { version } = require("../../package.json");
+const git = require("git-rev-sync");
 const bundle = require("./bundle_xml_templates");
+const parseArgs = require("minimist");
 
 const DEFAULT_DIR = "dist";
 
-const outDirFlagIndex = process.argv.findIndex((arg) => arg === "--outDir");
-const outDir = outDirFlagIndex !== -1 ? process.argv[outDirFlagIndex + 1] : DEFAULT_DIR;
+const argv = parseArgs(process.argv.slice(2));
 
-bundle.writeOwlTemplateBundleToFile(outDir || DEFAULT_DIR);
+let commitHash = "";
+
+try {
+  commitHash = git.short();
+} catch (_) {}
+
+const OUTRO = `
+  __info__.version = '${version}';
+  __info__.date = '${new Date().toISOString()}';
+  __info__.hash = '${commitHash}';
+`;
+
+bundle.writeOwlTemplateBundleToFile(argv.outDir || DEFAULT_DIR, OUTRO);


### PR DESCRIPTION
This commit replace the parsing by hand of the arguments of the script bundling xml by the library minimist.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo