### PR TITLE
[IMP] composer: double click on range will select the whole range

### DIFF
--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -18,6 +18,7 @@
         t-on-paste.stop=""
         t-on-compositionstart="onCompositionStart"
         t-on-compositionend="onCompositionEnd"
+        t-on-dblclick="onDblClick"
       />
 
       <div


### PR DESCRIPTION
## Description:

Previously, when double clicking on a range in a formula, for example `A1:A30`, only `A1` or `A30` will be selected because of the colon.

This PR improves the selection so `A1:A30` the whole range will be selected when double clicking.

Normal text including colon will not be impacted. Double clicking `A1:A30` won't select the whole string.

Odoo task ID : [3266412](https://www.odoo.com/web#id=3266412&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo