### PR TITLE
[REL] 16.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.2.1",
+  "version": "16.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.2.1",
+      "version": "16.2.2",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.2.1",
+  "version": "16.2.2",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/e56757ac [FIX] viewport: viewport maxSize should consider the client size Task: 3204720
https://github.com/odoo/o-spreadsheet/commit/c47fcd7a [IMP] test: make test tsconfig work in vscode
https://github.com/odoo/o-spreadsheet/commit/50326101 [FIX] header_size: prevent row resize caused by multiline formulas
https://github.com/odoo/o-spreadsheet/commit/c17bb3e2 [FIX] *: use `Color` alias wherever we work with color strings
https://github.com/odoo/o-spreadsheet/commit/084a0f53 [FIX] *: standardization of color representation Task: 3193882
https://github.com/odoo/o-spreadsheet/commit/11f722ec [FIX] type: Fix the Alias type
https://github.com/odoo/o-spreadsheet/commit/502e93e3 [MOV] filter: rename fitler_icons_overlay file
https://github.com/odoo/o-spreadsheet/commit/13d673c8 [IMP] xlsx_import: support more date formats
https://github.com/odoo/o-spreadsheet/commit/010bf8e8 [FIX] popover: adjusted z-index for popovers
https://github.com/odoo/o-spreadsheet/commit/63d428f0 [FIX] tests: Bypass useless `drawGrid` Task: 3254822
https://github.com/odoo/o-spreadsheet/commit/7374fbc1 [FIX] tokenizer: detect xc with sheet name starting with a number Task: 3215464
https://github.com/odoo/o-spreadsheet/commit/81e4b9e0 [FIX] clipboard: don't open composer on firefox
https://github.com/odoo/o-spreadsheet/commit/daf0d43b [FIX] demo: optional askConfirmation cancel argument
https://github.com/odoo/o-spreadsheet/commit/d7731998 [IMP] spreadsheet: inherit font family
