### PR TITLE
[WIP] Version history

### DIFF
--- a/src/collaborative/revisions.ts
+++ b/src/collaborative/revisions.ts
@@ -3,6 +3,8 @@ import { ClientId, CoreCommand, HistoryChange, RevisionData, UID } from "../type
 export class Revision implements RevisionData {
   public readonly id: UID;
   public readonly clientId: ClientId;
+  public readonly timestamp: number | undefined;
+
   private _commands: readonly CoreCommand[] = [];
   private _changes: readonly HistoryChange[] = [];
 
@@ -19,12 +21,14 @@ export class Revision implements RevisionData {
     id: UID,
     clientId: ClientId,
     commands: readonly CoreCommand[],
-    changes?: readonly HistoryChange[]
+    changes?: readonly HistoryChange[],
+    timestamp?: number
   ) {
     this.id = id;
     this.clientId = clientId;
     this._commands = [...commands];
     this._changes = changes ? [...changes] : [];
+    this.timestamp = timestamp;
   }
 
   setChanges(changes: readonly HistoryChange[]) {

--- a/src/components/side_panel/version_history/version_history.ts
+++ b/src/components/side_panel/version_history/version_history.ts
@@ -1,0 +1,94 @@
+import { Component, onWillUpdateProps, useState } from "@odoo/owl";
+import { Revision } from "../../../collaborative/revisions";
+import { _lt } from "../../../translation";
+import { OperationSequenceNode, SpreadsheetChildEnv } from "../../../types/index";
+import { UID } from "../../../types/misc";
+import { css } from "../../helpers/css";
+
+css/*scss*/ `
+  .o-version-history-date {
+    font-weight: bold;
+  }
+  .o-version-history-current-version {
+    color: #0066ff;
+    font-style: italic;
+    font-size: 0.9rem;
+  }
+  .o-version-history-item {
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+  .o-version-history-item:hover {
+    background-color: rgba(0, 255, 0, 0.15);
+    cursor: pointer;
+  }
+  .o-version-history-item:hover .o-version-history-date {
+    color: green;
+  }
+`;
+
+interface Props {
+  onCloseSidePanel: () => void;
+}
+
+interface VersionHistoryState {
+  currently_selected_revision_id: UID;
+}
+
+export class VersionHistory extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-VersionHistory";
+  static props = ["model"];
+
+  /* @ts-ignore => used in xml */
+  private readonly UITexts = {
+    displayedVersion: _lt("Displayed Version"),
+    dateNotAvaialble: _lt("Date not available"),
+  };
+
+  /* @ts-ignore => used in xml */
+  private revisions: OperationSequenceNode<Revision>[] = [
+    ...this.env.model
+      .getSession()
+      .getRevisions()
+      .getTree()
+      .revertedExecution(this.env.model.getSession().getRevisions().getHeadBranch()),
+  ];
+  private state: VersionHistoryState = useState({
+    currently_selected_revision_id: this.env.model.getSession().getRevisions().getHeadOperation()
+      .id,
+  });
+
+  setup() {
+    onWillUpdateProps(() => {
+      this.revisions = [
+        ...this.env.model
+          .getSession()
+          .getRevisions()
+          .getTree()
+          .revertedExecution(this.env.model.getSession().getRevisions().getHeadBranch()),
+      ];
+    });
+  }
+
+  formatDateFromTimestamp(unixTimespan) {
+    const date = new Date(unixTimespan);
+    const options: Intl.DateTimeFormatOptions = {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+    };
+    return date.toLocaleDateString(navigator.language, options);
+  }
+
+  onRevisionClick(revision) {
+    this.state.currently_selected_revision_id = revision.operation.id;
+    this.env.model.getSession().getRevisions().fastForward();
+    this.env.model.getSession().getRevisions().revertTo(revision.operation.id);
+    this.env.model.trigger("update");
+  }
+}

--- a/src/components/side_panel/version_history/version_history.ts
+++ b/src/components/side_panel/version_history/version_history.ts
@@ -1,6 +1,5 @@
 import { Component, onWillUpdateProps, useState } from "@odoo/owl";
 import { Revision } from "../../../collaborative/revisions";
-import { _lt } from "../../../translation";
 import { OperationSequenceNode, SpreadsheetChildEnv } from "../../../types/index";
 import { UID } from "../../../types/misc";
 import { css } from "../../helpers/css";
@@ -34,18 +33,11 @@ interface Props {
 }
 
 interface VersionHistoryState {
-  currently_selected_revision_id: UID;
+  currentlySelectedRevisionId: UID;
 }
 
 export class VersionHistory extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-VersionHistory";
-  static props = ["model"];
-
-  /* @ts-ignore => used in xml */
-  private readonly UITexts = {
-    displayedVersion: _lt("Displayed Version"),
-    dateNotAvaialble: _lt("Date not available"),
-  };
 
   /* @ts-ignore => used in xml */
   private revisions: OperationSequenceNode<Revision>[] = [
@@ -56,8 +48,7 @@ export class VersionHistory extends Component<Props, SpreadsheetChildEnv> {
       .revertedExecution(this.env.model.getSession().getRevisions().getHeadBranch()),
   ];
   private state: VersionHistoryState = useState({
-    currently_selected_revision_id: this.env.model.getSession().getRevisions().getHeadOperation()
-      .id,
+    currentlySelectedRevisionId: this.env.model.getSession().getRevisions().getHeadOperation().id,
   });
 
   setup() {
@@ -86,7 +77,7 @@ export class VersionHistory extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onRevisionClick(revision) {
-    this.state.currently_selected_revision_id = revision.operation.id;
+    this.state.currentlySelectedRevisionId = revision.operation.id;
     this.env.model.getSession().getRevisions().fastForward();
     this.env.model.getSession().getRevisions().revertTo(revision.operation.id);
     this.env.model.trigger("update");

--- a/src/components/side_panel/version_history/version_history.xml
+++ b/src/components/side_panel/version_history/version_history.xml
@@ -13,14 +13,14 @@
             class="o-version-history-date"
             t-esc="formatDateFromTimestamp(revision.operation.data.timestamp)"
           />
-          <span t-else="" class="o-version-history-date" t-esc="UITexts.dateNotAvaialble"/>
+          <span t-else="" class="o-version-history-date">Date not available</span>
           <br/>
           <span
-            t-if="state.currently_selected_revision_id == revision.operation.id"
-            class="o-version-history-current-version"
-            t-esc="UITexts.displayedVersion"
-          />
-          <br t-if="state.currently_selected_revision_id == revision.operation.id"/>
+            t-if="state.currentlySelectedRevisionId == revision.operation.id"
+            class="o-version-history-current-version">
+            Displayed Version
+          </span>
+          <br t-if="state.currentlySelectedRevisionId == revision.operation.id"/>
         </div>
       </div>
     </div>

--- a/src/components/side_panel/version_history/version_history.xml
+++ b/src/components/side_panel/version_history/version_history.xml
@@ -1,0 +1,28 @@
+<templates>
+  <t t-name="o-spreadsheet-VersionHistory" owl="1">
+    <div class="o-version-history">
+      <div class="o-version-history-content">
+        <div
+          t-foreach="this.revisions"
+          t-as="revision"
+          t-key="revision.operation.id"
+          class="o-version-history-item"
+          t-on-click="() => this.onRevisionClick(revision)">
+          <span
+            t-if="revision.operation.data.timestamp"
+            class="o-version-history-date"
+            t-esc="formatDateFromTimestamp(revision.operation.data.timestamp)"
+          />
+          <span t-else="" class="o-version-history-date" t-esc="UITexts.dateNotAvaialble"/>
+          <br/>
+          <span
+            t-if="state.currently_selected_revision_id == revision.operation.id"
+            class="o-version-history-current-version"
+            t-esc="UITexts.displayedVersion"
+          />
+          <br t-if="state.currently_selected_revision_id == revision.operation.id"/>
+        </div>
+      </div>
+    </div>
+  </t>
+</templates>

--- a/src/history/selective_history.ts
+++ b/src/history/selective_history.ts
@@ -114,7 +114,7 @@ export class SelectiveHistory<T = unknown> {
   /**
    * Revert the state as it was *after* the given operation was executed.
    */
-  private revertTo(operationId: UID | null) {
+  revertTo(operationId: UID | null) {
     const execution = operationId
       ? this.tree.revertedExecution(this.HEAD_BRANCH).stopBefore(operationId)
       : this.tree.revertedExecution(this.HEAD_BRANCH);
@@ -139,7 +139,7 @@ export class SelectiveHistory<T = unknown> {
   /**
    * Replay the operations between the current HEAD_BRANCH and the end of the tree
    */
-  private fastForward() {
+  fastForward() {
     const operations = this.HEAD_OPERATION
       ? this.tree.execution(this.HEAD_BRANCH).startAfter(this.HEAD_OPERATION.id)
       : this.tree.execution(this.HEAD_BRANCH);
@@ -150,5 +150,17 @@ export class SelectiveHistory<T = unknown> {
       this.HEAD_OPERATION = operation;
       this.HEAD_BRANCH = branch;
     }
+  }
+
+  getTree() {
+    return this.tree;
+  }
+
+  getHeadBranch() {
+    return this.HEAD_BRANCH;
+  }
+
+  getHeadOperation() {
+    return this.HEAD_OPERATION;
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -174,6 +174,14 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
   uuidGenerator: UuidGenerator;
 
+  partialConfig: Partial<ModelConfig>;
+  beforeData: any;
+
+  getCopyWithMode(mode: Mode) {
+    const config = { ...this.partialConfig, mode: mode };
+    return new Model(this.beforeData, config, [], this.uuidGenerator, false);
+  }
+
   constructor(
     data: any = {},
     config: Partial<ModelConfig> = {},
@@ -183,6 +191,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   ) {
     super();
 
+    this.beforeData = data;
     stateUpdateMessages = repairInitialMessages(data, stateUpdateMessages);
 
     const workbookData = load(data, verboseImport);
@@ -191,6 +200,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
     this.uuidGenerator = uuidGenerator;
 
+    this.partialConfig = config;
     this.config = this.setupConfig(config);
 
     this.session = this.setupSession(workbookData.revisionId);
@@ -602,5 +612,9 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     for (const plugin of this.corePlugins) {
       plugin.garbageCollectExternalResources();
     }
+  }
+
+  getSession() {
+    return this.session;
   }
 }

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -723,3 +723,13 @@ export const SORT_CELLS_DESCENDING = (env: SpreadsheetChildEnv) => {
 export const IS_ONLY_ONE_RANGE = (env: SpreadsheetChildEnv): boolean => {
   return env.model.getters.getSelectedZones().length === 1;
 };
+
+export const OPEN_VERSION_HISTORY_SIDE_PANEL = (env: SpreadsheetChildEnv) => {
+  env.model.updateMode("readonly");
+  env.openSidePanel("VersionHistory", {
+    onCloseSidePanel: () => {
+      env.model.getSession().getRevisions().fastForward();
+      env.model.updateMode("normal");
+    },
+  });
+};

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -24,6 +24,13 @@ topbarMenuRegistry
     sequence: 10,
     action: () => console.log("Not implemented"),
   })
+  .addChild("version_history", ["file"], {
+    name: _lt("Version history"),
+  })
+  .addChild("see_version_history", ["file", "version_history"], {
+    name: _lt("See version history"),
+    action: ACTIONS.OPEN_VERSION_HISTORY_SIDE_PANEL,
+  })
   .addChild("undo", ["edit"], {
     name: _lt("Undo"),
     description: "Ctrl+Z",

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -2,6 +2,7 @@ import { ChartPanel } from "../components/side_panel/chart/main_chart_panel/main
 import { ConditionalFormattingPanel } from "../components/side_panel/conditional_formatting/conditional_formatting";
 import { CustomCurrencyPanel } from "../components/side_panel/custom_currency/custom_currency";
 import { FindAndReplacePanel } from "../components/side_panel/find_and_replace/find_and_replace";
+import { VersionHistory } from "../components/side_panel/version_history/version_history";
 import { _lt } from "../translation";
 import { SpreadsheetChildEnv } from "../types";
 import { Registry } from "./registry";
@@ -35,4 +36,9 @@ sidePanelRegistry.add("FindAndReplace", {
 sidePanelRegistry.add("CustomCurrency", {
   title: _lt("Custom currency format"),
   Body: CustomCurrencyPanel,
+});
+
+sidePanelRegistry.add("VersionHistory", {
+  title: _lt("Version History"),
+  Body: VersionHistory,
 });

--- a/src/types/collaborative/transport_service.ts
+++ b/src/types/collaborative/transport_service.ts
@@ -13,6 +13,7 @@ export interface RemoteRevisionMessage extends AbstractMessage {
   commands: readonly CoreCommand[];
   nextRevisionId: UID;
   serverRevisionId: UID;
+  timestamp: number | undefined;
 }
 
 export interface RevisionUndoneMessage extends AbstractMessage {

--- a/tools/server/main.js
+++ b/tools/server/main.js
@@ -132,6 +132,9 @@ app.ws("/", function (ws, req) {
       case "REVISION_UNDONE":
       case "REVISION_REDONE":
         if (msg.serverRevisionId === serverRevisionId) {
+          const timestamp = Date.now();
+          msg.timestamp = timestamp;
+          message.timestamp = timestamp;
           serverRevisionId = msg.nextRevisionId;
           messages.push(msg);
           broadcast(message);


### PR DESCRIPTION
Add a version history sidepanel, containing a list with all the revisions.
When opened, the spreadsheet goes in readonly mode.
When a revision is selected, the spreadsheet display its state when the revision occured.

Odoo task ID : [3142006](https://www.odoo.com/web#id=3142006&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [x] support of duplicate sheet (deep copy)
- [x] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [x] in model/UI: ranges are strings (to show the user)
- [x] undo-able commands (uses this.history.update)
- [x] multiuser-able commands (has inverse commands and transformations where needed)
- [x] new/updated/removed commands are documented
- [x] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo