### PR TITLE
[FIX] chart_scorecard: adjusted title and baseline description colors

### DIFF
--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -120,7 +120,7 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get secondaryFontColor() {
-    return relativeLuminance(this.primaryFontColor) <= 0.3 ? "#757575" : "#bbbbbb";
+    return relativeLuminance(this.backgroundColor) > 0.3 ? "#525252" : "#C8C8C8";
   }
 
   get figure() {

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -53,7 +53,7 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
         style="
 font-size: 18px;
 display: inline-block;
-color: #757575;
+color: #525252;
 "
       >
         hello
@@ -113,7 +113,7 @@ color: #00A04A;
             style="
 font-size: 33.55526293945314px;
 display: inline-block;
-color: #757575;
+color: #525252;
 "
           >
              description
@@ -184,7 +184,7 @@ cursor: grabbing;
         style="
 font-size: 18px;
 display: inline-block;
-color: #757575;
+color: #525252;
 "
       >
         hello
@@ -244,7 +244,7 @@ color: #00A04A;
             style="
 font-size: 14.764795898437502px;
 display: inline-block;
-color: #757575;
+color: #525252;
 "
           >
              description

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -180,7 +180,7 @@ describe("Scorecard charts", () => {
 
     expect(getChartElement()).toBeTruthy();
     expect(getChartBaselineTextContent()).toEqual("1");
-    expect(toHex(getChartBaselineTextElement()!.style["color"])).toEqual("#757575");
+    expect(toHex(getChartBaselineTextElement()!.style["color"])).toEqual("#525252");
   });
 
   test("Key < baseline display in red with down arrow", async () => {
@@ -206,7 +206,7 @@ describe("Scorecard charts", () => {
 
     const baselineElement = getChartBaselineElement();
     expect(baselineElement.querySelector("svg")).toBeFalsy();
-    expect(toHex(baselineElement.querySelector("span")!.style["color"])).toEqual("#757575");
+    expect(toHex(baselineElement.querySelector("span")!.style["color"])).toEqual("#525252");
     expect(getChartBaselineTextContent()).toEqual("0");
   });
 
@@ -319,9 +319,9 @@ describe("Scorecard charts", () => {
       chartId
     );
 
-    expect(toHex(getChartTitleElement()!.style["color"])).toEqual("#BBBBBB");
-    expect(toHex(getChartBaselineTextElement()!.style["color"])).toEqual("#BBBBBB");
-    expect(toHex(getChartBaselineDescrElement()!.style["color"])).toEqual("#BBBBBB");
+    expect(toHex(getChartTitleElement()!.style["color"])).toEqual("#C8C8C8");
+    expect(toHex(getChartBaselineTextElement()!.style["color"])).toEqual("#C8C8C8");
+    expect(toHex(getChartBaselineDescrElement()!.style["color"])).toEqual("#C8C8C8");
     expect(toHex(getChartKeyElement()!.style["color"])).toEqual("#FFFFFF");
   });
 


### PR DESCRIPTION
## Description:

Earlier color of the chart title and description in the Scorecard were shades of grey, that's why they appeared too similar upon change of background. A slight tweak in color shades fixed this issue.

Odoo task ID : [3216001](https://www.odoo.com/web#id=3216001&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo