### PR TITLE
[IMP] Top_bar: added selection indicator

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -50,6 +50,12 @@ css/* scss */ `
       .o-icon {
         width: 10px;
       }
+      &.o-menu-item.active::before {
+        left: 5px;
+        content: "✓";
+        font-weight: bold;
+        position: absolute;
+      }
 
       &:not(.disabled) {
         &:hover,
@@ -75,6 +81,8 @@ interface Props {
   onClose: () => void;
   onMenuClicked?: (ev: CustomEvent) => void;
   menuId?: UID;
+  currentFontSize?: number;
+  currentFormatName?: string;
 }
 
 export interface MenuState {
@@ -97,6 +105,8 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     position: null,
     scrollOffset: 0,
     menuItems: [],
+    currentFontSize: this.props.currentFontSize,
+    currentFormatName: this.props.currentFormatName,
   });
   private menuRef = useRef("menu");
   private position = useAbsolutePosition(this.menuRef);

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -24,7 +24,7 @@
             t-on-click="() => this.onClickMenu(menuItem, menuItem_index)"
             t-on-mouseover="() => this.onMouseOver(menuItem, menuItem_index)"
             class="o-menu-item"
-            t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem)}"
+            t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem), 'active': getName(menuItem).toLowerCase() === subMenu.currentFormatName or +getName(menuItem) === subMenu.currentFontSize}"
             t-att-style="getColor(menuItem)">
             <span class="o-menu-item-name" t-esc="getName(menuItem)"/>
             <span
@@ -50,6 +50,8 @@
         onMenuClicked="props.onMenuClicked"
         onClose="() => this.close()"
         menuId="props.menuId"
+        currentFontSize="subMenu.currentFontSize"
+        currentFormatName="subMenu.currentFormatName"
       />
     </Popover>
   </t>

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -41,6 +41,8 @@ type Tool =
   | "fontSizeTool";
 
 interface State {
+  currentFontSize: number;
+  currentFormatName: string;
   menuState: MenuState;
   activeTool: Tool;
 }
@@ -269,6 +271,11 @@ css/* scss */ `
                 }
               }
             }
+            &.o-font-size {
+              .active {
+                background-color: #efefef;
+              }
+            }
           }
         }
       }
@@ -293,7 +300,6 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   static components = { ColorPicker, Menu, Composer };
   commonFormats = FORMATS;
   customFormats = CUSTOM_FORMATS;
-  currentFormatName = "automatic";
   fontSizes = fontSizes;
 
   get dropdownStyle() {
@@ -302,6 +308,8 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
 
   style: Style = {};
   state: State = useState({
+    currentFontSize: 10,
+    currentFormatName: "automatic",
     menuState: { isOpen: false, position: null, menuItems: [] },
     activeTool: "",
   });
@@ -414,12 +422,11 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
     this.redoTool = this.env.model.getters.canRedo();
     this.paintFormatTool = this.env.model.getters.isPaintingFormat();
     const cell = this.env.model.getters.getActiveCell();
-    if (cell && cell.format) {
-      const currentFormat = this.commonFormats.find((f) => f.value === cell.format);
-      this.currentFormatName = currentFormat ? currentFormat.name : "";
-    } else {
-      this.currentFormatName = "automatic";
-    }
+    const { format, style } = cell || {};
+    const currentFormat = this.commonFormats.find((f) => f.value === format);
+    this.state.currentFormatName = currentFormat?.name || "automatic";
+    const currentFont = this.fontSizes.find((f) => f.pt === style?.fontSize);
+    this.state.currentFontSize = currentFont?.pt || 10;
     this.style = { ...this.env.model.getters.getCurrentStyle() };
     this.style.align = this.style.align || cell?.defaultAlign;
     this.fillColor = this.style.fillColor || "#ffffff";

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -20,6 +20,8 @@
             position="state.menuState.position"
             menuItems="state.menuState.menuItems"
             onClose="() => this.closeMenus()"
+            currentFontSize="state.currentFontSize"
+            currentFormatName="state.currentFormatName"
           />
         </div>
         <div class="o-topbar-topright">
@@ -97,7 +99,7 @@
               <t t-foreach="commonFormats" t-as="commonFormat" t-key="commonFormat.name">
                 <div
                   t-att-data-format="commonFormat.name"
-                  t-att-class="{active: currentFormatName === commonFormat.name}">
+                  t-att-class="{active: state.currentFormatName === commonFormat.name}">
                   <t t-esc="commonFormat.text"/>
                   <span class="float-end text-muted" t-esc="commonFormat.description"/>
                 </div>
@@ -119,12 +121,16 @@
               <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
             </div>
             <div
-              class="o-dropdown-content o-text-options "
+              class="o-dropdown-content o-text-options o-font-size"
               t-att-style="dropdownStyle"
               t-if="state.activeTool === 'fontSizeTool'"
               t-on-click="setSize">
               <t t-foreach="fontSizes" t-as="font" t-key="font_index">
-                <div t-esc="font.pt" t-att-data-size="font.pt"/>
+                <div
+                  t-esc="font.pt"
+                  t-att-data-size="font.pt"
+                  t-att-class="{active: state.currentFontSize === font.pt}"
+                />
               </t>
             </div>
           </div>


### PR DESCRIPTION
## Description:

Previously, there was no selection indicator available to identify the chosen property value. To address this, a check icon has been added as a visual cue to indicate the selected value.

Odoo task ID : [3205662](https://www.odoo.com/web#id=3205662&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo