### PR TITLE
[FIX] topbar: fix borderEditor props

### DIFF
--- a/src/components/border_editor/border_editor.ts
+++ b/src/components/border_editor/border_editor.ts
@@ -45,7 +45,7 @@ export interface BorderEditorProps {
   class?: string;
   currentBorderColor: Color;
   currentBorderStyle: BorderStyle;
-  currentBorderPosition: BorderPosition;
+  currentBorderPosition: BorderPosition | undefined;
   onBorderColorPicked: (color: Color) => void;
   onBorderStylePicked: (style: BorderStyle) => void;
   onBorderPositionPicked: (position: BorderPosition) => void;
@@ -196,7 +196,7 @@ BorderEditor.props = {
   class: { type: String, optional: true },
   currentBorderColor: { type: String, optional: false },
   currentBorderStyle: { type: String, optional: false },
-  currentBorderPosition: { type: String, optional: false },
+  currentBorderPosition: { type: String, optional: true },
   onBorderColorPicked: Function,
   onBorderStylePicked: Function,
   onBorderPositionPicked: Function,


### PR DESCRIPTION
## Description:

Nowadays, when we try to open the border editor in Odoo, we get an error about invalid props. This PR aims to fix it by adding "undefined" as a valid value for currentBorderPosition, making it logical compared to the borderEditorWidget props.

## Review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo