### PR TITLE
[FIX] chart panel: title state in chart design panel 

### DIFF
--- a/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
@@ -17,7 +17,7 @@
         <div class="o-section-title">Title</div>
         <input
           type="text"
-          t-att-value="env._t(props.definition.title)"
+          t-model="state.title"
           t-on-change="updateTitle"
           class="o-input o-optional"
           placeholder="New Chart"

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -1,5 +1,6 @@
 import { Component, useExternalListener, useState } from "@odoo/owl";
 import { deepCopy } from "../../../../helpers/index";
+import { _t } from "../../../../translation";
 import { GaugeChartDefinition, SectionRule } from "../../../../types/chart/gauge_chart";
 import {
   Color,
@@ -57,6 +58,7 @@ interface Props {
 }
 
 interface PanelState {
+  title: string;
   openedMenu?: GaugeMenu;
   sectionRuleDispatchResult?: DispatchResult;
 }
@@ -66,11 +68,13 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
   static components = { ColorPickerWidget };
 
   private state: PanelState = useState({
+    title: "",
     openedMenu: undefined,
     sectionRuleDispatchResult: undefined,
   });
 
   setup() {
+    this.state.title = _t(this.props.definition.title);
     useExternalListener(window, "click", this.closeMenus);
   }
 
@@ -88,9 +92,9 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     });
   }
 
-  updateTitle(ev) {
+  updateTitle() {
     this.props.updateChart(this.props.figureId, {
-      title: ev.target.value,
+      title: this.state.title,
     });
   }
 

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
@@ -18,7 +18,7 @@
         <div class="o-section-title">Title</div>
         <input
           type="text"
-          t-att-value="env._t(props.definition.title)"
+          t-model="state.title"
           t-on-change="updateTitle"
           class="o-input o-optional"
           placeholder="New Chart"

--- a/src/components/side_panel/chart/line_bar_pie_panel/design_panel.ts
+++ b/src/components/side_panel/chart/line_bar_pie_panel/design_panel.ts
@@ -1,4 +1,5 @@
 import { Component, useExternalListener, useState } from "@odoo/owl";
+import { _t } from "../../../../translation";
 import { BarChartDefinition } from "../../../../types/chart/bar_chart";
 import { LineChartDefinition } from "../../../../types/chart/line_chart";
 import { PieChartDefinition } from "../../../../types/chart/pie_chart";
@@ -15,6 +16,7 @@ interface Props {
 }
 
 interface State {
+  title: string;
   fillColorTool: boolean;
 }
 
@@ -23,6 +25,7 @@ export class LineBarPieDesignPanel extends Component<Props, SpreadsheetChildEnv>
   static components = { ColorPickerWidget };
 
   private state: State = useState({
+    title: "",
     fillColorTool: false,
   });
 
@@ -31,6 +34,7 @@ export class LineBarPieDesignPanel extends Component<Props, SpreadsheetChildEnv>
   }
 
   setup() {
+    this.state.title = _t(this.props.definition.title);
     useExternalListener(window as any, "click", this.onClick);
   }
 
@@ -44,9 +48,9 @@ export class LineBarPieDesignPanel extends Component<Props, SpreadsheetChildEnv>
     });
   }
 
-  updateTitle(ev) {
+  updateTitle() {
     this.props.updateChart(this.props.figureId, {
-      title: ev.target.value,
+      title: this.state.title,
     });
   }
 

--- a/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
@@ -17,7 +17,7 @@
         <div class="o-section-title">Title</div>
         <input
           type="text"
-          t-att-value="env._t(props.definition.title)"
+          t-model="state.title"
           t-on-change="updateTitle"
           class="o-input o-optional"
           placeholder="New Chart"

--- a/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
@@ -17,7 +17,7 @@
         <div class="o-section-title">Title</div>
         <input
           type="text"
-          t-att-value="props.definition.title"
+          t-model="state.title"
           t-on-change="updateTitle"
           class="o-input o-optional"
           placeholder="New Chart"

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
@@ -1,4 +1,5 @@
 import { Component, useExternalListener, useState } from "@odoo/owl";
+import { _t } from "../../../../translation";
 import { ScorecardChartDefinition } from "../../../../types/chart/scorecard_chart";
 import { Color, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
 import { ColorPickerWidget } from "../../../color_picker/color_picker_widget";
@@ -12,6 +13,7 @@ interface Props {
 }
 
 interface PanelState {
+  title: string;
   openedColorPicker: ColorPickerId;
 }
 
@@ -20,16 +22,18 @@ export class ScorecardChartDesignPanel extends Component<Props, SpreadsheetChild
   static components = { ColorPickerWidget };
 
   private state: PanelState = useState({
+    title: "",
     openedColorPicker: undefined,
   });
 
   setup() {
+    this.state.title = _t(this.props.definition.title);
     useExternalListener(window, "click", this.closeMenus);
   }
 
-  updateTitle(ev) {
+  updateTitle() {
     this.props.updateChart(this.props.figureId, {
-      title: ev.target.value,
+      title: this.state.title,
     });
   }
 

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
@@ -18,7 +18,7 @@
         <div class="o-section-title">Title</div>
         <input
           type="text"
-          t-att-value="env._t(props.definition.title)"
+          t-model="state.title"
           t-on-change="updateTitle"
           class="o-input o-optional"
           placeholder="New Chart"

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -328,11 +328,31 @@ describe("charts", () => {
     await simulateClick(".o-panel .inactive");
     await simulateClick(figures[1] as HTMLElement);
     await simulateClick(".o-chart-title input");
+    setInputValueAndTrigger(".o-chart-title input", "new_title", "input");
     setInputValueAndTrigger(".o-chart-title input", "new_title", "change");
 
     expect(model.getters.getChartDefinition("1").title).toBe("old_title_1");
     expect(model.getters.getChartDefinition("2").title).toBe("new_title");
   });
+
+  test.each(["basicChart", "scorecard", "gauge"])(
+    "defocusing sidepanel after modifying chart title w/o saving should maintain the new title %s",
+    async (chartType: string) => {
+      createTestChart(chartType);
+      await nextTick();
+      await simulateClick(".o-figure");
+      await simulateClick(".o-figure-menu-item");
+      await simulateClick(".o-menu div[data-name='edit']");
+      await simulateClick(".o-panel .inactive");
+      await simulateClick(".o-chart-title input");
+      const chartTitle = document.querySelector(".o-chart-title input") as HTMLInputElement;
+      expect(chartTitle.value).toBe("hello");
+      setInputValueAndTrigger(".o-chart-title input", "hello_new_title", "input");
+      await nextTick();
+      await simulateClick(".o-grid-overlay");
+      expect(chartTitle.value).toBe("hello_new_title");
+    }
+  );
 
   test.each(["basicChart", "scorecard"])(
     "can edit charts %s background",


### PR DESCRIPTION

## Description:

Implemented t-model for state management of the chart title within
the sidepanel. By using t-model, the input value remains persistent
throughout rerendering, even when triggered by dispatches like multi-user
commands. This implementation ensures consistent display of the correct
value entered in the title input

Odoo task ID : [2991474](https://www.odoo.com/web#id=2991474&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo