### PR TITLE
[FIX] tests: Use only faketimers in autofill tests

### DIFF
--- a/tests/components/autofill.test.ts
+++ b/tests/components/autofill.test.ts
@@ -15,11 +15,10 @@ let fixture: HTMLElement;
 let model: Model;
 let parent: Spreadsheet;
 
-beforeEach(async () => {
-  ({ parent, model, fixture } = await mountSpreadsheet());
-});
-
 describe("Autofill component", () => {
+  beforeEach(async () => {
+    ({ parent, model, fixture } = await mountSpreadsheet());
+  });
   test("Can drag and drop autofill on columns", async () => {
     const dispatch = spyDispatch(parent);
     const autofill = fixture.querySelector(".o-autofill-handler");
@@ -257,6 +256,11 @@ describe("Autofill component", () => {
 describe("Autofill edge scrolling", () => {
   beforeEach(async () => {
     jest.useFakeTimers();
+    ({ parent, model, fixture } = await mountSpreadsheet());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   test("Can edge scroll horizontally", () => {


### PR DESCRIPTION
When using fakeTimers in UI tests, we need to ensure that we start the fakeTimer before instantiating a `Model` because it will start a `Session` that will use set/clearTimeout.

Task: 3293232

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo