### PR TITLE
[FIX] ColorPicker: Convert custom string to valid HEX color

### DIFF
--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -5,7 +5,7 @@ import {
   MENU_SEPARATOR_BORDER_WIDTH,
   MENU_SEPARATOR_PADDING,
 } from "../../constants";
-import { hslaToRGBA, isColorValid, rgbaToHex } from "../../helpers";
+import { hslaToRGBA, isColorValid, rgbaToHex, toHex } from "../../helpers";
 import { chartFontColor } from "../../helpers/charts";
 import { Color, Pixel } from "../../types";
 import { SpreadsheetChildEnv } from "../../types/env";
@@ -224,7 +224,7 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
 
   onColorClick(color: Color) {
     if (color) {
-      this.props.onColorPicked(color);
+      this.props.onColorPicked(toHex(color));
     }
   }
 
@@ -242,8 +242,10 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
       this.state.isCurrentColorInvalid = true;
       return;
     }
+    const color = toHex(this.state.currentColor);
     this.state.isCurrentColorInvalid = false;
-    this.props.onColorPicked(this.state.currentColor);
+    this.props.onColorPicked(color);
+    this.state.currentColor = color;
   }
 
   toggleColorPicker() {

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1053,7 +1053,7 @@ describe("figures", () => {
         sheetId,
         definition: {
           ...model.getters.getChartDefinition(chartId),
-          baselineColorUp: "#0000ff",
+          baselineColorUp: "#0000FF",
         },
       });
 
@@ -1075,7 +1075,7 @@ describe("figures", () => {
         sheetId,
         definition: {
           ...model.getters.getChartDefinition(chartId),
-          baselineColorDown: "#ff0000",
+          baselineColorDown: "#FF0000",
         },
       });
     });

--- a/tests/components/color_picker.test.ts
+++ b/tests/components/color_picker.test.ts
@@ -91,7 +91,7 @@ describe("Color Picker buttons", () => {
     const onColorPicked = jest.fn();
     await mountColorPicker({ onColorPicked });
     await simulateClick("div[data-color='#ff9900']");
-    expect(onColorPicked).toHaveBeenCalledWith("#ff9900");
+    expect(onColorPicked).toHaveBeenCalledWith("#FF9900");
   });
 
   test("Can pick a custom color in the gradient", async () => {
@@ -100,13 +100,11 @@ describe("Color Picker buttons", () => {
     await simulateClick(".o-color-picker-toggler");
     await simulateClick(".o-gradient");
     const inputCodeEl = fixture.querySelector(".o-custom-input-preview input") as HTMLInputElement;
-    const previewColor = toHex(
-      getElComputedStyle(".o-color-preview", "backgroundColor")
-    ).toLowerCase();
-    const inputColorCode = inputCodeEl.value;
-    expect(previewColor).toEqual(inputColorCode.toLowerCase());
+    const previewColor = toHex(getElComputedStyle(".o-color-preview", "backgroundColor"));
+    const inputColorCode = toHex(inputCodeEl.value);
+    expect(previewColor).toEqual(inputColorCode);
     await simulateClick(".o-add-button");
-    expect(onColorPicked).toHaveBeenCalledWith(previewColor);
+    expect(onColorPicked).toHaveBeenCalledWith(inputColorCode);
   });
 
   test("Can choose a custom color with the input", async () => {
@@ -114,15 +112,25 @@ describe("Color Picker buttons", () => {
     await mountColorPicker({ onColorPicked });
     await simulateClick(".o-color-picker-toggler");
     await simulateClick(".o-gradient");
-    const color = "#12ef78";
-    setInputValueAndTrigger(".o-custom-input-preview input", "#12ef78", "input");
+    const color = "#12EF78";
+    setInputValueAndTrigger(".o-custom-input-preview input", color, "input");
     await nextTick();
-    const previewColor = toHex(
-      getElComputedStyle(".o-color-preview", "backgroundColor")
-    ).toLowerCase();
+    const previewColor = toHex(getElComputedStyle(".o-color-preview", "backgroundColor"));
     expect(previewColor).toEqual(color);
     await simulateClick(".o-add-button");
     expect(onColorPicked).toHaveBeenCalledWith(color);
+  });
+
+  test("Color from the input is sanitized", async () => {
+    const onColorPicked = jest.fn();
+    await mountColorPicker({ onColorPicked });
+    await simulateClick(".o-color-picker-toggler");
+    await simulateClick(".o-gradient");
+    const color = "12ef78";
+    setInputValueAndTrigger(".o-custom-input-preview input", color, "input");
+    await nextTick();
+    await simulateClick(".o-add-button");
+    expect(onColorPicked).toHaveBeenCalledWith(toHex(color));
   });
 
   test("Cannot input an invalid color code", async () => {


### PR DESCRIPTION
When defining a custom color, a user can input pretty much any string, the validity of the said string will only be checked when he will try to add the custom value.
More specifically, a user can input a hex value without its prefix `#` (e.g. `eeeaaa` instead of `#eeeaaa`). Such value is interpreted in css but not by the canvas context. Trying to set the `fillColor` to a hex value without the prefix will simply fail.

```javascript
const canvas = document.querySelector('canvas')
const ctx = canvas.getContext('2d')

ctx.fillColor = "#FFF"
console.log(ctx.fillColor) // "#FFF"

ctx.fillColor = "eeeaaa"
console.log(ctx.fillColor) // "#FFF"

ctx.fillColor = "#eeeaaa"
console.log(ctx.fillColor) // "#eeeaaa"
```

This commit ensures that we convert the user input to a proper HEX representation before invoking the `onColorPicked` callback.

Task: 3224839

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo