### PR TITLE
[FIX] chart: don't close side panel with invalid definition

### DIFF
--- a/tests/components/chart_side_panel_test.ts
+++ b/tests/components/chart_side_panel_test.ts
@@ -74,6 +74,14 @@ describe("Chart sidepanel component", () => {
     parent.unmount();
   });
 
+  test("hit create button with invalid definition", async () => {
+    const { parent } = await createChartPanel();
+    expect(fixture.querySelector(".o-sidePanelButton.o-error")).toBeNull();
+    await simulateClick(".o-sidePanelButton");
+    expect(fixture.querySelector(".o-sidePanelButton.o-error")).not.toBeNull();
+    parent.unmount();
+  });
+
   // Skipped because updating of a chart is not yet supported
   test.skip("update chart", async () => {
     const model = new Model();


### PR DESCRIPTION
- click Insert > Chart menu: the side panel opens
- hit the "Create chart" button => the side panel closes but nothing happens

The definition is wrong, so the chart isn't created. With this commit, the user has a little feedback that something happened but there's an error

Reported by PTH

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo