### PR TITLE
[FIX] SelectionInputPlugin: prevent multiple range in 'singleRange' i…

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -149,6 +149,10 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     this.previousRanges = ranges;
   }
 
+  private extractRanges(value: string): string {
+    return this.props.hasSingleRange ? value.split(",")[0] : value;
+  }
+
   focus(rangeId: string) {
     this.state.isMissing = false;
     this.env.model.dispatch("FOCUS_RANGE", {
@@ -169,16 +173,17 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
 
   onInputChanged(rangeId: string, ev: InputEvent) {
     const target = ev.target as HTMLInputElement;
+    const value = this.extractRanges(target.value);
     this.env.model.dispatch("CHANGE_RANGE", {
       id: this.id,
       rangeId,
-      value: target.value,
+      value,
     });
     target.blur();
     this.triggerChange();
   }
 
-  disable() {
+  confirm() {
     this.env.model.dispatch("UNFOCUS_SELECTION_INPUT");
     const ranges = this.env.model.getters.getSelectionInputValue(this.id);
     if (this.props.required && ranges.length === 0) {

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -50,6 +50,12 @@ css/* scss */ `
         height: 25px;
       }
     }
+    /** Make the character a bit bigger
+    compared to its neighbor INPUT box  */
+    .o-remove-selection {
+      font-weight: bold;
+      font-size: calc(100% + 4px);
+    }
   }
 `;
 

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -25,7 +25,7 @@
           class="o-btn o-remove-selection"
           t-if="ranges.length > 1"
           t-on-click="() => this.removeInput(range.id)">
-          ✖
+          ✕
         </button>
       </div>
 

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -33,7 +33,7 @@
         <button class="o-btn-action o-add-selection" t-if="canAddRange" t-on-click="addEmptyInput">
           Add range
         </button>
-        <button class="o-btn-action o-selection-ok" t-if="hasFocus" t-on-click="disable">
+        <button class="o-btn-action o-selection-ok" t-if="hasFocus" t-on-click="confirm">
           Confirm
         </button>
       </div>

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -28,7 +28,6 @@ css/* scss */ `
         color: dimgrey;
       }
       .o-sidePanelClose {
-        font-size: 1.5rem;
         padding: 5px 10px;
         cursor: pointer;
         &:hover {

--- a/src/components/side_panel/side_panel/side_panel.xml
+++ b/src/components/side_panel/side_panel/side_panel.xml
@@ -3,7 +3,7 @@
     <div class="o-sidePanel">
       <div class="o-sidePanelHeader">
         <div class="o-sidePanelTitle" t-esc="getTitle()"/>
-        <div class="o-sidePanelClose" t-on-click="() => this.props.onCloseSidePanel()">×</div>
+        <div class="o-sidePanelClose" t-on-click="() => this.props.onCloseSidePanel()">✕</div>
       </div>
       <div class="o-sidePanelBody">
         <t

--- a/src/plugins/ui/selection_input.ts
+++ b/src/plugins/ui/selection_input.ts
@@ -56,6 +56,11 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
     initialRanges: string[],
     private readonly inputHasSingleRange: boolean
   ) {
+    if (inputHasSingleRange && initialRanges.length > 1) {
+      throw new Error(
+        "Input with a single range cannot be instantiated with several range references."
+      );
+    }
     super(getters, state, dispatch, config, selection);
     this.insertNewRange(0, initialRanges);
     this.activeSheet = this.getters.getActiveSheetId();
@@ -73,6 +78,11 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
     switch (cmd.type) {
       case "ADD_EMPTY_RANGE":
         if (this.inputHasSingleRange && this.ranges.length === 1) {
+          return CommandResult.MaximumRangesReached;
+        }
+        break;
+      case "CHANGE_RANGE":
+        if (this.inputHasSingleRange && cmd.value.split(",").length > 1) {
           return CommandResult.MaximumRangesReached;
         }
         break;

--- a/tests/components/__snapshots__/conditional_formatting.test.ts.snap
+++ b/tests/components/__snapshots__/conditional_formatting.test.ts.snap
@@ -15,7 +15,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
     <div
       class="o-sidePanelClose"
     >
-      ×
+      ✕
     </div>
   </div>
   <div

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -339,4 +339,10 @@ describe("Selection Input", () => {
     input = fixture.querySelector(".o-selection-input input") as HTMLInputElement;
     expect(input.value).toBe("A2");
   });
+
+  test("In 'isSingleRange' mode, capture the first part of a multi range input", async () => {
+    const { model, id } = await createSelectionInput({ hasSingleRange: true });
+    await writeInput(0, "C2,A1");
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("C2");
+  });
 });

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -156,6 +156,14 @@ describe("selection input plugin", () => {
     );
   });
 
+  test("Cannot add multiple ranges to a 'singleRange' input", () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, hasSingleRange: true });
+    expect(model.getters.getSelectionInput(id)).toHaveLength(1);
+    expect(
+      model.dispatch("CHANGE_RANGE", { id, rangeId: idOfRange(model, id, 0), value: "A3,A1" })
+    ).toBeCancelledBecause(CommandResult.MaximumRangesReached);
+  });
+
   test("add an empty range", () => {
     model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
     expect(model.getters.getSelectionInput(id).length).toBe(1);


### PR DESCRIPTION
…nput

The SelectionInputPlugin only partially prevent the addition of multiple ranges while in `inputHasSingleRange` mode. It would handle the command `ADD_EMPTY_RANGE` but unfortunately, we can also add multiple ranges by providing a range string composed of several xc joined by a comma.

This commit ensures that we reject such ranges through the command `CHANGE_RANGE` and also at the selectionInput creation.

Task: 3237798

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3237798](https://www.odoo.com/web#id=3237798&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo