### PR TITLE
[IMP] model: canDispatch method

### DIFF
--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -50,10 +50,6 @@ css/* scss */ `
     .o-bottom-bar-arrows {
       .o-bottom-bar-arrow {
         cursor: pointer;
-        &.o-disabled {
-          opacity: 0.4;
-          cursor: default;
-        }
         &:hover:not([class*="o-disabled"]) {
           .o-icon {
             opacity: 0.9;

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -54,6 +54,11 @@ css/* scss */ `
     button {
       color: #333;
     }
+    .o-disabled {
+      opacity: 0.4;
+      pointer: default;
+      pointer-events: none;
+    }
 
     &,
     *,

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -184,11 +184,6 @@ css/* scss */ `
           margin: 0 6px;
         }
 
-        .o-disabled {
-          opacity: 0.6;
-          cursor: default;
-        }
-
         .o-dropdown {
           position: relative;
           display: flex;

--- a/src/model.ts
+++ b/src/model.ts
@@ -449,6 +449,14 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   }
 
   /**
+   * Check if a command can be dispatched, and returns a DispatchResult object with the possible
+   * reasons the dispatch failed.
+   */
+  canDispatch: CommandDispatcher["canDispatch"] = (type: string, payload?: any) => {
+    return this.checkDispatchAllowed({ ...payload, type });
+  };
+
+  /**
    * The dispatch method is the only entry point to manipulate data in the model.
    * This is through this method that commands are dispatched most of the time
    * recursively until no plugin want to react anymore.

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1160,6 +1160,10 @@ export interface CommandDispatcher {
     type: T,
     r: Omit<C, "type">
   ): DispatchResult;
+  canDispatch<T extends CommandTypes, C extends Extract<Command, { type: T }>>(
+    type: T,
+    r: Omit<C, "type">
+  ): DispatchResult;
 }
 
 export interface CoreCommandDispatcher {
@@ -1167,6 +1171,10 @@ export interface CoreCommandDispatcher {
     type: {} extends Omit<C, "type"> ? T : never
   ): DispatchResult;
   dispatch<T extends CoreCommandTypes, C extends Extract<CoreCommand, { type: T }>>(
+    type: T,
+    r: Omit<C, "type">
+  ): DispatchResult;
+  canDispatch<T extends CoreCommandTypes, C extends Extract<CoreCommand, { type: T }>>(
     type: T,
     r: Omit<C, "type">
   ): DispatchResult;

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -111,6 +111,31 @@ describe("Model", () => {
     featurePluginRegistry.remove("myUIPlugin");
   });
 
+  test("canDispatch method is exposed and works", () => {
+    class MyCorePlugin extends CorePlugin {
+      allowDispatch(cmd: CoreCommand) {
+        if (cmd.type === "CREATE_SHEET") {
+          return CommandResult.CancelledForUnknownReason;
+        }
+        return CommandResult.Success;
+      }
+    }
+    corePluginRegistry.add("myCorePlugin", MyCorePlugin);
+    const model = new Model();
+    expect(model.canDispatch("CREATE_SHEET", { sheetId: "42", position: 1 })).toBeCancelledBecause(
+      CommandResult.CancelledForUnknownReason
+    );
+    expect(model.dispatch("CREATE_SHEET", { sheetId: "42", position: 1 })).toBeCancelledBecause(
+      CommandResult.CancelledForUnknownReason
+    );
+
+    expect(model.canDispatch("UPDATE_CELL", { sheetId: "42", col: 0, row: 0, content: "hey" }))
+      .toBeSuccessfullyDispatched;
+    expect(model.dispatch("UPDATE_CELL", { sheetId: "42", col: 0, row: 0, content: "hey" }))
+      .toBeSuccessfullyDispatched;
+    corePluginRegistry.remove("myCorePlugin");
+  });
+
   test("Can open a model in readonly mode", () => {
     const model = new Model({}, { mode: "readonly" });
     expect(model.getters.isReadonly()).toBe(true);

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -129,10 +129,13 @@ describe("Model", () => {
       CommandResult.CancelledForUnknownReason
     );
 
-    expect(model.canDispatch("UPDATE_CELL", { sheetId: "42", col: 0, row: 0, content: "hey" }))
-      .toBeSuccessfullyDispatched;
-    expect(model.dispatch("UPDATE_CELL", { sheetId: "42", col: 0, row: 0, content: "hey" }))
-      .toBeSuccessfullyDispatched;
+    const sheetId = model.getters.getActiveSheetId();
+    expect(
+      model.canDispatch("UPDATE_CELL", { sheetId, col: 0, row: 0, content: "hey" })
+    ).toBeSuccessfullyDispatched();
+    expect(
+      model.dispatch("UPDATE_CELL", { sheetId, col: 0, row: 0, content: "hey" })
+    ).toBeSuccessfullyDispatched();
     corePluginRegistry.remove("myCorePlugin");
   });
 


### PR DESCRIPTION
## Description:

Add the method `canDispatch` in the model, that will run the given commands
against the `allowDispatch` of the handlers, and return the result.

This will be useful to dynamically display errors in side panels, without
waiting for user confirmation.

Also create global css class `o-disabled`

Odoo task ID : [3271348]
(https://www.odoo.com/web#id=3271348&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo