### PR TITLE
[FIX] menu: separator for last visible item

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -139,6 +139,9 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
         menuItemsAndSeparators.push("separator");
       }
     }
+    if (menuItemsAndSeparators[menuItemsAndSeparators.length - 1] === "separator") {
+      menuItemsAndSeparators.pop();
+    }
     if (menuItemsAndSeparators.length === 1 && menuItemsAndSeparators[0] === "separator") {
       return [];
     }

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -1,5 +1,5 @@
 import { Component, xml } from "@odoo/owl";
-import { Action, createActions } from "../../src/actions/action";
+import { Action, ActionSpec, createActions } from "../../src/actions/action";
 import { Menu } from "../../src/components/menu/menu";
 import {
   MENU_ITEM_HEIGHT,
@@ -861,5 +861,67 @@ describe("Context menu react to grid size changes", () => {
     menus = fixture.querySelectorAll(".o-menu");
     expect(menus[0].parentElement?.style.left).toBe(`${500 - MENU_WIDTH}px`);
     expect(menus[1]).toBeFalsy();
+  });
+});
+
+describe("Context menu separator", () => {
+  function getSimpleMenuItem(
+    name: string,
+    options?: {
+      hidden?: boolean;
+      separator?: boolean;
+    }
+  ): ActionSpec {
+    return {
+      id: name,
+      name,
+      isVisible: () => !options?.hidden,
+      separator: options?.separator,
+    };
+  }
+
+  test("Separators are displayed", async () => {
+    const menuItems = createActions([
+      getSimpleMenuItem("1", { separator: true }),
+      getSimpleMenuItem("2"),
+    ]);
+
+    await renderContextMenu(0, 0, { menuItems });
+    expect(fixture.querySelector(".o-menu")?.children[1].classList).toContain("o-separator");
+    expect(fixture.querySelectorAll(".o-menu .o-separator").length).toBe(1);
+  });
+
+  test("Separators of hidden items are displayed", async () => {
+    const menuItems = createActions([
+      getSimpleMenuItem("1"),
+      getSimpleMenuItem("2", { separator: true, hidden: true }),
+      getSimpleMenuItem("3"),
+    ]);
+
+    await renderContextMenu(0, 0, { menuItems });
+    expect(fixture.querySelector(".o-menu")?.children[1].classList).toContain("o-separator");
+    expect(fixture.querySelectorAll(".o-menu .o-separator").length).toBe(1);
+  });
+
+  test("No separator for empty menu", async () => {
+    const menuItems = createActions([getSimpleMenuItem("1", { separator: true, hidden: true })]);
+    await renderContextMenu(0, 0, { menuItems });
+    expect(fixture.querySelectorAll(".o-menu .o-separator").length).toBe(0);
+  });
+
+  test("No separator for last menu item in menu", async () => {
+    const menuItems = createActions([getSimpleMenuItem("1", { separator: true })]);
+    await renderContextMenu(0, 0, { menuItems });
+    expect(fixture.querySelectorAll(".o-menu .o-separator").length).toBe(0);
+  });
+
+  test("No separator for last visible menu item menu", async () => {
+    const menuItems = createActions([
+      getSimpleMenuItem("1", { separator: true }),
+      getSimpleMenuItem("2", { hidden: true }),
+    ]);
+
+    await renderContextMenu(0, 0, { menuItems });
+    expect(fixture.querySelectorAll(".o-menu .o-separator").length).toBe(0);
   });
 });


### PR DESCRIPTION
## Description

If the last item of a menu contained a separator,
the separator shouldn't be displayed. But it
was displayed anyway if there were only invisible
menu items after the separator.

Odoo task ID : [3276939](https://www.odoo.com/web#id=3276939&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo