### PR TITLE
[FIX] ColorPicker: Fix checkmark symbol

### DIFF
--- a/demo/main.css
+++ b/demo/main.css
@@ -9,7 +9,8 @@ body {
   height: 100%;
   margin: 0px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Ubuntu,
-    "Noto Sans", Arial, sans-serif !important;
+    "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji" !important;
 }
 .o-spreadsheet {
   width: 100%;

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -18,7 +18,7 @@
             t-if="isSameColor(props.currentColor, color)"
             align="center"
             t-attf-style="color:{{getCheckMarkColor()}}">
-            &#10004;
+            ✓
           </div>
         </div>
       </div>
@@ -44,7 +44,7 @@
             t-if="isSameColor(props.currentColor, color)"
             align="center"
             t-attf-style="color:{{getCheckMarkColor()}}">
-            &#10004;
+            ✓
           </div>
         </div>
       </div>

--- a/tests/components/color_picker.test.ts
+++ b/tests/components/color_picker.test.ts
@@ -142,7 +142,7 @@ describe("Color Picker buttons", () => {
   test("initial standard color", async () => {
     await mountColorPicker({ currentColor: "#45818e" });
     const color = fixture.querySelector("div[data-color='#45818E']") as HTMLElement;
-    expect(color?.textContent).toBe(" ✔ ");
+    expect(color?.textContent).toBe(" ✓ ");
   });
 
   test("initial custom color", async () => {
@@ -150,7 +150,7 @@ describe("Color Picker buttons", () => {
     setStyle(model, "A1", { fillColor: "#123456" });
     await mountColorPicker({ currentColor: "#123456" }, model);
     const color = fixture.querySelector("div[data-color='#123456']") as HTMLElement;
-    expect(color?.textContent).toBe(" ✔ ");
+    expect(color?.textContent).toBe(" ✓ ");
   });
 
   test("wrong initial color", async () => {


### PR DESCRIPTION
The checkmark that we used in the ColorPicker was actually an emoji code, which unfortunately has different rendering aspects accross devices/font families.
This commit replaces the emoji code with the unicode char '✓' which should be more consistent.

Task: 3269724

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo