### PR TITLE
[FIX] ContentEditableHelper: do not throw on missing node

### DIFF
--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -199,7 +199,14 @@ export class ContentEditableHelper {
       current = it.next();
     }
     if (current.value !== nodeToFind) {
-      throw new Error("Cannot find the node in the children of the element");
+      /** This situation can happen if the code is called while the selection is not currently on the ContentEditableHelper.
+       * In this case, we return 0 because we don't know the size of the text before the selection.
+       *
+       * A known occurence is triggered since the introduction of commit d4663158 (PR #2038).
+       *
+       * FIXME: find a way to test eventhough the selection API is not available in jsDOM.
+       */
+      return 0;
     } else {
       if (!current.value.hasChildNodes()) {
         usedCharacters += nodeOffset;


### PR DESCRIPTION
Currently,the method `findSizeBeforeElement` will throw if called when the selection is not targetting a node inside the ContentEditableHelper instance.

Unfortunately, this can happen since commit d4663158. If a menu is opened and we decide to click on the composer, the click event if first caught by the menu global listener which will close the menu and invoke a callback that focuses the grid; this focus will alter the selection of `document`. The event is then handled by the composer component but at that point, the selection is not targetting it anymore.

With this revision, we change the behavior of `findSizeBeforeElement` to return a default value of 0 in those situations as we simply don't know how to determine the selection outside of the scope of the ContentEditableHelper.

There is a functional drawback to this solution:
When clicking on a specific character of the composer when a menu is opened, the selection will be set to `{ start: 0, end: 0 }`.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo