### PR TITLE
[FIX] topbar: active item color

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -82,7 +82,7 @@ css/* scss */ `
       margin-bottom: ${MENU_SEPARATOR_PADDING}px;
     }
     .o-hoverable-button {
-      border-radius: 2px
+      border-radius: 2px;
       cursor: pointer;
       .o-icon {
         color: ${ICONS_COLOR};

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -12,6 +12,7 @@ import { setStyle } from "../../actions/menu_items_actions";
 import * as ACTION_VIEW from "../../actions/view_actions";
 import {
   BACKGROUND_HEADER_COLOR,
+  BG_HOVER_COLOR,
   ComponentsImportance,
   SEPARATOR_COLOR,
   TOPBAR_TOOLBAR_HEIGHT,
@@ -62,6 +63,11 @@ css/* scss */ `
         .o-topbar-menu {
           padding: 4px 6px;
           margin: 0 2px;
+
+          &.active {
+            background-color: ${BG_HOVER_COLOR};
+            color: #000;
+          }
         }
       }
     }


### PR DESCRIPTION
Change the color of active items in the topbar to be the same color as hover instead of the default green color.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo