### PR TITLE
[FIX] composer: autocomplete in topbar composer

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -247,6 +247,11 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
         this.autocompleteAPI.moveDown();
       }
     }
+    if (!this.env.model.getters.isSelectingForComposer()) {
+      const { start, end } = this.contentHelper.getCurrentSelection();
+      this.env.model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start, end });
+      this.isKeyStillDown = true;
+    }
   }
 
   private processTabKey(ev: KeyboardEvent) {
@@ -308,11 +313,6 @@ export class Composer extends Component<Props, SpreadsheetChildEnv> {
       handler.call(this, ev);
     } else {
       ev.stopPropagation();
-    }
-    const { start, end } = this.contentHelper.getCurrentSelection();
-    if (!this.env.model.getters.isSelectingForComposer()) {
-      this.env.model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start, end });
-      this.isKeyStillDown = true;
     }
   }
 


### PR DESCRIPTION
## Description:

Previously, when we write a formula and tried to autocomplete it by pressing tab or enter, it wouldn't update topbar composer. To fix this, we update a onKeydown to manage the enter and tab buttons.

Odoo task ID : [3291781](https://www.odoo.com/web#id=3291781&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo