### PR TITLE
[FIX] xlsx export: empty string in filtered range

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -170,9 +170,9 @@ class Demo extends Component {
       this.transportService = undefined;
       this.stateUpdateMessages = [];
     }
-    this.createModel(data || demoData);
+    // this.createModel(data || demoData);
     // this.createModel(makeLargeDataset(26, 10_000, ["numbers"]));
-    // this.createModel({});
+    this.createModel({});
   }
 
   createModel(data) {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -333,6 +333,10 @@ export function isDefined<T>(argument: T | undefined): argument is T {
   return argument !== undefined;
 }
 
+export function isNonEmptyString(str: string | undefined): str is string {
+  return str !== undefined && str !== "";
+}
+
 /**
  * Check if all the values of an object, and all the values of the objects inside of it, are undefined.
  */

--- a/src/plugins/ui/filter_evaluation.ts
+++ b/src/plugins/ui/filter_evaluation.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_FILTER_BORDER_DESC } from "../../constants";
 import {
-  isDefined,
   isInside,
+  isNonEmptyString,
   isObjectEmptyRecursive,
   positions,
   range,
@@ -230,7 +230,7 @@ export class FilterEvaluationPlugin extends UIPlugin {
           const valuesInFilterZone = filter.filteredZone
             ? positions(filter.filteredZone)
                 .map((pos) => this.getters.getCell(sheetData.id, pos.col, pos.row)?.formattedValue)
-                .filter(isDefined)
+                .filter(isNonEmptyString)
             : [];
 
           // In xlsx, filtered values = values that are displayed, not values that are hidden

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -1029,6 +1029,14 @@ describe("Test XLSX export", () => {
       expect(exported.sheets[0].filterTables[0].filters[0].filteredValues).toEqual([]);
     });
 
+    test("Formulas evaluated to empty string are not added to filteredValues", () => {
+      const model = new Model();
+      createFilter(model, "A1:B4");
+      setCellContent(model, "A2", '=""');
+      const exported = getExportedExcelData(model);
+      expect(exported.sheets[0].filterTables[0].filters[0].filteredValues).toEqual([]);
+    });
+
     test("Export data filters snapshot", async () => {
       const model = new Model();
       setCellContent(model, "A1", "Hello");


### PR DESCRIPTION
## Description

When we try to export a sheet that have a data filter, and that in the filtered zone there is a formula evaluating to an empty string, Excel will say that it found an issue when opening the xlsx.

That's because in the xlsx we have to put all the values that are not filtered, except for empty values. This was correctly handled for simple empty cells, but not for cells evaluating to an empty string.

Odoo task ID : [3231699](https://www.odoo.com/web#id=3231699&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo