### PR TITLE
[FIX] correctly auto-size o-spreadsheet

### DIFF
--- a/demo/main.css
+++ b/demo/main.css
@@ -2,16 +2,10 @@
   font-size: 12px;
 }
 
-html {
-  height: 100%;
-}
 body {
-  height: 100%;
-  margin: 0px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Ubuntu,
     "Noto Sans", Arial, sans-serif !important;
 }
 .o-spreadsheet {
-  width: 100%;
   height: 100%;
 }

--- a/demo/main.js
+++ b/demo/main.js
@@ -66,7 +66,7 @@ let start;
 
 class Demo extends Component {
   setup() {
-    this.state = useState({ key: 0 });
+    this.state = useState({ key: 0, displayHeader: false });
     this.stateUpdateMessages = [];
     this.client = {
       id: uuidGenerator.uuidv4(),
@@ -92,6 +92,11 @@ class Demo extends Component {
       sequence: 13,
       isReadonlyAllowed: true,
       action: () => this.model.updateMode("normal"),
+    });
+    topbarMenuRegistry.addChild("read_write", ["file"], {
+      name: () => (this.state.displayHeader ? "Hide header" : "Show header"),
+      isReadonlyAllowed: true,
+      action: () => (this.state.displayHeader = !this.state.displayHeader),
     });
 
     topbarMenuRegistry.add("notify", {
@@ -262,9 +267,16 @@ class Demo extends Component {
 }
 
 Demo.template = xml/* xml */ `
-  <div>
+  <div t-if="state.displayHeader" class="d-flex flex flex-column justify-content vh-100">
+    <div class="p-3 border-bottom">A header</div>
+    <div class="flex-fill">
+      <Spreadsheet model="model" t-key="state.key"/>
+    </div>
+  </div>
+  <div t-else="">
     <Spreadsheet model="model" t-key="state.key"/>
-  </div>`;
+  </div>
+`;
 Demo.components = { Spreadsheet };
 
 // Setup code

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -209,8 +209,15 @@ export enum ComponentsImportance {
   FigureAnchor = 1000,
   FigureSnapLine = 1001,
 }
+let DEFAULT_SHEETVIEW_SIZE = 0;
 
-export const DEFAULT_SHEETVIEW_SIZE = 1000;
+export function getDefaultSheetViewSize() {
+  return DEFAULT_SHEETVIEW_SIZE;
+}
+
+export function setDefaultSheetViewSize(size: number) {
+  DEFAULT_SHEETVIEW_SIZE = size;
+}
 
 export const MAXIMAL_FREEZABLE_RATIO = 0.85;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ import { CellErrorLevel, EvaluationError } from "./types/errors";
 export const __info__ = {};
 export { Revision } from "./collaborative/revisions";
 export { Spreadsheet } from "./components/index";
-export { DATETIME_FORMAT } from "./constants";
+export { DATETIME_FORMAT, setDefaultSheetViewSize } from "./constants";
 export { compile, functionCache } from "./formulas/compiler";
 export { astToFormula, convertAstNodes, parse } from "./formulas/parser";
 export { tokenize } from "./formulas/tokenizer";

--- a/src/plugins/ui_core_views/sheetview.ts
+++ b/src/plugins/ui_core_views/sheetview.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SHEETVIEW_SIZE } from "../../constants";
+import { getDefaultSheetViewSize } from "../../constants";
 import { clip, findCellInNewZone, isDefined, range } from "../../helpers";
 import { scrollDelay } from "../../helpers/index";
 import { InternalViewport } from "../../helpers/internal_viewport";
@@ -108,8 +108,8 @@ export class SheetViewPlugin extends UIPlugin {
    * In the absence of a component (standalone model), is it mandatory to set reasonable default values
    * to ensure the correct operation of this plugin.
    */
-  private sheetViewWidth: Pixel = DEFAULT_SHEETVIEW_SIZE;
-  private sheetViewHeight: Pixel = DEFAULT_SHEETVIEW_SIZE;
+  private sheetViewWidth: Pixel = getDefaultSheetViewSize();
+  private sheetViewHeight: Pixel = getDefaultSheetViewSize();
   private gridOffsetX: Pixel = 0;
   private gridOffsetY: Pixel = 0;
 

--- a/tests/components/highlight.test.ts
+++ b/tests/components/highlight.test.ts
@@ -3,7 +3,7 @@ import { Highlight } from "../../src/components/highlight/highlight/highlight";
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
-  DEFAULT_SHEETVIEW_SIZE,
+  getDefaultSheetViewSize,
 } from "../../src/constants";
 import { toHex, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
@@ -132,8 +132,8 @@ async function mountHighlight(zone: string, color: Color): Promise<Parent> {
 const genericBeforeEach = async () => {
   model = new Model();
   model.dispatch("RESIZE_SHEETVIEW", {
-    width: DEFAULT_SHEETVIEW_SIZE,
-    height: DEFAULT_SHEETVIEW_SIZE,
+    width: getDefaultSheetViewSize(),
+    height: getDefaultSheetViewSize(),
     gridOffsetX: 0,
     gridOffsetY: 0,
   });

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -2,7 +2,7 @@ import { CommandResult } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
-  DEFAULT_SHEETVIEW_SIZE,
+  getDefaultSheetViewSize,
 } from "../../src/constants";
 import { isDefined, numberToLetters, range, toXC, toZone, zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
@@ -761,8 +761,8 @@ describe("Viewport of Simple sheet", () => {
   test("Resizing the viewport impacts current Offset", () => {
     // set coherent size and offset limit
     model.dispatch("RESIZE_SHEETVIEW", {
-      width: DEFAULT_SHEETVIEW_SIZE,
-      height: DEFAULT_SHEETVIEW_SIZE,
+      width: getDefaultSheetViewSize(),
+      height: getDefaultSheetViewSize(),
       gridOffsetX: 0,
       gridOffsetY: 0,
     });
@@ -1324,7 +1324,7 @@ describe("shift viewport up/down", () => {
     const { bottom } = model.getters.getActiveMainViewport();
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("RESIZE_SHEETVIEW", {
-      width: DEFAULT_SHEETVIEW_SIZE,
+      width: getDefaultSheetViewSize(),
       height: bottom * DEFAULT_CELL_HEIGHT,
       gridOffsetX: 0,
       gridOffsetY: 0,

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -1,6 +1,7 @@
 /**
  * This file will be run before each test file
  */
+import { setDefaultSheetViewSize } from "../../src/constants";
 import { getParsedOwlTemplateBundle } from "../../tools/bundle_xml/bundle_xml_templates";
 import "./canvas.mock";
 import "./jest_extend";
@@ -10,6 +11,7 @@ export let OWL_TEMPLATES: Document;
 
 beforeAll(async () => {
   OWL_TEMPLATES = await getParsedOwlTemplateBundle();
+  setDefaultSheetViewSize(1000);
 });
 
 beforeEach(() => {

--- a/tests/test_helpers/renderer_helpers.ts
+++ b/tests/test_helpers/renderer_helpers.ts
@@ -1,5 +1,5 @@
 import { Model } from "../../src";
-import { DEFAULT_SHEETVIEW_SIZE } from "../../src/constants";
+import { getDefaultSheetViewSize } from "../../src/constants";
 import { GridRenderingContext, Viewport, Zone } from "../../src/types";
 import { MockCanvasRenderingContext2D } from "../setup/canvas.mock";
 
@@ -56,7 +56,7 @@ export class MockGridRenderingContext implements GridRenderingContext {
  * outline around copied zones
  */
 export function watchClipboardOutline(model: Model) {
-  const sheetViewSize = DEFAULT_SHEETVIEW_SIZE;
+  const sheetViewSize = getDefaultSheetViewSize();
   let lineDash = false;
   let outlinedRects: any[][] = [];
   const ctx = new MockGridRenderingContext(model, sheetViewSize, sheetViewSize, {


### PR DESCRIPTION
## Description:

Sizing `o-spreadsheet` has always been difficult because it auto-size itself.

We've had cases where it would start with a sensible size but then shrink to 0 height (ever seen that when debugging QUnit tests ?).

We rely on `o-grid-overlay`'s natural size in the DOM to actually sync the size in the model.
However, its natural size was influenced by the initial state of the model.
Because the default size in the model was (1000, 1000) the canvas is sized to (1000,1000) and since the canvas is a child
of  `o-grid-overlay`, its natural size is ~ (1000, 1000).
You had to apply very strict css rules to `o-spreadsheet` or `o-grid-overlay` to force another size.
In particular, it didn't work well if you want css such that "`o-spreadsheet` fills the remaining place".
If the available space was smaller than 1000, it couldn't properly "fill the remaining space" because it was already larger!
A standard monitor height is 1080, taking into account, a header, the topbar and the bottom bar, you probably never have more than 1000 pixels available.

With this change, it's much easier to size `o-spreadsheet` the way you want because it's not influenced by it's initial default size. 

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo