### PR TITLE
Bump owl version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "16.0.4",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@odoo/owl": "2.0.3",
+        "@odoo/owl": "2.0.9",
         "bootstrap": "^5.1.3"
       },
       "devDependencies": {
@@ -1363,9 +1363,9 @@
       }
     },
     "node_modules/@odoo/owl": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-2.0.3.tgz",
-      "integrity": "sha512-mMto/9NhB0jVU6bBbJmP1+ul7e83/4f/1F6ZRNjYEt1riT5inknhIdcnJvaCC2TgcO76vHz4H7n1x6TSGAFegA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-2.0.9.tgz",
+      "integrity": "sha512-i5wmSyU9uiM/ncglZ6IUbBzwwxft5w9S6e29VOpP+bfPvoVh4b9z2SrTeOsijOYYuh15b0iAOZeHhEE/fjq3Mg==",
       "engines": {
         "node": ">=12.18.3"
       }
@@ -12181,9 +12181,9 @@
       }
     },
     "@odoo/owl": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-2.0.3.tgz",
-      "integrity": "sha512-mMto/9NhB0jVU6bBbJmP1+ul7e83/4f/1F6ZRNjYEt1riT5inknhIdcnJvaCC2TgcO76vHz4H7n1x6TSGAFegA=="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@odoo/owl/-/owl-2.0.9.tgz",
+      "integrity": "sha512-i5wmSyU9uiM/ncglZ6IUbBzwwxft5w9S6e29VOpP+bfPvoVh4b9z2SrTeOsijOYYuh15b0iAOZeHhEE/fjq3Mg=="
     },
     "@popperjs/core": {
       "version": "2.11.5",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "xmlSelfClosingSpace": false
   },
   "dependencies": {
-    "@odoo/owl": "2.0.3",
+    "@odoo/owl": "2.0.9",
     "bootstrap": "^5.1.3"
   },
   "jest": {

--- a/tests/components/__snapshots__/context_menu.test.ts.snap
+++ b/tests/components/__snapshots__/context_menu.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Context Menu context menu simple rendering 1`] = `
+exports[`Context Menu integration tests context menu simple rendering 1`] = `
 <div
   class="o-menu"
 >

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -1,5 +1,3 @@
-import { App } from "@odoo/owl";
-import { Spreadsheet } from "../../src";
 import { args, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import { selectCell } from "../test_helpers/commands_helpers";
@@ -7,7 +5,6 @@ import { clickCell } from "../test_helpers/dom_helper";
 import { getCellText } from "../test_helpers/getters_helpers";
 import {
   clearFunctions,
-  makeTestFixture,
   mountSpreadsheet,
   nextTick,
   restoreDefaultFunctions,
@@ -21,8 +18,6 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 let model: Model;
 let composerEl: Element;
 let fixture: HTMLElement;
-let parent: Spreadsheet;
-let app: App;
 let cehMock: ContentEditableHelper;
 
 async function typeInComposerGrid(text: string, fromScratch: boolean = true) {
@@ -34,19 +29,12 @@ async function typeInComposerGrid(text: string, fromScratch: boolean = true) {
 }
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, parent } = await mountSpreadsheet(fixture));
-  model = parent.model;
+  ({ model, fixture } = await mountSpreadsheet());
 
   // start composition
   fixture.querySelector(".o-grid")!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
   await nextTick();
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
-});
-
-afterEach(() => {
-  fixture.remove();
-  app.destroy();
 });
 
 describe("Functions autocomplete", () => {

--- a/tests/components/autofill.test.ts
+++ b/tests/components/autofill.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
@@ -9,22 +9,14 @@ import {
 import { Model } from "../../src/model";
 import { setCellContent, setSelection, setViewportOffset } from "../test_helpers/commands_helpers";
 import { clickCell, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let model: Model;
 let parent: Spreadsheet;
-let app: App;
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, parent } = await mountSpreadsheet(fixture));
-  model = parent.model;
-});
-
-afterEach(() => {
-  fixture.remove();
-  app.destroy();
+  ({ parent, model, fixture } = await mountSpreadsheet());
 });
 
 describe("Autofill component", () => {

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -1,17 +1,15 @@
-import { App, Component, onMounted, onWillUnmount, useSubEnv, xml } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
 import { BottomBar } from "../../src/components/bottom_bar/bottom_bar";
 import { Model } from "../../src/model";
-import { CommandResult } from "../../src/types";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
+import { SpreadsheetChildEnv } from "../../src/types";
 import {
-  activateSheet,
   createSheet,
   hideSheet,
   selectCell,
   setCellContent,
 } from "../test_helpers/commands_helpers";
 import { triggerMouseEvent } from "../test_helpers/dom_helper";
-import { makeTestFixture, mockUuidV4To, nextTick } from "../test_helpers/helpers";
+import { mockUuidV4To, mountComponent, nextTick } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
 let fixture: HTMLElement;
@@ -25,14 +23,6 @@ class Parent extends Component<any, any> {
   static components = { BottomBar };
 
   setup() {
-    this.props.model.dispatch = jest.fn(() => CommandResult.Success as CommandResult);
-    useSubEnv({
-      openSidePanel: (panel: string) => {},
-      model: this.props.model,
-      _t: (s: string) => s,
-      askConfirmation: jest.fn(),
-      isDashboard: () => this.props.model.getters.isDashboard(),
-    });
     onMounted(() => this.props.model.on("update", this, this.render));
     onWillUnmount(() => this.props.model.off("update", this));
   }
@@ -41,97 +31,82 @@ class Parent extends Component<any, any> {
   }
 }
 
-async function mountTopBar(model: Model = new Model()): Promise<{ parent: Parent; app: App }> {
-  const app = new App(Parent, { props: { model } });
-  app.addTemplates(OWL_TEMPLATES);
-  const parent = await app.mount(fixture);
-  return { app, parent };
+async function mountBottomBar(
+  model: Model = new Model(),
+  env: Partial<SpreadsheetChildEnv> = {}
+): Promise<{ parent: Parent; model: Model }> {
+  let parent: Component;
+  ({ fixture, parent } = await mountComponent(Parent, { model, env, props: { model } }));
+  return { parent: parent as Parent, model };
 }
-
-beforeEach(() => {
-  fixture = makeTestFixture();
-});
-
-afterEach(() => {
-  fixture.remove();
-});
 
 describe("BottomBar component", () => {
   test("simple rendering", async () => {
-    const { app } = await mountTopBar();
+    await mountBottomBar();
 
     expect(fixture.querySelector(".o-spreadsheet-bottom-bar")).toMatchSnapshot();
-    app.destroy();
   });
 
   test("Can create a new sheet", async () => {
-    const model = new Model();
-    const { app } = await mountTopBar(model);
-
+    const { model } = await mountBottomBar();
+    const dispatch = jest.spyOn(model, "dispatch");
     mockUuidV4To(model, 42);
-    triggerMouseEvent(".o-add-sheet", "click");
     const activeSheetId = model.getters.getActiveSheetId();
-    expect(model.dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
+    triggerMouseEvent(".o-add-sheet", "click");
+    expect(dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
       name: "Sheet2",
       sheetId: "42",
       position: 1,
     });
-    expect(model.dispatch).toHaveBeenNthCalledWith(2, "ACTIVATE_SHEET", {
+    expect(dispatch).toHaveBeenNthCalledWith(2, "ACTIVATE_SHEET", {
       sheetIdTo: "42",
       sheetIdFrom: activeSheetId,
     });
-    app.destroy();
   });
 
   test("create a second sheet while the first one is called Sheet2", async () => {
     const model = new Model({ sheets: [{ name: "Sheet2" }] });
-    const { app } = await mountTopBar(model);
+    await mountBottomBar(model);
+    const dispatch = jest.spyOn(model, "dispatch");
     expect(model.getters.getSheetIds().map(model.getters.getSheetName)).toEqual(["Sheet2"]);
     triggerMouseEvent(".o-add-sheet", "click");
-    expect(model.dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
+    expect(dispatch).toHaveBeenNthCalledWith(1, "CREATE_SHEET", {
       sheetId: expect.any(String),
       name: "Sheet1",
       position: 1,
     });
-    app.destroy();
   });
 
   test("Can activate a sheet", async () => {
-    const { app, parent } = await mountTopBar();
-
+    const { model } = await mountBottomBar();
+    const dispatch = jest.spyOn(model, "dispatch");
     triggerMouseEvent(".o-sheet", "click");
-    const sheetIdFrom = parent.props.model.getters.getActiveSheetId();
+    const sheetIdFrom = model.getters.getActiveSheetId();
     const sheetIdTo = sheetIdFrom;
-    expect(parent.props.model.dispatch).toHaveBeenCalledWith("ACTIVATE_SHEET", {
+    expect(dispatch).toHaveBeenCalledWith("ACTIVATE_SHEET", {
       sheetIdFrom,
       sheetIdTo,
     });
-    app.destroy();
   });
 
   test("Can open context menu of a sheet", async () => {
-    const { app } = await mountTopBar();
-
+    await mountBottomBar();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
-    app.destroy();
   });
 
   test("Can open context menu of a sheet with the arrow", async () => {
-    const { app } = await mountTopBar();
-
+    await mountBottomBar();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     triggerMouseEvent(".o-sheet-icon", "click");
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
-    app.destroy();
   });
 
   test("Click on the arrow when the context menu is open should close it", async () => {
-    const { app } = await mountTopBar();
-
+    await mountBottomBar();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     triggerMouseEvent(".o-sheet-icon", "click");
     await nextTick();
@@ -139,14 +114,11 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-sheet-icon", "click");
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    app.destroy();
   });
 
   test("Can open context menu of a sheet with the arrow if another menu is already open", async () => {
-    const { app } = await mountTopBar();
-
+    await mountBottomBar();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-
     triggerMouseEvent(".o-sheet-item.o-list-sheets", "click");
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
@@ -156,13 +128,11 @@ describe("BottomBar component", () => {
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Duplicate");
-    app.destroy();
   });
 
   test("Can open list of sheet menu if another menu is already open", async () => {
-    const { app } = await mountTopBar();
+    await mountBottomBar();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-
     triggerMouseEvent(".o-sheet-icon", "click");
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
@@ -172,240 +142,153 @@ describe("BottomBar component", () => {
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Sheet1");
-    app.destroy();
   });
 
   test("Can move right a sheet", async () => {
     const model = new Model();
     createSheet(model, { sheetId: "42" });
-    const { app } = await mountTopBar(model);
+    await mountBottomBar(model);
+    const dispatch = jest.spyOn(model, "dispatch");
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheetId = model.getters.getActiveSheetId();
     triggerMouseEvent(".o-menu-item[data-name='move_right'", "click");
-    expect(model.dispatch).toHaveBeenCalledWith("MOVE_SHEET", {
+    expect(dispatch).toHaveBeenCalledWith("MOVE_SHEET", {
       sheetId,
       direction: "right",
     });
-    app.destroy();
   });
 
   test("Can move left a sheet", async () => {
     const model = new Model();
-    createSheet(model, { sheetId: "42" });
-    activateSheet(model, "42");
-    const { app } = await mountTopBar(model);
+    createSheet(model, { sheetId: "42", activate: true });
+    await mountBottomBar(model);
+    const dispatch = jest.spyOn(model, "dispatch");
 
-    triggerMouseEvent(".o-sheet", "contextmenu");
+    const target = fixture.querySelectorAll(".o-sheet")[1]!;
+    triggerMouseEvent(target, "contextmenu");
     await nextTick();
     const sheetId = model.getters.getActiveSheetId();
     triggerMouseEvent(".o-menu-item[data-name='move_left'", "click");
-    expect(model.dispatch).toHaveBeenCalledWith("MOVE_SHEET", {
+    expect(dispatch).toHaveBeenCalledWith("MOVE_SHEET", {
       sheetId,
       direction: "left",
     });
-    app.destroy();
   });
 
   test("Can hide a sheet", async () => {
     const model = new Model();
     createSheet(model, { sheetId: "42" });
-    activateSheet(model, "42");
-    const { app } = await mountTopBar(model);
+    await mountBottomBar(model);
+    const dispatch = jest.spyOn(model, "dispatch");
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheetId = model.getters.getActiveSheetId();
     triggerMouseEvent(".o-menu-item[data-name='hide_sheet'", "click");
-    expect(model.dispatch).toHaveBeenCalledWith("HIDE_SHEET", {
+    expect(dispatch).toHaveBeenCalledWith("HIDE_SHEET", {
       sheetId,
     });
-    app.destroy();
   });
 
   test("Hide sheet menu is not visible if there's only one visible sheet", async () => {
     const model = new Model();
     createSheet(model, { sheetId: "42" });
     hideSheet(model, "42");
-    const { app } = await mountTopBar(model);
+    await mountBottomBar(model);
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     expect(fixture.querySelector(".o-menu")).not.toBeNull();
-    expect(fixture.querySelector(".o-menu-item[data-name='hide_sheet'")).toBeNull();
-    app.destroy();
+    expect(fixture.querySelector(".o-menu-item[data-name='hide_sheet']")).toBeNull();
   });
 
   test("Move right and left are not visible when it's not possible to move", async () => {
-    const model = new Model();
-    const { app } = await mountTopBar(model);
+    await mountBottomBar();
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     expect(fixture.querySelector(".o-menu-item[data-name='move_left'")).toBeNull();
     expect(fixture.querySelector(".o-menu-item[data-name='move_right'")).toBeNull();
-    app.destroy();
   });
 
   test("Can rename a sheet", async () => {
-    const model = new Model();
-    class Parent extends Component<any, any> {
-      static template = xml/* xml */ `
-        <div class="o-spreadsheet">
-          <BottomBar onClick="()=>{}" model="props.model"/>
-        </div>
-  `;
-      static components = { BottomBar };
-
-      setup() {
-        useSubEnv({
-          openSidePanel: (panel: string) => {},
-          model: this.props.model,
-          _t: (s: string) => s,
-          askConfirmation: jest.fn(),
-          editText: jest.fn((title, callback, options) => callback("new_name")),
-          isDashboard: () => this.props.model.getters.isDashboard(),
-        });
-        onMounted(() => this.props.model.on("update", this, this.render));
-        onWillUnmount(() => this.props.model.off("update", this));
-      }
-      getSubEnv() {
-        return this.__owl__.childEnv;
-      }
-    }
-
-    const app = new App(Parent, { props: { model } });
-    app.addTemplates(OWL_TEMPLATES);
-    await app.mount(fixture);
+    const { model } = await mountBottomBar(new Model(), {
+      editText: jest.fn((title, callback, options) => {
+        callback("new_name");
+      }),
+    });
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     triggerMouseEvent(".o-menu-item[data-name='rename'", "click");
     expect(model.getters.getActiveSheet().name).toEqual("new_name");
-    app.destroy();
   });
 
   test("Can rename a sheet with dblclick", async () => {
-    const model = new Model();
-
-    class Parent extends Component<any, any> {
-      static template = xml/* xml */ `
-        <div class="o-spreadsheet">
-          <BottomBar onClick="()=>{}" model="props.model"/>
-        </div>
-  `;
-      static components = { BottomBar };
-
-      setup() {
-        useSubEnv({
-          openSidePanel: (panel: string) => {},
-          model: this.props.model,
-          _t: (s: string) => s,
-          askConfirmation: jest.fn(),
-          editText: jest.fn((title, callback, options) => callback("new_name")),
-          isDashboard: () => this.props.model.getters.isDashboard(),
-        });
-        onMounted(() => this.props.model.on("update", this, this.render));
-        onWillUnmount(() => this.props.model.off("update", this));
-      }
-      getSubEnv() {
-        return this.__owl__.childEnv;
-      }
-    }
-
-    const app = new App(Parent, { props: { model } });
-    app.addTemplates(OWL_TEMPLATES);
-    await app.mount(fixture);
+    const { model } = await mountBottomBar(new Model(), {
+      editText: jest.fn((title, callback, options) => {
+        callback("new_name");
+      }),
+    });
 
     triggerMouseEvent(".o-sheet-name", "dblclick");
     await nextTick();
     expect(model.getters.getActiveSheet().name).toEqual("new_name");
-    app.destroy();
   });
 
   test("Can duplicate a sheet", async () => {
-    const model = new Model();
-    const { app } = await mountTopBar(model);
+    const { model } = await mountBottomBar();
+    const dispatch = jest.spyOn(model, "dispatch");
     mockUuidV4To(model, 123);
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheet = model.getters.getActiveSheetId();
     triggerMouseEvent(".o-menu-item[data-name='duplicate'", "click");
-    expect(model.dispatch).toHaveBeenCalledWith("DUPLICATE_SHEET", {
+    expect(dispatch).toHaveBeenCalledWith("DUPLICATE_SHEET", {
       sheetId: sheet,
       sheetIdTo: "123",
     });
-    app.destroy();
   });
 
   test("Can delete a sheet", async () => {
-    const model = new Model();
+    const { model } = await mountBottomBar(new Model(), {
+      askConfirmation: jest.fn((title, callback) => callback()),
+    });
+    const dispatch = jest.spyOn(model, "dispatch");
     createSheet(model, { sheetId: "42" });
-
-    class Parent extends Component<any, any> {
-      static template = xml/* xml */ `
-        <div class="o-spreadsheet">
-          <BottomBar onClick="()=>{}" model="props.model"/>
-        </div>
-  `;
-      static components = { BottomBar };
-
-      setup() {
-        this.props.model.dispatch = jest.fn(() => CommandResult.Success as CommandResult);
-        useSubEnv({
-          openSidePanel: (panel: string) => {},
-          model: this.props.model,
-          _t: (s: string) => s,
-          askConfirmation: jest.fn((title, callback) => callback()),
-          isDashboard: () => this.props.model.getters.isDashboard(),
-        });
-        onMounted(() => this.props.model.on("update", this, this.render));
-        onWillUnmount(() => this.props.model.off("update", this));
-      }
-      getSubEnv() {
-        return this.__owl__.childEnv;
-      }
-    }
-
-    const app = new App(Parent, { props: { model } });
-    app.addTemplates(OWL_TEMPLATES);
-    await app.mount(fixture);
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     const sheetId = model.getters.getActiveSheetId();
     triggerMouseEvent(".o-menu-item[data-name='delete'", "click");
-    expect(model.dispatch).toHaveBeenCalledWith("DELETE_SHEET", { sheetId });
-    app.destroy();
+    expect(dispatch).toHaveBeenCalledWith("DELETE_SHEET", { sheetId });
   });
 
   test("Delete sheet is not visible when there is only one sheet", async () => {
-    const model = new Model();
-    const { app } = await mountTopBar(model);
+    await mountBottomBar();
 
     triggerMouseEvent(".o-sheet", "contextmenu");
     await nextTick();
     expect(fixture.querySelector(".o-menu-item[data-name='delete'")).toBeNull();
-    app.destroy();
   });
 
   test("Can open the list of sheets", async () => {
-    const { app } = await mountTopBar();
+    await mountBottomBar();
 
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     triggerMouseEvent(".o-list-sheets", "click");
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
-    app.destroy();
   });
 
   test("Can open the list of sheets", async () => {
-    const model = new Model();
+    const { model } = await mountBottomBar();
     const sheet = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42" });
-    const { app } = await mountTopBar(model);
+
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     triggerMouseEvent(".o-list-sheets", "click");
     await nextTick();
@@ -414,29 +297,24 @@ describe("BottomBar component", () => {
     expect(sheets.length).toBe(2);
     expect((sheets[0] as HTMLElement).dataset.name).toBe(sheet);
     expect((sheets[1] as HTMLElement).dataset.name).toBe("42");
-    app.destroy();
   });
 
   test("Can activate a sheet from the list of sheets", async () => {
-    const model = new Model();
+    const { model } = await mountBottomBar();
+    const dispatch = jest.spyOn(model, "dispatch");
     const sheet = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42" });
-    const { app } = await mountTopBar(model);
     triggerMouseEvent(".o-list-sheets", "click");
     await nextTick();
     triggerMouseEvent(".o-menu-item[data-name='42'", "click");
-    expect(model.dispatch).toHaveBeenCalledWith("ACTIVATE_SHEET", {
+    expect(dispatch).toHaveBeenCalledWith("ACTIVATE_SHEET", {
       sheetIdFrom: sheet,
       sheetIdTo: "42",
     });
-    app.destroy();
   });
 
   test("Display the statistic button only if no-empty cells are selected", async () => {
-    const model = new Model();
-    const nonMockedDispatch = model.dispatch;
-    const { app } = await mountTopBar(model);
-    model.dispatch = nonMockedDispatch;
+    const { model } = await mountBottomBar();
     setCellContent(model, "A2", "24");
     setCellContent(model, "A3", "=A1");
 
@@ -451,14 +329,10 @@ describe("BottomBar component", () => {
     selectCell(model, "A3");
     await nextTick();
     expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Sum: 0");
-    app.destroy();
   });
 
   test("Display empty information if the statistic function doesn't handle the types of the selected cells", async () => {
-    const model = new Model();
-    const nonMockedDispatch = model.dispatch;
-    await mountTopBar(model);
-    model.dispatch = nonMockedDispatch;
+    const { model } = await mountBottomBar();
     setCellContent(model, "A2", "I am not a number");
 
     selectCell(model, "A2");
@@ -467,10 +341,7 @@ describe("BottomBar component", () => {
   });
 
   test("Can open the list of statistics", async () => {
-    const model = new Model();
-    const nonMockedDispatch = model.dispatch;
-    const { app } = await mountTopBar(model);
-    model.dispatch = nonMockedDispatch;
+    const { model } = await mountBottomBar();
     setCellContent(model, "A2", "24");
 
     selectCell(model, "A2");
@@ -478,13 +349,12 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-selection-statistic", "click");
     await nextTick();
     expect(fixture.querySelector(".o-menu")).toMatchSnapshot();
-    app.destroy();
   });
 
   test("Can open the list of statistics if another menu is already open", async () => {
     const model = new Model();
     const nonMockedDispatch = model.dispatch;
-    const { app } = await mountTopBar(model);
+    await mountBottomBar(model);
     model.dispatch = nonMockedDispatch;
     setCellContent(model, "A2", "24");
     selectCell(model, "A2");
@@ -497,14 +367,10 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-selection-statistic", "click");
     await nextTick();
     expect(fixture.querySelector(".o-menu-item")!.textContent).toEqual("Sum: 24");
-    app.destroy();
   });
 
   test("Can activate a statistic from the list of statistics", async () => {
-    const model = new Model();
-    const nonMockedDispatch = model.dispatch;
-    const { app } = await mountTopBar(model);
-    model.dispatch = nonMockedDispatch;
+    const { model } = await mountBottomBar();
     setCellContent(model, "A2", "24");
 
     selectCell(model, "A2");
@@ -516,6 +382,5 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-menu-item[data-name='Count Numbers'", "click");
     await nextTick();
     expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Count Numbers: 1");
-    app.destroy();
   });
 });

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { CommandResult, Model, Spreadsheet } from "../../src";
 import { ChartTerms } from "../../src/components/translations_terms";
 import { BACKGROUND_CHART_COLOR, MENU_WIDTH } from "../../src/constants";
@@ -21,7 +20,6 @@ import {
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import {
-  makeTestFixture,
   mockChart,
   MockClipboard,
   mountSpreadsheet,
@@ -112,7 +110,7 @@ let chartId: string;
 let sheetId: string;
 
 let parent: Spreadsheet;
-let app: App;
+
 describe("figures", () => {
   beforeEach(async () => {
     const clipboard = new MockClipboard();
@@ -122,7 +120,6 @@ describe("figures", () => {
       },
       configurable: true,
     });
-    fixture = makeTestFixture();
     mockChartData = mockChart();
     chartId = "someuuid";
     sheetId = "Sheet1";
@@ -151,16 +148,12 @@ describe("figures", () => {
         },
       ],
     };
-    ({ app, parent } = await mountSpreadsheet(fixture, { model: new Model(data) }));
-    model = parent.model;
+    ({ parent, model, fixture } = await mountSpreadsheet({ model: new Model(data) }));
     await nextTick();
     await nextTick();
     await nextTick();
   });
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
-  });
+
   test.each(["basicChart", "scorecard", "gauge"])("can export a chart %s", (chartType: string) => {
     createTestChart(chartType);
     const data = model.exportData();
@@ -1184,7 +1177,6 @@ describe("figures", () => {
 
 describe("charts with multiple sheets", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
     mockChartData = mockChart();
     const data = {
       sheets: [
@@ -1241,14 +1233,10 @@ describe("charts with multiple sheets", () => {
         },
       ],
     };
-    ({ app, parent } = await mountSpreadsheet(fixture, { model: new Model(data) }));
-    model = parent.model;
+    ({ parent, model, fixture } = await mountSpreadsheet({ model: new Model(data) }));
     await nextTick();
   });
-  afterEach(() => {
-    fixture.remove();
-    app.destroy();
-  });
+
   test("delete sheet containing chart data does not crash", async () => {
     expect(model.getters.getSheetName(model.getters.getActiveSheetId())).toBe("Sheet1");
     model.dispatch("DELETE_SHEET", { sheetId: model.getters.getActiveSheetId() });
@@ -1261,14 +1249,10 @@ describe("charts with multiple sheets", () => {
 
 describe("Default background on runtime tests", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture, { model: new Model() }));
-    model = parent.model;
+    ({ parent, fixture, model } = await mountSpreadsheet({ model: new Model() }));
     await nextTick();
   });
-  afterEach(() => {
-    app.destroy();
-  });
+
   test("Creating a 'basicChart' without background should have default background on runtime", async () => {
     createChart(model, { dataSets: ["A1"] }, "1", sheetId);
     expect(model.getters.getChartDefinition("1")?.background).toBeUndefined();

--- a/tests/components/color_picker.test.ts
+++ b/tests/components/color_picker.test.ts
@@ -1,44 +1,24 @@
-import { App } from "@odoo/owl";
 import { Model } from "../../src";
 import { ColorPicker, ColorPickerProps } from "../../src/components/color_picker/color_picker";
 import { toHex } from "../../src/helpers";
-import { SpreadsheetChildEnv } from "../../src/types";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { setStyle } from "../test_helpers/commands_helpers";
 import {
   getElComputedStyle,
   setInputValueAndTrigger,
   simulateClick,
 } from "../test_helpers/dom_helper";
-import { makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { mountComponent, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-beforeEach(async () => {
-  fixture = makeTestFixture();
-});
-
-afterEach(() => {
-  fixture.remove();
-});
-
-async function mountColorPicker(
-  props: Partial<ColorPickerProps> = {},
-  model = new Model()
-): Promise<ColorPicker> {
-  const app = new App(ColorPicker, {
-    props: {
-      dropdownDirection: props.dropdownDirection,
-      onColorPicked: props.onColorPicked || (() => {}),
-      currentColor: props.currentColor || "#000000",
-      maxHeight: props.maxHeight !== undefined ? props.maxHeight : 1000,
-    },
-    env: {
-      model,
-    } as SpreadsheetChildEnv,
-  });
-  app.addTemplates(OWL_TEMPLATES);
-  return await app.mount(fixture);
+async function mountColorPicker(partialProps: Partial<ColorPickerProps> = {}, model = new Model()) {
+  const props = {
+    dropdownDirection: partialProps.dropdownDirection,
+    onColorPicked: partialProps.onColorPicked || (() => {}),
+    currentColor: partialProps.currentColor || "#000000",
+    maxHeight: partialProps.maxHeight !== undefined ? partialProps.maxHeight : 1000,
+  };
+  ({ fixture } = await mountComponent(ColorPicker, { model, props }));
 }
 
 describe("Color Picker position tests", () => {

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -1,5 +1,3 @@
-import { App } from "@odoo/owl";
-import { Spreadsheet } from "../../src";
 import {
   MatchingParenColor,
   NumberColor,
@@ -31,7 +29,6 @@ import {
 import { getActiveXc, getCell, getCellContent, getCellText } from "../test_helpers/getters_helpers";
 import {
   createEqualCF,
-  makeTestFixture,
   MockClipboard,
   mountSpreadsheet,
   nextTick,
@@ -48,8 +45,6 @@ let model: Model;
 let composerEl: Element;
 let gridInputEl: Element;
 let fixture: HTMLElement;
-let parent: Spreadsheet;
-let app: App;
 let cehMock: ContentEditableHelper;
 
 function getHighlights(model: Model): Highlight[] {
@@ -72,15 +67,8 @@ async function typeInComposerGrid(text: string, fromScratch: boolean = true) {
 
 beforeEach(async () => {
   jest.useFakeTimers();
-  fixture = makeTestFixture();
-  ({ app, parent } = await mountSpreadsheet(fixture));
-  model = parent.model;
-  gridInputEl = document.querySelector(".o-grid>input")!;
-});
-
-afterEach(() => {
-  app.destroy();
-  fixture.remove();
+  ({ model, fixture } = await mountSpreadsheet());
+  gridInputEl = fixture.querySelector(".o-grid>input")!;
 });
 
 describe("ranges and highlights", () => {
@@ -1538,14 +1526,14 @@ describe("Copy/paste in composer", () => {
   });
 
   test("Can copy random content inside the composer", async () => {
-    const sypeDispatch = jest.spyOn(parent.model, "dispatch");
+    const sypeDispatch = jest.spyOn(model, "dispatch");
     await startComposition();
     const clipboardEvent = new Event("paste", { bubbles: true, cancelable: true });
     //@ts-ignore
     clipboardEvent.clipboardData = { getData: () => "unimportant" };
     fixture.querySelector(".o-grid-composer .o-composer")!.dispatchEvent(clipboardEvent);
     await nextTick();
-    expect(parent.model.getters.getEditionMode()).not.toBe("inactive");
+    expect(model.getters.getEditionMode()).not.toBe("inactive");
     expect(fixture.querySelectorAll(".o-grid-composer .o-composer")).toHaveLength(1);
     expect(sypeDispatch).not.toBeCalledWith("PASTE_FROM_OS_CLIPBOARD", expect.any);
     expect(sypeDispatch).not.toBeCalledWith("PASTE", expect.any);

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import { toZone } from "../../src/helpers/zones";
 import { ConditionalFormatPlugin } from "../../src/plugins/core/conditional_format";
@@ -15,7 +14,6 @@ import {
   createColorScale,
   createEqualCF,
   getPlugin,
-  makeTestFixture,
   mockUuidV4To,
   mountSpreadsheet,
   nextTick,
@@ -30,19 +28,11 @@ let model: Model;
 describe("UI of conditional formats", () => {
   let fixture: HTMLElement;
   let parent: Spreadsheet;
-  let app: App;
 
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ parent, model, fixture } = await mountSpreadsheet());
     parent.env.openSidePanel("ConditionalFormatting");
     await nextTick();
-  });
-
-  afterEach(() => {
-    fixture.remove();
-    app.destroy();
   });
 
   function errorMessages(): string[] {

--- a/tests/components/custom_currency_side_panel.test.ts
+++ b/tests/components/custom_currency_side_panel.test.ts
@@ -1,10 +1,9 @@
-import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import { currenciesRegistry } from "../../src/registries/currencies_registry";
 import { Currency } from "../../src/types/currency";
 import { setSelection } from "../test_helpers/commands_helpers";
 import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 jest.useFakeTimers();
 
@@ -43,19 +42,15 @@ const loadCurrencies = async () => {
   return currenciesData;
 };
 
-let fixture: HTMLElement;
 let parent: Spreadsheet;
-let app: App;
-let dispatch;
+let dispatch: jest.SpyInstance;
 let currenciesContent: { [key: string]: Currency };
 let model: Model;
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
   currenciesContent = Object.assign({}, currenciesRegistry.content);
 
-  ({ app, parent } = await mountSpreadsheet(fixture, { model: new Model() }, { loadCurrencies }));
-  model = parent.model;
+  ({ parent, model } = await mountSpreadsheet({ model: new Model() }, { loadCurrencies }));
   dispatch = spyDispatch(parent);
 
   parent.env.openSidePanel("CustomCurrency");
@@ -63,8 +58,6 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-  app.destroy();
-  fixture.remove();
   currenciesRegistry.content = currenciesContent;
 });
 
@@ -91,13 +84,10 @@ describe("custom currency sidePanel component", () => {
     test("if currencies aren't provided in spreadsheet --> remove 'available currencies' section", async () => {
       // create spreadsheet without loadCurrencies in env
       currenciesRegistry.content = {};
-      const fixture = makeTestFixture();
-      const { app, parent } = await mountSpreadsheet(fixture);
+      const { parent, fixture } = await mountSpreadsheet();
       parent.env.openSidePanel("CustomCurrency");
       await nextTick();
       expect(fixture.querySelector(selectors.availableCurrencies)).toBe(null);
-      fixture.remove();
-      app.destroy();
     });
 
     // -------------------------------------------------------------------------

--- a/tests/components/dashboard_grid.test.ts
+++ b/tests/components/dashboard_grid.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
@@ -10,12 +9,11 @@ import { Model } from "../../src/model";
 import { createFilter, selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
 import { getActiveXc } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let parent: Spreadsheet;
 let model: Model;
-let app: App;
 
 function getEmptyClipboardEvent(type: "copy" | "paste" | "cut") {
   const event = new Event(type, { bubbles: true });
@@ -30,15 +28,8 @@ function getEmptyClipboardEvent(type: "copy" | "paste" | "cut") {
 
 describe("Grid component in dashboard mode", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ parent, fixture, model } = await mountSpreadsheet());
     await nextTick();
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
   });
 
   test("simple dashboard rendering snapshot", async () => {

--- a/tests/components/drag_and_drop.test.ts
+++ b/tests/components/drag_and_drop.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, useSubEnv, xml } from "@odoo/owl";
+import { Component, useSubEnv, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { dragAndDropBeyondTheViewport } from "../../src/components/helpers/drag_and_drop";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
@@ -14,14 +14,12 @@ import {
   setViewportOffset,
 } from "../test_helpers/commands_helpers";
 import { edgeScrollDelay, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { makeTestFixture, nextTick } from "../test_helpers/helpers";
+import { mountComponent, nextTick } from "../test_helpers/helpers";
 
 // As we test an isolated component, grid and gridOverlay won't exist
 jest.mock("../../src/components/helpers/dom_helpers", () => require("./__mocks__/dom_helpers"));
 
-let fixture: HTMLElement;
 let model: Model;
-let app: App;
 let sheetId: UID;
 
 //Test Component required
@@ -68,16 +66,10 @@ afterAll(() => {
 
 beforeEach(async () => {
   model = new Model();
-  app = new App(FakeGridComponent, { props: { model } });
+  await mountComponent(FakeGridComponent, { model, props: { model } });
   selectedCol = selectedRow = undefined;
-  fixture = makeTestFixture();
-  await app.mount(fixture);
   sheetId = model.getters.getActiveSheetId();
   await nextTick();
-});
-
-afterEach(() => {
-  app.destroy();
 });
 
 describe("Drag And Drop horizontal tests", () => {

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -1,5 +1,5 @@
-import { App, Component, xml } from "@odoo/owl";
-import { Model, Spreadsheet } from "../../src";
+import { Component, xml } from "@odoo/owl";
+import { Model } from "../../src";
 import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
@@ -25,12 +25,10 @@ import {
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let model: Model;
-let parent: Spreadsheet;
-let app: App;
 let sheetId: UID;
 
 function createFigure(
@@ -47,7 +45,7 @@ function createFigure(
     tag: "text",
   };
 
-  model.dispatch("CREATE_FIGURE", {
+  return model.dispatch("CREATE_FIGURE", {
     sheetId,
     figure: { ...defaultParameters, ...figureParameters },
   });
@@ -90,14 +88,8 @@ afterAll(() => {
 
 describe("figures", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ model, fixture } = await mountSpreadsheet());
     sheetId = model.getters.getActiveSheetId();
-  });
-
-  afterEach(() => {
-    app.destroy();
   });
 
   test("can create a figure with some data", () => {

--- a/tests/components/filter_menu.test.ts
+++ b/tests/components/filter_menu.test.ts
@@ -1,5 +1,4 @@
-import { App } from "@odoo/owl";
-import { Model, Spreadsheet } from "../../src";
+import { Model } from "../../src";
 import { UID } from "../../src/types";
 import {
   createFilter,
@@ -9,13 +8,7 @@ import {
   updateFilter,
 } from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
-import {
-  getCellsObject,
-  makeTestFixture,
-  mountSpreadsheet,
-  nextTick,
-  target,
-} from "../test_helpers/helpers";
+import { getCellsObject, mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
 
 async function openFilterMenu() {
   await simulateClick(".o-filter-icon");
@@ -25,8 +18,6 @@ describe("Filter menu component", () => {
   let fixture: HTMLElement;
   let model: Model;
   let sheetId: UID;
-  let parent: Spreadsheet;
-  let app: App;
 
   function getFilterMenuValues() {
     const values: { value: string; isChecked: boolean }[] = [];
@@ -41,15 +32,8 @@ describe("Filter menu component", () => {
   }
 
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ model, fixture } = await mountSpreadsheet());
     sheetId = model.getters.getActiveSheetId();
-  });
-
-  afterEach(() => {
-    fixture.remove();
-    app.destroy();
   });
 
   describe("Filter Tests", () => {

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -1,8 +1,7 @@
-import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../src";
 import { setCellContent } from "../test_helpers/commands_helpers";
 import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
 let model: Model;
@@ -33,19 +32,13 @@ const selectors = {
 describe("find and replace sidePanel component", () => {
   let fixture: HTMLElement;
   let parent: Spreadsheet;
-  let app: App;
+
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ parent, model, fixture } = await mountSpreadsheet());
     parent.env.openSidePanel("FindAndReplace");
     await nextTick();
   });
 
-  afterEach(() => {
-    fixture.remove();
-    app.destroy();
-  });
   describe("Sidepanel", () => {
     test("Can close the find and replace side panel", async () => {
       expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -1,10 +1,7 @@
-import { App } from "@odoo/owl";
-import { Spreadsheet } from "../../src";
 import { args, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import {
   clearFunctions,
-  makeTestFixture,
   mountSpreadsheet,
   nextTick,
   restoreDefaultFunctions,
@@ -17,23 +14,14 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
 let model: Model;
 let composerEl: Element;
 let fixture: HTMLElement;
-let parent: Spreadsheet;
-let app: App;
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, parent } = await mountSpreadsheet(fixture));
-  model = parent.model;
+  ({ model, fixture } = await mountSpreadsheet());
 
   // start composition
   document.querySelector(".o-grid")!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
   await nextTick();
   composerEl = fixture.querySelector(".o-grid div.o-composer")!;
-});
-
-afterEach(() => {
-  app.destroy();
-  fixture.remove();
 });
 
 describe("formula assistant", () => {

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -1,4 +1,3 @@
-import { App } from "@odoo/owl";
 import { Spreadsheet, TransportService } from "../../src";
 import { ChartJsComponent } from "../../src/components/figures/chart/chartJs/chartjs";
 import {
@@ -46,13 +45,7 @@ import {
   getCellContent,
   getCellText,
 } from "../test_helpers/getters_helpers";
-import {
-  makeTestFixture,
-  MockClipboard,
-  mountSpreadsheet,
-  nextTick,
-  Touch,
-} from "../test_helpers/helpers";
+import { MockClipboard, mountSpreadsheet, nextTick, Touch } from "../test_helpers/helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
 import { mockChart } from "./__mocks__/chart";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
@@ -72,30 +65,14 @@ function getHorizontalScroll(): number {
 let fixture: HTMLElement;
 let model: Model;
 let parent: Spreadsheet;
-let app: App;
 
 chartComponentRegistry.add("bar", ChartJsComponent);
 
 jest.useFakeTimers();
 
-beforeEach(async () => {
-  fixture = makeTestFixture();
-});
-
-afterEach(() => {
-  fixture.remove();
-});
-
 describe("Grid component", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
 
   test("simple rendering snapshot", async () => {
@@ -434,7 +411,7 @@ describe("Grid component", () => {
 
     test("can save the sheet with CTRL+S", async () => {
       let saveContentCalled = false;
-      ({ app, parent } = await mountSpreadsheet(fixture, {
+      ({ parent } = await mountSpreadsheet({
         model: new Model(),
         onContentSaved: () => {
           saveContentCalled = true;
@@ -798,14 +775,9 @@ describe("Multi User selection", () => {
   let transportService: TransportService;
   beforeEach(async () => {
     transportService = new MockTransportService();
-    fixture = makeTestFixture();
-    model = new Model({}, { transportService });
-    ({ app, parent } = await mountSpreadsheet(fixture, { model }));
-  });
 
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    model = new Model({}, { transportService });
+    ({ parent, fixture } = await mountSpreadsheet({ model }));
   });
 
   test("Do not render multi user selection with invalid sheet", async () => {
@@ -852,13 +824,11 @@ describe("Multi User selection", () => {
 describe("error tooltip", () => {
   beforeEach(async () => {
     jest.useFakeTimers();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
 
   afterEach(() => {
     jest.useRealTimers();
-    app.destroy();
   });
 
   test("can display error on A1", async () => {
@@ -919,21 +889,10 @@ describe("error tooltip", () => {
 
 describe("Events on Grid update viewport correctly", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
-  });
+
   test("Vertical scroll", async () => {
-    // expect(model.getters.getActiveMainViewport()).toMatchObject({
-    //   top: 0,
-    //   bottom: 94,
-    //   left: 0,
-    //   right: 10,
-    // });
     fixture.querySelector(".o-grid")!.dispatchEvent(new WheelEvent("wheel", { deltaY: 1200 }));
     await nextTick();
     expect(model.getters.getActiveMainViewport()).toMatchObject({
@@ -1328,24 +1287,12 @@ describe("Events on Grid update viewport correctly", () => {
     await clickCell(model, "Y1", { shiftKey: true });
     expect(model.getters.getActiveMainViewport()).toMatchObject(viewport);
   });
-
-  test("resize event handler is removed", () => {
-    app.destroy();
-    window.dispatchEvent(new Event("resize"));
-  });
 });
 
 describe("Edge-Scrolling on mouseMove in selection", () => {
   beforeEach(async () => {
     jest.useFakeTimers();
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
 
   test("Can edge-scroll horizontally", async () => {
@@ -1448,15 +1395,8 @@ describe("Copy paste keyboard shortcut", () => {
       },
       configurable: true,
     });
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ parent, model, fixture } = await mountSpreadsheet());
     sheetId = model.getters.getActiveSheetId();
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
   });
 
   test("Can copy/paste cells", async () => {

--- a/tests/components/grid_manipulation.test.ts
+++ b/tests/components/grid_manipulation.test.ts
@@ -1,11 +1,10 @@
-import { App } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { Model } from "../../src/model";
 import { selectColumn, selectRow } from "../test_helpers/commands_helpers";
 import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getActiveXc } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 
 const COLUMN_D = { x: 340, y: 10 };
 const ROW_5 = { x: 30, y: 100 };
@@ -14,17 +13,9 @@ const OUTSIDE_CM = { x: 50, y: 50 };
 let fixture: HTMLElement;
 let model: Model;
 let parent: Spreadsheet;
-let app: App;
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, parent } = await mountSpreadsheet(fixture));
-  model = parent.model;
-});
-
-afterEach(() => {
-  app.destroy();
-  fixture.remove();
+  ({ parent, model, fixture } = await mountSpreadsheet());
 });
 
 function simulateContextMenu(selector: string, coord: { x: number; y: number }) {

--- a/tests/components/highlight.test.ts
+++ b/tests/components/highlight.test.ts
@@ -1,5 +1,4 @@
-import { App, Component, useSubEnv, xml } from "@odoo/owl";
-import { Spreadsheet } from "../../src";
+import { Component, useSubEnv, xml } from "@odoo/owl";
 import { Highlight } from "../../src/components/highlight/highlight/highlight";
 import {
   DEFAULT_CELL_HEIGHT,
@@ -9,11 +8,10 @@ import {
 import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { DispatchResult } from "../../src/types/commands";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { merge } from "../test_helpers/commands_helpers";
 import { edgeScrollDelay, triggerMouseEvent } from "../test_helpers/dom_helper";
 import {
-  makeTestFixture,
+  mountComponent,
   mountSpreadsheet,
   nextTick,
   startGridComposition,
@@ -96,9 +94,7 @@ async function moveToCell(el: Element, xc: string) {
 }
 
 let model: Model;
-let app: App;
 let fixture: HTMLElement;
-let parent: Parent;
 let cornerEl: Element;
 let borderEl: Element;
 
@@ -120,13 +116,14 @@ class Parent extends Component {
 }
 
 async function mountHighlight(zone: string, color: string): Promise<Parent> {
-  app = new App(Parent, { props: { zone: toZone(zone), color, model } });
-  app.addTemplates(OWL_TEMPLATES);
-  return await app.mount(fixture);
+  let parent: Component;
+  ({ fixture, parent } = await mountComponent(Parent, {
+    props: { zone: toZone(zone), color, model },
+  }));
+  return parent as Parent;
 }
 
 const genericBeforeEach = async () => {
-  fixture = makeTestFixture();
   model = new Model();
   model.dispatch("RESIZE_SHEETVIEW", {
     width: DEFAULT_SHEETVIEW_SIZE,
@@ -136,17 +133,11 @@ const genericBeforeEach = async () => {
   });
 };
 
-const genericAfterEach = () => {
-  app.destroy();
-  fixture.remove();
-};
-
 describe("Corner component", () => {
   beforeEach(genericBeforeEach);
-  afterEach(genericAfterEach);
   describe("can drag all corners", () => {
     test("start on nw corner", async () => {
-      parent = await mountHighlight("B2", "#666");
+      await mountHighlight("B2", "#666");
       cornerEl = fixture.querySelector(".o-corner-nw")!;
 
       // select B2 nw corner
@@ -162,7 +153,7 @@ describe("Corner component", () => {
     });
 
     test("start on ne corner", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       cornerEl = fixture.querySelector(".o-corner-ne")!;
 
       // select B2 ne corner
@@ -179,7 +170,7 @@ describe("Corner component", () => {
     });
 
     test("start on sw corner", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       cornerEl = fixture.querySelector(".o-corner-sw")!;
 
       // select B2 sw corner
@@ -196,7 +187,7 @@ describe("Corner component", () => {
     });
 
     test("start on se corner", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       cornerEl = fixture.querySelector(".o-corner-se")!;
 
       // select B2 se corner
@@ -214,7 +205,7 @@ describe("Corner component", () => {
   });
 
   test("do nothing if drag outside the grid", async () => {
-    parent = await mountHighlight("A1", "#666");
+    const parent = await mountHighlight("A1", "#666");
     cornerEl = fixture.querySelector(".o-corner-nw")!;
 
     // select A1 nw corner
@@ -236,7 +227,7 @@ describe("Corner component", () => {
 
   test("drag highlight corner on merged cells expands the final highlight zone", async () => {
     merge(model, "B1:C1");
-    parent = await mountHighlight("B2", "#666");
+    const parent = await mountHighlight("B2", "#666");
     cornerEl = fixture.querySelector(".o-corner-nw")!;
 
     // select B2 se corner
@@ -260,7 +251,7 @@ describe("Corner component", () => {
       elements: [0, 1],
       size: width / 2,
     });
-    parent = await mountHighlight("B1", "#666");
+    const parent = await mountHighlight("B1", "#666");
     cornerEl = fixture.querySelector(".o-corner-nw")!;
 
     // select B1 nw corner
@@ -285,7 +276,7 @@ describe("Corner component", () => {
       elements: [0, 1],
       size: height / 2,
     });
-    parent = await mountHighlight("A2", "#666");
+    const parent = await mountHighlight("A2", "#666");
     cornerEl = fixture.querySelector(".o-corner-nw")!;
 
     // select A2 nw corner
@@ -305,10 +296,9 @@ describe("Corner component", () => {
 
 describe("Border component", () => {
   beforeEach(genericBeforeEach);
-  afterEach(genericAfterEach);
   describe("can drag all borders", () => {
     test("start on top border", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       borderEl = fixture.querySelector(".o-border-n")!;
 
       // select B2 top border
@@ -325,7 +315,7 @@ describe("Border component", () => {
     });
 
     test("start on left border", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       borderEl = fixture.querySelector(".o-border-w")!;
 
       // select B2 left border
@@ -342,7 +332,7 @@ describe("Border component", () => {
     });
 
     test("start on right border", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       borderEl = fixture.querySelector(".o-border-w")!;
 
       // select B2 right border
@@ -359,7 +349,7 @@ describe("Border component", () => {
     });
 
     test("start on bottom border", async () => {
-      parent = await mountHighlight("B2", "#666");
+      const parent = await mountHighlight("B2", "#666");
       borderEl = fixture.querySelector(".o-border-w")!;
 
       // select B2 bottom border
@@ -377,7 +367,7 @@ describe("Border component", () => {
   });
 
   test("drag the A1:B2 highlight, start on A1 top border, finish on C1 --> set C1:D2 highlight", async () => {
-    parent = await mountHighlight("A1:B2", "#666");
+    const parent = await mountHighlight("A1:B2", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select A1 top border
@@ -400,7 +390,7 @@ describe("Border component", () => {
   });
 
   test("drag the A1:B2 highlight, start on B1 top border, finish on C1 --> set B1:C2 highlight", async () => {
-    parent = await mountHighlight("A1:B2", "#666");
+    const parent = await mountHighlight("A1:B2", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select B1 top border
@@ -417,7 +407,7 @@ describe("Border component", () => {
   });
 
   test("cannot drag highlight zone if already beside limit border", async () => {
-    parent = await mountHighlight("A1:B2", "#666");
+    const parent = await mountHighlight("A1:B2", "#666");
     borderEl = fixture.querySelector(".o-border-s")!;
 
     // select B2 bottom border
@@ -433,7 +423,7 @@ describe("Border component", () => {
 
   test("drag highlight order on merged cells expands the final highlight zone", async () => {
     merge(model, "B1:C1");
-    parent = await mountHighlight("A1", "#666");
+    const parent = await mountHighlight("A1", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select A1 top border
@@ -451,7 +441,7 @@ describe("Border component", () => {
 
   test("drag highlight on merged cells expands the highlight zone", async () => {
     merge(model, "B1:C1");
-    parent = await mountHighlight("A1", "#666");
+    const parent = await mountHighlight("A1", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select A1 top border
@@ -475,7 +465,7 @@ describe("Border component", () => {
       elements: [0, 1],
       size: width / 2,
     });
-    parent = await mountHighlight("B1", "#666");
+    const parent = await mountHighlight("B1", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select B1 top border
@@ -500,7 +490,7 @@ describe("Border component", () => {
       elements: [0, 1],
       size: height / 2,
     });
-    parent = await mountHighlight("A2", "#666");
+    const parent = await mountHighlight("A2", "#666");
     borderEl = fixture.querySelector(".o-border-n")!;
 
     // select A2 top border
@@ -519,22 +509,14 @@ describe("Border component", () => {
 });
 
 describe("Edge-Scrolling on mouseMove of hightlights", () => {
-  let parent: Spreadsheet;
-
   beforeEach(async () => {
     jest.useFakeTimers();
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+    ({ model, fixture } = await mountSpreadsheet());
     // ensure that highlights exist
     await startGridComposition();
     await typeInComposerGrid("=A1");
   });
 
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
-  });
   test("Can edge-scroll border horizontally", async () => {
     const { width } = model.getters.getSheetViewDimensionWithHeaders();
     const y = DEFAULT_CELL_HEIGHT;

--- a/tests/components/link/link_display.test.ts
+++ b/tests/components/link/link_display.test.ts
@@ -1,27 +1,18 @@
-import { App } from "@odoo/owl";
 import { Model, Spreadsheet } from "../../../src";
 import { buildSheetLink } from "../../../src/helpers";
 import { clearCell, createSheet, merge, setCellContent } from "../../test_helpers/commands_helpers";
 import { clickCell, hoverCell, rightClickCell, simulateClick } from "../../test_helpers/dom_helper";
 import { getCell } from "../../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+import { mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
 
 describe("link display component", () => {
   let fixture: HTMLElement;
   let model: Model;
-  let app: App;
   let parent: Spreadsheet;
 
   beforeEach(async () => {
     jest.useFakeTimers();
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ parent, model, fixture } = await mountSpreadsheet());
   });
 
   test("simple snapshot", async () => {

--- a/tests/components/link/link_editor.test.ts
+++ b/tests/components/link/link_editor.test.ts
@@ -1,5 +1,4 @@
-import { App } from "@odoo/owl";
-import { Model, Spreadsheet } from "../../../src";
+import { Model } from "../../../src";
 import { buildSheetLink } from "../../../src/helpers";
 import { LinkCell } from "../../../src/types";
 import {
@@ -15,13 +14,11 @@ import {
   simulateClick,
 } from "../../test_helpers/dom_helper";
 import { getCell } from "../../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+import { mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
 
 describe("link editor component", () => {
   let fixture: HTMLElement;
   let model: Model;
-  let grid: Spreadsheet;
-  let app: App;
 
   async function openLinkEditor(model: Model, xc: string) {
     await rightClickCell(model, xc);
@@ -43,14 +40,7 @@ describe("link editor component", () => {
   }
 
   beforeEach(async () => {
-    fixture = makeTestFixture();
-    ({ app, parent: grid } = await mountSpreadsheet(fixture));
-    model = grid.model;
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ model, fixture } = await mountSpreadsheet());
   });
 
   test("open link editor from cell context menu", async () => {

--- a/tests/components/overlay.test.ts
+++ b/tests/components/overlay.test.ts
@@ -1,5 +1,3 @@
-import { App } from "@odoo/owl";
-import { Spreadsheet } from "../../src";
 import { ColResizer, RowResizer } from "../../src/components/headers_overlay/headers_overlay";
 import {
   DEFAULT_CELL_HEIGHT,
@@ -26,11 +24,10 @@ import {
   triggerMouseEvent,
 } from "../test_helpers/dom_helper";
 import { getActiveXc, getCell } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let model: Model;
-let app: App;
 
 ColResizer.prototype._getMaxSize = () => 1000;
 RowResizer.prototype._getMaxSize = () => 1000;
@@ -139,7 +136,6 @@ async function dblClickRow(index: number) {
 
 describe("Resizer component", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
     const data = {
       sheets: [
         {
@@ -149,12 +145,7 @@ describe("Resizer component", () => {
       ],
     };
     model = new Model(data);
-    ({ app } = await mountSpreadsheet(fixture, { model }));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ fixture } = await mountSpreadsheet({ model }));
   });
 
   test("can click on a header to select a column", async () => {
@@ -750,18 +741,12 @@ describe("Resizer component", () => {
 });
 
 describe("Edge-Scrolling on mouseMove in selection", () => {
-  let parent: Spreadsheet;
   beforeEach(async () => {
     jest.useFakeTimers();
-    fixture = makeTestFixture();
-    ({ app, parent } = await mountSpreadsheet(fixture));
-    model = parent.model;
+
+    ({ model, fixture } = await mountSpreadsheet());
   });
 
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
-  });
   test("Can edge-scroll horizontally", async () => {
     const { width } = model.getters.getSheetViewDimension();
     const y = DEFAULT_CELL_HEIGHT;
@@ -832,7 +817,6 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
 
 describe("move selected element(s)", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
     const data = {
       sheets: [
         {
@@ -843,12 +827,7 @@ describe("move selected element(s)", () => {
       ],
     };
     model = new Model(data);
-    ({ app } = await mountSpreadsheet(fixture, { model }));
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ fixture } = await mountSpreadsheet({ model }));
   });
 
   test("select the last selected cols/rows keep all selected zone active", async () => {

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -1,5 +1,4 @@
-import { App } from "@odoo/owl";
-import { Model, Spreadsheet } from "../../src";
+import { Model } from "../../src";
 import { toHex } from "../../src/helpers";
 import { UID } from "../../src/types";
 import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart";
@@ -10,15 +9,12 @@ import {
 } from "../test_helpers/commands_helpers";
 import { dragElement, getElComputedStyle, simulateClick } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
-import { makeTestFixture, mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let model: Model;
 let chartId: string;
 let sheetId: string;
-
-let parent: Spreadsheet;
-let app: App;
 
 function getChartElement(): HTMLElement {
   return fixture.querySelector(".o-figure")!;
@@ -83,7 +79,6 @@ function getChartBaselineTextContent() {
 
 describe("Scorecard charts", () => {
   beforeEach(async () => {
-    fixture = makeTestFixture();
     chartId = "someuuid";
     sheetId = "Sheet1";
     const data = {
@@ -104,13 +99,7 @@ describe("Scorecard charts", () => {
         },
       ],
     };
-    ({ app, parent } = await mountSpreadsheet(fixture, { model: new Model(data) }));
-    model = parent.model;
-  });
-
-  afterEach(() => {
-    app.destroy();
-    fixture.remove();
+    ({ model, fixture } = await mountSpreadsheet({ model: new Model(data) }));
   });
 
   test("Scorecard snapshot", async () => {

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -2,12 +2,12 @@ import { App, Component, onMounted, onWillUnmount, useSubEnv, xml } from "@odoo/
 import { Model } from "../../src";
 import { SelectionInput } from "../../src/components/selection_input/selection_input";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/registries";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import { activateSheet, createSheet, selectCell, undo } from "../test_helpers/commands_helpers";
 import { clickCell, keyDown, keyUp, simulateClick } from "../test_helpers/dom_helper";
 import {
   getChildFromComponent,
   makeTestFixture,
+  mountComponent,
   mountSpreadsheet,
   nextTick,
 } from "../test_helpers/helpers";
@@ -38,7 +38,7 @@ interface SelectionInputTestConfig {
 class Parent extends Component<any> {
   static template = xml/* xml */ `
     <SelectionInput
-      ranges="initialRanges"
+      ranges="initialRanges || []"
       hasSingleRange="hasSingleRange"
       onSelectionChanged="(ranges) => this.onChanged(ranges)" />
   `;
@@ -73,10 +73,10 @@ class MultiParent extends Component<any> {
   static template = xml/* xml */ `
     <div>
       <div class="input-1">
-        <SelectionInput/>
+        <SelectionInput ranges="[]"/>
       </div>
       <div class="input-2">
-        <SelectionInput/>
+        <SelectionInput ranges="[]"/>
       </div>
     </div>
   `;
@@ -94,46 +94,42 @@ class MultiParent extends Component<any> {
   }
 }
 
-async function createSelectionInput(config: SelectionInputTestConfig = {}) {
+async function createSelectionInput(
+  config: SelectionInputTestConfig = {},
+  fixtureEl?: HTMLElement
+) {
   model = new Model();
-  const app = new App(Parent, { props: { model, config } });
-  app.addTemplates(OWL_TEMPLATES);
-  const parent = await app.mount(fixture);
+  let parent: Component;
+  let app: App;
+  ({ fixture, parent, app } = await mountComponent(Parent, {
+    model,
+    fixture: fixtureEl,
+    props: { model, config },
+  }));
   await nextTick();
-  const id = parent.id;
-  return { parent, model, id, app };
+  const id = (parent as Parent).id;
+  return { parent: parent as Parent, model, id, app };
 }
 
 describe("Selection Input", () => {
-  beforeEach(async () => {
-    fixture = makeTestFixture();
-  });
-
-  afterEach(() => {
-    fixture.remove();
-  });
-
   test("empty input is not colored", async () => {
-    const { app } = await createSelectionInput();
+    await createSelectionInput();
     expect(fixture.querySelectorAll("input")[0].getAttribute("style")).toBe("color: #000;");
-    app.destroy();
   });
 
   test("remove button is not displayed with a single input", async () => {
-    const { app } = await createSelectionInput();
+    await createSelectionInput();
     expect(fixture.querySelectorAll(".o-remove-selection").length).toBeFalsy();
-    app.destroy();
   });
 
   test("remove button is displayed with more than one input", async () => {
-    const { app } = await createSelectionInput();
+    await createSelectionInput();
     await simulateClick(".o-add-selection");
     expect(fixture.querySelectorAll(".o-remove-selection").length).toBe(2);
-    app.destroy();
   });
 
   test("input is filled when new cells are selected", async () => {
-    const { app, model } = await createSelectionInput();
+    const { model } = await createSelectionInput();
     selectCell(model, "B4");
     await nextTick();
     expect(fixture.querySelector("input")!.value).toBe("B4");
@@ -147,20 +143,19 @@ describe("Selection Input", () => {
     expect(fixture.querySelectorAll("input")[0].getAttribute("style")).toBe(`color: ${color};`);
     expect(fixture.querySelectorAll("input")[1].value).toBe("B5");
     expect(fixture.querySelectorAll("input")[1].getAttribute("style")).toBe(`color: ${color2};`);
-    app.destroy();
   });
 
   test("ctrl + select cell --> add new input", async () => {
-    const { app, parent } = await mountSpreadsheet(fixture);
-    OPEN_CF_SIDEPANEL_ACTION(parent.env);
+    const { env, model, fixture } = await mountSpreadsheet();
+    OPEN_CF_SIDEPANEL_ACTION(env);
     await nextTick();
     await simulateClick(".o-cf-add");
     await nextTick();
     const input = fixture.querySelector(".o-selection-input input") as HTMLInputElement;
     await simulateClick(input);
-    clickCell(parent.model, "B4");
+    clickCell(model, "B4");
     await nextTick();
-    clickCell(parent.model, "B5", { ctrlKey: true });
+    clickCell(model, "B5", { ctrlKey: true });
     await nextTick();
     const inputs = fixture.querySelectorAll(
       ".o-selection-input input"
@@ -168,11 +163,10 @@ describe("Selection Input", () => {
     expect(inputs.length).toBe(2);
     expect(inputs[0].value).toBe("B4");
     expect(inputs[1].value).toBe("B5");
-    app.destroy();
   });
 
   test("input is not filled with highlight when maximum ranges reached", async () => {
-    const { app, model } = await createSelectionInput({ hasSingleRange: true });
+    const { model } = await createSelectionInput({ hasSingleRange: true });
     expect(fixture.querySelectorAll("input")).toHaveLength(1);
     model.dispatch("PREPARE_SELECTION_INPUT_EXPANSION");
     selectCell(model, "B2");
@@ -180,77 +174,69 @@ describe("Selection Input", () => {
     expect(fixture.querySelectorAll("input")).toHaveLength(1);
     expect(fixture.querySelector("input")!.value).toBe("B2");
     expect(fixture.querySelector(".o-add-selection")).toBeNull();
-    app.destroy();
   });
 
   test("new range is added when button clicked", async () => {
-    const { app } = await createSelectionInput();
+    await createSelectionInput();
     expect(fixture.querySelectorAll("input").length).toBe(1);
     await simulateClick(".o-add-selection");
     expect(fixture.querySelectorAll("input").length).toBe(2);
-    app.destroy();
   });
 
   test("can set initial ranges", async () => {
-    const { app } = await createSelectionInput({ initialRanges: ["C4", "A1"] });
+    await createSelectionInput({ initialRanges: ["C4", "A1"] });
     expect(fixture.querySelectorAll("input").length).toBe(2);
     expect(fixture.querySelectorAll("input")[0].value).toBe("C4");
     expect(fixture.querySelectorAll("input")[1].value).toBe("A1");
-    app.destroy();
   });
 
   test("can focus a range", async () => {
-    const { app } = await createSelectionInput();
+    await createSelectionInput();
     await simulateClick(".o-add-selection"); // last input is now focused
     expect(fixture.querySelectorAll("input")[0].classList).not.toContain("o-focused");
     expect(fixture.querySelectorAll("input")[1].classList).toContain("o-focused");
     await simulateClick("input"); // focus the first input
     expect(fixture.querySelectorAll("input")[0].classList).toContain("o-focused");
     expect(fixture.querySelectorAll("input")[1].classList).not.toContain("o-focused");
-    app.destroy();
   });
 
   test("unmounting deletes the state", async () => {
-    const { app, model, id } = await createSelectionInput();
+    const { model, id, app } = await createSelectionInput();
     expect(model.getters.getSelectionInput(id).length).toBe(1);
     app.destroy();
     expect(model.getters.getSelectionInput(id).length).toBe(0);
   });
 
   test("can unfocus all inputs with the OK button", async () => {
-    const { app } = await createSelectionInput();
+    await createSelectionInput();
     expect(fixture.querySelector(".o-focused")).toBeTruthy();
     await simulateClick(".o-selection-ok");
     expect(fixture.querySelector(".o-focused")).toBeFalsy();
-    app.destroy();
   });
 
   test("manually input a single cell", async () => {
-    const { app, model, id } = await createSelectionInput();
+    const { model, id } = await createSelectionInput();
     await writeInput(0, "C2");
     expect(fixture.querySelectorAll("input")[0].value).toBe("C2");
     expect(model.getters.getSelectionInput(id)[0].xc).toBe("C2");
-    app.destroy();
   });
 
   test("manually input multiple cells", async () => {
-    const { app, model, id } = await createSelectionInput();
+    const { model, id } = await createSelectionInput();
     await writeInput(0, "C2,A1");
     expect(fixture.querySelectorAll("input")[0].value).toBe("C2");
     expect(model.getters.getSelectionInput(id)[0].xc).toBe("C2");
     expect(fixture.querySelectorAll("input")[1].value).toBe("A1");
     expect(model.getters.getSelectionInput(id)[1].xc).toBe("A1");
-    app.destroy();
   });
 
   test("manually add another cell", async () => {
-    const { app, model, id } = await createSelectionInput({ initialRanges: ["C2"] });
+    const { model, id } = await createSelectionInput({ initialRanges: ["C2"] });
     await writeInput(0, "C2,A1");
     expect(fixture.querySelectorAll("input")[0].value).toBe("C2");
     expect(model.getters.getSelectionInput(id)[0].xc).toBe("C2");
     expect(fixture.querySelectorAll("input")[1].value).toBe("A1");
     expect(model.getters.getSelectionInput(id)[1].xc).toBe("A1");
-    app.destroy();
   });
 
   test("changed event is triggered when input changed", async () => {
@@ -258,11 +244,10 @@ describe("Selection Input", () => {
     const onChanged = jest.fn((ranges) => {
       newRanges = ranges;
     });
-    const { app } = await createSelectionInput({ onChanged });
+    await createSelectionInput({ onChanged });
     await writeInput(0, "C2");
     expect(onChanged).toHaveBeenCalled();
     expect(newRanges).toStrictEqual(["C2"]);
-    app.destroy();
   });
 
   test("changed event is triggered when cell is selected", async () => {
@@ -270,48 +255,45 @@ describe("Selection Input", () => {
     const onChanged = jest.fn((ranges) => {
       newRanges = ranges;
     });
-    const { app, model } = await createSelectionInput({ onChanged });
+    const { model } = await createSelectionInput({ onChanged });
     selectCell(model, "B4");
     await nextTick();
     expect(onChanged).toHaveBeenCalled();
     expect(newRanges).toStrictEqual(["B4"]);
-    app.destroy();
   });
 
   test("focus is transferred from one input to another", async () => {
     model = new Model();
-    const app = new App(MultiParent, { props: { model } });
-    app.addTemplates(OWL_TEMPLATES);
-    await app.mount(fixture);
+    ({ fixture } = await mountComponent(MultiParent, { props: { model }, model }));
     await nextTick();
     expect(fixture.querySelector(".input-1 .o-focused")).toBeTruthy();
     expect(fixture.querySelector(".input-2 .o-focused")).toBeFalsy();
     await simulateClick(".input-2 input");
     expect(fixture.querySelector(".input-1 .o-focused")).toBeFalsy();
     expect(fixture.querySelector(".input-2 .o-focused")).toBeTruthy();
-    app.destroy();
   });
 
   test("go back to initial sheet when selection is finished", async () => {
-    const { app, model } = await createSelectionInput();
+    const fixture = makeTestFixture();
+    const { model } = await createSelectionInput({}, fixture);
     const sheet1Id = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42", activate: true });
-    const { app: app1 } = await createSelectionInput();
+    await createSelectionInput({}, fixture);
     activateSheet(model, "42");
     selectCell(model, "B4");
     await nextTick();
     expect(fixture.querySelector("input")!.value).toBe("Sheet2!B4");
     await simulateClick(".o-selection-ok");
     expect(model.getters.getActiveSheetId()).toBe(sheet1Id);
-    app.destroy();
-    app1.destroy();
+    fixture.remove();
   });
 
   test("undo after selection won't change active sheet", async () => {
-    const { app, model } = await createSelectionInput();
+    const fixture = makeTestFixture();
+    const { model } = await createSelectionInput({}, fixture);
     const sheet1Id = model.getters.getActiveSheetId();
     createSheet(model, { sheetId: "42" });
-    const { app: app1 } = await createSelectionInput();
+    await createSelectionInput({}, fixture);
     activateSheet(model, "42");
     selectCell(model, "B4");
     await nextTick();
@@ -319,11 +301,10 @@ describe("Selection Input", () => {
     expect(model.getters.getActiveSheetId()).toBe(sheet1Id);
     undo(model);
     expect(model.getters.getActiveSheetId()).toBe(sheet1Id);
-    app.destroy();
-    app1.destroy();
+    fixture.remove();
   });
   test("show red border if and only if invalid range", async () => {
-    const { app } = await createSelectionInput();
+    await createSelectionInput();
     await writeInput(0, "A1");
     expect(fixture.querySelectorAll("input")[0].value).toBe("A1");
     expect(fixture.querySelectorAll("input")[0].getAttribute("style")).not.toBe("color: #000;");
@@ -336,17 +317,15 @@ describe("Selection Input", () => {
     expect(fixture.querySelectorAll("input")[0].value).toBe("B1");
     expect(fixture.querySelectorAll("input")[0].getAttribute("style")).not.toBe("color: #000;");
     expect(fixture.querySelectorAll("input")[0].classList).not.toContain("o-invalid");
-    app.destroy();
   });
   test("don't show red border initially", async () => {
-    const { app } = await createSelectionInput();
+    await createSelectionInput();
     expect(fixture.querySelectorAll("input")[0].classList).not.toContain("o-invalid");
-    app.destroy();
   });
 
   test("pressing and releasing control has no effect on future clicks", async () => {
-    const { app, parent } = await mountSpreadsheet(fixture);
-    OPEN_CF_SIDEPANEL_ACTION(parent.env);
+    const { env, model, fixture } = await mountSpreadsheet();
+    OPEN_CF_SIDEPANEL_ACTION(env);
     await nextTick();
     await simulateClick(".o-cf-add");
     await nextTick();
@@ -355,10 +334,9 @@ describe("Selection Input", () => {
     expect(input.value).toBe("A1");
     await keyDown("Control");
     await keyUp("Control");
-    await clickCell(parent.model, "A2");
+    await clickCell(model, "A2");
     expect(fixture.querySelectorAll(".o-selection-input input")).toHaveLength(1);
     input = fixture.querySelector(".o-selection-input input") as HTMLInputElement;
     expect(input.value).toBe("A2");
-    app.destroy();
   });
 });

--- a/tests/components/side_panel.test.ts
+++ b/tests/components/side_panel.test.ts
@@ -1,13 +1,12 @@
-import { App, Component, xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
 import { sidePanelRegistry } from "../../src/registries/index";
 import { SidePanelContent } from "../../src/registries/side_panel_registry";
 import { simulateClick } from "../test_helpers/dom_helper";
-import { makeTestFixture, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let parent: Spreadsheet;
-let app: App;
 let sidePanelContent: { [key: string]: SidePanelContent };
 
 class Body extends Component<any, any> {
@@ -27,14 +26,11 @@ class Body2 extends Component<any, any> {
 }
 
 beforeEach(async () => {
-  fixture = makeTestFixture();
-  ({ app, parent } = await mountSpreadsheet(fixture));
+  ({ parent, fixture } = await mountSpreadsheet());
   sidePanelContent = Object.assign({}, sidePanelRegistry.content);
 });
 
 afterEach(() => {
-  app.destroy();
-  fixture.remove();
   sidePanelRegistry.content = sidePanelContent;
 });
 

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -1,4 +1,5 @@
-import { App, Component, onMounted, onWillUnmount, useState, useSubEnv, xml } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, useState, useSubEnv, xml } from "@odoo/owl";
+import { ComposerFocusType } from "../../src/components/spreadsheet/spreadsheet";
 import { TopBar } from "../../src/components/top_bar/top_bar";
 import { DEFAULT_FONT_SIZE } from "../../src/constants";
 import { toZone } from "../../src/helpers";
@@ -7,7 +8,6 @@ import { topbarComponentRegistry } from "../../src/registries";
 import { getMenuChildren } from "../../src/registries/menus/helpers";
 import { topbarMenuRegistry } from "../../src/registries/menus/topbar_menu_registry";
 import { ConditionalFormat, Pixel, Style } from "../../src/types";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import {
   addCellToSelection,
   createFilter,
@@ -15,14 +15,15 @@ import {
   setAnchorCorner,
   setCellContent,
   setSelection,
+  setStyle,
 } from "../test_helpers/commands_helpers";
 import { getElComputedStyle, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { getBorder, getCell } from "../test_helpers/getters_helpers";
 import {
-  makeTestFixture,
+  makeTestEnv,
+  mountComponent,
   mountSpreadsheet,
   nextTick,
-  target,
   toRangesData,
   typeInComposerTopBar,
 } from "../test_helpers/helpers";
@@ -38,7 +39,11 @@ const t = (s: string): string => s;
 class Parent extends Component {
   static template = xml/* xml */ `
     <div class="o-spreadsheet">
-      <TopBar focusComposer="state.focusComposer" dropdownMaxHeight="gridHeight" onClick="() => {}"/>
+      <TopBar 
+        focusComposer="state.focusComposer"
+        onComposerContentFocused="()=>{}"
+        dropdownMaxHeight="gridHeight"
+        onClick="() => {}"/>
     </div>
   `;
   static components = { TopBar };
@@ -71,33 +76,31 @@ class Parent extends Component {
 
 async function mountParent(
   model: Model = new Model(),
-  focusComposer: boolean = false
-): Promise<{ parent: Parent; app: App }> {
-  const app = new App(Parent, { props: { model, focusComposer } });
-  app.addTemplates(OWL_TEMPLATES);
-  const parent = await app.mount(fixture);
-  return { app, parent };
+  focusComposer: ComposerFocusType = "inactive"
+): Promise<{ parent: Parent; model: Model; fixture: HTMLElement }> {
+  const env = makeTestEnv({
+    model,
+    isDashboard: () => model.getters.isDashboard(),
+  });
+  let parent: Component;
+  ({ parent, fixture } = await mountComponent(Parent, {
+    props: { focusComposer, model },
+    env,
+    model,
+  }));
+  return { parent: parent as Parent, model, fixture };
 }
-
-beforeEach(() => {
-  fixture = makeTestFixture();
-});
-
-afterEach(() => {
-  fixture.remove();
-});
 
 describe("TopBar component", () => {
   test("simple rendering", async () => {
-    const { app } = await mountParent();
+    await mountParent();
     expect(fixture.querySelector(".o-spreadsheet-topbar")).toMatchSnapshot();
-    app.destroy();
   });
 
   test("opening a second menu closes the first one", async () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
-    const { app } = await mountParent(model);
+    await mountParent(model);
 
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
     fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
@@ -110,12 +113,10 @@ describe("TopBar component", () => {
     await nextTick();
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(1);
     expect(fixture.querySelectorAll(".o-color-line").length).toBe(0);
-    app.destroy();
   });
 
   test("Menu should be closed while clicking on composer", async () => {
-    const { app } = await mountParent();
-
+    await mountParent();
     expect(fixture.querySelectorAll(".o-menu").length).toBe(0);
     fixture
       .querySelector(".o-topbar-menu[data-id='file']")!
@@ -127,7 +128,6 @@ describe("TopBar component", () => {
     )!;
     await simulateClick(topbarComposerElement);
     expect(fixture.querySelectorAll(".o-menu").length).toBe(0);
-    app.destroy();
   });
 
   test("merging cell button state is correct", async () => {
@@ -141,7 +141,7 @@ describe("TopBar component", () => {
         },
       ],
     });
-    const { app } = await mountParent(model);
+    await mountParent(model);
     const mergeTool = fixture.querySelector('.o-tool[title="Merge Cells"]')!;
     expect(mergeTool.classList.contains("active")).toBeTruthy();
 
@@ -150,14 +150,13 @@ describe("TopBar component", () => {
     setAnchorCorner(model, "A2");
     await nextTick();
     expect(mergeTool.classList.contains("active")).toBeFalsy();
-    app.destroy();
   });
 
   test("multiple selection zones => merge tools is disabled", async () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
 
-    const { app } = await mountParent(model);
+    await mountParent(model);
     const mergeTool = fixture.querySelector('.o-tool[title="Merge Cells"]')!;
 
     // should be disabled, because the selection is just one cell
@@ -172,13 +171,10 @@ describe("TopBar component", () => {
     await nextTick();
     // should be disabled, because multiple zones are selected
     expect(mergeTool.classList.contains("o-disabled")).toBeTruthy();
-    app.destroy();
   });
 
   test("undo/redo tools", async () => {
-    const model = new Model();
-
-    const { app } = await mountParent(model);
+    const { model } = await mountParent();
     const undoTool = fixture.querySelector('.o-tool[title="Undo"]')!;
     const redoTool = fixture.querySelector('.o-tool[title="Redo"]')!;
 
@@ -202,13 +198,10 @@ describe("TopBar component", () => {
     expect(redoTool.classList.contains("o-disabled")).toBeFalsy();
 
     expect(getCell(model, "A1")).toBeUndefined();
-    app.destroy();
   });
 
   test("paint format tools", async () => {
-    const model = new Model();
-
-    const { app } = await mountParent(model);
+    await mountParent();
     const paintFormatTool = fixture.querySelector('.o-tool[title="Paint Format"]')!;
 
     expect(paintFormatTool.classList.contains("active")).toBeFalsy();
@@ -217,20 +210,13 @@ describe("TopBar component", () => {
     await nextTick();
 
     expect(paintFormatTool.classList.contains("active")).toBeTruthy();
-    app.destroy();
   });
 
   describe("Filter Tool", () => {
     let model: Model;
-    let app: App;
 
     beforeEach(async () => {
-      model = new Model();
-      ({ app } = await mountParent(model));
-    });
-
-    afterEach(() => {
-      app.destroy();
+      ({ model } = await mountParent());
     });
 
     test("Filter tool is enabled with single selection", async () => {
@@ -278,17 +264,15 @@ describe("TopBar component", () => {
       border: "all",
     });
     expect(getBorder(model, "B1")).toBeDefined();
-    const { app } = await mountParent(model);
+    await mountParent(model);
     const clearFormatTool = fixture.querySelector('.o-tool[title="Clear Format"]')!;
     clearFormatTool.dispatchEvent(new Event("click"));
     expect(getCell(model, "B1")).toBeUndefined();
-    app.destroy();
   });
 
   test("can set cell format", async () => {
-    const model = new Model();
+    const { model } = await mountParent();
     expect(getCell(model, "A1")).toBeUndefined();
-    const { app } = await mountParent(model);
     const formatTool = fixture.querySelector('.o-tool[title="More formats"]')!;
     formatTool.dispatchEvent(new Event("click"));
     await nextTick();
@@ -298,12 +282,10 @@ describe("TopBar component", () => {
       .dispatchEvent(new Event("click", { bubbles: true }));
     await nextTick();
     expect(getCell(model, "A1")!.format).toEqual("0.00%");
-    app.destroy();
   });
 
   test("can set font size", async () => {
-    const model = new Model();
-    const { app } = await mountParent(model);
+    const { model } = await mountParent();
     const fontSizeTool = fixture.querySelector('.o-tool[title="Font Size"]')!;
     expect(fontSizeTool.textContent!.trim()).toBe(DEFAULT_FONT_SIZE.toString());
     fontSizeTool.dispatchEvent(new Event("click"));
@@ -315,7 +297,6 @@ describe("TopBar component", () => {
     expect(fontSizeTool.textContent!.trim()).toBe("8");
     const style = model.getters.getCellStyle(getCell(model, "A1")!);
     expect(style.fontSize).toBe(8);
-    app.destroy();
   });
 
   test.each([
@@ -325,7 +306,7 @@ describe("TopBar component", () => {
   ])("can set horizontal alignment with the toolbar", async (iconClass, expectedStyle) => {
     const model = new Model();
     selectCell(model, "A1");
-    const { app } = await mountParent(model);
+    await mountParent(model);
     const alignTool = fixture.querySelector('.o-tool[title="Horizontal align"]')!;
     alignTool.dispatchEvent(new Event("click"));
     await nextTick();
@@ -340,8 +321,8 @@ describe("TopBar component", () => {
     button.dispatchEvent(new Event("click"));
     await nextTick();
     expect(model.getters.getCurrentStyle()).toEqual(expectedStyle);
-    app.destroy();
   });
+
   test.each([
     ["text", {}, "align-left"],
     ["0", {}, "align-right"],
@@ -358,17 +339,16 @@ describe("TopBar component", () => {
         target: [toZone("A1")],
         style: style as Style,
       });
-      const { app } = await mountParent(model);
+      await mountParent(model);
       const alignTool = fixture.querySelector('.o-tool[title="Horizontal align"]')!;
       expect(alignTool.querySelector("svg")!.classList).toContain(expectedIconClass);
-      app.destroy();
     }
   );
 
   test("opening, then closing same menu", async () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
-    const { app } = await mountParent(model);
+    await mountParent(model);
 
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
     fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
@@ -377,11 +357,10 @@ describe("TopBar component", () => {
     fixture.querySelector('.o-tool[title="Borders"]')!.dispatchEvent(new Event("click"));
     await nextTick();
     expect(fixture.querySelectorAll(".o-dropdown-content").length).toBe(0);
-    app.destroy();
   });
 
   test("Can open a Topbar menu", async () => {
-    const { app, parent } = await mountParent();
+    const { parent } = await mountParent();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     const items = topbarMenuRegistry.getAll();
     const number = items.filter((item) => item.children.length !== 0).length;
@@ -397,11 +376,10 @@ describe("TopBar component", () => {
     triggerMouseEvent(".o-spreadsheet-topbar", "click");
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    app.destroy();
   });
 
   test("Can open a Topbar menu with mousemove", async () => {
-    const { app, parent } = await mountParent();
+    const { parent } = await mountParent();
     triggerMouseEvent(".o-topbar-menu[data-id='file']", "click");
     await nextTick();
     const file = topbarMenuRegistry.get("file");
@@ -418,7 +396,6 @@ describe("TopBar component", () => {
     ).length;
     expect(fixture.querySelectorAll(".o-menu-item")).toHaveLength(numberChild);
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
-    app.destroy();
   });
 
   test("Can click on a menuItem do execute action and close menus", async () => {
@@ -432,7 +409,7 @@ describe("TopBar component", () => {
         number++;
       },
     });
-    const { app } = await mountParent();
+    const { fixture } = await mountParent();
     triggerMouseEvent(".o-topbar-menu[data-id='test']", "click");
     await nextTick();
     triggerMouseEvent(".o-menu-item", "click");
@@ -440,11 +417,10 @@ describe("TopBar component", () => {
     expect(fixture.querySelectorAll(".o-menu-dropdown-content")).toHaveLength(0);
     expect(number).toBe(1);
     topbarMenuRegistry.content = menuDefinitions;
-    app.destroy();
   });
 
   test("Opened menu parent is highlighted", async () => {
-    const { app } = await mountParent();
+    await mountParent();
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
     const menuItem = fixture.querySelector(".o-topbar-menu[data-id='edit']");
     expect(menuItem?.classList).not.toContain("o-topbar-menu-active");
@@ -456,7 +432,6 @@ describe("TopBar component", () => {
     await nextTick();
     expect(menuItem?.classList).not.toContain("o-topbar-menu-active");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
-    app.destroy();
   });
 
   test("Can add a custom component to topbar", async () => {
@@ -465,10 +440,9 @@ describe("TopBar component", () => {
       static template = xml`<div class="o-topbar-test">Test</div>`;
     }
     topbarComponentRegistry.add("1", { component: Comp });
-    const { app } = await mountParent();
+    await mountParent();
     expect(fixture.querySelectorAll(".o-topbar-test")).toHaveLength(1);
     topbarComponentRegistry.content = compDefinitions;
-    app.destroy();
   });
 
   test("Can add multiple components to topbar with different visibilities", async () => {
@@ -487,7 +461,7 @@ describe("TopBar component", () => {
       },
     });
     topbarComponentRegistry.add("second", { component: Comp2 });
-    const { app, parent } = await mountParent();
+    const { parent } = await mountParent();
     expect(fixture.querySelectorAll(".o-topbar-test1")).toHaveLength(0);
     expect(fixture.querySelectorAll(".o-topbar-test2")).toHaveLength(1);
 
@@ -499,12 +473,10 @@ describe("TopBar component", () => {
 
     // reset Top Component Registry
     topbarComponentRegistry.content = compDefinitions;
-    app.destroy();
   });
 
   test("Readonly spreadsheet has a specific top bar", async () => {
-    const model = new Model();
-    const { app } = await mountParent(model);
+    const { model } = await mountParent();
 
     expect(fixture.querySelectorAll(".o-readonly-toolbar")).toHaveLength(0);
     model.updateMode("readonly");
@@ -514,12 +486,11 @@ describe("TopBar component", () => {
     await nextTick();
     const insertMenuItems = fixture.querySelectorAll(".o-menu div.o-menu-item");
     expect([...insertMenuItems].every((item) => item.classList.contains("disabled"))).toBeTruthy();
-    app.destroy();
   });
 
   test("Cannot edit cell in a readonly spreadsheet", async () => {
     const model = new Model({}, { mode: "readonly" });
-    const { app, parent } = await mountParent(model);
+    const { parent } = await mountParent(model);
 
     let composerEl = fixture.querySelector(".o-spreadsheet-topbar div.o-composer")!;
 
@@ -533,7 +504,6 @@ describe("TopBar component", () => {
     expect(content).toBe("");
     composerEl = await typeInComposerTopBar("tabouret", false);
     expect(model.getters.getCurrentContent()).toBe(content);
-    app.destroy();
   });
 });
 
@@ -553,35 +523,27 @@ test("Can show/hide a TopBarComponent based on condition", async () => {
     component: Comp2,
     isVisible: (env) => false,
   });
-  const { app } = await mountParent();
+  await mountParent();
   expect(fixture.querySelectorAll(".o-topbar-test1")).toHaveLength(1);
   expect(fixture.querySelectorAll(".o-topbar-test2")).toHaveLength(0);
   topbarComponentRegistry.content = compDefinitions;
-  app.destroy();
 });
 
 describe("TopBar - Custom currency", () => {
   test("can open custom currency sidepanel from tool", async () => {
-    const { app } = await mountSpreadsheet(fixture);
+    const { fixture } = await mountSpreadsheet();
     triggerMouseEvent(".o-tool[title='More formats']", "click");
     await nextTick();
     triggerMouseEvent(".o-format-tool div[data-custom='custom_currency']", "click");
     await nextTick();
     expect(fixture.querySelector(".o-custom-currency")).toBeTruthy();
-    app.destroy();
   });
 });
 
 describe("Format", () => {
   test("can clear format", async () => {
-    const { app, parent } = await mountSpreadsheet(fixture);
-    const model = parent.model;
-    const sheetId = model.getters.getActiveSheetId();
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1, B2:B3"),
-      style: { fillColor: "#000000" },
-    });
+    const { model } = await mountSpreadsheet();
+    setStyle(model, "A1, B2:B3", { fillColor: "#000000" });
     selectCell(model, "A1");
     addCellToSelection(model, "B2");
     setAnchorCorner(model, "B3");
@@ -595,13 +557,12 @@ describe("Format", () => {
     expect(getCell(model, "A1")?.style).toBeUndefined();
     expect(getCell(model, "B2")?.style).toBeUndefined();
     expect(getCell(model, "B3")?.style).toBeUndefined();
-    app.destroy();
   });
 });
 
 describe("TopBar - CF", () => {
   test("open sidepanel with no CF in selected zone", async () => {
-    const { app } = await mountSpreadsheet(fixture);
+    const { fixture } = await mountSpreadsheet();
     triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
     await nextTick();
     triggerMouseEvent(".o-menu-item[data-name='format_cf']", "click");
@@ -612,12 +573,10 @@ describe("TopBar - CF", () => {
     expect(
       fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-cf .o-cf-ruleEditor")
     ).toBeFalsy();
-    app.destroy();
   });
 
   test("open sidepanel with one CF in selected zone", async () => {
-    const { app, parent } = await mountSpreadsheet(fixture);
-    const model = parent.model;
+    const { model, fixture } = await mountSpreadsheet();
 
     const cfRule: ConditionalFormat = {
       ranges: ["A1:C7"],
@@ -647,12 +606,10 @@ describe("TopBar - CF", () => {
     expect(
       fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-cf .o-cf-ruleEditor")
     ).toBeTruthy();
-    app.destroy();
   });
 
   test("open sidepanel with with more then one CF in selected zone", async () => {
-    const { app, parent } = await mountSpreadsheet(fixture);
-    const model = parent.model;
+    const { model, fixture } = await mountSpreadsheet();
 
     const cfRule1: ConditionalFormat = {
       ranges: ["A1:C7"],
@@ -697,12 +654,10 @@ describe("TopBar - CF", () => {
     expect(
       fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-cf .o-cf-ruleEditor")
     ).toBeFalsy();
-    app.destroy();
   });
 
   test("will update sidepanel if we reopen it from other cell", async () => {
-    const { app, parent } = await mountSpreadsheet(fixture);
-    const model = parent.model;
+    const { model, fixture } = await mountSpreadsheet();
 
     const cfRule1: ConditionalFormat = {
       ranges: ["A1:A10"],
@@ -743,19 +698,17 @@ describe("TopBar - CF", () => {
     expect(
       fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-cf .o-cf-ruleEditor")
     ).toBeFalsy();
-    app.destroy();
   });
 });
 describe("Topbar - View", () => {
   test("Setting show formula from topbar should retain its state even it's changed via f&r side panel upon closing", async () => {
-    const { app, parent } = await mountSpreadsheet(fixture);
-    const model = parent.model;
+    const { model, env } = await mountSpreadsheet();
     triggerMouseEvent(".o-topbar-menu[data-id='view']", "click");
     await nextTick();
     triggerMouseEvent(".o-menu-item[data-name='view_formulas']", "click");
     await nextTick();
     expect(model.getters.shouldShowFormulas()).toBe(true);
-    parent.env.openSidePanel("FindAndReplace");
+    env.openSidePanel("FindAndReplace");
     await nextTick();
     expect(model.getters.shouldShowFormulas()).toBe(true);
     await nextTick();
@@ -773,14 +726,13 @@ describe("Topbar - View", () => {
     );
     await nextTick();
     expect(model.getters.shouldShowFormulas()).toBe(true);
-    app.destroy();
   });
 });
 
 describe("Topbar - menu item resizing with viewport", () => {
   test("font size dropdown in top bar is resized with screen size change", async () => {
-    const model = new Model();
-    const { app } = await mountParent(model);
+    const { model } = await mountParent();
+
     triggerMouseEvent('.o-tool[title="Font Size"]', "click");
     await nextTick();
     let height = getElComputedStyle(".o-dropdown-content.o-text-options", "maxHeight");
@@ -793,12 +745,11 @@ describe("Topbar - menu item resizing with viewport", () => {
     expect(parseInt(height)).toBe(
       model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
     );
-    app.destroy();
   });
 
   test("color picker of fill color in top bar is resized with screen size change", async () => {
-    const model = new Model();
-    const { app } = await mountParent(model);
+    const { model } = await mountParent();
+
     triggerMouseEvent('.o-tool[title="Fill Color"]', "click");
     await nextTick();
     let height = getElComputedStyle(".o-color-picker.right", "maxHeight");
@@ -811,12 +762,10 @@ describe("Topbar - menu item resizing with viewport", () => {
     expect(parseInt(height)).toBe(
       model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
     );
-    app.destroy();
   });
 
   test("color picker of text color in top bar is resized with screen size change", async () => {
-    const model = new Model();
-    const { app } = await mountParent(model);
+    const { model } = await mountParent();
     triggerMouseEvent('.o-tool[title="Text Color"]', "click");
     await nextTick();
     let height = getElComputedStyle(".o-color-picker.right", "maxHeight");
@@ -829,16 +778,15 @@ describe("Topbar - menu item resizing with viewport", () => {
     expect(parseInt(height)).toBe(
       model.getters.getVisibleRect(model.getters.getActiveMainViewport()).height
     );
-    app.destroy();
   });
 });
 
 test("The composer helper should be closed on toggle topbar context menu", async () => {
-  const { parent } = await mountSpreadsheet(fixture);
+  const { model, fixture } = await mountSpreadsheet();
   await typeInComposerTopBar("=sum(");
-  expect(parent.model.getters.getEditionMode()).not.toBe("inactive");
+  expect(model.getters.getEditionMode()).not.toBe("inactive");
   expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(1);
   await simulateClick(".o-topbar-topleft .o-topbar-menu");
-  expect(parent.model.getters.getEditionMode()).toBe("inactive");
+  expect(model.getters.getEditionMode()).toBe("inactive");
   expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(0);
 });

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -1,9 +1,6 @@
-import { App, Component, useSubEnv, xml } from "@odoo/owl";
-import { Spreadsheet } from "../../src";
 import { toCartesian, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { CommandResult, Style } from "../../src/types/index";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
 import {
   addColumns,
   deleteRows,
@@ -19,7 +16,6 @@ import {
   undo,
   unMerge,
 } from "../test_helpers/commands_helpers";
-import { simulateClick } from "../test_helpers/dom_helper";
 import {
   getActiveXc,
   getBorder,
@@ -27,14 +23,7 @@ import {
   getCellContent,
   getMerges,
 } from "../test_helpers/getters_helpers";
-import {
-  getChildFromComponent,
-  getMergeCellMap,
-  makeTestFixture,
-  nextTick,
-  target,
-  XCToMergeCellMap,
-} from "../test_helpers/helpers";
+import { getMergeCellMap, target, XCToMergeCellMap } from "../test_helpers/helpers";
 
 function getCellsXC(model: Model): string[] {
   return Object.values(model.getters.getCells(model.getters.getActiveSheetId())).map((cell) => {
@@ -306,40 +295,6 @@ describe("merges", () => {
       styles: { 1: {} },
     });
     expect(merge(model, "A1:C4")).toBeSuccessfullyDispatched();
-  });
-
-  test("merging destructively a selection ask for confirmation", async () => {
-    const askConfirmation = jest.fn();
-    class Parent extends Component<any> {
-      static template = xml/* xml */ `<Spreadsheet model="_model"/>`;
-      static components = { Spreadsheet };
-      private _model!: Model;
-      setup() {
-        this._model = new Model();
-        useSubEnv({
-          askConfirmation,
-        });
-      }
-
-      get spreadsheet(): Spreadsheet {
-        return getChildFromComponent(this, Spreadsheet);
-      }
-
-      get model(): Model {
-        return this._model;
-      }
-    }
-    const fixture = makeTestFixture();
-    const app = new App(Parent);
-    app.addTemplates(OWL_TEMPLATES);
-    const parent = await app.mount(fixture);
-    const model = parent.model;
-    setCellContent(model, "B2", "b2");
-
-    setAnchorCorner(model, "F6");
-    await nextTick();
-    await simulateClick(".o-merge-tool");
-    expect(askConfirmation).toHaveBeenCalled();
   });
 
   test("merging cells with values will do nothing if not forced", () => {

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -34,4 +34,18 @@ beforeEach(() => {
 afterEach(() => {
   //@ts-ignore
   global.resizers.removeAll();
+  executeCleanups();
 });
+
+const cleanUps: (() => void)[] = [];
+
+export function registerCleanup(cleanupFn: () => void) {
+  cleanUps.push(cleanupFn);
+}
+
+function executeCleanups() {
+  let cleanupFn: (() => void) | undefined;
+  while ((cleanupFn = cleanUps.pop())) {
+    cleanupFn();
+  }
+}

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -1,4 +1,4 @@
-import { App, Component, xml } from "@odoo/owl";
+import { App, Component, ComponentConstructor, xml } from "@odoo/owl";
 import { ChartConfiguration } from "chart.js";
 import format from "xml-formatter";
 import { Spreadsheet, SpreadsheetProps } from "../../src/components/spreadsheet/spreadsheet";
@@ -6,12 +6,12 @@ import { functionRegistry } from "../../src/functions/index";
 import { toCartesian, toUnboundedZone, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { MergePlugin } from "../../src/plugins/core/merge";
-import { _t } from "../../src/translation";
 import {
   ColorScaleMidPointThreshold,
   ColorScaleThreshold,
   CommandTypes,
   ConditionalFormat,
+  Currency,
   RangeData,
   SpreadsheetChildEnv,
   Style,
@@ -19,7 +19,7 @@ import {
   Zone,
 } from "../../src/types";
 import { XLSXExport } from "../../src/types/xlsx";
-import { OWL_TEMPLATES } from "../setup/jest.setup";
+import { OWL_TEMPLATES, registerCleanup } from "../setup/jest.setup";
 import { CellEvaluation } from "./../../src/types/cells";
 import { redo, setCellContent, undo } from "./commands_helpers";
 import { getCell, getCellContent } from "./getters_helpers";
@@ -108,6 +108,26 @@ export class MockClipboard implements Clipboard {
   }
 }
 
+export function makeTestEnv(mockEnv: Partial<SpreadsheetChildEnv> = {}): SpreadsheetChildEnv {
+  return {
+    model: mockEnv.model || new Model(),
+    isDashboard: mockEnv.isDashboard || (() => false),
+    openSidePanel: mockEnv.openSidePanel || (() => {}),
+    toggleSidePanel: mockEnv.toggleSidePanel || (() => {}),
+    clipboard: mockEnv.clipboard || new MockClipboard(),
+    _t: mockEnv._t || ((str: string, ...values: any) => str),
+    notifyUser: mockEnv.notifyUser || (() => {}),
+    raiseError: mockEnv.raiseError || (() => {}),
+    askConfirmation: mockEnv.askConfirmation || (() => {}),
+    editText: mockEnv.editText || (() => {}),
+    loadCurrencies:
+      mockEnv.loadCurrencies ||
+      (async () => {
+        return [] as Currency[];
+      }),
+  };
+}
+
 export function testUndoRedo(model: Model, expect: jest.Expect, command: CommandTypes, args: any) {
   const before = model.exportData();
   model.dispatch(command, args);
@@ -118,35 +138,60 @@ export function testUndoRedo(model: Model, expect: jest.Expect, command: Command
   expect(model).toExport(after);
 }
 
+export async function mountComponent<Props extends { [key: string]: any }>(
+  component: ComponentConstructor<Props, SpreadsheetChildEnv>,
+  optionalArgs: {
+    props?: Props;
+    env?: Partial<SpreadsheetChildEnv>;
+    model?: Model;
+    fixture?: HTMLElement;
+  } = {}
+): Promise<{
+  app: App;
+  parent: Component<Props, SpreadsheetChildEnv>;
+  model: Model;
+  fixture: HTMLElement;
+  env: SpreadsheetChildEnv;
+}> {
+  const model = optionalArgs.model || optionalArgs?.env?.model || new Model();
+  const env = makeTestEnv({ ...optionalArgs.env, model: model });
+  const props = optionalArgs.props || ({} as Props);
+  const app = new App(component, { props, env, test: true });
+  app.addTemplates(OWL_TEMPLATES);
+  const fixture = optionalArgs?.fixture || makeTestFixture();
+  const parent = await app.mount(fixture);
+
+  registerCleanup(() => {
+    app.destroy();
+    fixture.remove();
+  });
+
+  return { app, parent, model, fixture, env: parent.env };
+}
+
 // Requires to be called wit jest realTimers
 export async function mountSpreadsheet(
-  fixture: HTMLElement,
   props: SpreadsheetProps = { model: new Model() },
-  env: Partial<SpreadsheetChildEnv> = {}
-): Promise<{ app: App; parent: Spreadsheet }> {
-  const mockEnv: SpreadsheetChildEnv = {
+  partialEnv: Partial<SpreadsheetChildEnv> = {}
+): Promise<{
+  app: App;
+  parent: Spreadsheet;
+  model: Model;
+  fixture: HTMLElement;
+  env: SpreadsheetChildEnv;
+}> {
+  const { app, parent, model, fixture, env } = await mountComponent(Spreadsheet, {
+    props,
+    env: partialEnv,
     model: props.model,
-    _t: _t,
-    clipboard: new MockClipboard(),
-    openSidePanel: () => {},
-    toggleSidePanel: () => {},
-    loadCurrencies: async () => [],
-    editText: () => {},
-    notifyUser: () => {},
-    raiseError: () => {},
-    askConfirmation: () => {},
-    isDashboard: () => false,
-    ...env,
-  };
-  const app = new App(Spreadsheet, { props, env: mockEnv, test: true });
-  app.addTemplates(OWL_TEMPLATES);
-  const parent = (await app.mount(fixture)) as Spreadsheet;
+  });
+
   /**
    * The following nextTick is necessary to ensure that a re-render is correctly
    * done after the resize of the sheet view.
    */
   await nextTick();
-  return { app, parent };
+  return { app, parent: parent as Spreadsheet, model, fixture, env };
 }
 
 type GridDescr = { [xc: string]: string | undefined };


### PR DESCRIPTION
## Description:

this PR bumps the version of OWL in o-spreadshset to catch up with its counterpart in odoo: version 2.0.9
One major change (one could argue breaking) is that the property `el` of a `Ref` is now `undefined` once the component is no longer mounted. This change of behaviour highlighted several issues in our tests setup. Since several of them were addressed in PR #2045, it was decided to backport the said pull request in version 16.0 to ease the transition of owl versions.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo