### PR TITLE
[REL] 16.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.0.5",
+  "version": "16.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.0.5",
+      "version": "16.0.6",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.0.5",
+  "version": "16.0.6",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/a4a82304 [IMP] test: make test tsconfig work in vscode
https://github.com/odoo/o-spreadsheet/commit/752f2f20 [MOV] filter: rename fitler_icons_overlay file
https://github.com/odoo/o-spreadsheet/commit/cb964cf2 [FIX] viewport: viewport maxSize should consider the client size
https://github.com/odoo/o-spreadsheet/commit/617cbc40 [FIX] chart: typo in template
https://github.com/odoo/o-spreadsheet/commit/ad41c5a2 [FIX] Chart panels: close color picker when clicking outside of it
https://github.com/odoo/o-spreadsheet/commit/0dc464fe [FIX] *: use `Color` alias wherever we work with color strings
https://github.com/odoo/o-spreadsheet/commit/46004a6c [FIX] *: standardization of color representation Task: 3193882
https://github.com/odoo/o-spreadsheet/commit/7d40008c [FIX] type: Fix the Alias type
https://github.com/odoo/o-spreadsheet/commit/b0744a45 [FIX] tests: Bypass useless `drawGrid` Task: 3254822
https://github.com/odoo/o-spreadsheet/commit/38993377 [IMP] xlsx_import: support more date formats
https://github.com/odoo/o-spreadsheet/commit/6c09c3c6 [FIX] xlsx_import: fix xlsx import in demo data
https://github.com/odoo/o-spreadsheet/commit/a7e221fe [FIX] tokenizer: detect xc with sheet name starting with a number Task: 3215464
https://github.com/odoo/o-spreadsheet/commit/8c89731d [FIX] popover: adjusted z-index for the popovers
https://github.com/odoo/o-spreadsheet/commit/07582df1 [FIX] composer: adjusted z-index for grid composer and topbar composer
https://github.com/odoo/o-spreadsheet/commit/d87d0dd2 [FIX] dropdown: adjusted z-index for dropdowns
https://github.com/odoo/o-spreadsheet/commit/9f5d31d5 [FIX] demo: optional askConfirmation cancel argument
