### PR TITLE
[REF] Selection: Let caller control selection visibilty

### DIFF
--- a/src/plugins/ui_core_views/sheetview.ts
+++ b/src/plugins/ui_core_views/sheetview.ts
@@ -133,29 +133,24 @@ export class SheetViewPlugin extends UIPlugin {
   }
 
   private handleEvent(event: SelectionEvent) {
-    switch (event.type) {
-      case "HeadersSelected":
-      case "AlterZone":
-        break;
-      case "ZonesSelected":
-        let { col, row } = findCellInNewZone(event.previousAnchor.zone, event.anchor.zone);
-        if (event.mode === "updateAnchor") {
-          const oldZone = event.previousAnchor.zone;
-          const newZone = event.anchor.zone;
-          // altering a zone should not move the viewport in a dimension that wasn't changed
-          const { top, bottom, left, right } = this.getters.getActiveMainViewport();
-          if (oldZone.left === newZone.left && oldZone.right === newZone.right) {
-            col = left > col || col > right ? left : col;
-          }
-          if (oldZone.top === newZone.top && oldZone.bottom === newZone.bottom) {
-            row = top > row || row > bottom ? top : row;
-          }
+    if (event.options.scrollIntoView) {
+      let { col, row } = findCellInNewZone(event.previousAnchor.zone, event.anchor.zone);
+      if (event.mode === "updateAnchor") {
+        const oldZone = event.previousAnchor.zone;
+        const newZone = event.anchor.zone;
+        // altering a zone should not move the viewport in a dimension that wasn't changed
+        const { top, bottom, left, right } = this.getters.getActiveMainViewport();
+        if (oldZone.left === newZone.left && oldZone.right === newZone.right) {
+          col = left > col || col > right ? left : col;
         }
-        const sheetId = this.getters.getActiveSheetId();
-        col = Math.min(col, this.getters.getNumberCols(sheetId) - 1);
-        row = Math.min(row, this.getters.getNumberRows(sheetId) - 1);
-        this.refreshViewport(this.getters.getActiveSheetId(), { col, row });
-        break;
+        if (oldZone.top === newZone.top && oldZone.bottom === newZone.bottom) {
+          row = top > row || row > bottom ? top : row;
+        }
+      }
+      const sheetId = this.getters.getActiveSheetId();
+      col = Math.min(col, this.getters.getNumberCols(sheetId) - 1);
+      row = Math.min(row, this.getters.getNumberRows(sheetId) - 1);
+      this.refreshViewport(this.getters.getActiveSheetId(), { col, row });
     }
   }
 

--- a/src/plugins/ui_feature/selection_input.ts
+++ b/src/plugins/ui_feature/selection_input.ts
@@ -80,7 +80,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
     const zone = event.anchor.zone;
     const range = this.getters.getRangeFromZone(
       sheetId,
-      event.type === "HeadersSelected" ? this.getters.getUnboundedZone(sheetId, zone) : zone
+      event.options.unbounded ? this.getters.getUnboundedZone(sheetId, zone) : zone
     );
     this.add([this.getters.getSelectionRangeString(range, inputSheetId)]);
   }

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -106,7 +106,7 @@ export class EditionPlugin extends UIPlugin {
     }
     const sheetId = this.getters.getActiveSheetId();
     let unboundedZone: UnboundedZone;
-    if (event.type === "HeadersSelected") {
+    if (event.options.unbounded) {
       unboundedZone = this.getters.getUnboundedZone(sheetId, event.anchor.zone);
     } else {
       unboundedZone = event.anchor.zone;

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -170,7 +170,7 @@ export class GridSelectionPlugin extends UIPlugin {
         break;
     }
     this.setSelectionMixin(event.anchor, zones);
-    /** Any change to the selection has to be  reflected in the selection processor. */
+    /** Any change to the selection has to be reflected in the selection processor. */
     this.selection.resetDefaultAnchor(this, deepCopy(this.gridSelection.anchor));
     const { col, row } = this.gridSelection.anchor.cell;
     this.moveClient({

--- a/src/types/event_stream/selection_events.ts
+++ b/src/types/event_stream/selection_events.ts
@@ -1,21 +1,13 @@
 import { AnchorZone } from "..";
 
-interface SelectionEventPayload {
+export type SelectionEventOptions = {
+  scrollIntoView?: boolean;
+  unbounded?: boolean;
+};
+
+export interface SelectionEvent {
   anchor: AnchorZone;
   previousAnchor: AnchorZone;
   mode: "newAnchor" | "overrideSelection" | "updateAnchor";
+  options: SelectionEventOptions;
 }
-
-export interface ZonesSelected extends SelectionEventPayload {
-  type: "ZonesSelected";
-}
-
-export interface HeadersSelected extends SelectionEventPayload {
-  type: "HeadersSelected";
-}
-
-export interface AlterZone extends SelectionEventPayload {
-  type: "AlterZone";
-}
-
-export type SelectionEvent = Readonly<ZonesSelected | HeadersSelected | AlterZone>;


### PR DESCRIPTION
The first design of the processor was too intertwined with the viewport,
and we ended up designing some commands mode/types  so that they would
simultaneously:
- fit our need to distinguish use cases that required the viewport(1)
  to move or not.
- still made sense from a functional point of view (the types & modes
  reflect the intention)

Unfortunately, we already have 9 different combinations of types, only
two third of them really used in order to distinguish intensions) and
a bug was reported (see https://github.com/odoo/o-spreadsheet/pull/2369) taht ipplies that this does not cover
all the expected behaviours.

We might have mistaken the role of the processor by thinking the API
so that the viewport would determine itself how to react to an update
of the selection when we actually implemented are methods that suit the
caller's will to reflect the change of the selection in the viewport or
not.

The processor is just a channel that should:

- dispatch the selection changes to the right listener
- in some cases notify the viewport that it should react to that change

This commit gets rid of the `SelectionEvent.type` in favor of specific
options to explicitely request some side effect behaviours like:
- scroll the viewport to display the newly selected cells
- whether the zone should be treated as an unbounded zone or not

Task: 3348042

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3348042](https://www.odoo.com/web#id=3348042&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo