### PR TITLE
[REL] 16.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.1.6",
+  "version": "16.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.1.6",
+      "version": "16.1.7",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.1.6",
+  "version": "16.1.7",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/24ab3ed5 [FIX] viewport: viewport maxSize should consider the client size Task: 3204720
https://github.com/odoo/o-spreadsheet/commit/97297b50 [IMP] test: make test tsconfig work in vscode
https://github.com/odoo/o-spreadsheet/commit/6726299f [FIX] chart: typo in template
https://github.com/odoo/o-spreadsheet/commit/eeffa885 [FIX] Chart panels: close color picker when clicking outside of it
https://github.com/odoo/o-spreadsheet/commit/6e161ff8 [FIX] *: use `Color` alias wherever we work with color strings
https://github.com/odoo/o-spreadsheet/commit/bec6ce86 [FIX] *: standardization of color representation Task: 3193882
https://github.com/odoo/o-spreadsheet/commit/4289c2a1 [FIX] type: Fix the Alias type
https://github.com/odoo/o-spreadsheet/commit/46788632 [MOV] filter: rename fitler_icons_overlay file
https://github.com/odoo/o-spreadsheet/commit/c712b029 [IMP] xlsx_import: support more date formats
https://github.com/odoo/o-spreadsheet/commit/37929884 [FIX] tests: Bypass useless `drawGrid` Task: 3254822
https://github.com/odoo/o-spreadsheet/commit/aadde0e3 [FIX] popover: adjusted z-index for popovers
https://github.com/odoo/o-spreadsheet/commit/a6f93004 [FIX] tokenizer: detect xc with sheet name starting with a number Task: 3215464
https://github.com/odoo/o-spreadsheet/commit/11499072 [IMP] spreadsheet: inherit font family
https://github.com/odoo/o-spreadsheet/commit/f64e73df [FIX] demo: optional askConfirmation cancel argument
