### PR TITLE
[FIX] xlsx: force the use of formatAttributes

### DIFF
--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -203,9 +203,14 @@ export function addSheetViews(sheet: ExcelSheetData) {
     `;
   }
 
+  const sheetViewAttrs: XMLAttributes = [
+    ["showGridLines", sheet.areGridLinesVisible ? 1 : 0],
+    ["workbookViewId", 0],
+  ];
+
   let sheetView = escapeXml/*xml*/ `
       <sheetViews>
-        <sheetView showGridLines="${sheet.areGridLinesVisible ? 1 : 0}" workbookViewId="0">
+        <sheetView ${formatAttributes(sheetViewAttrs)}>
           ${splitPanes}
         </sheetView>
       </sheetViews>

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -315,10 +315,20 @@ function createContentTypes(files: XLSXExportFile[]): XLSXExportXMLFile {
       overrideNodes.push(createOverride("/" + file.path, CONTENT_TYPES[file.contentType]));
     }
   }
+  const relsAttributes: XMLAttributes = [
+    ["Extension", "rels"],
+    ["ContentType", "application/vnd.openxmlformats-package.relationships+xml"],
+  ];
+
+  const xmlAttributes: XMLAttributes = [
+    ["Extension", "xml"],
+    ["ContentType", "application/xml"],
+  ];
+
   const xml = escapeXml/*xml*/ `
     <Types xmlns="${NAMESPACE["Types"]}">
-      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
-      <Default Extension="xml" ContentType="application/xml" />
+      <Default ${formatAttributes(relsAttributes)} />
+      <Default ${formatAttributes(xmlAttributes)} />
       ${joinXmlNodes(overrideNodes)}
     </Types>
   `;


### PR DESCRIPTION
For some reason still unknown, the minification of the generated lib file `o_spreadsheet.js`inside Odoo now destroys the spaces between attributes when they are defined in a template literal. This corrupts the generated xml which  breaks the XLSX export.

This problem only arises since very recent commits and will be investigated later on but we need to update the library in Odoo for sevaral bug fixes.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo