### PR TITLE
[IMP/REF] menu: display separator of hidden items

### DIFF
--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-Menu" owl="1">
-    <Popover t-if="visibleMenuItems.length" t-props="popoverProps">
+    <Popover t-if="menuItemsAndSeparators.length" t-props="popoverProps">
       <div
         t-ref="menu"
         class="o-menu"
@@ -8,31 +8,33 @@
         t-on-wheel.stop=""
         t-on-click.stop=""
         t-on-contextmenu.prevent="">
-        <t t-foreach="visibleMenuItems" t-as="menuItem" t-key="menuItem.id">
-          <t t-set="isMenuRoot" t-value="isRoot(menuItem)"/>
-          <t t-set="isMenuEnabled" t-value="isEnabled(menuItem)"/>
-          <div
-            t-att-title="getName(menuItem)"
-            t-att-data-name="menuItem.id"
-            t-on-click="() => this.onClickMenu(menuItem, menuItem_index)"
-            t-on-mouseover="() => this.onMouseOver(menuItem, menuItem_index)"
-            class="o-menu-item"
-            t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem)}"
-            t-att-style="getColor(menuItem)">
-            <span class="o-menu-item-name" t-esc="getName(menuItem)"/>
-            <span
-              t-if="menuItem.description"
-              class="o-menu-item-description"
-              t-esc="menuItem.description"
-            />
-            <t t-if="isMenuRoot">
-              <span t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
-            </t>
-            <t t-elif="menuItem.icon">
-              <i t-att-class="menuItem.icon" class="o-menu-item-icon"/>
-            </t>
-          </div>
-          <div t-if="menuItem.separator and !menuItem_last" class="o-separator"/>
+        <t t-foreach="menuItemsAndSeparators" t-as="menuItem" t-key="menuItem_index">
+          <div t-if="menuItem === 'separator'" class="o-separator"/>
+          <t t-else="">
+            <t t-set="isMenuRoot" t-value="isRoot(menuItem)"/>
+            <t t-set="isMenuEnabled" t-value="isEnabled(menuItem)"/>
+            <div
+              t-att-title="getName(menuItem)"
+              t-att-data-name="menuItem.id"
+              t-on-click="(ev) => this.onClickMenu(menuItem, menuItem_index, ev)"
+              t-on-mouseover="(ev) => this.onMouseOver(menuItem, menuItem_index, ev)"
+              class="o-menu-item"
+              t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem)}"
+              t-att-style="getColor(menuItem)">
+              <span class="o-menu-item-name" t-esc="getName(menuItem)"/>
+              <span
+                t-if="menuItem.description"
+                class="o-menu-item-description"
+                t-esc="menuItem.description"
+              />
+              <t t-if="isMenuRoot">
+                <span t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
+              </t>
+              <t t-elif="menuItem.icon">
+                <i t-att-class="menuItem.icon" class="o-menu-item-icon"/>
+              </t>
+            </div>
+          </t>
         </t>
       </div>
       <Menu

--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -4,6 +4,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
 <div
   class="o-menu"
 >
+  
   <div
     class="o-menu-item"
     data-name="Sum"
@@ -93,7 +94,6 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     
     
   </div>
-  
   
 </div>
 `;

--- a/tests/components/__snapshots__/context_menu.test.ts.snap
+++ b/tests/components/__snapshots__/context_menu.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
 <div
   class="o-menu"
 >
+  
   <div
     class="o-menu-item"
     data-name="cut"
@@ -92,6 +93,8 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   <div
     class="o-separator"
   />
+  
+  
   <div
     class="o-menu-item"
     data-name="add_row_before"
@@ -150,6 +153,8 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   <div
     class="o-separator"
   />
+  
+  
   <div
     class="o-menu-item"
     data-name="delete_row"
@@ -220,7 +225,6 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
     
     
   </div>
-  
   
 </div>
 `;

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -1,6 +1,11 @@
 import { Component, xml } from "@odoo/owl";
 import { Menu } from "../../src/components/menu/menu";
-import { MENU_ITEM_HEIGHT, MENU_VERTICAL_PADDING, MENU_WIDTH } from "../../src/constants";
+import {
+  MENU_ITEM_HEIGHT,
+  MENU_SEPARATOR_HEIGHT,
+  MENU_VERTICAL_PADDING,
+  MENU_WIDTH,
+} from "../../src/constants";
 import { toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { cellMenuRegistry } from "../../src/registries/menus/cell_menu_registry";
@@ -32,6 +37,25 @@ mockGetBoundingClientRect({
     return getMenuSize();
   },
   "o-spreadsheet": () => ({ top: 0, left: 0, height: 1000, width: 1000 }),
+  "o-menu-item": (el) => {
+    const parentPosition = getElPosition(el.parentElement!);
+    let offset = MENU_VERTICAL_PADDING;
+    for (let e of el.parentElement!.children) {
+      if (e === el) break;
+
+      if (el.classList.contains("o-menu-item")) {
+        offset += MENU_ITEM_HEIGHT;
+      } else if (el.classList.contains("o-separator")) {
+        offset += MENU_SEPARATOR_HEIGHT;
+      }
+    }
+    return {
+      top: parentPosition.top + offset,
+      left: parentPosition.left,
+      height: MENU_ITEM_HEIGHT,
+      width: MENU_WIDTH,
+    };
+  },
 });
 
 function getElPosition(element: string | Element): {
@@ -729,7 +753,7 @@ describe("Context Menu position on large screen 1000px/1000px", () => {
     const { height, width } = getSubMenuSize();
     const { height: rootHeight } = getMenuSize();
     expect(rootTop).toBe(clickY - rootHeight);
-    expect(top).toBe(clickY - height);
+    expect(top).toBe(clickY + MENU_ITEM_HEIGHT - height);
     expect(left).toBe(clickX + width);
   });
 


### PR DESCRIPTION
## Description

Previously, if a menu item wasn't visible, its separator was also not displayed. This commit changes this behavior to display the separator even if the menu item is hidden.

Also changed the way we computed the subMenu position, using the position of the target of the event opening the submenu, rather than doing a lengthy computation of the menu position.

Odoo task ID : [3253132](https://www.odoo.com/web#id=3253132&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo