### PR TITLE
[IMP] color_picker : added accessibility to custom color picker

### DIFF
--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -21,13 +21,13 @@
           </div>
         </div>
         <div class="o-separator"/>
-        <div class="o-color-picker-section-name">
+        <div
+          class="o-color-picker-section-name o-color-picker-toggler"
+          t-on-click="toggleColorPicker">
           <span>Custom</span>
         </div>
-        <div class="colors-grid">
-          <div
-            class="o-color-picker-toggler o-color-picker-line-item"
-            t-on-click.stop="toggleColorPicker">
+        <div class="colors-grid o-color-picker-toggler" t-on-click.stop="toggleColorPicker">
+          <div class="o-color-picker-line-item o-color-picker-toggler">
             <div align="center">+</div>
           </div>
           <div

--- a/tests/components/color_picker.test.ts
+++ b/tests/components/color_picker.test.ts
@@ -51,12 +51,15 @@ describe("Color Picker buttons", () => {
     expect(onColorPicked).toHaveBeenCalledWith("");
   });
 
-  test("Click on '+' button toggle the custom color part", async () => {
+  test("Clicking on '+', custom section except custom added colors must toggle the custom color picker", async () => {
     await mountColorPicker();
-    await simulateClick(".o-color-picker-toggler");
-    expect(fixture.querySelector(".o-custom-selector")).toBeDefined();
-    await simulateClick(".o-color-picker-toggler");
-    expect(fixture.querySelector(".o-custom-selector")).toBeNull();
+    const elements = fixture.querySelectorAll(".o-color-picker-toggler");
+    for (const element of elements) {
+      await simulateClick(element);
+      expect(fixture.querySelector(".o-custom-selector")).toBeDefined();
+      await simulateClick(element);
+      expect(fixture.querySelector(".o-custom-selector")).toBeNull();
+    }
   });
 
   test("Can pick a standard color", async () => {


### PR DESCRIPTION
Enabled custom color picker to open by clicking on Custom part no matter where we click (not only on the +), beside the already added colors.

Task-3223388

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3223388](https://www.odoo.com/web#id=3223388&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo