### PR TITLE
[FIX] Composer: autocomplete in topbar composer

### DIFF
--- a/src/components/composer/composer.ts
+++ b/src/components/composer/composer.ts
@@ -289,6 +289,7 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
         autoCompleteComp.moveDown();
       }
     }
+    this.updateCursorIfNeeded();
   }
 
   private processTabKey(ev: KeyboardEvent) {
@@ -348,9 +349,13 @@ export class Composer extends Component<Props, SpreadsheetEnv> {
       handler.call(this, ev);
     } else {
       ev.stopPropagation();
+      this.updateCursorIfNeeded();
     }
-    const { start, end } = this.contentHelper.getCurrentSelection();
+  }
+
+  private updateCursorIfNeeded() {
     if (!this.getters.isSelectingForComposer()) {
+      const { start, end } = this.contentHelper.getCurrentSelection();
       this.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start, end });
       this.isKeyStillDown = true;
     }

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -199,6 +199,25 @@ describe("Functions autocomplete", () => {
     });
   });
 
+  test.each(["Enter", "Tab"])(
+    "=S(A1:A5) + %s complete the function --> =SUM(A1:A5)",
+    async (buttonkey) => {
+      await typeInComposer("=S(A1:A5)");
+      model.dispatch("STOP_COMPOSER_RANGE_SELECTION");
+      model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 2, end: 2 });
+      await nextTick();
+      await typeInComposer("U", false);
+      expect(model.getters.getCurrentContent()).toBe("=SU(A1:A5)");
+      expect(model.getters.getComposerSelection()).toEqual({ start: 3, end: 3 });
+      expect(document.activeElement).toBe(composerEl);
+      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(1);
+      await nextTick();
+      composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: buttonkey }));
+      await nextTick();
+      expect(composerEl.textContent).toBe("=SUM(A1:A5)");
+    }
+  );
+
   describe("autocomplete functions SUM IF", () => {
     test("empty not show autocomplete", async () => {
       await typeInComposer("");


### PR DESCRIPTION

## Description:

Previously, when we write a formula and tried to autocomplete it by pressing tab or enter, it wouldn't update topbar composer. To fix this, we update a function called onKeydown to manage the enter and tab buttons.

Odoo task ID : [3291781](https://www.odoo.com/web#id=3291781&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo