### PR TITLE
[IMP] TopBar: Add split icon an gray disabled icons

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -99,6 +99,7 @@ class Demo extends Component {
       isReadonlyAllowed: true,
       isVisible: () => this.model.config.mode !== "normal",
       execute: () => this.model.updateMode("normal"),
+      icon: "o-spreadsheet-Icon.OPEN_READ_WRITE",
     });
 
     topbarMenuRegistry.addChild("display_header", ["file"], {

--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -40,4 +40,5 @@ export const splitToColumns: ActionSpec = {
   sequence: 1,
   execute: (env) => env.openSidePanel("SplitToColumns", {}),
   isEnabled: (env) => env.model.getters.isSingleColSelected(),
+  icon: "o-spreadsheet-Icon.SPLIT_TEXT",
 };

--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -20,6 +20,7 @@ export const rowInsertRowBefore: ActionSpec = {
     isConsecutive(env.model.getters.getActiveRows()) &&
     ACTIONS.IS_ONLY_ONE_RANGE(env) &&
     env.model.getters.getActiveCols().size === 0,
+  icon: "o-spreadsheet-Icon.INSERT_ROW_BEFORE",
 };
 
 export const topBarInsertRowsBefore: ActionSpec = {
@@ -30,7 +31,8 @@ export const topBarInsertRowsBefore: ActionSpec = {
 export const cellInsertRowsBefore: ActionSpec = {
   ...rowInsertRowBefore,
   name: ACTIONS.CELL_INSERT_ROWS_BEFORE_NAME,
-  icon: "o-spreadsheet-Icon.INSERT_ROW",
+  isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
+  icon: "o-spreadsheet-Icon.INSERT_ROW_BEFORE",
 };
 
 export const rowInsertRowsAfter: ActionSpec = {
@@ -40,6 +42,7 @@ export const rowInsertRowsAfter: ActionSpec = {
     isConsecutive(env.model.getters.getActiveRows()) &&
     ACTIONS.IS_ONLY_ONE_RANGE(env) &&
     env.model.getters.getActiveCols().size === 0,
+  icon: "o-spreadsheet-Icon.INSERT_ROW_AFTER",
 };
 
 export const topBarInsertRowsAfter: ActionSpec = {
@@ -63,6 +66,7 @@ export const colInsertColsBefore: ActionSpec = {
     isConsecutive(env.model.getters.getActiveCols()) &&
     ACTIONS.IS_ONLY_ONE_RANGE(env) &&
     env.model.getters.getActiveRows().size === 0,
+  icon: "o-spreadsheet-Icon.INSERT_COL_BEFORE",
 };
 
 export const topBarInsertColsBefore: ActionSpec = {
@@ -73,7 +77,8 @@ export const topBarInsertColsBefore: ActionSpec = {
 export const cellInsertColsBefore: ActionSpec = {
   ...colInsertColsBefore,
   name: ACTIONS.CELL_INSERT_COLUMNS_BEFORE_NAME,
-  icon: "o-spreadsheet-Icon.INSERT_COL",
+  isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
+  icon: "o-spreadsheet-Icon.INSERT_COL_BEFORE",
 };
 
 export const colInsertColsAfter: ActionSpec = {
@@ -83,6 +88,7 @@ export const colInsertColsAfter: ActionSpec = {
     isConsecutive(env.model.getters.getActiveCols()) &&
     ACTIONS.IS_ONLY_ONE_RANGE(env) &&
     env.model.getters.getActiveRows().size === 0,
+  icon: "o-spreadsheet-Icon.INSERT_COL_AFTER",
 };
 
 export const topBarInsertColsAfter: ActionSpec = {
@@ -105,6 +111,7 @@ export const insertCellShiftDown: ActionSpec = {
   execute: ACTIONS.INSERT_CELL_SHIFT_DOWN,
   isVisible: (env) =>
     env.model.getters.getActiveRows().size === 0 && env.model.getters.getActiveCols().size === 0,
+  icon: "o-spreadsheet-Icon.INSERT_CELL_SHIFT_DOWN",
 };
 
 export const insertCellShiftRight: ActionSpec = {
@@ -112,6 +119,7 @@ export const insertCellShiftRight: ActionSpec = {
   execute: ACTIONS.INSERT_CELL_SHIFT_RIGHT,
   isVisible: (env) =>
     env.model.getters.getActiveRows().size === 0 && env.model.getters.getActiveCols().size === 0,
+  icon: "o-spreadsheet-Icon.INSERT_CELL_SHIFT_RIGHT",
 };
 
 export const insertChart: ActionSpec = {

--- a/src/actions/view_actions.ts
+++ b/src/actions/view_actions.ts
@@ -10,6 +10,7 @@ export const hideCols: ActionSpec = {
   name: ACTIONS.HIDE_COLUMNS_NAME,
   execute: ACTIONS.HIDE_COLUMNS_ACTION,
   isVisible: ACTIONS.NOT_ALL_VISIBLE_COLS_SELECTED,
+  icon: "o-spreadsheet-Icon.HIDE_COL",
 };
 
 export const unhideCols: ActionSpec = {
@@ -35,6 +36,7 @@ export const hideRows: ActionSpec = {
   name: ACTIONS.HIDE_ROWS_NAME,
   execute: ACTIONS.HIDE_ROWS_ACTION,
   isVisible: ACTIONS.NOT_ALL_VISIBLE_ROWS_SELECTED,
+  icon: "o-spreadsheet-Icon.HIDE_ROW",
 };
 
 export const unhideRows: ActionSpec = {

--- a/src/components/filters/filter_icon/filter_icon.ts
+++ b/src/components/filters/filter_icon/filter_icon.ts
@@ -5,13 +5,13 @@ import { css } from "../../helpers/css";
 
 const CSS = css/* scss */ `
   .o-filter-icon {
+    color: ${FILTERS_COLOR};
     position: absolute;
     display: flex;
     align-items: center;
     justify-content: center;
     width: ${FILTER_ICON_EDGE_LENGTH}px;
     height: ${FILTER_ICON_EDGE_LENGTH}px;
-    color: #4a4f59;
   }
   .o-filter-icon:hover {
     background: ${FILTERS_COLOR};

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -104,6 +104,13 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.CLEAR" owl="1">
+    <svg class="o-icon">
+      <path
+        d="M1.5 15a.75.75 0 0 0 0 1.5h15a.75.75 0 0 0 0-1.5M5.3 12.75c.1.1.3.2.5.2h4c.2 0 .4-.1.5-.2l5.5-5.5c.2-.3.2-.6 0-.8l-4.4-4.4c-.3-.2-.6-.2-.8 0l-4.8 4.8c-2.7 2.9-3.1 2.8-2.4 4M7 7.25l3.6 3.6-1 1-3.6.1-1.8-1.9"
+      />
+    </svg>
+  </t>
   <t t-name="o-spreadsheet-Icon.FREEZE" owl="1">
     <svg class="o-icon">
       <path
@@ -128,11 +135,43 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.HIDE_ROW" owl="1">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v3.5h14V2H2v9h14V7H2v9h14v-3.5H2M1 12l4-5h2l-4 5m2 0 4-5h2l-4 5m2 0 4-5h2l-4 5m2 0 4-5v4"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.HIDE_COL" owl="1">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M16 .5A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2A1.5 1.5 0 0 1 2 .5h14V2h-3.5v14H16V2H7v14h4V2H2v14h3.5V2M6 1l5 4v2L6 3m0 2 5 4v2L6 7m0 2 5 4v2l-5-4m0 2 5 4H"
+      />
+    </svg>
+  </t>
   <t t-name="o-spreadsheet-Icon.INSERT_ROW" owl="1">
     <svg class="o-icon">
       <path
         fill="currentColor"
         d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v3.5h14V2H2v9h14V7H2v9h14v-3.5H2"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.INSERT_ROW_BEFORE" owl="1">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M3.5 14.5A1.5 1.5 0 0 0 5 16h10a1.5 1.5 0 0 0 1.5-1.5v-7h-3V5h3V1.5A1.5 1.5 0 0 0 15 0H5a1.5 1.5 0 0 0-1.5 1.5v2h-3V9h3M15 12.5v2H5v-2M15 9v2H5V9m10-7.5v2H5v-2M12 5v2.5H2V5"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.INSERT_ROW_AFTER" owl="1">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M3.5 1.5A1.5 1.5 0 0 1 5 0h10a1.5 1.5 0 0 1 1.5 1.5v7h-3V11h3v3.5A1.5 1.5 0 0 1 15 16H5a1.5 1.5 0 0 1-1.5-1.5v-2h-3V7h3M15 3.5v-2H5v2M15 7V5H5v2m10 7.5v-2H5v2m7-3.5V8.5H2V11"
       />
     </svg>
   </t>
@@ -144,6 +183,22 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.INSERT_COL_AFTER" owl="1">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M2.5 3A1.5 1.5 0 0 0 1 4.5v10A1.5 1.5 0 0 0 2.5 16h7v-3H12v3h3.5a1.5 1.5 0 0 0 1.5-1.5v-10A1.5 1.5 0 0 0 15.5 3h-2V0H8v3M4.5 14.5h-2v-10h2m3.5 10H6v-10h2m7.5 10h-2v-10h2m-3.5 7H9.5v-10H12"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.INSERT_COL_BEFORE" owl="1">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M15.5 3A1.5 1.5 0 0 1 17 4.5v10a1.5 1.5 0 0 1-1.5 1.5h-7v-3H6v3H2.5A1.5 1.5 0 0 1 1 14.5v-10A1.5 1.5 0 0 1 2.5 3h2V0H10v3m3.5 11.5h2v-10h-2m-3.5 10h2v-10h-2m-7.5 10h2v-10h-2m3.5 7h2.5v-10H6"
+      />
+    </svg>
+  </t>
   <t t-name="o-spreadsheet-Icon.INSERT_CELL" owl="1">
     <svg class="o-icon">
       <path
@@ -152,16 +207,34 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.DELETE_CELL_SHIFT_UP" owl="1">
-    <svg class="o-icon" fill="currentColor">
+  <t t-name="o-spreadsheet-Icon.INSERT_CELL_SHIFT_DOWN" owl="1">
+    <svg class="o-icon">
       <path
+        fill="currentColor"
+        d="M5 2.5A1.5 1.5 0 0 1 6.5 1h10A1.5 1.5 0 0 1 18 2.5v13a1.5 1.5 0 0 1-1.5 1.5h-10A1.5 1.5 0 0 1 5 15.5v-5h5.25v-3H5m11.5-2v-3h-4.75v3m-1.5 0v-3H6.5v3m10 5v-3h-4.75v3m-1.5 5v-3H6.5v3m10 0v-3h-4.75v3M0 12.5l2.5 4 2.5-4H3.25v-6h-1.5v6"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.INSERT_CELL_SHIFT_RIGHT" owl="1">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M2.5 5A1.5 1.5 0 0 0 1 6.5v10A1.5 1.5 0 0 0 2.5 18h13a1.5 1.5 0 0 0 1.5-1.5v-10A1.5 1.5 0 0 0 15.5 5h-5v5.25h-3V5m-2 11.5h-3v-4.75h3m0-1.5h-3V6.5h3m5 10h-3v-4.75h3m5-1.5h-3V6.5h3m0 10h-3v-4.75h3M12.5 0l4 2.5-4 2.5V3.25h-6v-1.5h6"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.DELETE_CELL_SHIFT_UP" owl="1">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
         d="M5 2.5A1.5 1.5 0 0 1 6.5 1h10A1.5 1.5 0 0 1 18 2.5v13a1.5 1.5 0 0 1-1.5 1.5h-10A1.5 1.5 0 0 1 5 15.5v-5h5.25v-3H5m11.5-2v-3h-4.75v3m-1.5 0v-3H6.5v3m10 5v-3h-4.75v3m-1.5 5v-3H6.5v3m10 0v-3h-4.75v3M0 10l2.5-4L5 10H3.25v6h-1.5v-6"
       />
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.DELETE_CELL_SHIFT_LEFT" owl="1">
-    <svg class="o-icon" fill="currentColor">
+    <svg class="o-icon">
       <path
+        fill="currentColor"
         d="M2.5 5A1.5 1.5 0 0 0 1 6.5v10A1.5 1.5 0 0 0 2.5 18h13a1.5 1.5 0 0 0 1.5-1.5v-10A1.5 1.5 0 0 0 15.5 5h-5v5.25h-3V5m-2 11.5h-3v-4.75h3m0-1.5h-3V6.5h3m5 10h-3v-4.75h3m5-1.5h-3V6.5h3m0 10h-3v-4.75h3M10 0 6 2.5 10 5V3.25h6v-1.5h-6"
       />
     </svg>
@@ -652,7 +725,7 @@
       </style>
       <path d="m3 13-1-1-1 1 3 3 3-3-1-1-1 1V0H3"/>
       <text x="9" y="7" class="small">A</text>
-      <text x="9" y="15" class="small">Z</text>
+      <text x="9.3" y="15" class="small">Z</text>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.SORT_DESCENDING" owl="1">
@@ -663,8 +736,8 @@
         }
       </style>
       <path d="m3 13.9-1-1-1 1 3 3 3-3-1-1-1 1V.9H3"/>
-      <text x="9" y="7.9" class="small">A</text>
-      <text x="9.25" y="15.9" class="small">Z</text>
+      <text x="9.3" y="7.9" class="small">Z</text>
+      <text x="9" y="15.9" class="small">A</text>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.FILTER_ICON" owl="1">
@@ -675,6 +748,7 @@
       focusable="false"
       viewBox="0 0 850 850">
       <path
+        fill="currentColor"
         d="M 339.667 681 L 510.333 681 L 510.333 595.667 L 339.667 595.667 L 339.667 681 Z M 41 169 L 41 254.333 L 809 254.333 L 809 169 L 41 169 Z M 169 467.667 L 681 467.667 L 681 382.333 L 169 382.333 L 169 467.667 Z"
       />
     </svg>
@@ -764,6 +838,14 @@
       <path
         fill="currentColor"
         d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24V296c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.SPLIT_TEXT" owl="1">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M14 6v2h-4v2h4v2l3-3m-9 1V8H4V6L1 9l3 3v-2m3.5-6.5h3V7H12V3.5h3V2H3v1.5h3V7h1.5m3 7.5h-3V11H6v3.5H3V16h12v-1.5h-3V11h-1.5"
       />
     </svg>
   </t>

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -53,10 +53,6 @@ css/* scss */ `
         margin: 0px 8px 0px 0px;
         width: ${MENU_ITEM_HEIGHT - 2 * MENU_ITEM_PADDING_VERTICAL}px;
         line-height: ${MENU_ITEM_HEIGHT - 2 * MENU_ITEM_PADDING_VERTICAL}px;
-
-        .o-icon {
-          color: ${ICONS_COLOR};
-        }
       }
       .o-menu-item-root {
         width: 10px;
@@ -69,6 +65,11 @@ css/* scss */ `
         }
         .o-menu-item-description {
           color: grey;
+        }
+        .o-menu-item-icon {
+          .o-icon {
+            color: ${ICONS_COLOR};
+          }
         }
       }
       &.disabled {

--- a/src/registries/menus/col_menu_registry.ts
+++ b/src/registries/menus/col_menu_registry.ts
@@ -60,19 +60,21 @@ colMenuRegistry
   .add("delete_column", {
     ...ACTION_EDIT.deleteCols,
     sequence: 90,
+    icon: "o-spreadsheet-Icon.DELETE",
   })
   .add("clear_column", {
     ...ACTION_EDIT.clearCols,
     sequence: 100,
+    icon: "o-spreadsheet-Icon.CLEAR",
   })
   .add("hide_columns", {
     ...ACTION_VIEW.hideCols,
-    sequence: 85,
+    sequence: 105,
     separator: true,
   })
   .add("unhide_columns", {
     ...ACTION_VIEW.unhideCols,
-    sequence: 86,
+    sequence: 106,
     separator: true,
   })
   .add("conditional_formatting", {

--- a/src/registries/menus/row_menu_registry.ts
+++ b/src/registries/menus/row_menu_registry.ts
@@ -43,10 +43,12 @@ rowMenuRegistry
   .add("delete_row", {
     ...ACTION_EDIT.deleteRows,
     sequence: 70,
+    icon: "o-spreadsheet-Icon.DELETE",
   })
   .add("clear_row", {
     ...ACTION_EDIT.clearRows,
     sequence: 80,
+    icon: "o-spreadsheet-Icon.CLEAR",
   })
   .add("hide_rows", {
     ...ACTION_VIEW.hideRows,

--- a/tests/components/__snapshots__/context_menu.test.ts.snap
+++ b/tests/components/__snapshots__/context_menu.test.ts.snap
@@ -166,7 +166,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
           class="o-icon"
         >
           <path
-            d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v3.5h14V2H2v9h14V7H2v9h14v-3.5H2"
+            d="M3.5 14.5A1.5 1.5 0 0 0 5 16h10a1.5 1.5 0 0 0 1.5-1.5v-7h-3V5h3V1.5A1.5 1.5 0 0 0 15 0H5a1.5 1.5 0 0 0-1.5 1.5v2h-3V9h3M15 12.5v2H5v-2M15 9v2H5V9m10-7.5v2H5v-2M12 5v2.5H2V5"
             fill="currentColor"
           />
         </svg>
@@ -195,7 +195,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
           class="o-icon"
         >
           <path
-            d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v14h3.5V2H2h5v14h4V2H2h10.5v14H16V2H2"
+            d="M15.5 3A1.5 1.5 0 0 1 17 4.5v10a1.5 1.5 0 0 1-1.5 1.5h-7v-3H6v3H2.5A1.5 1.5 0 0 1 1 14.5v-10A1.5 1.5 0 0 1 2.5 3h2V0H10v3m3.5 11.5h2v-10h-2m-3.5 10h2v-10h-2m-7.5 10h2v-10h-2m3.5 7h2.5v-10H6"
             fill="currentColor"
           />
         </svg>


### PR DESCRIPTION
## Description:

This PR aims to add an icon to the newly added "Split text" action as well as graying the disabled icons in read-only mode.

Odoo task ID : N./A.

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo