### PR TITLE
[FIX] demoData: fix XSLX demo data

### DIFF
--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet2.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" xmlns:xr2="http://schemas.microsoft.com/office/spreadsheetml/2015/revision2" xmlns:xr3="http://schemas.microsoft.com/office/spreadsheetml/2016/revision3" mc:Ignorable="x14ac xr xr2 xr3" xr:uid="{00000000-0001-0000-0200-000000000000}">
-  <dimension ref="A1:R161"/>
+  <dimension ref="A1:R163"/>
   <sheetViews>
     <sheetView topLeftCell="A97" workbookViewId="0">
       <selection activeCell="G115" sqref="G115"/>
@@ -2568,7 +2568,7 @@
         <v>208</v>
       </c>
       <c r="D145" s="2">
-        <f t="shared" ref="D145:D161" si="9">IF(B145=C145,1,0)</f>
+        <f t="shared" ref="D145:D163" si="9">IF(B145=C145,1,0)</f>
         <v>1</v>
       </c>
     </row>
@@ -2849,11 +2849,11 @@
       <c r="A163" s="2" t="s">
         <v>410</v>
       </c>
-      <c r="B163" s="2" t="str">
+      <c r="B163" s="2">
         <f>DATEDIF("2002/01/01","2002/01/02","D")</f>
         <v>1</v>
       </c>
-      <c r="C163" s="2" t="str">
+      <c r="C163" s="2">
         <v>1</v>
       </c>
       <c r="D163" s="2">


### PR DESCRIPTION
## Description

Since bf20db7f3577a4c096b2a9158683bf8c0c701c4b, the .xlsx file generated by the demodata can't be opened in a real XLSX client, while there is no problem with GSheet and Excel Online.

This PR fixes the corrupted data so that it can be imported again

## Related Task
Odoo task ID : [3251186](https://www.odoo.com/web#id=3251186&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo