### PR TITLE
[IMP] charts: dynamic errors in side panel

### DIFF
--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
@@ -57,10 +57,9 @@
           as headers
         </label>
       </div>
-      <div class="o-section o-sidepanel-error" t-if="errorMessages">
-        <div t-foreach="errorMessages" t-as="error" t-key="error">
-          <t t-esc="error"/>
-        </div>
+
+      <div class="o-section" t-if="errorMessages.length">
+        <SidePanelErrors messages="errorMessages" msgType="'error'"/>
       </div>
     </div>
   </t>

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
@@ -3,10 +3,12 @@ import { GaugeChartDefinition } from "../../../../types/chart/gauge_chart";
 import { CommandResult, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { ChartTerms } from "../../../translations_terms";
+import { SidePanelErrors } from "../../side_panel_errors/side_panel_errors";
 
 interface Props {
   figureId: UID;
   definition: GaugeChartDefinition;
+  canUpdateChart: (figureId: UID, definition: Partial<GaugeChartDefinition>) => DispatchResult;
   updateChart: (figureId: UID, definition: Partial<GaugeChartDefinition>) => DispatchResult;
 }
 
@@ -16,7 +18,7 @@ interface PanelState {
 
 export class GaugeChartConfigPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GaugeChartConfigPanel";
-  static components = { SelectionInput };
+  static components = { SelectionInput, SidePanelErrors };
 
   private state: PanelState = useState({
     dataRangeDispatchResult: undefined,
@@ -39,6 +41,9 @@ export class GaugeChartConfigPanel extends Component<Props, SpreadsheetChildEnv>
 
   onDataRangeChanged(ranges: string[]) {
     this.dataRange = ranges[0];
+    this.state.dataRangeDispatchResult = this.props.canUpdateChart(this.props.figureId, {
+      dataRange: this.dataRange,
+    });
   }
 
   updateDataRange() {
@@ -56,4 +61,5 @@ GaugeChartConfigPanel.props = {
   figureId: String,
   definition: Object,
   updateChart: Function,
+  canUpdateChart: Function,
 };

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.xml
@@ -12,10 +12,9 @@
           onSelectionConfirmed="() => this.updateDataRange()"
         />
       </div>
-      <div class="o-section o-sidepanel-error" t-if="configurationErrorMessages">
-        <div t-foreach="configurationErrorMessages" t-as="error" t-key="error">
-          <t t-esc="error"/>
-        </div>
+
+      <div class="o-section" t-if="configurationErrorMessages.length">
+        <SidePanelErrors messages="configurationErrorMessages" msgType="'error'"/>
       </div>
     </div>
   </t>

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../types/index";
 import { css } from "../../../helpers/css";
 import { ChartTerms } from "../../../translations_terms";
+import { SidePanelErrors } from "../../side_panel_errors/side_panel_errors";
 import { ColorPickerWidget } from "./../../../color_picker/color_picker_widget";
 
 css/* scss */ `
@@ -53,21 +54,24 @@ type GaugeMenu =
 interface Props {
   figureId: UID;
   definition: GaugeChartDefinition;
+  canUpdateChart: (figureId: UID, definition: Partial<GaugeChartDefinition>) => DispatchResult;
   updateChart: (figureId: UID, definition: Partial<GaugeChartDefinition>) => DispatchResult;
 }
 
 interface PanelState {
   openedMenu?: GaugeMenu;
   sectionRuleDispatchResult?: DispatchResult;
+  sectionRule: SectionRule;
 }
 
 export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GaugeChartDesignPanel";
-  static components = { ColorPickerWidget };
+  static components = { ColorPickerWidget, SidePanelErrors };
 
   private state: PanelState = useState({
     openedMenu: undefined,
     sectionRuleDispatchResult: undefined,
+    sectionRule: deepCopy(this.props.definition.sectionRule),
   });
 
   setup() {
@@ -140,41 +144,11 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     );
   }
 
-  updateInflectionPointValue(attr: string, ev) {
-    const sectionRule = deepCopy(this.props.definition.sectionRule);
-    sectionRule[attr].value = ev.target.value;
-    this.updateSectionRule(sectionRule);
-  }
-
-  updateInflectionPointType(attr: string, ev) {
-    const sectionRule = deepCopy(this.props.definition.sectionRule);
-    sectionRule[attr].type = ev.target.value;
-    this.updateSectionRule(sectionRule);
-  }
-
   updateSectionColor(target: string, color: Color) {
-    const sectionRule = deepCopy(this.props.definition.sectionRule);
+    const sectionRule = deepCopy(this.state.sectionRule);
     sectionRule.colors[target] = color;
     this.updateSectionRule(sectionRule);
     this.closeMenus();
-  }
-
-  updateRangeMin(ev) {
-    let sectionRule = deepCopy(this.props.definition.sectionRule);
-    sectionRule = {
-      ...sectionRule,
-      rangeMin: ev.target.value,
-    };
-    this.updateSectionRule(sectionRule);
-  }
-
-  updateRangeMax(ev) {
-    let sectionRule = deepCopy(this.props.definition.sectionRule);
-    sectionRule = {
-      ...sectionRule,
-      rangeMax: ev.target.value,
-    };
-    this.updateSectionRule(sectionRule);
   }
 
   toggleMenu(menu: GaugeMenu) {
@@ -185,8 +159,14 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     }
   }
 
-  private updateSectionRule(sectionRule: SectionRule) {
+  updateSectionRule(sectionRule: SectionRule) {
     this.state.sectionRuleDispatchResult = this.props.updateChart(this.props.figureId, {
+      sectionRule,
+    });
+  }
+
+  canUpdateSectionRule(sectionRule: SectionRule) {
+    this.state.sectionRuleDispatchResult = this.props.canUpdateChart(this.props.figureId, {
       sectionRule,
     });
   }
@@ -200,4 +180,5 @@ GaugeChartDesignPanel.props = {
   figureId: String,
   definition: Object,
   updateChart: Function,
+  canUpdateChart: Function,
 };

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
@@ -30,8 +30,9 @@
         <div class="o-subsection-left">
           <input
             type="text"
-            t-att-value="props.definition.sectionRule.rangeMin"
-            t-on-change="updateRangeMin"
+            t-model="state.sectionRule.rangeMin"
+            t-on-change="() => this.updateSectionRule(state.sectionRule)"
+            t-on-input="() => this.canUpdateSectionRule(state.sectionRule)"
             class="o-input o-data-range-min"
             t-att-class="{ 'o-invalid': isRangeMinInvalid() }"
           />
@@ -39,8 +40,9 @@
         <div class="o-subsection-right">
           <input
             type="text"
-            t-att-value="props.definition.sectionRule.rangeMax"
-            t-on-change="updateRangeMax"
+            t-model="state.sectionRule.rangeMax"
+            t-on-change="() => this.updateSectionRule(state.sectionRule)"
+            t-on-input="() => this.canUpdateSectionRule(state.sectionRule)"
             class="o-input o-data-range-max"
             t-att-class="{ 'o-invalid': isRangeMaxInvalid() }"
           />
@@ -50,14 +52,12 @@
       <div class="o-section">
         <div class="o-section-title">Thresholds</div>
         <t t-call="o-spreadsheet-GaugeChartColorSectionTemplate">
-          <t t-set="sectionRule" t-value="props.definition.sectionRule"/>
+          <t t-set="sectionRule" t-value="state.sectionRule"/>
         </t>
       </div>
 
-      <div class="o-section o-sidepanel-error" t-if="designErrorMessages.length">
-        <div t-foreach="designErrorMessages" t-as="error" t-key="error">
-          <t t-esc="error"/>
-        </div>
+      <div class="o-section" t-if="designErrorMessages.length">
+        <SidePanelErrors messages="designErrorMessages" msgType="'error'"/>
       </div>
     </div>
   </t>
@@ -123,10 +123,11 @@
         <input
           type="text"
           class="o-input"
-          t-on-change="(ev) => this.updateInflectionPointValue(inflectionPointName, ev)"
+          t-model="inflectionPoint.value"
+          t-on-input="() => this.canUpdateSectionRule(state.sectionRule)"
+          t-on-change="() => this.updateSectionRule(state.sectionRule)"
           t-attf-class="o-input-{{inflectionPointName}}"
           t-att-class="{ 'o-invalid': isInvalid }"
-          t-model="inflectionPoint.value"
         />
       </td>
       <td>
@@ -134,7 +135,7 @@
           class="o-input"
           name="valueType"
           t-model="inflectionPoint.type"
-          t-on-change="(ev) => this.updateInflectionPointType(inflectionPointName, ev)">
+          t-on-change="(ev) => this.updateSectionRule(state.sectionRule)">
           <option value="number">Number</option>
           <option value="percentage">Percentage</option>
         </select>

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
@@ -7,10 +7,15 @@ import { PieChartDefinition } from "../../../../types/chart/pie_chart";
 import { CommandResult, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { ChartTerms } from "../../../translations_terms";
+import { SidePanelErrors } from "../../side_panel_errors/side_panel_errors";
 
 interface Props {
   figureId: UID;
   definition: LineChartDefinition | BarChartDefinition | PieChartDefinition;
+  canUpdateChart: (
+    figureId: UID,
+    definition: Partial<LineChartDefinition | BarChartDefinition | PieChartDefinition>
+  ) => DispatchResult;
   updateChart: (
     figureId: UID,
     definition: Partial<LineChartDefinition | BarChartDefinition | PieChartDefinition>
@@ -24,7 +29,7 @@ interface ChartPanelState {
 
 export class LineBarPieConfigPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-LineBarPieConfigPanel";
-  static components = { SelectionInput };
+  static components = { SelectionInput, SidePanelErrors };
 
   private state: ChartPanelState = useState({
     datasetDispatchResult: undefined,
@@ -69,6 +74,9 @@ export class LineBarPieConfigPanel extends Component<Props, SpreadsheetChildEnv>
    */
   onDataSeriesRangesChanged(ranges: string[]) {
     this.dataSeriesRanges = ranges;
+    this.state.datasetDispatchResult = this.props.canUpdateChart(this.props.figureId, {
+      dataSets: this.dataSeriesRanges,
+    });
   }
 
   onDataSeriesConfirmed() {
@@ -88,6 +96,9 @@ export class LineBarPieConfigPanel extends Component<Props, SpreadsheetChildEnv>
    */
   onLabelRangeChanged(ranges: string[]) {
     this.labelRange = ranges[0];
+    this.state.labelsDispatchResult = this.props.canUpdateChart(this.props.figureId, {
+      labelRange: this.labelRange,
+    });
   }
 
   onLabelRangeConfirmed() {
@@ -132,4 +143,5 @@ LineBarPieConfigPanel.props = {
   figureId: String,
   definition: Object,
   updateChart: Function,
+  canUpdateChart: Function,
 };

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
@@ -43,10 +43,9 @@
           as headers
         </label>
       </div>
-      <div class="o-section o-sidepanel-error" t-if="errorMessages">
-        <div t-foreach="errorMessages" t-as="error" t-key="error">
-          <t t-esc="error"/>
-        </div>
+
+      <div class="o-section" t-if="errorMessages.length">
+        <SidePanelErrors messages="errorMessages" msgType="'error'"/>
       </div>
     </div>
   </t>

--- a/src/components/side_panel/chart/line_bar_pie_panel/design_panel.ts
+++ b/src/components/side_panel/chart/line_bar_pie_panel/design_panel.ts
@@ -2,16 +2,19 @@ import { Component, useExternalListener, useState } from "@odoo/owl";
 import { BarChartDefinition } from "../../../../types/chart/bar_chart";
 import { LineChartDefinition } from "../../../../types/chart/line_chart";
 import { PieChartDefinition } from "../../../../types/chart/pie_chart";
-import { Color, CommandResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
+import { Color, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
 import { ColorPickerWidget } from "../../../color_picker/color_picker_widget";
 
 interface Props {
   figureId: UID;
   definition: LineChartDefinition | BarChartDefinition | PieChartDefinition;
+  canUpdateChart: (
+    definition: Partial<LineChartDefinition | BarChartDefinition | PieChartDefinition>
+  ) => DispatchResult;
   updateChart: (
     figureId: UID,
     definition: Partial<LineChartDefinition | BarChartDefinition | PieChartDefinition>
-  ) => CommandResult | CommandResult[];
+  ) => DispatchResult;
 }
 
 interface State {
@@ -61,4 +64,5 @@ LineBarPieDesignPanel.props = {
   figureId: String,
   definition: Object,
   updateChart: Function,
+  canUpdateChart: Function,
 };

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -68,10 +68,9 @@
           as headers
         </label>
       </div>
-      <div class="o-section o-sidepanel-error" t-if="errorMessages">
-        <div t-foreach="errorMessages" t-as="error" t-key="error">
-          <t t-esc="error"/>
-        </div>
+
+      <div class="o-section" t-if="errorMessages.length">
+        <SidePanelErrors messages="errorMessages" msgType="'error'"/>
       </div>
     </div>
   </t>

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -89,6 +89,21 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 
+  canUpdateChart<T extends ChartDefinition>(figureId: UID, updateDefinition: Partial<T>) {
+    if (figureId !== this.figureId) {
+      return;
+    }
+    const definition: T = {
+      ...(this.getChartDefinition() as T),
+      ...updateDefinition,
+    };
+    return this.env.model.canDispatch("UPDATE_CHART", {
+      definition,
+      id: figureId,
+      sheetId: this.env.model.getters.getFigureSheetId(figureId)!,
+    });
+  }
+
   onTypeChange(type: ChartType) {
     const context = this.env.model.getters.getContextCreationChart(this.figureId);
     if (!context) {

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
@@ -41,6 +41,7 @@
           definition="definition"
           figureId="figureId"
           updateChart.bind="updateChart"
+          canUpdateChart.bind="canUpdateChart"
           t-key="figureId + definition.type"
         />
       </t>
@@ -50,6 +51,7 @@
           definition="definition"
           figureId="figureId"
           updateChart.bind="updateChart"
+          canUpdateChart.bind="canUpdateChart"
           t-key="figureId + definition.type"
         />
       </t>

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
@@ -3,10 +3,12 @@ import { ScorecardChartDefinition } from "../../../../types/chart/scorecard_char
 import { CommandResult, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { ChartTerms } from "../../../translations_terms";
+import { SidePanelErrors } from "../../side_panel_errors/side_panel_errors";
 
 interface Props {
   figureId: UID;
   definition: ScorecardChartDefinition;
+  canUpdateChart: (figureId: UID, definition: Partial<ScorecardChartDefinition>) => DispatchResult;
   updateChart: (figureId: UID, definition: Partial<ScorecardChartDefinition>) => DispatchResult;
 }
 
@@ -17,7 +19,7 @@ interface PanelState {
 
 export class ScorecardChartConfigPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChartConfigPanel";
-  static components = { SelectionInput };
+  static components = { SelectionInput, SidePanelErrors };
 
   private state: PanelState = useState({
     keyValueDispatchResult: undefined,
@@ -51,6 +53,9 @@ export class ScorecardChartConfigPanel extends Component<Props, SpreadsheetChild
 
   onKeyValueRangeChanged(ranges: string[]) {
     this.keyValue = ranges[0];
+    this.state.keyValueDispatchResult = this.props.canUpdateChart(this.props.figureId, {
+      keyValue: this.keyValue,
+    });
   }
 
   updateKeyValueRange() {
@@ -65,6 +70,9 @@ export class ScorecardChartConfigPanel extends Component<Props, SpreadsheetChild
 
   onBaselineRangeChanged(ranges: string[]) {
     this.baseline = ranges[0];
+    this.state.baselineDispatchResult = this.props.canUpdateChart(this.props.figureId, {
+      baseline: this.baseline,
+    });
   }
 
   updateBaselineRange() {
@@ -86,4 +94,5 @@ ScorecardChartConfigPanel.props = {
   figureId: String,
   definition: Object,
   updateChart: Function,
+  canUpdateChart: Function,
 };

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
@@ -32,10 +32,9 @@
           <option value="percentage">Percentage change from key value</option>
         </select>
       </div>
-      <div class="o-section o-sidepanel-error" t-if="errorMessages">
-        <div t-foreach="errorMessages" t-as="error" t-key="error">
-          <t t-esc="error"/>
-        </div>
+
+      <div class="o-section" t-if="errorMessages.length">
+        <SidePanelErrors messages="errorMessages" msgType="'error'"/>
       </div>
     </div>
   </t>

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
@@ -8,6 +8,7 @@ type ColorPickerId = undefined | "backgroundColor" | "baselineColorUp" | "baseli
 interface Props {
   figureId: UID;
   definition: ScorecardChartDefinition;
+  canUpdateChart: (figureId: UID, definition: Partial<ScorecardChartDefinition>) => DispatchResult;
   updateChart: (figureId: UID, definition: Partial<ScorecardChartDefinition>) => DispatchResult;
 }
 
@@ -69,4 +70,5 @@ ScorecardChartDesignPanel.props = {
   figureId: String,
   definition: Object,
   updateChart: Function,
+  canUpdateChart: Function,
 };

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -71,17 +71,6 @@ css/* scss */ `
       }
     }
 
-    .o-sidepanel-error,
-    .o-sidepanel-warning {
-      margin-top: 10px;
-
-      .o-icon {
-        margin-right: 5px;
-        height: 1.2em;
-        width: 1.2em;
-      }
-    }
-
     .o-sidePanelButtons {
       padding: 16px;
       text-align: right;

--- a/src/components/side_panel/side_panel_errors/side_panel_errors.ts
+++ b/src/components/side_panel/side_panel_errors/side_panel_errors.ts
@@ -1,0 +1,36 @@
+import { Component } from "@odoo/owl";
+import { SpreadsheetChildEnv } from "../../../types/index";
+import { css } from "../../helpers";
+
+interface Props {
+  messages: string[];
+  msgType: "warning" | "error";
+}
+
+css/* scss */ `
+  .o-sidepanel-error,
+  .o-sidepanel-warning {
+    margin-top: 10px;
+
+    .o-icon {
+      margin-right: 5px;
+      height: 1.2em;
+      width: 1.2em;
+    }
+  }
+`;
+export class SidePanelErrors extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-SidePanelErrors";
+
+  get divClasses() {
+    if (this.props.msgType === "warning") {
+      return "o-sidepanel-warning text-warning";
+    }
+    return "o-sidepanel-error text-danger";
+  }
+}
+
+SidePanelErrors.props = {
+  messages: Array,
+  msgType: String,
+};

--- a/src/components/side_panel/side_panel_errors/side_panel_errors.xml
+++ b/src/components/side_panel/side_panel_errors/side_panel_errors.xml
@@ -1,0 +1,10 @@
+<templates>
+  <t t-name="o-spreadsheet-SidePanelErrors" owl="1">
+    <t t-foreach="props.messages" t-as="msg" t-key="msg">
+      <div class="d-flex align-items-center" t-att-class="divClasses">
+        <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
+        <span t-esc="msg"/>
+      </div>
+    </t>
+  </t>
+</templates>

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -4,6 +4,7 @@ import { interactiveSplitToColumns } from "../../../helpers/ui/split_to_columns_
 import { _lt } from "../../../translation";
 import { CommandResult, SpreadsheetChildEnv } from "../../../types/index";
 import { SplitToColumnsTerms } from "../../translations_terms";
+import { SidePanelErrors } from "../side_panel_errors/side_panel_errors";
 
 type SeparatorValue = "auto" | "custom" | " " | "," | ";" | typeof NEWLINE;
 
@@ -33,6 +34,7 @@ interface State {
 
 export class SplitIntoColumnsPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SplitIntoColumnsPanel";
+  static components = { SidePanelErrors };
 
   state = useState<State>({ separatorValue: "auto", addNewColumns: false, customSeparator: "" });
 

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.xml
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.xml
@@ -46,18 +46,8 @@
           </button>
         </div>
 
-        <t t-foreach="errorMessages" t-as="error" t-key="error">
-          <div class="o-sidepanel-error d-flex align-items-center text-danger">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
-            <span t-esc="error"/>
-          </div>
-        </t>
-        <t t-foreach="warningMessages" t-as="warning" t-key="warning">
-          <div class="o-sidepanel-warning d-flex align-items-center text-warning">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
-            <span t-esc="warning"/>
-          </div>
-        </t>
+        <SidePanelErrors messages="errorMessages" msgType="'error'"/>
+        <SidePanelErrors messages="warningMessages" msgType="'warning'"/>
       </div>
     </div>
   </t>

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -50,7 +50,7 @@ function createTestChart(type: string) {
 }
 
 function errorMessages(): string[] {
-  return textContentAll(".o-sidepanel-error div");
+  return textContentAll(".o-sidepanel-error");
 }
 
 let fixture: HTMLElement;
@@ -676,12 +676,12 @@ describe("charts", () => {
     ]);
   });
 
-  describe("Chart error messages", () => {
+  describe("Chart error messages appear and don't need to click confirm", () => {
     test.each([
       ["basicChart", []],
       ["scorecard", []],
     ])(
-      "update basic chart with empty labels/baseline",
+      "update %s with empty labels/baseline",
       async (chartType: string, expectedResults: CommandResult[]) => {
         createTestChart(chartType);
         await nextTick();
@@ -693,7 +693,6 @@ describe("charts", () => {
         await simulateClick(".o-data-labels input");
         setInputValueAndTrigger(".o-data-labels input", "", "input");
         await nextTick();
-        await simulateClick(".o-data-labels .o-selection-ok");
 
         const expectedErrors = expectedResults.map((result) =>
           ChartTerms.Errors[result].toString()
@@ -874,8 +873,8 @@ describe("charts", () => {
       });
     });
 
-    test.each(["scorecard"])("error displayed on input fields", async (chartType: string) => {
-      createTestChart(chartType);
+    test("Scorecard > error displayed on input fields", async () => {
+      createTestChart("scorecard");
       await nextTick();
 
       parent.env.model.dispatch("SELECT_FIGURE", { id: chartId });


### PR DESCRIPTION
## Description

Improve the chart side panels to display errors
without having to click on the "confirm" button.

Odoo task ID : [3271374](https://www.odoo.com/web#id=3271374&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo