### PR TITLE
[FIX] tests: Use only faketimers in find&replace

### DIFF
--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -33,13 +33,12 @@ describe("find and replace sidePanel component", () => {
   let fixture: HTMLElement;
   let parent: Spreadsheet;
 
-  beforeEach(async () => {
-    ({ parent, model, fixture } = await mountSpreadsheet());
-    parent.env.openSidePanel("FindAndReplace");
-    await nextTick();
-  });
-
   describe("Sidepanel", () => {
+    beforeEach(async () => {
+      ({ parent, model, fixture } = await mountSpreadsheet());
+      parent.env.openSidePanel("FindAndReplace");
+      await nextTick();
+    });
     test("Can close the find and replace side panel", async () => {
       expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
       triggerMouseEvent(document.querySelector(selectors.closeSidepanel), "click");
@@ -88,21 +87,28 @@ describe("find and replace sidePanel component", () => {
   });
   describe("basic search", () => {
     let dispatch;
-    beforeEach(() => {
+
+    beforeEach(async () => {
+      jest.useFakeTimers();
+      ({ parent, model, fixture } = await mountSpreadsheet());
+      parent.env.openSidePanel("FindAndReplace");
+      await nextTick();
       dispatch = spyDispatch(parent);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
     });
 
     test("simple search", async () => {
       /** Fake timers use to control debounceSearch in Find and Replace */
-      jest.useFakeTimers();
       setInputValueAndTrigger(selectors.inputSearch, "1", "input");
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
       await nextTick();
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
         searchOptions: { exactMatch: false, matchCase: false, searchFormulas: false },
         toSearch: "1",
       });
-      jest.useRealTimers();
     });
 
     test("clicking on next", async () => {
@@ -129,22 +135,24 @@ describe("find and replace sidePanel component", () => {
     });
 
     test("search on empty string", async () => {
-      jest.useFakeTimers();
       setInputValueAndTrigger(selectors.inputSearch, "", "input");
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
       await nextTick();
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
         searchOptions: { exactMatch: false, matchCase: false, searchFormulas: false },
         toSearch: "",
       });
-      jest.useRealTimers();
     });
   });
 
   describe("search count match", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       jest.useFakeTimers();
+      ({ parent, model, fixture } = await mountSpreadsheet());
+      parent.env.openSidePanel("FindAndReplace");
+      await nextTick();
     });
+
     afterEach(() => {
       jest.useRealTimers();
     });
@@ -152,7 +160,7 @@ describe("find and replace sidePanel component", () => {
       setCellContent(model, "A1", "Hello");
       expect(fixture.querySelector(".o-input-count")).toBeNull();
       setInputValueAndTrigger(selectors.inputSearch, "Hel", "input");
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
       await nextTick();
       expect(fixture.querySelector(".o-input-count")?.innerHTML).toBe("1 / 1");
     });
@@ -160,17 +168,22 @@ describe("find and replace sidePanel component", () => {
     test("search match count is removed when input is cleared", async () => {
       setCellContent(model, "A1", "Hello");
       setInputValueAndTrigger(selectors.inputSearch, "Hel", "input");
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
       await nextTick();
       expect(fixture.querySelector(".o-input-count")?.innerHTML).toBe("1 / 1");
       setInputValueAndTrigger(selectors.inputSearch, "", "input");
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
       await nextTick();
       expect(fixture.querySelector(".o-input-count")).toBeNull();
     });
   });
 
   describe("search options", () => {
+    beforeEach(async () => {
+      ({ parent, model, fixture } = await mountSpreadsheet());
+      parent.env.openSidePanel("FindAndReplace");
+      await nextTick();
+    });
     test("Can search matching case", async () => {
       const dispatch = spyDispatch(parent);
 
@@ -222,6 +235,11 @@ describe("find and replace sidePanel component", () => {
     });
   });
   describe("replace options", () => {
+    beforeEach(async () => {
+      ({ parent, model, fixture } = await mountSpreadsheet());
+      parent.env.openSidePanel("FindAndReplace");
+      await nextTick();
+    });
     test("Can replace a simple text value", async () => {
       setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "hello", "input");
       setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "kikou", "input");


### PR DESCRIPTION
When using fakeTimers in UI tests, we need to ensure that we start the fakeTimer before instantiating a `Model` because it will start a `Session` that will use `set/clearTimeout`.

Task: 3293232

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo