### PR TITLE
[IMP] tsconfig: allow es2022

### DIFF
--- a/src/history/selective_history.ts
+++ b/src/history/selective_history.ts
@@ -5,7 +5,7 @@ import { OperationSequence } from "./operation_sequence";
 import { Tree } from "./tree";
 
 export class SelectiveHistory<T = unknown> {
-  private HEAD_BRANCH: Branch<T> = new Branch<T>(this.buildTransformation);
+  private HEAD_BRANCH: Branch<T>;
   private HEAD_OPERATION: Operation<T>;
   private tree: Tree<T>;
 
@@ -36,6 +36,7 @@ export class SelectiveHistory<T = unknown> {
     private buildEmpty: (id: UID) => T,
     private readonly buildTransformation: TransformationFactory<T>
   ) {
+    this.HEAD_BRANCH = new Branch<T>(this.buildTransformation);
     this.tree = new Tree(buildTransformation, this.HEAD_BRANCH);
     const initial = new Operation(initialOperationId, buildEmpty(initialOperationId));
     this.tree.insertOperationLast(this.HEAD_BRANCH, initial);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitThis": true,
     "moduleResolution": "node",
     "removeComments": false,
-    "target": "es2019",
+    "target": "es2022",
     "outDir": "build/js",
     "alwaysStrict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION

## Description:

Odoo now allows es2022 features (see [1]). Let's allow it here as well. I want to use `.at(-1)` :p

[1] https://github.com/odoo/odoo/commit/7455bd4d7953306c57380bf66c4d088ce0a01b6c

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo