### PR TITLE
[FIX] menus: mark automatic format as active

### DIFF
--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -271,17 +271,17 @@ function fontSizeMenuBuilder(): ActionSpec[] {
   });
 }
 
-function isAutomaticFormatSelected(env): boolean {
-  const activeCell = env.model.getters.getActiveCell();
+function isAutomaticFormatSelected(env: SpreadsheetChildEnv): boolean {
+  const activeCell = env.model.getters.getCell(env.model.getters.getActivePosition());
   return !activeCell || !activeCell.format;
 }
 
-function isFormatSelected(env, format: string): boolean {
-  const activeCell = env.model.getters.getActiveCell();
-  return activeCell && activeCell.format === format;
+function isFormatSelected(env: SpreadsheetChildEnv, format: string): boolean {
+  const activeCell = env.model.getters.getCell(env.model.getters.getActivePosition());
+  return activeCell?.format === format;
 }
 
-function isFontSizeSelected(env, fontSize: number): boolean {
+function isFontSizeSelected(env: SpreadsheetChildEnv, fontSize: number): boolean {
   const currentFontSize = env.model.getters.getCurrentStyle().fontSize || DEFAULT_FONT_SIZE;
   return currentFontSize === fontSize;
 }


### PR DESCRIPTION
- Set a number and a number format in A1
- reference A1 in B1 (`=A1`) => B1's format is automatic and computed from A1's format
- Select B1 => in the top bar menu Format > Numbers, the format is not marked as being automatic but marked as being A1's format.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo