### PR TITLE
[FIX] chart: don't open side panel readonly when double clicking

### DIFF
--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -5,7 +5,6 @@ import {
   getChartDefinitionFromContextCreation,
   getChartTypes,
 } from "../../../../helpers/figures/charts";
-import { _lt } from "../../../../translation";
 import { ChartDefinition, ChartType, SpreadsheetChildEnv, UID } from "../../../../types/index";
 import { css } from "../../../helpers/css";
 
@@ -61,7 +60,8 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
   setup(): void {
     const selectedFigureId = this.env.model.getters.getSelectedFigureId();
     if (!selectedFigureId) {
-      throw new Error(_lt("Cannot open the chart side panel while no chart are selected"));
+      this.props.onCloseSidePanel();
+      return;
     }
     this.state = useState({
       panel: "configuration",

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -460,6 +460,19 @@ describe("charts", () => {
     }
   );
 
+  test("double click a chart in readonly mode does not open the side panel", async () => {
+    createTestChart("basicChart");
+    await nextTick();
+
+    expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
+    model.updateMode("readonly");
+    expect(model.getters.getSelectedFigureId()).toBeNull();
+    await nextTick();
+    triggerMouseEvent(".o-chart-container", "dblclick");
+    await nextTick();
+    expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
+  });
+
   describe.each(["basicChart", "scorecard", "gauge"])(
     "selecting other chart will adapt sidepanel",
     (chartType: string) => {


### PR DESCRIPTION
In readonly mode, double clicking a chart figure make the spreadsheet crash.

With this commit, the side panel is more robust when no figure is selected.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3293322](https://www.odoo.com/web#id=3293322&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo