### PR TITLE
[IMP] header_size: handle wrapped text for row size

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -9,5 +9,6 @@ export * from "./range";
 export * from "./references";
 export * from "./search";
 export * from "./sheet";
+export * from "./text_helper";
 export * from "./uuid";
 export * from "./zones";

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -1,18 +1,9 @@
 //------------------------------------------------------------------------------
 // Miscellaneous
 //------------------------------------------------------------------------------
-import {
-  DEFAULT_CELL_HEIGHT,
-  DEFAULT_FONT,
-  DEFAULT_FONT_SIZE,
-  DEFAULT_FONT_WEIGHT,
-  MIN_CELL_TEXT_MARGIN,
-  MIN_CF_ICON_MARGIN,
-  NEWLINE,
-  PADDING_AUTORESIZE_VERTICAL,
-} from "../constants";
-import { Cell, ConsecutiveIndexes, Lazy, Style, UID } from "../types";
-import { Cloneable, Matrix, Pixel } from "./../types/misc";
+import { NEWLINE } from "../constants";
+import { ConsecutiveIndexes, Lazy, UID } from "../types";
+import { Cloneable, Matrix } from "./../types/misc";
 /**
  * Stringify an object, like JSON.stringify, except that the first level of keys
  * is ordered.
@@ -114,96 +105,6 @@ export function getCanonicalSheetName(sheetName: string): string {
 
 export function clip(val: number, min: number, max: number): number {
   return val < min ? min : val > max ? max : val;
-}
-
-export function computeTextLinesHeight(textLineHeight: number, numberOfLines: number = 1) {
-  return numberOfLines * (textLineHeight + MIN_CELL_TEXT_MARGIN) - MIN_CELL_TEXT_MARGIN;
-}
-
-/**
- * Get the default height of the cell given its style.
- */
-export function getDefaultCellHeight(cell: Cell | undefined): Pixel {
-  if (!cell || !cell.content) {
-    return DEFAULT_CELL_HEIGHT;
-  }
-  const fontSize = computeTextFontSizeInPixels(cell.style);
-
-  // the number of lines should be computed from the formula result, but it's not evaluated at this point
-  const numberOfLines = cell.isFormula ? 1 : cell.content.split(NEWLINE).length;
-  return computeTextLinesHeight(fontSize, numberOfLines) + 2 * PADDING_AUTORESIZE_VERTICAL;
-}
-
-export function computeTextWidth(context: CanvasRenderingContext2D, text: string, style: Style) {
-  const font = computeTextFont(style);
-  if (!textWidthCache[font]) {
-    textWidthCache[font] = {};
-  }
-  if (textWidthCache[font][text] === undefined) {
-    context.save();
-    context.font = font;
-    const textWidth = context.measureText(text).width;
-    context.restore();
-    textWidthCache[font][text] = textWidth;
-  }
-  return textWidthCache[font][text];
-}
-
-const textWidthCache: Record<string, Record<string, number>> = {};
-
-export function fontSizeInPixels(fontSize: number) {
-  return Math.round((fontSize * 96) / 72);
-}
-
-export function computeTextFont(style: Style): string {
-  const italic = style.italic ? "italic " : "";
-  const weight = style.bold ? "bold" : DEFAULT_FONT_WEIGHT;
-  const size = computeTextFontSizeInPixels(style);
-  return `${italic}${weight} ${size}px ${DEFAULT_FONT}`;
-}
-
-export function computeTextFontSizeInPixels(style?: Style): number {
-  const sizeInPt = style?.fontSize || DEFAULT_FONT_SIZE;
-  return fontSizeInPixels(sizeInPt);
-}
-
-/**
- * Return the font size that makes the width of a text match the given line width.
- * Minimum font size is 1.
- *
- * @param getTextWidth function that takes a fontSize as argument, and return the width of the text with this font size.
- */
-export function getFontSizeMatchingWidth(
-  lineWidth: number,
-  maxFontSize: number,
-  getTextWidth: (fontSize: number) => number,
-  precision = 0.25
-) {
-  let minFontSize = 1;
-  if (getTextWidth(minFontSize) > lineWidth) return minFontSize;
-  if (getTextWidth(maxFontSize) < lineWidth) return maxFontSize;
-
-  // Dichotomic search
-  let fontSize = (minFontSize + maxFontSize) / 2;
-  let currentTextWidth = getTextWidth(fontSize);
-
-  // Use a maximum number of iterations to be safe, because measuring text isn't 100% precise
-  let iterations = 0;
-  while (Math.abs(currentTextWidth - lineWidth) > precision && iterations < 20) {
-    if (currentTextWidth >= lineWidth) {
-      maxFontSize = (minFontSize + maxFontSize) / 2;
-    } else {
-      minFontSize = (minFontSize + maxFontSize) / 2;
-    }
-    fontSize = (minFontSize + maxFontSize) / 2;
-    currentTextWidth = getTextWidth(fontSize);
-    iterations++;
-  }
-  return fontSize;
-}
-
-export function computeIconWidth(style: Style) {
-  return computeTextFontSizeInPixels(style) + 2 * MIN_CF_ICON_MARGIN;
 }
 
 /**
@@ -485,11 +386,6 @@ export function removeFalsyAttributes(obj: Object): Object {
   const cleanObject = { ...obj };
   Object.keys(cleanObject).forEach((key) => !cleanObject[key] && delete cleanObject[key]);
   return cleanObject;
-}
-
-/** Transform a string to lower case. If the string is undefined, return an empty string */
-export function toLowerCase(str: string | undefined): string {
-  return str ? str.toLowerCase() : "";
 }
 
 export function transpose2dArray<T>(matrix: Matrix<T>): Matrix<T>;

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -494,3 +494,13 @@ export function memoize<T extends any[], U>(func: (...args: T) => U): (...args: 
     },
   }[funcName];
 }
+
+export function removeIndexesFromArray<T>(array: readonly T[], indexes: number[]): T[] {
+  return array.filter((_, index) => !indexes.includes(index));
+}
+
+export function insertItemsAtIndex<T>(array: readonly T[], items: T[], index: number): T[] {
+  const newArray = [...array];
+  newArray.splice(index, 0, ...items);
+  return newArray;
+}

--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -1,0 +1,104 @@
+import {
+  DEFAULT_CELL_HEIGHT,
+  DEFAULT_FONT,
+  DEFAULT_FONT_SIZE,
+  DEFAULT_FONT_WEIGHT,
+  MIN_CELL_TEXT_MARGIN,
+  MIN_CF_ICON_MARGIN,
+  NEWLINE,
+  PADDING_AUTORESIZE_VERTICAL,
+} from "../constants";
+import { Cell, Pixel, Style } from "../types";
+
+export function computeTextLinesHeight(textLineHeight: number, numberOfLines: number = 1) {
+  return numberOfLines * (textLineHeight + MIN_CELL_TEXT_MARGIN) - MIN_CELL_TEXT_MARGIN;
+}
+
+/**
+ * Get the default height of the cell given its style.
+ */
+export function getDefaultCellHeight(cell: Cell | undefined): Pixel {
+  if (!cell || !cell.content) {
+    return DEFAULT_CELL_HEIGHT;
+  }
+  const fontSize = computeTextFontSizeInPixels(cell.style);
+  const numberOfLines = cell.isFormula ? 1 : cell.content.split(NEWLINE).length;
+  return computeTextLinesHeight(fontSize, numberOfLines) + 2 * PADDING_AUTORESIZE_VERTICAL;
+}
+
+const textWidthCache: Record<string, Record<string, number>> = {};
+
+export function computeTextWidth(context: CanvasRenderingContext2D, text: string, style: Style) {
+  const font = computeTextFont(style);
+  if (!textWidthCache[font]) {
+    textWidthCache[font] = {};
+  }
+  if (textWidthCache[font][text] === undefined) {
+    context.save();
+    context.font = font;
+    const textWidth = context.measureText(text).width;
+    context.restore();
+    textWidthCache[font][text] = textWidth;
+  }
+  return textWidthCache[font][text];
+}
+
+export function fontSizeInPixels(fontSize: number) {
+  return Math.round((fontSize * 96) / 72);
+}
+
+export function computeTextFont(style: Style): string {
+  const italic = style.italic ? "italic " : "";
+  const weight = style.bold ? "bold" : DEFAULT_FONT_WEIGHT;
+  const size = computeTextFontSizeInPixels(style);
+  return `${italic}${weight} ${size}px ${DEFAULT_FONT}`;
+}
+
+export function computeTextFontSizeInPixels(style?: Style): number {
+  const sizeInPt = style?.fontSize || DEFAULT_FONT_SIZE;
+  return fontSizeInPixels(sizeInPt);
+}
+
+/**
+ * Return the font size that makes the width of a text match the given line width.
+ * Minimum font size is 1.
+ *
+ * @param getTextWidth function that takes a fontSize as argument, and return the width of the text with this font size.
+ */
+export function getFontSizeMatchingWidth(
+  lineWidth: number,
+  maxFontSize: number,
+  getTextWidth: (fontSize: number) => number,
+  precision = 0.25
+) {
+  let minFontSize = 1;
+  if (getTextWidth(minFontSize) > lineWidth) return minFontSize;
+  if (getTextWidth(maxFontSize) < lineWidth) return maxFontSize;
+
+  // Dichotomic search
+  let fontSize = (minFontSize + maxFontSize) / 2;
+  let currentTextWidth = getTextWidth(fontSize);
+
+  // Use a maximum number of iterations to be safe, because measuring text isn't 100% precise
+  let iterations = 0;
+  while (Math.abs(currentTextWidth - lineWidth) > precision && iterations < 20) {
+    if (currentTextWidth >= lineWidth) {
+      maxFontSize = (minFontSize + maxFontSize) / 2;
+    } else {
+      minFontSize = (minFontSize + maxFontSize) / 2;
+    }
+    fontSize = (minFontSize + maxFontSize) / 2;
+    currentTextWidth = getTextWidth(fontSize);
+    iterations++;
+  }
+  return fontSize;
+}
+
+export function computeIconWidth(style: Style) {
+  return computeTextFontSizeInPixels(style) + 2 * MIN_CF_ICON_MARGIN;
+}
+
+/** Transform a string to lower case. If the string is undefined, return an empty string */
+export function toLowerCase(str: string | undefined): string {
+  return str ? str.toLowerCase() : "";
+}

--- a/src/plugins/core/figures.ts
+++ b/src/plugins/core/figures.ts
@@ -8,6 +8,7 @@ import {
   WorkbookData,
 } from "../../types/index";
 import { CorePlugin } from "../core_plugin";
+import { DEFAULT_CELL_HEIGHT } from "./../../constants";
 
 interface FigureState {
   readonly figures: { [sheet: string]: Record<UID, Figure | undefined> | undefined };
@@ -66,7 +67,9 @@ export class FigurePlugin extends CorePlugin<FigureState> implements FigureState
     const numHeader = this.getters.getNumberRows(sheetId);
     let gridHeight = 0;
     for (let i = 0; i < numHeader; i++) {
-      gridHeight += this.getters.getRowSize(sheetId, i);
+      // TODO : since the row size is an UI value now, this doesn't work anymore. Using the default cell height is
+      // a temporary solution at best, but is broken.
+      gridHeight += this.getters.getUserRowSize(sheetId, i) || DEFAULT_CELL_HEIGHT;
     }
     const figures = this.getters.getFigures(sheetId);
     for (const figure of figures) {

--- a/src/plugins/core/header_size.ts
+++ b/src/plugins/core/header_size.ts
@@ -1,48 +1,25 @@
-import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../constants";
-import { deepCopy, getAddHeaderStartIndex, getDefaultCellHeight, lazy, range } from "../../helpers";
+import { DEFAULT_CELL_WIDTH } from "../../constants";
+import { deepCopy, getAddHeaderStartIndex, range, removeIndexesFromArray } from "../../helpers";
 import { Command, ExcelWorkbookData, WorkbookData } from "../../types";
-import { CellPosition, Dimension, HeaderIndex, Lazy, Pixel, UID } from "../../types/misc";
+import { Dimension, HeaderIndex, Pixel, UID } from "../../types/misc";
 import { CorePlugin } from "../core_plugin";
-
-interface HeaderSize {
-  manualSize: Pixel | undefined;
-  computedSize: Lazy<Pixel>;
-}
+import { DEFAULT_CELL_HEIGHT } from "./../../constants";
 
 interface HeaderSizeState {
-  sizes: Record<UID, Record<Dimension, Array<HeaderSize>>>;
+  sizes: Record<UID, Record<Dimension, Array<Pixel | undefined>>>;
 }
-
 export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements HeaderSizeState {
-  static getters = ["getRowSize", "getColSize"] as const;
+  static getters = ["getUserRowSize", "getColSize"] as const;
 
-  readonly sizes: Record<UID, Record<Dimension, Array<HeaderSize>>> = {};
+  readonly sizes: Record<UID, Record<Dimension, Array<Pixel | undefined>>> = {};
 
   handle(cmd: Command) {
     switch (cmd.type) {
       case "CREATE_SHEET": {
-        const computedSizes = this.computeSheetSizes(cmd.sheetId);
-        const sizes = {
-          COL: computedSizes.COL.map((size) => ({
-            manualSize: undefined,
-            computedSize: lazy(size),
-          })),
-          ROW: computedSizes.ROW.map((size) => ({
-            manualSize: undefined,
-            computedSize: lazy(size),
-          })),
-        };
-        this.history.update("sizes", cmd.sheetId, sizes);
+        this.history.update("sizes", cmd.sheetId, { COL: [], ROW: [] });
         break;
       }
       case "DUPLICATE_SHEET":
-        // make sure the values are computed in case the original sheet is deleted
-        for (const row of this.sizes[cmd.sheetId].ROW) {
-          row.computedSize();
-        }
-        for (const col of this.sizes[cmd.sheetId].COL) {
-          col.computedSize();
-        }
         this.history.update("sizes", cmd.sheetIdTo, deepCopy(this.sizes[cmd.sheetId]));
         break;
       case "DELETE_SHEET":
@@ -51,21 +28,8 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
         this.history.update("sizes", sizes);
         break;
       case "REMOVE_COLUMNS_ROWS": {
-        let sizes = [...this.sizes[cmd.sheetId][cmd.dimension]];
-        for (let headerIndex of [...cmd.elements].sort((a, b) => b - a)) {
-          sizes.splice(headerIndex, 1);
-        }
-        const min = Math.min(...cmd.elements);
-        sizes = sizes.map((size, row) => {
-          if (cmd.dimension === "ROW" && row >= min) {
-            // invalidate sizes
-            return {
-              manualSize: size.manualSize,
-              computedSize: lazy(() => this.getRowTallestCellSize(cmd.sheetId, row)),
-            };
-          }
-          return size;
-        });
+        const arr = this.sizes[cmd.sheetId][cmd.dimension];
+        const sizes = removeIndexesFromArray(arr, cmd.elements);
         this.history.update("sizes", cmd.sheetId, cmd.dimension, sizes);
         break;
       }
@@ -74,170 +38,53 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
         const addIndex = getAddHeaderStartIndex(cmd.position, cmd.base);
         const baseSize = sizes[cmd.base];
         sizes.splice(addIndex, 0, ...Array(cmd.quantity).fill(baseSize));
-        sizes = sizes.map((size, row) => {
-          if (cmd.dimension === "ROW" && row > cmd.base + cmd.quantity) {
-            // invalidate sizes
-            return {
-              manualSize: size.manualSize,
-              computedSize: lazy(() => this.getRowTallestCellSize(cmd.sheetId, row)),
-            };
-          }
-          return size;
-        });
         this.history.update("sizes", cmd.sheetId, cmd.dimension, sizes);
         break;
       }
       case "RESIZE_COLUMNS_ROWS":
-        for (let el of cmd.elements) {
-          if (cmd.dimension === "ROW") {
-            const height = this.getRowTallestCellSize(cmd.sheetId, el);
-            const size = height;
-            this.history.update("sizes", cmd.sheetId, cmd.dimension, el, {
-              manualSize: cmd.size || undefined,
-              computedSize: lazy(size),
-            });
-          } else {
-            this.history.update("sizes", cmd.sheetId, cmd.dimension, el, {
-              manualSize: cmd.size || undefined,
-              computedSize: lazy(cmd.size || DEFAULT_CELL_WIDTH),
-            });
+        if (cmd.dimension === "ROW") {
+          for (const el of cmd.elements) {
+            this.history.update("sizes", cmd.sheetId, cmd.dimension, el, cmd.size || undefined);
+          }
+        } else {
+          for (const el of cmd.elements) {
+            this.history.update("sizes", cmd.sheetId, cmd.dimension, el, cmd.size || undefined);
           }
         }
-        break;
-      case "UPDATE_CELL":
-        if (!this.sizes[cmd.sheetId]?.["ROW"]?.[cmd.row]?.manualSize) {
-          const { sheetId, row } = cmd;
-          this.history.update(
-            "sizes",
-            sheetId,
-            "ROW",
-            row,
-            "computedSize",
-            lazy(() => this.getRowTallestCellSize(sheetId, row))
-          );
-        }
-        break;
-      case "ADD_MERGE":
-      case "REMOVE_MERGE":
-        for (let target of cmd.target) {
-          for (let row of range(target.top, target.bottom + 1)) {
-            const rowHeight = this.getRowTallestCellSize(cmd.sheetId, row);
-            if (rowHeight !== this.getRowSize(cmd.sheetId, row)) {
-              this.history.update(
-                "sizes",
-                cmd.sheetId,
-                "ROW",
-                row,
-                "computedSize",
-                lazy(rowHeight)
-              );
-            }
-          }
-        }
+
         break;
     }
     return;
   }
 
   getColSize(sheetId: UID, index: HeaderIndex): Pixel {
-    return this.getHeaderSize(sheetId, "COL", index);
+    return Math.round(this.sizes[sheetId]?.["COL"][index] || DEFAULT_CELL_WIDTH);
   }
 
-  getRowSize(sheetId: UID, index: HeaderIndex): Pixel {
-    return this.getHeaderSize(sheetId, "ROW", index);
-  }
-
-  private getHeaderSize(sheetId: UID, dimension: Dimension, index: HeaderIndex): Pixel {
-    return Math.round(
-      this.sizes[sheetId]?.[dimension][index]?.manualSize ||
-        this.sizes[sheetId]?.[dimension][index]?.computedSize() ||
-        this.getDefaultHeaderSize(dimension)
-    );
-  }
-
-  private computeSheetSizes(sheetId: UID): Record<Dimension, Array<Pixel>> {
-    const sizes: Record<Dimension, Array<Pixel>> = { COL: [], ROW: [] };
-    for (let col of range(0, this.getters.getNumberCols(sheetId))) {
-      sizes.COL.push(this.getHeaderSize(sheetId, "COL", col));
-    }
-    for (let row of range(0, this.getters.getNumberRows(sheetId))) {
-      let rowSize = this.sizes[sheetId]?.["ROW"]?.[row].manualSize;
-      if (!rowSize) {
-        const height = this.getRowTallestCellSize(sheetId, row);
-        rowSize = height;
-      }
-      sizes.ROW.push(rowSize);
-    }
-    return sizes;
-  }
-
-  private getDefaultHeaderSize(dimension: Dimension): Pixel {
-    return dimension === "COL" ? DEFAULT_CELL_WIDTH : DEFAULT_CELL_HEIGHT;
-  }
-
-  /**
-   * Return the height the cell should have in the sheet, which is either DEFAULT_CELL_HEIGHT if the cell is in a multi-row
-   * merge, or the height of the cell computed based on its font size.
-   */
-  private getCellHeight(position: CellPosition): Pixel {
-    const merge = this.getters.getMerge(position);
-    if (merge && merge.bottom !== merge.top) {
-      return DEFAULT_CELL_HEIGHT;
-    }
-    const cell = this.getters.getCell(position);
-    return getDefaultCellHeight(cell);
-  }
-
-  /**
-   * Get the tallest cell of a row and its size.
-   *
-   * The tallest cell of the row correspond to the cell with the biggest font size,
-   * and that is not part of a multi-line merge.
-   */
-  private getRowTallestCellSize(sheetId: UID, row: HeaderIndex): Pixel {
-    const cellIds = this.getters.getRowCells(sheetId, row);
-    let maxHeight = 0;
-    for (let i = 0; i < cellIds.length; i++) {
-      const cell = this.getters.getCellById(cellIds[i]);
-      if (!cell) continue;
-      const position = this.getters.getCellPosition(cell.id);
-      const cellHeight = this.getCellHeight(position);
-      if (cellHeight > maxHeight && cellHeight > DEFAULT_CELL_HEIGHT) {
-        maxHeight = cellHeight;
-      }
-    }
-
-    if (maxHeight <= DEFAULT_CELL_HEIGHT) {
-      return DEFAULT_CELL_HEIGHT;
-    }
-    return maxHeight;
+  getUserRowSize(sheetId: UID, index: HeaderIndex): Pixel | undefined {
+    const rowSize = this.sizes[sheetId]?.["ROW"][index];
+    return rowSize ? Math.round(rowSize) : undefined;
   }
 
   import(data: WorkbookData) {
     for (let sheet of data.sheets) {
-      const manualSizes: Record<Dimension, Array<HeaderIndex>> = { COL: [], ROW: [] };
+      const sizes: Record<Dimension, Array<Pixel | undefined>> = {
+        COL: Array(sheet.colNumber).fill(undefined),
+        ROW: Array(sheet.rowNumber).fill(undefined),
+      };
       for (let [rowIndex, row] of Object.entries(sheet.rows)) {
         if (row.size) {
-          manualSizes["ROW"][rowIndex] = row.size;
+          sizes["ROW"][rowIndex] = row.size;
         }
       }
 
       for (let [colIndex, col] of Object.entries(sheet.cols)) {
         if (col.size) {
-          manualSizes["COL"][colIndex] = col.size;
+          sizes["COL"][colIndex] = col.size;
         }
       }
-      const computedSizes = this.computeSheetSizes(sheet.id);
-      this.sizes[sheet.id] = {
-        COL: computedSizes.COL.map((size, i) => ({
-          manualSize: manualSizes.COL[i],
-          computedSize: lazy(size),
-        })),
-        ROW: computedSizes.ROW.map((size, i) => ({
-          manualSize: manualSizes.ROW[i],
-          computedSize: lazy(size),
-        })),
-      };
+
+      this.sizes[sheet.id] = sizes;
     }
     return;
   }
@@ -261,9 +108,12 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
       if (sheet.rows === undefined) {
         sheet.rows = {};
       }
-      for (let row of range(0, this.getters.getNumberRows(sheet.id))) {
-        if (exportDefaults || this.sizes[sheet.id]["ROW"][row]?.manualSize) {
-          sheet.rows[row] = { ...sheet.rows[row], size: this.getRowSize(sheet.id, row) };
+      for (const row of range(0, this.getters.getNumberRows(sheet.id))) {
+        if (exportDefaults || this.sizes[sheet.id]["ROW"][row]) {
+          sheet.rows[row] = {
+            ...sheet.rows[row],
+            size: this.getUserRowSize(sheet.id, row) ?? DEFAULT_CELL_HEIGHT,
+          };
         }
       }
 
@@ -272,7 +122,7 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
         sheet.cols = {};
       }
       for (let col of range(0, this.getters.getNumberCols(sheet.id))) {
-        if (exportDefaults || this.sizes[sheet.id]["COL"][col]?.manualSize) {
+        if (exportDefaults || this.sizes[sheet.id]["COL"][col]) {
           sheet.cols[col] = { ...sheet.cols[col], size: this.getColSize(sheet.id, col) };
         }
       }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -20,6 +20,7 @@ import {
   EvaluationConditionalFormatPlugin,
   EvaluationPlugin,
 } from "./ui_core_views";
+import { UIRowSizePlugin } from "./ui_core_views/row_size";
 import {
   AutofillPlugin,
   AutomaticSumPlugin,
@@ -91,4 +92,5 @@ export const coreViewsPluginRegistry = new Registry<UIPluginConstructor>()
   .add("evaluation", EvaluationPlugin)
   .add("evaluation_chart", EvaluationChartPlugin)
   .add("evaluation_cf", EvaluationConditionalFormatPlugin)
+  .add("row_size", UIRowSizePlugin)
   .add("custom_colors", CustomColorsPlugin);

--- a/src/plugins/ui_core_views/row_size.ts
+++ b/src/plugins/ui_core_views/row_size.ts
@@ -1,0 +1,199 @@
+import { DEFAULT_CELL_HEIGHT } from "../../constants";
+import {
+  deepCopy,
+  getAddHeaderStartIndex,
+  getDefaultCellHeight,
+  insertItemsAtIndex,
+  positions,
+  range,
+  removeIndexesFromArray,
+} from "../../helpers";
+import { Command } from "../../types";
+import { CellPosition, HeaderIndex, Immutable, Pixel, UID } from "../../types/misc";
+import { UIPlugin } from "../ui_plugin";
+
+interface HeaderSizeState {
+  tallestCellInRow: Immutable<Record<UID, Array<CellWithSize | undefined>>>;
+}
+
+interface CellWithSize {
+  cell: CellPosition;
+  size: Pixel;
+}
+
+export class UIRowSizePlugin extends UIPlugin<HeaderSizeState> implements HeaderSizeState {
+  static getters = ["getRowSize"] as const;
+
+  readonly tallestCellInRow: Immutable<Record<UID, Array<CellWithSize | undefined>>> = {};
+
+  private ctx = document.createElement("canvas").getContext("2d")!;
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "START":
+        for (const sheetId of this.getters.getSheetIds()) {
+          this.initializeSheet(sheetId);
+        }
+        break;
+      case "CREATE_SHEET": {
+        this.initializeSheet(cmd.sheetId);
+        break;
+      }
+      case "DUPLICATE_SHEET": {
+        const tallestCells = deepCopy(this.tallestCellInRow[cmd.sheetId]);
+        this.history.update("tallestCellInRow", cmd.sheetIdTo, tallestCells);
+        break;
+      }
+      case "DELETE_SHEET":
+        const tallestCells = { ...this.tallestCellInRow };
+        delete tallestCells[cmd.sheetId];
+        this.history.update("tallestCellInRow", tallestCells);
+        break;
+      case "REMOVE_COLUMNS_ROWS": {
+        if (cmd.dimension === "COL") {
+          return;
+        }
+        const tallestCells = removeIndexesFromArray(
+          this.tallestCellInRow[cmd.sheetId],
+          cmd.elements
+        );
+        this.history.update("tallestCellInRow", cmd.sheetId, tallestCells);
+        break;
+      }
+      case "ADD_COLUMNS_ROWS": {
+        if (cmd.dimension === "COL") {
+          return;
+        }
+        const addIndex = getAddHeaderStartIndex(cmd.position, cmd.base);
+        const newCells = Array(cmd.quantity).fill(undefined);
+        const newTallestCells = insertItemsAtIndex(
+          this.tallestCellInRow[cmd.sheetId],
+          newCells,
+          addIndex
+        );
+        this.history.update("tallestCellInRow", cmd.sheetId, newTallestCells);
+        break;
+      }
+      case "RESIZE_COLUMNS_ROWS":
+        {
+          const sheetId = cmd.sheetId;
+          if (cmd.dimension === "ROW") {
+            for (const row of cmd.elements) {
+              const tallestCell = this.getRowTallestCell(sheetId, row);
+              this.history.update("tallestCellInRow", sheetId, row, tallestCell);
+            }
+          } else {
+            // Recompute row heights on col size change, they might have changed because of wrapped text
+            for (const row of range(0, this.getters.getNumberRows(sheetId))) {
+              for (const col of cmd.elements) {
+                this.updateRowSizeForCellChange(sheetId, row, col);
+              }
+            }
+          }
+        }
+        break;
+      case "UPDATE_CELL":
+        this.updateRowSizeForCellChange(cmd.sheetId, cmd.row, cmd.col);
+        break;
+      case "ADD_MERGE":
+      case "REMOVE_MERGE":
+        for (const target of cmd.target) {
+          for (const position of positions(target)) {
+            this.updateRowSizeForCellChange(cmd.sheetId, position.row, position.col);
+          }
+        }
+    }
+    return;
+  }
+
+  getRowSize(sheetId: UID, row: HeaderIndex): Pixel {
+    return Math.round(
+      this.getters.getUserRowSize(sheetId, row) ??
+        this.tallestCellInRow[sheetId][row]?.size ??
+        DEFAULT_CELL_HEIGHT
+    );
+  }
+
+  private updateRowSizeForCellChange(sheetId: UID, row: HeaderIndex, col: HeaderIndex) {
+    const tallestCellInRow = this.tallestCellInRow[sheetId]?.[row];
+    if (tallestCellInRow?.cell.col === col) {
+      const newTallestCell = this.getRowTallestCell(sheetId, row);
+      this.history.update("tallestCellInRow", sheetId, row, newTallestCell);
+    }
+
+    const updatedCellHeight = this.getCellHeight({ sheetId, col, row });
+    if (updatedCellHeight <= DEFAULT_CELL_HEIGHT) {
+      return;
+    }
+
+    if (
+      (!tallestCellInRow && updatedCellHeight > DEFAULT_CELL_HEIGHT) ||
+      (tallestCellInRow && updatedCellHeight > tallestCellInRow.size)
+    ) {
+      const newTallestCell = { cell: { sheetId, col, row }, size: updatedCellHeight };
+      this.history.update("tallestCellInRow", sheetId, row, newTallestCell);
+    }
+  }
+
+  private initializeSheet(sheetId: UID) {
+    const tallestCells: Array<CellWithSize | undefined> = [];
+    for (let row = 0; row < this.getters.getNumberRows(sheetId); row++) {
+      const tallestCell = this.getRowTallestCell(sheetId, row);
+      tallestCells.push(tallestCell);
+    }
+    this.history.update("tallestCellInRow", sheetId, tallestCells);
+  }
+
+  /**
+   * Return the height the cell should have in the sheet, which is either DEFAULT_CELL_HEIGHT if the cell is in a multi-row
+   * merge, or the height of the cell computed based on its style/content.
+   */
+  private getCellHeight(position: CellPosition): Pixel {
+    if (this.isInMultiRowMerge(position)) {
+      return DEFAULT_CELL_HEIGHT;
+    }
+
+    const cell = this.getters.getCell(position);
+
+    const colSize = this.getters.getColSize(position.sheetId, position.col);
+    return getDefaultCellHeight(this.ctx, cell, colSize);
+  }
+
+  private isInMultiRowMerge(position: CellPosition): boolean {
+    const merge = this.getters.getMerge(position);
+    return !!merge && merge.bottom !== merge.top;
+  }
+
+  /**
+   * Get the tallest cell of a row and its size.
+   */
+  private getRowTallestCell(sheetId: UID, row: HeaderIndex): CellWithSize | undefined {
+    const userRowSize = this.getters.getUserRowSize(sheetId, row);
+    if (userRowSize !== undefined) {
+      return undefined;
+    }
+
+    const cellIds = this.getters.getRowCells(sheetId, row);
+    let maxHeight = 0;
+    let tallestCell: CellWithSize | undefined = undefined;
+    for (let i = 0; i < cellIds.length; i++) {
+      const cell = this.getters.getCellById(cellIds[i]);
+      if (!cell) {
+        continue;
+      }
+      const position = this.getters.getCellPosition(cell.id);
+      const cellHeight = this.getCellHeight(position);
+
+      if (cellHeight > maxHeight && cellHeight > DEFAULT_CELL_HEIGHT) {
+        maxHeight = cellHeight;
+        tallestCell = { cell: position, size: cellHeight };
+      }
+    }
+
+    if (tallestCell && tallestCell.size > DEFAULT_CELL_HEIGHT) {
+      return tallestCell;
+    }
+
+    return undefined;
+  }
+}

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -15,6 +15,7 @@ import { EvaluationPlugin } from "../plugins/ui_core_views/cell_evaluation";
 import { CustomColorsPlugin } from "../plugins/ui_core_views/custom_colors";
 import { EvaluationChartPlugin } from "../plugins/ui_core_views/evaluation_chart";
 import { EvaluationConditionalFormatPlugin } from "../plugins/ui_core_views/evaluation_conditional_format";
+import { UIRowSizePlugin } from "../plugins/ui_core_views/row_size";
 import { AutofillPlugin } from "../plugins/ui_feature/autofill";
 import { AutomaticSumPlugin } from "../plugins/ui_feature/automatic_sum";
 import { CellPopoverPlugin } from "../plugins/ui_feature/cell_popovers";
@@ -140,6 +141,7 @@ type FilterEvaluationGetters = Pick<
   GetterNames<typeof FilterEvaluationPlugin>
 >;
 type SplitToColumnsGetters = Pick<SplitToColumnsPlugin, GetterNames<typeof SplitToColumnsPlugin>>;
+type UIRowSizeGetters = Pick<UIRowSizePlugin, GetterNames<typeof UIRowSizePlugin>>;
 
 export type Getters = {
   isReadonly: () => boolean;
@@ -167,4 +169,5 @@ export type Getters = {
   CellPopoverPluginGetters &
   FilterEvaluationGetters &
   HeaderVisibilityIUIGetters &
-  SplitToColumnsGetters;
+  SplitToColumnsGetters &
+  UIRowSizeGetters;

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -1005,9 +1005,11 @@ describe("Multi users synchronisation", () => {
       });
       charlie.dispatch("DELETE_SHEET", { sheetId: firstSheetId });
     });
+    const colSize = alice.getters.getColSize("sheet2", 0);
+    const ctx = document.createElement("canvas").getContext("2d")!;
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getRowSize("sheet2", 0),
-      getDefaultCellHeight(getCell(alice, "A1"))
+      getDefaultCellHeight(ctx, getCell(alice, "A1"), colSize)
     );
   });
 });

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -32,6 +32,7 @@ import {
   setStyle,
   setZoneBorders,
 } from "../test_helpers/commands_helpers";
+import { getCell } from "../test_helpers/getters_helpers";
 import { createEqualCF, getPlugin, target, toRangesData } from "../test_helpers/helpers";
 import { watchClipboardOutline } from "../test_helpers/renderer_helpers";
 import { DEFAULT_CELL_WIDTH } from "./../../src/constants";
@@ -950,7 +951,7 @@ describe("renderer", () => {
     model.drawGrid(ctx);
 
     const centeredBox = getBoxFromText(model, overflowingContent);
-    const cell = model.getters.getCell({ sheetId: "sheet1", row: 0, col: 2 })!;
+    const cell = getCell(model, "C1")!;
     const contentWidth =
       model.getters.getTextWidth(cell.content, cell.style || {}) + MIN_CELL_TEXT_MARGIN;
     const expectedClipX = 2 * DEFAULT_CELL_WIDTH + colSize / 2 - contentWidth / 2;
@@ -1052,7 +1053,7 @@ describe("renderer", () => {
         x: DEFAULT_CELL_WIDTH, // clipped to the left
         y: 0,
         width: 20, // clipped to the right
-        height: DEFAULT_CELL_HEIGHT,
+        height: model.getters.getRowSize("sheet1", 0),
       });
     }
   );
@@ -1083,7 +1084,7 @@ describe("renderer", () => {
         x: DEFAULT_CELL_WIDTH, // clipped to the left
         y: 0,
         width: 20, // clipped to the right
-        height: DEFAULT_CELL_HEIGHT,
+        height: model.getters.getRowSize("sheet1", 0),
       });
     }
   );
@@ -1264,7 +1265,7 @@ describe("renderer", () => {
       let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
       model.drawGrid(ctx);
       const box = getBoxFromText(model, cellContent);
-      const cell = model.getters.getCell({ sheetId: "sheet1", row: 1, col: 1 })!;
+      const cell = getCell(model, "B2")!;
       const textWidth = model.getters.getTextWidth(cell.content, cell.style || {});
       const expectedClipRect = model.getters.getVisibleRect({
         left: 0,

--- a/tests/plugins/resizing.test.ts
+++ b/tests/plugins/resizing.test.ts
@@ -28,8 +28,9 @@ import {
 import { getCell } from "../test_helpers/getters_helpers";
 import { DEFAULT_CELL_HEIGHT } from "./../../src/constants";
 
-function getDefaultCellHeight(cell: Cell | undefined) {
-  return Math.round(getDefaultCellHeightHelper(cell));
+const ctx = document.createElement("canvas").getContext("2d")!;
+function getDefaultCellHeight(cell: Cell | undefined, colSize = DEFAULT_CELL_WIDTH) {
+  return Math.round(getDefaultCellHeightHelper(ctx, cell, colSize));
 }
 
 describe("Model resizer", () => {
@@ -381,6 +382,39 @@ describe("Model resizer", () => {
           MIN_CELL_TEXT_MARGIN
       );
       expect(model.getters.getRowSize(sheet.id, 0)).toBe(multiLineHeight);
+    });
+
+    test("wrapped text updates the row size", () => {
+      setStyle(model, "C1", { fontSize: 10, wrapping: "wrap" });
+      resizeColumns(model, ["C"], 100);
+      setCellContent(model, "C1", "multiples wrapped lines");
+
+      const cell = getCell(model, "C1");
+      const expectedHeight = getDefaultCellHeight(cell, 100);
+      expect(expectedHeight).toBeGreaterThan(DEFAULT_CELL_HEIGHT);
+      expect(model.getters.getRowSize(sheet.id, 0)).toBe(expectedHeight);
+    });
+
+    test("text that is no longer wrapped updates the row size", () => {
+      setStyle(model, "C1", { fontSize: 10, wrapping: "wrap" });
+      resizeColumns(model, ["C"], 100);
+
+      setCellContent(model, "C1", "multiples wrapped lines");
+      expect(model.getters.getRowSize(sheet.id, 0)).toBeGreaterThan(DEFAULT_CELL_HEIGHT);
+
+      setCellContent(model, "C1", "a");
+      expect(model.getters.getRowSize(sheet.id, 0)).toBe(DEFAULT_CELL_HEIGHT);
+    });
+
+    test("updating column size updates row height with wrapped text", () => {
+      setCellContent(model, "A1", "multiples wrapped lines");
+      setStyle(model, "A1", { fontSize: 10, wrapping: "wrap" });
+
+      const cell = getCell(model, "A1");
+      expect(model.getters.getRowSize(sheet.id, 0)).toBe(getDefaultCellHeight(cell));
+
+      resizeColumns(model, ["A"], 5);
+      expect(model.getters.getRowSize(sheet.id, 0)).toBe(getDefaultCellHeight(cell, 5));
     });
 
     test("deleting tallest cell in the row update row height", () => {


### PR DESCRIPTION
The plugin HeaderSizePlugin was computing the row size based on the font
size and the number of lines of the text (NEWLINES). But it wasn't
taking into account text wrapped into multiple lines.

Also transformed private functions of SheetUIPlugin to helpers inside
the text_helper.ts file.

Odoo task ID : [3240138](https://www.odoo.com/web#id=3240138&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo