### PR TITLE
[IMP] ColorPicker: Extend the custom color selection

### DIFF
--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -1,53 +1,64 @@
 import { Component, useState } from "@odoo/owl";
 import {
   COLOR_PICKER_DEFAULTS,
+  ICON_EDGE_LENGTH,
   MENU_SEPARATOR_BORDER_WIDTH,
   MENU_SEPARATOR_PADDING,
   SEPARATOR_COLOR,
 } from "../../constants";
-import { hslaToRGBA, isColorValid, isSameColor, rgbaToHex, toHex } from "../../helpers";
+import {
+  clip,
+  hexToHSLA,
+  hslaToHex,
+  isColorValid,
+  isHSLAValid,
+  isSameColor,
+  toHex,
+} from "../../helpers";
 import { chartFontColor } from "../../helpers/figures/charts";
-import { Color, Pixel, Rect } from "../../types";
+import { Color, HSLA, Pixel, PixelPosition, Rect } from "../../types";
 import { SpreadsheetChildEnv } from "../../types/env";
 import { css, cssPropertiesToCss } from "../helpers/css";
+import { startDnd } from "../helpers/drag_and_drop";
 import { Popover, PopoverProps } from "../popover/popover";
 
-const PICKER_PADDING = 6;
-
 const LINE_VERTICAL_PADDING = 1;
-const LINE_HORIZONTAL_PADDING = 6;
 
-const ITEM_HORIZONTAL_MARGIN = 1;
-const ITEM_EDGE_LENGTH = 18;
+const PICKER_PADDING = 8;
 const ITEM_BORDER_WIDTH = 1;
-
+const ITEM_EDGE_LENGTH = 18;
 const ITEMS_PER_LINE = 10;
-const PICKER_WIDTH =
-  ITEMS_PER_LINE * (ITEM_EDGE_LENGTH + ITEM_HORIZONTAL_MARGIN * 2 + 2 * ITEM_BORDER_WIDTH) +
-  2 * LINE_HORIZONTAL_PADDING;
+const MAGNIFIER_EDGE = 16;
+const ITEM_GAP = 2;
 
-const GRADIENT_WIDTH = PICKER_WIDTH - 2 * LINE_HORIZONTAL_PADDING - 2 * ITEM_BORDER_WIDTH;
-const GRADIENT_HEIGHT = PICKER_WIDTH - 50;
+const CONTENT_WIDTH =
+  ITEMS_PER_LINE * (ITEM_EDGE_LENGTH + 2 * ITEM_BORDER_WIDTH) + (ITEMS_PER_LINE - 1) * ITEM_GAP;
+
+const INNER_GRADIENT_WIDTH = CONTENT_WIDTH - 2 * ITEM_BORDER_WIDTH;
+const INNER_GRADIENT_HEIGHT = CONTENT_WIDTH - 30 - 2 * ITEM_BORDER_WIDTH;
+
+const CONTAINER_WIDTH = CONTENT_WIDTH + 2 * PICKER_PADDING;
 
 css/* scss */ `
   .o-color-picker {
-    padding: ${PICKER_PADDING}px 0px;
+    padding: ${PICKER_PADDING}px 0;
+    /** FIXME: this is useless, overiden by the popover container */
     box-shadow: 1px 2px 5px 2px rgba(51, 51, 51, 0.15);
     background-color: white;
     line-height: 1.2;
     overflow-y: auto;
     overflow-x: hidden;
-    width: ${GRADIENT_WIDTH + 2 * PICKER_PADDING}px;
+    width: ${CONTAINER_WIDTH}px;
 
     .o-color-picker-section-name {
-      margin: 0px ${ITEM_HORIZONTAL_MARGIN}px;
-      padding: 4px ${LINE_HORIZONTAL_PADDING}px;
+      margin: 0px ${ITEM_BORDER_WIDTH}px;
+      padding: 4px ${PICKER_PADDING}px;
     }
     .colors-grid {
       display: grid;
-      padding: ${LINE_VERTICAL_PADDING}px ${LINE_HORIZONTAL_PADDING}px;
+      padding: ${LINE_VERTICAL_PADDING}px ${PICKER_PADDING}px;
       grid-template-columns: repeat(${ITEMS_PER_LINE}, 1fr);
-      grid-gap: ${ITEM_HORIZONTAL_MARGIN * 2}px;
+      grid-gap: ${ITEM_GAP}px;
     }
     .o-color-picker-toggler-button {
       display: flex;
@@ -77,16 +88,16 @@ css/* scss */ `
       }
     }
     .o-buttons {
-      padding: 6px;
+      padding: ${PICKER_PADDING}px;
       display: flex;
       .o-cancel {
-        margin: 0px ${ITEM_HORIZONTAL_MARGIN}px;
         border: ${ITEM_BORDER_WIDTH}px solid #c0c0c0;
         width: 100%;
         padding: 5px;
         font-size: 14px;
         background: white;
         border-radius: 4px;
+        box-sizing: border-box;
         &:hover:enabled {
           background-color: rgba(0, 0, 0, 0.08);
         }
@@ -106,77 +117,95 @@ css/* scss */ `
       margin-top: ${MENU_SEPARATOR_PADDING}px;
       margin-bottom: ${MENU_SEPARATOR_PADDING}px;
     }
-    input {
-      box-sizing: border-box;
-      width: 100%;
-      border-radius: 4px;
-      padding: 4px 23px 4px 10px;
-      height: 24px;
-      border: 1px solid #c0c0c0;
-      margin: 0 2px 0 0;
-    }
-    input.o-wrong-color {
-      border-color: red;
-    }
+
     .o-custom-selector {
-      padding: ${LINE_HORIZONTAL_PADDING}px;
+      padding: ${PICKER_PADDING + 2}px ${PICKER_PADDING}px;
       position: relative;
       .o-gradient {
-        background: linear-gradient(to bottom, hsl(0 100% 0%), transparent, hsl(0 0% 100%)),
-          linear-gradient(
-            to right,
-            hsl(0 100% 50%) 0%,
-            hsl(0.2turn 100% 50%) 20%,
-            hsl(0.3turn 100% 50%) 30%,
-            hsl(0.4turn 100% 50%) 40%,
-            hsl(0.5turn 100% 50%) 50%,
-            hsl(0.6turn 100% 50%) 60%,
-            hsl(0.7turn 100% 50%) 70%,
-            hsl(0.8turn 100% 50%) 80%,
-            hsl(0.9turn 100% 50%) 90%,
-            hsl(1turn 100% 50%) 100%
-          );
+        margin-bottom: ${MAGNIFIER_EDGE / 2}px;
         border: ${ITEM_BORDER_WIDTH}px solid #c0c0c0;
-        width: ${GRADIENT_WIDTH}px;
-        height: ${GRADIENT_HEIGHT}px;
-        &:hover {
-          cursor: crosshair;
-        }
+        box-sizing: border-box;
+        width: ${INNER_GRADIENT_WIDTH + 2 * ITEM_BORDER_WIDTH}px;
+        height: ${INNER_GRADIENT_HEIGHT + 2 * ITEM_BORDER_WIDTH}px;
+        position: relative;
+      }
+
+      .magnifier {
+        height: ${MAGNIFIER_EDGE}px;
+        width: ${MAGNIFIER_EDGE}px;
+        box-sizing: border-box;
+        border-radius: 50%;
+        border: 2px solid #fff;
+        box-shadow: 0px 0px 3px #c0c0c0;
+        position: absolute;
+        z-index: 2;
+      }
+      .saturation {
+        background: linear-gradient(to right, #fff 0%, transparent 100%);
+      }
+      .lightness {
+        background: linear-gradient(to top, #000 0%, transparent 100%);
+      }
+      .o-hue-picker {
+        border: ${ITEM_BORDER_WIDTH}px solid #c0c0c0;
+        box-sizing: border-box;
+        width: 100%;
+        height: 12px;
+        border-radius: 4px;
+        background: linear-gradient(
+          to right,
+          hsl(0 100% 50%) 0%,
+          hsl(0.2turn 100% 50%) 20%,
+          hsl(0.3turn 100% 50%) 30%,
+          hsl(0.4turn 100% 50%) 40%,
+          hsl(0.5turn 100% 50%) 50%,
+          hsl(0.6turn 100% 50%) 60%,
+          hsl(0.7turn 100% 50%) 70%,
+          hsl(0.8turn 100% 50%) 80%,
+          hsl(0.9turn 100% 50%) 90%,
+          hsl(1turn 100% 50%) 100%
+        );
+        position: relative;
+        cursor: crosshair;
+      }
+      .o-hue-slider {
+        margin-top: -3px;
       }
       .o-custom-input-preview {
-        padding: 2px ${LINE_VERTICAL_PADDING}px;
+        padding: 2px 0px;
         display: flex;
+        input {
+          box-sizing: border-box;
+          width: 50%;
+          border-radius: 4px;
+          padding: 4px 23px 4px 10px;
+          height: 24px;
+          border: 1px solid #c0c0c0;
+          margin-right: 2px;
+        }
+        .o-wrong-color {
+          /** FIXME bootstrap class instead? */
+          outline-color: red;
+          border-color: red;
+          &:focus {
+            outline-style: solid;
+            outline-width: 1px;
+          }
+        }
       }
       .o-custom-input-buttons {
-        padding: 2px ${LINE_VERTICAL_PADDING}px;
-        text-align: right;
+        padding: 2px 0px;
+        display: flex;
+        justify-content: end;
       }
       .o-color-preview {
         border: 1px solid #c0c0c0;
         border-radius: 4px;
-        width: 100%;
+        width: 50%;
       }
     }
   }
-  .o-magnifier-glass {
-    position: absolute;
-    border: ${ITEM_BORDER_WIDTH}px solid #c0c0c0;
-    border-radius: 50%;
-    width: 30px;
-    height: 30px;
-  }
 `;
-
-function computeCustomColor(ev: MouseEvent) {
-  return rgbaToHex(
-    hslaToRGBA({
-      h: (360 * ev.offsetX) / GRADIENT_WIDTH,
-      s: 100,
-      l: (100 * ev.offsetY) / GRADIENT_HEIGHT,
-      a: 1,
-    })
-  );
-}
 
 export interface ColorPickerProps {
   anchorRect: Rect;
@@ -187,34 +216,23 @@ export interface ColorPickerProps {
 
 interface State {
   showGradient: boolean;
-  currentColor: Color;
-  isCurrentColorInvalid: boolean;
-  style: {
-    display: string;
-    background: Color;
-    left: string;
-    top: string;
-  };
+  currentHslaColor: HSLA;
+  customHexColor: Color;
 }
 
 export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColorPicker";
-  static defaultProps = {
-    currentColor: "", //TODO Change it to false instead of empty string
-  };
+  static defaultProps = { currentColor: "" };
   static components = { Popover };
+
   COLORS = COLOR_PICKER_DEFAULTS;
 
   private state: State = useState({
     showGradient: false,
-    currentColor: isColorValid(this.props.currentColor) ? this.props.currentColor : "",
-    isCurrentColorInvalid: false,
-    style: {
-      display: "none",
-      background: "#ffffff",
-      left: "0",
-      top: "0",
-    },
+    currentHslaColor: isColorValid(this.props.currentColor)
+      ? { ...hexToHSLA(this.props.currentColor), a: 1 }
+      : { h: 0, s: 100, l: 100, a: 1 },
+    customHexColor: isColorValid(this.props.currentColor) ? toHex(this.props.currentColor) : "",
   });
 
   get colorPickerStyle(): string {
@@ -232,64 +250,133 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
       verticalOffset: 0,
     };
   }
+
+  get gradientHueStyle(): string {
+    const hue = this.state.currentHslaColor?.h || 0;
+    return cssPropertiesToCss({
+      background: `hsl(${hue} 100% 50%)`,
+    });
+  }
+
+  get sliderStyle(): string {
+    const hue = this.state.currentHslaColor?.h || 0;
+    const delta = Math.round((hue / 360) * INNER_GRADIENT_WIDTH);
+    const left = clip(delta, 1, INNER_GRADIENT_WIDTH) - ICON_EDGE_LENGTH / 2;
+    return cssPropertiesToCss({
+      "margin-left": `${left}px`,
+    });
+  }
+
+  get pointerStyle(): string {
+    const { s, l } = this.state.currentHslaColor || { s: 0, l: 0 };
+    const left = Math.round(INNER_GRADIENT_WIDTH * clip(s / 100, 0, 1));
+    const top = Math.round(INNER_GRADIENT_HEIGHT * clip(1 - (2 * l) / (200 - s), 0, 1));
+
+    return cssPropertiesToCss({
+      left: `${-MAGNIFIER_EDGE / 2 + left}px`,
+      top: `${-MAGNIFIER_EDGE / 2 + top}px`,
+      background: hslaToHex(this.state.currentHslaColor),
+    });
+  }
+
+  get colorPreviewStyle(): string {
+    return cssPropertiesToCss({
+      "background-color": hslaToHex(this.state.currentHslaColor),
+    });
+  }
+
+  get checkmarkColor(): Color {
+    return chartFontColor(this.props.currentColor);
+  }
+
+  get isHexColorInputValid(): boolean {
+    return !this.state.customHexColor || isColorValid(this.state.customHexColor);
+  }
+
+  private setCustomGradient({ x, y }: PixelPosition) {
+    const offsetX = clip(x, 0, INNER_GRADIENT_WIDTH);
+    const offsetY = clip(y, 0, INNER_GRADIENT_HEIGHT);
+    const deltaX = offsetX / INNER_GRADIENT_WIDTH;
+    const deltaY = offsetY / INNER_GRADIENT_HEIGHT;
+    const s = 100 * deltaX;
+    const l = 100 * (1 - deltaY) * (1 - 0.5 * deltaX);
+    this.updateColor({ s, l });
+  }
+
+  private setCustomHue(x: Pixel) {
+    // needs to be capped such that h is in [0°, 359°]
+    const h = Math.round(clip((360 * x) / INNER_GRADIENT_WIDTH, 0, 359));
+    this.updateColor({ h });
+  }
+
+  private updateColor(newHsl: Partial<Omit<HSLA, "a">>) {
+    this.state.currentHslaColor = { ...this.state.currentHslaColor, ...newHsl };
+    this.state.customHexColor = hslaToHex(this.state.currentHslaColor);
+  }
+
   onColorClick(color: Color) {
     if (color) {
       this.props.onColorPicked(toHex(color));
     }
   }
 
-  getCheckMarkColor(): Color {
-    return chartFontColor(this.props.currentColor);
-  }
-
   resetColor() {
     this.props.onColorPicked("");
-  }
-
-  setCustomColor(ev: Event) {
-    if (!isColorValid(this.state.currentColor)) {
-      ev.stopPropagation();
-      this.state.isCurrentColorInvalid = true;
-      return;
-    }
-    const color = toHex(this.state.currentColor);
-    this.state.isCurrentColorInvalid = false;
-    this.props.onColorPicked(color);
-    this.state.currentColor = color;
   }
 
   toggleColorPicker() {
     this.state.showGradient = !this.state.showGradient;
   }
 
-  computeCustomColor(ev: MouseEvent) {
-    this.state.isCurrentColorInvalid = false;
-    this.state.currentColor = computeCustomColor(ev);
+  dragGradientPointer(ev: MouseEvent) {
+    const initialGradientCoordinates = { x: ev.offsetX, y: ev.offsetY };
+    this.setCustomGradient(initialGradientCoordinates);
+
+    const initialMousePosition = { x: ev.clientX, y: ev.clientY };
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const currentMousePosition = { x: ev.clientX, y: ev.clientY };
+      const deltaX = currentMousePosition.x - initialMousePosition.x;
+      const deltaY = currentMousePosition.y - initialMousePosition.y;
+
+      const currentGradientCoordinates = {
+        x: initialGradientCoordinates.x + deltaX,
+        y: initialGradientCoordinates.y + deltaY,
+      };
+      this.setCustomGradient(currentGradientCoordinates);
+    };
+
+    startDnd(onMouseMove, () => {});
   }
 
-  hideMagnifier(_ev: MouseEvent) {
-    this.state.style.display = "none";
+  dragHuePointer(ev: MouseEvent) {
+    const initialX = ev.offsetX;
+    const initialMouseX = ev.clientX;
+    this.setCustomHue(initialX);
+    const onMouseMove = (ev: MouseEvent) => {
+      const currentMouseX = ev.clientX;
+      const deltaX = currentMouseX - initialMouseX;
+      const x = initialX + deltaX;
+      this.setCustomHue(x);
+    };
+    startDnd(onMouseMove, () => {});
   }
 
-  showMagnifier(_ev: MouseEvent) {
-    this.state.style.display = "block";
+  setHexColor(ev: InputEvent) {
+    // only support HEX code input
+    const val = (ev.target as HTMLInputElement).value.slice(0, 7);
+    this.state.customHexColor = val;
+    if (!isColorValid(val)) {
+    } else {
+      this.state.currentHslaColor = { ...hexToHSLA(val), a: 1 };
+    }
   }
 
-  moveMagnifier(ev: MouseEvent) {
-    this.state.style.background = computeCustomColor(ev);
-    const shiftFromCursor = 10;
-    this.state.style.left = `${ev.offsetX + shiftFromCursor}px`;
-    this.state.style.top = `${ev.offsetY + shiftFromCursor}px`;
-  }
-
-  get magnifyingGlassStyle() {
-    const { display, background, left, top } = this.state.style;
-    return cssPropertiesToCss({
-      display,
-      "background-color": display === "block" ? background : undefined,
-      left,
-      top,
-    });
+  addCustomColor(ev: Event) {
+    if (!isHSLAValid(this.state.currentHslaColor) || !isColorValid(this.state.customHexColor)) {
+      return;
+    }
+    this.props.onColorPicked(toHex(this.state.customHexColor));
   }
 
   isSameColor(color1: Color, color2: Color): boolean {

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -15,7 +15,7 @@
             <div
               t-if="isSameColor(props.currentColor, color)"
               align="center"
-              t-attf-style="color:{{getCheckMarkColor()}}">
+              t-attf-style="color:{{checkmarkColor}}">
               ✓
             </div>
           </div>
@@ -41,38 +41,52 @@
             t-attf-style="background-color:{{color}};"
             t-on-click="() => this.onColorClick(color)">
             <div
-              t-if="props.currentColor === color"
+              t-if="isSameColor(props.currentColor, color)"
               align="center"
-              t-attf-style="color:{{getCheckMarkColor()}}">
+              t-attf-style="color:{{checkmarkColor}}">
               ✓
             </div>
           </div>
         </div>
         <div t-if="state.showGradient" class="o-custom-selector">
-          <div class="o-magnifier-glass" t-att-style="magnifyingGlassStyle"/>
           <div
             class="o-gradient"
-            t-on-click.stop="computeCustomColor"
-            t-on-mouseout="hideMagnifier"
-            t-on-mousemove="moveMagnifier"
-            t-on-mouseover="showMagnifier"
-          />
+            t-on-click.stop=""
+            t-on-mousedown="dragGradientPointer"
+            t-att-style="gradientHueStyle">
+            <div class="saturation w-100 h-100 position-absolute pe-none"/>
+            <div class="lightness w-100 h-100 position-absolute pe-none"/>
+            <div class="magnifier pe-none" t-att-style="pointerStyle"/>
+          </div>
+          <div class="o-hue-container" t-on-mousedown="dragHuePointer">
+            <div class="o-hue-picker" t-on-click.stop=""/>
+            <div class="o-hue-slider pe-none" t-att-style="sliderStyle">
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>
+            </div>
+          </div>
           <div class="o-custom-input-preview">
             <input
               type="text"
-              t-att-class="{'o-wrong-color': state.isCurrentColorInvalid }"
+              t-att-class="{'o-wrong-color': !isHexColorInputValid }"
               t-on-click.stop=""
-              t-model="state.currentColor"
+              t-att-value="state.customHexColor"
+              t-on-input="setHexColor"
+              maxlength="7"
             />
-            <div class="o-color-preview" t-attf-style="background-color:{{state.currentColor}}"/>
+            <div class="o-color-preview" t-att-style="colorPreviewStyle"/>
           </div>
           <div class="o-custom-input-buttons">
-            <button class="o-add-button" t-on-click="setCustomColor">Add</button>
+            <button
+              class="o-add-button"
+              t-att-class="{'o-disabled': !state.customHexColor or !isHexColorInputValid}"
+              t-on-click.stop="addCustomColor">
+              Add
+            </button>
           </div>
         </div>
         <div class="o-separator"/>
         <div class="o-buttons">
-          <button t-on-click="resetColor" class="o-cancel">Reset</button>
+          <button t-on-click="resetColor" class="o-cancel">No Color</button>
         </div>
       </div>
     </Popover>

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -75,6 +75,15 @@ export function isColorValid(color: Color): boolean {
   }
 }
 
+export function isHSLAValid(color: HSLA): boolean {
+  try {
+    hslaToHex(color);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 const isColorValueValid = (v) => v >= 0 && v <= 255;
 
 export function rgba(r: number, g: number, b: number, a: number = 1): RGBA {
@@ -274,6 +283,39 @@ export function rgbaToHSLA(rgba: RGBA): HSLA {
   return { a: rgba.a, h, s, l };
 }
 
-export function isSameColor(color1: Color, color2: Color): boolean {
-  return isColorValid(color1) && isColorValid(color2) && toHex(color1) === toHex(color2);
+export function hslaToHex(hsla: HSLA): Color {
+  return rgbaToHex(hslaToRGBA(hsla));
+}
+
+export function hexToHSLA(hex: Color): HSLA {
+  return rgbaToHSLA(colorToRGBA(hex));
+}
+
+/**
+ * Will compare two color strings
+ * A tolerance can be provided to account for small differences that could
+ * be introduced by non-bijective transformations between color spaces.
+ *
+ * E.g. HSV <-> RGB is not a bijection
+ *
+ * Note that the tolerance is applied on the euclidean distance between
+ * the two **normalized** color values.
+ */
+export function isSameColor(color1: Color, color2: Color, tolerance: number = 0): boolean {
+  if (!(isColorValid(color1) && isColorValid(color2))) {
+    return false;
+  }
+
+  const rgb1 = colorToRGBA(color1);
+  const rgb2 = colorToRGBA(color2);
+
+  // alpha cannot differ as it is not impacted by transformations
+  if (rgb1.a !== rgb2.a) {
+    return false;
+  }
+
+  const diff = Math.sqrt(
+    ((rgb1.r - rgb2.r) / 255) ** 2 + ((rgb1.g - rgb2.g) / 255) ** 2 + ((rgb1.b - rgb2.b) / 255) ** 2
+  );
+  return diff <= tolerance;
 }

--- a/tests/components/__snapshots__/color_picker.test.ts.snap
+++ b/tests/components/__snapshots__/color_picker.test.ts.snap
@@ -459,21 +459,51 @@ exports[`Color Picker buttons Full component rendering 1`] = `
     class="o-custom-selector"
   >
     <div
-      class="o-magnifier-glass"
-      style="display:none; left:0; top:0;"
-    />
-    <div
       class="o-gradient"
-    />
+      style="background:hsl(0 100% 50%);"
+    >
+      <div
+        class="saturation w-100 h-100 position-absolute pe-none"
+      />
+      <div
+        class="lightness w-100 h-100 position-absolute pe-none"
+      />
+      <div
+        class="magnifier pe-none"
+        style="left:-8px; top:178px; background:#000000;"
+      />
+    </div>
+    <div
+      class="o-hue-container"
+    >
+      <div
+        class="o-hue-picker"
+      />
+      <div
+        class="o-hue-slider pe-none"
+        style="margin-left:-8px;"
+      >
+        <svg
+          class="o-icon"
+        >
+          <polygon
+            fill="currentColor"
+            points="4 0 0 4 8 4"
+            transform="translate(5 7)"
+          />
+        </svg>
+      </div>
+    </div>
     <div
       class="o-custom-input-preview"
     >
       <input
+        maxlength="7"
         type="text"
       />
       <div
         class="o-color-preview"
-        style="background-color:#000000"
+        style="background-color:#000000;"
       />
     </div>
     <div
@@ -482,7 +512,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       <button
         class="o-add-button"
       >
-        Add
+         Add 
       </button>
     </div>
   </div>
@@ -496,7 +526,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
     <button
       class="o-cancel"
     >
-      Reset
+      No Color
     </button>
   </div>
 </div>

--- a/tests/setup/jest_extend.ts
+++ b/tests/setup/jest_extend.ts
@@ -23,7 +23,7 @@ declare global {
       toBeCancelledBecause(...expected: CancelledReason[]): R;
       toBeSuccessfullyDispatched(): R;
       toBeBetween(lower: number, upper: number): R;
-      toBeSameColorAs(expected: string): R;
+      toBeSameColorAs(expected: string, tolerance?: number): R;
     }
   }
 }
@@ -133,9 +133,12 @@ CancelledReasons: ${this.utils.printReceived(dispatchResult.reasons)}
     }
     return { pass: true, message: () => "" };
   },
-  toBeSameColorAs(received: string, expected: string) {
-    const pass = isSameColor(received, expected); //
-    const message = () => (pass ? "" : `Expected ${received} to be equivalent to ${expected}`);
+  toBeSameColorAs(received: string, expected: string, tolerance: number = 0) {
+    const pass = isSameColor(received, expected, tolerance);
+    const message = () =>
+      pass
+        ? ""
+        : `Expected ${received} to be equivalent to ${expected} with a tolerance of ${tolerance}`;
     return {
       pass,
       message,


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

The current color picker does not allow to visually choose a custom
color accross the whole web-compliant color spectrum. More specifically,
we could not change the saturation of the color, its level of grays [1].

This commit addresses this issue by changing the helper to use the HSL
color representation. This was based on the visual of Google sheet
color picker. As a side effet, it also addresses the magnifying glass
issue reported.

Small caveat of this approach is that there is no direct equivalence
between the HSL and RBG/HEX representations. As we store the color hex
value, the conversion from hex to hsl and vice versa might sometimes
differ slightly. However, the end user should not be able to notice it
and still has the possibility to introduce a specific hex color at will.

[1] Users could already do it by specifying a hex code directly but it
was not feasible with the visual helper.

Task: 3272474

Odoo task ID : [3272474](https://www.odoo.com/web#id=3272474&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo