### PR TITLE
[FIX] viewport: warning message on resized viewport size

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -264,6 +264,12 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     const { xRatio, yRatio } = this.env.model.getters.getFrozenSheetViewRatio(
       this.env.model.getters.getActiveSheetId()
     );
+
+    if (!isFinite(xRatio) || !isFinite(yRatio)) {
+      // before mounting, the ratios can be NaN or Infinity if the viewport size is 0
+      return;
+    }
+
     if (yRatio > MAXIMAL_FREEZABLE_RATIO || xRatio > MAXIMAL_FREEZABLE_RATIO) {
       if (this.isViewportTooSmall) {
         return;

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -1,6 +1,7 @@
-import { Model } from "../../src";
+import { Model, setDefaultSheetViewSize } from "../../src";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/actions/menu_items_actions";
 import { Spreadsheet } from "../../src/components";
+import { getDefaultSheetViewSize } from "../../src/constants";
 import { functionRegistry } from "../../src/functions";
 import { toZone } from "../../src/helpers";
 import { SpreadsheetChildEnv } from "../../src/types";
@@ -254,6 +255,19 @@ test("Spreadsheet detects frozen panes that exceed the limit size at start", asy
   const model = new Model({ sheets: [{ panes: { xSplit: 12, ySplit: 50 } }] });
   ({ parent, fixture } = await mountSpreadsheet({ model }, { notifyUser }));
   expect(notifyUser).toHaveBeenCalled();
+});
+
+test("Warns user when viewport is too small for frozen panes but stops warning after resizing/Unmounted", async () => {
+  const originalViewSize = getDefaultSheetViewSize();
+
+  // Setting the sheet viewport size to 0 to represent the "real life" scenario where the default size is 0
+  setDefaultSheetViewSize(0);
+  const notifyUser = jest.fn();
+  const model = new Model({ sheets: [{ panes: { xSplit: 0, ySplit: 20 } }] });
+  ({ parent, fixture } = await mountSpreadsheet({ model }, { notifyUser }));
+  expect(notifyUser).toHaveBeenCalledTimes(0);
+
+  setDefaultSheetViewSize(originalViewSize);
 });
 
 test("Warn user only once when the viewport is too small for its frozen panes", async () => {

--- a/tests/setup/resize_observer.mock.ts
+++ b/tests/setup/resize_observer.mock.ts
@@ -6,7 +6,7 @@ class MockResizeObserver {
   observe() {
     //@ts-ignore
     global.resizers.add(this);
-    this.cb();
+    Promise.resolve().then(() => this.cb());
   }
 
   unobserve() {


### PR DESCRIPTION
## Description:

Fix warning not closing issue caused by changing the value of `DEFAULT_SHEETVIEW_SIZE` to 0 from 1000 in a previous 
PR #2188. The problem arose due to `xRatio` and `yRatio` becoming `NaN` and `Infinity` prior to mounting.

To resolve this issue, Added an if condition that returns the function if either xRatio or yRatio is Infinity.

Odoo task ID : [3318806](https://www.odoo.com/web#id=3318806&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo