### PR TITLE
[REF] xlsx: remove useless exported check

### DIFF
--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -1,6 +1,4 @@
 import { DEFAULT_FONT_SIZE } from "../../constants";
-import { tokenize } from "../../formulas";
-import { functionRegistry } from "../../functions";
 import { splitReference, toUnboundedZone } from "../../helpers";
 import {
   BorderDescr,
@@ -138,16 +136,6 @@ export function extractStyle(cell: ExcelCellData, data: WorkbookData): Extracted
 function extractFormat(cell: ExcelCellData, data: WorkbookData): Format | undefined {
   if (cell.format) {
     return data.formats[cell.format];
-  }
-  if (cell.isFormula) {
-    const tokens = tokenize(cell.content || "");
-    const functions = functionRegistry.content;
-    const isExported = tokens
-      .filter((tk) => tk.type === "FUNCTION")
-      .every((tk) => functions[tk.value.toUpperCase()].isExported);
-    if (!isExported) {
-      return cell.computedFormat;
-    }
   }
   return undefined;
 }


### PR DESCRIPTION
## Description:

Since 0a6a786e, functions that are not exported are entirely managed by the plugin. The cell content and format are replaced directly in `exportForExcel`

That means it's useless to check if the format needs to replaced by the computed format

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo