### PR TITLE
[REF] collaborative: move getters to plugins

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -211,9 +211,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.getters = {
       isReadonly: () => this.config.mode === "readonly" || this.config.mode === "dashboard",
       isDashboard: () => this.config.mode === "dashboard",
-      getClient: this.session.getClient.bind(this.session),
-      getConnectedClients: this.session.getConnectedClients.bind(this.session),
-      isFullySynchronized: this.session.isFullySynchronized.bind(this.session),
     } as Getters;
 
     this.uuidGenerator.setIsFastStrategy(true);

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -25,13 +25,13 @@ import {
   AutofillPlugin,
   AutomaticSumPlugin,
   CellPopoverPlugin,
+  CollaborativePlugin,
   FindAndReplacePlugin,
   FormatPlugin,
   HeaderVisibilityUIPlugin,
   HighlightPlugin,
   RendererPlugin,
   SelectionInputsManagerPlugin,
-  SelectionMultiUserPlugin,
   SheetUIPlugin,
   SortPlugin,
   UIOptionsPlugin,
@@ -67,7 +67,7 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("automatic_sum", AutomaticSumPlugin)
   .add("format", FormatPlugin)
   .add("cell_popovers", CellPopoverPlugin)
-  .add("selection_multiuser", SelectionMultiUserPlugin)
+  .add("collaborative", CollaborativePlugin)
   .add("history", HistoryPlugin);
 
 // Plugins which have a state, but which should not be shared in collaborative

--- a/src/plugins/ui_feature/collaborative.ts
+++ b/src/plugins/ui_feature/collaborative.ts
@@ -1,7 +1,7 @@
 import { ClientDisconnectedError } from "../../collaborative/session";
 import { DEFAULT_FONT, DEFAULT_FONT_SIZE } from "../../constants";
 import { Client, ClientPosition, Color, GridRenderingContext, LAYERS, UID } from "../../types";
-import { UIPlugin } from "../ui_plugin";
+import { UIPlugin, UIPluginConfig } from "../ui_plugin";
 
 function randomChoice(arr: string[]): string {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -26,11 +26,22 @@ interface ClientToDisplay extends Required<Client> {
   color: Color;
 }
 
-export class SelectionMultiUserPlugin extends UIPlugin {
-  static getters = ["getClientsToDisplay"] as const;
+export class CollaborativePlugin extends UIPlugin {
+  static getters = [
+    "getClientsToDisplay",
+    "getClient",
+    "getConnectedClients",
+    "isFullySynchronized",
+  ] as const;
   static layers = [LAYERS.Selection];
   private availableColors = new Set(colors);
   private colors: Record<UID, Color> = {};
+  private session: UIPluginConfig["session"];
+
+  constructor(config: UIPluginConfig) {
+    super(config);
+    this.session = config.session;
+  }
 
   private isPositionValid(position: ClientPosition): boolean {
     return (
@@ -46,6 +57,18 @@ export class SelectionMultiUserPlugin extends UIPlugin {
     const color = randomChoice([...this.availableColors.values()]);
     this.availableColors.delete(color);
     return color;
+  }
+
+  getClient() {
+    return this.session.getClient();
+  }
+
+  getConnectedClients() {
+    return this.session.getConnectedClients();
+  }
+
+  isFullySynchronized() {
+    return this.session.isFullySynchronized();
   }
 
   /**

--- a/src/plugins/ui_feature/index.ts
+++ b/src/plugins/ui_feature/index.ts
@@ -1,6 +1,7 @@
 export * from "./autofill";
 export * from "./automatic_sum";
 export * from "./cell_popovers";
+export * from "./collaborative";
 export * from "./find_and_replace";
 export * from "./format";
 export * from "./header_visibility_ui";
@@ -8,7 +9,6 @@ export * from "./highlight";
 export * from "./renderer";
 export * from "./selection_input";
 export * from "./selection_inputs_manager";
-export * from "./selection_multiuser";
 export * from "./sort";
 export * from "./ui_options";
 export * from "./ui_sheet";

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -1,4 +1,3 @@
-import { Session } from "../collaborative/session";
 import { BordersPlugin } from "../plugins/core/borders";
 import { CellPlugin } from "../plugins/core/cell";
 import { ChartPlugin } from "../plugins/core/chart";
@@ -20,13 +19,13 @@ import { SheetViewPlugin } from "../plugins/ui_core_views/sheetview";
 import { AutofillPlugin } from "../plugins/ui_feature/autofill";
 import { AutomaticSumPlugin } from "../plugins/ui_feature/automatic_sum";
 import { CellPopoverPlugin } from "../plugins/ui_feature/cell_popovers";
+import { CollaborativePlugin } from "../plugins/ui_feature/collaborative";
 import { FindAndReplacePlugin } from "../plugins/ui_feature/find_and_replace";
 import { HeaderVisibilityUIPlugin } from "../plugins/ui_feature/header_visibility_ui";
 import { HighlightPlugin } from "../plugins/ui_feature/highlight";
 import { HistoryPlugin } from "../plugins/ui_feature/local_history";
 import { RendererPlugin } from "../plugins/ui_feature/renderer";
 import { SelectionInputsManagerPlugin } from "../plugins/ui_feature/selection_inputs_manager";
-import { SelectionMultiUserPlugin } from "../plugins/ui_feature/selection_multiuser";
 import { SortPlugin } from "../plugins/ui_feature/sort";
 import { UIOptionsPlugin } from "../plugins/ui_feature/ui_options";
 import { SheetUIPlugin } from "../plugins/ui_feature/ui_sheet";
@@ -126,19 +125,11 @@ type SelectionInputGetters = Pick<
   SelectionInputsManagerPlugin,
   GetterNames<typeof SelectionInputsManagerPlugin>
 >;
-type SelectionMultiUserGetters = Pick<
-  SelectionMultiUserPlugin,
-  GetterNames<typeof SelectionMultiUserPlugin>
->;
+type CollaborativeGetters = Pick<CollaborativePlugin, GetterNames<typeof CollaborativePlugin>>;
 type SortGetters = Pick<SortPlugin, GetterNames<typeof SortPlugin>>;
 type UIOptionsGetters = Pick<UIOptionsPlugin, GetterNames<typeof UIOptionsPlugin>>;
 type SheetUIGetters = Pick<SheetUIPlugin, GetterNames<typeof SheetUIPlugin>>;
 type ViewportGetters = Pick<SheetViewPlugin, GetterNames<typeof SheetViewPlugin>>;
-type SessionGetters = {
-  getClient: Session["getClient"];
-  getConnectedClients: Session["getConnectedClients"];
-  isFullySynchronized: Session["isFullySynchronized"];
-};
 type CellPopoverPluginGetters = Pick<CellPopoverPlugin, GetterNames<typeof CellPopoverPlugin>>;
 type FilterEvaluationGetters = Pick<
   FilterEvaluationPlugin,
@@ -150,7 +141,6 @@ export type Getters = {
   isDashboard: () => boolean;
 } & LocalHistoryGetters &
   CoreGetters &
-  SessionGetters &
   AutofillGetters &
   AutomaticSumGetters &
   ClipboardGetters &
@@ -164,7 +154,7 @@ export type Getters = {
   RendererGetters &
   SelectionGetters &
   SelectionInputGetters &
-  SelectionMultiUserGetters &
+  CollaborativeGetters &
   SortGetters &
   UIOptionsGetters &
   SheetUIGetters &


### PR DESCRIPTION
Since 5d6d39f, the session is available in the plugin config. This allows to clean part of the model by moving the collaborative getters to a plugin, which is the standard place for getters.

The `SelectionMultiUserPlugin` is renamed since it no longer only deals with selection.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo