### PR TITLE
[FIX] misc: type of isCloneable interface

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -39,7 +39,7 @@ export function removeStringQuotes(str: string): string {
   return str;
 }
 
-function isCloneable<T>(obj: T | Cloneable<T>): obj is Cloneable<T> {
+function isCloneable<T extends Object>(obj: T | Cloneable<T>): obj is Cloneable<T> {
   return "clone" in obj && obj.clone instanceof Function;
 }
 


### PR DESCRIPTION
The generic T of the `isCloneable` interface was not properly typed, there was no guarantee that it was an Object. This didn't cause an issue in our current version of TypeScript (4.8.3) but won't work for more recent versions (tested with 5.0.4).

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo