### PR TITLE
[FIX] lookup: horizontal search in LOOKUP function

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -170,7 +170,12 @@ export const LOOKUP: AddFunctionDescription = {
       rangeLength,
       getElement
     );
-    assertAvailable(searchArray[0][index], searchKey);
+
+    if (index === -1) assertAvailable(undefined, searchKey);
+
+    verticalSearch
+      ? assertAvailable(searchArray[0][index], searchKey)
+      : assertAvailable(searchArray[index][nbRow - 1], searchKey);
 
     if (resultRange === undefined) {
       return (

--- a/tests/functions/module_lookup.test.ts
+++ b/tests/functions/module_lookup.test.ts
@@ -102,6 +102,40 @@ describe("LOOKUP formula", () => {
   test("Accents and uppercase are ignored", () => {
     expect(evaluateCell("A1", { A1: '=LOOKUP("epee", B1)', B1: "Épée" })).toBe("Épée");
   });
+
+  test("Horizontal search in LOOKUP function with and without result range", () => {
+    const grid = {
+      A1: "1",
+      B1: "2",
+      C1: "3",
+      A2: "4",
+      B2: "5",
+      C2: "6",
+      D1: "=LOOKUP(C1, A1:C1)",
+      D2: "=LOOKUP(3, A1:C1)",
+      D3: "=LOOKUP(C1, A1:C1, A2:C2)",
+    };
+
+    const evaluatedGrid = evaluateGrid(grid);
+    expect(evaluatedGrid.D1).toBe(3);
+    expect(evaluatedGrid.D2).toBe(3);
+    expect(evaluatedGrid.D3).toBe(6);
+  });
+
+  test("Horizontal search in LOOKUP function without result range in multiple rows", () => {
+    const grid = {
+      A1: "1",
+      B1: "2",
+      C1: "3",
+      A2: "A",
+      B2: "B",
+      C2: "C",
+      D1: "=LOOKUP(3, A1:C2)",
+    };
+
+    const evaluatedGrid = evaluateGrid(grid);
+    expect(evaluatedGrid.D1).toBe("C");
+  });
 });
 
 describe("MATCH formula", () => {


### PR DESCRIPTION
## Description:

Previously, the `=LOOKUP` function did not work properly when performing a
horizontal search, as it would always pass `searchArray[0][index]` to the
`assertAvailable` function parameter.

To resolve this issue, we added a check to determine whether it is a horizontal
or vertical search, and passed the appropriate parameter to the `assertAvailable`
function accordingly.

Odoo task ID : [3277145](https://www.odoo.com/web#id=3277145&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo