### PR TITLE
[FIX] config: Saas-16.2 becomes the latest  release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.2.0-alpha.4",
+  "version": "16.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.2.0-alpha.4",
+      "version": "16.2.0",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.2.0-alpha.4",
+  "version": "16.2.0",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",
@@ -133,6 +133,6 @@
     "*": "prettier --write"
   },
   "publishConfig": {
-    "tag": "alpha"
+    "tag": "latest"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { ChartJsComponent } from "./components/figures/chart/chartJs/chartjs";
 import { ScorecardChart } from "./components/figures/chart/scorecard/chart_scorecard";
+import { FigureComponent } from "./components/figures/figure/figure";
 import { ChartFigure } from "./components/figures/figure_chart/figure_chart";
 import { Grid } from "./components/grid/grid";
 import { GridOverlay } from "./components/grid_overlay/grid_overlay";
@@ -208,6 +209,7 @@ export const components = {
   GaugeChartDesignPanel,
   ScorecardChartConfigPanel,
   ScorecardChartDesignPanel,
+  FigureComponent,
 };
 
 export function addFunction(functionName: string, functionDescription: FunctionDescription) {


### PR DESCRIPTION
Following the freeze of saas-16.2, it now is the latest release and will have the tag 'latest' in npm publications.
This commit bumps the tag and versions of the package.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo