### PR TITLE
[FIX] SheetUIPlugin: set column height for multi line content

### DIFF
--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -1,6 +1,7 @@
 import {
   FILTER_ICON_MARGIN,
   ICON_EDGE_LENGTH,
+  NEWLINE,
   PADDING_AUTORESIZE_HORIZONTAL,
 } from "../../constants";
 import { computeIconWidth, computeTextWidth, positions } from "../../helpers/index";
@@ -81,7 +82,8 @@ export class SheetUIPlugin extends UIPlugin {
   getCellWidth(position: CellPosition): number {
     const text = this.getCellText(position);
     const style = this.getters.getCellComputedStyle(position);
-    let contentWidth = this.getTextWidth(text, style);
+    const multiLineText = text.split(NEWLINE);
+    let contentWidth = Math.max(...multiLineText.map((line) => this.getTextWidth(line, style)));
     const icon = this.getters.getConditionalIcon(position);
     if (icon) {
       contentWidth += computeIconWidth(this.getters.getCellStyle(position));

--- a/tests/plugins/formatting.test.ts
+++ b/tests/plugins/formatting.test.ts
@@ -4,12 +4,13 @@ import {
   DEFAULT_FONT_SIZE,
   FILTER_ICON_MARGIN,
   ICON_EDGE_LENGTH,
+  NEWLINE,
   PADDING_AUTORESIZE_HORIZONTAL,
   PADDING_AUTORESIZE_VERTICAL,
 } from "../../src/constants";
 import { arg, functionRegistry } from "../../src/functions";
 import { toString } from "../../src/functions/helpers";
-import { fontSizeInPixels, toZone } from "../../src/helpers";
+import { fontSizeInPixels, toCartesian, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import {
   Arg,
@@ -446,6 +447,18 @@ describe("Autoresize", () => {
     const initCellWidth = sizes[0] + hPadding;
     model.dispatch("AUTORESIZE_COLUMNS", { sheetId, cols: [0] });
     expect(model.getters.getColSize(sheetId, 0)).toBe(initCellWidth);
+  });
+
+  test("Can autoresize a column with multiline content", () => {
+    const content = `Hello this is \nmultiline content for test`;
+    setCellContent(model, "A1", content);
+    model.dispatch("AUTORESIZE_COLUMNS", { sheetId, cols: [0] });
+    const position = { sheetId, ...toCartesian("A1") };
+    const style = model.getters.getCellComputedStyle(position);
+    const multiLineText = content.split(NEWLINE);
+    expect(model.getters.getColSize(sheetId, 0)).toBe(
+      Math.max(...multiLineText.map((line) => model.getters.getTextWidth(line, style))) + hPadding
+    );
   });
 
   test("Can autoresize a column with text width smaller than cell width", () => {


### PR DESCRIPTION
Previously, when double-clicking on the overlay header to auto-resize column size, the auto-resizing did not work accurately for multi-line content. This was due to auto-resizing taking the whole length of the text without considering whether the content was multi-line or not.

To fix this, we modified the auto-resizing to consider the maximum length of the broken content for multi-line cells. This will ensure that column height is properly set for cells with multi-line content.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3250821](https://www.odoo.com/web#id=3250821&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo