### PR TITLE
[FIX] CellPopoverPlugin: popovers not closing

### DIFF
--- a/src/components/popover/popover.xml
+++ b/src/components/popover/popover.xml
@@ -5,7 +5,8 @@
         class="o-popover"
         t-ref="popover"
         t-on-wheel="props.onMouseWheel"
-        t-att-style="popoverStyle">
+        t-att-style="popoverStyle"
+        t-on-click.stop="">
         <t t-slot="default"/>
       </div>
     </t>

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -194,6 +194,7 @@ describe("Simple Spreadsheet Component", () => {
     expect(dropDownZIndex).toBeLessThan(topBarComposerZIndex);
     expect(topBarComposerZIndex).toBeLessThan(popoverZIndex);
     expect(popoverZIndex).toBeLessThan(figureAnchorZIndex);
+    jest.useRealTimers();
   });
 
   test("Keydown is ineffective in dashboard mode", async () => {
@@ -394,4 +395,16 @@ describe("Composer / selectionInput interactions", () => {
     await clickCell(model, "D1");
     expect(model.getters.getSelectedZones()).toEqual([toZone("D1")]);
   });
+});
+test("cell popovers to be closed on clicking outside grid", async () => {
+  jest.useFakeTimers();
+  ({ model, fixture } = await mountSpreadsheet());
+
+  setCellContent(model, "A1", "=SUM(");
+  await nextTick();
+  await hoverCell(model, "A1", 400);
+  expect(fixture.querySelector(".o-popover .o-error-tooltip")).not.toBeNull();
+  await simulateClick(".o-topbar-menu");
+  expect(fixture.querySelector(".o-popover .o-error-tooltip")).toBeNull();
+  jest.useRealTimers();
 });


### PR DESCRIPTION
## Description:

Previously, both non-persistent and persistent popovers remained open even when the user clicked outside the grid. Now, both types of popovers are closed when the user clicks outside the grid.
closed when the user clicks outside the grid. when the cursor is moved away from the grid.

Odoo task ID : [3222450](https://www.odoo.com/web#id=3222450&cids=2&menu_id=3940&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo