### PR TITLE
[FIX] menu: correctly await paste action

### DIFF
--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -25,7 +25,6 @@ import {
   getNode,
   makeTestEnv,
   mockUuidV4To,
-  nextTick,
   spyModelDispatch,
   target,
 } from "./test_helpers/helpers";
@@ -129,8 +128,7 @@ describe("Menu Item actions", () => {
   test("Edit -> paste from OS clipboard if copied from outside world last", async () => {
     doAction(["edit", "copy"], env); // first copy from grid
     await env.clipboard.writeText("Then copy in OS clipboard");
-    doAction(["edit", "paste"], env);
-    await nextTick();
+    await doAction(["edit", "paste"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
       text: "Then copy in OS clipboard",
       target: [{ bottom: 0, left: 0, right: 0, top: 0 }],
@@ -140,8 +138,7 @@ describe("Menu Item actions", () => {
   test("Edit -> paste if copied from grid last", async () => {
     await env.clipboard.writeText("First copy in OS clipboard");
     doAction(["edit", "copy"], env); // then copy from grid
-    doAction(["edit", "paste"], env);
-    await nextTick();
+    await doAction(["edit", "paste"], env);
     interactivePaste(env, target("A1"));
     expect(getCellContent(model, "A1")).toEqual("");
   });
@@ -158,8 +155,7 @@ describe("Menu Item actions", () => {
 
   test("Edit -> paste_special -> paste_special_value", async () => {
     doAction(["edit", "copy"], env);
-    doAction(["edit", "paste_special", "paste_special_value"], env);
-    await nextTick();
+    await doAction(["edit", "paste_special", "paste_special_value"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE", {
       target: env.model.getters.getSelectedZones(),
       pasteOption: "onlyValue",
@@ -169,8 +165,7 @@ describe("Menu Item actions", () => {
   test("Edit -> paste_special -> paste_special_value from OS clipboard", async () => {
     const text = "in OS clipboard";
     await env.clipboard.writeText(text);
-    doAction(["edit", "paste_special", "paste_special_value"], env);
-    await nextTick();
+    await doAction(["edit", "paste_special", "paste_special_value"], env);
     expect(dispatch).toHaveBeenCalledWith("PASTE_FROM_OS_CLIPBOARD", {
       target: target("A1"),
       text,
@@ -1039,10 +1034,9 @@ describe("Menu Item actions", () => {
     });
   });
 
-  test("Data -> Split to columns action", async () => {
+  test("Data -> Split to columns action", () => {
     const spyOpenSidePanel = jest.spyOn(env, "openSidePanel");
     doAction(["data", "split_to_columns"], env);
-    await nextTick();
     expect(spyOpenSidePanel).toHaveBeenCalledWith("SplitToColumns", {});
   });
 

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -554,13 +554,13 @@ export function getCellsObject(model: Model, sheetId: UID): Record<string, CellV
   return cells;
 }
 
-export function doAction(
+export async function doAction(
   path: string[],
   env: SpreadsheetChildEnv,
   menuRegistry: MenuItemRegistry = topbarMenuRegistry
-): void {
+) {
   const node = getNode(path, menuRegistry);
-  node.execute?.(env);
+  await node.execute?.(env);
 }
 
 export function getNode(


### PR DESCRIPTION
The `paste` function in the paste action was not awaited, and thus the actual paste was put in the JS action queue. This had no real impact in practice, but was a bit ugly in the tests with an `await nextTick`.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo