### PR TITLE
[IMP] find_and_replace: sheet granularity in Find & Replace

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -2,7 +2,6 @@ import {
   Component,
   onMounted,
   useChildSubEnv,
-  useEffect,
   useExternalListener,
   useRef,
   useState,
@@ -155,10 +154,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     useGridDrawing("canvas", this.env.model, () =>
       this.env.model.getters.getSheetViewDimensionWithHeaders()
     );
-    useEffect(
-      () => this.focus(),
-      () => [this.env.model.getters.getActiveSheetId()]
-    );
+
     this.onMouseWheel = useWheelHandler((deltaX, deltaY) => {
       this.moveCanvas(deltaX, deltaY);
       this.hoveredCell.col = undefined;

--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -1,7 +1,10 @@
 import { Component, onMounted, onWillUnmount, useEffect, useRef } from "@odoo/owl";
-import { SearchOptions } from "../../../plugins/ui_feature";
+import { zoneToXc } from "../../../helpers";
+import { _t } from "../../../translation";
+import { SearchOptions } from "../../../types/find_and_replace";
 import { SpreadsheetChildEnv } from "../../../types/index";
 import { css } from "../../helpers/css";
+import { SelectionInput } from "../../selection_input/selection_input";
 
 css/* scss */ `
   .o-find-and-replace {
@@ -18,7 +21,7 @@ css/* scss */ `
       }
       .o-input-count {
         width: fit-content;
-        padding: 4 0 4 4;
+        padding: 4px 0 4px 4px;
       }
     }
   }
@@ -30,10 +33,12 @@ interface Props {
 
 export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FindAndReplacePanel";
+  static components = { SelectionInput };
 
   private debounceTimeoutId;
-  private showFormulaState: boolean = false;
+  private initialShowFormulaState: boolean = false;
 
+  private dataRange: string = "";
   private searchInput = useRef("searchInput");
   private replaceInput = useRef("replaceInput");
 
@@ -57,15 +62,38 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     return (this.replaceInput.el as HTMLInputElement)?.value || "";
   }
 
-  setup() {
-    this.showFormulaState = this.env.model.getters.shouldShowFormulas();
+  get allSheetsMatchesCount() {
+    return _t("%s in all sheets", this.env.model.getters.getAllSheetMatchesCount());
+  }
 
+  get currentSheetMatchesCount() {
+    return _t("%(matches)s in sheet %(sheetName)s", {
+      matches: this.env.model.getters.getActiveSheetMatchesCount(),
+      sheetName: this.env.model.getters.getSheetName(this.env.model.getters.getActiveSheetId()),
+    });
+  }
+
+  get specificRangeMatchesCount() {
+    const range = this.searchOptions.specificRange;
+    if (!range) {
+      return "";
+    }
+    const { _sheetId, _zone } = range;
+    return _t("%(matches)s in range %(range)s of sheet %(sheetName)s", {
+      matches: this.env.model.getters.getSpecificRangeMatchesCount().toString(),
+      range: zoneToXc(_zone),
+      sheetName: this.env.model.getters.getSheetName(_sheetId),
+    });
+  }
+
+  setup() {
+    this.initialShowFormulaState = this.env.model.getters.shouldShowFormulas();
     onMounted(() => this.searchInput.el?.focus());
 
     onWillUnmount(() => {
       clearTimeout(this.debounceTimeoutId);
       this.env.model.dispatch("CLEAR_SEARCH");
-      this.env.model.dispatch("SET_FORMULA_VISIBILITY", { show: this.showFormulaState });
+      this.env.model.dispatch("SET_FORMULA_VISIBILITY", { show: this.initialShowFormulaState });
     });
 
     useEffect(
@@ -77,6 +105,9 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     );
   }
 
+  onFocusSearch() {
+    this.updateDataRange();
+  }
   onInput() {
     this.debouncedUpdateSearch();
   }
@@ -115,9 +146,32 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     this.updateSearch({ matchCase });
   }
 
+  changeSearchScope(ev) {
+    const searchScope = ev.target.value;
+    this.updateSearch({ searchScope });
+  }
+
+  onSearchRangeChanged(ranges: string[]) {
+    this.dataRange = ranges[0];
+  }
+
+  updateDataRange() {
+    if (!this.dataRange) {
+      return;
+    }
+    if (this.searchOptions.searchScope === "specificRange") {
+      const specificRange = this.env.model.getters.getRangeFromSheetXC(
+        this.env.model.getters.getActiveSheetId(),
+        this.dataRange
+      ).rangeData;
+      this.updateSearch({ specificRange });
+    }
+  }
+
   onSelectPreviousCell() {
     this.env.model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
   }
+
   onSelectNextCell() {
     this.env.model.dispatch("SELECT_SEARCH_NEXT_MATCH");
   }

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -16,29 +16,29 @@
             /
             <t t-esc="env.model.getters.getSearchMatches().length"/>
           </div>
-          <div t-elif="!pendingSearch and state.toSearch !== ''" class="o-input-count">0 / 0</div>
+          <div t-elif="!pendingSearch and toSearch !== ''" class="o-input-count">0 / 0</div>
         </div>
         <div>
           <!-- TODO: go through this css, the group misses a padding and could profit from BootStrap -->
           <label class="o-checkbox mt-1">
             <input
-              t-model="state.searchOptions.matchCase"
-              t-on-change="updateSearch"
+              t-att-checked="searchOptions.matchCase"
+              t-on-change="searchMatchCase"
               type="checkbox"
             />
             <span>Match case</span>
           </label>
           <label class="o-checkbox">
             <input
-              t-model="state.searchOptions.exactMatch"
-              t-on-change="updateSearch"
+              t-att-checked="searchOptions.exactMatch"
+              t-on-change="searchExactMatch"
               type="checkbox"
             />
             <span>Match entire cell content</span>
           </label>
           <label class="o-checkbox">
             <input
-              t-model="state.searchOptions.searchFormulas"
+              t-att-checked="searchOptions.searchFormulas"
               t-on-change="searchFormulas"
               type="checkbox"
             />
@@ -63,7 +63,7 @@
           <input
             type="text"
             class="o-input o-input-without-count"
-            t-model="state.replaceWith"
+            t-ref="replaceInput"
             t-on-keydown="onKeydownReplace"
           />
         </div>

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -9,6 +9,7 @@
             t-ref="searchInput"
             class="o-input o-input-with-count"
             t-on-input="onInput"
+            t-on-focus="onFocusSearch"
             t-on-keydown="onKeydownSearch"
           />
           <div class="o-input-count" t-if="hasSearchResult">
@@ -17,6 +18,22 @@
             <t t-esc="env.model.getters.getSearchMatches().length"/>
           </div>
           <div t-elif="!pendingSearch and toSearch !== ''" class="o-input-count">0 / 0</div>
+        </div>
+        <select
+          class="o-input o-type-selector o-type-range-selector mt-3 mb-3"
+          t-on-change="changeSearchScope">
+          <option value="allSheets">All sheets</option>
+          <option value="activeSheet">Current sheet</option>
+          <option value="specificRange">Specific range</option>
+        </select>
+        <div t-if="searchOptions.searchScope === 'specificRange'">
+          <SelectionInput
+            ranges="() => [this.dataRange]"
+            onSelectionChanged="(ranges) => this.onSearchRangeChanged(ranges)"
+            onSelectionConfirmed.bind="updateDataRange"
+            hasSingleRange="true"
+            required="true"
+          />
         </div>
         <div>
           <!-- TODO: go through this css, the group misses a padding and could profit from BootStrap -->
@@ -44,6 +61,17 @@
             />
             <span>Search in formulas</span>
           </label>
+        </div>
+        <div class="o-matches-count mt-4" t-if="toSearch !== ''">
+          <div t-if="searchOptions.searchScope === 'specificRange' and dataRange != ''">
+            <t t-esc="specificRangeMatchesCount"/>
+          </div>
+          <div>
+            <t t-esc="currentSheetMatchesCount"/>
+          </div>
+          <div>
+            <t t-esc="allSheetsMatchesCount"/>
+          </div>
         </div>
       </div>
       <div class="o-sidePanelButtons">

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -394,7 +394,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
   }
   focusGrid() {
     if (!this._focusGrid) {
-      throw new Error("_focusGrid should be exposed by the grid component");
+      return;
     }
     this._focusGrid();
   }

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -4,7 +4,9 @@ import {
   onPatched,
   onWillUnmount,
   onWillUpdateProps,
+  useEffect,
   useExternalListener,
+  useRef,
   useState,
   useSubEnv,
 } from "@odoo/owl";
@@ -255,6 +257,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
 
   sidePanel!: SidePanelState;
   composer!: ComposerState;
+  spreadsheetRef = useRef("spreadsheet");
 
   private _focusGrid?: () => void;
 
@@ -295,6 +298,24 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       clipboard: this.env.clipboard || instantiateClipboard(),
       startCellEdition: (content?: string) => this.onGridComposerCellFocused(content),
     });
+
+    useEffect(
+      () => {
+        /**
+         * Only refocus the grid if the active element is not a child of the spreadsheet
+         * (i.e. activeElement is outside of the spreadsheetRef component)
+         * and spreadsheet is a child of that element. Anything else means that the focus
+         * is on an element that needs to keep it.
+         */
+        if (
+          !this.spreadsheetRef.el!.contains(document.activeElement) &&
+          document.activeElement?.contains(this.spreadsheetRef.el!)
+        ) {
+          this.focusGrid();
+        }
+      },
+      () => [this.env.model.getters.getActiveSheetId()]
+    );
 
     useExternalListener(window as any, "resize", () => this.render(true));
     useExternalListener(window, "beforeunload", this.unbindModelEvents.bind(this));

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -3,6 +3,7 @@
     <div
       class="o-spreadsheet"
       t-on-keydown="(ev) => !env.isDashboard() and this.onKeydown(ev)"
+      t-ref="spreadsheet"
       t-att-style="getStyle()">
       <t t-if="env.isDashboard()">
         <SpreadsheetDashboard/>

--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -44,7 +44,11 @@ interface SearchMatch {
 
 export class FindAndReplacePlugin extends UIPlugin {
   static layers = [LAYERS.Search];
-  static getters = ["getSearchMatches", "getCurrentSelectedMatchIndex"] as const;
+  static getters = [
+    "getSearchMatches",
+    "getCurrentSelectedMatchIndex",
+    "getSearchOptions",
+  ] as const;
   private searchMatches: SearchMatch[] = [];
   private selectedMatchIndex: number | null = null;
   private currentSearchRegex: RegExp | null = null;
@@ -114,6 +118,9 @@ export class FindAndReplacePlugin extends UIPlugin {
   }
   getCurrentSelectedMatchIndex(): number | null {
     return this.selectedMatchIndex;
+  }
+  getSearchOptions(): SearchOptions {
+    return this.searchOptions;
   }
   // ---------------------------------------------------------------------------
   // Search

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,9 +1,9 @@
-import { SearchOptions } from "../plugins/ui_feature/find_and_replace";
 import { ComposerSelection } from "../plugins/ui_stateful/edition";
 import { CellPopoverType } from "./cell_popovers";
 import { ChartDefinition } from "./chart/chart";
 import { ClipboardPasteOptions } from "./clipboard";
 import { FigureSize } from "./figure";
+import { SearchOptions } from "./find_and_replace";
 import { Image } from "./image";
 import {
   ConditionalFormat,

--- a/src/types/find_and_replace.ts
+++ b/src/types/find_and_replace.ts
@@ -1,0 +1,13 @@
+import { Range, RangeData } from "./range";
+
+export interface SearchOptions {
+  matchCase: boolean;
+  exactMatch: boolean;
+  searchFormulas: boolean;
+  searchScope: "allSheets" | "activeSheet" | "specificRange";
+  specificRange?: RangeData;
+}
+
+export interface SearchOptionsInternal extends Omit<SearchOptions, "specificRange"> {
+  specificRange?: Range;
+}

--- a/tests/find_and_replace/find_and_replace_plugin.test.ts
+++ b/tests/find_and_replace/find_and_replace_plugin.test.ts
@@ -40,8 +40,8 @@ function p(xc: string) {
   return { col: z.left, row: z.top };
 }
 
-function match(sheetId: UID, xc: string, selected: boolean) {
-  return { sheetId, ...p(xc), selected };
+function match(sheetId: UID, xc: string) {
+  return { sheetId, ...p(xc) };
 }
 
 function getMatches(model: Model) {
@@ -71,10 +71,10 @@ describe("basic search", () => {
     setCellContent(model, "A1", "test");
     setCellContent(model, "A2", "test");
     updateSearch(model, "test", { searchScope: "activeSheet" });
-    expect(getMatches(model)).toEqual([match("sh2", "A1", true), match("sh2", "A2", false)]);
+    expect(getMatches(model)).toEqual([match("sh2", "A1"), match("sh2", "A2")]);
     expect(getMatchIndex(model)).toStrictEqual(0);
     activateSheet(model, sheetId1);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2", true)]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2")]);
     expect(getMatchIndex(model)).toStrictEqual(0);
   });
 
@@ -84,7 +84,7 @@ describe("basic search", () => {
     setCellContent(model, "A2", "test", "sh2");
     updateSearch(model, "test");
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toEqual([match(sheetId1, "A2", true), match("sh2", "A2", false)]);
+    expect(getMatches(model)).toEqual([match(sheetId1, "A2"), match("sh2", "A2")]);
   });
 
   test("simple search for search scope specificRange", () => {
@@ -95,13 +95,13 @@ describe("basic search", () => {
       specificRange: toRangeData(sheetId1, "A1:B1"),
     });
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1", true)]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1")]);
   });
 
   test("search with a regexp characters", () => {
     setCellContent(model, "A1", "hello (world).*");
     updateSearch(model, "hello (world).*");
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1", true)]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1")]);
   });
 
   test("Update search automatically select the first match", () => {
@@ -118,16 +118,10 @@ describe("basic search", () => {
     updateSearch(model, "hello", { searchScope: "activeSheet" });
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     expect(getMatchIndex(model)).toStrictEqual(1);
-    expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", false),
-      match(sheetId1, "A2", true),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "A2")]);
     updateSearch(model, "1", { searchScope: "activeSheet" });
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A2", true),
-      match(sheetId1, "A3", false),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2"), match(sheetId1, "A3")]);
   });
 
   test("change the search for allSheet searchScope", () => {
@@ -139,16 +133,10 @@ describe("basic search", () => {
     updateSearch(model, "hello");
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     expect(getMatchIndex(model)).toStrictEqual(1);
-    expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", false),
-      match(sheetId1, "A2", true),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "A2")]);
     updateSearch(model, "1");
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A2", true),
-      match(sheetId2, "A1", false),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2"), match(sheetId2, "A1")]);
   });
 
   test("change the search for specificRange searchScope", () => {
@@ -165,21 +153,21 @@ describe("basic search", () => {
     updateSearch(model, "1");
     expect(model.getters.getActiveSheetId()).toBe(sheetId2);
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId2, "A2", true)]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId2, "A2")]);
   });
 
   test("refresh search when cell is updated", async () => {
     setCellContent(model, "A1", "hello");
     updateSearch(model, "hello");
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1", true)]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1")]);
     setCellContent(model, "B1", "hello");
     setCellContent(model, "B2", '="hello"');
     expect(getMatchIndex(model)).toStrictEqual(0);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", true),
-      match(sheetId1, "B1", false),
-      match(sheetId1, "B2", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "B1"),
+      match(sheetId1, "B2"),
     ]);
   });
 
@@ -195,15 +183,12 @@ describe("basic search", () => {
     setCellContent(model, "B1", "=GETVALUE()");
     updateSearch(model, "hello");
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1", true)]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1")]);
     value = "hello";
     model.dispatch("EVALUATE_CELLS", { sheetId: model.getters.getActiveSheetId() });
     expect(getCellContent(model, "B1")).toBe(value);
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", true),
-      match(sheetId1, "B1", false),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "B1")]);
   });
 
   test("search on empty string does not match anything", () => {
@@ -241,9 +226,9 @@ describe("basic search", () => {
     expect(getActivePosition(model)).toBe("A2");
     expect(getMatchIndex(model)).toStrictEqual(2);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", false),
-      match(sheetId2, "A2", true),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
+      match(sheetId2, "A2"),
     ]);
   });
 
@@ -253,10 +238,10 @@ describe("basic search", () => {
     setCellContent(model, "A2", "=111", sheetId2);
     updateSearch(model, "1", { searchScope: "activeSheet" });
     expect(getActivePosition(model)).toBe("A3");
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A3", true)]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A3")]);
     activateSheet(model, "s2");
     expect(getActivePosition(model)).toBe("A2");
-    expect(getMatches(model)).toStrictEqual([match(sheetId2, "A2", true)]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId2, "A2")]);
   });
 
   test("Update search if column or row is added", () => {
@@ -264,16 +249,10 @@ describe("basic search", () => {
     setCellContent(model, "A4", "1");
     updateSearch(model, "1");
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A3", true),
-      match(sheetId1, "A4", false),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A3"), match(sheetId1, "A4")]);
     addRows(model, "after", 1, 1);
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A4", true),
-      match(sheetId1, "A5", false),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A4"), match(sheetId1, "A5")]);
   });
 
   test("Search is updated if column or row is removed", () => {
@@ -282,13 +261,10 @@ describe("basic search", () => {
     updateSearch(model, "1");
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     expect(getMatchIndex(model)).toStrictEqual(1);
-    expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", true),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2"), match(sheetId1, "A3")]);
     deleteRows(model, [1]);
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2", true)]);
+    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2")]);
   });
 
   test("Update search upon undo/redo operations, which can update the cell", () => {
@@ -346,7 +322,7 @@ test("simple search with array formula", () => {
   setCellContent(model, "B1", "=TRANSPOSE(A1:A3)");
   updateSearch(model, "hello");
   expect(getMatchIndex(model)).toStrictEqual(0);
-  expect(getMatches(model)).toStrictEqual([match("sh1", "C1", true), match("sh1", "A2", false)]);
+  expect(getMatches(model)).toStrictEqual([match("sh1", "C1"), match("sh1", "A2")]);
 });
 
 test("replace don't replace value resulting from array formula", () => {
@@ -381,9 +357,9 @@ describe("next/previous cycle", () => {
     updateSearch(model, "1");
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", false),
-      match(sheetId1, "A2", true),
-      match(sheetId1, "A3", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
   });
   test("Next than previous will cancel each other", () => {
@@ -391,9 +367,9 @@ describe("next/previous cycle", () => {
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", true),
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
   });
 
@@ -401,44 +377,44 @@ describe("next/previous cycle", () => {
     updateSearch(model, "1");
     expect(getActivePosition(model)).toBe("A1");
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", true),
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     expect(getActivePosition(model)).toBe("A2");
     expect(getMatchIndex(model)).toStrictEqual(1);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", false),
-      match(sheetId1, "A2", true),
-      match(sheetId1, "A3", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
 
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     expect(getActivePosition(model)).toBe("A3");
     expect(getMatchIndex(model)).toStrictEqual(2);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", false),
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", true),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
 
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     expect(getActivePosition(model)).toBe("A1");
     expect(getMatchIndex(model)).toStrictEqual(0);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", true),
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
 
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
     expect(getActivePosition(model)).toBe("A2");
     expect(getMatchIndex(model)).toStrictEqual(1);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", false),
-      match(sheetId1, "A2", true),
-      match(sheetId1, "A3", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
   });
   test("search will cycle with previous", () => {
@@ -446,45 +422,45 @@ describe("next/previous cycle", () => {
     expect(getActivePosition(model)).toBe("A1");
     expect(getMatchIndex(model)).toStrictEqual(0);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", true),
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
 
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     expect(getActivePosition(model)).toBe("A3");
     expect(getMatchIndex(model)).toStrictEqual(2);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", false),
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", true),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
 
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     expect(getActivePosition(model)).toBe("A2");
     expect(getMatchIndex(model)).toStrictEqual(1);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", false),
-      match(sheetId1, "A2", true),
-      match(sheetId1, "A3", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
 
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     expect(getActivePosition(model)).toBe("A1");
     expect(getMatchIndex(model)).toStrictEqual(0);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", true),
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", false),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
 
     model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
     expect(getActivePosition(model)).toBe("A3");
     expect(getMatchIndex(model)).toStrictEqual(2);
     expect(getMatches(model)).toStrictEqual([
-      match(sheetId1, "A1", false),
-      match(sheetId1, "A2", false),
-      match(sheetId1, "A3", true),
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A3"),
     ]);
   });
 });
@@ -546,35 +522,29 @@ describe("search options", () => {
   test("Can search matching case", () => {
     updateSearch(model, "Hell", { matchCase: true });
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match("Sheet1", "A2", true),
-      match("Sheet1", "A5", false),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A2"), match("Sheet1", "A5")]);
   });
 
   test("Can search matching entire cell", () => {
     updateSearch(model, "Hell", { exactMatch: true });
-    expect(getMatches(model)).toStrictEqual([
-      match("Sheet1", "A4", true),
-      match("Sheet1", "A5", false),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A4"), match("Sheet1", "A5")]);
   });
 
   test("Can search in formulas", () => {
     updateSearch(model, "Hell", { searchFormulas: true });
     expect(getMatchIndex(model)).toStrictEqual(0);
     expect(getMatches(model)).toStrictEqual([
-      match("Sheet1", "A1", true),
-      match("Sheet1", "A2", false),
-      match("Sheet1", "A4", false),
-      match("Sheet1", "A5", false),
+      match("Sheet1", "A1"),
+      match("Sheet1", "A2"),
+      match("Sheet1", "A4"),
+      match("Sheet1", "A5"),
     ]);
   });
 
   test("Can search in formulas(2)", () => {
     updateSearch(model, "4", { searchFormulas: false });
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A3", true)]);
+    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A3")]);
     updateSearch(model, "4", { searchFormulas: true });
     expect(getMatches(model)).toStrictEqual([]);
     expect(getMatchIndex(model)).toBe(null);
@@ -584,38 +554,32 @@ describe("search options", () => {
     updateSearch(model, "hell");
     expect(getMatchIndex(model)).toStrictEqual(0);
     expect(getMatches(model)).toStrictEqual([
-      match("Sheet1", "A1", true),
-      match("Sheet1", "A2", false),
-      match("Sheet1", "A4", false),
-      match("Sheet1", "A5", false),
+      match("Sheet1", "A1"),
+      match("Sheet1", "A2"),
+      match("Sheet1", "A4"),
+      match("Sheet1", "A5"),
     ]);
     //match case
     updateSearch(model, "hell", { matchCase: true });
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match("Sheet1", "A1", true),
-      match("Sheet1", "A4", false),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A1"), match("Sheet1", "A4")]);
 
     //match case + exact match
     updateSearch(model, "hell", { matchCase: true, exactMatch: true });
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A4", true)]);
+    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A4")]);
 
     //change input and remove match case + exact match and add look in formula
     updateSearch(model, "hell", { matchCase: false, exactMatch: false, searchFormulas: true });
     model.dispatch("UPDATE_SEARCH", { toSearch: "SUM", searchOptions: getSearchOptions() });
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match("Sheet1", "A1", true),
-      match("Sheet1", "A3", false),
-    ]);
+    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A1"), match("Sheet1", "A3")]);
 
     //add match case
     updateSearch(model, "hell", { matchCase: true, searchFormulas: true });
     model.dispatch("UPDATE_SEARCH", { toSearch: "SUM", searchOptions: getSearchOptions() });
     expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A3", true)]);
+    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A3")]);
   });
 });
 


### PR DESCRIPTION
## Description:

Previously, the find and replace functionality only worked on the active sheet,
which made it difficult to determine if the content was available in any other
sheet or to replace content in all sheets. To address this issue, the code has
been updated to search for content in all available sheets and replace it in
all sheets.

Implemented range highlighting for user-selected search scopes to assist in
identifying the target area.

Maintained search index and match positions when switching sheets, preventing
unnecessary jumps to the first match.

Optimized row and column hiding behavior to manage values more efficiently during
search and replace operations.

Improvements:

Implemented a feature to find in 'allSheet', 'thisSheet', and
'specificRange' search scopes

Highlight the selected range in specificRange search scope.
Managed sheet changes in 'allSheet' mode. This is specifically for
scenarios where the user is not intentionally changing the sheet, but
it's instead due to matching queries

Use 'selectionInput' for obtaining specific ranges

Manage the state of specific ranges whenever we modify the 'searchScope'
Organized 'match' and 'matchIndex' first by 'sheetIndex', followed by
'row', and then by 'column'

Handled scenarios where the sheet changes due to a matching, which
previously caused a shift of focus from the side panel to the grid

Odoo task ID : [3250881](https://www.odoo.com/web#id=3250881&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo