### PR TITLE
[FIX] filters: export xlsx of empty cells

### DIFF
--- a/src/plugins/ui/filter_evaluation.ts
+++ b/src/plugins/ui/filter_evaluation.ts
@@ -228,18 +228,23 @@ export class FilterEvaluationPlugin extends UIPlugin {
           if (!filter) continue;
 
           const valuesInFilterZone = filter.filteredZone
-            ? positions(filter.filteredZone)
-                .map((pos) => this.getters.getCell(sheetData.id, pos.col, pos.row)?.formattedValue)
-                .filter(isNonEmptyString)
+            ? positions(filter.filteredZone).map(
+                (pos) => this.getters.getCell(sheetData.id, pos.col, pos.row)?.formattedValue
+              )
             : [];
 
-          // In xlsx, filtered values = values that are displayed, not values that are hidden
-          const xlsxFilteredValues = valuesInFilterZone.filter(
-            (val) => !filteredValues.includes(val)
-          );
-          filters.push({ colId: i, filteredValues: [...new Set(xlsxFilteredValues)] });
+          if (filteredValues.length) {
+            const xlsxDisplayedValues = valuesInFilterZone
+              .filter(isNonEmptyString)
+              .filter((val) => !filteredValues.includes(val));
+            filters.push({
+              colId: i,
+              displayedValues: [...new Set(xlsxDisplayedValues)],
+              displayBlanks: !filteredValues.includes("") && valuesInFilterZone.some((val) => !val),
+            });
+          }
 
-          // In xlsx, filter header should ALWAYS be a string and should be unique
+          // In xlsx, filter header should ALWAYS be a string and should be unique in the table
           const headerPosition = { col: filter.col, row: filter.zoneWithHeaders.top };
           const headerString = this.getters.getCell(
             sheetData.id,

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -84,5 +84,6 @@ export interface ExcelFilterTableData {
 
 export interface ExcelFilterData {
   colId: number;
-  filteredValues: string[];
+  displayedValues: string[];
+  displayBlanks?: boolean;
 }

--- a/src/xlsx/functions/table.ts
+++ b/src/xlsx/functions/table.ts
@@ -42,15 +42,10 @@ function addAutoFilter(table: ExcelFilterTableData): XMLString {
 }
 
 function addFilterColumns(table: ExcelFilterTableData): XMLString[] {
-  const tableZone = toZone(table.range);
   const columns: XMLString[] = [];
-  for (const i of range(0, zoneToDimension(tableZone).width)) {
-    const filter = table.filters[i];
-    if (!filter || !filter.filteredValues.length) {
-      continue;
-    }
+  for (const filter of table.filters) {
     const colXml = escapeXml/*xml*/ `
-      <filterColumn ${formatAttributes([["colId", i]])}>
+      <filterColumn ${formatAttributes([["colId", filter.colId]])}>
         ${addFilter(filter)}
       </filterColumn>
       `;
@@ -60,11 +55,12 @@ function addFilterColumns(table: ExcelFilterTableData): XMLString[] {
 }
 
 function addFilter(filter: ExcelFilterData): XMLString {
-  const filterValues = filter.filteredValues.map(
+  const filterValues = filter.displayedValues.map(
     (val) => escapeXml/*xml*/ `<filter ${formatAttributes([["val", val]])}/>`
   );
+  const filterAttributes: XMLAttributes = filter.displayBlanks ? [["blank", 1]] : [];
   return escapeXml/*xml*/ `
-  <filters>
+  <filters ${formatAttributes(filterAttributes)}>
       ${joinXmlNodes(filterValues)}
   </filters>
 `;

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -9316,6 +9316,14 @@ Object {
                 <filter val=\\"78\\"/>
             </filters>
         </filterColumn>
+        <filterColumn colId=\\"1\\">
+            <filters blank=\\"1\\">
+            </filters>
+        </filterColumn>
+        <filterColumn colId=\\"2\\">
+            <filters blank=\\"1\\">
+            </filters>
+        </filterColumn>
     </autoFilter>
     <tableColumns count=\\"3\\">
         <tableColumn id=\\"1\\" name=\\"Hello\\"/>
@@ -9386,9 +9394,24 @@ Object {
                     5
                 </v>
             </c>
+            <c r=\\"B2\\" s=\\"1\\">
+                <f>
+                    \\"\\"
+                </f>
+            </c>
+            <c r=\\"C2\\" s=\\"1\\">
+                <v>
+                    5
+                </v>
+            </c>
         </row>
         <row r=\\"3\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"1\\">
             <c r=\\"A3\\" s=\\"1\\">
+                <v>
+                    5
+                </v>
+            </c>
+            <c r=\\"B3\\" s=\\"1\\">
                 <v>
                     5
                 </v>

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -1006,11 +1006,20 @@ describe("Test XLSX export", () => {
       updateFilter(model, "A1", ["Konnichiwa"]);
       const exported = getExportedExcelData(model);
       // Filtered values are the values that are displayed in xlsx, not the values that are hidden
-      expect(exported.sheets[0].filterTables[0].filters[0].filteredValues).toEqual([
+      expect(exported.sheets[0].filterTables[0].filters[0].displayedValues).toEqual([
         "Hello",
         "Bonjour",
       ]);
       expect(exported.sheets[0].rows[2].isHidden).toBeTruthy();
+    });
+
+    test("Empty filters aren't exported", () => {
+      const model = new Model();
+      createFilter(model, "A1:B4");
+      setCellContent(model, "A2", "Hello");
+      setCellContent(model, "B2", "Hello");
+      const exported = getExportedExcelData(model);
+      expect(exported.sheets[0].filterTables[0].filters).toHaveLength(0);
     });
 
     test("Filtered values are not duplicated", () => {
@@ -1018,35 +1027,51 @@ describe("Test XLSX export", () => {
       createFilter(model, "A1:B4");
       setCellContent(model, "A2", "Konnichiwa");
       setCellContent(model, "A3", "Konnichiwa");
+      setCellContent(model, "A4", "5");
+      updateFilter(model, "A1", ["5"]);
       const exported = getExportedExcelData(model);
-      expect(exported.sheets[0].filterTables[0].filters[0].filteredValues).toEqual(["Konnichiwa"]);
+      expect(exported.sheets[0].filterTables[0].filters[0].displayedValues).toEqual(["Konnichiwa"]);
     });
 
-    test("Empty cells are not added to filteredValues", () => {
+    test("Empty cells are not added to displayedValues", () => {
       const model = new Model();
       createFilter(model, "A1:B4");
+      setCellContent(model, "A2", "5");
+      updateFilter(model, "A1", ["5"]);
       const exported = getExportedExcelData(model);
-      expect(exported.sheets[0].filterTables[0].filters[0].filteredValues).toEqual([]);
+      expect(exported.sheets[0].filterTables[0].filters[0].displayedValues).toEqual([]);
     });
 
-    test("Formulas evaluated to empty string are not added to filteredValues", () => {
+    test("Formulas evaluated to empty string are not added to displayedValues", () => {
       const model = new Model();
       createFilter(model, "A1:B4");
-      setCellContent(model, "A2", '=""');
+      setCellContent(model, "A2", "5");
+      updateFilter(model, "A1", ["5"]);
+      setCellContent(model, "A3", '=""');
       const exported = getExportedExcelData(model);
-      expect(exported.sheets[0].filterTables[0].filters[0].filteredValues).toEqual([]);
+      expect(exported.sheets[0].filterTables[0].filters[0].displayedValues).toEqual([]);
+      expect(exported.sheets[0].filterTables[0].filters[0].displayBlanks).toEqual(true);
     });
 
     test("Export data filters snapshot", async () => {
       const model = new Model();
+      createFilter(model, "A1:C4");
+
       setCellContent(model, "A1", "Hello");
-      setCellContent(model, "B1", "Hello");
-      setCellContent(model, "C1", "56");
       setCellContent(model, "A2", "5");
       setCellContent(model, "A3", "5");
       setCellContent(model, "A4", "78");
-      createFilter(model, "A1:C4");
       updateFilter(model, "A1", ["5"]);
+
+      setCellContent(model, "B1", "Hello");
+      setCellContent(model, "B2", '=""');
+      setCellContent(model, "B3", "5");
+      updateFilter(model, "B1", ["5"]);
+
+      setCellContent(model, "C1", "56");
+      setCellContent(model, "C2", "5");
+      updateFilter(model, "C2", ["5"]);
+
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
## Description

441e9f8 imrpoved the handling of empty cells inside filters in the xlsx export, but didn't fix it fully.

When empty cells are present in the filtered zone, we should add an attribute `blank="1"` to the `filters` tag in the XML.

Odoo task ID : [3231170](https://www.odoo.com/web#id=3231170&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo