### PR TITLE
[FIX] chart: edit side panel after selecting other graph

### DIFF
--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -52,7 +52,6 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartPanel";
 
   private state!: State;
-  private shouldUpdateChart: boolean = true;
 
   get figureId(): UID {
     return this.state.figureId;
@@ -78,9 +77,6 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
       if (selectedFigureId && selectedFigureId !== this.state.figureId) {
         this.state.figureId = selectedFigureId;
         this.state.sheetId = this.env.model.getters.getActiveSheetId();
-        this.shouldUpdateChart = false;
-      } else {
-        this.shouldUpdateChart = true;
       }
       if (!this.env.model.getters.isChartDefined(this.figureId)) {
         this.props.onCloseSidePanel();
@@ -90,9 +86,7 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   updateChart<T extends ChartDefinition>(updateDefinition: Partial<T>) {
-    if (!this.shouldUpdateChart) {
-      return;
-    }
+    debugger;
     const definition: T = {
       ...(this.getChartDefinition() as T),
       ...updateDefinition,


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo