### PR TITLE
[FIX] top_bar_composer: fixed fx placeholder broken css

### DIFF
--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -23,6 +23,7 @@ css/* scss */ `
     .o-composer:empty:not(:focus)::before {
       /* svg free of use from https://uxwing.com/formula-fx-icon/ */
       content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -10 121.8 142.9' width='24' height='24' focusable='false'%3E%3Cpath d='m28 34-4 5v2h10l-6 40c-4 22-6 28-7 30-2 2-3 3-5 3-3 0-7-2-9-4H4c-2 2-4 4-4 7s4 6 8 6 9-2 15-8c8-7 13-17 18-39l7-35 13-1 3-6H49c4-23 7-27 11-27 2 0 5 2 8 6h4c1-1 4-4 4-7 0-2-3-6-9-6-5 0-13 4-20 10-6 7-9 14-11 24h-8zm41 16c4-5 7-7 8-7s2 1 5 9l3 12c-7 11-12 17-16 17l-3-1-2-1c-3 0-6 3-6 7s3 7 7 7c6 0 12-6 22-23l3 10c3 9 6 13 10 13 5 0 11-4 18-15l-3-4c-4 6-7 8-8 8-2 0-4-3-6-10l-5-15 8-10 6-4 3 1 3 2c2 0 6-3 6-7s-2-7-6-7c-6 0-11 5-21 20l-2-6c-3-9-5-14-9-14-5 0-12 6-18 15l3 3z' fill='%23BDBDBD' /%3E%3C/svg%3E");
+      position: absolute;
     }
   }
 `;
@@ -40,7 +41,9 @@ export class TopBarComposer extends Component<Props, SpreadsheetChildEnv> {
     const style: CSSProperties = {
       padding: "5px 0px 5px 8px",
       "max-height": `${COMPOSER_MAX_HEIGHT}px`,
+      "min-height": `${TOPBAR_TOOLBAR_HEIGHT}px`,
       "line-height": "24px",
+      cursor: "text",
     };
     style.height = this.props.focus === "inactive" ? `${TOPBAR_TOOLBAR_HEIGHT}px` : "fit-content";
     return cssPropertiesToCss(style);

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -513,7 +513,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
             class="o-composer w-100 text-start"
             contenteditable="true"
             spellcheck="false"
-            style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
+            style="padding:5px 0px 5px 8px; max-height:100px; min-height:34px; line-height:24px; cursor:text; height:34px;"
             tabindex="1"
           />
           

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -626,7 +626,7 @@ exports[`TopBar component can set cell format 1`] = `
               class="o-composer w-100 text-start"
               contenteditable="true"
               spellcheck="false"
-              style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
+              style="padding:5px 0px 5px 8px; max-height:100px; min-height:34px; line-height:24px; cursor:text; height:34px;"
               tabindex="1"
             />
             
@@ -1147,7 +1147,7 @@ exports[`TopBar component simple rendering 1`] = `
           class="o-composer w-100 text-start"
           contenteditable="true"
           spellcheck="false"
-          style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
+          style="padding:5px 0px 5px 8px; max-height:100px; min-height:34px; line-height:24px; cursor:text; height:34px;"
           tabindex="1"
         />
         


### PR DESCRIPTION
## Description:

The current height of TopbarComposer is determined by its content, but there is a visible scrollbar due to the SVG being slightly taller.

However, reducing the SVG's height would make it look too small in the UI. Therefore, I chosen the second option: setting the SVG as absolute and adjusting the Topbar composer's min-height to match TOPBAR_TOOLBAR_HEIGHT.

Odoo task ID : [3258920](https://www.odoo.com/web#id=3258920&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo