### PR TITLE
[FIX] tests: Bypass useless `drawGrid`

### DIFF
--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -154,6 +154,7 @@ export async function mountComponent<Props extends { [key: string]: any }>(
   env: SpreadsheetChildEnv;
 }> {
   const model = optionalArgs.model || optionalArgs?.env?.model || new Model();
+  model.drawGrid = () => {};
   const env = makeTestEnv({ ...optionalArgs.env, model: model });
   const props = optionalArgs.props || ({} as Props);
   const app = new App(component, { props, env, test: true });


### PR DESCRIPTION
A non negligeable part of the rendering process consists of computations before drawing on the canvas. At runtime, drawgrid takes around 99% of the rendering time with in details:

Model.drawgrid : 8.7 ms
getGridBoxes: 3.53 ms
GetHeaderOffset: 1.09 ms
getVisibleRect: 0.37 ms
getSheetViewVisibleCols: 0.13ms

Which sums to (3.53+1.09+0.37+0.13)/8.7  * .99 = 58.2% of the rendering time.

In the tests, we completely mock the canvas to not draw anything. Based on that, we are left with the computations which are not used anyway.

Tests `npm run test -- --maxWorkers=2 components`

before: 1108 tests > 108 seconds

after:  1108 tests > 85.77 seconds

==> 20.5 % improvement

Task: 3254822

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo