### PR TITLE
[FIX] demo: fix topbar file menu

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -77,6 +77,7 @@ class Demo extends Component {
     topbarMenuRegistry.addChild("readonly", ["file"], {
       name: "Open in read-only",
       sequence: 11,
+      isVisible: () => this.model.config.mode !== "readonly",
       execute: () => this.model.updateMode("readonly"),
     });
 
@@ -84,6 +85,7 @@ class Demo extends Component {
       name: "Open in dashboard",
       sequence: 12,
       isReadonlyAllowed: true,
+      isVisible: () => this.model.config.mode !== "dashboard",
       execute: () => this.model.updateMode("dashboard"),
     });
 
@@ -91,12 +93,14 @@ class Demo extends Component {
       name: "Open with write access",
       sequence: 13,
       isReadonlyAllowed: true,
+      isVisible: () => this.model.config.mode !== "normal",
       execute: () => this.model.updateMode("normal"),
     });
-    topbarMenuRegistry.addChild("read_write", ["file"], {
+
+    topbarMenuRegistry.addChild("display_header", ["file"], {
       name: () => (this.state.displayHeader ? "Hide header" : "Show header"),
       isReadonlyAllowed: true,
-      action: () => (this.state.displayHeader = !this.state.displayHeader),
+      execute: () => (this.state.displayHeader = !this.state.displayHeader),
     });
 
     topbarMenuRegistry.add("notify", {


### PR DESCRIPTION
## Description

Remove duplicate menu item id "read_write".
Only display "Open in readonly"/"Open with write access" if we're not already in this mode.

Odoo task ID : [3290927](https://www.odoo.com/web#id=3290927&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo