### PR TITLE
[FIX] index.ts: export `invalidateXCommand` sets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,13 @@ export {
   RevisionUndoneMessage,
   TransportService,
 } from "./types/collaborative/transport_service";
-export { coreTypes, invalidateEvaluationCommands, readonlyAllowedCommands } from "./types/commands";
+export {
+  coreTypes,
+  invalidateCFEvaluationCommands,
+  invalidateDependenciesCommands,
+  invalidateEvaluationCommands,
+  readonlyAllowedCommands,
+} from "./types/commands";
 export { EvaluationError } from "./types/errors";
 export const SPREADSHEET_DIMENSIONS = {
   MIN_ROW_HEIGHT,


### PR DESCRIPTION
The different sets had to be extended inside the integrations that would add commands that impact the evaluation.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo