### PR TITLE
[IMP] spreadsheet: add split to columns feature

### DIFF
--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -31,3 +31,10 @@ export const removeDataFilter: ActionSpec = {
   isVisible: ACTIONS.SELECTION_CONTAINS_FILTER,
   icon: "o-spreadsheet-Icon.FILTER_ICON_INACTIVE",
 };
+
+export const splitToColumns: ActionSpec = {
+  name: _lt("Split text to columns"),
+  sequence: 1,
+  execute: (env) => env.openSidePanel("SplitToColumns", {}),
+  isEnabled: (env) => env.model.getters.isSingleColSelected(),
+};

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -553,4 +553,12 @@
   <t t-name="o-spreadsheet-Icon.NUMBER_FORMATS" owl="1">
     <span class="o-text-icon">123</span>
   </t>
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION" owl="1">
+    <svg class="o-icon" viewBox="0 0 512 512">
+      <path
+        fill="currentColor"
+        d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24V296c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z"
+      />
+    </svg>
+  </t>
 </templates>

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -72,9 +72,15 @@ css/* scss */ `
       }
     }
 
-    .o-sidepanel-error {
-      color: red;
+    .o-sidepanel-error,
+    .o-sidepanel-warning {
       margin-top: 10px;
+
+      .o-icon {
+        margin-right: 5px;
+        height: 1.2em;
+        width: 1.2em;
+      }
     }
 
     .o-sidePanelButtons {
@@ -130,6 +136,16 @@ css/* scss */ `
     select.o-input {
       background-color: white;
       text-align: left;
+    }
+
+    .o-checkbox {
+      label {
+        display: flex;
+        justify-items: center;
+        input {
+          margin-right: 5px;
+        }
+      }
     }
 
     .o-inflection {

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -1,0 +1,135 @@
+import { Component, onMounted, onWillUpdateProps, useState } from "@odoo/owl";
+import { NEWLINE } from "../../../constants";
+import { interactiveSplitToColumns } from "../../../helpers/ui/split_to_columns_interactive";
+import { _lt } from "../../../translation";
+import { CommandResult, SpreadsheetChildEnv } from "../../../types/index";
+import { SplitToColumnsTerms } from "../../translations_terms";
+
+type SeparatorValue = "auto" | "custom" | " " | "," | ";" | typeof NEWLINE;
+
+interface Separator {
+  name: string;
+  value: SeparatorValue;
+}
+
+const SEPARATORS: Separator[] = [
+  { name: _lt("Detect automatically"), value: "auto" },
+  { name: _lt("Custom separator"), value: "custom" },
+  { name: _lt("Space"), value: " " },
+  { name: _lt("Comma"), value: "," },
+  { name: _lt("Semicolon"), value: ";" },
+  { name: _lt("Line Break"), value: NEWLINE },
+];
+
+interface Props {
+  onCloseSidePanel: () => void;
+}
+
+interface State {
+  separatorValue: SeparatorValue;
+  customSeparator: string;
+  addNewColumns: boolean;
+}
+
+export class SplitIntoColumnsPanel extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-SplitIntoColumnsPanel";
+
+  state = useState<State>({ separatorValue: "auto", addNewColumns: false, customSeparator: "" });
+
+  setup() {
+    onWillUpdateProps(() => {
+      // The feature makes no sense if we are editing a cell, because then the selection isn't active
+      // Stop the edition when the panel is mounted, and close the panel if the user start editing a cell
+      if (this.env.model.getters.getEditionMode() !== "inactive") {
+        this.props.onCloseSidePanel();
+      }
+    });
+
+    onMounted(() => {
+      this.env.model.dispatch("STOP_EDITION");
+    });
+  }
+
+  onSeparatorChange(value: SeparatorValue) {
+    this.state.separatorValue = value;
+  }
+
+  updateCustomSeparator(ev: InputEvent) {
+    if (!ev.target) return;
+    this.state.customSeparator = (ev.target as HTMLInputElement).value;
+  }
+
+  updateAddNewColumnsCheckbox(ev: Event) {
+    if (!ev.target) return;
+    this.state.addNewColumns = (ev.target as HTMLInputElement).checked;
+  }
+
+  confirm() {
+    const result = interactiveSplitToColumns(
+      this.env,
+      this.separatorValue,
+      this.state.addNewColumns
+    );
+
+    if (result.isSuccessful) {
+      this.props.onCloseSidePanel();
+    }
+  }
+
+  get errorMessages(): string[] {
+    const cancelledReasons = this.env.model.canDispatch("SPLIT_TEXT_INTO_COLUMNS", {
+      separator: this.separatorValue,
+      addNewColumns: this.state.addNewColumns,
+      force: true,
+    }).reasons;
+
+    const errors = new Set<string>();
+
+    for (const reason of cancelledReasons) {
+      switch (reason) {
+        case CommandResult.SplitWillOverwriteContent:
+        case CommandResult.EmptySplitSeparator:
+          break;
+        default:
+          errors.add(SplitToColumnsTerms.Errors[reason] || SplitToColumnsTerms.Errors.Unexpected);
+      }
+    }
+    return Array.from(errors);
+  }
+
+  get warningMessages(): string[] {
+    const warnings: string[] = [];
+    const cancelledReasons = this.env.model.canDispatch("SPLIT_TEXT_INTO_COLUMNS", {
+      separator: this.separatorValue,
+      addNewColumns: this.state.addNewColumns,
+      force: false,
+    }).reasons;
+
+    if (cancelledReasons.includes(CommandResult.SplitWillOverwriteContent)) {
+      warnings.push(SplitToColumnsTerms.Errors[CommandResult.SplitWillOverwriteContent]);
+    }
+
+    return warnings;
+  }
+
+  get separatorValue(): string {
+    if (this.state.separatorValue === "custom") {
+      return this.state.customSeparator;
+    } else if (this.state.separatorValue === "auto") {
+      return this.env.model.getters.getAutomaticSeparator();
+    }
+    return this.state.separatorValue;
+  }
+
+  get separators(): Separator[] {
+    return SEPARATORS;
+  }
+
+  get isConfirmDisabled(): boolean {
+    return !this.separatorValue || this.errorMessages.length > 0;
+  }
+}
+
+SplitIntoColumnsPanel.props = {
+  onCloseSidePanel: Function,
+};

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.xml
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.xml
@@ -1,0 +1,64 @@
+<templates>
+  <t t-name="o-spreadsheet-SplitIntoColumnsPanel" owl="1">
+    <div class="o-split-to-cols-panel">
+      <div class="o-section">
+        <div class="o-section-title">Separator</div>
+        <select
+          class="o-input o-type-selector"
+          t-on-change="(ev) => this.onSeparatorChange(ev.target.value)">
+          <option
+            t-foreach="separators"
+            t-as="separator"
+            t-key="separator.value"
+            t-att-value="separator.value"
+            t-esc="separator.name"
+            t-att-selected="state.separatorValue === separator.value"
+          />
+        </select>
+
+        <input
+          class="o-input o-required mt-3"
+          type="text"
+          t-if="state.separatorValue === 'custom'"
+          t-att-value="state.customSeparator"
+          t-on-input="updateCustomSeparator"
+          placeholder="Add any characters or symbol"
+        />
+
+        <div class="o-checkbox">
+          <label>
+            <input
+              type="checkbox"
+              name="add columns"
+              t-att-checked="state.addNewColumns"
+              t-on-change="updateAddNewColumnsCheckbox"
+            />
+            Add new columns to avoid overwriting cells
+          </label>
+        </div>
+
+        <div class="o-sidePanelButtons">
+          <button
+            class="o-sidePanelButton"
+            t-att-class="{'o-disabled': isConfirmDisabled}"
+            t-on-click="confirm">
+            Confirm
+          </button>
+        </div>
+
+        <t t-foreach="errorMessages" t-as="error" t-key="error">
+          <div class="o-sidepanel-error d-flex align-items-center text-danger">
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
+            <span t-esc="error"/>
+          </div>
+        </t>
+        <t t-foreach="warningMessages" t-as="warning" t-key="warning">
+          <div class="o-sidepanel-warning d-flex align-items-center text-warning">
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
+            <span t-esc="warning"/>
+          </div>
+        </t>
+      </div>
+    </div>
+  </t>
+</templates>

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -81,3 +81,16 @@ export const CustomCurrencyTerms = {
 export const MergeErrorMessage = _lt(
   "Merged cells are preventing this operation. Unmerge those cells and try again."
 );
+
+export const SplitToColumnsTerms = {
+  Errors: {
+    Unexpected: _lt("Cannot split the selection for an unknown reason"),
+    [CommandResult.NoSplitSeparatorInSelection]: _lt(
+      "There is no match for the selected separator in the selection"
+    ),
+    [CommandResult.MoreThanOneColumnSelected]: _lt(
+      "Only a selection from a single column can be split"
+    ),
+    [CommandResult.SplitWillOverwriteContent]: _lt("Splitting will overwrite existing content"),
+  },
+};

--- a/src/helpers/ui/split_to_columns_interactive.ts
+++ b/src/helpers/ui/split_to_columns_interactive.ts
@@ -1,0 +1,26 @@
+import { CommandResult } from "../..";
+import { _lt } from "../../translation";
+import { SpreadsheetChildEnv } from "../../types";
+import { DispatchResult } from "./../../types/commands";
+
+export const SplitToColumnsInteractiveContent = {
+  SplitIsDestructive: _lt("This will overwrite data in the subsequent columns. Split anyway?"),
+};
+
+export function interactiveSplitToColumns(
+  env: SpreadsheetChildEnv,
+  separator: string,
+  addNewColumns: boolean
+): DispatchResult {
+  let result = env.model.dispatch("SPLIT_TEXT_INTO_COLUMNS", { separator, addNewColumns });
+  if (result.isCancelledBecause(CommandResult.SplitWillOverwriteContent)) {
+    env.askConfirmation(SplitToColumnsInteractiveContent.SplitIsDestructive, () => {
+      result = env.model.dispatch("SPLIT_TEXT_INTO_COLUMNS", {
+        separator,
+        addNewColumns,
+        force: true,
+      });
+    });
+  }
+  return result;
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -37,6 +37,7 @@ import {
   UIOptionsPlugin,
 } from "./ui_feature";
 import { HistoryPlugin } from "./ui_feature/local_history";
+import { SplitToColumnsPlugin } from "./ui_feature/split_to_columns";
 import { UIPluginConstructor } from "./ui_plugin";
 import { ClipboardPlugin, EditionPlugin, GridSelectionPlugin } from "./ui_stateful";
 
@@ -66,6 +67,7 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("sort", SortPlugin)
   .add("automatic_sum", AutomaticSumPlugin)
   .add("format", FormatPlugin)
+  .add("split_to_columns", SplitToColumnsPlugin)
   .add("cell_popovers", CellPopoverPlugin)
   .add("collaborative", CollaborativePlugin)
   .add("history", HistoryPlugin);

--- a/src/plugins/ui_feature/split_to_columns.ts
+++ b/src/plugins/ui_feature/split_to_columns.ts
@@ -1,0 +1,226 @@
+import { NEWLINE } from "../../constants";
+import { range } from "../../helpers";
+import {
+  CellPosition,
+  CellValueType,
+  Command,
+  CommandResult,
+  SplitTextIntoColumnsCommand,
+  Zone,
+} from "../../types/index";
+import { UIPlugin } from "../ui_plugin";
+
+export class SplitToColumnsPlugin extends UIPlugin {
+  static getters = ["getAutomaticSeparator"] as const;
+
+  allowDispatch(cmd: Command) {
+    switch (cmd.type) {
+      case "SPLIT_TEXT_INTO_COLUMNS":
+        return this.chainValidations(
+          this.batchValidations(this.checkSingleColSelected, this.checkNonEmptySelector),
+          this.batchValidations(this.checkNotOverwritingContent, this.checkSeparatorInSelection)
+        )(cmd);
+    }
+    return CommandResult.Success;
+  }
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "SPLIT_TEXT_INTO_COLUMNS":
+        this.splitIntoColumns(cmd);
+        break;
+    }
+  }
+
+  getAutomaticSeparator(): string {
+    const cells = this.getters.getSelectedCells();
+    for (const cell of cells) {
+      if (cell.value && cell.type === CellValueType.text) {
+        const separator = this.getAutoSeparatorForString(cell.value);
+        if (separator) {
+          return separator;
+        }
+      }
+    }
+    return " ";
+  }
+
+  private getAutoSeparatorForString(str: string): string | undefined {
+    const separators = [NEWLINE, ";", ",", " ", "."];
+    for (const separator of separators) {
+      if (str.includes(separator)) {
+        return separator;
+      }
+    }
+    return;
+  }
+
+  private splitIntoColumns({ separator, addNewColumns }: SplitTextIntoColumnsCommand) {
+    const selection = this.getters.getSelectedZone();
+    const sheetId = this.getters.getActiveSheetId();
+    const splitted = this.getSplittedCols(selection, separator);
+    if (addNewColumns) {
+      this.addColsToAvoidCollisions(selection, splitted);
+    }
+    this.removeMergesInSplitZone(selection, splitted);
+    this.addColumnsToNotOverflowSheet(selection, splitted);
+
+    for (let i = 0; i < splitted.length; i++) {
+      const row = selection.top + i;
+      const splittedContent = splitted[i];
+
+      const col = selection.left;
+      const mainCell = this.getters.getCell({ sheetId, col, row });
+
+      if (splittedContent.length === 1 && splittedContent[0] === mainCell?.content) {
+        continue;
+      }
+
+      for (const [index, content] of splittedContent.entries()) {
+        this.dispatch("UPDATE_CELL", {
+          sheetId,
+          col: col + index,
+          row,
+          content,
+          format: "",
+          style: mainCell?.style || null,
+        });
+      }
+    }
+  }
+
+  private getSplittedCols(selection: Zone, separator: string): string[][] {
+    if (!separator) {
+      throw new Error("Separator cannot be empty");
+    }
+    const sheetId = this.getters.getActiveSheetId();
+    const splitted: string[][] = [];
+    for (const row of range(selection.top, selection.bottom + 1)) {
+      const text = this.getters.getEvaluatedCell({
+        sheetId,
+        col: selection.left,
+        row,
+      }).formattedValue;
+      splitted.push(this.splitAndRemoveTrailingEmpty(text, separator));
+    }
+    return splitted;
+  }
+
+  private splitAndRemoveTrailingEmpty(string: string, separator: string) {
+    const splitted = string.split(separator);
+    while (splitted.length > 1 && splitted[splitted.length - 1] === "") {
+      splitted.pop();
+    }
+    return splitted;
+  }
+
+  private willSplittedColsOverwriteContent(selection: Zone, splittedCols: string[][]) {
+    const sheetId = this.getters.getActiveSheetId();
+    for (const row of range(selection.top, selection.bottom + 1)) {
+      const splittedText = splittedCols[row - selection.top];
+      for (let i = 1; i < splittedText.length; i++) {
+        const cell = this.getters.getCell({ sheetId, col: selection.left + i, row });
+        if (cell && cell.content) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private removeMergesInSplitZone(selection: Zone, splittedCols: string[][]) {
+    const sheetId = this.getters.getActiveSheetId();
+    const colsInSplitZone = Math.max(...splittedCols.map((s) => s.length));
+    const splitZone = { ...selection, right: selection.left + colsInSplitZone - 1 };
+    const merges = this.getters.getMergesInZone(sheetId, splitZone);
+    this.dispatch("REMOVE_MERGE", { sheetId, target: merges });
+  }
+
+  private addColsToAvoidCollisions(selection: Zone, splittedCols: string[][]) {
+    const sheetId = this.getters.getActiveSheetId();
+
+    let colsToAdd = 0;
+
+    for (const row of range(selection.top, selection.bottom + 1)) {
+      const cellPosition = { sheetId, col: selection.left, row };
+      const splittedText = splittedCols[row - selection.top];
+      const colsToAddInRow = this.getColsToAddToAvoidCollision(cellPosition, splittedText);
+      colsToAdd = Math.max(colsToAdd, colsToAddInRow);
+    }
+
+    if (colsToAdd) {
+      this.dispatch("ADD_COLUMNS_ROWS", {
+        dimension: "COL",
+        base: selection.left,
+        sheetId,
+        quantity: colsToAdd,
+        position: "after",
+      });
+    }
+  }
+
+  private getColsToAddToAvoidCollision(cellPosition: CellPosition, splittedText: string[]): number {
+    const maxColumnsToSpread = splittedText.length;
+
+    for (let i = 1; i < maxColumnsToSpread; i++) {
+      const col = cellPosition.col + i;
+      const cell = this.getters.getCell({ ...cellPosition, col });
+      if (cell && cell.content) {
+        return maxColumnsToSpread - i;
+      }
+    }
+
+    return 0;
+  }
+
+  private addColumnsToNotOverflowSheet(selection: Zone, splittedCols: string[][]) {
+    const sheetId = this.getters.getActiveSheetId();
+    const maxColumnsToSpread = Math.max(...splittedCols.map((s) => s.length - 1));
+    const maxColIndex = this.getters.getNumberCols(sheetId) - 1;
+    if (selection.left + maxColumnsToSpread > maxColIndex) {
+      this.dispatch("ADD_COLUMNS_ROWS", {
+        dimension: "COL",
+        base: maxColIndex,
+        sheetId,
+        quantity: selection.left + maxColumnsToSpread - maxColIndex,
+        position: "after",
+      });
+    }
+  }
+
+  private checkSingleColSelected(): CommandResult {
+    if (!this.getters.isSingleColSelected()) {
+      return CommandResult.MoreThanOneColumnSelected;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkNonEmptySelector(cmd: SplitTextIntoColumnsCommand): CommandResult {
+    if (cmd.separator === "") {
+      return CommandResult.EmptySplitSeparator;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkNotOverwritingContent(cmd: SplitTextIntoColumnsCommand): CommandResult {
+    if (cmd.addNewColumns || cmd.force) {
+      return CommandResult.Success;
+    }
+    const selection = this.getters.getSelectedZones()[0];
+    const splitted = this.getSplittedCols(selection, cmd.separator);
+    if (this.willSplittedColsOverwriteContent(selection, splitted)) {
+      return CommandResult.SplitWillOverwriteContent;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkSeparatorInSelection({ separator }: SplitTextIntoColumnsCommand): CommandResult {
+    const cells = this.getters.getSelectedCells();
+    for (const cell of cells) {
+      if (cell.formattedValue.includes(separator)) {
+        return CommandResult.Success;
+      }
+    }
+    return CommandResult.NoSplitSeparatorInSelection;
+  }
+}

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -95,6 +95,7 @@ export class GridSelectionPlugin extends UIPlugin {
     "getCurrentStyle",
     "getSelectedZones",
     "getSelectedZone",
+    "getSelectedCells",
     "getStatisticFnResults",
     "getAggregate",
     "getSelectedFigureId",
@@ -102,6 +103,7 @@ export class GridSelectionPlugin extends UIPlugin {
     "getActivePosition",
     "getSheetPosition",
     "isSelected",
+    "isSingleColSelected",
     "getElementsFromSelection",
   ] as const;
 
@@ -389,6 +391,15 @@ export class GridSelectionPlugin extends UIPlugin {
     return deepCopy(this.gridSelection);
   }
 
+  getSelectedCells(): EvaluatedCell[] {
+    const sheetId = this.getters.getActiveSheetId();
+    const cells: EvaluatedCell[] = [];
+    for (const zone of this.gridSelection.zones) {
+      cells.push(...this.getters.getEvaluatedCellsInZone(sheetId, zone));
+    }
+    return cells;
+  }
+
   getSelectedFigureId(): UID | null {
     return this.selectedFigureId;
   }
@@ -465,6 +476,14 @@ export class GridSelectionPlugin extends UIPlugin {
 
   isSelected(zone: Zone): boolean {
     return !!this.getters.getSelectedZones().find((z) => isEqual(z, zone));
+  }
+
+  isSingleColSelected() {
+    const selection = this.getters.getSelectedZones();
+    if (selection.length !== 1 || selection[0].left !== selection[0].right) {
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -355,6 +355,11 @@ topbarMenuRegistry
     ...ACTION_DATA.sortDescending,
     sequence: 20,
   })
+  .addChild("split_to_columns", ["data"], {
+    ...ACTION_DATA.splitToColumns,
+    sequence: 10,
+    separator: true,
+  })
   .addChild("add_data_filter", ["data"], {
     ...ACTION_DATA.addDataFilter,
     sequence: 10,

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -2,6 +2,7 @@ import { ChartPanel } from "../components/side_panel/chart/main_chart_panel/main
 import { ConditionalFormattingPanel } from "../components/side_panel/conditional_formatting/conditional_formatting";
 import { CustomCurrencyPanel } from "../components/side_panel/custom_currency/custom_currency";
 import { FindAndReplacePanel } from "../components/side_panel/find_and_replace/find_and_replace";
+import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns_panel/split_to_columns_panel";
 import { _lt } from "../translation";
 import { SpreadsheetChildEnv } from "../types";
 import { Registry } from "./registry";
@@ -35,4 +36,9 @@ sidePanelRegistry.add("FindAndReplace", {
 sidePanelRegistry.add("CustomCurrency", {
   title: _lt("Custom currency format"),
   Body: CustomCurrencyPanel,
+});
+
+sidePanelRegistry.add("SplitToColumns", {
+  title: _lt("Split text into columns"),
+  Body: SplitIntoColumnsPanel,
 });

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -886,6 +886,13 @@ export interface CloseCellPopoverCommand {
   type: "CLOSE_CELL_POPOVER";
 }
 
+export interface SplitTextIntoColumnsCommand {
+  type: "SPLIT_TEXT_INTO_COLUMNS";
+  separator: string;
+  addNewColumns: boolean;
+  force?: boolean;
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1016,7 +1023,8 @@ export type LocalCommand =
   | CloseCellPopoverCommand
   | ActivateNextSheetCommand
   | ActivatePreviousSheetCommand
-  | UpdateFilterCommand;
+  | UpdateFilterCommand
+  | SplitTextIntoColumnsCommand;
 
 export type Command = CoreCommand | LocalCommand;
 
@@ -1149,6 +1157,10 @@ export const enum CommandResult {
   ChartDoesNotExist,
   InvalidHeaderIndex,
   InvalidQuantity,
+  MoreThanOneColumnSelected,
+  EmptySplitSeparator,
+  SplitWillOverwriteContent,
+  NoSplitSeparatorInSelection,
 }
 
 export interface CommandHandler<T> {

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -27,6 +27,7 @@ import { HistoryPlugin } from "../plugins/ui_feature/local_history";
 import { RendererPlugin } from "../plugins/ui_feature/renderer";
 import { SelectionInputsManagerPlugin } from "../plugins/ui_feature/selection_inputs_manager";
 import { SortPlugin } from "../plugins/ui_feature/sort";
+import { SplitToColumnsPlugin } from "../plugins/ui_feature/split_to_columns";
 import { UIOptionsPlugin } from "../plugins/ui_feature/ui_options";
 import { SheetUIPlugin } from "../plugins/ui_feature/ui_sheet";
 import { ClipboardPlugin } from "../plugins/ui_stateful/clipboard";
@@ -135,6 +136,7 @@ type FilterEvaluationGetters = Pick<
   FilterEvaluationPlugin,
   GetterNames<typeof FilterEvaluationPlugin>
 >;
+type SplitToColumnsGetters = Pick<SplitToColumnsPlugin, GetterNames<typeof SplitToColumnsPlugin>>;
 
 export type Getters = {
   isReadonly: () => boolean;
@@ -161,4 +163,5 @@ export type Getters = {
   ViewportGetters &
   CellPopoverPluginGetters &
   FilterEvaluationGetters &
-  HeaderVisibilityIUIGetters;
+  HeaderVisibilityIUIGetters &
+  SplitToColumnsGetters;

--- a/tests/components/split_to_columns_panel.test.ts
+++ b/tests/components/split_to_columns_panel.test.ts
@@ -1,0 +1,184 @@
+import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
+import { Model } from "../../src";
+import { SplitIntoColumnsPanel } from "../../src/components/side_panel/split_to_columns_panel/split_to_columns_panel";
+import { SpreadsheetChildEnv } from "../../src/types";
+import { setCellContent, setSelection } from "../test_helpers/commands_helpers";
+import {
+  click,
+  setCheckboxValueAndTrigger,
+  setInputValueAndTrigger,
+} from "../test_helpers/dom_helper";
+import { mountComponent, nextTick, setGrid, spyModelDispatch } from "../test_helpers/helpers";
+
+interface ParentProps {
+  onCloseSidePanel: () => void;
+}
+class Parent extends Component<ParentProps, SpreadsheetChildEnv> {
+  static components = { SplitIntoColumnsPanel };
+  static template = xml/*xml*/ `
+    <SplitIntoColumnsPanel onCloseSidePanel="props.onCloseSidePanel"/>
+  `;
+  setup() {
+    onMounted(() => this.env.model.on("update", this, () => this.render(true)));
+    onWillUnmount(() => this.env.model.off("update", this));
+  }
+}
+
+describe("split to columns sidePanel component", () => {
+  let model: Model;
+  let fixture: HTMLElement;
+  let dispatch: jest.SpyInstance;
+  let confirmButton: HTMLButtonElement;
+  let checkBox: HTMLInputElement;
+  let onCloseSidePanel: jest.Mock;
+
+  beforeEach(async () => {
+    onCloseSidePanel = jest.fn();
+    ({ model, fixture } = await mountComponent(Parent, {
+      props: { onCloseSidePanel: () => onCloseSidePanel() },
+    }));
+    dispatch = spyModelDispatch(model);
+    await nextTick();
+    confirmButton = fixture.querySelector(".o-split-to-cols-panel button")!;
+    checkBox = fixture.querySelector('.o-split-to-cols-panel input[type="checkbox"]')!;
+  });
+
+  test("Separator values", () => {
+    const separatorValues = fixture.querySelectorAll<HTMLOptionElement>(
+      ".o-split-to-cols-panel select option"
+    );
+    const values = Array.from(separatorValues).map((option) => option.value);
+    expect(values).toHaveLength(6);
+    expect(values).toContain(" ");
+    expect(values).toContain(",");
+    expect(values).toContain(";");
+    expect(values).toContain("\n");
+    expect(values).toContain("custom");
+    expect(values).toContain("auto");
+  });
+
+  test("Selected separator is dispatched on confirm", () => {
+    setInputValueAndTrigger(".o-split-to-cols-panel select", ",", "change");
+    click(confirmButton);
+    expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      separator: ",",
+      addNewColumns: expect.any(Boolean),
+    });
+
+    setInputValueAndTrigger(".o-split-to-cols-panel select", ";", "change");
+    click(confirmButton);
+    expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      separator: ";",
+      addNewColumns: expect.any(Boolean),
+    });
+  });
+
+  test("Custom separator", async () => {
+    let input = fixture.querySelector('.o-split-to-cols-panel input[type="text"]')!;
+    expect(input).toBeFalsy();
+    setInputValueAndTrigger(".o-split-to-cols-panel select", "custom", "change");
+    await nextTick();
+
+    input = fixture.querySelector('.o-split-to-cols-panel input[type="text"]')!;
+    expect(input).toBeTruthy();
+    setInputValueAndTrigger(input, "customSeparator", "input");
+    click(confirmButton);
+    expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      separator: "customSeparator",
+      addNewColumns: expect.any(Boolean),
+    });
+  });
+
+  test("Add new columns checkbox", async () => {
+    setCheckboxValueAndTrigger(checkBox, true, "change");
+    click(confirmButton);
+    expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      separator: expect.any(String),
+      addNewColumns: true,
+    });
+
+    setCheckboxValueAndTrigger(checkBox, false, "change");
+    click(confirmButton);
+    expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
+      separator: expect.any(String),
+      addNewColumns: true,
+    });
+  });
+
+  test("Multiple columns selected : confirm button disabled + error message", async () => {
+    setSelection(model, ["A1:B3"]);
+    await nextTick();
+
+    expect(confirmButton.classList).toContain("o-disabled");
+    expect(fixture.querySelectorAll(".o-sidepanel-error")).toHaveLength(1);
+  });
+
+  test("Empty custom separator : confirm button disabled but no error message", async () => {
+    setInputValueAndTrigger(".o-split-to-cols-panel select", "custom", "change");
+    await nextTick();
+
+    expect(confirmButton.classList).toContain("o-disabled");
+    expect(fixture.querySelectorAll(".o-sidepanel-error")).toHaveLength(0);
+  });
+
+  test("No separator in selection : confirm button disabled + error message", async () => {
+    setSelection(model, ["A1"]);
+    setCellContent(model, "A1", "hello");
+    setInputValueAndTrigger(".o-split-to-cols-panel select", " ", "change");
+    setCheckboxValueAndTrigger(checkBox, false, "change");
+    await nextTick();
+
+    expect(confirmButton.classList).toContain("o-disabled");
+    expect(fixture.querySelectorAll(".o-sidepanel-error")).toHaveLength(1);
+  });
+
+  test("Warning if we will overwrite some content", async () => {
+    setSelection(model, ["A1"]);
+    setGrid(model, { A1: "hello there", B1: "content" });
+    setInputValueAndTrigger(".o-split-to-cols-panel select", " ", "change");
+    setCheckboxValueAndTrigger(checkBox, false, "change");
+    await nextTick();
+
+    expect(confirmButton.classList).not.toContain("o-disabled");
+    expect(fixture.querySelectorAll(".o-sidepanel-warning")).toHaveLength(1);
+  });
+
+  test("Warning not displayed if there's an error", async () => {
+    setSelection(model, ["A1:B1"]);
+    setGrid(model, { A1: "hello there", B1: "content" });
+    setInputValueAndTrigger(".o-split-to-cols-panel select", " ", "change");
+    setCheckboxValueAndTrigger(checkBox, false, "change");
+    await nextTick();
+
+    expect(fixture.querySelectorAll(".o-sidepanel-warning")).toHaveLength(0);
+    expect(fixture.querySelectorAll(".o-sidepanel-error")).toHaveLength(1);
+  });
+
+  test("Errors updated on separator selection change", async () => {
+    setSelection(model, ["A1"]);
+    setCellContent(model, "A1", "hello there");
+    setInputValueAndTrigger(".o-split-to-cols-panel select", " ", "change");
+    await nextTick();
+
+    expect(fixture.querySelectorAll(".o-sidepanel-error")).toHaveLength(0);
+
+    setInputValueAndTrigger(".o-split-to-cols-panel select", ";", "change");
+    await nextTick();
+
+    expect(fixture.querySelectorAll(".o-sidepanel-error")).toHaveLength(1);
+  });
+
+  test("Panel is closed if the user starts to edit a cell", async () => {
+    model.dispatch("START_EDITION");
+    await nextTick();
+    expect(onCloseSidePanel).toHaveBeenCalled();
+  });
+
+  test("Panel is closed after a successful split", async () => {
+    setSelection(model, ["A1"]);
+    setCellContent(model, "A1", "hello there");
+    click(confirmButton);
+    await nextTick();
+    expect(onCloseSidePanel).toHaveBeenCalled();
+  });
+});

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -25,6 +25,7 @@ import {
   makeTestEnv,
   mockUuidV4To,
   nextTick,
+  spyModelDispatch,
   target,
 } from "./test_helpers/helpers";
 jest.mock("../src/helpers/uuid", () => require("./__mocks__/uuid"));
@@ -97,7 +98,7 @@ describe("Menu Item actions", () => {
   beforeEach(async () => {
     env = makeTestEnv();
     model = env.model;
-    dispatch = jest.spyOn(model, "dispatch");
+    dispatch = spyModelDispatch(model);
   });
 
   test("Edit -> undo", () => {
@@ -745,6 +746,24 @@ describe("Menu Item actions", () => {
         style: { wrapping: "clip" },
       });
     });
+  });
+
+  test("Data -> Split to columns action", async () => {
+    const spyOpenSidePanel = jest.spyOn(env, "openSidePanel");
+    doAction(["data", "split_to_columns"], env);
+    await nextTick();
+    expect(spyOpenSidePanel).toHaveBeenCalledWith("SplitToColumns", {});
+  });
+
+  test("Data -> Split to columns is disabled when multiple cols are selected", () => {
+    setSelection(model, ["A1"]);
+    expect(getNode(["data", "split_to_columns"]).isEnabled(env)).toBeTruthy();
+
+    setSelection(model, ["A1:C1"]);
+    expect(getNode(["data", "split_to_columns"]).isEnabled(env)).toBeFalsy();
+
+    setSelection(model, ["A1", "B1"]);
+    expect(getNode(["data", "split_to_columns"]).isEnabled(env)).toBeFalsy();
   });
 
   test("Data -> Sort ascending", () => {

--- a/tests/plugins/split_to_column.test.ts
+++ b/tests/plugins/split_to_column.test.ts
@@ -1,0 +1,250 @@
+import { toZone } from "../../src/helpers";
+import { Model } from "../../src/model";
+import { CommandResult, UID } from "../../src/types";
+import {
+  merge,
+  redo,
+  setCellContent,
+  setCellFormat,
+  setSelection,
+  splitTextToColumns,
+  undo,
+} from "../test_helpers/commands_helpers";
+import { getCellContent } from "../test_helpers/getters_helpers";
+import {
+  getGrid,
+  getGridFormat,
+  getGridStyle,
+  setGrid,
+  setGridStyle,
+} from "../test_helpers/helpers";
+
+describe("Split text into columns", () => {
+  let model: Model;
+  let sheetId: UID;
+  beforeEach(() => {
+    model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
+    sheetId = model.getters.getActiveSheetId();
+  });
+
+  describe("allowDispatch results", () => {
+    test("Selection with more than one zone", () => {
+      setSelection(model, ["A1", "B2"]);
+      const result = splitTextToColumns(model, " ");
+      expect(result).toBeCancelledBecause(CommandResult.MoreThanOneColumnSelected);
+    });
+
+    test("Selection with more than one column", () => {
+      setSelection(model, ["A1:C2"]);
+      const result = splitTextToColumns(model, " ");
+      expect(result).toBeCancelledBecause(CommandResult.MoreThanOneColumnSelected);
+    });
+
+    test("Empty separator", () => {
+      const result = splitTextToColumns(model, "", "A1");
+      expect(result).toBeCancelledBecause(CommandResult.EmptySplitSeparator);
+    });
+
+    test("Won't overwrite content without force", () => {
+      setGrid(model, { A1: "Hello there", B1: "Hi!" });
+      const result = splitTextToColumns(model, " ", "A1");
+      expect(result).toBeCancelledBecause(CommandResult.SplitWillOverwriteContent);
+    });
+
+    test("Won't overwrite content in merge without force", () => {
+      merge(model, "B1:C2");
+      setGrid(model, { A1: "Hello there", B1: "merged" });
+      const result = splitTextToColumns(model, " ", "A1");
+      expect(result).toBeCancelledBecause(CommandResult.SplitWillOverwriteContent);
+    });
+
+    test("Will overwrite content with force", () => {
+      setGrid(model, { A1: "Hello there", B1: "Hi!" });
+      const result = splitTextToColumns(model, " ", "A1", { force: true });
+      expect(result).toBeSuccessfullyDispatched();
+    });
+
+    test("Will overwrite content in merge with force", () => {
+      merge(model, "B1:C2");
+      setGrid(model, { A1: "Hello there", B1: "merged" });
+      const result = splitTextToColumns(model, " ", "A1", { force: true });
+      expect(result).toBeSuccessfullyDispatched();
+    });
+  });
+
+  test("Split a text into columns", () => {
+    setCellContent(model, "A1", "Hello there");
+    splitTextToColumns(model, " ", "A1");
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there" });
+  });
+
+  test("Multi-character separator", () => {
+    setCellContent(model, "A1", "Hello there");
+    splitTextToColumns(model, "th", "A1");
+    expect(getGrid(model)).toEqual({ A1: "Hello ", B1: "ere" });
+  });
+
+  test("Split a formula into columns", () => {
+    setCellContent(model, "A1", '=CONCAT("Hello ", "there")');
+    splitTextToColumns(model, " ", "A1");
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there" });
+  });
+
+  test("Split a formatted value into columns", () => {
+    setCellContent(model, "A1", "0");
+    setCellFormat(model, "A1", "m/d/yyyy hh:mm:ss");
+    expect(getCellContent(model, "A1")).toBe("12/30/1899 00:00:00");
+    splitTextToColumns(model, "/", "A1");
+    expect(getGrid(model)).toEqual({ A1: 12, B1: 30, C1: "1899 00:00:00" });
+    expect(getGridFormat(model)).toMatchObject({ A1: undefined, B1: undefined, C1: undefined });
+  });
+
+  test("Split don't overwrite values with trailing empty content", () => {
+    setGrid(model, { A1: "a,b,,,", C1: "C1" });
+    splitTextToColumns(model, ",", "A1", { force: true });
+    expect(getGrid(model)).toEqual({ A1: "a", B1: "b", C1: "C1" });
+  });
+
+  test("Split cell with only separators", () => {
+    setGrid(model, { A1: ",,,,", C1: "C1" });
+    splitTextToColumns(model, ",", "A1", { force: true });
+    expect(getGrid(model)).toEqual({ A1: undefined, C1: "C1" });
+  });
+
+  test("Split multiple rows", () => {
+    setGrid(model, { A1: "Hello there", A2: "General Kenobi" });
+    splitTextToColumns(model, " ", "A1:A2");
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there", A2: "General", B2: "Kenobi" });
+  });
+
+  test("Splitted cell style is propagated", () => {
+    setGrid(model, { A1: "Hello there", A2: "General Kenobi" });
+    setGridStyle(model, { A1: { bold: true }, A2: { italic: true } });
+    splitTextToColumns(model, " ", "A1:A2");
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there", A2: "General", B2: "Kenobi" });
+    expect(getGridStyle(model)).toEqual({
+      A1: { bold: true },
+      B1: { bold: true },
+      A2: { italic: true },
+      B2: { italic: true },
+    });
+  });
+
+  test("Style of overwritten cell is overwritten too", () => {
+    setGrid(model, { A1: "a b", A2: "c d", B1: "overwritten", B2: "overwritten" });
+    setGridStyle(model, { A2: { italic: true }, B1: { bold: true }, B2: { bold: true } });
+
+    splitTextToColumns(model, " ", "A1:A2", { force: true });
+    expect(getGrid(model)).toEqual({ A1: "a", B1: "b", A2: "c", B2: "d" });
+    expect(getGridStyle(model)).toEqual({
+      A1: undefined,
+      B1: undefined,
+      A2: { italic: true },
+      B2: { italic: true },
+    });
+  });
+
+  test("Add new columns to the sheet if there is not enough of them", () => {
+    expect(model.getters.getNumberCols(sheetId)).toBe(10);
+    setGrid(model, { J1: "Hello there; General", J2: "Hi!" });
+    splitTextToColumns(model, " ", "J1:J2");
+    expect(model.getters.getNumberCols(sheetId)).toBe(12);
+    expect(getGrid(model)).toEqual({ J1: "Hello", K1: "there;", L1: "General", J2: "Hi!" });
+  });
+
+  test("Overwrite other cells if forced", () => {
+    setGrid(model, { A1: "Hello there", B1: "Hi!" });
+    splitTextToColumns(model, " ", "A1", { force: true });
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there" });
+  });
+
+  test("Add new columns to avoid collisions", () => {
+    expect(model.getters.getNumberCols(sheetId)).toBe(10);
+    setGrid(model, { A1: "Hello there", B1: "Hi!" });
+    splitTextToColumns(model, " ", "A1", { addNewColumns: true });
+    expect(model.getters.getNumberCols(sheetId)).toBe(11);
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there", C1: "Hi!" });
+  });
+
+  test("Collision computation with multiple rows", () => {
+    expect(model.getters.getNumberCols(sheetId)).toBe(10);
+    // prettier-ignore
+    setGrid(model, {
+      A1: "Hello there",        B1: "B1",
+      A2: "Hi! This is longer", B2 : undefined, C2: "C2"
+    });
+
+    splitTextToColumns(model, " ", "A1:A2", { addNewColumns: true });
+    expect(model.getters.getNumberCols(sheetId)).toBe(12);
+    // prettier-ignore
+    expect(getGrid(model)).toEqual({
+      A1: "Hello", B1: "there", C1: undefined, D1: "B1",
+      A2: "Hi!",   B2: "This",  C2: "is",      D2: "longer", E2: "C2",
+    });
+  });
+
+  test("Empty merges are removed when splitting cell into columns", () => {
+    merge(model, "B1:C2");
+    setCellContent(model, "A1", "Hello there");
+    splitTextToColumns(model, " ", "A1");
+    expect(model.getters.getMerges(sheetId)).toEqual([]);
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there" });
+  });
+
+  test("Non-empty merges are removed when splitting cell into columns with force", () => {
+    merge(model, "B1:C2");
+    setCellContent(model, "B1", "merged");
+    setCellContent(model, "A1", "Hello there");
+    splitTextToColumns(model, " ", "A1", { force: true });
+    expect(model.getters.getMerges(sheetId)).toEqual([]);
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there" });
+  });
+
+  test("Can add new columns to not overwrite merge with content", () => {
+    merge(model, "B1:C2");
+    setCellContent(model, "B1", "merged");
+    setCellContent(model, "A1", "Hello there");
+    splitTextToColumns(model, " ", "A1", { addNewColumns: true });
+    expect(model.getters.getNumberCols(sheetId)).toBe(11);
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there", C1: "merged" });
+    expect(model.getters.getMerges(sheetId)).toMatchObject([toZone("C1:D2")]);
+  });
+
+  test("Can undo/redo split into columns", () => {
+    setCellContent(model, "A1", "Hello there");
+    splitTextToColumns(model, " ", "A1");
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there" });
+    undo(model);
+    expect(getGrid(model)).toEqual({ A1: "Hello there" });
+    redo(model);
+    expect(getGrid(model)).toEqual({ A1: "Hello", B1: "there" });
+  });
+
+  test.each([
+    ["hello there", " "],
+    ["hello,there", ","],
+    ["hello.there", "."],
+    ["hello\nthere", "\n"],
+    ["hello;there", ";"],
+
+    // Priority : \n > ; > , > space > .
+    ["hello;,\n .there", "\n"],
+    ["hello;, .there", ";"],
+    ["hello, .there", ","],
+    ["hello .there", " "],
+  ])(
+    "Automatic separator detection value %s %s",
+    (cellContent: string, expectedSeparator: string) => {
+      setSelection(model, ["A1"]);
+      setCellContent(model, "A1", cellContent);
+      expect(model.getters.getAutomaticSeparator()).toEqual(expectedSeparator);
+    }
+  );
+
+  test("Automatic separator detection works if first cell in the selection is empty or don't have a separator", () => {
+    setSelection(model, ["A1:A3"]);
+    setCellContent(model, "A2", "singleWordWithoutSeparator");
+    setCellContent(model, "A3", "hello;there");
+    expect(model.getters.getAutomaticSeparator()).toEqual(";");
+  });
+});

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -9,6 +9,7 @@ import {
   DispatchResult,
   SortDirection,
   SortOptions,
+  SplitTextIntoColumnsCommand,
   Style,
   UID,
   UpDown,
@@ -833,5 +834,21 @@ export function setFormat(
     sheetId,
     target,
     format,
+  });
+}
+
+export function splitTextToColumns(
+  model: Model,
+  separator: string,
+  target?: string,
+  options: Partial<Omit<SplitTextIntoColumnsCommand, "type" | "separator">> = {}
+) {
+  if (target) {
+    setSelection(model, [target]);
+  }
+  return model.dispatch("SPLIT_TEXT_INTO_COLUMNS", {
+    separator,
+    force: options.force || false,
+    addNewColumns: options.addNewColumns || false,
   });
 }


### PR DESCRIPTION
## Description:

Add a menu item "Split to columns" in the topbar menu. This opens a side
panel that allows the user to split some text into multiple columns.

The user can choose the separator to use to split the text. It can be a
separator in a list of separators, a separator can be detected automatically,
or the user can input a custom separator.

There is an option to add new columns when splitting, so that no cell is
overwritten.

Odoo task ID : [2984931](https://www.odoo.com/web#id=2984931&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo