### PR TITLE
[FIX] misc: prevent row resize caused by multiline formulas

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -129,8 +129,10 @@ export function getDefaultCellHeight(cell: Cell | undefined): Pixel {
     return DEFAULT_CELL_HEIGHT;
   }
   const fontSize = computeTextFontSizeInPixels(cell.style);
-  const multiLineText = cell.content.split(NEWLINE);
-  return computeTextLinesHeight(fontSize, multiLineText.length) + 2 * PADDING_AUTORESIZE_VERTICAL;
+
+  // the number of lines should be computed from the formula result, but it's not evaluated at this point
+  const numberOfLines = cell.isFormula ? 1 : cell.content.split(NEWLINE).length;
+  return computeTextLinesHeight(fontSize, numberOfLines) + 2 * PADDING_AUTORESIZE_VERTICAL;
 }
 
 export function computeTextWidth(context: CanvasRenderingContext2D, text: string, style: Style) {

--- a/tests/plugins/formatting.test.ts
+++ b/tests/plugins/formatting.test.ts
@@ -561,4 +561,11 @@ describe("Autoresize", () => {
     model.dispatch("AUTORESIZE_COLUMNS", { sheetId, cols: [0] });
     expect(model.getters.getColSize(sheetId, 0)).toBe(initialSize);
   });
+
+  test("row height does not take into account line breaks in the formula", async () => {
+    const initialSize = model.getters.getRowSize(sheetId, 0);
+    setCellContent(model, "A1", "=5\n\n-3\n\n-9");
+    expect(getCellContent(model, "A1")).toEqual("-7");
+    expect(model.getters.getRowSize(sheetId, 0)).toEqual(initialSize);
+  });
 });


### PR DESCRIPTION
## Description:

Previously, typing a formula with multiple lines (e.g. = A1 + [NEWLINE] 2)
caused the rows to resize, as the formula was displayed on two lines.
To prevent this unnecessary row resize, a hard-coded value of `1` is now
returned from `getDefaultCellHeight` in the case of formula syntax.

Odoo task ID : [3221078](https://www.odoo.com/web#id=3221078&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo