### PR TITLE
[FIX] composer: fix placeholder scrollbar

### DIFF
--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -3,7 +3,7 @@
     <div class="o-composer-container w-100 h-100">
       <div
         class="o-composer w-100 text-start"
-        t-att-class="{ 'text-muted': env.model.getters.isReadonly(), 'unfocusable': env.model.getters.isReadonly() }"
+        t-att-class="{ 'text-muted': env.model.getters.isReadonly(), 'unfocusable': env.model.getters.isReadonly(), 'active': props.focus !== 'inactive' }"
         t-att-style="props.inputStyle"
         t-ref="o_composer"
         tabindex="1"

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -13,6 +13,13 @@ import { Composer } from "../composer/composer";
 
 const COMPOSER_MAX_HEIGHT = 100;
 
+/* svg free of use from https://uxwing.com/formula-fx-icon/ */
+const FX_SVG = /*xml*/ `
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 121.8 122.9' width='16' height='16' focusable='false'>
+  <path d='m28 34-4 5v2h10l-6 40c-4 22-6 28-7 30-2 2-3 3-5 3-3 0-7-2-9-4H4c-2 2-4 4-4 7s4 6 8 6 9-2 15-8c8-7 13-17 18-39l7-35 13-1 3-6H49c4-23 7-27 11-27 2 0 5 2 8 6h4c1-1 4-4 4-7 0-2-3-6-9-6-5 0-13 4-20 10-6 7-9 14-11 24h-8zm41 16c4-5 7-7 8-7s2 1 5 9l3 12c-7 11-12 17-16 17l-3-1-2-1c-3 0-6 3-6 7s3 7 7 7c6 0 12-6 22-23l3 10c3 9 6 13 10 13 5 0 11-4 18-15l-3-4c-4 6-7 8-8 8-2 0-4-3-6-10l-5-15 8-10 6-4 3 1 3 2c2 0 6-3 6-7s-2-7-6-7c-6 0-11 5-21 20l-2-6c-3-9-5-14-9-14-5 0-12 6-18 15l3 3z' fill='#BDBDBD'/>
+</svg>
+`;
+
 css/* scss */ `
   .o-topbar-composer {
     height: fit-content;
@@ -20,9 +27,10 @@ css/* scss */ `
     border: 1px solid;
     z-index: ${ComponentsImportance.TopBarComposer};
 
-    .o-composer:empty:not(:focus)::before {
-      /* svg free of use from https://uxwing.com/formula-fx-icon/ */
-      content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -10 121.8 142.9' width='24' height='24' focusable='false'%3E%3Cpath d='m28 34-4 5v2h10l-6 40c-4 22-6 28-7 30-2 2-3 3-5 3-3 0-7-2-9-4H4c-2 2-4 4-4 7s4 6 8 6 9-2 15-8c8-7 13-17 18-39l7-35 13-1 3-6H49c4-23 7-27 11-27 2 0 5 2 8 6h4c1-1 4-4 4-7 0-2-3-6-9-6-5 0-13 4-20 10-6 7-9 14-11 24h-8zm41 16c4-5 7-7 8-7s2 1 5 9l3 12c-7 11-12 17-16 17l-3-1-2-1c-3 0-6 3-6 7s3 7 7 7c6 0 12-6 22-23l3 10c3 9 6 13 10 13 5 0 11-4 18-15l-3-4c-4 6-7 8-8 8-2 0-4-3-6-10l-5-15 8-10 6-4 3 1 3 2c2 0 6-3 6-7s-2-7-6-7c-6 0-11 5-21 20l-2-6c-3-9-5-14-9-14-5 0-12 6-18 15l3 3z' fill='%23BDBDBD' /%3E%3C/svg%3E");
+    .o-composer:empty:not(:focus):not(.active)::before {
+      content: url("data:image/svg+xml,${encodeURIComponent(FX_SVG)}");
+      position: relative;
+      top: 20%;
     }
   }
 `;

--- a/tests/components/__snapshots__/composer_integration.test.ts.snap
+++ b/tests/components/__snapshots__/composer_integration.test.ts.snap
@@ -9,7 +9,7 @@ exports[`Grid composer grid composer basic style Grid composer snapshot 1`] = `
     class="o-composer-container w-100 h-100"
   >
     <div
-      class="o-composer w-100 text-start"
+      class="o-composer w-100 text-start active"
       contenteditable="true"
       spellcheck="false"
       style="max-width:985px; max-height:985px;"


### PR DESCRIPTION
In odoo, a scrollbar appears when the "fx" placeholder is displayed. It is unclear why it happens in odoo and not with a standalone o-spreadsheet It's probably a browser size rounding corner case when the composer has other elements above it.

This commit partly reverts 9781b7e3a030e585c26117a8187712d9e986c82e The issue it was trying to fix is fixed in another way in this commit. The issue happened because the css was applied when the composer input was not focused (DOM focus) but the composer was active (from the edition plugin).
With this commit, the placeholder is displayed only when the composer is not active.

Odoo task ID : [3258920](https://www.odoo.com/web#id=3258920&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo