### PR TITLE
[IMP] xml_bundle: make bundling xml templates sync

### DIFF
--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -9,8 +9,8 @@ import "./resize_observer.mock";
 
 export let OWL_TEMPLATES: Document;
 
-beforeAll(async () => {
-  OWL_TEMPLATES = await getParsedOwlTemplateBundle();
+beforeAll(() => {
+  OWL_TEMPLATES = getParsedOwlTemplateBundle();
   setDefaultSheetViewSize(1000);
 });
 

--- a/tools/bundle_xml/bundle_xml_templates.js
+++ b/tools/bundle_xml/bundle_xml_templates.js
@@ -7,8 +7,8 @@ const config = require("../../package.json");
 /**
  * Returns a bundle of all the xml templates, as a parsed xml Document
  */
-async function getParsedOwlTemplateBundle() {
-  const xml = await getOwlTemplatesBundle();
+function getParsedOwlTemplateBundle() {
+  const xml = getOwlTemplatesBundle();
   const parser = new DOMParser();
   const doc = parser.parseFromString(xml, "text/xml");
   return doc;
@@ -19,21 +19,21 @@ async function getParsedOwlTemplateBundle() {
  *
  * @param {boolean} removeRootTags : remove the unnecessary <templates> root tags for export to Odoo. Slightly slower.
  */
-async function getOwlTemplatesBundle(removeRootTags = false) {
+function getOwlTemplatesBundle(removeRootTags = false) {
   const srcPath = path.join(__dirname, "../../src");
-  const files = await getXmlTemplatesFiles(srcPath);
-  const templateBundle = await createOwlTemplateBundle(files, removeRootTags);
+  const files = getXmlTemplatesFiles(srcPath);
+  const templateBundle = createOwlTemplateBundle(files, removeRootTags);
   return templateBundle;
 }
 
-async function getXmlTemplatesFiles(dir) {
+function getXmlTemplatesFiles(dir) {
   let xmls = [];
-  const files = await fs.promises.readdir(dir);
-  const filesStats = await Promise.all(files.map((file) => fs.promises.stat(dir + "/" + file)));
+  const files = fs.readdirSync(dir);
+  const filesStats = files.map((file) => fs.statSync(dir + "/" + file));
   for (let i in files) {
     const name = dir + "/" + files[i];
     if (filesStats[i].isDirectory()) {
-      xmls = xmls.concat(await getXmlTemplatesFiles(name));
+      xmls = xmls.concat(getXmlTemplatesFiles(name));
     } else {
       if (name.endsWith(".xml")) {
         xmls.push(name);
@@ -43,8 +43,8 @@ async function getXmlTemplatesFiles(dir) {
   return xmls;
 }
 
-async function createOwlTemplateBundle(files, removeRootTags) {
-  const xmls = await Promise.all(files.map((file) => fs.promises.readFile(file, "utf8")));
+function createOwlTemplateBundle(files, removeRootTags) {
+  const xmls = files.map((file) => fs.readFileSync(file, "utf8"));
   let xml = xmls.join("\n");
   // individual xml files need a root tag but we can remove them in the bundle
   if (removeRootTags) {


### PR DESCRIPTION
Change the methods of `bundle_xml_templates.js` to make them synchronous. This should fix the issue of timeout when launching the tests.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo