### PR TITLE
[IMP] Formula: Add Statistics formulas

### DIFF
--- a/src/functions/helper_statistical.ts
+++ b/src/functions/helper_statistical.ts
@@ -1,0 +1,17 @@
+import { _t } from "../translation";
+import { assert } from "./helpers";
+
+export function assertSameNumberOfElements(...args: any[][]) {
+  const dims = args[0].length;
+  args.forEach((arg, i) =>
+    assert(
+      () => arg.length === dims,
+      _t(
+        "[[FUNCTION_NAME]] has mismatched dimensions for argument %s (%s vs %s).",
+        i.toString(),
+        dims.toString(),
+        arg.length.toString()
+      )
+    )
+  );
+}

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -61,6 +61,23 @@ export function toNumber(
   }
 }
 
+export function tryCastAsNumberMatrix(data: Matrix<any>, argName: string): Matrix<number> {
+  data.forEach((row) => {
+    row.forEach((cell) => {
+      if (typeof cell !== "number") {
+        throw new Error(
+          _t(
+            "Function [[FUNCTION_NAME]] expects number values for %s, but got a %s.",
+            typeof cell,
+            argName
+          )
+        );
+      }
+    });
+  });
+  return data as Matrix<number>;
+}
+
 export function strictToNumber(
   value: string | number | boolean | null | undefined,
   locale: Locale

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -1,5 +1,6 @@
+import { range } from "../helpers";
 import { parseDateTime } from "../helpers/dates";
-import { isNumber, percentile } from "../helpers/numbers";
+import { isNumber, percentile } from "../helpers/index";
 import { _t } from "../translation";
 import {
   AddFunctionDescription,
@@ -13,73 +14,84 @@ import {
   isMatrix,
 } from "../types";
 import { arg } from "./arguments";
+import { invertMatrix, multiplyMatrices } from "./helper_matrices";
+import { assertSameNumberOfElements } from "./helper_statistical";
 import {
   assert,
   dichotomicSearch,
+  matrixMap,
   reduceAny,
   reduceNumbers,
   reduceNumbersTextAs0,
+  toBoolean,
   toMatrix,
   toNumber,
+  transposeMatrix,
+  tryCastAsNumberMatrix,
   visitAny,
   visitMatchingRanges,
   visitNumbers,
 } from "./helpers";
 
-// Note: dataY and dataX may not have the same dimension
-function covariance(dataY: ArgValue, dataX: ArgValue, isSample: boolean): number {
-  let flatDataY: Maybe<CellValue>[] = [];
-  let flatDataX: Maybe<CellValue>[] = [];
+function filterAndFlatData(
+  dataY: ArgValue,
+  dataX: ArgValue
+): { flatDataY: number[]; flatDataX: number[] } {
+  const _flatDataY: Maybe<CellValue>[] = [];
+  const _flatDataX: Maybe<CellValue>[] = [];
   let lenY = 0;
   let lenX = 0;
 
   visitAny([dataY], (y) => {
-    flatDataY.push(y);
+    _flatDataY.push(y);
     lenY += 1;
   });
 
   visitAny([dataX], (x) => {
-    flatDataX.push(x);
+    _flatDataX.push(x);
     lenX += 1;
   });
 
   assert(
     () => lenY === lenX,
-    _t(
-      "[[FUNCTION_NAME]] has mismatched argument count %s vs %s.",
-      lenY.toString(),
-      lenX.toString()
-    )
+    _t("[[FUNCTION_NAME]] has mismatched argument count %s vs %s.", lenY, lenX)
   );
-
-  let count = 0;
-  let sumY = 0;
-  let sumX = 0;
+  const flatDataX: number[] = [];
+  const flatDataY: number[] = [];
   for (let i = 0; i < lenY; i++) {
-    const valueY = flatDataY[i];
-    const valueX = flatDataX[i];
+    const valueY = _flatDataY[i];
+    const valueX = _flatDataX[i];
     if (typeof valueY === "number" && typeof valueX === "number") {
-      count += 1;
-      sumY += valueY;
-      sumX += valueX;
+      flatDataY.push(valueY);
+      flatDataX.push(valueX);
     }
   }
+  return { flatDataX, flatDataY };
+}
+
+// Note: dataY and dataX may not have the same dimension
+function covariance(dataY: ArgValue, dataX: ArgValue, isSample: boolean): number {
+  const { flatDataX, flatDataY } = filterAndFlatData(dataY, dataX);
+  const count = flatDataY.length;
 
   assert(
     () => count !== 0 && (!isSample || count !== 1),
     _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
   );
 
+  let sumY = 0;
+  let sumX = 0;
+  for (let i = 0; i < count; i++) {
+    sumY += flatDataY[i];
+    sumX += flatDataX[i];
+  }
+
   const averageY = sumY / count;
   const averageX = sumX / count;
 
   let acc = 0;
-  for (let i = 0; i < lenY; i++) {
-    const valueY = flatDataY[i];
-    const valueX = flatDataX[i];
-    if (typeof valueY === "number" && typeof valueX === "number") {
-      acc += (valueY - averageY) * (valueX - averageX);
-    }
+  for (let i = 0; i < count; i++) {
+    acc += (flatDataY[i] - averageY) * (flatDataX[i] - averageX);
   }
 
   return acc / (count - (isSample ? 1 : 0));
@@ -151,6 +163,192 @@ function centile(
   }
 
   return percentile(sortedArray, _percent, isInclusive);
+}
+
+function prepareDataForRegression(X: Matrix<number>, Y: Matrix<number>, newX: Matrix<number>) {
+  const _X = X.length ? X : [range(1, Y.flat().length + 1)];
+  const nVar = _X.length;
+  let _newX = newX.length ? newX : _X;
+  _newX = _newX.length === nVar ? transposeMatrix(_newX) : _newX;
+  return { _X, _newX };
+}
+
+/*
+ * This function performs a linear regression on the data set. It returns an array with two elements.
+ * The first element is the slope, and the second element is the intercept.
+ * The linear regression line is: y = slope*x + intercept
+ * The function use the least squares method to find the best fit for the data set :
+ * see https://www.mathsisfun.com/data/least-squares-regression.html
+ *     https://www.statology.org/standard-error-of-estimate/
+ *     https://agronomy4future.org/?p=16670
+ *     https://vitalflux.com/interpreting-f-statistics-in-linear-regression-formula-examples/
+ *     https://web.ist.utl.pt/~ist11038/compute/errtheory/,regression/regrthroughorigin.pdf
+ */
+
+function fullLinearRegression(
+  X: Matrix<number>,
+  Y: Matrix<number>,
+  computeIntercept = true,
+  verbose: boolean = false
+) {
+  const y = Y.flat();
+  const n = y.length;
+  let { _X } = prepareDataForRegression(X, Y, []);
+  _X = _X.length === n ? transposeMatrix(_X) : _X.slice();
+  assertSameNumberOfElements(_X[0], y);
+  const nVar = _X.length;
+  const nDeg = n - nVar - (computeIntercept ? 1 : 0);
+  const yMatrix = [y];
+  const xMatrix: Matrix<number> = transposeMatrix(_X.reverse());
+  let avgX: number[] = [];
+  for (let i = 0; i < nVar; i++) {
+    avgX.push(0);
+    if (computeIntercept) {
+      for (const xij of _X[i]) {
+        avgX[i] += xij;
+      }
+      avgX[i] /= n;
+    }
+  }
+  let avgY = 0;
+  if (computeIntercept) {
+    for (const yi of y) {
+      avgY += yi;
+    }
+    avgY /= n;
+  }
+  const redX: Matrix<number> = xMatrix.map((row) => row.map((value, i) => value - avgX[i]));
+  if (computeIntercept) {
+    xMatrix.forEach((row) => row.push(1));
+  }
+  const coeffs = getLMSCoefficients(xMatrix, yMatrix);
+  if (!computeIntercept) {
+    coeffs.push([0]);
+  }
+  if (!verbose) {
+    return coeffs;
+  }
+  const dot1 = multiplyMatrices(redX, transposeMatrix(redX));
+  const { inverted: dotInv } = invertMatrix(dot1);
+  if (dotInv === undefined) {
+    throw new Error(_t("Matrix is not invertible"));
+  }
+  let SSE = 0,
+    SSR = 0;
+  for (let i = 0; i < n; i++) {
+    const yi = y[i] - avgY;
+    let temp = 0;
+    for (let j = 0; j < nVar; j++) {
+      const xi = redX[i][j];
+      temp += xi * coeffs[j][0];
+    }
+    const ei = yi - temp;
+    SSE += ei * ei;
+    SSR += temp * temp;
+  }
+  const RMSE = Math.sqrt(SSE / nDeg);
+  const r2 = SSR / (SSR + SSE);
+  const f_stat = SSR / nVar / (SSE / nDeg);
+  const deltaCoeffs: number[] = [];
+  for (let i = 0; i < nVar; i++) {
+    deltaCoeffs.push(RMSE * Math.sqrt(dotInv[i][i]));
+  }
+  if (computeIntercept) {
+    const dot2 = multiplyMatrices(dotInv, [avgX]);
+    const dot3 = multiplyMatrices(transposeMatrix([avgX]), dot2);
+    deltaCoeffs.push(RMSE * Math.sqrt(dot3[0][0] + 1 / y.length));
+  }
+  const returned: (number | string)[][] = [
+    [coeffs[0][0], deltaCoeffs[0], r2, f_stat, SSR],
+    [coeffs[1][0], deltaCoeffs[1], RMSE, nDeg, SSE],
+  ];
+  for (let i = 2; i < nVar; i++) {
+    returned.push([coeffs[i][0], deltaCoeffs[i], "", "", ""]);
+  }
+  if (computeIntercept) {
+    returned.push([coeffs[nVar][0], deltaCoeffs[nVar], "", "", ""]);
+  } else {
+    returned.push([0, "", "", "", ""]);
+  }
+  return returned;
+}
+
+/*
+  This function performs a polynomial regression on the data set. It returns the coefficients of
+  the polynomial function that best fits the data set.
+  The polynomial function is: y = c0 + c1*x + c2*x^2 + ... + cn*x^n, where n is the order (degree)
+  of the polynomial. The returned coefficients are then in the form: [c0, c1, c2, ..., cn]
+  The function is based on the method of least squares :
+  see: https://mathworld.wolfram.com/LeastSquaresFittingPolynomial.html
+*/
+function polynomialRegression(
+  flatY: number[],
+  flatX: number[],
+  order: number,
+  intercept: boolean
+): Matrix<number> {
+  assertSameNumberOfElements(flatX, flatY);
+  assert(
+    () => order >= 1,
+    _t(`Function [[FUNCTION_NAME]] A regression of order less than 1 cannot be possible.`)
+  );
+
+  const yMatrix = [flatY];
+  const xMatrix: Matrix<number> = flatX.map((x) =>
+    range(0, order).map((i) => Math.pow(x, order - i))
+  );
+  if (intercept) {
+    xMatrix.forEach((row) => row.push(1));
+  }
+
+  const coeffs = getLMSCoefficients(xMatrix, yMatrix);
+  if (!intercept) {
+    coeffs.push([0]);
+  }
+  return coeffs;
+}
+
+function getLMSCoefficients(xMatrix: Matrix<number>, yMatrix: Matrix<number>): Matrix<number> {
+  const xMatrixT = transposeMatrix(xMatrix);
+  const dot1 = multiplyMatrices(xMatrix, xMatrixT);
+  const { inverted: dotInv } = invertMatrix(dot1);
+  if (dotInv === undefined) {
+    throw new Error(_t("Matrix is not invertible"));
+  }
+  const dot2 = multiplyMatrices(xMatrix, yMatrix);
+  return transposeMatrix(multiplyMatrices(dotInv, dot2));
+}
+
+function evaluatePolynomial(coeffs: number[], x: number, order: number): number {
+  return coeffs.reduce((acc, coeff, i) => acc + coeff * Math.pow(x, order - i), 0);
+}
+
+function expM(M: Matrix<number>): Matrix<number> {
+  return M.map((col) => col.map((cell) => Math.exp(cell)));
+}
+
+function logM(M: Matrix<number>): Matrix<number> {
+  return M.map((col) => col.map((cell) => Math.log(cell)));
+}
+
+function predictLinearValues(
+  Y: Matrix<number>,
+  X: Matrix<number>,
+  newX: Matrix<number>,
+  computeIntercept: boolean
+): Matrix<number> {
+  const { _X, _newX } = prepareDataForRegression(X, Y, newX);
+  const coeffs = fullLinearRegression(_X, Y, computeIntercept, false);
+  const nVar = coeffs.length - 1;
+  const newY = _newX.map((col) => {
+    let value = 0;
+    for (let i = 0; i < nVar; i++) {
+      value += (coeffs[i][0] as number) * col[nVar - i - 1];
+    }
+    value += coeffs[nVar][0] as number;
+    return [value];
+  });
+  return newY.length === newX.length ? newY : transposeMatrix(newY);
 }
 
 // -----------------------------------------------------------------------------
@@ -556,6 +754,110 @@ export const COVARIANCE_S = {
 } satisfies AddFunctionDescription;
 
 // -----------------------------------------------------------------------------
+// FORECAST
+// -----------------------------------------------------------------------------
+export const FORECAST: AddFunctionDescription = {
+  description: _t(
+    "Calculates the expected y-value for a specified x based on a linear regression of a dataset."
+  ),
+  args: [
+    arg("x (number, range<number>)", _t("The value(s) on the x-axis to forecast.")),
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>)",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (
+    x: ArgValue,
+    dataY: Matrix<CellValue>,
+    dataX: Matrix<CellValue>
+  ): number | Matrix<number> {
+    const { flatDataX, flatDataY } = filterAndFlatData(dataY, dataX);
+    return predictLinearValues(
+      [flatDataY],
+      [flatDataX],
+      matrixMap(toMatrix(x), (value) => toNumber(value, this.locale)),
+      true
+    );
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// GROWTH
+// -----------------------------------------------------------------------------
+export const GROWTH: AddFunctionDescription = {
+  description: _t("Fits points to exponential growth trend."),
+  args: [
+    arg(
+      "known_data_y (range<number>)",
+      _t(
+        "The array or range containing dependent (y) values that are already known, used to curve fit an ideal exponential growth curve."
+      )
+    ),
+    arg(
+      "known_data_x (range<number>, default={1;2;3;...})",
+      _t("The values of the independent variable(s) corresponding with known_data_y.")
+    ),
+    arg(
+      "new_data_x (any, range, default=known_data_x)",
+      _t("The data points to return the y values for on the ideal curve fit.")
+    ),
+    arg(
+      "b (boolean, default=TRUE)",
+      _t(
+        "Given a general exponential form of y = b*m^x for a curve fit, calculates b if TRUE or forces b to be 1 and only calculates the m values if FALSE."
+      )
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (
+    knownDataY: Matrix<CellValue>,
+    knownDataX: Matrix<CellValue> = [],
+    newDataX: Matrix<CellValue> = [],
+    b: Maybe<CellValue> = true
+  ): Matrix<number> {
+    return expM(
+      predictLinearValues(
+        logM(tryCastAsNumberMatrix(knownDataY, "the first argument (known_data_y)")),
+        tryCastAsNumberMatrix(knownDataX, "the second argument (known_data_x)"),
+        tryCastAsNumberMatrix(newDataX, "the third argument (new_data_y)"),
+        toBoolean(b)
+      )
+    );
+  },
+};
+
+// -----------------------------------------------------------------------------
+// INTERCEPT
+// -----------------------------------------------------------------------------
+export const INTERCEPT: AddFunctionDescription = {
+  description: _t("Compute the intercept of the linear regression."),
+  args: [
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>)",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (dataY: Matrix<CellValue>, dataX: Matrix<CellValue>): number {
+    const { flatDataX, flatDataY } = filterAndFlatData(dataY, dataX);
+    const [[], [intercept]] = fullLinearRegression([flatDataX], [flatDataY]);
+    return intercept as number;
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
 // LARGE
 // -----------------------------------------------------------------------------
 export const LARGE = {
@@ -592,12 +894,148 @@ export const LARGE = {
     assert(() => result !== undefined, _t(`[[FUNCTION_NAME]] has no valid input data.`));
     assert(
       () => count >= _n,
-      _t("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n.toString())
+      _t("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n)
     );
     return result!;
   },
   isExported: true,
 } satisfies AddFunctionDescription;
+
+// -----------------------------------------------------------------------------
+// LINEST
+// -----------------------------------------------------------------------------
+export const LINEST: AddFunctionDescription = {
+  description: _t("Compute the intercept of the linear regression."),
+  args: [
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>, default={1;2;3;...})",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+    arg(
+      "calculate_b (boolean, default=TRUE)",
+      _t("A flag specifying wheter to compute the slope or not")
+    ),
+    arg(
+      "verbose (boolean, default=FALSE)",
+      _t(
+        "A flag specifying whether to return additional regression statistics or only the linear coefficients and the y-intercept"
+      )
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (
+    dataY: Matrix<CellValue>,
+    dataX: Matrix<CellValue> = [],
+    calculateB: Maybe<CellValue> = true,
+    verbose: Maybe<CellValue> = false
+  ): (number | string)[][] {
+    return fullLinearRegression(
+      tryCastAsNumberMatrix(dataX, "the first argument (data_y)"),
+      tryCastAsNumberMatrix(dataY, "the second argument (data_x)"),
+      toBoolean(calculateB),
+      toBoolean(verbose)
+    );
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// LOGEST
+// -----------------------------------------------------------------------------
+export const LOGEST: AddFunctionDescription = {
+  description: _t("Compute the intercept of the linear regression."),
+  args: [
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>, optional, default={1;2;3;...})",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+    arg(
+      "calculate_b (boolean, default=TRUE)",
+      _t("A flag specifying wheter to compute the slope or not")
+    ),
+    arg(
+      "verbose (boolean, default=FALSE)",
+      _t(
+        "A flag specifying whether to return additional regression statistics or only the linear coefficients and the y-intercept"
+      )
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (
+    dataY: Matrix<CellValue>,
+    dataX: Matrix<CellValue> = [],
+    calculateB: Maybe<CellValue> = true,
+    verbose: Maybe<CellValue> = false
+  ): (number | string)[][] {
+    const coeffs = fullLinearRegression(
+      tryCastAsNumberMatrix(dataX, "the second argument (data_x)"),
+      logM(tryCastAsNumberMatrix(dataY, "the first argument (data_y)")),
+      toBoolean(calculateB),
+      toBoolean(verbose)
+    );
+    for (let i = 0; i < coeffs.length; i++) {
+      coeffs[i][0] = Math.exp(coeffs[i][0] as number);
+    }
+    return coeffs;
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// MATTHEWS
+// -----------------------------------------------------------------------------
+export const MATTHEWS: AddFunctionDescription = {
+  description: _t("Compute the Matthews correlation coefficient of a dataset."),
+  args: [
+    arg("data_x (range)", _t("The range representing the array or matrix of observed data.")),
+    arg("data_y (range)", _t("The range representing the array or matrix of predicted data.")),
+  ],
+  returns: ["NUMBER"],
+  compute: function (dataX: Matrix<CellValue>, dataY: Matrix<CellValue>): number {
+    const flatX = dataX.flat();
+    const flatY = dataY.flat();
+    assertSameNumberOfElements(flatX, flatY);
+    if (flatX.length === 0) {
+      throw new Error(_t("[[FUNCTION_NAME]] expects non-empty ranges for both parameters."));
+    }
+    const n = flatX.length;
+
+    let trueN = 0,
+      trueP = 0,
+      falseP = 0,
+      falseN = 0;
+    for (let i = 0; i < n; ++i) {
+      const isTrue1 = toBoolean(flatX[i]);
+      const isTrue2 = toBoolean(flatY[i]);
+      if (isTrue1 === isTrue2) {
+        if (isTrue1) {
+          trueP++;
+        } else {
+          trueN++;
+        }
+      } else {
+        if (isTrue1) {
+          falseN++;
+        } else {
+          falseP++;
+        }
+      }
+    }
+    return (
+      (trueP * trueN - falseP * falseN) /
+      Math.sqrt((trueP + falseP) * (trueP + falseN) * (trueN + falseP) * (trueN + falseN))
+    );
+  },
+  isExported: false,
+};
 
 // -----------------------------------------------------------------------------
 // MAX
@@ -833,6 +1271,57 @@ export const MINIFS = {
 } satisfies AddFunctionDescription;
 
 // -----------------------------------------------------------------------------
+// PEARSON
+// -----------------------------------------------------------------------------
+export const PEARSON: AddFunctionDescription = {
+  description: _t("Compute the Pearson product-moment correlation coefficient of a dataset."),
+  args: [
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>)",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (dataY: Matrix<CellValue>, dataX: Matrix<CellValue>): number {
+    const { flatDataX, flatDataY } = filterAndFlatData(dataX, dataY);
+    if (flatDataX.length === 0) {
+      throw new Error(_t("[[FUNCTION_NAME]] expects non-empty ranges for both parameters."));
+    }
+    if (flatDataX.length < 2) {
+      throw new Error(_t("[[FUNCTION_NAME]] needs at least two values for both parameters"));
+    }
+    const n = flatDataX.length;
+
+    let sumX = 0,
+      sumY = 0,
+      sumXY = 0,
+      sumXX = 0,
+      sumYY = 0;
+    for (let i = 0; i < n; i++) {
+      const xij = flatDataX[i];
+      const yij = flatDataY[i];
+
+      sumX += xij;
+      sumY += yij;
+
+      sumXY += xij * yij;
+      sumXX += xij * xij;
+      sumYY += yij * yij;
+    }
+    return (
+      (n * sumXY - sumX * sumY) / Math.sqrt((n * sumXX - sumX * sumX) * (n * sumYY - sumY * sumY))
+    );
+  },
+  isExported: true,
+};
+// In GSheet, CORREL is just an alias to PEARSON
+export const CORREL: AddFunctionDescription = PEARSON;
+
+// -----------------------------------------------------------------------------
 // PERCENTILE
 // -----------------------------------------------------------------------------
 export const PERCENTILE = {
@@ -901,6 +1390,83 @@ export const PERCENTILE_INC = {
 } satisfies AddFunctionDescription;
 
 // -----------------------------------------------------------------------------
+// POLYFIT
+// -----------------------------------------------------------------------------
+export const POLYFIT_COEFFS: AddFunctionDescription = {
+  description: _t("Compute the coefficients of polynomial regression of the dataset."),
+  args: [
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>)",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+    arg("order (number)", _t("The order of the polynomial to fit the data, between 1 and 6.")),
+    arg(
+      "intercept (boolean, default=TRUE)",
+      _t("A flag specifying whether to compute the intercept or not.")
+    ),
+  ],
+  returns: ["RANGE<NUMBER>"],
+  compute: function (
+    dataY: Matrix<CellValue>,
+    dataX: Matrix<CellValue>,
+    order: Maybe<CellValue>,
+    intercept: Maybe<CellValue> = true
+  ): Matrix<number> {
+    const { flatDataX, flatDataY } = filterAndFlatData(dataY, dataX);
+    return polynomialRegression(
+      flatDataY,
+      flatDataX,
+      toNumber(order, this.locale),
+      toBoolean(intercept)
+    );
+  },
+  isExported: false,
+};
+
+// -----------------------------------------------------------------------------
+// POLYFIT.FORECAST
+// -----------------------------------------------------------------------------
+export const POLYFIT_FORECAST: AddFunctionDescription = {
+  description: _t("Predict value by computing a polynomial regression of the dataset."),
+  args: [
+    arg("x (number, range<number>)", _t("The value(s) on the x-axis to forecast.")),
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>)",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+    arg("order (number)", _t("The order of the polynomial to fit the data, between 1 and 6.")),
+    arg(
+      "intercept (boolean, default=TRUE)",
+      _t("A flag specifying whether to compute the intercept or not.")
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (
+    x: ArgValue,
+    dataY: Matrix<CellValue>,
+    dataX: Matrix<CellValue>,
+    order: Maybe<CellValue>,
+    intercept: Maybe<CellValue> = true
+  ): number | Matrix<number> {
+    const _order = toNumber(order, this.locale);
+    const { flatDataX, flatDataY } = filterAndFlatData(dataY, dataX);
+    const coeffs = polynomialRegression(flatDataY, flatDataX, _order, toBoolean(intercept)).flat();
+    return matrixMap(toMatrix(x), (xij) =>
+      evaluatePolynomial(coeffs, toNumber(xij, this.locale), _order)
+    );
+  },
+  isExported: false,
+};
+
+// -----------------------------------------------------------------------------
 // QUARTILE
 // -----------------------------------------------------------------------------
 export const QUARTILE = {
@@ -960,6 +1526,55 @@ export const QUARTILE_INC = {
 } satisfies AddFunctionDescription;
 
 // -----------------------------------------------------------------------------
+// RSQ
+// -----------------------------------------------------------------------------
+export const RSQ: AddFunctionDescription = {
+  description: _t(
+    "Compute the square of r, the Pearson product-moment correlation coefficient of a dataset."
+  ),
+  args: [
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>)",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (dataY: Matrix<CellValue>, dataX: Matrix<CellValue>): number {
+    const pearson = PEARSON.compute.bind(this);
+    return Math.pow(pearson(dataX, dataY) as number, 2.0);
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// SLOPE
+// -----------------------------------------------------------------------------
+export const SLOPE: AddFunctionDescription = {
+  description: _t("Compute the slope of the linear regression."),
+  args: [
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>)",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (dataY: Matrix<CellValue>, dataX: Matrix<CellValue>): number {
+    const { flatDataX, flatDataY } = filterAndFlatData(dataY, dataX);
+    const [[slope]] = fullLinearRegression([flatDataX], [flatDataY]);
+    return slope as number;
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
 // SMALL
 // -----------------------------------------------------------------------------
 export const SMALL = {
@@ -996,12 +1611,49 @@ export const SMALL = {
     assert(() => result !== undefined, _t(`[[FUNCTION_NAME]] has no valid input data.`));
     assert(
       () => count >= _n,
-      _t("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n.toString())
+      _t("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n)
     );
     return result!;
   },
   isExported: true,
 } satisfies AddFunctionDescription;
+
+// -----------------------------------------------------------------------------
+// SPEARMAN
+// -----------------------------------------------------------------------------
+export const SPEARMAN: AddFunctionDescription = {
+  description: _t("Compute the Spearman rank correlation coefficient of a dataset."),
+  args: [
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>)",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (dataX: Matrix<CellValue>, dataY: Matrix<CellValue>): number {
+    const { flatDataX, flatDataY } = filterAndFlatData(dataY, dataX);
+    const n = flatDataX.length;
+
+    const order = flatDataX.map((e, i) => [e, flatDataY[i]]);
+    order.sort((a, b) => a[0] - b[0]);
+
+    for (let i = 0; i < n; ++i) {
+      order[i][0] = i;
+    }
+    order.sort((a, b) => a[1] - b[1]);
+
+    let sum = 0.0;
+    for (let i = 0; i < n; ++i) {
+      sum += (order[i][0] - i) ** 2;
+    }
+    return 1 - (6 * sum) / (n ** 3 - n);
+  },
+  isExported: false,
+};
 
 // -----------------------------------------------------------------------------
 // STDEV
@@ -1116,6 +1768,75 @@ export const STDEVPA = {
   },
   isExported: true,
 } satisfies AddFunctionDescription;
+
+// -----------------------------------------------------------------------------
+// STEYX
+// -----------------------------------------------------------------------------
+export const STEYX: AddFunctionDescription = {
+  description: _t(
+    "Calculates the standard error of the predicted y-value for each x in the regression of a dataset."
+  ),
+  args: [
+    arg(
+      "data_y (range<number>)",
+      _t("The range representing the array or matrix of dependent data.")
+    ),
+    arg(
+      "data_x (range<number>)",
+      _t("The range representing the array or matrix of independent data.")
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (dataY: Matrix<CellValue>, dataX: Matrix<CellValue>): number {
+    const { flatDataX, flatDataY } = filterAndFlatData(dataY, dataX);
+    const data = fullLinearRegression([flatDataX], [flatDataY], true, true);
+    return data[1][2] as number;
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// TREND
+// -----------------------------------------------------------------------------
+export const TREND: AddFunctionDescription = {
+  description: _t("Fits points to linear trend derived via least-squares."),
+  args: [
+    arg(
+      "known_data_y (number, range<number>)",
+      _t(
+        "The array or range containing dependent (y) values that are already known, used to curve fit an ideal linear trend."
+      )
+    ),
+    arg(
+      "known_data_x (number, range<number>, optional, default={1;2;3;...})",
+      _t("The values of the independent variable(s) corresponding with known_data_y.")
+    ),
+    arg(
+      "new_data_x (number, range<number>, optional, default=known_data_x)",
+      _t("The data points to return the y values for on the ideal curve fit.")
+    ),
+    arg(
+      "b (boolean, optional, default=TRUE)",
+      _t(
+        "Given a general linear form of y = m*x+b for a curve fit, calculates b if TRUE or forces b to be 0 and only calculates the m values if FALSE, i.e. forces the curve fit to pass through the origin."
+      )
+    ),
+  ],
+  returns: ["NUMBER"],
+  compute: function (
+    knownDataY: Matrix<CellValue>,
+    knownDataX: Matrix<CellValue> = [],
+    newDataX: Matrix<CellValue> = [],
+    b: Maybe<CellValue> = true
+  ): Matrix<number> {
+    return predictLinearValues(
+      tryCastAsNumberMatrix(knownDataY, "the first argument (known_data_y)"),
+      tryCastAsNumberMatrix(knownDataX, "the second argument (known_data_x)"),
+      tryCastAsNumberMatrix(newDataX, "the third argument (new_data_y)"),
+      toBoolean(b)
+    );
+  },
+};
 
 // -----------------------------------------------------------------------------
 // VAR

--- a/tests/functions/module_statistical.test.ts
+++ b/tests/functions/module_statistical.test.ts
@@ -1,4 +1,12 @@
-import { evaluateCell, evaluateCellFormat, evaluateGrid } from "../test_helpers/helpers";
+import { toXC } from "../../src/helpers";
+import { getEvaluatedCell } from "../test_helpers/getters_helpers";
+import {
+  createModelFromGrid,
+  evaluateCell,
+  evaluateCellFormat,
+  evaluateGrid,
+  getRangeValuesAsMatrix,
+} from "../test_helpers/helpers";
 
 describe("AVEDEV formula", () => {
   test("functional tests on simple arguments", () => {
@@ -2483,5 +2491,1522 @@ describe("VARPA formula", () => {
     expect(
       evaluateCell("A1", { A1: "=VARPA(A2, A3, A4)", A2: "1/11/1900", A3: "1/8/1900", A4: "test" })
     ).toBe(26);
+  });
+});
+
+describe("PEARSON/CORREL and RSQ formula", () => {
+  test("Unrelated values", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "2", B1: "4", C1: "9", D1: "10",
+      A2: "5", B2: "3", C2: "7", D2: "6",
+      A3: "7", B3: "6", C3: "5", D3: "1",
+      A4: "1", B4: "1", C4: "3", D4: "5",
+      A5: "8", B5: "5", C5: "1", D5: "3",
+      A6: "=PEARSON(A1:A5, B1:B5)", B6: "=CORREL(A1:A5, B1:B5)", C6: "=RSQ(A1:A5, B1:B5)",
+      A7: "=PEARSON(B1:B5, C1:C5)", B7: "=CORREL(B1:B5, C1:C5)", C7: "=RSQ(B1:B5, C1:C5)",
+      A8: "=PEARSON(C1:C5, D1:D5)", B8: "=CORREL(C1:C5, D1:D5)", C8: "=RSQ(C1:C5, D1:D5)",
+    };
+    expect(evaluateCell("A6", grid)).toBeCloseTo(0.7927032095);
+    expect(evaluateCell("B6", grid)).toBeCloseTo(0.7927032095);
+    expect(evaluateCell("C6", grid)).toBeCloseTo(0.628458498);
+    expect(evaluateCell("A7", grid)).toBeCloseTo(0);
+    expect(evaluateCell("B7", grid)).toBeCloseTo(0);
+    expect(evaluateCell("C7", grid)).toBeCloseTo(0);
+    expect(evaluateCell("A8", grid)).toBeCloseTo(0.6993786062);
+    expect(evaluateCell("B8", grid)).toBeCloseTo(0.6993786062);
+    expect(evaluateCell("C8", grid)).toBeCloseTo(0.4892550143);
+  });
+
+  test("Perfect correlation", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1:  "2", C1:  "3", D1:  "4",
+      A2: "2", B2:  "4", C2:  "6", D2:  "8",
+      A3: "3", B3:  "6", C3:  "9", D3: "12",
+      A4: "4", B4:  "8", C4: "12", D4: "16",
+      A5: "5", B5: "10", C5: "15", D5: "20",
+      A6: "=PEARSON(A1:A5, B1:B5)", B6: "=CORREL(A1:A5, B1:B5)", C6: "=RSQ(A1:A5, B1:B5)",
+      A7: "=PEARSON(B1:B5, C1:C5)", B7: "=CORREL(B1:B5, C1:C5)", C7: "=RSQ(B1:B5, C1:C5)",
+      A8: "=PEARSON(C1:C5, D1:D5)", B8: "=CORREL(C1:C5, D1:D5)", C8: "=RSQ(C1:C5, D1:D5)",
+    };
+    for (const cell of ["A6", "B6", "A7", "B7", "A8", "B8", "C6", "C7", "C8"]) {
+      expect(evaluateCell(cell, grid)).toBeCloseTo(1);
+    }
+  });
+
+  test("Non-numeric values are ignored", () => {
+    //prettier-ignore
+    const grid = {
+      A1:  "1", B1:  "2",
+      A2:  "2", B2:  "4",
+      A3: "ko", B3:  "4",
+      A4:  "3", B4:  "6",
+      A5:  "3", B5: "=TRUE()",
+      A6:  "4", B6:  "8",
+      A7:  "5", B7: "10",
+      A8: "=PEARSON(A1:A7, B1:B7)", B8: "=CORREL(A1:A7, B1:B7)", C8: "=RSQ(A1:A7, B1:B7)",
+    };
+    expect(evaluateCell("A8", grid)).toBeCloseTo(1);
+    expect(evaluateCell("B8", grid)).toBeCloseTo(1);
+    expect(evaluateCell("C8", grid)).toBeCloseTo(1);
+  });
+
+  test("Perfect negative correlation", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "10", C1:  "3", D1: "20",
+      A2: "2", B2:  "8", C2:  "6", D2: "16",
+      A3: "3", B3:  "6", C3:  "9", D3: "12",
+      A4: "4", B4:  "4", C4: "12", D4:  "8",
+      A5: "5", B5:  "2", C5: "15", D5:  "4",
+      A6: "=PEARSON(A1:A5, B1:B5)", B6: "=CORREL(A1:A5, B1:B5)", C6: "=RSQ(A1:A5, B1:B5)",
+      A7: "=PEARSON(B1:B5, C1:C5)", B7: "=CORREL(B1:B5, C1:C5)", C7: "=RSQ(B1:B5, C1:C5)",
+      A8: "=PEARSON(C1:C5, D1:D5)", B8: "=CORREL(C1:C5, D1:D5)", C8: "=RSQ(C1:C5, D1:D5)",
+    };
+    for (const cell of ["A6", "B6", "A7", "B7", "A8", "B8"]) {
+      expect(evaluateCell(cell, grid)).toBeCloseTo(-1);
+    }
+    for (const cell of ["C6", "C7", "C8"]) {
+      expect(evaluateCell(cell, grid)).toBeCloseTo(1);
+    }
+  });
+
+  test("Unconsistent dimensions", () => {
+    //prettier-ignore
+    const grid = {
+      A6: "=PEARSON(A1:A5, B1:B4)", B6: "=CORREL(A1:A5, B1:B4)", C6: "=RSQ(A1:A5, B1:B4)",
+      A7: "=PEARSON(B1:B4, C1:C5)", B7: "=CORREL(B1:B4, C1:C5)", C7: "=RSQ(B1:B4, C1:C5)",
+    };
+    for (const cell of ["A6", "B6", "A7", "B7", "C6", "C7"]) {
+      expect(evaluateCell(cell, grid)).toBe("#ERROR");
+    }
+  });
+
+  test("Ignore non-numeric pairs", () => {
+    //prettier-ignore
+    const grid = {
+      A1:  "1", B1:  "2", C1:  "3", D1:  "4",
+      A2: "ko", B2:  "4", C2:  "6", D2:  "8",
+      A3:  "3", B3: "ko", C3:  "9", D3: "12",
+      A4:  "4", B4:  "8", C4: "ko", D4: "16",
+      A5:  "5", B5: "10", C5: "15", D5: "TRUE",
+      A6: "=PEARSON(A1:A5, B1:B5)", B6: "=CORREL(A1:A5, B1:B5)", C6: "=RSQ(A1:A5, B1:B5)",
+      A7: "=PEARSON(B1:B5, C1:C5)", B7: "=CORREL(B1:B5, C1:C5)", C7: "=RSQ(B1:B5, C1:C5)",
+      A8: "=PEARSON(C1:C5, D1:D5)", B8: "=CORREL(C1:C5, D1:D5)", C8: "=RSQ(C1:C5, D1:D5)",
+    };
+    for (const cell of ["A6", "B6", "A7", "B7", "A8", "B8", "C6", "C7", "C8"]) {
+      expect(evaluateCell(cell, grid)).toBeCloseTo(1);
+    }
+  });
+});
+
+describe("SPEARMAN formula", () => {
+  test("Unrelated values", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "2", B1: "4", C1: "9", D1: "10",
+      A2: "5", B2: "3", C2: "7", D2: "6",
+      A3: "7", B3: "6", C3: "5", D3: "1",
+      A4: "1", B4: "1", C4: "3", D4: "5",
+      A5: "8", B5: "5", C5: "1", D5: "3",
+      A6: "=SPEARMAN(A1:A5, B1:B5)",
+      A7: "=SPEARMAN(B1:B5, C1:C5)",
+      A8: "=SPEARMAN(C1:C5, D1:D5)",
+    };
+    expect(evaluateCell("A6", grid)).toBeCloseTo(0.8);
+    expect(evaluateCell("A7", grid)).toBeCloseTo(-0.1);
+    expect(evaluateCell("A8", grid)).toBeCloseTo(0.7);
+  });
+
+  test("Perfect correlation", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1:  "2", C1:  "3", D1:  "4",
+      A2: "2", B2:  "4", C2:  "6", D2:  "8",
+      A3: "3", B3:  "6", C3:  "9", D3: "12",
+      A4: "4", B4:  "8", C4: "12", D4: "16",
+      A5: "5", B5: "10", C5: "15", D5: "20",
+      A6: "=SPEARMAN(A1:A5, B1:B5)",
+      A7: "=SPEARMAN(B1:B5, C1:C5)",
+      A8: "=SPEARMAN(C1:C5, D1:D5)",    };
+    for (const cell of ["A6", "A7", "A8"]) {
+      expect(evaluateCell(cell, grid)).toBeCloseTo(1);
+    }
+  });
+
+  test("Non-numeric values are ignored", () => {
+    //prettier-ignore
+    const grid = {
+      A1:  "1", B1:  "2",
+      A2:  "2", B2:  "4",
+      A3: "ko", B3:  "4",
+      A4:  "3", B4:  "6",
+      A5:  "3", B5: "=TRUE()",
+      A6:  "4", B6:  "8",
+      A7:  "5", B7: "10",
+      A8: "=SPEARMAN(B1:B7, A1:A7)",
+    };
+    expect(evaluateCell("A8", grid)).toBeCloseTo(1);
+  });
+
+  test("Perfect negative correlation", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "10", C1:  "3", D1: "20",
+      A2: "2", B2:  "8", C2:  "6", D2: "16",
+      A3: "3", B3:  "6", C3:  "9", D3: "12",
+      A4: "4", B4:  "4", C4: "12", D4:  "8",
+      A5: "5", B5:  "2", C5: "15", D5:  "4",
+      A6: "=SPEARMAN(A1:A5, B1:B5)",
+      A7: "=SPEARMAN(B1:B5, C1:C5)",
+      A8: "=SPEARMAN(C1:C5, D1:D5)",
+    };
+    for (const cell of ["A6", "A7", "A8"]) {
+      expect(evaluateCell(cell, grid)).toBeCloseTo(-1);
+    }
+  });
+
+  test("Unconsistent dimensions", () => {
+    //prettier-ignore
+    const grid = {
+      A6: "=SPEARMAN(A1:A5, B1:B4)",
+      A7: "=SPEARMAN(B1:B4, C1:C5)",
+    };
+    expect(evaluateCell("A6", grid)).toBe("#ERROR");
+    expect(evaluateCell("A7", grid)).toBe("#ERROR");
+  });
+});
+
+describe("MATTHEWS formula", () => {
+  test("Correctly compute result", () => {
+    //pretier-ignore
+    const grid = {
+      A1: "TRUE",
+      B1: "TRUE",
+      C1: "FALSE",
+      D1: "FALSE",
+      A2: "TRUE",
+      B2: "TRUE",
+      C2: "FALSE",
+      D2: "TRUE",
+      A3: "TRUE",
+      B3: "TRUE",
+      C3: "FALSE",
+      D3: "FALSE",
+      A4: "TRUE",
+      B4: "TRUE",
+      C4: "FALSE",
+      D4: "TRUE",
+      A5: "TRUE",
+      B5: "TRUE",
+      C5: "FALSE",
+      D5: "FALSE",
+      A6: "FALSE",
+      B6: "FALSE",
+      C6: "TRUE",
+      D6: "TRUE",
+      A7: "FALSE",
+      B7: "FALSE",
+      C7: "TRUE",
+      D7: "FALSE",
+      A8: "FALSE",
+      B8: "FALSE",
+      C8: "TRUE",
+      D8: "TRUE",
+      A9: "FALSE",
+      B9: "FALSE",
+      C9: "TRUE",
+      D9: "FALSE",
+      A10: "FALSE",
+      B10: "FALSE",
+      C10: "TRUE",
+      D10: "TRUE",
+      A11: "=MATTHEWS(A1:A10, B1:B10)",
+      A12: "=MATTHEWS(A1:A10, C1:C10)",
+      A13: "=MATTHEWS(A1:A10, D1:D10)",
+    };
+    expect(evaluateCell("A11", grid)).toBeCloseTo(1);
+    expect(evaluateCell("A12", grid)).toBeCloseTo(-1);
+    expect(evaluateCell("A13", grid)).toBeCloseTo(-0.2);
+  });
+
+  test("Unconsistent dimensions", () => {
+    const grid = {
+      A11: "=MATTHEWS(A1:A10, B1:B9)",
+      A12: "=MATTHEWS(A1:A9, B1:B10)",
+    };
+    expect(evaluateCell("A11", grid)).toBe("#ERROR");
+    expect(evaluateCell("A12", grid)).toBe("#ERROR");
+  });
+});
+
+describe("SLOPE formula", () => {
+  test("Unrelated values", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "2", B1: "4", C1: "9", D1: "10",
+      A2: "5", B2: "3", C2: "7", D2: "6",
+      A3: "7", B3: "6", C3: "5", D3: "1",
+      A4: "1", B4: "1", C4: "3", D4: "5",
+      A5: "8", B5: "5", C5: "1", D5: "3",
+      A6: "=SLOPE(B1:B5, A1:A5)",
+      A7: "=SLOPE(C1:C5, B1:B5)",
+      A8: "=SLOPE(D1:D5, C1:C5)",
+    };
+    expect(evaluateCell("A6", grid)).toBeCloseTo(0.5);
+    expect(evaluateCell("A7", grid)).toBeCloseTo(0);
+    expect(evaluateCell("A8", grid)).toBeCloseTo(0.75);
+  });
+
+  test("Perfect correlation", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1:  "2", C1: "15", D1: "4",
+      A2: "2", B2:  "4", C2: "12", D2: "5",
+      A3: "3", B3:  "6", C3:  "9", D3: "6",
+      A4: "4", B4:  "8", C4:  "6", D4: "7",
+      A5: "5", B5: "10", C5:  "3", D5: "8",
+      A6: "=SLOPE(B1:B5, A1:A5)",
+      A7: "=SLOPE(C1:C5, B1:B5)",
+      A8: "=SLOPE(D1:D5, A1:A5)",
+    };
+    expect(evaluateCell("A6", grid)).toBeCloseTo(2);
+    expect(evaluateCell("A7", grid)).toBeCloseTo(-1.5);
+    expect(evaluateCell("A8", grid)).toBeCloseTo(1);
+  });
+
+  test("Non-numeric values are ignored", () => {
+    //prettier-ignore
+    const grid = {
+      A1:  "1", B1:  "2",
+      A2:  "2", B2:  "4",
+      A3: "ko", B3:  "4",
+      A4:  "3", B4:  "6",
+      A5:  "3", B5: "=TRUE()",
+      A6:  "4", B6:  "8",
+      A7:  "5", B7: "10",
+      A8: "=SLOPE(B1:B7, A1:A7)",
+    };
+    expect(evaluateCell("A8", grid)).toBeCloseTo(2);
+  });
+
+  test("Unconsistent dimensions", () => {
+    //prettier-ignore
+    const grid = {
+      A6: "=SLOPE(A1:A5, B1:B4)",
+      A7: "=SLOPE(B1:B4, C1:C5)",
+    };
+    expect(evaluateCell("A6", grid)).toBe("#ERROR"); //@compatibility : On google sheet, returns #N/A
+    expect(evaluateCell("A7", grid)).toBe("#ERROR"); //@compatibility : On google sheet, returns #N/A
+  });
+});
+
+describe("INTERCEPT formula", () => {
+  test("Unrelated values", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "2", B1: "4", C1: "9", D1: "10",
+      A2: "5", B2: "3", C2: "7", D2: "6",
+      A3: "7", B3: "6", C3: "5", D3: "1",
+      A4: "1", B4: "1", C4: "3", D4: "5",
+      A5: "8", B5: "5", C5: "1", D5: "3",
+      A6: "=INTERCEPT(B1:B5, A1:A5)",
+      A7: "=INTERCEPT(C1:C5, B1:B5)",
+      A8: "=INTERCEPT(D1:D5, C1:C5)",
+    };
+    expect(evaluateCell("A6", grid)).toBeCloseTo(1.5);
+    expect(evaluateCell("A7", grid)).toBeCloseTo(5);
+    expect(evaluateCell("A8", grid)).toBeCloseTo(1.25);
+  });
+
+  test("Perfect correlation", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1:  "2", C1: "15", D1: "-8",
+      A2: "2", B2:  "4", C2: "12", D2: "-7",
+      A3: "3", B3:  "6", C3:  "9", D3: "-6",
+      A4: "4", B4:  "8", C4:  "6", D4: "-5",
+      A5: "5", B5: "10", C5:  "3", D5: "-4",
+      A6: "=INTERCEPT(B1:B5, A1:A5)",
+      A7: "=INTERCEPT(C1:C5, B1:B5)",
+      A8: "=INTERCEPT(D1:D5, A1:A5)",
+    };
+    expect(evaluateCell("A6", grid)).toBeCloseTo(0);
+    expect(evaluateCell("A7", grid)).toBeCloseTo(18);
+    expect(evaluateCell("A8", grid)).toBeCloseTo(-9);
+  });
+
+  test("Non-numeric values are ignored", () => {
+    //prettier-ignore
+    const grid = {
+      A1:  "1", B1:  "2",
+      A2:  "2", B2:  "4",
+      A3: "ko", B3:  "4",
+      A4:  "3", B4:  "6",
+      A5:  "3", B5: "=TRUE()",
+      A6:  "4", B6:  "8",
+      A7:  "5", B7: "10",
+      A8: "=INTERCEPT(B1:B7, A1:A7)",
+    };
+    expect(evaluateCell("A8", grid)).toBeCloseTo(0);
+  });
+
+  test("Unconsistent dimensions", () => {
+    //prettier-ignore
+    const grid = {
+      A6: "=INTERCEPT(A1:A5, B1:B4)",
+      A7: "=INTERCEPT(B1:B4, C1:C5)",
+    };
+    expect(evaluateCell("A6", grid)).toBe("#ERROR"); //@compatibility : On google sheet, returns #N/A
+    expect(evaluateCell("A7", grid)).toBe("#ERROR"); //@compatibility : On google sheet, returns #N/A
+  });
+});
+
+describe("FORECAST formula", () => {
+  test("Correctly predicts a single value", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1:  "2", C1: "15", D1: "-8",
+      A2: "2", B2:  "4", C2: "12", D2: "-7",
+      A3: "3", B3:  "6", C3:  "9", D3: "-6",
+      A4: "4", B4:  "8", C4:  "6", D4: "-5",
+      A5: "5", B5: "10", C5:  "3", D5: "-4",
+      B6: "=FORECAST(6, B1:B5, A1:A5)",
+      C6: "=FORECAST(12, C1:C5, B1:B5)",
+      D6: "=FORECAST(6, D1:D5, A1:A5)",
+    };
+    expect(evaluateCell("B6", grid)).toBeCloseTo(12);
+    expect(evaluateCell("C6", grid)).toBeCloseTo(0);
+    expect(evaluateCell("D6", grid)).toBeCloseTo(-3);
+  });
+
+  test("Correctly predicts a column of values", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1:  "2", C1: "6",
+      A2: "2", B2:  "4", C2: "7",
+      A3: "3", B3:  "6", C3: "8",
+      A4: "4", B4:  "8", C4: "9",
+      A5: "5", B5: "10",
+      B6: "=FORECAST(C1:C4, B1:B5, A1:A5)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getRangeValuesAsMatrix(model, "B6:B9")).toEqual([[12], [14], [16], [18]]);
+  });
+
+  test("Correctly predicts a row of values", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1:  "2", C1: "6", D1: "7", E1: "8", F1: "9",
+      A2: "2", B2:  "4",
+      A3: "3", B3:  "6",
+      A4: "4", B4:  "8",
+      A5: "5", B5: "10",
+      B6: "=FORECAST(C1:F1, B1:B5, A1:A5)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getRangeValuesAsMatrix(model, "B6:E6")).toEqual([[12, 14, 16, 18]]);
+  });
+
+  test("Unconsistent dimensions", () => {
+    //prettier-ignore
+    const grid = {
+      A6: "=FORECAST(6, A1:A5, B1:B4)",
+      A7: "=FORECAST(12, B1:B4, C1:C5)",
+    };
+    expect(evaluateCell("A6", grid)).toBe("#ERROR"); //@compatibility : On google sheet, returns #N/A
+    expect(evaluateCell("A7", grid)).toBe("#ERROR"); //@compatibility : On google sheet, returns #N/A
+  });
+
+  test("Wrong type of arguments", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "10", C1:  "3",
+      A2: "2", B2:  "8", C2:  "6",
+      A3: "3", B3:  "6", C3:  "9",
+      A4: "4", B4:  "4", C4: "12",
+      A5: "5", B5:   "", C5: "15",
+      A6: '=FORECAST("wrong", A1:A5, B1:B4)',
+      A7: '=FORECAST(5, "wrong", B1:B4)',
+      A8: '=FORECAST(5, A1:A5, "wrong")',
+    };
+    expect(evaluateCell("A6", grid)).toBe("#ERROR"); //@compatibility : On google sheet, returns #VALUE
+    expect(evaluateCell("A7", grid)).toBe("#BAD_EXPR"); //@compatibility : On google sheet, returns #N/A
+    expect(evaluateCell("A8", grid)).toBe("#BAD_EXPR"); //@compatibility : On google sheet, returns #N/A
+  });
+});
+
+describe("STEYX formula", () => {
+  test("Nul standard error for linear-dependant data", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1:  "2", C1: "15",
+      A2: "2", B2:  "4", C2: "12",
+      A3: "3", B3:  "6", C3:  "9",
+      A4: "4", B4:  "8", C4:  "6",
+      A5: "5", B5: "10", C5:  "3",
+      B6: "=STEYX(A1:A5, B1:B5)",
+      C6: "=STEYX(B1:B5, C1:C5)",
+    };
+    expect(evaluateCell("B6", grid)).toBeCloseTo(0);
+    expect(evaluateCell("C6", grid)).toBeCloseTo(0);
+  });
+
+  test("Correct standard error for uncorrelated data", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "5",    B1: "1",
+       A2:  "8.5",  B2: "2.5",
+       A3: "10",    B3: "3.1",
+       A4: "11.2",  B4: "4",
+       A5: "14",    B5: "4.7",
+       A6: "16",    B6: "5.3",
+       A7: "16.8",  B7: "6",
+       A8: "18.55", B8: "7.1",
+       A9: "20",    B9: "9",
+      A10: "=STEYX(A1:A9, B1:B9)",
+    };
+    expect(evaluateCell("A10", grid)).toBeCloseTo(1.121834626);
+  });
+
+  test("Non-numeric values are ignored", () => {
+    //prettier-ignore
+    const grid = {
+        A1:  "5",     B1: "1",
+        A2:  "8.5",   B2: "2.5",
+        A3: "10",     B3: "3.1",
+        A4: "11.2",   B4: "4",
+        A5: "ko",     B5: "4",
+        A6: "14",     B6: "4.7",
+        A7: "16",     B7: "5.3",
+        A8: "16",     B8: "=TRUE()",
+        A9: "16.8",   B9: "6",
+       A10: "18.55", B10: "7.1",
+       A11: "20",    B11: "9",
+       A12: "=STEYX(A1:A11, B1:B11)",
+    };
+    expect(evaluateCell("A12", grid)).toBeCloseTo(1.121834626);
+  });
+});
+
+describe("POLYFIT.COEFFS formula", () => {
+  test("Noisy values", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "2",  B1: "18",
+       A2:  "4",  B2: "14",
+       A3:  "4",  B3: "16",
+       A4:  "5",  B4: "17",
+       A5:  "6",  B5: "18",
+       A6:  "7",  B6: "23",
+       A7:  "7",  B7: "25",
+       A8:  "8",  B8: "28",
+       A9:  "9",  B9: "32",
+      A10: "12", B10: "29",
+      A11: "=POLYFIT.COEFFS(B1:B10, A1:A10, 3)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(-0.12648192);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(2.648191999);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(-14.23806978);
+    expect(getEvaluatedCell(model, "D11").value).toBeCloseTo(37.21341211);
+  });
+
+  test.each(["1", "2", "3", "4"])("degree %s polynomial data", async (degree: string) => {
+    const order = parseInt(degree);
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: Math.pow(1, order).toString(),
+      A2: "2", B2: Math.pow(2, order).toString(),
+      A3: "3", B3: Math.pow(3, order).toString(),
+      A4: "4", B4: Math.pow(4, order).toString(),
+      A5: "5", B5: Math.pow(5, order).toString(),
+      A6: `=POLYFIT.COEFFS(B1:B5, A1:A5, ${order})`,
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A6").value).toBeCloseTo(1);
+    for (let i = 1; i < order; i++) {
+      expect(getEvaluatedCell(model, toXC(i, 5)).value).toBeCloseTo(0);
+    }
+  });
+
+  test("Non-numeric data are ignored", () => {
+    //prettier-ignore
+    const grid = {
+      A1:  "1", B1: "1",
+      A2:  "2", B2: "4",
+      A3: "ko", B3: "4",
+      A4:  "3", B4: "9",
+      A5:  "4", B5: "16",
+      A6:  "4", B6: "=TRUE()",
+      A7:  "5", B7: "25",
+      A8: "=POLYFIT.COEFFS(B1:B7, A1:A7, 2)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A8").value).toBeCloseTo(1);
+    expect(getEvaluatedCell(model, "B8").value).toBeCloseTo(0);
+  });
+
+  test("Unconsistent data", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "2",
+      A2: "2", B2: "4",
+      A3: "3", B3: "6",
+      A4: "4", B4: "8",
+      A5: "5", B5: "10",
+      A6: "=POLYFIT.COEFFS(B1:B5, A1:A4, 3)",
+      A7: "=POLYFIT.COEFFS(B1:B4, A1:A5, 3)",
+    };
+    expect(evaluateCell("A6", grid)).toBe("#ERROR");
+    expect(evaluateCell("A7", grid)).toBe("#ERROR");
+  });
+});
+
+describe("POLYFIT.FORECAST formula", () => {
+  test.each(["1", "2", "3", "4"])("degree %s polynomial data", async (degree: string) => {
+    const order = parseInt(degree);
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: Math.pow(1, order).toString(),
+      A2: "2", B2: Math.pow(2, order).toString(),
+      A3: "3", B3: Math.pow(3, order).toString(),
+      A4: "4", B4: Math.pow(4, order).toString(),
+      A5: "5", B5: Math.pow(5, order).toString(),
+      A6: `=POLYFIT.FORECAST(6, B1:B5, A1:A5, ${order})`,
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A6").value).toBeCloseTo(Math.pow(6, order));
+  });
+
+  test.each(["1", "2", "3", "4"])(
+    "degree %s polynomial data with row data",
+    async (degree: string) => {
+      const order = parseInt(degree);
+      //prettier-ignore
+      const grid = {
+      A1: "1", B1: Math.pow(1, order).toString(), C1: "6", D1: "7", E1: "8", F1: "9",
+      A2: "2", B2: Math.pow(2, order).toString(),
+      A3: "3", B3: Math.pow(3, order).toString(),
+      A4: "4", B4: Math.pow(4, order).toString(),
+      A5: "5", B5: Math.pow(5, order).toString(),
+      A6: `=POLYFIT.FORECAST(C1:F1, B1:B5, A1:A5, ${order})`,
+    };
+      const model = createModelFromGrid(grid);
+      expect(getEvaluatedCell(model, "A6").value).toBeCloseTo(Math.pow(6, order));
+      expect(getEvaluatedCell(model, "B6").value).toBeCloseTo(Math.pow(7, order));
+      expect(getEvaluatedCell(model, "C6").value).toBeCloseTo(Math.pow(8, order));
+      expect(getEvaluatedCell(model, "D6").value).toBeCloseTo(Math.pow(9, order));
+    }
+  );
+
+  test("Non-numeric data are ignored", () => {
+    //prettier-ignore
+    const grid = {
+      A1:  "1", B1: "1",
+      A2:  "2", B2: "4",
+      A3: "ko", B3: "4",
+      A4:  "3", B4: "9",
+      A5:  "4", B5: "16",
+      A6:  "4", B6: "=TRUE()",
+      A7:  "5", B7: "25",
+      A8: "=POLYFIT.FORECAST(6, B1:B7, A1:A7, 2)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A8").value).toBeCloseTo(36);
+  });
+
+  test("Unconsistent data", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "2",
+      A2: "2", B2: "4",
+      A3: "3", B3: "6",
+      A4: "4", B4: "8",
+      A5: "5", B5: "10",
+      A6: "=POLYFIT.FORECAST(6, B1:B5, A1:A4, 3)",
+      A7: "=POLYFIT.FORECAST(6, B1:B4, A1:A5, 3)",
+    };
+    expect(evaluateCell("A6", grid)).toBe("#ERROR");
+    expect(evaluateCell("A7", grid)).toBe("#ERROR");
+  });
+});
+
+describe("LINEST formula", () => {
+  test("1-variable : no-intercept regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",
+       A2: "8.50",  B2: "2.5",
+       A3: "10.00", B3: "3.1",
+       A4: "11.20", B4: "4",
+       A5: "14.00", B5: "4.7",
+       A6: "16.00", B6: "5.3",
+       A7: "16.80", B7: "6",
+       A8: "18.55", B8: "7.1",
+       A9: "20.00", B9: "9",
+      A10: "=LINEST(A1:A9, B1:B9, 0, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(2.655839489);
+    expect(getEvaluatedCell(model, "B10").value).toBe(0);
+    expect(getEvaluatedCell(model, "A11").value).toBe("");
+  });
+
+  test("1-variable : no-intercept regression (verbose)", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",
+       A2: "8.50",  B2: "2.5",
+       A3: "10.00", B3: "3.1",
+       A4: "11.20", B4: "4",
+       A5: "14.00", B5: "4.7",
+       A6: "16.00", B6: "5.3",
+       A7: "16.80", B7: "6",
+       A8: "18.55", B8: "7.1",
+       A9: "20.00", B9: "9",
+      A10: "=LINEST(A1:A9, B1:B9, 0, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(2.655839489);
+    expect(getEvaluatedCell(model, "B10").value).toBe(0);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(0.131197596);
+    expect(getEvaluatedCell(model, "B11").value).toBe("");
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(0.980851215);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(2.076282277);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(409.7810683);
+    expect(getEvaluatedCell(model, "B13").value).toBe(8);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(1766.544915);
+    expect(getEvaluatedCell(model, "B14").value).toBeCloseTo(34.48758475);
+  });
+
+  test("1-variable : classical regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",
+       A2: "8.50",  B2: "2.5",
+       A3: "10.00", B3: "3.1",
+       A4: "11.20", B4: "4",
+       A5: "14.00", B5: "4.7",
+       A6: "16.00", B6: "5.3",
+       A7: "16.80", B7: "6",
+       A8: "18.55", B8: "7.1",
+       A9: "20.00", B9: "9",
+      A10: "=LINEST(A1:A9, B1:B9, 1, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.997074937);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(3.863877797);
+    expect(getEvaluatedCell(model, "A11").value).toBe("");
+  });
+
+  test("1-variable : classical regression (verbose)", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",
+       A2: "8.50",  B2: "2.5",
+       A3: "10.00", B3: "3.1",
+       A4: "11.20", B4: "4",
+       A5: "14.00", B5: "4.7",
+       A6: "16.00", B6: "5.3",
+       A7: "16.80", B7: "6",
+       A8: "18.55", B8: "7.1",
+       A9: "20.00", B9: "9",
+      A10: "=LINEST(A1:A9, B1:B9, 1, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.997074937);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(3.863877797);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(0.1621557716);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(0.8554047831);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(0.9558856309);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(1.121834626);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(151.6784566);
+    expect(getEvaluatedCell(model, "B13").value).toBe(7);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(190.8892984);
+    expect(getEvaluatedCell(model, "B14").value).toBeCloseTo(8.809590491);
+  });
+
+  test("multiple-variables : no-intercept regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",   C1: "9",
+       A2: "8.50",  B2: "2.5", C2: "12",
+       A3: "10.00", B3: "3.1", C3: "13",
+       A4: "11.20", B4: "4",   C4: "14",
+       A5: "14.00", B5: "4.7", C5: "14.5",
+       A6: "16.00", B6: "5.3", C6: "16",
+       A7: "16.80", B7: "6",   C7: "17",
+       A8: "18.55", B8: "7.1", C8: "19",
+       A9: "20.00", B9: "9",   C9: "19.6",
+      A10: "=LINEST(A1:A9, B1:C9, 0, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(0.476184886);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(1.321970426);
+    expect(getEvaluatedCell(model, "C10").value).toBe(0);
+    expect(getEvaluatedCell(model, "A11").value).toBe("");
+  });
+
+  test("multiple-variables : no-intercept regression (verbose)", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",   C1: "9",
+       A2: "8.50",  B2: "2.5", C2: "12",
+       A3: "10.00", B3: "3.1", C3: "13",
+       A4: "11.20", B4: "4",   C4: "14",
+       A5: "14.00", B5: "4.7", C5: "14.5",
+       A6: "16.00", B6: "5.3", C6: "16",
+       A7: "16.80", B7: "6",   C7: "17",
+       A8: "18.55", B8: "7.1", C8: "19",
+       A9: "20.00", B9: "9",   C9: "19.6",
+      A10: "=LINEST(A1:A9, B1:C9, 0, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(0.476184886);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(1.321970426);
+    expect(getEvaluatedCell(model, "C10").value).toBe(0);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(0.083307592);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(0.240679888);
+    expect(getEvaluatedCell(model, "C11").value).toBe("");
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(0.996621297);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(0.932366663);
+    expect(getEvaluatedCell(model, "C12").value).toBe("");
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(1032.400591);
+    expect(getEvaluatedCell(model, "B13").value).toBe(7);
+    expect(getEvaluatedCell(model, "C13").value).toBe("");
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(1794.947347);
+    expect(getEvaluatedCell(model, "B14").value).toBeCloseTo(6.085153157);
+    expect(getEvaluatedCell(model, "C14").value).toBe("");
+  });
+
+  test("multiple-variables : classical regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",   C1: "9",
+       A2: "8.50",  B2: "2.5", C2: "12",
+       A3: "10.00", B3: "3.1", C3: "13",
+       A4: "11.20", B4: "4",   C4: "14",
+       A5: "14.00", B5: "4.7", C5: "14.5",
+       A6: "16.00", B6: "5.3", C6: "16",
+       A7: "16.80", B7: "6",   C7: "17",
+       A8: "18.55", B8: "7.1", C8: "19",
+       A9: "20.00", B9: "9",   C9: "19.6",
+      A10: "=LINEST(A1:A9, B1:C9, 1, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.151703005);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(0.4252874858);
+    expect(getEvaluatedCell(model, "C10").value).toBeCloseTo(-5.839238736);
+    expect(getEvaluatedCell(model, "A11").value).toBe("");
+  });
+
+  test("multiple-variables : classical regression (verbose)", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",   C1: "9",
+       A2: "8.50",  B2: "2.5", C2: "12",
+       A3: "10.00", B3: "3.1", C3: "13",
+       A4: "11.20", B4: "4",   C4: "14",
+       A5: "14.00", B5: "4.7", C5: "14.5",
+       A6: "16.00", B6: "5.3", C6: "16",
+       A7: "16.80", B7: "6",   C7: "17",
+       A8: "18.55", B8: "7.1", C8: "19",
+       A9: "20.00", B9: "9",   C9: "19.6",
+      A10: "=LINEST(A1:A9, B1:C9, 1, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.151703005);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(0.4252874858);
+    expect(getEvaluatedCell(model, "C10").value).toBeCloseTo(-5.839238736);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(0.4913762308);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(0.6824417895);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(4.193330885);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(0.9769708817);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(0.8754893237);
+    expect(getEvaluatedCell(model, "C12").value).toBe("");
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(127.2698593);
+    expect(getEvaluatedCell(model, "B13").value).toBe(6);
+    expect(getEvaluatedCell(model, "C13").value).toBe("");
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(195.0999996);
+    expect(getEvaluatedCell(model, "B14").value).toBeCloseTo(4.598889335);
+    expect(getEvaluatedCell(model, "C14").value).toBe("");
+  });
+
+  test("Non-numerica values cause an error", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",
+       A2: "8.50",  B2: "2.5",
+       A3: "10.00", B3: "3.1",
+       A4: "11.20", B4: "4",
+       A5: "=TRUE()", B5: "4.7",
+       A6: "16.00", B6: "5.3",
+       A7: "16.80", B7: "=FALSE",
+       A8: "18.55", B8: "7.1",
+       A9: "20.00", B9: "9",
+      A10: "=LINEST(A1:A9, B1:B9, 0, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBe("#ERROR");
+  });
+});
+
+describe("LOGEST formula", () => {
+  test("1-variable : no-intercept regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "7", B1: "1.1",
+       A2: "8.9", B2: "2",
+       A3: "10.56", B3: "3.2",
+       A4: "12.33", B4: "4",
+       A5: "14", B5: "4.9",
+       A6: "15.9", B6: "5.1",
+       A7: "18.4", B7: "6",
+       A8: "23.7", B8: "7.2",
+       A9: "38.66", B9: "8.8",
+      A10: "=LOGEST(A1:A9, B1:B9, 0, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.650030078);
+    expect(getEvaluatedCell(model, "B10").value).toBe(1);
+    expect(getEvaluatedCell(model, "A11").value).toBe("");
+  });
+
+  test("1-variable : no-intercept regression (verbose)", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "7", B1: "1.1",
+       A2: "8.9", B2: "2",
+       A3: "10.56", B3: "3.2",
+       A4: "12.33", B4: "4",
+       A5: "14", B5: "4.9",
+       A6: "15.9", B6: "5.1",
+       A7: "18.4", B7: "6",
+       A8: "23.7", B8: "7.2",
+       A9: "38.66", B9: "8.8",
+      A10: "=LOGEST(A1:A9, B1:B9, 0, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.650030078);
+    expect(getEvaluatedCell(model, "B10").value).toBe(1);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(0.05045293016);
+    expect(getEvaluatedCell(model, "B11").value).toBe("");
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(0.9248999647);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(0.7925286566);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(98.52458373);
+    expect(getEvaluatedCell(model, "B13").value).toBe(8);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(61.88345572);
+    expect(getEvaluatedCell(model, "B14").value).toBeCloseTo(5.024813372);
+  });
+
+  test("1-variable : classical regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "7", B1: "1.1",
+       A2: "8.9", B2: "2",
+       A3: "10.56", B3: "3.2",
+       A4: "12.33", B4: "4",
+       A5: "14", B5: "4.9",
+       A6: "15.9", B6: "5.1",
+       A7: "18.4", B7: "6",
+       A8: "23.7", B8: "7.2",
+       A9: "38.66", B9: "8.8",
+      A10: "=LOGEST(A1:A9, B1:B9, 1, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.234958605);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(5.420801689);
+    expect(getEvaluatedCell(model, "A11").value).toBe("");
+  });
+
+  test("1-variable : classical regression (verbose)", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "7", B1: "1.1",
+       A2: "8.9", B2: "2",
+       A3: "10.56", B3: "3.2",
+       A4: "12.33", B4: "4",
+       A5: "14", B5: "4.9",
+       A6: "15.9", B6: "5.1",
+       A7: "18.4", B7: "6",
+       A8: "23.7", B8: "7.2",
+       A9: "38.66", B9: "8.8",
+      A10: "=LOGEST(A1:A9, B1:B9, 1, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.234958605);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(5.420801689);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(0.009340554356);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(0.04890800839);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(0.9864727545);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(0.06467280043);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(510.4741588);
+    expect(getEvaluatedCell(model, "B13").value).toBe(7);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(2.135094472);
+    expect(getEvaluatedCell(model, "B14").value).toBeCloseTo(0.02927799781);
+  });
+
+  test("multiple-variables : no-intercept regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "7.00",  B1: "1",   C1: "9",
+       A2: "8.90",  B2: "2.5", C2: "12",
+       A3: "10.56", B3: "3.1", C3: "13",
+       A4: "12.33", B4: "4",   C4: "14",
+       A5: "14.00", B5: "4.7", C5: "14.5",
+       A6: "15.90", B6: "5.3", C6: "16",
+       A7: "18.40", B7: "6",   C7: "17",
+       A8: "23.70", B8: "7.1", C8: "19",
+       A9: "38.66", B9: "9",   C9: "19.6",
+      A10: "=LOGEST(A1:A9, B1:C9, 0, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.212565933);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(0.9587796002);
+    expect(getEvaluatedCell(model, "C10").value).toBe(1);
+    expect(getEvaluatedCell(model, "A11").value).toBe("");
+  });
+
+  test("multiple-variables : no-intercept regression (verbose)", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "7.00",  B1: "1",   C1: "9",
+       A2: "8.90",  B2: "2.5", C2: "12",
+       A3: "10.56", B3: "3.1", C3: "13",
+       A4: "12.33", B4: "4",   C4: "14",
+       A5: "14.00", B5: "4.7", C5: "14.5",
+       A6: "15.90", B6: "5.3", C6: "16",
+       A7: "18.40", B7: "6",   C7: "17",
+       A8: "23.70", B8: "7.1", C8: "19",
+       A9: "38.66", B9: "9",   C9: "19.6",
+      A10: "=LOGEST(A1:A9, B1:C9, 0, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(1.212565933);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(0.9587796002);
+    expect(getEvaluatedCell(model, "C10").value).toBe(1);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(0.01483874916);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(0.04286990415);
+    expect(getEvaluatedCell(model, "C11").value).toBe("");
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(0.9971145262);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(0.1660731594);
+    expect(getEvaluatedCell(model, "C12").value).toBe("");
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(1209.472357);
+    expect(getEvaluatedCell(model, "B13").value).toBe(7);
+    expect(getEvaluatedCell(model, "C13").value).toBe("");
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(66.71520704);
+    expect(getEvaluatedCell(model, "B14").value).toBeCloseTo(0.1930620599);
+    expect(getEvaluatedCell(model, "C14").value).toBe("");
+  });
+
+  test("multiple-variables : classical regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "7.00",  B1: "1",   C1: "9",
+       A2: "8.90",  B2: "2.5", C2: "12",
+       A3: "10.56", B3: "3.1", C3: "13",
+       A4: "12.33", B4: "4",   C4: "14",
+       A5: "14.00", B5: "4.7", C5: "14.5",
+       A6: "15.90", B6: "5.3", C6: "16",
+       A7: "18.40", B7: "6",   C7: "17",
+       A8: "23.70", B8: "7.1", C8: "19",
+       A9: "38.66", B9: "9",   C9: "19.6",
+      A10: "=LOGEST(A1:A9, B1:C9, 1, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(0.9543419384);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(1.317559421);
+    expect(getEvaluatedCell(model, "C10").value).toBeCloseTo(7.924957718);
+    expect(getEvaluatedCell(model, "A11").value).toBe("");
+  });
+
+  test("multiple-variables : classical regression (verbose)", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "7.00",  B1: "1",   C1: "9",
+       A2: "8.90",  B2: "2.5", C2: "12",
+       A3: "10.56", B3: "3.1", C3: "13",
+       A4: "12.33", B4: "4",   C4: "14",
+       A5: "14.00", B5: "4.7", C5: "14.5",
+       A6: "15.90", B6: "5.3", C6: "16",
+       A7: "18.40", B7: "6",   C7: "17",
+       A8: "23.70", B8: "7.1", C8: "19",
+       A9: "38.66", B9: "9",   C9: "19.6",
+      A10: "=LOGEST(A1:A9, B1:C9, 1, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(0.9543419384);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(1.317559421);
+    expect(getEvaluatedCell(model, "C10").value).toBeCloseTo(7.924957718);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(0.01816040272);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(0.02522185029);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(0.1549781468);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(0.9970976912);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(0.0323565482);
+    expect(getEvaluatedCell(model, "C12").value).toBe("");
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(1030.659822);
+    expect(getEvaluatedCell(model, "B13").value).toBe(6);
+    expect(getEvaluatedCell(model, "C13").value).toBe("");
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(2.158090792);
+    expect(getEvaluatedCell(model, "B14").value).toBeCloseTo(0.006281677268);
+    expect(getEvaluatedCell(model, "C14").value).toBe("");
+  });
+
+  test("Non-numerica values cause an error", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",
+       A2: "8.50",  B2: "2.5",
+       A3: "10.00", B3: "3.1",
+       A4: "11.20", B4: "4",
+       A5: "=TRUE()", B5: "4.7",
+       A6: "16.00", B6: "5.3",
+       A7: "16.80", B7: "=FALSE",
+       A8: "18.55", B8: "7.1",
+       A9: "20.00", B9: "9",
+      A10: "=LOGEST(A1:A9, B1:B9, 0, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBe("#ERROR");
+  });
+});
+
+describe("TREND formula", () => {
+  test("1-variable : no-intercept regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "1",  B1: "$15.53",
+       A2:  "2",  B2: "$19.99",
+       A3:  "3",  B3: "$20.43",
+       A4:  "4",  B4: "$21.18",
+       A5:  "5",  B5: "$25.93",
+       A6:  "6",  B6: "$30.00",
+       A7:  "7",  B7: "$30.00",
+       A8:  "8",  B8: "$34.01",
+       A9:  "9",  B9: "$36.47",
+      A10: "10", B10: "=TREND(B1:B9, A1:A9, A10:A12, 0)",
+      A11: "11",
+      A12: "12",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(46.3677193);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(51.00449123);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(55.64126316);
+  });
+
+  test("1-variable : no-intercept regression (new_X as row)", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "1",  B1: "$15.53",
+       A2:  "2",  B2: "$19.99",
+       A3:  "3",  B3: "$20.43",
+       A4:  "4",  B4: "$21.18",
+       A5:  "5",  B5: "$25.93",
+       A6:  "6",  B6: "$30.00",
+       A7:  "7",  B7: "$30.00",
+       A8:  "8",  B8: "$34.01",
+       A9:  "9",  B9: "$36.47",
+      A10: "10", B10: "11", C10: "12",
+      A11: "=TREND(B1:B9, A1:A9, A10:C10, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(46.3677193);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(51.00449123);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(55.64126316);
+  });
+
+  test("1-variable : classical regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "1",  B1: "$15.53",
+       A2:  "2",  B2: "$19.99",
+       A3:  "3",  B3: "$20.43",
+       A4:  "4",  B4: "$21.18",
+       A5:  "5",  B5: "$25.93",
+       A6:  "6",  B6: "$30.00",
+       A7:  "7",  B7: "$30.00",
+       A8:  "8",  B8: "$34.01",
+       A9:  "9",  B9: "$36.47",
+      A10: "10", B10: "=TREND(B1:B9, A1:A9, A10:A12, 1)",
+      A11: "11",
+      A12: "12",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(38.76388889);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(41.32688889);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(43.88988889);
+  });
+
+  test("1-variable : classical regression (new_X as row)", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "1",  B1: "$15.53",
+       A2:  "2",  B2: "$19.99",
+       A3:  "3",  B3: "$20.43",
+       A4:  "4",  B4: "$21.18",
+       A5:  "5",  B5: "$25.93",
+       A6:  "6",  B6: "$30.00",
+       A7:  "7",  B7: "$30.00",
+       A8:  "8",  B8: "$34.01",
+       A9:  "9",  B9: "$36.47",
+      A10: "10", B10: "11", C10: "12",
+      A11: "=TREND(B1:B9, A1:A9, A10:C10, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(38.76388889);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(41.32688889);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(43.88988889);
+  });
+
+  test("multiple-variable : classical regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "1",  B1: "1",  C1: "15.53",
+       A2:  "2",  B2: "1",  C2: "19.99",
+       A3:  "3",  B3: "2",  C3: "20.43",
+       A4:  "4",  B4: "2",  C4: "21.18",
+       A5:  "5",  B5: "3",  C5: "25.93",
+       A6:  "6",  B6: "3",  C6: "30.00",
+       A7:  "7",  B7: "4",  C7: "30.00",
+       A8:  "8",  B8: "4",  C8: "34.01",
+       A9:  "9",  B9: "5",  C9: "36.47",
+      A10: "10", B10: "5", C10: "=TREND(C1:C9, A1:B9, A10:B12, 1)",
+      A11: "11", B11: "6",
+      A12: "12", B12: "6",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "C10").value).toBeCloseTo(39.11);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(41.05);
+    expect(getEvaluatedCell(model, "C12").value).toBeCloseTo(44.236);
+  });
+
+  test("multiple-variable : no-intercept regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "1",  B1: "1",  C1: "15.53",
+       A2:  "2",  B2: "1",  C2: "19.99",
+       A3:  "3",  B3: "2",  C3: "20.43",
+       A4:  "4",  B4: "2",  C4: "21.18",
+       A5:  "5",  B5: "3",  C5: "25.93",
+       A6:  "6",  B6: "3",  C6: "30.00",
+       A7:  "7",  B7: "4",  C7: "30.00",
+       A8:  "8",  B8: "4",  C8: "34.01",
+       A9:  "9",  B9: "5",  C9: "36.47",
+      A10: "10", B10: "5", C10: "=TREND(C1:C9, A1:B9, A10:B12, 0)",
+      A11: "11", B11: "6",
+      A12: "12", B12: "6",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "C10").value).toBeCloseTo(42.48);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(51.16);
+    expect(getEvaluatedCell(model, "C12").value).toBeCloseTo(50.976);
+  });
+
+  test("1-variable : no newX-data", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1", B1: "$15.53",
+       A2: "2", B2: "$19.99",
+       A3: "3", B3: "$20.43",
+       A4: "4", B4: "$21.18",
+       A5: "5", B5: "$25.93",
+       A6: "6", B6: "$30.00",
+       A7: "7", B7: "$30.00",
+       A8: "8", B8: "$34.01",
+       A9: "9", B9: "$36.47",
+      A10: "=TREND(B1:B9, A1:A9)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(15.69688889);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(18.25988889);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(20.82288889);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(23.38588889);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(25.94888889);
+    expect(getEvaluatedCell(model, "A15").value).toBeCloseTo(28.51188889);
+    expect(getEvaluatedCell(model, "A16").value).toBeCloseTo(31.07488889);
+    expect(getEvaluatedCell(model, "A17").value).toBeCloseTo(33.63788889);
+    expect(getEvaluatedCell(model, "A18").value).toBeCloseTo(36.20088889);
+  });
+
+  test("1-variable : no X-data", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "$15.53",
+       A2: "$19.99",
+       A3: "$20.43",
+       A4: "$21.18",
+       A5: "$25.93",
+       A6: "$30.00",
+       A7: "$30.00",
+       A8: "$34.01",
+       A9: "$36.47",
+      A10: "=TREND(A1:A9)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(15.69688889);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(18.25988889);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(20.82288889);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(23.38588889);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(25.94888889);
+    expect(getEvaluatedCell(model, "A15").value).toBeCloseTo(28.51188889);
+    expect(getEvaluatedCell(model, "A16").value).toBeCloseTo(31.07488889);
+    expect(getEvaluatedCell(model, "A17").value).toBeCloseTo(33.63788889);
+    expect(getEvaluatedCell(model, "A18").value).toBeCloseTo(36.20088889);
+  });
+
+  test("multiple-variable : no newX data", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1", B1: "1", C1: "15.53",
+       A2: "2", B2: "1", C2: "19.99",
+       A3: "3", B3: "2", C3: "20.43",
+       A4: "4", B4: "2", C4: "21.18",
+       A5: "5", B5: "3", C5: "25.93",
+       A6: "6", B6: "3", C6: "30.00",
+       A7: "7", B7: "4", C7: "30.00",
+       A8: "8", B8: "4", C8: "34.01",
+       A9: "9", B9: "5", C9: "36.47",
+      A10: "=TREND(C1:C9, A1:B9)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(15.42);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(18.606);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(20.546);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(23.732);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(25.672);
+    expect(getEvaluatedCell(model, "A15").value).toBeCloseTo(28.858);
+    expect(getEvaluatedCell(model, "A16").value).toBeCloseTo(30.798);
+    expect(getEvaluatedCell(model, "A17").value).toBeCloseTo(33.984);
+    expect(getEvaluatedCell(model, "A18").value).toBeCloseTo(35.924);
+  });
+
+  test("Non-numerica values cause an error", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "5.00",  B1: "1",
+       A2: "8.50",  B2: "2.5",
+       A3: "10.00", B3: "3.1",
+       A4: "11.20", B4: "4",
+       A5: "=TRUE()", B5: "4.7",
+       A6: "16.00", B6: "5.3",
+       A7: "16.80", B7: "=FALSE",
+       A8: "18.55", B8: "7.1",
+       A9: "20.00", B9: "9",
+      A10: "=GROWTH(A1:A9, B1:B9)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBe("#ERROR");
+  });
+});
+
+describe("GROWTH formula", () => {
+  test("1-variable : no-intercept regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",   B1: "$15.53",
+       A2: "2",   B2: "$19.99",
+       A3: "3",   B3: "$20.43",
+       A4: "4",   B4: "$21.18",
+       A5: "5",   B5: "$25.93",
+       A6: "6",   B6: "$30.00",
+       A7: "7",   B7: "$30.00",
+       A8: "8",   B8: "$34.01",
+       A9: "9",   B9: "$36.47",
+      A10: "10", B10: "=GROWTH(B1:B9, A1:A9, A10:A12, 0)",
+      A11: "11",
+      A12: "12",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(200.4823447);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(340.630668);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(578.7504737);
+  });
+
+  test("1-variable : no-intercept regression (new_X as row)", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",   B1: "$15.53",
+       A2: "2",   B2: "$19.99",
+       A3: "3",   B3: "$20.43",
+       A4: "4",   B4: "$21.18",
+       A5: "5",   B5: "$25.93",
+       A6: "6",   B6: "$30.00",
+       A7: "7",   B7: "$30.00",
+       A8: "8",   B8: "$34.01",
+       A9: "9",   B9: "$36.47",
+      A10: "10", B10: "11", C10: "12",
+      A11: "=GROWTH(B1:B9, A1:A9, A10:C10, 0)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(200.4823447);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(340.630668);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(578.7504737);
+  });
+
+  test("1-variable : classical regression", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1",   B1: "$15.53",
+      A2: "2",   B2: "$19.99",
+      A3: "3",   B3: "$20.43",
+      A4: "4",   B4: "$21.18",
+      A5: "5",   B5: "$25.93",
+      A6: "6",   B6: "$30.00",
+      A7: "7",   B7: "$30.00",
+      A8: "8",   B8: "$34.01",
+      A9: "9",   B9: "$36.47",
+      A10: "10", B10: "=GROWTH(B1:B9, A1:A9, A10:A12, 1)",
+      A11: "11",
+      A12: "12",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "B10").value).toBeCloseTo(41.74052172);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(46.22712349);
+    expect(getEvaluatedCell(model, "B12").value).toBeCloseTo(51.19598075);
+  });
+
+  test("1-variable : classical regression (new_X as row)", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1",   B1: "$15.53",
+      A2: "2",   B2: "$19.99",
+      A3: "3",   B3: "$20.43",
+      A4: "4",   B4: "$21.18",
+      A5: "5",   B5: "$25.93",
+      A6: "6",   B6: "$30.00",
+      A7: "7",   B7: "$30.00",
+      A8: "8",   B8: "$34.01",
+      A9: "9",   B9: "$36.47",
+      A10: "10", B10: "11", C10: "12",
+      A11: "=GROWTH(B1:B9, A1:A9, A10:C10, 1)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(41.74052172);
+    expect(getEvaluatedCell(model, "B11").value).toBeCloseTo(46.22712349);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(51.19598075);
+  });
+
+  test("multiple-variable : classical regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "1",  B1: "1",  C1: "15.53",
+       A2:  "2",  B2: "1",  C2: "19.99",
+       A3:  "3",  B3: "2",  C3: "20.43",
+       A4:  "4",  B4: "2",  C4: "21.18",
+       A5:  "5",  B5: "3",  C5: "25.93",
+       A6:  "6",  B6: "3",  C6: "30.00",
+       A7:  "7",  B7: "4",  C7: "30.00",
+       A8:  "8",  B8: "4",  C8: "34.01",
+       A9:  "9",  B9: "5",  C9: "36.47",
+      A10: "10", B10: "5", C10: "=GROWTH(C1:C9, A1:B9, A10:B12, 1)",
+      A11: "11", B11: "6",
+      A12: "12", B12: "6",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "C10").value).toBeCloseTo(42.71315425);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(45.38306815);
+    expect(getEvaluatedCell(model, "C12").value).toBeCloseTo(52.38894322);
+  });
+
+  test("multiple-variable : no-intercept regression", () => {
+    //prettier-ignore
+    const grid = {
+       A1:  "1",  B1: "1",  C1: "15.53",
+       A2:  "2",  B2: "1",  C2: "19.99",
+       A3:  "3",  B3: "2",  C3: "20.43",
+       A4:  "4",  B4: "2",  C4: "21.18",
+       A5:  "5",  B5: "3",  C5: "25.93",
+       A6:  "6",  B6: "3",  C6: "30.00",
+       A7:  "7",  B7: "4",  C7: "30.00",
+       A8:  "8",  B8: "4",  C8: "34.01",
+       A9:  "9",  B9: "5",  C9: "36.47",
+      A10: "10", B10: "5", C10: "=GROWTH(C1:C9, A1:B9, A10:B12, 0)",
+      A11: "11", B11: "6",
+      A12: "12", B12: "6",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "C10").value).toBeCloseTo(84.59692215);
+    expect(getEvaluatedCell(model, "C11").value).toBeCloseTo(352.5921256);
+    expect(getEvaluatedCell(model, "C12").value).toBeCloseTo(205.5064585);
+  });
+
+  test("1-variable : no newX-data", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1", B1: "$15.53",
+       A2: "2", B2: "$19.99",
+       A3: "3", B3: "$20.43",
+       A4: "4", B4: "$21.18",
+       A5: "5", B5: "$25.93",
+       A6: "6", B6: "$30.00",
+       A7: "7", B7: "$30.00",
+       A8: "8", B8: "$34.01",
+       A9: "9", B9: "$36.47",
+      A10: "=GROWTH(B1:B9, A1:A9)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(16.65355287);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(18.4436086);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(20.42607368);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(22.62162981);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(25.0531817);
+    expect(getEvaluatedCell(model, "A15").value).toBeCloseTo(27.74609604);
+    expect(getEvaluatedCell(model, "A16").value).toBeCloseTo(30.72846613);
+    expect(getEvaluatedCell(model, "A17").value).toBeCloseTo(34.03140497);
+    expect(getEvaluatedCell(model, "A18").value).toBeCloseTo(37.68936983);
+  });
+
+  test("1-variable : no X-data", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "$15.53",
+       A2: "$19.99",
+       A3: "$20.43",
+       A4: "$21.18",
+       A5: "$25.93",
+       A6: "$30.00",
+       A7: "$30.00",
+       A8: "$34.01",
+       A9: "$36.47",
+      A10: "=GROWTH(A1:A9)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(16.65355287);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(18.4436086);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(20.42607368);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(22.62162981);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(25.0531817);
+    expect(getEvaluatedCell(model, "A15").value).toBeCloseTo(27.74609604);
+    expect(getEvaluatedCell(model, "A16").value).toBeCloseTo(30.72846613);
+    expect(getEvaluatedCell(model, "A17").value).toBeCloseTo(34.03140497);
+    expect(getEvaluatedCell(model, "A18").value).toBeCloseTo(37.68936983);
+  });
+
+  test("multiple-variable : no newX data", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1", B1: "1", C1: "15.53",
+       A2: "2", B2: "1", C2: "19.99",
+       A3: "3", B3: "2", C3: "20.43",
+       A4: "4", B4: "2", C4: "21.18",
+       A5: "5", B5: "3", C5: "25.93",
+       A6: "6", B6: "3", C6: "30.00",
+       A7: "7", B7: "4", C7: "30.00",
+       A8: "8", B8: "4", C8: "34.01",
+       A9: "9", B9: "5", C9: "36.47",
+      A10: "=GROWTH(C1:C9, A1:B9)",
+    };
+    const model = createModelFromGrid(grid);
+    expect(getEvaluatedCell(model, "A10").value).toBeCloseTo(16.34947771);
+    expect(getEvaluatedCell(model, "A11").value).toBeCloseTo(18.87337931);
+    expect(getEvaluatedCell(model, "A12").value).toBeCloseTo(20.05311653);
+    expect(getEvaluatedCell(model, "A13").value).toBeCloseTo(23.14875626);
+    expect(getEvaluatedCell(model, "A14").value).toBeCloseTo(24.59573875);
+    expect(getEvaluatedCell(model, "A15").value).toBeCloseTo(28.39263217);
+    expect(getEvaluatedCell(model, "A16").value).toBeCloseTo(30.16739886);
+    expect(getEvaluatedCell(model, "A17").value).toBeCloseTo(34.8244006);
+    expect(getEvaluatedCell(model, "A18").value).toBeCloseTo(37.00120429);
   });
 });


### PR DESCRIPTION
## Task Description

This PR aims to add some missing statistics formulas from GSheet (`PEARSON`, `SLOPE`, `INTERCEPT`, `STEYX`, `FORECAST` and `CORREL`) as well as new formulas undefined in other spreadsheet :

1. `SPEARMAN(dependant_data, independant_data)` : Kind of Pearson correlation coefficient, but based on the ranking of values in each dataset
2. `MATTHEWS(dependant_data, independant_data)` : Kind of Pearson correlation coefficient, but checking prediction of boolean value (used in classification model validation)
3. `POLYFIT.COEFFS(dependant_data, independant_data, order)`: Compute the polynomial regression of the data to the given order and returns the coefficient
4. `POLYFIT.FORECAST(x, dependant_data, independant_data, order)` : Compute the polynomial regression of the data and perform the prediction of the value(s) given as 'x'

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo