### PR TITLE
[IMP] edition: remove `getEditionSheet` for redundancy

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -603,7 +603,7 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     const highlights = this.env.model.getters.getHighlights();
     const refSheet = sheetName
       ? this.env.model.getters.getSheetIdByName(sheetName)
-      : this.env.model.getters.getEditionSheet();
+      : this.env.model.getters.getCurrentEditedCell().sheetId;
 
     const highlight = highlights.find((highlight) => {
       if (highlight.sheetId !== refSheet) return false;

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -55,7 +55,6 @@ export class EditionPlugin extends UIPlugin {
     "isSelectingForComposer",
     "showSelectionIndicator",
     "getCurrentContent",
-    "getEditionSheet",
     "getComposerSelection",
     "getCurrentTokens",
     "getTokenAtCursor",
@@ -247,10 +246,6 @@ export class EditionPlugin extends UIPlugin {
       return this.getComposerContent(this.getters.getActivePosition());
     }
     return this.currentContent;
-  }
-
-  getEditionSheet(): string {
-    return this.sheetId;
   }
 
   getComposerSelection(): ComposerSelection {
@@ -583,7 +578,7 @@ export class EditionPlugin extends UIPlugin {
   ): string {
     const sheetId = this.getters.getActiveSheetId();
     let selectedXc = this.getters.zoneToXC(sheetId, zone, fixedParts);
-    if (this.getters.getEditionSheet() !== this.getters.getActiveSheetId()) {
+    if (this.getters.getCurrentEditedCell().sheetId !== this.getters.getActiveSheetId()) {
       const sheetName = getComposerSheetName(
         this.getters.getSheetName(this.getters.getActiveSheetId())
       );
@@ -603,7 +598,10 @@ export class EditionPlugin extends UIPlugin {
       _fixedParts.pop();
     }
     const newRange = range.clone({ parts: _fixedParts });
-    return this.getters.getSelectionRangeString(newRange, this.getters.getEditionSheet());
+    return this.getters.getSelectionRangeString(
+      newRange,
+      this.getters.getCurrentEditedCell().sheetId
+    );
   }
 
   /**
@@ -640,7 +638,7 @@ export class EditionPlugin extends UIPlugin {
     if (!this.currentContent.startsWith("=") || this.mode === "inactive") {
       return;
     }
-    const editionSheetId = this.getters.getEditionSheet();
+    const editionSheetId = this.getters.getCurrentEditedCell().sheetId;
     const XCs = this.getReferencedRanges().map((range) =>
       this.getters.getRangeString(range, editionSheetId)
     );
@@ -671,7 +669,7 @@ export class EditionPlugin extends UIPlugin {
     if (!this.currentContent.startsWith("=") || this.mode === "inactive") {
       return [];
     }
-    const editionSheetId = this.getters.getEditionSheet();
+    const editionSheetId = this.getters.getCurrentEditedCell().sheetId;
     const rangeColor = (rangeString: string) => {
       const colorIndex = this.colorIndexByRange[rangeString];
       return colors[colorIndex % colors.length];
@@ -690,7 +688,7 @@ export class EditionPlugin extends UIPlugin {
    * Return ranges currently referenced in the composer
    */
   getReferencedRanges(): Range[] {
-    const editionSheetId = this.getters.getEditionSheet();
+    const editionSheetId = this.getters.getCurrentEditedCell().sheetId;
     return this.currentTokens
       .filter((token) => token.type === "REFERENCE")
       .map((token) => this.getters.getRangeFromSheetXC(editionSheetId, token.value));

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -90,10 +90,10 @@ describe("edition", () => {
     const sheet1 = model.getters.getSheetIds()[0];
     model.dispatch("START_EDITION", { text: "=" });
     expect(model.getters.getEditionMode()).toBe("selecting");
-    expect(model.getters.getEditionSheet()).toBe(sheet1);
+    expect(model.getters.getCurrentEditedCell().sheetId).toBe(sheet1);
     createSheet(model, { activate: true, sheetId: "42" });
     expect(model.getters.getEditionMode()).toBe("selecting");
-    expect(model.getters.getEditionSheet()).toBe(sheet1);
+    expect(model.getters.getCurrentEditedCell().sheetId).toBe(sheet1);
     model.dispatch("STOP_EDITION");
     expect(model.getters.getActiveSheetId()).toBe(sheet1);
     expect(getCellText(model, "A1")).toBe("=");


### PR DESCRIPTION
A new getter `getCurrentEditedCell` was recently indroduced. The information of this getter includes all the info from getter `getEditionSheet` (`CellPosition` includes `sheetId`). This commit removes the latter getter to have a single entry point to access the information.

Task: 3229919

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo