### PR TITLE
Master allow dispatch UI plugin generic adrm

### DIFF
--- a/doc/extending/command.md
+++ b/doc/extending/command.md
@@ -90,3 +90,15 @@ type LocalRepeatTransform = (
   childCommands: readonly CoreCommand[]
 ) => CoreCommand[] | LocalCommand | undefined;
 ```
+
+## Reserved keywords in commands
+
+Some parameters in command payload are reserved, and should always have the same meaning and type each time they appear in a command. Those are :
+
+- `sheetId` : should be a string that is an id of a valid sheet
+- `col`/`row`: should be numbers describing a valid sheet position
+- `zone` : should be a valid `Zone`
+- `target` : should be a valid array of `Zone`
+- `ranges`: should be a valid array of `RangeData`
+
+These parameters are automatically validated for any commands by an internal `allowDispatch` test. `sheetId` must refer to an existing sheet and other parameters must describe valid positions in the sheet.

--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -330,8 +330,8 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
         this.pasteCell(origin, position, this.operation, clipboardOptions);
         if (shouldPasteCF) {
           this.dispatch("PASTE_CONDITIONAL_FORMAT", {
-            origin: origin.position,
-            target: position,
+            originPosition: origin.position,
+            targetPosition: position,
             operation: this.operation,
           });
         }

--- a/src/model.ts
+++ b/src/model.ts
@@ -174,6 +174,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   uuidGenerator: UuidGenerator;
 
   private readonly handlers: CommandHandler<Command>[] = [];
+  private readonly uiHandlers: CommandHandler<Command>[] = [];
   private readonly coreHandlers: CommandHandler<CoreCommand>[] = [];
 
   constructor(
@@ -236,17 +237,20 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       const plugin = this.setupUiPlugin(Plugin);
       this.statefulUIPlugins.push(plugin);
       this.handlers.push(plugin);
+      this.uiHandlers.push(plugin);
     }
     for (let Plugin of coreViewsPluginRegistry.getAll()) {
       const plugin = this.setupUiPlugin(Plugin);
       this.coreViewsPlugins.push(plugin);
       this.handlers.push(plugin);
+      this.uiHandlers.push(plugin);
       this.coreHandlers.push(plugin);
     }
     for (let Plugin of featurePluginRegistry.getAll()) {
       const plugin = this.setupUiPlugin(Plugin);
       this.featurePlugins.push(plugin);
       this.handlers.push(plugin);
+      this.uiHandlers.push(plugin);
     }
     this.uuidGenerator.setIsFastStrategy(false);
 
@@ -320,7 +324,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.handlers.push(plugin);
   }
 
-  private onRemoteRevisionReceived({ commands }: { commands: CoreCommand[] }) {
+  private onRemoteRevisionReceived({ commands }: { commands: readonly CoreCommand[] }) {
     for (let command of commands) {
       const previousStatus = this.status;
       this.status = Status.RunningCore;
@@ -436,7 +440,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   }
 
   private checkDispatchAllowedLocalCommand(command: LocalCommand): DispatchResult {
-    const results = this.handlers.map((handler) => handler.allowDispatch(command));
+    const results = this.uiHandlers.map((handler) => handler.allowDispatch(command));
     return new DispatchResult(results.flat());
   }
 

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -481,10 +481,10 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     if ("zone" in cmd) {
       zones.push(cmd.zone);
     }
-    if ("target" in cmd && Array.isArray(cmd.target)) {
+    if ("target" in cmd) {
       zones.push(...cmd.target);
     }
-    if ("ranges" in cmd && Array.isArray(cmd.ranges)) {
+    if ("ranges" in cmd) {
       zones.push(
         ...cmd.ranges.map((rangeData) => this.getters.getRangeFromRangeData(rangeData).zone)
       );

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -69,6 +69,8 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "getSheetSize",
     "getSheetZone",
     "getPaneDivisions",
+    "checkZonesExistInSheet",
+    "getCommandZones",
   ] as const;
 
   readonly sheetIdsMapName: Record<string, UID | undefined> = {};
@@ -81,7 +83,11 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   // ---------------------------------------------------------------------------
 
   allowDispatch(cmd: CoreCommand) {
-    const genericChecks = this.chainValidations(this.checkSheetExists, this.checkZones)(cmd);
+    const genericChecks = this.chainValidations(
+      this.checkSheetExists,
+      this.checkZonesAreInSheet
+    )(cmd);
+
     if (genericChecks !== CommandResult.Success) {
       return genericChecks;
     }
@@ -468,6 +474,38 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     return positions(zone)
       .map(({ col, row }) => this.getCell({ sheetId, col, row }))
       .every((cell) => !cell || cell.content === "");
+  }
+
+  getCommandZones(cmd: Command): Zone[] {
+    const zones: Zone[] = [];
+    if ("zone" in cmd) {
+      zones.push(cmd.zone);
+    }
+    if ("target" in cmd && Array.isArray(cmd.target)) {
+      zones.push(...cmd.target);
+    }
+    if ("ranges" in cmd && Array.isArray(cmd.ranges)) {
+      zones.push(
+        ...cmd.ranges.map((rangeData) => this.getters.getRangeFromRangeData(rangeData).zone)
+      );
+    }
+    return zones;
+  }
+
+  /**
+   * Check if zones in the command are well formed and
+   * not outside the sheet.
+   */
+  checkZonesExistInSheet(sheetId: UID, zones: Zone[]): CommandResult {
+    if (!zones.every(isZoneValid)) return CommandResult.InvalidRange;
+
+    if (zones.length) {
+      const sheetZone = this.getSheetZone(sheetId);
+      return zones.every((zone) => isZoneInside(zone, sheetZone))
+        ? CommandResult.Success
+        : CommandResult.TargetOutOfSheet;
+    }
+    return CommandResult.Success;
   }
 
   private updateCellPosition(cmd: UpdateCellPositionCommand) {
@@ -981,15 +1019,11 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     return { rowNumber, colNumber };
   }
 
-  // ----------------------------------------------------
-  //  HIDE / SHOW
-  // ----------------------------------------------------
-
   /**
    * Check that any "sheetId" in the command matches an existing
    * sheet.
    */
-  private checkSheetExists(cmd: Command): CommandResult {
+  private checkSheetExists(cmd: CoreCommand): CommandResult {
     if (cmd.type !== "CREATE_SHEET" && "sheetId" in cmd && this.sheets[cmd.sheetId] === undefined) {
       return CommandResult.InvalidSheetId;
     } else if (cmd.type === "CREATE_SHEET" && this.sheets[cmd.sheetId] !== undefined) {
@@ -1002,27 +1036,8 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
    * Check if zones in the command are well formed and
    * not outside the sheet.
    */
-  private checkZones(cmd: Command): CommandResult {
-    const zones: Zone[] = [];
-    if ("zone" in cmd) {
-      zones.push(cmd.zone);
-    }
-    if ("target" in cmd && Array.isArray(cmd.target)) {
-      zones.push(...cmd.target);
-    }
-    if ("ranges" in cmd && Array.isArray(cmd.ranges)) {
-      zones.push(
-        ...cmd.ranges.map((rangeData) => this.getters.getRangeFromRangeData(rangeData).zone)
-      );
-    }
-    if (!zones.every(isZoneValid)) {
-      return CommandResult.InvalidRange;
-    } else if (zones.length && "sheetId" in cmd) {
-      const sheetZone = this.getSheetZone(cmd.sheetId);
-      return zones.every((zone) => isZoneInside(zone, sheetZone))
-        ? CommandResult.Success
-        : CommandResult.TargetOutOfSheet;
-    }
-    return CommandResult.Success;
+  private checkZonesAreInSheet(cmd: CoreCommand): CommandResult {
+    if (!("sheetId" in cmd)) return CommandResult.Success;
+    return this.checkZonesExistInSheet(cmd.sheetId, this.getCommandZones(cmd));
   }
 }

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -489,6 +489,9 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
         ...cmd.ranges.map((rangeData) => this.getters.getRangeFromRangeData(rangeData).zone)
       );
     }
+    if ("col" in cmd && "row" in cmd) {
+      zones.push({ top: cmd.row, left: cmd.col, bottom: cmd.row, right: cmd.col });
+    }
     return zones;
   }
 

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -64,7 +64,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
         }
         break;
       case "PASTE_CONDITIONAL_FORMAT":
-        this.pasteCf(cmd.origin, cmd.target, cmd.operation);
+        this.pasteCf(cmd.originPosition, cmd.targetPosition, cmd.operation);
         break;
     }
   }

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -53,7 +53,7 @@ export class ClipboardPlugin extends UIPlugin {
   allowDispatch(cmd: LocalCommand): CommandResult {
     switch (cmd.type) {
       case "CUT":
-        const zones = cmd.target || this.getters.getSelectedZones();
+        const zones = cmd.cutTarget || this.getters.getSelectedZones();
         const state = this.getClipboardState(zones, cmd.type);
         return state.isCutAllowed(zones);
       case "PASTE":
@@ -84,7 +84,7 @@ export class ClipboardPlugin extends UIPlugin {
     switch (cmd.type) {
       case "COPY":
       case "CUT":
-        const zones = ("target" in cmd && cmd.target) || this.getters.getSelectedZones();
+        const zones = ("cutTarget" in cmd && cmd.cutTarget) || this.getters.getSelectedZones();
         this.state = this.getClipboardState(zones, cmd.type);
         this.status = "visible";
         break;

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -105,6 +105,7 @@ export class GridSelectionPlugin extends UIPlugin {
     "isSelected",
     "isSingleColSelected",
     "getElementsFromSelection",
+    "tryGetActiveSheetId",
   ] as const;
 
   private gridSelection: {
@@ -339,6 +340,10 @@ export class GridSelectionPlugin extends UIPlugin {
 
   getActiveSheetId(): UID {
     return this.activeSheet.id;
+  }
+
+  tryGetActiveSheetId(): UID | undefined {
+    return this.activeSheet?.id;
   }
 
   getActiveCell(): EvaluatedCell {

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -642,7 +642,7 @@ export class GridSelectionPlugin extends UIPlugin {
     const deltaRow = isBasedBefore && !isCol ? thickness : 0;
 
     this.dispatch("CUT", {
-      target: [
+      cutTarget: [
         {
           left: isCol ? start + deltaCol : 0,
           right: isCol ? end + deltaCol : this.getters.getNumberCols(cmd.sheetId) - 1,

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -499,7 +499,7 @@ export interface CopyCommand {
 export interface CutCommand {
   type: "CUT";
   /** Zones to cut. If none were given, will copy the zones in the selection*/
-  target?: Zone[];
+  cutTarget?: Zone[];
 }
 
 export interface PasteCommand {
@@ -866,8 +866,8 @@ export interface InsertCellCommand {
 
 export interface PasteCFCommand {
   type: "PASTE_CONDITIONAL_FORMAT";
-  origin: CellPosition;
-  target: CellPosition;
+  originPosition: CellPosition;
+  targetPosition: CellPosition;
   operation: "CUT" | "COPY";
 }
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1168,6 +1168,7 @@ export const enum CommandResult {
   EmptySplitSeparator,
   SplitWillOverwriteContent,
   NoSplitSeparatorInSelection,
+  NoActiveSheet,
 }
 
 export interface CommandHandler<T> {

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -146,7 +146,7 @@ describe("Menu Item actions", () => {
   });
 
   test("Edit -> paste_special should be hidden after a CUT ", () => {
-    model.dispatch("CUT", { target: env.model.getters.getSelectedZones() });
+    model.dispatch("CUT", { cutTarget: env.model.getters.getSelectedZones() });
     expect(getNode(["edit", "paste_special"]).isVisible(env)).toBeFalsy();
   });
 

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -3,7 +3,7 @@ import { toZone } from "../src/helpers";
 import { Model, ModelConfig } from "../src/model";
 import { corePluginRegistry, featurePluginRegistry } from "../src/plugins/index";
 import { UIPlugin } from "../src/plugins/ui_plugin";
-import { Command, CoreCommand, coreTypes, DispatchResult } from "../src/types";
+import { Command, CommandTypes, CoreCommand, coreTypes, DispatchResult } from "../src/types";
 import { setupCollaborativeEnv } from "./collaborative/collaborative_helpers";
 import { copy, selectCell, setCellContent } from "./test_helpers/commands_helpers";
 import {
@@ -114,6 +114,20 @@ describe("Model", () => {
     setCellContent(model, "A1", "hello");
     expect(getCellContent(model, "A1")).toBe("hello");
     featurePluginRegistry.remove("myUIPlugin");
+  });
+
+  test("Core plugins allowDispatch don't receive UI commands", () => {
+    const receivedCommands: CommandTypes[] = [];
+    class MyCorePlugin extends CorePlugin {
+      allowDispatch(cmd: CoreCommand): CommandResult {
+        receivedCommands.push(cmd.type);
+        return CommandResult.Success;
+      }
+    }
+    corePluginRegistry.add("myCorePlugin", MyCorePlugin);
+    const model = new Model();
+    model.dispatch("COPY");
+    expect(receivedCommands).not.toContain("COPY");
   });
 
   test("canDispatch method is exposed and works", () => {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -1845,7 +1845,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "B1", "2");
 
-      model.dispatch("CUT", { target: target("A1:B1") });
+      cut(model, "A1:B1");
       addColumns(model, "before", "A", 1);
       model.dispatch("PASTE", { target: [toZone("A2")] });
       expect(getCellContent(model, "B1")).toBe("1");
@@ -1860,7 +1860,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "B1", "2");
 
-      model.dispatch("CUT", { target: target("A1:B1") });
+      cut(model, "A1:B1");
       addColumns(model, "after", "B", 1);
       model.dispatch("PASTE", { target: [toZone("A2")] });
       expect(getCellContent(model, "A1")).toBe("");
@@ -1874,7 +1874,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "B1", "2");
 
-      model.dispatch("CUT", { target: target("A1:B1") });
+      cut(model, "A1:B1");
       addColumns(model, "after", "A", 1);
       model.dispatch("PASTE", { target: [toZone("A2")] });
       expect(getCellContent(model, "A1")).toBe("1");
@@ -1888,7 +1888,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "B1", "2");
 
-      model.dispatch("CUT", { target: target("A1:B1") });
+      cut(model, "A1:B1");
       addColumns(model, "after", "A", 5);
       model.dispatch("PASTE", { target: [toZone("A2")] });
       expect(getCellContent(model, "A1")).toBe("1");
@@ -1902,7 +1902,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "2");
 
-      model.dispatch("CUT", { target: target("A1:A2") });
+      cut(model, "A1:A2");
       addRows(model, "before", 0, 1);
       model.dispatch("PASTE", { target: [toZone("C1")] });
       expect(getCellContent(model, "A2")).toBe("1");
@@ -1917,7 +1917,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "2");
 
-      model.dispatch("CUT", { target: target("A1:A2") });
+      cut(model, "A1:A2");
       addRows(model, "after", 2, 1);
       model.dispatch("PASTE", { target: [toZone("C1")] });
       expect(getCellContent(model, "A1")).toBe("");
@@ -1931,7 +1931,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "2");
 
-      model.dispatch("CUT", { target: target("A1:A2") });
+      cut(model, "A1:A2");
       addRows(model, "after", 0, 1);
       model.dispatch("PASTE", { target: [toZone("C1")] });
       expect(getCellContent(model, "A1")).toBe("1");
@@ -1945,7 +1945,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "2");
 
-      model.dispatch("CUT", { target: target("A1:A2") });
+      cut(model, "A1:A2");
       addRows(model, "after", 0, 5);
       model.dispatch("PASTE", { target: [toZone("C1")] });
       expect(getCellContent(model, "A1")).toBe("1");
@@ -1961,7 +1961,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteColumns(model, ["A"]);
       model.dispatch("PASTE", { target: [toZone("D1")] });
       expect(getCellContent(model, "A2")).toBe("1");
@@ -1975,7 +1975,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteColumns(model, ["D"]);
       model.dispatch("PASTE", { target: [toZone("D1")] });
       expect(getCellContent(model, "B2")).toBe("");
@@ -1989,7 +1989,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteColumns(model, ["C"]);
       model.dispatch("PASTE", { target: [toZone("D1")] });
       expect(getCellContent(model, "B2")).toBe("1");
@@ -2001,7 +2001,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteRows(model, [0]);
       model.dispatch("PASTE", { target: [toZone("D1")] });
       expect(getCellContent(model, "B1")).toBe("1");
@@ -2015,7 +2015,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteRows(model, [3]);
       model.dispatch("PASTE", { target: [toZone("D1")] });
       expect(getCellContent(model, "B2")).toBe("");
@@ -2029,7 +2029,7 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "B3", "2");
 
-      model.dispatch("CUT", { target: target("B2:B3") });
+      cut(model, "B2:B3");
       deleteRows(model, [2]);
       model.dispatch("PASTE", { target: [toZone("D1")] });
       expect(getCellContent(model, "B2")).toBe("1");

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -1,6 +1,7 @@
 import { functionRegistry } from "../../src/functions";
+import { zoneToXc } from "../../src/helpers";
 import { Model } from "../../src/model";
-import { CommandResult } from "../../src/types";
+import { CommandResult, coreTypes, UID } from "../../src/types";
 import {
   activateSheet,
   addCellToSelection,
@@ -26,6 +27,7 @@ import {
   getRangeFormattedValues,
   getRangeValues,
 } from "../test_helpers/getters_helpers";
+import { toRangesData } from "../test_helpers/helpers";
 
 describe("core", () => {
   describe("statistic functions", () => {
@@ -760,6 +762,59 @@ describe("history", () => {
       expect(getRangeValues(model, "Sheet2!B2", sheet2Id)).toEqual([true]);
       expect(getRangeValues(model, "Sheet2!B2", sheet1Id)).toEqual([true]);
       expect(getRangeValues(model, "B2", "invalidSheetId")).toEqual([]);
+    });
+  });
+});
+
+describe("Generic allowDispatch", () => {
+  let model: Model;
+  let sheetId: UID;
+
+  function dispatch(type: string, payload: any) {
+    //@ts-ignore
+    return model.dispatch(type, payload);
+  }
+
+  beforeEach(() => {
+    //@ts-ignore
+    coreTypes.add("MY_CORE_CMD");
+    model = new Model();
+    sheetId = model.getters.getActiveSheetId();
+  });
+
+  afterEach(() => {
+    //@ts-ignore
+    coreTypes.delete("MY_CORE_CMD");
+  });
+
+  describe.each(["MY_CORE_CMD", "My_UI_CMD"])("Generic allowDispatch", (cmdType: string) => {
+    test("Sheet dependant command", () => {
+      const result = dispatch(cmdType, { sheetId: "notARealSheet" });
+      expect(result).toBeCancelledBecause(CommandResult.InvalidSheetId);
+    });
+
+    test("Zone dependant command", () => {
+      const sheetZone = model.getters.getSheetZone(sheetId);
+      const outOfSheetZone = { ...sheetZone, right: sheetZone.right + 10 };
+      const result = dispatch(cmdType, { sheetId, zone: outOfSheetZone });
+      expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
+    });
+
+    test("Target dependant command", () => {
+      const sheetZone = model.getters.getSheetZone(sheetId);
+      const outOfSheetZone = { ...sheetZone, right: sheetZone.right + 10 };
+      const result = dispatch(cmdType, { sheetId, target: [outOfSheetZone] });
+      expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
+    });
+
+    test("Range dependant command", () => {
+      const sheetZone = model.getters.getSheetZone(sheetId);
+      const outOfSheetZoneXc = zoneToXc({ ...sheetZone, right: sheetZone.right + 10 });
+      const result = dispatch(cmdType, {
+        sheetId,
+        ranges: toRangesData(sheetId, outOfSheetZoneXc),
+      });
+      expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
     });
   });
 });

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -816,5 +816,15 @@ describe("Generic allowDispatch", () => {
       });
       expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
     });
+
+    test("Position dependant command", () => {
+      const sheetZone = model.getters.getSheetZone(sheetId);
+      const result = dispatch(cmdType, {
+        sheetId,
+        col: sheetZone.right + 1,
+        row: sheetZone.bottom + 1,
+      });
+      expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
+    });
   });
 });


### PR DESCRIPTION
## [IMP] model: core allowDispatch for local commands:

Before this commit, local commands were going through the allowDispatch
of core plugins. This wasn't a problem per se, but was wrong from an
architecture standpoint, core plugins shouldn't be aware of what's
happening locally. This also made it so that zones/ranges of local commands
missing a sheetId (because it is implicitly the active sheet) weren't
checked.

Now the local commands don't go through the core allowDispatch, and both
plugins SheetPlugin and SheetUIPlugin are in charge of the generics
allowDispatch.

## [IMP] commands: generic check for position

Add a check that the position {col, row} is in the sheet for
position dependant commands.

## [IMP] commands: introduce reserved keywords

Introduce reserved keywords in command payload, that should always
have the same meaning.type. Those are :

- `sheetId`
- `col`/`row`
- `zone`
- `target`
- `ranges`

Changed the few commands that didn't follow this convention.


Odoo task ID : [3276541](https://www.odoo.com/web#id=3276541&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo