### PR TITLE
[FIX] xlsx: fix demo data error

### DIFF
--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet2.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet2.xml
@@ -2831,7 +2831,7 @@
     </row>
     <row r="162" spans="1:4" ht="17.25" customHeight="1" x14ac:dyDescent="0.2">
       <c r="A162" s="2" t="s">
-        <v>410</v>
+        <v>409</v>
       </c>
       <c r="B162" s="2" t="str">
         <f>ADDRESS(1,1,4,FALSE,"sheet!")</f>
@@ -2847,7 +2847,7 @@
     </row>
     <row r="163" spans="1:4" ht="17.25" customHeight="1" x14ac:dyDescent="0.2">
       <c r="A163" s="2" t="s">
-        <v>411</v>
+        <v>410</v>
       </c>
       <c r="B163" s="2" t="str">
         <f>DATEDIF("2002/01/01","2002/01/02","D")</f>


### PR DESCRIPTION
## Description:

This PR fixes the demo data error when opening demo .xlsx file for importing tests in Excel (online). 

The root cause is the incorrect id of shared strings.

Odoo task ID : [3251186](https://www.odoo.com/web#id=3251186&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo