### PR TITLE
[REF] selective_history: name constructor arguments

### DIFF
--- a/src/history/selective_history.ts
+++ b/src/history/selective_history.ts
@@ -9,6 +9,11 @@ export class SelectiveHistory<T = unknown> {
   private HEAD_OPERATION: Operation<T>;
   private tree: Tree<T>;
 
+  private readonly applyOperation: (data: T) => void;
+  private readonly revertOperation: (data: T) => void;
+  private readonly buildEmpty: (id: UID) => T;
+  private readonly buildTransformation: TransformationFactory<T>;
+
   /**
    * The selective history is a data structure used to register changes/updates of a state.
    * Each change/update is called an "operation".
@@ -29,16 +34,22 @@ export class SelectiveHistory<T = unknown> {
    *                    (used for internal implementation)
    * @param buildTransformation Factory used to build transformations
    */
-  constructor(
-    initialOperationId: UID,
-    private applyOperation: (data: T) => void,
-    private revertOperation: (data: T) => void,
-    private buildEmpty: (id: UID) => T,
-    private readonly buildTransformation: TransformationFactory<T>
-  ) {
+  constructor(args: {
+    initialOperationId: UID;
+    applyOperation: (data: T) => void;
+    revertOperation: (data: T) => void;
+    buildEmpty: (id: UID) => T;
+    buildTransformation: TransformationFactory<T>;
+  }) {
+    this.applyOperation = args.applyOperation;
+    this.revertOperation = args.revertOperation;
+    this.buildEmpty = args.buildEmpty;
+    this.buildTransformation = args.buildTransformation;
+
     this.HEAD_BRANCH = new Branch<T>(this.buildTransformation);
-    this.tree = new Tree(buildTransformation, this.HEAD_BRANCH);
-    const initial = new Operation(initialOperationId, buildEmpty(initialOperationId));
+    this.tree = new Tree(this.buildTransformation, this.HEAD_BRANCH);
+    const initialOperationId = args.initialOperationId;
+    const initial = new Operation(initialOperationId, this.buildEmpty(initialOperationId));
     this.tree.insertOperationLast(this.HEAD_BRANCH, initial);
     this.HEAD_OPERATION = initial;
   }

--- a/src/model.ts
+++ b/src/model.ts
@@ -332,10 +332,10 @@ export class Model extends EventBus<any> implements CommandDispatcher {
 
   private setupSession(revisionId: UID): Session {
     const session = new Session(
-      buildRevisionLog(
-        revisionId,
-        this.state.recordChanges.bind(this.state),
-        (command: CoreCommand) => {
+      buildRevisionLog({
+        initialRevisionId: revisionId,
+        recordChanges: this.state.recordChanges.bind(this.state),
+        dispatch: (command: CoreCommand) => {
           const result = this.checkDispatchAllowed(command);
           if (!result.isSuccessful) {
             return;
@@ -343,8 +343,8 @@ export class Model extends EventBus<any> implements CommandDispatcher {
           this.isReplayingCommand = true;
           this.dispatchToHandlers(this.coreHandlers, command);
           this.isReplayingCommand = false;
-        }
-      ),
+        },
+      }),
       this.config.transportService,
       revisionId
     );

--- a/tests/collaborative/collaborative_session.test.ts
+++ b/tests/collaborative/collaborative_session.test.ts
@@ -19,11 +19,11 @@ describe("Collaborative session", () => {
       id: "alice",
       name: "Alice",
     };
-    const revisionLog = buildRevisionLog(
-      "START_REVISION",
-      () => ({ changes: [], commands: [] }),
-      () => CommandResult.Success
-    );
+    const revisionLog = buildRevisionLog({
+      initialRevisionId: "START_REVISION",
+      recordChanges: () => ({ changes: [], commands: [] }),
+      dispatch: () => CommandResult.Success,
+    });
     session = new Session(revisionLog, transport);
     session.join(client);
   });

--- a/tests/selective_history.test.ts
+++ b/tests/selective_history.test.ts
@@ -60,12 +60,12 @@ class MiniEditor {
     this.state = this.state.slice(0, position + 1) + this.state.slice(position + value.length + 1);
   };
 
-  private history = new SelectiveHistory(
-    "initial",
-    this.apply,
-    this.revert,
-    (id) => ({ position: -1, value: "" }),
-    {
+  private history = new SelectiveHistory({
+    initialOperationId: "initial",
+    applyOperation: this.apply,
+    revertOperation: this.revert,
+    buildEmpty: (id) => ({ position: -1, value: "" }),
+    buildTransformation: {
       /**
        * Build a transformation function to transform any command as if the execution of
        * a previous `command` was omitted.
@@ -78,8 +78,8 @@ class MiniEditor {
        */
       with: (command) => (commandToTransform) =>
         this.redoTransformation(commandToTransform as Command, command as Command),
-    }
-  );
+    },
+  });
 
   execAfter(insertAfter: UID | null, instruction: [UID, string, number]) {
     const [commandId, text, position] = instruction;


### PR DESCRIPTION
## Description

The constructor of the SelectiveHistory takes 5 arguments, but most of them are functions, and it's hard to see at first glance exactly what each argument does. Transform the arguments into a single object to have named arguments and make the call to the constructor a bit more readable.

Task:

Odoo task ID : [3301044](https://www.odoo.com/web#id=3301044&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo