### PR TITLE
[FIX] xlsx: export computed format

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -253,6 +253,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
         const exportedCellData = sheet.cells[xc]!;
         exportedCellData.value = cell.evaluated.value;
         exportedCellData.isFormula = cell.isFormula();
+        if (cell.format !== cell.evaluated.format) {
+          exportedCellData.computedFormat = cell.evaluated.format;
+        }
       }
     }
   }

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -66,6 +66,7 @@ export interface ExcelWorkbookData extends WorkbookData {
 export interface ExcelCellData extends CellData {
   value: CellValue;
   isFormula: Boolean;
+  computedFormat?: Format;
 }
 export interface ExcelSheetData extends Omit<SheetData, "figureTables"> {
   cells: { [key: string]: ExcelCellData | undefined };

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -13229,6 +13229,13 @@ Object {
                 </v>
             </c>
         </row>
+        <row r=\\"21\\" ht=\\"17.25\\" customHeight=\\"1\\" hidden=\\"0\\">
+            <c r=\\"A21\\" s=\\"2\\" t=\\"n\\">
+                <v>
+                    1000
+                </v>
+            </c>
+        </row>
     </sheetData>
 </worksheet>",
       "contentType": "sheet",
@@ -13236,7 +13243,8 @@ Object {
     },
     Object {
       "content": "<styleSheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
-    <numFmts count=\\"0\\">
+    <numFmts count=\\"1\\">
+        <numFmt numFmtId=\\"164\\" formatCode=\\"#,##0,[$k]\\"/>
     </numFmts>
     <fonts count=\\"2\\">
         <font>
@@ -13267,11 +13275,14 @@ Object {
             <diagonal/>
         </border>
     </borders>
-    <cellXfs count=\\"2\\">
+    <cellXfs count=\\"3\\">
         <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"0\\" borderId=\\"0\\">
             <alignment vertical=\\"center\\"/>
         </xf>
         <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"1\\" borderId=\\"0\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+        <xf numFmtId=\\"164\\" fillId=\\"0\\" fontId=\\"1\\" borderId=\\"0\\">
             <alignment vertical=\\"center\\"/>
         </xf>
     </cellXfs>

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -379,6 +379,7 @@ const allNonExportableFormulasData = {
         A18: { content: "=AVERAGE.WEIGHTED(1,1,3,3)" },
         A19: { content: "=JOIN(1,2,3)" },
         A20: { content: "=MULTIPLY(42,0)" },
+        A21: { content: '=FORMAT.LARGE.NUMBER(1000, "k")' },
       },
     },
   ],


### PR DESCRIPTION


## Description:

Given a formula which is not exported to excel, we currently only export its value but not its computed format.

Odoo opw- : [3283235](https://www.odoo.com/web#id=3283235&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo