### PR TITLE
[16.0] Various easy performance boosts

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -1514,12 +1514,22 @@ function computeFormulaCells(cols, rows) {
   return cells;
 }
 
-function computeNumberCells(cols, rows) {
+function computeNumberCells(cols, rows, type = "numbers") {
   const cells = {};
   for (let col = 0; col < cols; col++) {
     const letter = _getColumnLetter(col);
     for (let index = 1; index < rows - 1; index++) {
-      cells[letter + index] = { content: `${col + index}` };
+      switch (type) {
+        case "numbers":
+          cells[letter + index] = { content: `${col + index}` };
+          break;
+        case "floats":
+          cells[letter + index] = { content: `${col + index}.123` };
+          break;
+        case "longFloats":
+          cells[letter + index] = { content: `${col + index}.123456789123456` };
+          break;
+      }
     }
   }
   return cells;
@@ -1552,7 +1562,9 @@ export function makeLargeDataset(cols, rows, sheetsInfo = ["formulas"]) {
         cells = computeFormulaCells(cols, rows);
         break;
       case "numbers":
-        cells = computeNumberCells(cols, rows);
+      case "floats":
+      case "longFloats":
+        cells = computeNumberCells(cols, rows, sheetsInfo[0]);
         break;
       case "strings":
         cells = computeStringCells(cols, rows);

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -5,7 +5,7 @@ import {
   HEADER_WIDTH,
   SCROLLBAR_WIDTH,
 } from "../../constants";
-import { isInside, range } from "../../helpers/index";
+import { isInside } from "../../helpers/index";
 import { interactiveCut } from "../../helpers/ui/cut_interactive";
 import { interactivePaste, interactivePasteFromOS } from "../../helpers/ui/paste_interactive";
 import { ComposerSelection } from "../../plugins/ui/edition";
@@ -224,12 +224,14 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       const col = this.env.model.getters.findVisibleHeader(
         sheetId,
         "COL",
-        range(0, this.env.model.getters.getNumberCols(sheetId)).reverse()
+        this.env.model.getters.getNumberCols(sheetId) - 1,
+        0
       )!;
       const row = this.env.model.getters.findVisibleHeader(
         sheetId,
         "ROW",
-        range(0, this.env.model.getters.getNumberRows(sheetId)).reverse()
+        this.env.model.getters.getNumberRows(sheetId) - 1,
+        0
       )!;
       this.env.model.selection.selectCell(col, row);
     },

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -188,12 +188,98 @@ const numberRepresentation: Intl.NumberFormat[] = [];
  * - all digit stored in the decimal part of the number
  *
  * The 'maxDecimal' parameter allows to indicate the number of digits to not
- * exceed in the decimal part, in which case digits are rounded
+ * exceed in the decimal part, in which case digits are rounded.
  *
- * Intl.Numberformat is used to properly handle all the roundings.
- * e.g. 1234.7  with format ### (<> maxDecimals=0) should become 1235, not 1234
  **/
 function splitNumber(
+  value: number,
+  maxDecimals: number = MAX_DECIMAL_PLACES
+): { integerDigits: string; decimalDigits: string | undefined } {
+  const asString = value.toString();
+  if (asString.includes("e")) return splitNumberIntl(value, maxDecimals);
+
+  if (Number.isInteger(value)) {
+    return { integerDigits: asString, decimalDigits: undefined };
+  }
+
+  const indexOfDot = asString.indexOf(".");
+  let integerDigits = asString.substring(0, indexOfDot);
+  let decimalDigits: string | undefined = asString.substring(indexOfDot + 1);
+
+  if (maxDecimals === 0) {
+    if (Number(decimalDigits[0]) >= 5) {
+      integerDigits = (Number(integerDigits) + 1).toString();
+    }
+    return { integerDigits, decimalDigits: undefined };
+  }
+
+  if (decimalDigits.length > maxDecimals) {
+    const { integerDigits: roundedIntegerDigits, decimalDigits: roundedDecimalDigits } =
+      limitDecimalDigits(decimalDigits, maxDecimals);
+
+    decimalDigits = roundedDecimalDigits;
+    if (roundedIntegerDigits !== "0") {
+      integerDigits = (Number(integerDigits) + Number(roundedIntegerDigits)).toString();
+    }
+  }
+
+  return { integerDigits, decimalDigits: removeTrailingZeroes(decimalDigits || "") };
+}
+
+/**
+ *  Return the given string minus the trailing "0" characters.
+ *
+ * @param numberString : a string of integers
+ * @returns the numberString, minus the eventual zeroes at the end
+ */
+function removeTrailingZeroes(numberString: string): string | undefined {
+  let i = numberString.length - 1;
+  while (i >= 0 && numberString[i] === "0") {
+    i--;
+  }
+  return numberString.slice(0, i + 1) || undefined;
+}
+
+/**
+ * Limit the size of the decimal part of a number to the given number of digits.
+ */
+function limitDecimalDigits(
+  decimalDigits: string,
+  maxDecimals: number
+): {
+  integerDigits: string;
+  decimalDigits: string | undefined;
+} {
+  let integerDigits = "0";
+  let resultDecimalDigits: string | undefined = decimalDigits;
+
+  // Note : we'd want to simply use number.toFixed() to handle the max digits & rounding,
+  // but it has very strange behaviour. Ex: 12.345.toFixed(2) => "12.35", but 1.345.toFixed(2) => "1.34"
+  let slicedDecimalDigits = decimalDigits.slice(0, maxDecimals);
+  const i = maxDecimals;
+
+  if (Number(Number(decimalDigits[i]) < 5)) {
+    return { integerDigits, decimalDigits: slicedDecimalDigits };
+  }
+
+  // round up
+  const slicedRoundedUp = (Number(slicedDecimalDigits) + 1).toString();
+  if (slicedRoundedUp.length > slicedDecimalDigits.length) {
+    integerDigits = (Number(integerDigits) + 1).toString();
+    resultDecimalDigits = undefined;
+  } else {
+    resultDecimalDigits = slicedRoundedUp;
+  }
+
+  return { integerDigits, decimalDigits: resultDecimalDigits };
+}
+
+/**
+ * Split numbers into decimal/integer digits using Intl.NumberFormat.
+ * Supports numbers with a lot of digits that are transformed to scientific notation by
+ * number.toString(), but is slow.
+ */
+function splitNumberIntl(
   value: number,
   maxDecimals: number = MAX_DECIMAL_PLACES
 ): { integerDigits: string; decimalDigits: string | undefined } {

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -4,7 +4,7 @@ import {
   FORBIDDEN_IN_EXCEL_REGEX,
   FORMULA_REF_IDENTIFIER,
 } from "../constants";
-import { getItemId, toXC, toZone, UuidGenerator } from "../helpers/index";
+import { deepCopy, getItemId, toXC, toZone, UuidGenerator } from "../helpers/index";
 import { StateUpdateMessage } from "../types/collaborative/transport_service";
 import {
   CoreCommand,
@@ -46,7 +46,7 @@ export function load(data?: any, verboseImport?: boolean): WorkbookData {
       }
     }
   }
-  data = JSON.parse(JSON.stringify(data));
+  data = deepCopy(data);
 
   // apply migrations, if needed
   if ("version" in data) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -504,7 +504,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       }
     }
     data.revisionId = this.session.getRevisionId() || DEFAULT_REVISION_ID;
-    data = JSON.parse(JSON.stringify(data));
+    data = deepCopy(data);
     return data;
   }
 
@@ -533,7 +533,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
         handler.exportForExcel(data);
       }
     }
-    data = JSON.parse(JSON.stringify(data));
+    data = deepCopy(data);
 
     return getXLSX(data);
   }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -834,10 +834,10 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   }
 
   private moveCellOnColumnsDeletion(sheet: Sheet, deletedColumn: number) {
-    for (let [index, row] of Object.entries(sheet.rows)) {
-      const rowIndex = parseInt(index, 10);
+    for (let rowIndex = 0; rowIndex < sheet.rows.length; rowIndex++) {
+      const row = sheet.rows[rowIndex];
       for (let i in row.cells) {
-        const colIndex = parseInt(i, 10);
+        const colIndex = Number(i);
         const cellId = row.cells[i];
         if (cellId) {
           if (colIndex === deletedColumn) {
@@ -870,11 +870,11 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     dimension: "rows" | "columns"
   ) {
     const commands: UpdateCellPositionCommand[] = [];
-    for (const [index, row] of Object.entries(sheet.rows)) {
-      const rowIndex = parseInt(index, 10);
+    for (let rowIndex = 0; rowIndex < sheet.rows.length; rowIndex++) {
+      const row = sheet.rows[rowIndex];
       if (dimension !== "rows" || rowIndex >= addedElement) {
         for (let i in row.cells) {
-          const colIndex = parseInt(i, 10);
+          const colIndex = Number(i);
           const cellId = row.cells[i];
           if (cellId) {
             if (dimension === "rows" || colIndex >= addedElement) {
@@ -909,11 +909,11 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     deleteToRow: HeaderIndex
   ) {
     const numberRows = deleteToRow - deleteFromRow + 1;
-    for (let [index, row] of Object.entries(sheet.rows)) {
-      const rowIndex = parseInt(index, 10);
+    for (let rowIndex = 0; rowIndex < sheet.rows.length; rowIndex++) {
+      const row = sheet.rows[rowIndex];
       if (rowIndex >= deleteFromRow && rowIndex <= deleteToRow) {
         for (let i in row.cells) {
-          const colIndex = parseInt(i, 10);
+          const colIndex = Number(i);
           const cellId = row.cells[i];
           if (cellId) {
             this.dispatch("CLEAR_CELL", {
@@ -926,7 +926,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
       }
       if (rowIndex > deleteToRow) {
         for (let i in row.cells) {
-          const colIndex = parseInt(i, 10);
+          const colIndex = Number(i);
           const cellId = row.cells[i];
           if (cellId) {
             this.dispatch("UPDATE_CELL_POSITION", {
@@ -945,7 +945,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     const rows: Row[] = [];
     const cellsQueue = sheet.rows.map((row) => row.cells);
     for (let i in sheet.rows) {
-      if (parseInt(i, 10) === index) {
+      if (Number(i) === index) {
         continue;
       }
       rows.push({

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -1,6 +1,7 @@
 import { FORBIDDEN_IN_EXCEL_REGEX } from "../../constants";
 import {
   createDefaultRows,
+  deepCopy,
   getUnquotedSheetName,
   groupConsecutive,
   isDefined,
@@ -686,7 +687,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   private duplicateSheet(fromId: UID, toId: UID) {
     const sheet = this.getSheet(fromId);
     const toName = this.getDuplicateSheetName(sheet.name);
-    const newSheet: Sheet = JSON.parse(JSON.stringify(sheet));
+    const newSheet: Sheet = deepCopy(sheet);
     newSheet.id = toId;
     newSheet.name = toName;
     for (let col = 0; col <= newSheet.numberOfCols; col++) {

--- a/src/plugins/ui/filter_evaluation.ts
+++ b/src/plugins/ui/filter_evaluation.ts
@@ -166,13 +166,11 @@ export class FilterEvaluationPlugin extends UIPlugin {
   }
 
   private intersectZoneWithViewport(sheetId: UID, zone: Zone) {
-    const colsRange = range(zone.left, zone.right + 1);
-    const rowsRange = range(zone.top, zone.bottom + 1);
     return {
-      left: this.getters.findVisibleHeader(sheetId, "COL", colsRange),
-      right: this.getters.findVisibleHeader(sheetId, "COL", colsRange.reverse()),
-      top: this.getters.findVisibleHeader(sheetId, "ROW", rowsRange),
-      bottom: this.getters.findVisibleHeader(sheetId, "ROW", rowsRange.reverse()),
+      left: this.getters.findVisibleHeader(sheetId, "COL", zone.left, zone.right),
+      right: this.getters.findVisibleHeader(sheetId, "COL", zone.right, zone.left),
+      top: this.getters.findVisibleHeader(sheetId, "ROW", zone.top, zone.bottom),
+      bottom: this.getters.findVisibleHeader(sheetId, "ROW", zone.bottom, zone.top),
     };
   }
 

--- a/src/plugins/ui/header_visibility_ui.ts
+++ b/src/plugins/ui/header_visibility_ui.ts
@@ -1,4 +1,3 @@
-import { range } from "../../helpers";
 import { Dimension, ExcelWorkbookData, HeaderIndex, Position, UID } from "../../types";
 import { UIPlugin } from "../ui_plugin";
 
@@ -31,17 +30,44 @@ export class HeaderVisibilityUIPlugin extends UIPlugin {
 
   getNextVisibleCellPosition(sheetId: UID, col: number, row: number): Position {
     return {
-      col: this.findVisibleHeader(sheetId, "COL", range(col, this.getters.getNumberCols(sheetId)))!,
-      row: this.findVisibleHeader(sheetId, "ROW", range(row, this.getters.getNumberRows(sheetId)))!,
+      col: this.findVisibleHeader(sheetId, "COL", col, this.getters.getNumberCols(sheetId) - 1)!,
+      row: this.findVisibleHeader(sheetId, "ROW", row, this.getters.getNumberRows(sheetId) - 1)!,
     };
   }
 
-  findVisibleHeader(sheetId: UID, dimension: Dimension, indexes: number[]): number | undefined {
-    return indexes.find(
-      (index) =>
-        this.getters.doesHeaderExist(sheetId, dimension, index) &&
-        !this.isHeaderHidden(sheetId, dimension, index)
-    );
+  /**
+   * Find the first visible header in the range [`from` => `to`].
+   *
+   * Both `from` and `to` are inclusive.
+   */
+  findVisibleHeader(
+    sheetId: UID,
+    dimension: Dimension,
+    from: number,
+    to: number
+  ): number | undefined {
+    if (from <= to) {
+      for (let i = from; i <= to; i++) {
+        if (
+          this.getters.doesHeaderExist(sheetId, dimension, i) &&
+          !this.isHeaderHidden(sheetId, dimension, i)
+        ) {
+          return i;
+        }
+      }
+    }
+    if (from > to) {
+      for (let i = from; i >= to; i--) {
+        if (
+          this.getters.doesHeaderExist(sheetId, dimension, i) &&
+          !this.isHeaderHidden(sheetId, dimension, i)
+        ) {
+          return i;
+        }
+      }
+    }
+
+    return undefined;
   }
 
   findLastVisibleColRowIndex(

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -421,8 +421,8 @@ export class SelectionStreamProcessor
     }
     const { left, right, top, bottom } = zone;
     const sheetId = this.getters.getActiveSheetId();
-    const refCol = this.getters.findVisibleHeader(sheetId, "COL", range(left, right + 1));
-    const refRow = this.getters.findVisibleHeader(sheetId, "ROW", range(top, bottom + 1));
+    const refCol = this.getters.findVisibleHeader(sheetId, "COL", left, right);
+    const refRow = this.getters.findVisibleHeader(sheetId, "ROW", top, bottom);
     if (refRow === undefined || refCol === undefined) {
       return CommandResult.SelectionOutOfBound;
     }
@@ -530,10 +530,10 @@ export class SelectionStreamProcessor
 
     return {
       col: this.getters.isColHidden(sheetId, anchorCol)
-        ? this.getters.findVisibleHeader(sheetId, "COL", range(left, right + 1)) || anchorCol
+        ? this.getters.findVisibleHeader(sheetId, "COL", left, right) || anchorCol
         : anchorCol,
       row: this.getters.isRowHidden(sheetId, anchorRow)
-        ? this.getters.findVisibleHeader(sheetId, "ROW", range(top, bottom + 1)) || anchorRow
+        ? this.getters.findVisibleHeader(sheetId, "ROW", top, bottom) || anchorRow
         : anchorRow,
     };
   }

--- a/tests/__mocks__/transport_service.ts
+++ b/tests/__mocks__/transport_service.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_REVISION_ID } from "../../src/constants";
+import { deepCopy } from "../../src/helpers";
 import { UID, WorkbookData } from "../../src/types";
 import {
   CollaborationMessage,
@@ -18,7 +19,7 @@ export class MockTransportService implements TransportService<CollaborationMessa
   }
 
   sendMessage(message: CollaborationMessage) {
-    const msg: CollaborationMessage = JSON.parse(JSON.stringify(message));
+    const msg: CollaborationMessage = deepCopy(message);
     switch (msg.type) {
       case "REMOTE_REVISION":
       case "REVISION_UNDONE":
@@ -62,7 +63,7 @@ export class MockTransportService implements TransportService<CollaborationMessa
 
   notifyListeners(message: CollaborationMessage) {
     for (const { callback } of this.listeners) {
-      callback(JSON.parse(JSON.stringify(message)));
+      callback(deepCopy(message));
     }
   }
 

--- a/tests/helpers/format.test.ts
+++ b/tests/helpers/format.test.ts
@@ -19,6 +19,12 @@ describe("formatValue on number", () => {
     expect(formatValue(0.00000000001)).toBe("0");
     expect(formatValue(0.000000000001)).toBe("0");
 
+    expect(formatValue(0.9999999)).toBe("0.9999999");
+    expect(formatValue(0.99999999)).toBe("0.99999999");
+    expect(formatValue(0.999999999)).toBe("0.999999999");
+    expect(formatValue(0.9999999999)).toBe("0.9999999999");
+    expect(formatValue(0.99999999999)).toBe("1");
+
     // @compatibility note: in Google Sheets, the next three tests result in 1234512345
     expect(formatValue(1234512345.1)).toBe("1234512345.1");
     expect(formatValue(1234512345.12)).toBe("1234512345.12");

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -18,7 +18,7 @@ import { exportPrettifiedXlsx, toRangesData } from "./test_helpers/helpers";
 function getExportedExcelData(model: Model): ExcelWorkbookData {
   model.dispatch("EVALUATE_CELLS");
   let data = createEmptyExcelWorkbookData();
-  for (let handler of model.handlers) {
+  for (let handler of model["handlers"]) {
     if (handler instanceof BasePlugin) {
       handler.exportForExcel(data);
     }


### PR DESCRIPTION
## [IMP] header_visibility: improve perfs of `findVisibleHeader`

The way the getter `findVisibleHeader` was implemented as that it received
an argument with all the indexes it need to check to find a visible header.

This means that if we want to get the first visible col of a sheet,
we have to first generate an array with all the indexes of the cols of the
sheet, then looping on this array to find a visible col. This was very
wasteful as :

1) we created an array that needed to be garbage collected after
2) the array contains all the indexes, but most of the time we only
loop on the first few

Changed the arguments of `findVisibleHeader` to receive `from` and `to`
arguments.

Benchmark :
on a sheet 26 cols x 10.000 rows filled with numbers, try to delete the last
column

Before : ~2050ms. Most time taken by :
- Garbage Collection : ~737ms
- range() : ~729ms

After: ~542ms. Most time taken by :
- Garbage Collection : ~124ms
- getRowTallestCellSize() : ~105ms

## [IMP] sheet: move cells methods performance

The methods `moveCellOn*()` in `sheet.ts` did an useless `parseInt()` to
loop through the indexes of an array, slightly decreasing the performance.

For when we really have to parse a string to an int, Number() is also
slightly faster than parseInt().

This saves 20-40ms on a 10.000 rows sheet with 26 columns, when deleting the
first column.

## [IMP] formats: performance of `splitNumber()`

To compute the formatted value of a number, we need to split it into
its integer digits and decimal digits. This was done by the function
`splitNumber()`, which was using Intl.NumberFormat, which handles
everything for us, but is quite slow.

Now convert the number to string using Number.toString(), and handle
the max number of decimal and the rounding by hand. We will still use
Intl.NumberFormat for numbers too big/small, for which Number.toString()
returns an exponential notation.

Rough benchmark :
Sheet 26 cols x 10.000 rows, using a CF on the whole sheet to force the
evaluation of the lazy values.

w/ sheet filled with integers:
old: splitNumber ~299ms
new: splitNumber ~9.5ms

w/ sheet filled with floats:
old: splitNumber ~555ms
new: splitNumber ~30ms

## [IMP] model: store handler arrays

Currently the model create a new array every time `this.handlers` or
`this.coreHandlers` are accessed. That means that
we create new arrays every time we dispatch a command, leading to
quite a bit of garbage collection.

When deleting the first column of a 26 x 1000 sheet filled with numbers,
initializing the arrays saves ~100ms in garbage collection.


Odoo task ID : [3272878](https://www.odoo.com/web#id=3272878&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo