### PR TITLE
[FIX] ChartFigure: chart menu options in readonly mode

### DIFF
--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -3,10 +3,11 @@
     <div
       class="o-chart-container w-100 h-100"
       t-ref="chartContainer"
-      t-on-contextmenu.prevent.stop="(ev) => !env.isDashboard() and this.onContextMenu(ev)">
+      t-on-contextmenu.prevent.stop="(ev) => !env.isDashboard() and !env.model.getters.isReadonly() and this.onContextMenu(ev)">
       <div class="o-chart-menu" t-if="!env.isDashboard()">
         <div
           class="o-chart-menu-item"
+          t-if="!env.model.getters.isReadonly()"
           t-on-click="showMenu"
           t-ref="menuButton"
           t-on-contextmenu.prevent.stop="showMenu">

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -195,6 +195,17 @@ describe("figures", () => {
   );
 
   test.each(["basicChart", "scorecard", "gauge"])(
+    "charts don't have a menu button in readonly mode",
+    async (chartType: string) => {
+      createTestChart(chartType);
+      model.updateMode("readonly");
+      await nextTick();
+      expect(fixture.querySelector(".o-figure")).not.toBeNull();
+      expect(fixture.querySelector(".o-chart-menu-item")).toBeNull();
+    }
+  );
+
+  test.each(["basicChart", "scorecard", "gauge"])(
     "Click on Menu button open context menu in %s",
     async (chartType: string) => {
       createTestChart(chartType);
@@ -730,6 +741,19 @@ describe("figures", () => {
     async (chartType: string) => {
       createTestChart(chartType);
       model.updateMode("dashboard");
+      await nextTick();
+
+      triggerMouseEvent(".o-chart-container", "contextmenu");
+      await nextTick();
+      expect(document.querySelector(".o-menu")).toBeFalsy();
+    }
+  );
+
+  test.each(["basicChart", "scorecard", "gauge"])(
+    "Cannot open context menu on right click in readonly mode",
+    async (chartType: string) => {
+      createTestChart(chartType);
+      model.updateMode("readonly");
       await nextTick();
 
       triggerMouseEvent(".o-chart-container", "contextmenu");


### PR DESCRIPTION
## Description:

Previously, the context menu options for charts remained visible even in read-only mode.

To address this issue, a  `t-if`  attribute was added to the  `Menu Component` , and a  `d-none`  class was added 
to the  `o-chart-menu-item`  when the  `isReadonly()`  method returned  `true`.

Odoo task ID : [3284659](https://www.odoo.com/web#id=3284659&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo