### PR TITLE
[FIX] package: correctly name package entry files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",
   "module": "dist/o-spreadsheet.es.js",
-  "types": "dist/o_spreadsheet.d.ts",
+  "types": "dist/o-spreadsheet.d.ts",
   "files": [
     "dist/*.js",
     "dist/*.d.ts"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ __info__.hash = '${commitHash}';
  */
 function getConfigForFormat(format, minified = false) {
   return {
-    file: minified ? `dist/o_spreadsheet.${format}.min.js` : `dist/o_spreadsheet.${format}.js`,
+    file: minified ? `dist/o-spreadsheet.${format}.min.js` : `dist/o-spreadsheet.${format}.js`,
     format,
     name: "o_spreadsheet",
     extend: true,
@@ -77,7 +77,7 @@ export default (commandLineArgs) => {
       },
       {
         input: "dist/types/index.d.ts",
-        output: [{ file: "dist/o_spreadsheet.d.ts", format: "es" }],
+        output: [{ file: "dist/o-spreadsheet.d.ts", format: "es" }],
         plugins: [dts()],
       },
     ];


### PR DESCRIPTION
Files are named o-spreadsheet[...] in package.json but rollup generates o_spreadsheet[...] files

as a result any import fails because it's looking for a file that doesn't exist

`import { Model } from @odoo/o-spreadsheet`

=> Error: Cannot find module '/home/odoo/odoo/upgrade-spreadsheet-data/node_modules/@odoo/o-spreadsheet/dist/o-spreadsheet.cjs.js'.
   Please verify that the package.json has a valid "main" entry

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo