### PR TITLE
[FIX] rendering: cache text width

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -131,12 +131,21 @@ export function getDefaultCellHeight(style: Style | undefined, numberOfLines?: n
 }
 
 export function computeTextWidth(context: CanvasRenderingContext2D, text: string, style: Style) {
-  context.save();
-  context.font = computeTextFont(style);
-  const textWidth = context.measureText(text).width;
-  context.restore();
-  return textWidth;
+  const font = computeTextFont(style);
+  if (!textWidthCache[font]) {
+    textWidthCache[font] = {};
+  }
+  if (textWidthCache[font][text] === undefined) {
+    context.save();
+    context.font = font;
+    const textWidth = context.measureText(text).width;
+    context.restore();
+    textWidthCache[font][text] = textWidth;
+  }
+  return textWidthCache[font][text];
 }
+
+const textWidthCache: Record<string, Record<string, number>> = {};
 
 export function computeTextFont(style: Style): string {
   const italic = style.italic ? "italic " : "";


### PR DESCRIPTION

## Description:

Computing the text width is expensive, so we cache it

Odoo task ID : [3354651](https://www.odoo.com/web#id=3354651&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo