### PR TITLE
[IMP] topbar: add shortcuts for opening menus

### DIFF
--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -254,6 +254,7 @@ export const categoriesFunctionListMenuBuilder: ActionBuilder = () => {
       (key) => functions[key].category === category
     );
     return {
+      id: `insert_function_category_${category}`,
       name: category,
       children: createFormulaFunctions(functionsInCategory),
     };
@@ -281,6 +282,7 @@ export const insertSheet: ActionSpec = {
 function createFormulaFunctions(fnNames: string[]): ActionSpec[] {
   return fnNames.sort().map((fnName, i) => {
     return {
+      id: `function_${fnName}`,
       name: fnName,
       sequence: i * 10,
       execute: (env) => env.startCellEdition(`=${fnName}(`),

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -203,8 +203,6 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       /** TODO: Clean once we introduce proper focus on sub components. Grid should not have to handle all this logic */
       if (this.env.model.getters.hasOpenedPopover()) {
         this.closeOpenedPopover();
-      } else if (this.menuState.isOpen) {
-        this.closeMenu();
       } else if (this.env.model.getters.isPaintingFormat()) {
         this.env.model.dispatch("CANCEL_PAINT_FORMAT");
       } else {

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -7,6 +7,8 @@
         t-on-scroll="onScroll"
         t-on-wheel.stop=""
         t-on-click.stop=""
+        t-on-keydown="onKeydown"
+        tabindex="-1"
         t-on-contextmenu.prevent="">
         <t t-foreach="menuItemsAndSeparators" t-as="menuItem" t-key="menuItem_index">
           <div t-if="menuItem === 'separator'" class="o-separator"/>
@@ -14,12 +16,14 @@
             <t t-set="isMenuRoot" t-value="isRoot(menuItem)"/>
             <t t-set="isMenuEnabled" t-value="isEnabled(menuItem)"/>
             <div
+              t-key="menuItem.id"
+              t-ref="{{menuItem.id}}"
               t-att-title="getName(menuItem)"
               t-att-data-name="menuItem.id"
-              t-on-click="(ev) => this.onClickMenu(menuItem, menuItem_index, ev)"
-              t-on-mouseover="(ev) => this.onMouseOver(menuItem, menuItem_index, ev)"
+              t-on-click="(ev) => this.onClickMenu(menuItem, ev)"
+              t-on-mousemove="(ev) => this.onMouseMove(menuItem, ev)"
               class="o-menu-item"
-              t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem)}"
+              t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isMenuItemActive(menuItem)}"
               t-att-style="getColor(menuItem)">
               <div class="d-flex w-100">
                 <div t-if="childrenHaveIcon" class="o-menu-item-icon align-middle">
@@ -44,6 +48,7 @@
       </div>
       <Menu
         t-if="subMenu.isOpen"
+        t-key="clickableMenuItems[menuItemSelection.selectedIndex].id"
         position="subMenuPosition"
         menuItems="subMenu.menuItems"
         depth="props.depth + 1"
@@ -51,6 +56,8 @@
         onMenuClicked="props.onMenuClicked"
         onClose="() => this.close()"
         menuId="props.menuId"
+        navigateBackToParent="(direction) => this.onSubmenuBackNavigation(direction)"
+        shouldSelectFirstItemWhenFirstOpened="subMenu.shouldSelectFirstItemWhenFirstOpened"
       />
     </Popover>
   </t>

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -8,6 +8,7 @@
         <div class="o-topbar-topleft d-flex">
           <t t-foreach="menus" t-as="menu" t-key="menu_index">
             <div
+              t-ref="{{menu.id}}"
               t-if="menu.children.length !== 0"
               class="o-topbar-menu o-hoverable-button rounded"
               t-att-class="{'active': state.menuState.parentMenu and state.menuState.parentMenu.id === menu.id}"
@@ -173,10 +174,12 @@
     </div>
     <Menu
       t-if="state.menuState.isOpen"
+      t-key="state.openedMenuId"
       position="state.menuState.position"
       menuItems="state.menuState.menuItems"
       onClose="() => this.closeMenus()"
       onMenuClicked="() => this.props.onClick()"
+      navigateBackToParent="(direction) => this.changeActiveMenu(direction)"
     />
   </t>
 </templates>

--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`BottomBar component Can open the list of statistics 1`] = `
 <div
   class="o-menu"
+  tabindex="-1"
 >
   
   <div

--- a/tests/components/__snapshots__/context_menu.test.ts.snap
+++ b/tests/components/__snapshots__/context_menu.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Context Menu integration tests context menu simple rendering 1`] = `
 <div
   class="o-menu"
+  tabindex="-1"
 >
   
   <div

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -580,6 +580,7 @@ exports[`TopBar component can set cell format 1`] = `
     >
       <div
         class="o-menu"
+        tabindex="-1"
       >
         
         <div

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -13,6 +13,7 @@ import { cellMenuRegistry } from "../../src/registries/menus/cell_menu_registry"
 import { setCellContent } from "../test_helpers/commands_helpers";
 import {
   click,
+  keyDown,
   rightClickCell,
   simulateClick,
   triggerMouseEvent,
@@ -28,6 +29,8 @@ import {
   nextTick,
 } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
+
+const ACTIVE_MENU_ITEM_CLASS = "o-menu-item-active";
 
 let fixture: HTMLElement;
 let model: Model;
@@ -399,10 +402,10 @@ describe("Context Menu internal tests", () => {
       },
     ]);
     await renderContextMenu(300, 300, { menuItems });
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root']", "mousemove");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='action']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='action']", "mousemove");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
   });
@@ -410,13 +413,13 @@ describe("Context Menu internal tests", () => {
   test("Submenu parent is highlighted", async () => {
     await renderContextMenu(300, 300, { menuItems: cellMenuRegistry.getMenuItems() });
     const menuItem = fixture.querySelector(".o-menu div[data-name='paste_special']");
-    expect(menuItem?.classList).not.toContain("o-menu-item-active");
-    triggerMouseEvent(menuItem, "mouseover");
+    expect(menuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    triggerMouseEvent(menuItem, "mousemove");
     await nextTick();
-    expect(menuItem?.classList).toContain("o-menu-item-active");
-    triggerMouseEvent(".o-menu div[data-name='paste_value_only']", "mouseover");
+    expect(menuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    triggerMouseEvent(".o-menu div[data-name='paste_value_only']", "mousemove");
     await nextTick();
-    expect(menuItem?.classList).toContain("o-menu-item-active");
+    expect(menuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
   });
 
   test("submenu does not open when disabled", async () => {
@@ -460,17 +463,17 @@ describe("Context Menu internal tests", () => {
     model.updateMode("readonly");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='root']")!.classList).toContain("disabled");
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root']", "mousemove");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
   });
 
   test("submenu does not close when sub item hovered", async () => {
     await renderContextMenu(300, 300, { menuItems: subMenu });
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root']", "mousemove");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='subMenu1']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='subMenu1']", "mousemove");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
   });
@@ -594,12 +597,12 @@ describe("Context Menu internal tests", () => {
     ]);
     await renderContextMenu(300, 300, { menuItems });
 
-    triggerMouseEvent(".o-menu div[data-name='root_1']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root_1']", "mousemove");
     await nextTick();
-    triggerMouseEvent(".o-menu div[data-name='root_1_1']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root_1_1']", "mousemove");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu_1']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='root_2']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root_2']", "mousemove");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu_1']")).toBeFalsy();
     expect(fixture.querySelector(".o-menu div[data-name='root_2_1']")).toBeTruthy();
@@ -637,10 +640,10 @@ describe("Context Menu internal tests", () => {
       },
     ]);
     await renderContextMenu(300, 300, { menuItems });
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root']", "mousemove");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='menu_1']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='menu_1']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='menu_1']", "mousemove");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='visible_submenu_1']")).toBeTruthy();
     expect(fixture.querySelector(".o-menu div[data-name='invisible_submenu_1']")).toBeFalsy();
@@ -903,5 +906,230 @@ describe("Context menu separator", () => {
 
     await renderContextMenu(0, 0, { menuItems });
     expect(fixture.querySelectorAll(".o-menu .o-separator").length).toBe(0);
+  });
+});
+
+describe("Context menu navigation via keyboard", () => {
+  test("Arrow down to select next menu item", async () => {
+    await renderContextMenu(300, 300, { menuItems: cellMenuRegistry.getMenuItems() });
+    const cutMenuItem = fixture.querySelector(".o-menu div[data-name='cut']");
+    const copyMenuItem = fixture.querySelector(".o-menu div[data-name='copy']");
+    expect(cutMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(copyMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    await keyDown({ key: "ArrowDown" });
+    expect(cutMenuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(copyMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    await keyDown({ key: "ArrowDown" });
+    expect(cutMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(copyMenuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+  });
+
+  test("Arrow down to select the first menu item if the current active menu item is the last one", async () => {
+    await renderContextMenu(300, 300, { menuItems: cellMenuRegistry.getMenuItems() });
+    const insertLinkMenuItem = fixture.querySelector(".o-menu div[data-name='insert_link']");
+    const cutMenuItem = fixture.querySelector(".o-menu div[data-name='cut']");
+    triggerMouseEvent(insertLinkMenuItem, "mousemove");
+    await nextTick();
+    expect(insertLinkMenuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(cutMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    await keyDown({ key: "ArrowDown" });
+    expect(insertLinkMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(cutMenuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+  });
+
+  test("Arrow up to select the preceding menu item", async () => {
+    await renderContextMenu(300, 300, { menuItems: cellMenuRegistry.getMenuItems() });
+    const cutMenuItem = fixture.querySelector(".o-menu div[data-name='cut']");
+    const copyMenuItem = fixture.querySelector(".o-menu div[data-name='copy']");
+    triggerMouseEvent(copyMenuItem, "mousemove");
+    await nextTick();
+    expect(copyMenuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(cutMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    await keyDown({ key: "ArrowUp" });
+    expect(copyMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(cutMenuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+  });
+
+  test("Arrow up to select the last menu item if the current active item is the first one", async () => {
+    await renderContextMenu(300, 300, { menuItems: cellMenuRegistry.getMenuItems() });
+    const cutMenuItem = fixture.querySelector(".o-menu div[data-name='cut']");
+    const insertLinkMenuItem = fixture.querySelector(".o-menu div[data-name='insert_link']");
+    triggerMouseEvent(cutMenuItem, "mousemove");
+    await nextTick();
+    expect(cutMenuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(insertLinkMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    await keyDown({ key: "ArrowUp" });
+    expect(cutMenuItem?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(insertLinkMenuItem?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+  });
+
+  test("Disabled menu items will not be selected by keyboard", async () => {
+    const menuItems: Action[] = createActions([
+      { id: "root1", name: "root1" },
+      { id: "root2", name: "root2", isEnabled: () => false },
+      { id: "root3", name: "root3" },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+    const root1 = fixture.querySelector(".o-menu div[data-name='root1']");
+    const root2 = fixture.querySelector(".o-menu div[data-name='root2']");
+    const root3 = fixture.querySelector(".o-menu div[data-name='root3']");
+    await keyDown({ key: "ArrowDown" });
+    expect(root1!.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root2!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root3!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    await keyDown({ key: "ArrowDown" });
+    expect(root1!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root2!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root3!.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    await keyDown({ key: "ArrowUp" });
+    expect(root1!.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root2!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root3!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+  });
+
+  test("Arrow right and left to open and close the sub menu", async () => {
+    const menuItems = createActions([
+      {
+        id: "root",
+        name: "root",
+        children: [
+          () => [
+            {
+              id: "subMenu",
+              name: "subMenu",
+              execute() {},
+            },
+          ],
+        ],
+      },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+    await keyDown({ key: "ArrowDown" });
+    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
+    await keyDown({ key: "ArrowRight" });
+    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeTruthy();
+    await keyDown({ key: "ArrowLeft" });
+    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
+  });
+
+  test("After opening the sub menu, controlling via keyboard will be on the sub menu", async () => {
+    const menuItems = createActions([
+      {
+        id: "root",
+        name: "root",
+        children: [
+          () => [
+            {
+              id: "subMenu1",
+              name: "subMenu1",
+              execute() {},
+            },
+            {
+              id: "subMenu2",
+              name: "subMenu2",
+              execute() {},
+            },
+          ],
+        ],
+      },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+    await keyDown({ key: "ArrowDown" });
+    await keyDown({ key: "ArrowRight" });
+    await nextTick();
+    const subMenu1 = fixture.querySelector(".o-menu div[data-name='subMenu1']");
+    const subMenu2 = fixture.querySelector(".o-menu div[data-name='subMenu2']");
+    expect(subMenu1?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(subMenu2?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    await keyDown({ key: "ArrowDown" });
+    expect(subMenu1?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(subMenu2?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+  });
+
+  test("After closing the sub menu, controlling via keyboard will be back to the parent menu", async () => {
+    const menuItems = createActions([
+      {
+        id: "root1",
+        name: "root1",
+        children: [
+          () => [
+            {
+              id: "subMenu",
+              name: "subMenu",
+              execute() {},
+            },
+          ],
+        ],
+      },
+      {
+        id: "root2",
+        name: "root2",
+      },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+    const root1 = fixture.querySelector(".o-menu div[data-name='root1']");
+    const root2 = fixture.querySelector(".o-menu div[data-name='root2']");
+    await keyDown({ key: "ArrowDown" });
+    await keyDown({ key: "ArrowRight" });
+    expect(root1?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root2?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeTruthy();
+    await keyDown({ key: "ArrowLeft" });
+    await keyDown({ key: "ArrowDown" });
+    expect(root1?.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root2?.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
+  });
+
+  test("Mouse can change the previous selection by keyboard", async () => {
+    const menuItems: Action[] = createActions([
+      { id: "root1", name: "root1" },
+      { id: "root2", name: "root2" },
+      { id: "root3", name: "root3" },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+    const root1 = fixture.querySelector(".o-menu div[data-name='root1']");
+    const root2 = fixture.querySelector(".o-menu div[data-name='root2']");
+    const root3 = fixture.querySelector(".o-menu div[data-name='root3']");
+    await keyDown({ key: "ArrowDown" });
+    expect(root1!.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root2!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root3!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    triggerMouseEvent(root3, "mousemove");
+    await nextTick();
+    expect(root1!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root2!.classList).not.toContain(ACTIVE_MENU_ITEM_CLASS);
+    expect(root3!.classList).toContain(ACTIVE_MENU_ITEM_CLASS);
+  });
+
+  test("ESC to close the sub menu and call the prop close callback", async () => {
+    const menuItems = createActions([
+      {
+        id: "root",
+        name: "root",
+        children: [
+          () => [
+            {
+              id: "subMenu",
+              name: "subMenu",
+              execute() {},
+            },
+          ],
+        ],
+      },
+    ]);
+    let number = 1;
+    await renderContextMenu(300, 300, {
+      menuItems,
+      onClose: () => {
+        number++;
+      },
+    });
+    await keyDown({ key: "ArrowDown" });
+    await keyDown({ key: "ArrowRight" });
+    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeTruthy();
+    await keyDown({ key: "Escape" });
+    expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
+    expect(number).toEqual(2);
   });
 });

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -148,6 +148,24 @@ describe("Simple Spreadsheet Component", () => {
     expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
   });
 
+  test("when side panel is opening and the search query input has focus, the input won't lose its focus", async () => {
+    ({ model, parent, fixture } = await mountSpreadsheet());
+    await keyDown({ key: "F", ctrlKey: true });
+    const input = document.querySelector(".o-sidePanel .o-input")!;
+    await click(input);
+    expect(document.activeElement).toBe(input);
+  });
+
+  test("when side panel is opening and the search query input has focus, arow keys will only work in input", async () => {
+    ({ model, parent, fixture } = await mountSpreadsheet());
+    await keyDown({ key: "F", ctrlKey: true });
+    const input = document.querySelector(".o-sidePanel .o-input")!;
+    await click(input);
+    await keyDown({ key: "ArrowRight" });
+    expect(document.activeElement).toBe(input);
+    expect(fixture.querySelector("o-menu")).toBeFalsy();
+  });
+
   test("Z-indexes of the various spreadsheet components", async () => {
     jest.useFakeTimers();
     ({ model, fixture } = await mountSpreadsheet());

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -12,6 +12,7 @@ export let OWL_TEMPLATES: Document;
 beforeAll(() => {
   OWL_TEMPLATES = getParsedOwlTemplateBundle();
   setDefaultSheetViewSize(1000);
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Description:

This PR implements the shortcuts to open topbar menus. It also implements the nagivation via keyboard in the menus.

The basic idea is to use an external listener to monitor keydown events in the topbar, and use props to do the bi-directional communication between topbar and menu component.

Odoo task ID : [3281058](https://www.odoo.com/web#id=3281058&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo