### PR TITLE
[IMP] tests: speed up menu items tests

### DIFF
--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -22,9 +22,11 @@ import {
 } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
 import {
+  doAction,
   mountSpreadsheet,
   nextTick,
   restoreDefaultFunctions,
+  spyDispatch,
   startGridComposition,
   typeInComposerGrid,
   typeInComposerTopBar,
@@ -236,6 +238,19 @@ describe("Simple Spreadsheet Component", () => {
     await simulateClick(".o-topbar-topleft .o-topbar-menu");
     expect(parent.model.getters.getEditionMode()).toBe("inactive");
     expect(fixture.querySelectorAll(".o-composer-assistant")).toHaveLength(0);
+  });
+
+  test("Insert a function properly sets the edition", async () => {
+    ({ model, parent, fixture, env } = await mountSpreadsheet());
+    const dispatch = spyDispatch(parent);
+    doAction(["insert", "insert_function", "insert_function_sum"], env);
+    expect(dispatch).toHaveBeenCalledWith("START_EDITION", {
+      text: "=SUM(",
+    });
+    doAction(["insert", "insert_function", "insert_function_sum"], env);
+    expect(dispatch).toHaveBeenCalledWith("SET_CURRENT_CONTENT", {
+      content: "=SUM(",
+    });
   });
 });
 


### PR DESCRIPTION
the test of the menu item actions were mounting a spreadsheet but they only require a spreadsheet env to be tested.

```bash
time npm run test -- menu_items_registry.test
```
before: 13 seconds
after: 5 seconds

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo