### PR TITLE
[FIX] evaluation: compute format from empty cell

### DIFF
--- a/src/plugins/ui/evaluation.ts
+++ b/src/plugins/ui/evaluation.ts
@@ -212,7 +212,7 @@ export class EvaluationPlugin extends UIPlugin {
         // magic "empty" value
         // Returning {value: null} instead of undefined will ensure that we don't
         // fall back on the default value of the argument provided to the formula's compute function
-        return { value: null };
+        return { value: null, format: cell?.format };
       }
       return getEvaluatedCell(cell);
     }

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -318,6 +318,13 @@ describe("core", () => {
           expect(getCell(model, "A2")!.evaluated.format).toBe("0%");
         });
 
+        test("with a reference to an empty cell", () => {
+          const model = new Model();
+          setCellFormat(model, "A1", "#,##0[$$]");
+          setCellContent(model, "A2", "=A1");
+          expect(getCell(model, "A2")?.evaluated.format).toBe("#,##0[$$]");
+        });
+
         test("with the reference declared before the formula and format applied on the formula", () => {
           const model = new Model();
           setCellContent(model, "A1", "3%");


### PR DESCRIPTION
When referencing an empty cell which has a format, the empty cell's format is ignored and not forwarded to the formula referencing it.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo