### PR TITLE
[FIX] XLSX: open exported .xlsx file containing images in Excel

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -49,8 +49,8 @@ topbarMenuRegistry.addChild("xlsx", ["file"], {
     const doc = await env.model.exportXLSX();
     const zip = new JSZip();
     for (const file of doc.files) {
-      if (file.imagePath) {
-        const fetchedImage = await fetch(file.imagePath).then((response) => response.blob());
+      if (file.imageSrc) {
+        const fetchedImage = await fetch(file.imageSrc).then((response) => response.blob());
         zip.file(file.path, fetchedImage);
       } else {
         zip.file(file.path, file.content.replaceAll(` xmlns=""`, ""));

--- a/src/helpers/figures/images/image_provider.ts
+++ b/src/helpers/figures/images/image_provider.ts
@@ -13,7 +13,7 @@ export class ImageProvider implements ImageProviderInterface {
     const file = await this.getImageFromUser();
     const path = await this.fileStore.upload(file);
     const size = await this.getImageSize(path);
-    return { path, size };
+    return { path, size, mimetype: file.type };
   }
 
   private getImageFromUser(): Promise<File> {

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -3,4 +3,5 @@ import { FigureSize } from "./figure";
 export interface Image {
   path: string;
   size: FigureSize;
+  mimetype?: string;
 }

--- a/src/types/xlsx.ts
+++ b/src/types/xlsx.ts
@@ -157,7 +157,7 @@ export interface XLSXExportXMLFile {
 
 export interface XLSXExportImageFile {
   path: string;
-  imagePath: string;
+  imageSrc: string;
 }
 
 export interface XLSXExport {

--- a/src/xlsx/conversion/conversion_maps.ts
+++ b/src/xlsx/conversion/conversion_maps.ts
@@ -341,3 +341,14 @@ export const XLSX_INDEXED_COLORS = {
   64: "000000", // system foreground
   65: "FFFFFF", // system background
 };
+
+export const IMAGE_MIMETYPE_EXTENSION_MAPPING = {
+  "image/avif": "avif",
+  "image/bmp": "bmp",
+  "image/gif": "gif",
+  "image/vnd.microsoft.icon": "ico",
+  "image/jpeg": "jpeg",
+  "image/png": "png",
+  "image/tiff": "tiff",
+  "image/webp": "webp",
+};

--- a/src/xlsx/helpers/xml_helpers.ts
+++ b/src/xlsx/helpers/xml_helpers.ts
@@ -85,6 +85,12 @@ export function createOverride(partName: string, contentType: string): XMLString
   `;
 }
 
+export function createDefaultXMLElement(extension: string, contentType: string): XMLString {
+  return escapeXml/*xml*/ `
+    <Default Extension="${extension}" ContentType="${contentType}" />
+  `;
+}
+
 export function joinXmlNodes(xmlNodes: XMLString[]): XMLString {
   return new XMLString(xmlNodes.join("\n"));
 }

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -10,6 +10,7 @@ import {
 } from "../types/xlsx";
 import { XLSXExportXMLFile } from "./../types/xlsx";
 import { CONTENT_TYPES, NAMESPACE, RELATIONSHIP_NSR, XLSX_RELATION_TYPE } from "./constants";
+import { IMAGE_MIMETYPE_EXTENSION_MAPPING } from "./conversion";
 import { createChart } from "./functions/charts";
 import { addConditionalFormatting } from "./functions/conditional_formatting";
 import { createDrawing } from "./functions/drawings";
@@ -37,6 +38,7 @@ import {
   convertWidthToExcel,
 } from "./helpers/content_helpers";
 import {
+  createDefaultXMLElement,
   createOverride,
   createXMLFile,
   escapeXml,
@@ -119,8 +121,7 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
     // Figures and Charts
     let drawingNode = escapeXml``;
     const drawingRelIds: string[] = [];
-    const charts = sheet.charts;
-    for (const chart of charts) {
+    for (const chart of sheet.charts) {
       const xlsxChartId = convertChartId(chart.id);
       const chartRelId = addRelsToFile(
         construct.relsFiles,
@@ -140,25 +141,31 @@ function createWorksheets(data: ExcelWorkbookData, construct: XLSXStructure): XL
       );
     }
 
-    const images = sheet.images;
-    for (const image of images) {
+    for (const image of sheet.images) {
+      const mimeType = image.data.mimetype;
+      if (mimeType === undefined) continue;
+      const extension = IMAGE_MIMETYPE_EXTENSION_MAPPING[mimeType];
+      // only support exporting images with mimetypes specified in the mapping
+      if (extension === undefined) continue;
       const xlsxImageId = convertImageId(image.id);
+      let imageFileName = `image${xlsxImageId}.${extension}`;
+
       const imageRelId = addRelsToFile(
         construct.relsFiles,
         `xl/drawings/_rels/drawing${sheetIndex}.xml.rels`,
         {
-          target: `../media/image${xlsxImageId}`,
+          target: `../media/${imageFileName}`,
           type: XLSX_RELATION_TYPE.image,
         }
       );
       drawingRelIds.push(imageRelId);
       files.push({
-        path: `xl/media/image${xlsxImageId}`,
-        imagePath: image.data.path,
+        path: `xl/media/${imageFileName}`,
+        imageSrc: image.data.path,
       });
     }
 
-    const drawings = [...charts, ...images];
+    const drawings = [...sheet.charts, ...sheet.images];
     if (drawings.length) {
       const drawingRelId = addRelsToFile(
         construct.relsFiles,
@@ -310,6 +317,10 @@ function createRelsFiles(relsFiles: XLSXRelFile[]): XLSXExportFile[] {
 
 function createContentTypes(files: XLSXExportFile[]): XLSXExportXMLFile {
   const overrideNodes: XMLString[] = [];
+  // hard-code supported image mimetypes
+  const imageDefaultNodes = Object.entries(IMAGE_MIMETYPE_EXTENSION_MAPPING).map(
+    ([mimetype, extension]) => createDefaultXMLElement(extension, mimetype)
+  );
   for (const file of files) {
     if ("contentType" in file && file.contentType) {
       overrideNodes.push(createOverride("/" + file.path, CONTENT_TYPES[file.contentType]));
@@ -317,6 +328,7 @@ function createContentTypes(files: XLSXExportFile[]): XLSXExportXMLFile {
   }
   const xml = escapeXml/*xml*/ `
     <Types xmlns="${NAMESPACE["Types"]}">
+      ${joinXmlNodes(Object.values(imageDefaultNodes))}
       <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
       <Default Extension="xml" ContentType="application/xml" />
       ${joinXmlNodes(overrideNodes)}

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -575,6 +575,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -1160,6 +1168,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -1745,6 +1761,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -3387,6 +3411,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -4385,6 +4417,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -5319,6 +5359,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -5881,6 +5929,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -6480,6 +6536,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -7041,6 +7105,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -7643,6 +7715,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -8121,6 +8201,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -8673,6 +8761,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -9272,6 +9368,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -9495,6 +9599,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -9856,6 +9968,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -9963,6 +10083,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -10099,6 +10227,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -10777,6 +10913,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -10813,8 +10957,8 @@ Object {
       "path": "xl/workbook.xml",
     },
     Object {
-      "imagePath": "image path",
-      "path": "xl/media/image7",
+      "imageSrc": "image path",
+      "path": "xl/media/image7.jpeg",
     },
     Object {
       "content": "<xdr:wsDr xmlns:xdr=\\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
@@ -10968,7 +11112,7 @@ Object {
     },
     Object {
       "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
-    <Relationship Id=\\"rId1\\" Target=\\"../media/image7\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
+    <Relationship Id=\\"rId1\\" Target=\\"../media/image7.jpeg\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -10982,6 +11126,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -11018,8 +11170,8 @@ Object {
       "path": "xl/workbook.xml",
     },
     Object {
-      "imagePath": "image path",
-      "path": "xl/media/image6",
+      "imageSrc": "image path",
+      "path": "xl/media/image6.jpeg",
     },
     Object {
       "content": "<xdr:wsDr xmlns:xdr=\\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
@@ -11173,7 +11325,7 @@ Object {
     },
     Object {
       "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
-    <Relationship Id=\\"rId1\\" Target=\\"../media/image6\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
+    <Relationship Id=\\"rId1\\" Target=\\"../media/image6.jpeg\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -11187,6 +11339,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -11224,8 +11384,8 @@ Object {
       "path": "xl/workbook.xml",
     },
     Object {
-      "imagePath": "image path",
-      "path": "xl/media/image4",
+      "imageSrc": "image path",
+      "path": "xl/media/image4.jpeg",
     },
     Object {
       "content": "<xdr:wsDr xmlns:xdr=\\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
@@ -11324,8 +11484,8 @@ Object {
       "path": "xl/worksheets/sheet0.xml",
     },
     Object {
-      "imagePath": "image path",
-      "path": "xl/media/image5",
+      "imageSrc": "image path",
+      "path": "xl/media/image5.jpeg",
     },
     Object {
       "content": "<xdr:wsDr xmlns:xdr=\\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
@@ -11481,7 +11641,7 @@ Object {
     },
     Object {
       "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
-    <Relationship Id=\\"rId1\\" Target=\\"../media/image4\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
+    <Relationship Id=\\"rId1\\" Target=\\"../media/image4.jpeg\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -11495,7 +11655,7 @@ Object {
     },
     Object {
       "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
-    <Relationship Id=\\"rId1\\" Target=\\"../media/image5\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
+    <Relationship Id=\\"rId1\\" Target=\\"../media/image5.jpeg\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing1.xml.rels",
@@ -11509,6 +11669,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -11547,12 +11715,12 @@ Object {
       "path": "xl/workbook.xml",
     },
     Object {
-      "imagePath": "image path",
-      "path": "xl/media/image2",
+      "imageSrc": "image path",
+      "path": "xl/media/image2.jpeg",
     },
     Object {
-      "imagePath": "image path",
-      "path": "xl/media/image3",
+      "imageSrc": "image path",
+      "path": "xl/media/image3.jpeg",
     },
     Object {
       "content": "<xdr:wsDr xmlns:xdr=\\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
@@ -11755,8 +11923,8 @@ Object {
     },
     Object {
       "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
-    <Relationship Id=\\"rId1\\" Target=\\"../media/image2\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
-    <Relationship Id=\\"rId2\\" Target=\\"../media/image3\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
+    <Relationship Id=\\"rId1\\" Target=\\"../media/image2.jpeg\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
+    <Relationship Id=\\"rId2\\" Target=\\"../media/image3.jpeg\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -11770,6 +11938,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -11806,8 +11982,8 @@ Object {
       "path": "xl/workbook.xml",
     },
     Object {
-      "imagePath": "image path",
-      "path": "xl/media/image1",
+      "imageSrc": "image path",
+      "path": "xl/media/image1.jpeg",
     },
     Object {
       "content": "<xdr:wsDr xmlns:xdr=\\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\" xmlns:a=\\"http://schemas.openxmlformats.org/drawingml/2006/main\\" xmlns:c=\\"http://schemas.openxmlformats.org/drawingml/2006/chart\\">
@@ -11961,7 +12137,7 @@ Object {
     },
     Object {
       "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
-    <Relationship Id=\\"rId1\\" Target=\\"../media/image1\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
+    <Relationship Id=\\"rId1\\" Target=\\"../media/image1.jpeg\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\\"/>
 </Relationships>",
       "contentType": undefined,
       "path": "xl/drawings/_rels/drawing0.xml.rels",
@@ -11975,6 +12151,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -12154,6 +12338,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -12329,6 +12521,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -12504,6 +12704,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -14224,6 +14432,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -14529,6 +14745,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -14718,6 +14942,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -14915,6 +15147,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -16690,6 +16930,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -16844,6 +17092,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -17048,6 +17304,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
@@ -17553,6 +17817,14 @@ Object {
     },
     Object {
       "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"avif\\" ContentType=\\"image/avif\\"/>
+    <Default Extension=\\"bmp\\" ContentType=\\"image/bmp\\"/>
+    <Default Extension=\\"gif\\" ContentType=\\"image/gif\\"/>
+    <Default Extension=\\"ico\\" ContentType=\\"image/vnd.microsoft.icon\\"/>
+    <Default Extension=\\"jpeg\\" ContentType=\\"image/jpeg\\"/>
+    <Default Extension=\\"png\\" ContentType=\\"image/png\\"/>
+    <Default Extension=\\"tiff\\" ContentType=\\"image/tiff\\"/>
+    <Default Extension=\\"webp\\" ContentType=\\"image/webp\\"/>
     <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
     <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>

--- a/tests/components/__mocks__/mock_image_provider.ts
+++ b/tests/components/__mocks__/mock_image_provider.ts
@@ -1,5 +1,5 @@
-import { FigureSize } from "../../../src/types";
 import { FileStore, ImageProviderInterface } from "../../../src/types/files";
+import { Image } from "../../../src/types/image";
 
 export class ImageProvider implements ImageProviderInterface {
   private path = "https://sorrygooglesheet.com/icon-picture";
@@ -7,10 +7,11 @@ export class ImageProvider implements ImageProviderInterface {
     width: 1443,
     height: 2168,
   };
+  private mimetype = "image/jpeg";
 
   constructor(_fileStore: FileStore) {}
 
-  async requestImage(): Promise<{ path: string; size: FigureSize }> {
-    return { path: this.path, size: this.size };
+  async requestImage(): Promise<Image> {
+    return { path: this.path, size: this.size, mimetype: this.mimetype };
   }
 }

--- a/tests/plugins/image/image.test.ts
+++ b/tests/plugins/image/image.test.ts
@@ -12,8 +12,9 @@ describe("image plugin", function () {
       sheetId,
       path: "image path",
       size: { width: 100, height: 100 },
+      mimetype: "image/jpeg",
     };
-    createImage(model, { figureId: imageId, definition: definition });
+    createImage(model, { figureId: imageId, definition });
     expect(model.getters.getImage(imageId)).toEqual(definition);
   });
 
@@ -35,8 +36,9 @@ describe("image plugin", function () {
       sheetId,
       path: "image path",
       size: { width: 100, height: 100 },
+      mimetype: "image/jpeg",
     };
-    createImage(model, { figureId: imageId, definition: definition });
+    createImage(model, { figureId: imageId, definition });
     model.dispatch("SELECT_FIGURE", { id: imageId });
     model.dispatch("COPY");
     paste(model, "D4");
@@ -55,8 +57,9 @@ describe("image plugin", function () {
       sheetId,
       path: "image path",
       size: { width: 100, height: 100 },
+      mimetype: "image/jpeg",
     };
-    createImage(model, { figureId: imageId, definition: definition });
+    createImage(model, { figureId: imageId, definition });
     model.dispatch("SELECT_FIGURE", { id: imageId });
     model.dispatch("CUT");
     paste(model, "D4");

--- a/tests/plugins/image/image_file_store.test.ts
+++ b/tests/plugins/image/image_file_store.test.ts
@@ -24,7 +24,7 @@ describe("image file store", () => {
           commands: [
             {
               type: "CREATE_IMAGE",
-              definition: { path: "/image/1", size },
+              definition: { path: "/image/1", size, mimetype: "image/jpeg" },
               figureId: "figureId",
               position: { x: 0, y: 0 },
               sheetId: data.sheets[0].id,
@@ -59,7 +59,7 @@ describe("image file store", () => {
           commands: [
             {
               type: "CREATE_IMAGE",
-              definition: { path: "/image/1", size },
+              definition: { path: "/image/1", size, mimetype: "image/jpeg" },
               figureId: "figureId",
               position: { x: 0, y: 0 },
               sheetId,
@@ -95,7 +95,7 @@ describe("image file store", () => {
           commands: [
             {
               type: "CREATE_IMAGE",
-              definition: { path: "/image/1", size },
+              definition: { path: "/image/1", size, mimetype: "image/jpeg" },
               figureId: "figureId",
               position: { x: 0, y: 0 },
               sheetId,
@@ -137,7 +137,7 @@ describe("image file store", () => {
           commands: [
             {
               type: "CREATE_IMAGE",
-              definition: { path: "/image/1", size },
+              definition: { path: "/image/1", size, mimetype: "image/jpeg" },
               figureId: "figureId",
               position: { x: 0, y: 0 },
               sheetId,
@@ -186,7 +186,7 @@ describe("image file store", () => {
           commands: [
             {
               type: "CREATE_IMAGE",
-              definition: { path: "/image/1", size },
+              definition: { path: "/image/1", size, mimetype: "image/jpeg" },
               figureId: "figure_1",
               position: { x: 0, y: 0 },
               sheetId,
@@ -230,7 +230,7 @@ describe("image file store", () => {
             { type: "CREATE_SHEET", position: 1, sheetId: "sheet_2" },
             {
               type: "CREATE_IMAGE",
-              definition: { path: "/image/1", size },
+              definition: { path: "/image/1", size, mimetype: "image/jpeg" },
               figureId: "figureId",
               position: { x: 0, y: 0 },
               sheetId: "sheet_2",
@@ -266,7 +266,7 @@ describe("image file store", () => {
             { type: "CREATE_SHEET", position: 1, sheetId: "sheet_2" },
             {
               type: "CREATE_IMAGE",
-              definition: { path: "/image/1", size },
+              definition: { path: "/image/1", size, mimetype: "image/jpeg" },
               figureId: "figureId",
               position: { x: 0, y: 0 },
               sheetId: "sheet_2",
@@ -302,6 +302,7 @@ describe("image file store", () => {
         data: {
           path: "/image/1",
           size: { width: 100, height: 100 },
+          mimetype: "image/jpeg",
         },
       },
     ];

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -104,6 +104,7 @@ export function createImage(
     definition: {
       path: "image path",
       size: { width: 380, height: 380 },
+      mimetype: "image/jpeg",
       ...partialParam.definition,
     },
   };

--- a/tests/xlsx_import_export.test.ts
+++ b/tests/xlsx_import_export.test.ts
@@ -39,7 +39,7 @@ function exportToXlsxThenImport(model: Model) {
   const exported = model.exportXLSX();
   const dataToImport = {};
   for (let file of exported.files) {
-    dataToImport[file.path] = isXLSXExportXMLFile(file) ? file.content : file.imagePath;
+    dataToImport[file.path] = isXLSXExportXMLFile(file) ? file.content : file.imageSrc;
   }
   const imported = new Model(dataToImport, undefined, undefined, undefined, false);
   return imported;


### PR DESCRIPTION
## Description:

This PR fixes the problem of openning exported .xlsx file containing images in Excel.

The fix is exporting the mime type of images together with other XML files. The mime type is stored when uploading new images.

Note that for images that are already in the database, the mime type in o-spreadsheet is undefined. When exporting files including these images, the mime type will be `images/jpeg` by default. 

Odoo task ID : [3239093](https://www.odoo.com/web#id=3239093&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo