### PR TITLE
[FIX] clipboard: Do not update viewport on `paste`

### DIFF
--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -281,7 +281,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
     if (height > 1 || width > 1 || isCutOperation) {
       const zones = this.pastedZones(target, width, height);
       const newZone = isCutOperation ? zones[0] : union(...zones);
-      this.selection.selectZone({ cell: { col, row }, zone: newZone });
+      this.selection.selectZone({ cell: { col, row }, zone: newZone }, { scrollIntoView: false });
     }
   }
 

--- a/src/helpers/clipboard/clipboard_os_state.ts
+++ b/src/helpers/clipboard/clipboard_os_state.ts
@@ -59,7 +59,10 @@ export class ClipboardOsState extends ClipboardCellsAbstractState {
       right: activeCol + numberOfCols - 1,
       bottom: activeRow + numberOfRows - 1,
     };
-    this.selection.selectZone({ cell: { col: activeCol, row: activeRow }, zone });
+    this.selection.selectZone(
+      { cell: { col: activeCol, row: activeRow }, zone },
+      { scrollIntoView: false }
+    );
   }
 
   getClipboardContent(): Record<string, string> {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -26,6 +26,7 @@ import {
   setCellFormat,
   setSelection,
   setStyle,
+  setViewportOffset,
   setZoneBorders,
   undo,
 } from "../test_helpers/commands_helpers";
@@ -556,6 +557,13 @@ describe("clipboard", () => {
     expect(model.getters.getMerges(sheetId).map(zoneToXc)).toEqual(["B2:C3"]);
   });
 
+  test("pasting from OS will not change the viewport", () => {
+    const model = new Model();
+    const viewport = model.getters.getActiveMainViewport();
+    pasteFromOSClipboard(model, "C60", "a\t1\nb\t2");
+    expect(model.getters.getActiveMainViewport()).toEqual(viewport);
+  });
+
   test("pasting numbers from windows clipboard => interpreted as number", () => {
     const model = new Model();
     pasteFromOSClipboard(model, "C1", "1\r\n2\r\n3");
@@ -598,6 +606,18 @@ describe("clipboard", () => {
     expect(getCellContent(model, "E2")).toBe("a2");
     expect(getCellContent(model, "F1")).toBe("c1");
     expect(getCellContent(model, "F2")).toBe("c2");
+  });
+
+  test("Viewport won't move after pasting", () => {
+    const model = new Model();
+    copy(model, "A1:B2");
+
+    setSelection(model, ["C60:D70"]);
+    setViewportOffset(model, 0, 0);
+    const viewport = model.getters.getActiveMainViewport();
+
+    paste(model, "C60:D70");
+    expect(model.getters.getActiveMainViewport()).toEqual(viewport);
   });
 
   describe("copy/paste a zone in a larger selection will duplicate the zone on the selection as long as it does not exceed it", () => {


### PR DESCRIPTION
## Description:

This PR fixes the problem that when pasting, the viewport will move if the end of pasted area is not in the current viewport. This problem is especially obvious when pasting a full col/row into a cell. After fixing, the viewport will not move, so it will stay at the location before pasting.

Odoo task ID : [3271366](https://www.odoo.com/web#id=3271366&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo