### PR TITLE
[REL] 16.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.1.4",
+  "version": "16.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.1.4",
+      "version": "16.1.5",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.1.4",
+  "version": "16.1.5",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/3cff999f [FIX] xlsx export: empty string in filtered range
https://github.com/odoo/o-spreadsheet/commit/e5f651a7 [FIX] package: saas-16.1 is no longer the latest version
https://github.com/odoo/o-spreadsheet/commit/33e8764b [FIX] chart_scorecard: adjusted title and baseline description colors
