### PR TITLE
[REV] test: make test tsconfig work in vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     ],
     "globals": {
       "ts-jest": {
-        "tsconfig": "tests/tsconfig.json"
+        "tsconfig": "tsconfig.jest.json"
       }
     }
   },

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../build/js"
-  },
-  "include": ["../src", "."]
-}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "preserveConstEnums": true,
+    "noImplicitThis": true,
+    "moduleResolution": "node",
+    "removeComments": false,
+    "target": "es2019",
+    "outDir": "dist",
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictPropertyInitialization": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "sourceMap": true
+  },
+  "include": ["src", "tests"],
+  "typedocOptions": {
+    "entryPoints": ["src/index.ts"],
+    "out": "doc/tsdoc",
+    "name": "o-spreadsheet API",
+    "readme": "none",
+    "excludePrivate": true,
+    "hideGenerator": true,
+    "disableSources": true,
+    "excludeExternals": true
+  }
+}


### PR DESCRIPTION


## Description:

This reverts commit c47fcd7a445ba51c3d20fba2cdf08a28731c44af.

Here goes the story:
we asked to upgrade nodejs version on runbot (which was version 12) It was upgraded to version 20 in the global master Docker image. It worked fine for odoo...but not for o-spreadsheet. The build hangs indefinitely at the end of the tests. We can't reproduce locally, even when using the same Dockerfile.

We found out this commit was the culprit, but we don't know why...
Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo