### PR TITLE
[IMP] spreadsheet: separate ZoneDimension and PixelDimension

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -4,10 +4,10 @@ import { EnrichedToken } from "../../../formulas/index";
 import { functionRegistry } from "../../../functions/index";
 import {
   fuzzyLookup,
+  getZoneArea,
   isEqual,
   rangeReference,
   splitReference,
-  zoneToDimension,
 } from "../../../helpers/index";
 import { ComposerSelection } from "../../../plugins/ui_stateful/edition";
 import {
@@ -603,8 +603,7 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
 
       const range = this.env.model.getters.getRangeFromSheetXC(refSheet, xc);
       let zone = range.zone;
-      const { height, width } = zoneToDimension(zone);
-      zone = height * width === 1 ? this.env.model.getters.expandZone(refSheet, zone) : zone;
+      zone = getZoneArea(zone) === 1 ? this.env.model.getters.expandZone(refSheet, zone) : zone;
       return isEqual(zone, highlight.zone);
     });
     return highlight && highlight.color ? highlight.color : undefined;

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -13,7 +13,6 @@ import { getTextDecoration } from "../../helpers";
 import { css, cssPropertiesToCss } from "../../helpers/css";
 import { ComposerFocusType } from "../../spreadsheet/spreadsheet";
 import { Composer } from "../composer/composer";
-import { ZoneDimension } from "./../../../types/misc";
 
 const COMPOSER_BORDER_WIDTH = 3 * 0.4 * window.devicePixelRatio || 1;
 const GRID_CELL_REFERENCE_TOP_OFFSET = 28;
@@ -50,7 +49,7 @@ interface Props {
   focus: ComposerFocusType;
   onComposerUnmounted: () => void;
   onComposerContentFocused: (selection: ComposerSelection) => void;
-  gridDims: ZoneDimension;
+  gridDims: DOMDimension;
 }
 
 /**

--- a/src/helpers/clipboard/clipboard_os_state.ts
+++ b/src/helpers/clipboard/clipboard_os_state.ts
@@ -40,9 +40,9 @@ export class ClipboardOsState extends ClipboardCellsAbstractState {
     const values = this.values;
     const pasteZone = this.getPasteZone(target);
     const { left: activeCol, top: activeRow } = pasteZone;
-    const { width, height } = zoneToDimension(pasteZone);
+    const { numberOfCols, numberOfRows } = zoneToDimension(pasteZone);
     const sheetId = this.getters.getActiveSheetId();
-    this.addMissingDimensions(width, height, activeCol, activeRow);
+    this.addMissingDimensions(numberOfCols, numberOfRows, activeCol, activeRow);
     for (let i = 0; i < values.length; i++) {
       for (let j = 0; j < values[i].length; j++) {
         this.dispatch("UPDATE_CELL", {
@@ -56,8 +56,8 @@ export class ClipboardOsState extends ClipboardCellsAbstractState {
     const zone = {
       left: activeCol,
       top: activeRow,
-      right: activeCol + width - 1,
-      bottom: activeRow + height - 1,
+      right: activeCol + numberOfCols - 1,
+      bottom: activeRow + numberOfRows - 1,
     };
     this.selection.selectZone({ cell: { col: activeCol, row: activeRow }, zone });
   }

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -242,10 +242,10 @@ export function toExcelDataset(getters: CoreGetters, ds: DataSet): ExcelChartDat
   const labelZone = ds.labelCell?.zone;
   let dataZone = ds.dataRange.zone;
   if (labelZone) {
-    const { height, width } = zoneToDimension(dataZone);
-    if (height === 1) {
+    const { numberOfRows, numberOfCols } = zoneToDimension(dataZone);
+    if (numberOfRows === 1) {
       dataZone = { ...dataZone, left: dataZone.left + 1 };
-    } else if (width === 1) {
+    } else if (numberOfCols === 1) {
       dataZone = { ...dataZone, top: dataZone.top + 1 };
     }
   }

--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../constants";
 import {
   Dimension,
+  DOMDimension,
   Getters,
   HeaderIndex,
   Pixel,
@@ -8,7 +9,6 @@ import {
   Rect,
   UID,
   Zone,
-  ZoneDimension,
 } from "../types";
 import { intersection, isInside } from "./zones";
 
@@ -55,7 +55,7 @@ export class InternalViewport {
 
   // PUBLIC
 
-  getMaxSize(): ZoneDimension {
+  getMaxSize(): DOMDimension {
     const lastCol = this.getters.findLastVisibleColRowIndex(this.sheetId, "COL", {
       first: this.boundaries.left,
       last: this.boundaries.right,

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -56,9 +56,9 @@ export class RangeImpl implements Range {
     const { left, top, bottom, right } = this._zone;
     if (right !== undefined && bottom !== undefined) return { left, top, right, bottom };
     else if (bottom === undefined && right !== undefined) {
-      return { right, top, left, bottom: this.getSheetSize(this.sheetId).height - 1 };
+      return { right, top, left, bottom: this.getSheetSize(this.sheetId).numberOfRows - 1 };
     } else if (right === undefined && bottom !== undefined) {
-      return { bottom, left, top, right: this.getSheetSize(this.sheetId).width - 1 };
+      return { bottom, left, top, right: this.getSheetSize(this.sheetId).numberOfCols - 1 };
     }
     throw new Error(_lt("Bad zone format"));
   }

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -477,14 +477,14 @@ function positionsDifference(positions: readonly Position[], toRemove: readonly 
 
 export function zoneToDimension(zone: Zone): ZoneDimension {
   return {
-    height: zone.bottom - zone.top + 1,
-    width: zone.right - zone.left + 1,
+    numberOfRows: zone.bottom - zone.top + 1,
+    numberOfCols: zone.right - zone.left + 1,
   };
 }
 
 export function isOneDimensional(zone: Zone): boolean {
-  const { width, height } = zoneToDimension(zone);
-  return width === 1 || height === 1;
+  const { numberOfCols, numberOfRows } = zoneToDimension(zone);
+  return numberOfCols === 1 || numberOfRows === 1;
 }
 
 /**

--- a/src/plugins/core/filters.ts
+++ b/src/plugins/core/filters.ts
@@ -200,7 +200,7 @@ export class FiltersPlugin extends CorePlugin<FiltersState> implements FiltersSt
       }
 
       // Add filters for new columns
-      if (filters.length < zoneToDimension(zone).width) {
+      if (filters.length < zoneToDimension(zone).numberOfCols) {
         for (let col = zone.left; col <= zone.right; col++) {
           if (!filters.find((filter) => filter.col === col)) {
             filters.push(

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -268,8 +268,8 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     if (merge) {
       return isEqual(zone, merge);
     }
-    const { width, height } = zoneToDimension(zone);
-    return width === 1 && height === 1;
+    const { numberOfCols, numberOfRows } = zoneToDimension(zone);
+    return numberOfCols === 1 && numberOfRows === 1;
   }
   // ---------------------------------------------------------------------------
   // Merges
@@ -454,8 +454,8 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
             this.removeMerge(sheetId, currentZone);
             break;
           default:
-            const { width, height } = zoneToDimension(result.range.zone);
-            if (width === 1 && height === 1) {
+            const { numberOfCols, numberOfRows } = zoneToDimension(result.range.zone);
+            if (numberOfCols === 1 && numberOfRows === 1) {
               this.removeMerge(sheetId, currentZone);
             } else {
               this.history.update("merges", sheetId, parseInt(mergeId, 10), result.range);

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -415,8 +415,8 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
 
   getSheetSize(sheetId: UID): ZoneDimension {
     return {
-      height: this.getNumberRows(sheetId),
-      width: this.getNumberCols(sheetId),
+      numberOfRows: this.getNumberRows(sheetId),
+      numberOfCols: this.getNumberCols(sheetId),
     };
   }
 

--- a/src/plugins/ui_core_views/filter_evaluation.ts
+++ b/src/plugins/ui_core_views/filter_evaluation.ts
@@ -217,7 +217,7 @@ export class FilterEvaluationPlugin extends UIPlugin {
         const tableZone = toZone(tableData.range);
         const filters: ExcelFilterData[] = [];
         const headerNames: string[] = [];
-        for (const i of range(0, zoneToDimension(tableZone).width)) {
+        for (const i of range(0, zoneToDimension(tableZone).numberOfCols)) {
           const position = {
             sheetId: sheetData.id,
             col: tableZone.left + i,

--- a/src/plugins/ui_core_views/sheetview.ts
+++ b/src/plugins/ui_core_views/sheetview.ts
@@ -9,6 +9,7 @@ import {
   CommandResult,
   Dimension,
   DOMCoordinates,
+  DOMDimension,
   EdgeScrollInfo,
   Figure,
   HeaderIndex,
@@ -22,7 +23,6 @@ import {
   UID,
   Viewport,
   Zone,
-  ZoneDimension,
 } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
@@ -268,14 +268,14 @@ export class SheetViewPlugin extends UIPlugin {
     return Math.max(...this.getSubViewports(sheetId).map((viewport) => viewport.getRowIndex(y)));
   }
 
-  getSheetViewDimensionWithHeaders(): ZoneDimension {
+  getSheetViewDimensionWithHeaders(): DOMDimension {
     return {
       width: this.sheetViewWidth + this.gridOffsetX,
       height: this.sheetViewHeight + this.gridOffsetY,
     };
   }
 
-  getSheetViewDimension(): ZoneDimension {
+  getSheetViewDimension(): DOMDimension {
     return {
       width: this.sheetViewWidth,
       height: this.sheetViewHeight,

--- a/src/plugins/ui_feature/automatic_sum.ts
+++ b/src/plugins/ui_feature/automatic_sum.ts
@@ -227,7 +227,7 @@ export class AutomaticSumPlugin extends UIPlugin {
   private dimensionsToSum(sheetId: UID, zone: Zone): Set<Dimension> {
     const dimensions = new Set<Dimension>();
     if (isOneDimensional(zone)) {
-      dimensions.add(zoneToDimension(zone).width === 1 ? "COL" : "ROW");
+      dimensions.add(zoneToDimension(zone).numberOfCols === 1 ? "COL" : "ROW");
       return dimensions;
     }
     if (this.lastColIsEmpty(sheetId, zone)) {

--- a/src/plugins/ui_feature/highlight.ts
+++ b/src/plugins/ui_feature/highlight.ts
@@ -33,9 +33,9 @@ export class HighlightPlugin extends UIPlugin {
           x.zone.right < this.getters.getNumberCols(x.sheetId)
       )
       .map((highlight) => {
-        const { height, width } = zoneToDimension(highlight.zone);
+        const { numberOfRows, numberOfCols } = zoneToDimension(highlight.zone);
         const zone =
-          height * width === 1
+          numberOfRows * numberOfCols === 1
             ? this.getters.expandZone(highlight.sheetId, highlight.zone)
             : highlight.zone;
         return {

--- a/src/plugins/ui_feature/sort.ts
+++ b/src/plugins/ui_feature/sort.ts
@@ -61,7 +61,7 @@ export class SortPlugin extends UIPlugin {
     const merges = this.getters.getMerges(sheetId).filter((merge) => overlap(merge, zone));
     /*Test the presence of merges of different sizes*/
     const mergeDimension = zoneToDimension(merges[0]);
-    let [widthFirst, heightFirst] = [mergeDimension.width, mergeDimension.height];
+    let [widthFirst, heightFirst] = [mergeDimension.numberOfCols, mergeDimension.numberOfRows];
     if (
       !merges.every((merge) => {
         let [widthCurrent, heightCurrent] = [

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -85,8 +85,8 @@ export interface UnboundedZone {
 }
 
 export interface ZoneDimension {
-  height: HeaderIndex;
-  width: HeaderIndex;
+  numberOfRows: HeaderIndex;
+  numberOfCols: HeaderIndex;
 }
 
 export type Align = "left" | "right" | "center" | undefined;

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -1,12 +1,5 @@
 import { Alias, Align, Border, Pixel, Style, VerticalAlign, Zone } from "./misc";
 
-export type Rect = {
-  x: Pixel;
-  y: Pixel;
-  width: Pixel;
-  height: Pixel;
-};
-
 /**
  * Coordinate in pixels
  */
@@ -14,6 +7,13 @@ export interface DOMCoordinates {
   x: Pixel;
   y: Pixel;
 }
+
+export interface DOMDimension {
+  width: Pixel;
+  height: Pixel;
+}
+
+export type Rect = DOMCoordinates & DOMDimension;
 
 export interface BoxTextContent {
   textLines: string[];
@@ -38,11 +38,6 @@ export interface Image {
   size: Pixel;
   type: "icon"; //| "Picture"
   image: HTMLImageElement;
-}
-
-export interface DOMDimension {
-  width: Pixel;
-  height: Pixel;
 }
 
 /**

--- a/src/xlsx/functions/table.ts
+++ b/src/xlsx/functions/table.ts
@@ -44,7 +44,7 @@ function addAutoFilter(table: ExcelFilterTableData): XMLString {
 function addFilterColumns(table: ExcelFilterTableData): XMLString[] {
   const tableZone = toZone(table.range);
   const columns: XMLString[] = [];
-  for (const i of range(0, zoneToDimension(tableZone).width)) {
+  for (const i of range(0, zoneToDimension(tableZone).numberOfCols)) {
     const filter = table.filters[i];
     if (!filter || !filter.filteredValues.length) {
       continue;
@@ -73,7 +73,7 @@ function addFilter(filter: ExcelFilterData): XMLString {
 function addTableColumns(table: ExcelFilterTableData, sheetData: ExcelSheetData): XMLString {
   const tableZone = toZone(table.range);
   const columns: XMLString[] = [];
-  for (const i of range(0, zoneToDimension(tableZone).width)) {
+  for (const i of range(0, zoneToDimension(tableZone).numberOfCols)) {
     const colHeaderXc = toXC(tableZone.left + i, tableZone.top);
     const colName = sheetData.cells[colHeaderXc]?.content || `col${i}`;
     const colAttributes: XMLAttributes = [


### PR DESCRIPTION
## Description

We currently have getters/helpers that return a size/dimension in `{width; height}`, but sometime the width is in pixel, and sometimes it's in columns. It is sometime unclear which is which without looking at the getter.

The goal here is to clarify this situation by defining 2 interfaces to avoid confusion:

- ZoneDimension : `{ nOfCols, nOfRows }`
- PixelDimension: `{width, height}`

Odoo task ID : [3217977](https://www.odoo.com/web#id=3217977&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo