### PR TITLE
[IMP] tests: improve readability of `new Model()` in tests

### DIFF
--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -525,14 +525,7 @@ describe("Autofill", () => {
   });
 
   test("autofill with merge greater than the grid size", () => {
-    model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 5,
-        },
-      ],
-    });
+    model = new Model({ sheets: [{ colNumber: 1, rowNumber: 5 }] });
     merge(model, "A1:A2");
     autofill("A1:A2", "A5");
     expect(getMergeCellMap(model)).toEqual(XCToMergeCellMap(model, ["A1", "A2", "A3", "A4"]));

--- a/tests/plugins/automatic_sum.test.ts
+++ b/tests/plugins/automatic_sum.test.ts
@@ -480,42 +480,21 @@ describe("automatic sum", () => {
   });
 
   test("sum data in the last row", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 2,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 2 }] });
     setCellContent(model, "A1", "4");
     setCellContent(model, "A2", "4");
     automaticSum(model, "A1:A2");
   });
 
   test("sum data horizontally in the bottom right corner", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 2,
-          rowNumber: 1,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 2, rowNumber: 1 }] });
     setCellContent(model, "A1", "4");
     setCellContent(model, "B1", "4");
     automaticSum(model, "A1:B1");
   });
 
   test("not at the end but no next empty row", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 3,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 3 }] });
     setCellContent(model, "A1", "4");
     setCellContent(model, "A2", "4");
     setCellContent(model, "A3", "4");
@@ -523,14 +502,7 @@ describe("automatic sum", () => {
   });
 
   test("not at the end but no next empty col", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 3,
-          rowNumber: 1,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 3, rowNumber: 1 }] });
     setCellContent(model, "A1", "4");
     setCellContent(model, "B1", "4");
     setCellContent(model, "C1", "4");

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -289,14 +289,7 @@ describe("clipboard", () => {
 
   test("can copy and paste merged content", () => {
     const model = new Model({
-      sheets: [
-        {
-          id: "s1",
-          colNumber: 5,
-          rowNumber: 5,
-          merges: ["B1:C2"],
-        },
-      ],
+      sheets: [{ id: "s1", colNumber: 5, rowNumber: 5, merges: ["B1:C2"] }],
     });
     copy(model, "B1");
     paste(model, "B4");
@@ -309,14 +302,7 @@ describe("clipboard", () => {
 
   test("can cut and paste merged content", () => {
     const model = new Model({
-      sheets: [
-        {
-          id: "s2",
-          colNumber: 5,
-          rowNumber: 5,
-          merges: ["B1:C2"],
-        },
-      ],
+      sheets: [{ id: "s2", colNumber: 5, rowNumber: 5, merges: ["B1:C2"] }],
     });
     cut(model, "B1:C2");
     paste(model, "B4");
@@ -337,11 +323,7 @@ describe("clipboard", () => {
           id: "s1",
           colNumber: 5,
           rowNumber: 5,
-          cells: {
-            A1: { content: "merge" },
-            C1: { content: "a" },
-            D2: { content: "a" },
-          },
+          cells: { A1: { content: "merge" }, C1: { content: "a" }, D2: { content: "a" } },
           merges: ["A1:B2"],
         },
       ],
@@ -357,17 +339,8 @@ describe("clipboard", () => {
   test("copy/paste a merge from one page to another", () => {
     const model = new Model({
       sheets: [
-        {
-          id: "s1",
-          colNumber: 5,
-          rowNumber: 5,
-          merges: ["B2:C3"],
-        },
-        {
-          id: "s2",
-          colNumber: 5,
-          rowNumber: 5,
-        },
+        { id: "s1", colNumber: 5, rowNumber: 5, merges: ["B2:C3"] },
+        { id: "s2", colNumber: 5, rowNumber: 5 },
       ],
     });
     const sheet2 = "s2";
@@ -383,17 +356,8 @@ describe("clipboard", () => {
   test("copy/paste a formula that has no sheet specific reference to another", () => {
     const model = new Model({
       sheets: [
-        {
-          id: "s1",
-          colNumber: 5,
-          rowNumber: 5,
-          cells: { A1: { content: "=A2" } },
-        },
-        {
-          id: "s2",
-          colNumber: 5,
-          rowNumber: 5,
-        },
+        { id: "s1", colNumber: 5, rowNumber: 5, cells: { A1: { content: "=A2" } } },
+        { id: "s2", colNumber: 5, rowNumber: 5 },
       ],
     });
 
@@ -1128,14 +1092,7 @@ describe("clipboard", () => {
   });
 
   test("can copy a cell with a conditional format and paste value only", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 5,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5 }] });
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
     setCellContent(model, "C1", "1");
@@ -1549,14 +1506,7 @@ describe("clipboard", () => {
   });
 
   test("can copy and paste a conditional formatted cell", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 5,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5 }] });
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
     setCellContent(model, "C1", "1");
@@ -1581,14 +1531,7 @@ describe("clipboard", () => {
     expect(getStyle(model, "C2")).toEqual({});
   });
   test("can cut and paste a conditional formatted cell", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 5,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5 }] });
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
     setCellContent(model, "C1", "1");
@@ -1612,14 +1555,7 @@ describe("clipboard", () => {
   });
 
   test("can copy and paste a conditional formatted zone", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 5,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5 }] });
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
     const sheetId = model.getters.getActiveSheetId();
@@ -1652,14 +1588,7 @@ describe("clipboard", () => {
   });
 
   test("can cut and paste a conditional formatted zone", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 5,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5 }] });
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "2");
     const sheetId = model.getters.getActiveSheetId();
@@ -1687,16 +1616,8 @@ describe("clipboard", () => {
   test("can copy and paste a conditional formatted cell to another page", () => {
     const model = new Model({
       sheets: [
-        {
-          id: "s1",
-          colNumber: 5,
-          rowNumber: 5,
-        },
-        {
-          id: "s2",
-          colNumber: 5,
-          rowNumber: 5,
-        },
+        { id: "s1", colNumber: 5, rowNumber: 5 },
+        { id: "s2", colNumber: 5, rowNumber: 5 },
       ],
     });
     setCellContent(model, "A1", "1");
@@ -1725,14 +1646,8 @@ describe("clipboard", () => {
   test("can cut and paste a conditional formatted cell to another page", () => {
     const model = new Model({
       sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 5,
-        },
-        {
-          colNumber: 5,
-          rowNumber: 5,
-        },
+        { colNumber: 5, rowNumber: 5 },
+        { colNumber: 5, rowNumber: 5 },
       ],
     });
     const sheet1 = model.getters.getSheetIds()[0];

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -489,9 +489,7 @@ describe("conditional format", () => {
           {
             colNumber: 7,
             rowNumber: 4,
-            cells: {
-              C3: { content: "42" },
-            },
+            cells: { C3: { content: "42" } },
             conditionalFormats: [
               { id: "1", ranges: ["A1:A1"], rule },
               { id: "2", ranges: ["B2:B2"], rule },
@@ -523,9 +521,7 @@ describe("conditional format", () => {
           {
             colNumber: 4,
             rowNumber: 7,
-            cells: {
-              C3: { content: "42" },
-            },
+            cells: { C3: { content: "42" } },
             conditionalFormats: [
               { id: "1", ranges: ["A1:A1"], rule },
               { id: "2", ranges: ["B2:B2"], rule },
@@ -561,9 +557,7 @@ describe("conditional format", () => {
           {
             colNumber: 3,
             rowNumber: 4,
-            cells: {
-              B4: { content: "42" },
-            },
+            cells: { B4: { content: "42" } },
             conditionalFormats: [
               { id: "1", ranges: ["A1:C1"], rule },
               { id: "2", ranges: ["A2:B2"], rule },
@@ -590,9 +584,7 @@ describe("conditional format", () => {
           {
             colNumber: 4,
             rowNumber: 3,
-            cells: {
-              D2: { content: "42" },
-            },
+            cells: { D2: { content: "42" } },
             conditionalFormats: [
               { id: "1", ranges: ["A1:A3"], rule },
               { id: "2", ranges: ["B1:B2"], rule },

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -415,9 +415,7 @@ describe("core", () => {
   });
 
   test("xc is expanded to overlapping merges", () => {
-    const model = new Model({
-      sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:B2"] }],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:B2"] }] });
     expect(
       model.getters.zoneToXC(
         model.getters.getActiveSheetId(),
@@ -439,9 +437,7 @@ describe("core", () => {
   });
 
   test("merge is considered as one single cell", () => {
-    const model = new Model({
-      sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:B2"] }],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:B2"] }] });
     expect(
       model.getters.zoneToXC(
         model.getters.getActiveSheetId(),
@@ -710,10 +706,7 @@ describe("history", () => {
             },
           },
         ],
-        formats: {
-          "1": "#,##0",
-          "2": "mm/dd/yyyy",
-        },
+        formats: { "1": "#,##0", "2": "mm/dd/yyyy" },
       });
       activateSheet(model, sheet2Id); // evaluate Sheet2
       expect(getRangeFormattedValues(model, "A1:A3", sheet1Id)).toEqual(["1,000", "", "2,000"]);

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -46,16 +46,8 @@ describe("edition", () => {
 
   test("deleting a cell with style does not remove it", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { A2: { style: 1, content: "a2" } },
-        },
-      ],
-      styles: {
-        1: { fillColor: "red" },
-      },
+      sheets: [{ colNumber: 10, rowNumber: 10, cells: { A2: { style: 1, content: "a2" } } }],
+      styles: { 1: { fillColor: "red" } },
     });
 
     // removing
@@ -621,13 +613,7 @@ describe("edition", () => {
 
   test("default active cell content when model is started", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 2,
-          rowNumber: 2,
-          cells: { A1: { content: "Hello" } },
-        },
-      ],
+      sheets: [{ colNumber: 2, rowNumber: 2, cells: { A1: { content: "Hello" } } }],
     });
     expect(model.getters.getCurrentContent()).toBe("Hello");
   });
@@ -643,13 +629,7 @@ describe("edition", () => {
 
   test("content is updated if cell content is updated", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 2,
-          rowNumber: 2,
-          cells: { B1: { content: "Hello" } },
-        },
-      ],
+      sheets: [{ colNumber: 2, rowNumber: 2, cells: { B1: { content: "Hello" } } }],
     });
     selectCell(model, "B1");
     expect(model.getters.getCurrentContent()).toBe("Hello");

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -1022,11 +1022,7 @@ describe("evaluateCells", () => {
           id: "sheet1",
           colNumber: 4,
           rowNumber: 4,
-          cells: {
-            A1: { content: "old" },
-            A2: { content: "=a1" },
-            A3: { content: "=a2" },
-          },
+          cells: { A1: { content: "old" }, A2: { content: "=a1" }, A3: { content: "=a2" } },
         },
       ],
     });

--- a/tests/plugins/figures.test.ts
+++ b/tests/plugins/figures.test.ts
@@ -323,16 +323,8 @@ describe("figure plugin", () => {
   test("change sheet deselect figure", () => {
     const model = new Model({
       sheets: [
-        {
-          id: "1",
-          colNumber: 2,
-          rowNumber: 2,
-        },
-        {
-          id: "2",
-          colNumber: 2,
-          rowNumber: 2,
-        },
+        { id: "1", colNumber: 2, rowNumber: 2 },
+        { id: "2", colNumber: 2, rowNumber: 2 },
       ],
     });
     model.dispatch("CREATE_FIGURE", {

--- a/tests/plugins/grid_manipulation.test.ts
+++ b/tests/plugins/grid_manipulation.test.ts
@@ -195,16 +195,7 @@ describe("Columns", () => {
   describe("Correctly update size, name, order and number", () => {
     beforeEach(() => {
       model = new Model({
-        sheets: [
-          {
-            colNumber: 4,
-            rowNumber: 1,
-            cols: {
-              1: { size: 10 },
-              2: { size: 20 },
-            },
-          },
-        ],
+        sheets: [{ colNumber: 4, rowNumber: 1, cols: { 1: { size: 10 }, 2: { size: 20 } } }],
       });
     });
     test("On deletion", () => {
@@ -217,22 +208,8 @@ describe("Columns", () => {
     test("On delete cols in inactive sheet", () => {
       model = new Model({
         sheets: [
-          {
-            id: "s1",
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              B2: { content: "B2 in sheet1" },
-            },
-          },
-          {
-            id: "s2",
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              B2: { content: "B2 in sheet2" },
-            },
-          },
+          { id: "s1", colNumber: 3, rowNumber: 3, cells: { B2: { content: "B2 in sheet1" } } },
+          { id: "s2", colNumber: 3, rowNumber: 3, cells: { B2: { content: "B2 in sheet2" } } },
         ],
       });
       const [sheet1Id, sheet2Id] = model.getters.getSheetIds();
@@ -283,13 +260,7 @@ describe("Columns", () => {
   describe("Correctly update merges", () => {
     beforeEach(() => {
       model = new Model({
-        sheets: [
-          {
-            colNumber: 5,
-            rowNumber: 4,
-            merges: ["A1:E1", "B2:E2", "C3:E3", "B4:D4"],
-          },
-        ],
+        sheets: [{ colNumber: 5, rowNumber: 4, merges: ["A1:E1", "B2:E2", "C3:E3", "B4:D4"] }],
       });
     });
 
@@ -329,16 +300,7 @@ describe("Columns", () => {
   describe("Correctly update borders", () => {
     test("Add columns with simple border", () => {
       const s = ["thin", "#000"];
-      model = new Model({
-        sheets: [
-          {
-            cells: {
-              A2: { border: 1 },
-            },
-          },
-        ],
-        borders: { 1: { top: s } },
-      });
+      model = new Model({ sheets: [{ cells: { A2: { border: 1 } } }], borders: { 1: { top: s } } });
       expect(getBorder(model, "A1")).toEqual({ bottom: s });
       expect(getBorder(model, "A2")).toEqual({ top: s });
       addColumns(model, "before", "A", 1);
@@ -595,10 +557,7 @@ describe("Columns", () => {
             id: "s1",
             colNumber: 4,
             rowNumber: 7,
-            cells: {
-              B2: { content: "=Sheet1!B3" },
-              C1: { content: "=Sheet2!B3" },
-            },
+            cells: { B2: { content: "=Sheet1!B3" }, C1: { content: "=Sheet2!B3" } },
           },
           {
             id: "s2",
@@ -627,14 +586,7 @@ describe("Columns", () => {
     test("On first col deletion", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              B2: { content: "=SUM(A1:C1)" },
-            },
-          },
+          { id: "sheet1", colNumber: 3, rowNumber: 3, cells: { B2: { content: "=SUM(A1:C1)" } } },
         ],
       });
       deleteColumns(model, ["A"]);
@@ -645,14 +597,7 @@ describe("Columns", () => {
     test("On multiple col deletion including the first one", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              C2: { content: "=SUM(A1:D1)" },
-            },
-          },
+          { id: "sheet1", colNumber: 3, rowNumber: 3, cells: { C2: { content: "=SUM(A1:D1)" } } },
         ],
       });
       deleteColumns(model, ["A", "B"]);
@@ -663,14 +608,7 @@ describe("Columns", () => {
     test("On last col deletion", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              A2: { content: "=SUM(A1:C1)" },
-            },
-          },
+          { id: "sheet1", colNumber: 3, rowNumber: 3, cells: { A2: { content: "=SUM(A1:C1)" } } },
         ],
       });
       deleteColumns(model, ["C"]);
@@ -681,14 +619,7 @@ describe("Columns", () => {
     test("delete almost all columns of a range", () => {
       model = new Model({
         sheets: [
-          {
-            id: "s1",
-            colNumber: 9,
-            rowNumber: 9,
-            cells: {
-              A1: { content: "=SUM(A2:E5)" },
-            },
-          },
+          { id: "s1", colNumber: 9, rowNumber: 9, cells: { A1: { content: "=SUM(A2:E5)" } } },
         ],
       });
       deleteColumns(model, ["B", "C", "D", "E"]);
@@ -723,9 +654,7 @@ describe("Columns", () => {
             id: "42",
             colNumber: 3,
             rowNumber: 9,
-            cells: {
-              A1: { content: "=SUM(Sheet1!B1:D3)" },
-            },
+            cells: { A1: { content: "=SUM(Sheet1!B1:D3)" } },
           },
         ],
       });
@@ -754,14 +683,7 @@ describe("Columns", () => {
     test("On multiple col deletion including the last one", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              A2: { content: "=SUM(A1:D1)" },
-            },
-          },
+          { id: "sheet1", colNumber: 3, rowNumber: 3, cells: { A2: { content: "=SUM(A1:D1)" } } },
         ],
       });
       deleteColumns(model, ["C", "D"]);
@@ -782,14 +704,7 @@ describe("Columns", () => {
 
     beforeEach(() => {
       model = new Model({
-        sheets: [
-          {
-            id: sheetId,
-            colNumber: 5,
-            rowNumber: 1,
-            cols: { 2: { isHidden: true } },
-          },
-        ],
+        sheets: [{ id: sheetId, colNumber: 5, rowNumber: 1, cols: { 2: { isHidden: true } } }],
       });
     });
     test("On addition before hidden col", () => {
@@ -888,16 +803,7 @@ describe("Rows", () => {
   describe("Correctly update size, name, order and number", () => {
     beforeEach(() => {
       model = new Model({
-        sheets: [
-          {
-            colNumber: 1,
-            rowNumber: 4,
-            rows: {
-              1: { size: 10 },
-              2: { size: 20 },
-            },
-          },
-        ],
+        sheets: [{ colNumber: 1, rowNumber: 4, rows: { 1: { size: 10 }, 2: { size: 20 } } }],
       });
     });
     test("On deletion", () => {
@@ -911,20 +817,8 @@ describe("Rows", () => {
     test("On delete row in inactive sheet", () => {
       model = new Model({
         sheets: [
-          {
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              B2: { content: "B2 in sheet1" },
-            },
-          },
-          {
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              B2: { content: "B2 in sheet2" },
-            },
-          },
+          { colNumber: 3, rowNumber: 3, cells: { B2: { content: "B2 in sheet1" } } },
+          { colNumber: 3, rowNumber: 3, cells: { B2: { content: "B2 in sheet2" } } },
         ],
       });
       const [sheet1Id, sheet2Id] = model.getters.getSheetIds();
@@ -982,9 +876,7 @@ describe("Rows", () => {
             id: "42",
             colNumber: 3,
             rowNumber: 9,
-            cells: {
-              A1: { content: "=SUM(Sheet1!A2:A3)" },
-            },
+            cells: { A1: { content: "=SUM(Sheet1!A2:A3)" } },
           },
         ],
       });
@@ -1065,13 +957,7 @@ describe("Rows", () => {
   describe("Correctly update merges", () => {
     beforeEach(() => {
       model = new Model({
-        sheets: [
-          {
-            colNumber: 4,
-            rowNumber: 5,
-            merges: ["A1:A5", "B2:B5", "C3:C5", "D2:D4"],
-          },
-        ],
+        sheets: [{ colNumber: 4, rowNumber: 5, merges: ["A1:A5", "B2:B5", "C3:C5", "D2:D4"] }],
       });
     });
     test("On deletion", () => {
@@ -1297,10 +1183,7 @@ describe("Rows", () => {
             id: "s1",
             colNumber: 4,
             rowNumber: 7,
-            cells: {
-              B2: { content: "=Sheet1!A2" },
-              C1: { content: "=Sheet2!A2" },
-            },
+            cells: { B2: { content: "=Sheet1!A2" }, C1: { content: "=Sheet2!A2" } },
           },
           {
             id: "s2",
@@ -1322,14 +1205,7 @@ describe("Rows", () => {
     test("On first row deletion", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              B2: { content: "=SUM(A1:A3)" },
-            },
-          },
+          { id: "sheet1", colNumber: 3, rowNumber: 3, cells: { B2: { content: "=SUM(A1:A3)" } } },
         ],
       });
       deleteRows(model, [0]);
@@ -1378,14 +1254,7 @@ describe("Rows", () => {
     test("On multiple row deletion including the first one", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 3,
-            rowNumber: 6,
-            cells: {
-              B1: { content: "=SUM(A2:A5)" },
-            },
-          },
+          { id: "sheet1", colNumber: 3, rowNumber: 6, cells: { B1: { content: "=SUM(A2:A5)" } } },
         ],
       });
       deleteRows(model, [1, 2]);
@@ -1400,10 +1269,7 @@ describe("Rows", () => {
             id: "sheet1",
             colNumber: 1,
             rowNumber: 1000,
-            cells: {
-              A5: { content: "=SUM(A6:A255)" },
-              A256: { content: "=SUM(A257:A506)" },
-            },
+            cells: { A5: { content: "=SUM(A6:A255)" }, A256: { content: "=SUM(A257:A506)" } },
           },
         ],
       });
@@ -1424,14 +1290,7 @@ describe("Rows", () => {
     test("On last row deletion", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 3,
-            rowNumber: 3,
-            cells: {
-              B1: { content: "=SUM(A1:A3)" },
-            },
-          },
+          { id: "sheet1", colNumber: 3, rowNumber: 3, cells: { B1: { content: "=SUM(A1:A3)" } } },
         ],
       });
       deleteRows(model, [2]);
@@ -1442,14 +1301,7 @@ describe("Rows", () => {
     test("On multiple row", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 1,
-            rowNumber: 8,
-            cells: {
-              A1: { content: "=SUM(A2:A5)" },
-            },
-          },
+          { id: "sheet1", colNumber: 1, rowNumber: 8, cells: { A1: { content: "=SUM(A2:A5)" } } },
         ],
       });
       deleteRows(model, [2, 3]);
@@ -1460,14 +1312,7 @@ describe("Rows", () => {
     test("On multiple rows (7)", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 1,
-            rowNumber: 8,
-            cells: {
-              A1: { content: "=SUM(A2:A8)" },
-            },
-          },
+          { id: "sheet1", colNumber: 1, rowNumber: 8, cells: { A1: { content: "=SUM(A2:A8)" } } },
         ],
       });
       deleteRows(model, [1, 2, 3, 4, 5, 6]);
@@ -1478,14 +1323,7 @@ describe("Rows", () => {
     test("On multiple row deletion including the last one", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 4,
-            rowNumber: 4,
-            cells: {
-              B1: { content: "=SUM(A1:A4)" },
-            },
-          },
+          { id: "sheet1", colNumber: 4, rowNumber: 4, cells: { B1: { content: "=SUM(A1:A4)" } } },
         ],
       });
       deleteRows(model, [2, 3]);
@@ -1496,14 +1334,7 @@ describe("Rows", () => {
     test("On multiple row deletion including the last and beyond", () => {
       model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 2,
-            rowNumber: 8,
-            cells: {
-              B2: { content: "=SUM(A1:A4)" },
-            },
-          },
+          { id: "sheet1", colNumber: 2, rowNumber: 8, cells: { B2: { content: "=SUM(A1:A4)" } } },
         ],
       });
       deleteRows(model, [3, 4, 5, 6, 7]);
@@ -1524,14 +1355,7 @@ describe("Rows", () => {
 
     beforeEach(() => {
       model = new Model({
-        sheets: [
-          {
-            id: sheetId,
-            colNumber: 1,
-            rowNumber: 5,
-            rows: { 2: { isHidden: true } },
-          },
-        ],
+        sheets: [{ id: sheetId, colNumber: 1, rowNumber: 5, rows: { 2: { isHidden: true } } }],
       });
     });
     test("On addition before hidden row", () => {

--- a/tests/plugins/header_visibility.test.ts
+++ b/tests/plugins/header_visibility.test.ts
@@ -25,15 +25,7 @@ let model: Model;
 describe("Hide Columns", () => {
   const sheetId = "1";
   beforeEach(() => {
-    model = new Model({
-      sheets: [
-        {
-          id: sheetId,
-          colNumber: 6,
-          rowNumber: 2,
-        },
-      ],
-    });
+    model = new Model({ sheets: [{ id: sheetId, colNumber: 6, rowNumber: 2 }] });
   });
 
   test("hide single column", () => {
@@ -87,14 +79,7 @@ describe("Hide Columns", () => {
   });
 
   test("hide/unhide Column on small sheet", () => {
-    model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 1,
-        },
-      ],
-    });
+    model = new Model({ sheets: [{ colNumber: 5, rowNumber: 1 }] });
     const sheet = model.getters.getActiveSheet();
     const dimensions = model.getters.getMainViewportRect();
     hideColumns(model, ["B", "C", "D"], sheet.id);
@@ -164,15 +149,7 @@ describe("Hide Columns", () => {
 describe("Hide Rows", () => {
   const sheetId = "2";
   beforeEach(() => {
-    model = new Model({
-      sheets: [
-        {
-          id: sheetId,
-          colNumber: 2,
-          rowNumber: 6,
-        },
-      ],
-    });
+    model = new Model({ sheets: [{ id: sheetId, colNumber: 2, rowNumber: 6 }] });
   });
 
   test("hide single row", () => {
@@ -196,14 +173,7 @@ describe("Hide Rows", () => {
   });
 
   test("hide/unhide Row on small sheet", () => {
-    model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 5,
-        },
-      ],
-    });
+    model = new Model({ sheets: [{ colNumber: 1, rowNumber: 5 }] });
     const sheet = model.getters.getActiveSheet();
     const dimensions = model.getters.getMainViewportRect();
     hideRows(model, [1, 2, 3], sheet.id);

--- a/tests/plugins/import_export.test.ts
+++ b/tests/plugins/import_export.test.ts
@@ -40,12 +40,8 @@ describe("Migrations", () => {
         {
           colNumber: 2,
           rowNumber: 2,
-          cols: {
-            0: { size: 42 },
-          },
-          rows: {
-            0: { size: 12 },
-          },
+          cols: { 0: { size: 42 } },
+          rows: { 0: { size: 12 } },
           cells: { A1: { content: "=a1" } },
           name: "My sheet",
           conditionalFormats: [],
@@ -91,12 +87,8 @@ describe("Migrations", () => {
         {
           colNumber: 2,
           rowNumber: 2,
-          cols: {
-            0: { size: 42 },
-          },
-          rows: {
-            0: { size: 12 },
-          },
+          cols: { 0: { size: 42 } },
+          rows: { 0: { size: 12 } },
           cells: { A1: { content: "=a1" } },
           name: "My sheet",
           conditionalFormats: [],
@@ -220,14 +212,7 @@ describe("Migrations", () => {
         { name: "My sheet" },
         {
           name: `sheetName${char}`,
-          cells: {
-            A1: {
-              formula: {
-                text: "=|0|",
-                dependencies: [`sheetName${char}!A2`],
-              },
-            },
-          },
+          cells: { A1: { formula: { text: "=|0|", dependencies: [`sheetName${char}!A2`] } } },
           figures: [
             {
               id: "1",
@@ -347,12 +332,7 @@ describe("Migrations", () => {
         {
           cells: {
             A1: { content: "1" },
-            A2: {
-              formula: {
-                text: "=|0|+|1|",
-                dependencies: ["A1", "A3"],
-              },
-            },
+            A2: { formula: { text: "=|0|+|1|", dependencies: ["A1", "A3"] } },
           },
         },
       ],
@@ -371,10 +351,7 @@ describe("Migrations", () => {
           id: "1",
           colNumber: 10,
           rowNumber: 10,
-          cells: {
-            A1: { content: "1000", format: "#,##0" },
-            A2: { content: "1000" },
-          },
+          cells: { A1: { content: "1000", format: "#,##0" }, A2: { content: "1000" } },
         },
         {
           id: "2",
@@ -403,16 +380,7 @@ describe("Import", () => {
   test("Import sheet with rows/cols size defined.", () => {
     const model = new Model({
       sheets: [
-        {
-          colNumber: 2,
-          rowNumber: 2,
-          cols: {
-            0: { size: 42 },
-          },
-          rows: {
-            1: { size: 13 },
-          },
-        },
+        { colNumber: 2, rowNumber: 2, cols: { 0: { size: 42 } }, rows: { 1: { size: 13 } } },
       ],
     });
     const sheet = model.getters.getActiveSheetId();
@@ -425,15 +393,8 @@ describe("Import", () => {
   test("Import 2 sheets with merges", () => {
     const model = new Model({
       sheets: [
-        {
-          colNumber: 2,
-          rowNumber: 2,
-          merges: ["A2:B2"],
-        },
-        {
-          colNumber: 2,
-          rowNumber: 2,
-        },
+        { colNumber: 2, rowNumber: 2, merges: ["A2:B2"] },
+        { colNumber: 2, rowNumber: 2 },
       ],
     });
     const sheet1 = model.getters.getSheetIds()[0];
@@ -447,17 +408,8 @@ describe("Import", () => {
 
   test("can import cell without content", () => {
     const model = new Model({
-      sheets: [
-        {
-          id: "1",
-          cells: {
-            A1: { format: 1 },
-          },
-        },
-      ],
-      formats: {
-        1: "0.00%",
-      },
+      sheets: [{ id: "1", cells: { A1: { format: 1 } } }],
+      formats: { 1: "0.00%" },
     });
     expect(getCell(model, "A1")?.content).toBe("");
     expect(getCell(model, "A1")?.format).toBe("0.00%");
@@ -466,28 +418,14 @@ describe("Import", () => {
 
 describe("Export", () => {
   test("Can export col size", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
     resizeColumns(model, ["B"], 150);
     const exp = model.exportData();
     expect(exp.sheets![0].cols![1].size).toBe(150);
   });
 
   test("Can export row size", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
     resizeRows(model, [1], 150);
     const exp = model.exportData();
     expect(exp.sheets![0].rows![1].size).toBe(150);
@@ -495,13 +433,7 @@ describe("Export", () => {
 
   test("Can export merges", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["A1:A2", "B1:C1", "D1:E2"],
-        },
-      ],
+      sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:A2", "B1:C1", "D1:E2"] }],
     });
     const exp = model.exportData();
     expect(exp.sheets![0].merges).toHaveLength(3);
@@ -509,18 +441,8 @@ describe("Export", () => {
 
   test("Can export format", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          cells: {
-            A1: { content: "145", format: 1 },
-          },
-        },
-      ],
-      formats: {
-        1: "0.00%",
-      },
+      sheets: [{ colNumber: 10, rowNumber: 10, cells: { A1: { content: "145", format: 1 } } }],
+      formats: { 1: "0.00%" },
     });
     const exp = model.exportData();
     expect(exp.sheets![0].cells!.A1!.format).toBe(1);
@@ -553,13 +475,7 @@ describe("Export", () => {
                 dataSets: ["B1:B4", "C1:C4"],
               },
             },
-            {
-              id: "id2",
-              x: 100,
-              y: 100,
-              width: 100,
-              height: 100,
-            },
+            { id: "id2", x: 100, y: 100, width: 100, height: 100 },
           ],
         },
       ],

--- a/tests/plugins/merges.test.ts
+++ b/tests/plugins/merges.test.ts
@@ -56,12 +56,7 @@ describe("merges", () => {
   test("can unmerge two cells", () => {
     const model = new Model({
       sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { B2: { content: "b2" } },
-          merges: ["B2:B3"],
-        },
+        { colNumber: 10, rowNumber: 10, cells: { B2: { content: "b2" } }, merges: ["B2:B3"] },
       ],
     });
     expect(getMergeCellMap(model)).toEqual(XCToMergeCellMap(model, ["B2", "B3"]));
@@ -120,14 +115,7 @@ describe("merges", () => {
   });
 
   test("merge outside the sheet is refused", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 2,
-          rowNumber: 2,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 2, rowNumber: 2 }] });
     const sheetId = model.getters.getActiveSheetId();
     expect(merge(model, "A1:C3")).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
     const { col, row } = toCartesian("A1");
@@ -138,12 +126,7 @@ describe("merges", () => {
   test("editing a merge cell actually edits the top left", () => {
     const model = new Model({
       sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { B2: { content: "b2" } },
-          merges: ["B2:C3"],
-        },
+        { colNumber: 10, rowNumber: 10, cells: { B2: { content: "b2" } }, merges: ["B2:C3"] },
       ],
     });
 
@@ -159,12 +142,7 @@ describe("merges", () => {
   test("setting a style to a merge edit all the cells", () => {
     const model = new Model({
       sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { B2: { content: "b2" } },
-          merges: ["B2:C3"],
-        },
+        { colNumber: 10, rowNumber: 10, cells: { B2: { content: "b2" } }, merges: ["B2:C3"] },
       ],
     });
 
@@ -213,29 +191,16 @@ describe("merges", () => {
   test("merge style is correct for inactive sheets", () => {
     const model = new Model({
       sheets: [
-        {
-          id: "1",
-          colNumber: 1,
-          rowNumber: 1,
-          cells: {
-            A1: { content: "1", style: 1 },
-          },
-        },
+        { id: "1", colNumber: 1, rowNumber: 1, cells: { A1: { content: "1", style: 1 } } },
         {
           id: "2",
           colNumber: 3,
           rowNumber: 3,
           merges: ["A1:B1"],
-          cells: {
-            A1: { content: "2", style: 2 },
-            B1: { content: "", style: 2 },
-          },
+          cells: { A1: { content: "2", style: 2 }, B1: { content: "", style: 2 } },
         },
       ],
-      styles: {
-        1: { fillColor: "#f2f2f2" },
-        2: { fillColor: "#a2a2a2" },
-      },
+      styles: { 1: { fillColor: "#f2f2f2" }, 2: { fillColor: "#a2a2a2" } },
     });
     const [, sheet2Id] = model.getters.getSheetIds();
     expect(sheet2Id).not.toBe(model.getters.getActiveSheetId());
@@ -264,14 +229,7 @@ describe("merges", () => {
   test("properly compute if a merge is destructive or not", () => {
     const sheetId = "42";
     const model = new Model({
-      sheets: [
-        {
-          id: sheetId,
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { B2: { content: "b2" } },
-        },
-      ],
+      sheets: [{ id: sheetId, colNumber: 10, rowNumber: 10, cells: { B2: { content: "b2" } } }],
     });
     // B2 is not top left, so it is destructive
 
@@ -286,14 +244,7 @@ describe("merges", () => {
   test("a merge with only style should not be considered destructive", () => {
     const sheetId = "42";
     const model = new Model({
-      sheets: [
-        {
-          id: sheetId,
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { B2: { style: 1 } },
-        },
-      ],
+      sheets: [{ id: sheetId, colNumber: 10, rowNumber: 10, cells: { B2: { style: 1 } } }],
       styles: { 1: {} },
     });
     expect(merge(model, "A1:C4")).toBeSuccessfullyDispatched();
@@ -508,9 +459,7 @@ describe("merges", () => {
   });
 
   test("selecting cell next to merge => expanding selection => merging => unmerging", () => {
-    const model = new Model({
-      sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:A2"] }],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:A2"] }] });
 
     //merging
     merge(model, "A1:A3");
@@ -597,9 +546,7 @@ describe("merges", () => {
           id: "sheet1",
           colNumber: 4,
           rowNumber: 5,
-          cells: {
-            B4: { style: 1, border: 1 },
-          },
+          cells: { B4: { style: 1, border: 1 } },
           merges: ["B4:C5"],
         },
       ],

--- a/tests/plugins/navigation.test.ts
+++ b/tests/plugins/navigation.test.ts
@@ -121,15 +121,7 @@ describe("navigation", () => {
   });
 
   test("move in and out of a merge", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["B1:C2"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["B1:C2"] }] });
     expect(getActivePosition(model)).toBe("A1");
 
     // move to the right, inside the merge
@@ -146,15 +138,7 @@ describe("navigation", () => {
   });
 
   test("do nothing if moving out of merge is out of grid", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["B1:C2"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["B1:C2"] }] });
     expect(getSelectionAnchorCellXc(model)).toEqual("A1");
 
     // put selection below merge
@@ -263,13 +247,7 @@ describe("navigation", () => {
 
   test("move through hidden column", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 1,
-          cols: { 2: { isHidden: true } },
-        },
-      ],
+      sheets: [{ colNumber: 5, rowNumber: 1, cols: { 2: { isHidden: true } } }],
     });
     //from the right
     selectCell(model, "D1");
@@ -283,11 +261,7 @@ describe("navigation", () => {
   test("don't move through hidden col if out of grid", () => {
     const model = new Model({
       sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 1,
-          cols: { 0: { isHidden: true }, 4: { isHidden: true } },
-        },
+        { colNumber: 5, rowNumber: 1, cols: { 0: { isHidden: true }, 4: { isHidden: true } } },
       ],
     });
     // move left from the first visible column
@@ -302,13 +276,7 @@ describe("navigation", () => {
 
   test("move through hidden row", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 5,
-          rows: { 2: { isHidden: true } },
-        },
-      ],
+      sheets: [{ colNumber: 1, rowNumber: 5, rows: { 2: { isHidden: true } } }],
     });
     selectCell(model, "A4");
     moveAnchorCell(model, "up");
@@ -321,14 +289,7 @@ describe("navigation", () => {
 
 describe("Navigation starting from hidden cells", () => {
   test("Cannot move position horizontally from hidden row", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 2,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 2 }] });
     selectCell(model, "C1");
     hideRows(model, [0]);
     const move1 = moveAnchorCell(model, "right");
@@ -338,14 +299,7 @@ describe("Navigation starting from hidden cells", () => {
   });
 
   test("Cannot move position vertically from hidden column", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 2,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 2 }] });
     selectCell(model, "C1");
     hideColumns(model, ["C"]);
     const move1 = moveAnchorCell(model, "down");
@@ -400,14 +354,7 @@ describe("Navigation starting from hidden cells", () => {
   );
 
   test("Cannot from zero or negative steps does nothing", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 2,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 2 }] });
     selectCell(model, "C1");
     hideColumns(model, ["C"]);
     const move1 = moveAnchorCell(model, "down", 0);

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -567,10 +567,7 @@ describe("Helpers", () => {
   ])("copyRangeWithNewSheetId", (xc, sheetIdFrom, sheetIdTo, result) => {
     const model = new Model({
       sheets: [
-        {
-          id: "s1",
-          name: "Sheet1",
-        },
+        { id: "s1", name: "Sheet1" },
         { id: "s2", name: "Sheet2" },
       ],
     });
@@ -581,9 +578,7 @@ describe("Helpers", () => {
 });
 describe("full column range", () => {
   beforeEach(() => {
-    m = new Model({
-      sheets: [{ id: "s1", name: "s1", rows: 10, cols: 10 }],
-    });
+    m = new Model({ sheets: [{ id: "s1", name: "s1", rows: 10, cols: 10 }] });
     m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["B:C"] });
   });
   afterEach(() => {
@@ -634,9 +629,7 @@ describe("full column range", () => {
 
 describe("full row range", () => {
   beforeEach(() => {
-    m = new Model({
-      sheets: [{ id: "s1", name: "s1", rows: 10, cols: 10 }],
-    });
+    m = new Model({ sheets: [{ id: "s1", name: "s1", rows: 10, cols: 10 }] });
     m.dispatch("USE_RANGE", { sheetId: m.getters.getActiveSheetId(), rangesXC: ["2:3"] });
   });
   afterEach(() => {

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -313,11 +313,7 @@ describe("renderer", () => {
                 type: "IconSetRule",
                 upperInflectionPoint: { type: "number", value: "1000", operator: "gt" },
                 lowerInflectionPoint: { type: "number", value: "0", operator: "gt" },
-                icons: {
-                  upper: "arrowGood",
-                  middle: "arrowNeutral",
-                  lower: "arrowBad",
-                },
+                icons: { upper: "arrowGood", middle: "arrowNeutral", lower: "arrowBad" },
               },
             },
           ],
@@ -345,14 +341,7 @@ describe("renderer", () => {
   });
 
   test("fillstyle of cell will be rendered", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 3,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 3 }] });
     model.dispatch("SET_FORMATTING", {
       sheetId: model.getters.getActiveSheetId(),
       target: [toZone("A1")],
@@ -401,14 +390,7 @@ describe("renderer", () => {
   });
 
   test("fillstyle of merge will be rendered for all cells in merge", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 3,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 3 }] });
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("SET_FORMATTING", {
       sheetId,
@@ -459,14 +441,7 @@ describe("renderer", () => {
   });
 
   test("fillstyle of cell works with CF", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 3,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 3 }] });
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#DC6CDF" }, "1"),
@@ -500,14 +475,7 @@ describe("renderer", () => {
   });
 
   test("fillstyle of merge works with CF", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 3,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 3 }] });
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#DC6CDF" }, "1"),
@@ -616,11 +584,7 @@ describe("renderer", () => {
                 type: "IconSetRule",
                 upperInflectionPoint: { type: "number", value: "1000", operator: "gt" },
                 lowerInflectionPoint: { type: "number", value: "0", operator: "gt" },
-                icons: {
-                  upper: "arrowGood",
-                  middle: "arrowNeutral",
-                  lower: "arrowBad",
-                },
+                icons: { upper: "arrowGood", middle: "arrowNeutral", lower: "arrowBad" },
               },
             },
           ],
@@ -773,14 +737,7 @@ describe("renderer", () => {
     );
   });
   test("CF on empty cell", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 1,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 1 }] });
     let fillStyle: any[] = [];
     let fillStyleColor1Called = false;
     let ctx = new MockGridRenderingContext(model, 1000, 1000, {
@@ -1204,11 +1161,7 @@ describe("renderer", () => {
                 type: "IconSetRule",
                 upperInflectionPoint: { type: "number", value: "1000", operator: "gt" },
                 lowerInflectionPoint: { type: "number", value: "0", operator: "gt" },
-                icons: {
-                  upper: "arrowGood",
-                  middle: "arrowNeutral",
-                  lower: "arrowBad",
-                },
+                icons: { upper: "arrowGood", middle: "arrowNeutral", lower: "arrowBad" },
               },
             },
           ],
@@ -1298,12 +1251,7 @@ describe("renderer", () => {
       const cellContent = "This is a long text larger than a cell";
       const model = new Model({
         sheets: [
-          {
-            id: "sheet1",
-            colNumber: 3,
-            rowNumber: 3,
-            cells: { B2: { content: cellContent } },
-          },
+          { id: "sheet1", colNumber: 3, rowNumber: 3, cells: { B2: { content: cellContent } } },
         ],
       });
 
@@ -1367,15 +1315,7 @@ describe("renderer", () => {
   );
   test("Box clip rect computation take the text margin into account", () => {
     let box: Box;
-    const model = new Model({
-      sheets: [
-        {
-          id: "sheet1",
-          colNumber: 1,
-          rowNumber: 1,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ id: "sheet1", colNumber: 1, rowNumber: 1 }] });
     resizeColumns(model, ["A"], 10);
 
     // Text + MIN_CELL_TEXT_MARGIN  <= col size, no clip
@@ -1512,13 +1452,7 @@ describe("renderer", () => {
   test("Do not draw gridLines over colored cells in dashboard mode", () => {
     const CellFillColor = "#fe0000";
     const model = new Model({
-      sheets: [
-        {
-          id: "Sheet1",
-          name: "Sheet1",
-          cells: { A1: { style: 1 }, A2: { style: 1 } },
-        },
-      ],
+      sheets: [{ id: "Sheet1", name: "Sheet1", cells: { A1: { style: 1 }, A2: { style: 1 } } }],
       styles: { 1: { fillColor: CellFillColor } },
     });
 
@@ -1547,13 +1481,7 @@ describe("renderer", () => {
   test("Do not draw gridLines over colored cells while hiding grid lines", () => {
     const CellFillColor = "#fe0000";
     const model = new Model({
-      sheets: [
-        {
-          id: "Sheet1",
-          name: "Sheet1",
-          cells: { A1: { style: 1 }, A2: { style: 1 } },
-        },
-      ],
+      sheets: [{ id: "Sheet1", name: "Sheet1", cells: { A1: { style: 1 }, A2: { style: 1 } } }],
       styles: { 1: { fillColor: CellFillColor } },
     });
 
@@ -1590,9 +1518,7 @@ describe("renderer", () => {
           colNumber: 1,
           rowNumber: 1,
           rows: { 0: { size: DEFAULT_CELL_HEIGHT * 2 } },
-          cells: {
-            A1: { content: "kikou" },
-          },
+          cells: { A1: { content: "kikou" } },
         },
       ],
     });

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -35,28 +35,12 @@ let model: Model;
 const hiddenContent = { content: "hidden content to be skipped" };
 describe("simple selection", () => {
   test("if A1 is in a merge, it is initially properly selected", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["A1:B3"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:B3"] }] });
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 0, right: 1, bottom: 2 });
   });
 
   test("Adding a cell of a merge in the selection adds the whole merge", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["A2:B3"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A2:B3"] }] });
 
     expect(model.getters.getSelectedZones()).toEqual([{ left: 0, top: 0, right: 0, bottom: 0 }]);
     addCellToSelection(model, "A2");
@@ -67,15 +51,7 @@ describe("simple selection", () => {
   });
 
   test("can select selection with shift-arrow", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["B1:C2"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["B1:C2"] }] });
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 0, right: 0, bottom: 0 });
     resizeAnchorZone(model, "right");
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 0, right: 2, bottom: 1 });
@@ -91,14 +67,7 @@ describe("simple selection", () => {
   });
 
   test("cannot expand select selection with shift-arrow if it is out of bound", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
     selectCell(model, "A2");
     resizeAnchorZone(model, "up");
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 0, right: 0, bottom: 1 });
@@ -114,30 +83,14 @@ describe("simple selection", () => {
   });
 
   test("can expand selection with mouse", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["B1:C2"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["B1:C2"] }] });
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 0, right: 0, bottom: 0 });
     setAnchorCorner(model, "B1");
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 0, right: 2, bottom: 1 });
   });
 
   test("move selection in and out of a merge (in opposite direction)", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["C1:D2"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["C1:D2"] }] });
     selectCell(model, "B1");
 
     // move to the right, inside the merge
@@ -153,14 +106,7 @@ describe("simple selection", () => {
   });
 
   test("select a cell outside the sheet", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 3,
-          rowNumber: 3,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 3, rowNumber: 3 }] });
     selectCell(model, "D4");
     const A1Zone = toZone("A1");
     expect(model.getters.getSelection()).toEqual({
@@ -173,15 +119,7 @@ describe("simple selection", () => {
     expect(getActivePosition(model)).toBe("A1");
   });
   test("update selection in some different directions", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["B2:C3"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["B2:C3"] }] });
     // move sell to B4
     selectCell(model, "B4");
     expect(getSelectionAnchorCellXc(model)).toBe("B4");
@@ -198,13 +136,7 @@ describe("simple selection", () => {
 
   test("expand selection when encountering a merge", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["B2:B3", "C2:D2"],
-        },
-      ],
+      sheets: [{ colNumber: 10, rowNumber: 10, merges: ["B2:B3", "C2:D2"] }],
     });
     // move sell to B4
     selectCell(model, "B3");
@@ -217,13 +149,7 @@ describe("simple selection", () => {
 
   test("expand selection when starting from a merge", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["B2:B3", "E2:G2"],
-        },
-      ],
+      sheets: [{ colNumber: 10, rowNumber: 10, merges: ["B2:B3", "E2:G2"] }],
     });
     selectCell(model, "B2");
     resizeAnchorZone(model, "down");
@@ -261,11 +187,7 @@ describe("simple selection", () => {
   test("extend and reduce selection through hidden columns", () => {
     const model = new Model({
       sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 1,
-          cols: { 2: { isHidden: true }, 3: { isHidden: true } },
-        },
+        { colNumber: 5, rowNumber: 1, cols: { 2: { isHidden: true }, 3: { isHidden: true } } },
       ],
     });
     selectCell(model, "B1");
@@ -278,11 +200,7 @@ describe("simple selection", () => {
   test("extend and reduce selection through hidden rows", () => {
     const model = new Model({
       sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 5,
-          rows: { 2: { isHidden: true }, 3: { isHidden: true } },
-        },
+        { colNumber: 1, rowNumber: 5, rows: { 2: { isHidden: true }, 3: { isHidden: true } } },
       ],
     });
     selectCell(model, "A5");
@@ -293,14 +211,7 @@ describe("simple selection", () => {
   });
 
   test("can select a whole column", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
     selectColumn(model, 4, "overrideSelection");
 
     expect(getSelectionAnchorCellXc(model)).toBe("E1");
@@ -309,15 +220,7 @@ describe("simple selection", () => {
   });
 
   test("can select a whole column with a merged cell", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["A1:B1"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:B1"] }] });
     selectColumn(model, 0, "overrideSelection");
 
     expect(getSelectionAnchorCellXc(model)).toBe("A1");
@@ -325,9 +228,7 @@ describe("simple selection", () => {
   });
 
   test("selection is clipped to sheet size", () => {
-    const model = new Model({
-      sheets: [{ colNumber: 3, rowNumber: 3 }],
-    });
+    const model = new Model({ sheets: [{ colNumber: 3, rowNumber: 3 }] });
     setSelection(model, ["A1:Z20"]);
     const zone = toZone("A1:C3");
     expect(model.getters.getSelection()).toEqual({
@@ -337,14 +238,7 @@ describe("simple selection", () => {
   });
 
   test("can select a whole row", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
 
     selectRow(model, 4, "overrideSelection");
     expect(getSelectionAnchorCellXc(model)).toBe("A5");
@@ -353,15 +247,7 @@ describe("simple selection", () => {
   });
 
   test("can select a whole row with a merged cell", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-          merges: ["A1:A2"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10, merges: ["A1:A2"] }] });
 
     selectRow(model, 0, "overrideSelection");
     expect(getSelectionAnchorCellXc(model)).toBe("A1");
@@ -369,14 +255,7 @@ describe("simple selection", () => {
   });
 
   test("cannot select out of bound row", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
     expect(selectRow(model, -1, "overrideSelection")).toBeCancelledBecause(
       CommandResult.SelectionOutOfBound
     );
@@ -386,14 +265,7 @@ describe("simple selection", () => {
   });
 
   test("cannot select out of bound column", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
     expect(selectColumn(model, -1, "overrideSelection")).toBeCancelledBecause(
       CommandResult.SelectionOutOfBound
     );
@@ -403,14 +275,7 @@ describe("simple selection", () => {
   });
 
   test("can select the whole sheet", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
     selectAll(model);
     expect(getSelectionAnchorCellXc(model)).toBe("A1");
 
@@ -418,15 +283,7 @@ describe("simple selection", () => {
   });
 
   test("invalid selection is updated after undo", () => {
-    const model = new Model({
-      sheets: [
-        {
-          id: "42",
-          colNumber: 3,
-          rowNumber: 3,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ id: "42", colNumber: 3, rowNumber: 3 }] });
     addColumns(model, "after", "A", 1);
     selectCell(model, "D1");
     undo(model);
@@ -435,15 +292,7 @@ describe("simple selection", () => {
   });
 
   test("invalid selection is updated after redo", () => {
-    const model = new Model({
-      sheets: [
-        {
-          id: "42",
-          colNumber: 3,
-          rowNumber: 3,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ id: "42", colNumber: 3, rowNumber: 3 }] });
     deleteColumns(model, ["A"]);
     undo(model);
     selectCell(model, "C1");
@@ -477,14 +326,7 @@ describe("simple selection", () => {
 
 describe("multiple selections", () => {
   test("can select a new range", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 10,
-          rowNumber: 10,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
     selectCell(model, "C3");
     let selection = model.getters.getSelection();
     expect(selection.zones.length).toBe(1);
@@ -563,9 +405,7 @@ describe("multiple sheets", () => {
   test("Activating an unvisited sheet selects its first visible cell", () => {
     const model = new Model({
       sheets: [
-        {
-          sheetId: "Sheet1",
-        },
+        { sheetId: "Sheet1" },
         {
           sheetId: "Sheet2",
           colNumber: 5,
@@ -584,14 +424,7 @@ describe("multiple sheets", () => {
 
 describe("Alter selection starting from hidden cells", () => {
   test("Cannot change selection if the current one is completely hidden", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 2,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 2 }] });
     selectCell(model, "C1");
     hideColumns(model, ["C"]);
     hideRows(model, [0]);
@@ -603,14 +436,7 @@ describe("Alter selection starting from hidden cells", () => {
   });
 
   test("Cannot move position vertically from hidden column", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 2,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 2 }] });
     selectCell(model, "C1");
     hideColumns(model, ["C"]);
     const move1 = moveAnchorCell(model, "down");
@@ -909,11 +735,7 @@ describe("Alter Selection with content in selection", () => {
         {
           colNumber: 9,
           rowNumber: 9,
-          cells: {
-            C3: { content: "1" },
-            C4: { content: "2" },
-            D3: { content: "3" },
-          },
+          cells: { C3: { content: "1" }, C4: { content: "2" }, D3: { content: "3" } },
         },
       ],
     });
@@ -962,14 +784,7 @@ describe("Alter Selection with content in selection", () => {
 
 describe("move elements(s)", () => {
   const model = new Model({
-    sheets: [
-      {
-        id: "1",
-        colNumber: 10,
-        rowNumber: 10,
-        merges: ["C3:D4", "G7:H8"],
-      },
-    ],
+    sheets: [{ id: "1", colNumber: 10, rowNumber: 10, merges: ["C3:D4", "G7:H8"] }],
   });
   test("can't move columns whose merges overflow from the selection", () => {
     const result = moveColumns(model, "F", ["B", "C"]);

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -250,18 +250,8 @@ describe("sheets", () => {
   test("evaluating multiple sheets", () => {
     const model = new Model({
       sheets: [
-        {
-          name: "ABC",
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { B1: { content: "=DEF!B2" } },
-        },
-        {
-          name: "DEF",
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { B2: { content: "3" } },
-        },
+        { name: "ABC", colNumber: 10, rowNumber: 10, cells: { B1: { content: "=DEF!B2" } } },
+        { name: "DEF", colNumber: 10, rowNumber: 10, cells: { B2: { content: "3" } } },
       ],
     });
 
@@ -272,20 +262,12 @@ describe("sheets", () => {
   test("evaluating multiple sheets, 2", () => {
     const model = new Model({
       sheets: [
-        {
-          name: "ABC",
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { B1: { content: "=DEF!B2" } },
-        },
+        { name: "ABC", colNumber: 10, rowNumber: 10, cells: { B1: { content: "=DEF!B2" } } },
         {
           name: "DEF",
           colNumber: 10,
           rowNumber: 10,
-          cells: {
-            B2: { content: "=A4" },
-            A4: { content: "3" },
-          },
+          cells: { B2: { content: "=A4" }, A4: { content: "3" } },
         },
       ],
     });
@@ -299,21 +281,12 @@ describe("sheets", () => {
   test("evaluating multiple sheets, 3 (with range)", () => {
     const model = new Model({
       sheets: [
-        {
-          name: "ABC",
-          colNumber: 10,
-          rowNumber: 10,
-          cells: { B1: { content: "=DEF!B2" } },
-        },
+        { name: "ABC", colNumber: 10, rowNumber: 10, cells: { B1: { content: "=DEF!B2" } } },
         {
           name: "DEF",
           colNumber: 10,
           rowNumber: 10,
-          cells: {
-            B2: { content: "=SUM(A1:A5)" },
-            A1: { content: "2" },
-            A4: { content: "3" },
-          },
+          cells: { B2: { content: "=SUM(A1:A5)" }, A1: { content: "2" }, A4: { content: "3" } },
         },
       ],
     });
@@ -339,10 +312,7 @@ describe("sheets", () => {
           name: "DEF",
           colNumber: 10,
           rowNumber: 10,
-          cells: {
-            B2: { content: "=ABC!B1" },
-            C5: { content: "=ABC!C4 + 1" },
-          },
+          cells: { B2: { content: "=ABC!B1" }, C5: { content: "=ABC!C4 + 1" } },
         },
       ],
     });
@@ -360,19 +330,14 @@ describe("sheets", () => {
           id: "smallId",
           colNumber: 2,
           rowNumber: 2,
-          cells: {
-            A2: { content: "=big!A2" },
-          },
+          cells: { A2: { content: "=big!A2" } },
         },
         {
           name: "big",
           id: "bigId",
           colNumber: 5,
           rowNumber: 5,
-          cells: {
-            A1: { content: "23" },
-            A2: { content: "=A1" },
-          },
+          cells: { A1: { content: "23" }, A2: { content: "=A1" } },
         },
       ],
     });
@@ -712,15 +677,7 @@ describe("sheets", () => {
 
   test("Cells are correctly duplicated", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 5,
-          cells: {
-            A1: { content: "42" },
-          },
-        },
-      ],
+      sheets: [{ colNumber: 5, rowNumber: 5, cells: { A1: { content: "42" } } }],
     });
     const sheet = model.getters.getActiveSheetId();
     model.dispatch("DUPLICATE_SHEET", { sheetId: sheet, sheetIdTo: model.uuidGenerator.uuidv4() });
@@ -766,15 +723,7 @@ describe("sheets", () => {
   });
 
   test("Merges are correctly duplicated", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 5,
-          merges: ["A1:A2"],
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5, merges: ["A1:A2"] }] });
     const sheet = model.getters.getActiveSheetId();
     model.dispatch("DUPLICATE_SHEET", { sheetId: sheet, sheetIdTo: model.uuidGenerator.uuidv4() });
     expect(model.getters.getSheetIds()).toHaveLength(2);
@@ -891,26 +840,13 @@ describe("sheets", () => {
   });
 
   test("Cannot remove more columns/rows than there are inside the sheet", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 3,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 3 }] });
     expect(deleteRows(model, [1, 2, 3, 4])).toBeCancelledBecause(CommandResult.NotEnoughElements);
   });
 
   test("Cannot have all rows/columns hidden at once", () => {
     const model = new Model({
-      sheets: [
-        {
-          colNumber: 1,
-          rowNumber: 4,
-          rows: { 2: { isHidden: true } },
-        },
-      ],
+      sheets: [{ colNumber: 1, rowNumber: 4, rows: { 2: { isHidden: true } } }],
     });
     expect(hideRows(model, [0, 1, 3])).toBeCancelledBecause(CommandResult.TooManyHiddenElements);
   });

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -262,9 +262,7 @@ describe("Viewport of Simple sheet", () => {
   });
 
   test("can horizontal scroll on sheet smaller than viewport", () => {
-    model = new Model({
-      sheets: [{ rowNumber: 2 }],
-    });
+    model = new Model({ sheets: [{ rowNumber: 2 }] });
     setViewportOffset(model, DEFAULT_CELL_WIDTH * 2, 0);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 0,
@@ -380,9 +378,7 @@ describe("Viewport of Simple sheet", () => {
   });
 
   test("can vertical scroll on sheet smaller than viewport", () => {
-    model = new Model({
-      sheets: [{ colNumber: 2 }],
-    });
+    model = new Model({ sheets: [{ colNumber: 2 }] });
     setViewportOffset(model, 0, DEFAULT_CELL_HEIGHT * 2);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 2,
@@ -1046,20 +1042,8 @@ describe("multi sheet with different sizes", () => {
   beforeEach(async () => {
     model = new Model({
       sheets: [
-        {
-          name: "small",
-          id: "small",
-          colNumber: 2,
-          rowNumber: 2,
-          cells: {},
-        },
-        {
-          name: "big",
-          id: "big",
-          colNumber: 5,
-          rowNumber: 5,
-          cells: {},
-        },
+        { name: "small", id: "small", colNumber: 2, rowNumber: 2 },
+        { name: "big", id: "big", colNumber: 5, rowNumber: 5 },
       ],
     });
   });

--- a/tests/plugins/sort.test.ts
+++ b/tests/plugins/sort.test.ts
@@ -22,16 +22,7 @@ describe("Basic Sorting", () => {
       A5: { content: "16" },
       A6: { content: "15" },
     };
-    model = new Model({
-      sheets: [
-        {
-          id: sheetId,
-          colNumber: 1,
-          rowNumber: 6,
-          cells: cells,
-        },
-      ],
-    });
+    model = new Model({ sheets: [{ id: sheetId, colNumber: 1, rowNumber: 6, cells: cells }] });
     sort(model, {
       zone: "A1:A6",
       anchor: "A2",
@@ -347,15 +338,7 @@ describe("Trigger sort generic errors", () => {
   const sheetId: UID = "sheet2";
 
   test("Sort with anchor outside of the sorting zone", () => {
-    const model = new Model({
-      sheets: [
-        {
-          id: sheetId,
-          colNumber: 1,
-          rowNumber: 6,
-        },
-      ],
-    });
+    const model = new Model({ sheets: [{ id: sheetId, colNumber: 1, rowNumber: 6 }] });
     expect(() => {
       sort(model, {
         zone: "A1:A3",


### PR DESCRIPTION
## Description:

Models are often initialized in the tests with a json object to initialize the sheets and cells. The problem is that we tend to define one attribute of the JSON per line of code, no matter the length of the line.

- this means that initializing a single model takes 7-10 lines of code, which bloats the test file and makes them harder to scroll trough.
- having a single attribute per line don't make the code of an individual test much more readable IMO.

I propose to discard useless newLines, and try to reduce the lines of code to initialize the model (while still running prettier). This makes the tests more readable.


Odoo task ID : [3256031](https://www.odoo.com/web#id=3256031&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo