### PR TITLE
[FIX] composer: do not autocomplete boolean values

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -418,7 +418,11 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
         };
       });
     if (searchTerm) {
-      values = fuzzyLookup(searchTerm, values, (t) => t.text);
+      if (searchTerm.toLowerCase() === "true" || searchTerm.toLowerCase() === "false") {
+        values = [];
+      } else {
+        values = fuzzyLookup(searchTerm, values, (t) => t.text);
+      }
     } else {
       // alphabetical order
       values = values.sort((a, b) => a.text.localeCompare(b.text));

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -309,6 +309,16 @@ describe("Functions autocomplete", () => {
       ).toBe("SUM");
     });
   });
+
+  describe("Edge cases with autocomplete", () => {
+    test("autocomplete dropdown should not trigger on =true or =false", async () => {
+      restoreDefaultFunctions();
+      await typeInComposerGrid("=true", true);
+      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
+      await typeInComposerGrid("=false", true);
+      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
+    });
+  });
 });
 
 describe("Autocomplete parenthesis", () => {


### PR DESCRIPTION
## Description:

Currently fuzzy lookup is showing random results for true or false values, which is not correct. This commit fixes that issue by hard coding the lookup values for true and false for now.

Future scope for same:
Create True and False functions, which upon autocomplete will return true and false respectively without any arguments required. May need to change a bit of tokenizer

Odoo task ID : [3213850](https://www.odoo.com/web#id=3213850&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo