### PR TITLE
[FIX] clipboard: fix behaviour when selection is updated before the paste

### DIFF
--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -14,7 +14,7 @@ import {
   interactivePasteFromOS,
 } from "../helpers/ui/paste_interactive";
 import { _lt } from "../translation";
-import { ClipboardPasteOptions } from "../types/clipboard";
+import { ClipboardMIMEType, ClipboardPasteOptions } from "../types/clipboard";
 import { Image } from "../types/image";
 import { Format, SpreadsheetChildEnv, Style } from "../types/index";
 
@@ -90,6 +90,9 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
         interactivePasteFromOS(env, target, osClipboard.content);
       } else {
         interactivePaste(env, target, pasteOption);
+      }
+      if (env.model.getters.isCutOperation() && pasteOption !== "onlyValue") {
+        await env.clipboard.write({ [ClipboardMIMEType.PlainText]: "" });
       }
       break;
     case "notImplemented":

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -87,7 +87,7 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
     case "ok":
       const target = env.model.getters.getSelectedZones();
       if (osClipboard && osClipboard.content !== spreadsheetClipboard) {
-        interactivePasteFromOS(env, target, osClipboard.content);
+        interactivePasteFromOS(env, target, osClipboard.content, pasteOption);
       } else {
         interactivePaste(env, target, pasteOption);
       }
@@ -112,8 +112,7 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
   }
 }
 
-export const PASTE_FORMAT_ACTION = (env: SpreadsheetChildEnv) =>
-  interactivePaste(env, env.model.getters.getSelectedZones(), "onlyFormat");
+export const PASTE_FORMAT_ACTION = (env: SpreadsheetChildEnv) => paste(env, "onlyFormat");
 
 export const DELETE_CONTENT_ACTION = (env: SpreadsheetChildEnv) =>
   env.model.dispatch("DELETE_CONTENT", {

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -605,7 +605,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     ev.preventDefault();
   }
 
-  paste(ev: ClipboardEvent) {
+  async paste(ev: ClipboardEvent) {
     if (!this.gridEl.contains(document.activeElement)) {
       return;
     }
@@ -625,6 +625,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
         interactivePaste(this.env, target);
       } else {
         interactivePasteFromOS(this.env, target, content);
+      }
+      if (this.env.model.getters.isCutOperation()) {
+        await this.env.clipboard.write({ [ClipboardMIMEType.PlainText]: "" });
       }
     }
   }

--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -30,7 +30,7 @@ interface CopiedTable {
 
 /** State of the clipboard when copying/cutting cells */
 export class ClipboardCellsState extends ClipboardCellsAbstractState {
-  private readonly cells: ClipboardCell[][];
+  private cells: ClipboardCell[][];
   private readonly copiedTables: CopiedTable[];
   private readonly zones: Zone[];
 
@@ -210,6 +210,13 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
       });
     }
     this.pasteCopiedTables(target);
+    this.cells.forEach((row) => {
+      row.forEach((c) => {
+        if (c.cell) {
+          c.cell = undefined;
+        }
+      });
+    });
   }
 
   /**
@@ -479,7 +486,9 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
         .map((cells) => {
           return cells
             .map((c) =>
-              c.cell ? this.getters.getCellText(c.position, this.getters.shouldShowFormulas()) : ""
+              this.getters.shouldShowFormulas() && c.cell?.isFormula
+                ? c.cell?.content || ""
+                : c.evaluatedCell?.formattedValue || ""
             )
             .join("\t");
         })

--- a/src/helpers/clipboard/clipboard_os_state.ts
+++ b/src/helpers/clipboard/clipboard_os_state.ts
@@ -36,7 +36,10 @@ export class ClipboardOsState extends ClipboardCellsAbstractState {
     return CommandResult.Success;
   }
 
-  paste(target: Zone[]) {
+  paste(target: Zone[], clipboardOption?: ClipboardOptions) {
+    if (clipboardOption?.pasteOption === "onlyFormat") {
+      return;
+    }
     const values = this.values;
     const pasteZone = this.getPasteZone(target);
     const { left: activeCol, top: activeRow } = pasteZone;

--- a/src/helpers/ui/paste_interactive.ts
+++ b/src/helpers/ui/paste_interactive.ts
@@ -34,7 +34,12 @@ export function interactivePaste(
   handlePasteResult(env, result);
 }
 
-export function interactivePasteFromOS(env: SpreadsheetChildEnv, target: Zone[], text: string) {
-  const result = env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", { target, text });
+export function interactivePasteFromOS(
+  env: SpreadsheetChildEnv,
+  target: Zone[],
+  text: string,
+  pasteOption?: ClipboardPasteOptions
+) {
+  const result = env.model.dispatch("PASTE_FROM_OS_CLIPBOARD", { target, text, pasteOption });
   handlePasteResult(env, result);
 }

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -65,7 +65,7 @@ export class ClipboardPlugin extends UIPlugin {
         return this.state.isPasteAllowed(cmd.target, { pasteOption });
       case "PASTE_FROM_OS_CLIPBOARD": {
         const state = new ClipboardOsState(cmd.text, this.getters, this.dispatch, this.selection);
-        return state.isPasteAllowed(cmd.target);
+        return state.isPasteAllowed(cmd.target, { pasteOption: cmd.pasteOption });
       }
       case "INSERT_CELL": {
         const { cut, paste } = this.getInsertCellsTargets(cmd.zone, cmd.shiftDimension);
@@ -156,7 +156,7 @@ export class ClipboardPlugin extends UIPlugin {
       }
       case "PASTE_FROM_OS_CLIPBOARD":
         this.state = new ClipboardOsState(cmd.text, this.getters, this.dispatch, this.selection);
-        this.state.paste(cmd.target);
+        this.state.paste(cmd.target, { pasteOption: cmd.pasteOption });
         this.lastPasteState = this.state;
         this.status = "invisible";
         break;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -541,6 +541,7 @@ export interface PasteFromOSClipboardCommand {
   type: "PASTE_FROM_OS_CLIPBOARD";
   target: Zone[];
   text: string;
+  pasteOption?: ClipboardPasteOptions;
 }
 
 export interface AutoresizeColumnsCommand {

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -143,6 +143,19 @@ describe("Menu Item actions", () => {
     expect(getCellContent(model, "A1")).toEqual("");
   });
 
+  test("'Edit -> paste' if copied from grid and content altered before paste", async () => {
+    setCellContent(model, "A1", "a1");
+    doAction(["edit", "copy"], env); // first copy from grid
+    setCellContent(model, "A1", "os clipboard");
+    selectCell(model, "C3");
+    await doAction(["edit", "paste"], env);
+    expect(dispatch).toHaveBeenCalledWith("PASTE", {
+      target: env.model.getters.getSelectedZones(),
+      pasteOption: undefined,
+    });
+    expect(getCellContent(model, "C3")).toEqual("a1");
+  });
+
   test("Edit -> paste_special should be hidden after a CUT ", () => {
     model.dispatch("CUT", { cutTarget: env.model.getters.getSelectedZones() });
     expect(getNode(["edit", "paste_special"]).isVisible(env)).toBeFalsy();

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -5,6 +5,7 @@ import { Model } from "../../src/model";
 import { ClipboardMIMEType, CommandResult } from "../../src/types/index";
 import { XMLString } from "../../src/types/xlsx";
 import { parseXML, xmlEscape } from "../../src/xlsx/helpers/xml_helpers";
+import { MockClipboardData } from "../test_helpers/clipboard";
 import {
   activateSheet,
   addCellToSelection,
@@ -190,6 +191,18 @@ describe("clipboard", () => {
 
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
     expect(getCell(model, "C2")!.style).toEqual({ bold: true });
+  });
+
+  test("copying external content & paste-format on a cell will not paste content", () => {
+    const model = new Model();
+    const clipboardData = new MockClipboardData();
+    clipboardData.setData(ClipboardMIMEType.PlainText, "Excalibur");
+
+    const content = clipboardData.getData(ClipboardMIMEType.PlainText);
+    pasteFromOSClipboard(model, "C2", content);
+    expect(getCellContent(model, "C2")).toBe(content);
+    pasteFromOSClipboard(model, "C3", content, "onlyFormat");
+    expect(getCellContent(model, "C3")).toBe("");
   });
 
   test("cannot paste multiple times after cut", () => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -270,8 +270,17 @@ export function paste(
 /**
  * Paste from OS clipboard on a zone
  */
-export function pasteFromOSClipboard(model: Model, range: string, content: string): DispatchResult {
-  return model.dispatch("PASTE_FROM_OS_CLIPBOARD", { text: content, target: target(range) });
+export function pasteFromOSClipboard(
+  model: Model,
+  range: string,
+  content: string,
+  pasteOption?: ClipboardPasteOptions
+): DispatchResult {
+  return model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
+    text: content,
+    target: target(range),
+    pasteOption,
+  });
 }
 
 /**


### PR DESCRIPTION
## Description:

Cut/Copy:
After a cut/copy operation, if the selection is updated before paste,  the content was pasted w/o any style. Also, the cut zone was not destroyed in case of cut operation.

This fix solves the problem by using the cells stored inside the Clipboard Plugin instead of the current state of the cells in the grid.

Also, this fix restricts pasting the content multiple times after a cut operation and clears the clipboard after a cut and single paste as well.

Only Format:
Copy external content and do 'Paste' or 'Paste-Only Value' on a cell. Now,  performing a 'Paste-Only Format' on a different cell would paste the content as well.

This fix solves the problem by handling content in case the pasteOption is 'onlyFormat'.

Odoo task ID : [3135623](https://www.odoo.com/web#id=3135623&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo