### PR TITLE
[FIX] ColorPicker: Fix style issue

### DIFF
--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -49,7 +49,7 @@ css/* scss */ `
       grid-template-columns: repeat(${ITEMS_PER_LINE}, 1fr);
       grid-gap: ${ITEM_HORIZONTAL_MARGIN * 2}px;
     }
-    .o-color-picker-toggler {
+    .o-color-picker-toggler-button {
       display: flex;
       .o-color-picker-toggler-sign {
         margin: auto auto;

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -27,7 +27,7 @@
           <span>Custom</span>
         </div>
         <div class="colors-grid o-color-picker-toggler" t-on-click.stop="toggleColorPicker">
-          <div class="o-color-picker-line-item o-color-picker-toggler">
+          <div class="o-color-picker-line-item o-color-picker-toggler-button">
             <div class="o-color-picker-toggler-sign">
               <t t-call="o-spreadsheet-Icon.PLUS"/>
             </div>

--- a/tests/components/__snapshots__/color_picker.test.ts.snap
+++ b/tests/components/__snapshots__/color_picker.test.ts.snap
@@ -436,7 +436,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
     class="colors-grid o-color-picker-toggler"
   >
     <div
-      class="o-color-picker-line-item o-color-picker-toggler"
+      class="o-color-picker-line-item o-color-picker-toggler-button"
     >
       <div
         class="o-color-picker-toggler-sign"


### PR DESCRIPTION
Wrong style introduced in e95c1f81 as the class `o-color-picker-toggler` has bee napplied to several divs as discriminant selectors in the tests. I did not test this properly at forward port.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo