### PR TITLE
[FIX] xlsx: Always export value of unsupported formulas

### DIFF
--- a/src/functions/module_operators.ts
+++ b/src/functions/module_operators.ts
@@ -227,7 +227,7 @@ export const POW: AddFunctionDescription = {
       base (number) ${_lt("The number to raise to the exponent power.")}
       exponent (number) ${_lt("The exponent to raise base to.")}
     `),
-  returns: ["BOOLEAN"],
+  returns: ["NUMBER"],
   compute: function (base: ArgValue, exponent: ArgValue): number {
     return POWER.compute(base, exponent);
   },

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -56,12 +56,9 @@ export function addFormula(cell: ExcelCellData): {
   } else {
     // Shouldn't we always output the value then ?
     const value = cell.value;
-    // what if value = 0? Is this condition correct?
-    if (value) {
-      const type = getCellType(value);
-      attrs.push(["t", type]);
-      node = escapeXml/*xml*/ `<v>${value}</v>`;
-    }
+    const type = getCellType(value);
+    attrs.push(["t", type]);
+    node = escapeXml/*xml*/ `<v>${value}</v>`;
     return { attrs, node };
   }
 }

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -10129,6 +10129,13 @@ Object {
                 </v>
             </c>
         </row>
+        <row r=\\"20\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A20\\" s=\\"1\\" t=\\"n\\">
+                <v>
+                    0
+                </v>
+            </c>
+        </row>
     </sheetData>
 </worksheet>",
       "contentType": "sheet",
@@ -12331,6 +12338,155 @@ Object {
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\\" PartName=\\"/xl/worksheets/sheet0.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\\" PartName=\\"/xl/worksheets/sheet1.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\\" PartName=\\"/xl/styles.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\\" PartName=\\"/xl/sharedStrings.xml\\"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\\" Target=\\"xl/workbook.xml\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
+exports[`Test XLSX export formulas Non exportable formulas are exported even with a falsy value 1`] = `
+Object {
+  "files": Array [
+    Object {
+      "content": "<workbook xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <sheets>
+        <sheet name=\\"Sheet1\\" sheetId=\\"1\\" r:id=\\"rId1\\"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    Object {
+      "content": "<worksheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <sheetFormatPr defaultRowHeight=\\"17.25\\" defaultColWidth=\\"13.68\\"/>
+    <cols>
+        <col min=\\"1\\" max=\\"1\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"2\\" max=\\"2\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"3\\" max=\\"3\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"4\\" max=\\"4\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"5\\" max=\\"5\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"6\\" max=\\"6\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"7\\" max=\\"7\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"8\\" max=\\"8\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"9\\" max=\\"9\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"10\\" max=\\"10\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"11\\" max=\\"11\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"12\\" max=\\"12\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"13\\" max=\\"13\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"14\\" max=\\"14\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"15\\" max=\\"15\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"16\\" max=\\"16\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"17\\" max=\\"17\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"18\\" max=\\"18\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"19\\" max=\\"19\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"20\\" max=\\"20\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"21\\" max=\\"21\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"22\\" max=\\"22\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"23\\" max=\\"23\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"24\\" max=\\"24\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"25\\" max=\\"25\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+        <col min=\\"26\\" max=\\"26\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+    </cols>
+    <sheetData>
+        <row r=\\"1\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A1\\" s=\\"1\\" t=\\"n\\">
+                <v>
+                    0
+                </v>
+            </c>
+        </row>
+        <row r=\\"2\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A2\\" s=\\"1\\" t=\\"b\\">
+                <v>
+                    false
+                </v>
+            </c>
+        </row>
+    </sheetData>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    Object {
+      "content": "<styleSheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <numFmts count=\\"0\\">
+    </numFmts>
+    <fonts count=\\"2\\">
+        <font>
+            <sz val=\\"10\\"/>
+            <color rgb=\\"000000\\"/>
+            <name val=\\"Calibri\\"/>
+        </font>
+        <font>
+            <sz val=\\"10\\"/>
+            <color rgb=\\"000000\\"/>
+            <name val=\\"Arial\\"/>
+        </font>
+    </fonts>
+    <fills count=\\"2\\">
+        <fill>
+            <patternFill patternType=\\"none\\"/>
+        </fill>
+        <fill>
+            <patternFill patternType=\\"gray125\\"/>
+        </fill>
+    </fills>
+    <borders count=\\"1\\">
+        <border>
+            <left/>
+            <right/>
+            <top/>
+            <bottom/>
+            <diagonal/>
+        </border>
+    </borders>
+    <cellXfs count=\\"2\\">
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"0\\" borderId=\\"0\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"1\\" borderId=\\"0\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+    </cellXfs>
+    <dxfs count=\\"0\\">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    Object {
+      "content": "<sst xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" count=\\"0\\" uniqueCount=\\"0\\">
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Target=\\"worksheets/sheet0.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\\"/>
+    <Relationship Id=\\"rId2\\" Target=\\"sharedStrings.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\\"/>
+    <Relationship Id=\\"rId3\\" Target=\\"styles.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    Object {
+      "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
+    <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\\" PartName=\\"/xl/worksheets/sheet0.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\\" PartName=\\"/xl/styles.xml\\"/>
     <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\\" PartName=\\"/xl/sharedStrings.xml\\"/>
 </Types>",

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -350,6 +350,7 @@ const allNonExportableFormulasData = {
         A17: { content: "=UPLUS(42)" },
         A18: { content: "=AVERAGE.WEIGHTED(1,1,3,3)" },
         A19: { content: "=JOIN(1,2,3)" },
+        A20: { content: "=MULTIPLY(42,0)" },
       },
     },
   ],
@@ -615,6 +616,13 @@ describe("Test XLSX export", () => {
 
     test("All non-exportable formulas", async () => {
       const model = new Model(allNonExportableFormulasData);
+      expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
+    });
+
+    test("Non exportable formulas are exported even with a falsy value", async () => {
+      const model = new Model({
+        sheets: [{ cells: { A1: { content: "=MULTIPLY(100,0)" }, A2: { content: "=EQ(2,4)" } } }],
+      });
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
 


### PR DESCRIPTION
when exporting a spreadsheet to xlsx, we only export the value of cells containing a formula that does not exist in Excel. Unfortunately, we would completely skip these cells when their value was falsy.

Task: 3276929

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo