### PR TITLE
[FIX] clipboard: don't open composer on firefox

### DIFF
--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -30,6 +30,7 @@ export class ContentEditableHelper {
         );
         if (start < 0) start = 0;
         if (end > this.el!.textContent!.length) end = this.el!.textContent!.length;
+        if (start > this.el!.textContent!.length) start = this.el!.textContent!.length;
       }
       let startNode = this.findChildAtCharacterIndex(start);
       let endNode = this.findChildAtCharacterIndex(end);

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -832,6 +832,10 @@ export class Grid extends Component<Props, SpreadsheetEnv> {
   }
 
   onInput(ev: InputEvent) {
+    // the user meant to paste in the sheet, not open the composer with the pasted content
+    if (!ev.isComposing && ev.inputType === "insertFromPaste") {
+      return;
+    }
     if (ev.data) {
       // if the user types a character on the grid, it means he wants to start composing the selected cell with that
       // character

--- a/src/plugins/ui/edition.ts
+++ b/src/plugins/ui/edition.ts
@@ -418,6 +418,7 @@ export class EditionPlugin extends UIPlugin {
   }
 
   private setContent(text: string, selection?: ComposerSelection, raise?: boolean) {
+    text = text.replace(/[\r\n]/g, "");
     const isNewCurrentContent = this.currentContent !== text;
     this.currentContent = text;
 

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -575,6 +575,18 @@ describe("composer", () => {
     await nextTick();
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
+  test("input event triggered from a paste should not open composer", async () => {
+    gridInputEl.dispatchEvent(
+      new InputEvent("input", {
+        data: "d",
+        bubbles: true,
+        isComposing: false,
+        inputType: "insertFromPaste",
+      })
+    );
+    await nextTick();
+    expect(model.getters.getEditionMode()).toBe("inactive");
+  });
 
   test("edit link cell changes the label", async () => {
     setCellContent(model, "A1", "[label](http://odoo.com)");

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -485,6 +485,12 @@ describe("edition", () => {
     expect(model.getters.getCurrentContent()).toBe("Hello from sheet1");
   });
 
+  test.each(["ABC\nDEF", "ABC\r\nDEF", "ABC\rDEF"])("carriage returns are cleaned", (text) => {
+    const model = new Model();
+    model.dispatch("START_EDITION", { text });
+    expect(model.getters.getCurrentContent()).toBe("ABCDEF");
+  });
+
   test("select another cell which is empty set the content to an empty string", () => {
     const model = new Model();
     setCellContent(model, "A1", "Hello sir");


### PR DESCRIPTION
Steps to reproduce:
- open a spreadsheet with firefox
- copy a cell
- paste it somewhere else => the composer is open with the pasted content.

Ok... that's weird, but not a big deal.
But it gets better:

- copy *multiple* cells
- paste them somewhere else => boom

The composer opens in the same way, but it doesn't support multiline text!

This commit fixes the composer opening and it also makes the edition plugin more robust by removing any carriage return that could slip through.

Additional small fix in the content editable helper, the selection `start` was not clipped if it was greater than the content length.

Note: it doesn't happen on Chrome because `ev.data` is null when pasting content. It doesn't correctly implements the spec
https://w3c.github.io/input-events/#dfn-data

opw-3236303

opw : [3236303](https://www.odoo.com/web#id=3236303&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo