### PR TITLE
[IMP] XLSX: import text wrapping modes

### DIFF
--- a/doc/extending/xlsx/xlsx_import.md
+++ b/doc/extending/xlsx/xlsx_import.md
@@ -64,7 +64,8 @@ NW = no warning generated for these conversions.
     - fill/justify -> left
     - centerContinuous/distributed -> center
   - some vertical alignements. We only support top/center/bottom. Other types will be converted to center.
-  - other align options (wrapText, indent, shrinkToFit, ...) (NW)
+  - some wrappingText modes. We only support wrap/overflow imported from Google Sheets and Excel. Clip mode from Google Sheets will be converted to overflow mode, because even if o-spreadsheet support clip mode, it isn't supported by xlsx files.
+  - other align options (indent, shrinkToFit, ...) (NW)
 - Fills :
   - we only support solid fill pattern. Convert all other patterns into solid fills.
 - Font :

--- a/src/xlsx/conversion/style_conversion.ts
+++ b/src/xlsx/conversion/style_conversion.ts
@@ -105,6 +105,7 @@ export function convertStyle(
         : convertColor(styleStruct.fillStyle?.bgColor),
     textColor: convertColor(styleStruct.fontStyle?.color),
     fontSize: styleStruct.fontStyle?.size,
+    wrapping: styleStruct.alignment?.wrapText ? "wrap" : "overflow",
   };
 }
 

--- a/src/xlsx/extraction/base_extractor.ts
+++ b/src/xlsx/extraction/base_extractor.ts
@@ -38,6 +38,8 @@ class AttributeValue {
   }
 
   asBool(): boolean {
+    if (this.value === "true") return true; // for files exported from Libre Office
+    if (this.value === "false") return false;
     return Boolean(Number(this.value));
   }
 

--- a/tests/__xlsx__/xlsx_demo_data/xl/sharedStrings.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/sharedStrings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="457" uniqueCount="409">
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="465" uniqueCount="414">
   <si>
     <t>CF =42</t>
   </si>
@@ -1233,5 +1233,17 @@
   </si>
   <si>
     <t>DATEDIF</t>
+  </si>
+  <si>
+    <t>this is a very long text to wrap</t>
+  </si>
+  <si>
+    <t>Wrap text:</t>
+  </si>
+  <si>
+    <t>overflow</t>
+  </si>
+  <si>
+    <t>wrap</t>
   </si>
 </sst>

--- a/tests/__xlsx__/xlsx_demo_data/xl/styles.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/styles.xml
@@ -896,6 +896,10 @@
     <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1">
       <alignment horizontal="center"/>
     </xf>
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1" />
+    <xf numFmtId="0" fontId="10" fillId="0" borderId="0" xfId="0" applyFont="1" applyAlignment="1">
+      <alignment horizontal="left" wrapText="1" />
+    </xf>
   </cellXfs>
   <cellStyles count="3">
     <cellStyle name="Hyperlink" xfId="2" builtinId="8"/>

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet2.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet2.xml
@@ -2831,7 +2831,7 @@
     </row>
     <row r="162" spans="1:4" ht="17.25" customHeight="1" x14ac:dyDescent="0.2">
       <c r="A162" s="2" t="s">
-        <v>410</v>
+        <v>409</v>
       </c>
       <c r="B162" s="2" t="str">
         <f>ADDRESS(1,1,4,FALSE,"sheet!")</f>
@@ -2847,7 +2847,7 @@
     </row>
     <row r="163" spans="1:4" ht="17.25" customHeight="1" x14ac:dyDescent="0.2">
       <c r="A163" s="2" t="s">
-        <v>411</v>
+        <v>410</v>
       </c>
       <c r="B163" s="2" t="str">
         <f>DATEDIF("2002/01/01","2002/01/02","D")</f>

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet4.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet4.xml
@@ -306,18 +306,34 @@
       <c r="C18" s="64" t="s">
         <v>269</v>
       </c>
+      <c r="E18" s="36" t="s">
+        <v>412</v>
+      </c>
+      <c r="F18" s="37"/>
     </row>
     <row r="19" spans="1:5" ht="13.5" thickBot="1" x14ac:dyDescent="0.25">
       <c r="A19" s="76" t="s">
         <v>256</v>
       </c>
+      <c r="E19" s="39" t="s">
+        <v>413</v>
+      </c>
+      <c r="F19" s="110" t="s">
+        <v>411</v>
+      </c>
     </row>
-    <row r="20" spans="1:5" ht="13.5" thickBot="1" x14ac:dyDescent="0.25">
+    <row r="20" spans="1:5" ht="53.25" thickBot="1" x14ac:dyDescent="0.25">
       <c r="A20" s="77" t="s">
         <v>257</v>
       </c>
       <c r="C20" s="65" t="s">
         <v>270</v>
+      </c>
+      <c r="E20" s="39" t="s">
+        <v>414</v>
+      </c>
+      <c r="F20" s="111" t="s">
+        <v>411</v>
       </c>
     </row>
     <row r="21" spans="1:5" ht="13.5" thickBot="1" x14ac:dyDescent="0.25">

--- a/tests/xlsx_import.test.ts
+++ b/tests/xlsx_import.test.ts
@@ -189,6 +189,16 @@ describe("Import xlsx data", () => {
   });
 
   test.each([
+    ["overflow", "F19"],
+    ["wrap", "F20"],
+  ])("Can import wrapping mode %s", (wrapType, cellXc) => {
+    const testSheet = getWorkbookSheet("jestStyles", convertedData)!;
+    const styledCell = testSheet.cells[cellXc]!;
+    const cellStyle = getWorkbookCellStyle(styledCell, convertedData);
+    expect(cellStyle?.wrapping).toEqual(wrapType);
+  });
+
+  test.each([
     ["0.00", "M2"],
     ["0.00%", "M3"],
     ["m/d/yyyy", "M4"],


### PR DESCRIPTION
## Description:

This PR implements the functionality of importing text wrapping mode.

Notice that only wrap/overflow modes are supported. Clip mode from Google Sheets is not supported.

Odoo task ID : [3249034](https://www.odoo.com/web#id=3249034&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo