### PR TITLE
[FIX] toolbar: no hover effect on font size editor

### DIFF
--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -13,13 +13,12 @@ interface State {
 interface Props {
   onToggle: () => void;
   dropdownStyle: string;
+  class: string;
 }
 
-// -----------------------------------------------------------------------------
-// TopBar
-// -----------------------------------------------------------------------------
 css/* scss */ `
   .o-font-size-editor {
+    height: calc(100% - 4px);
     input.o-font-size {
       outline-color: ${SELECTION_BORDER_COLOR};
       height: 20px;
@@ -32,13 +31,13 @@ css/* scss */ `
     input::-webkit-inner-spin-button {
       -webkit-appearance: none;
     }
-
-    .o-text-options > div {
-      line-height: 26px;
-      padding: 3px 12px;
-      &:hover {
-        background-color: rgba(0, 0, 0, 0.08);
-      }
+  }
+  .o-text-options > div {
+    cursor: pointer;
+    line-height: 26px;
+    padding: 3px 12px;
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.08);
     }
   }
 `;
@@ -116,4 +115,5 @@ export class FontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
 FontSizeEditor.props = {
   onToggle: Function,
   dropdownStyle: String,
+  class: String,
 };

--- a/src/components/font_size_editor/font_size_editor.xml
+++ b/src/components/font_size_editor/font_size_editor.xml
@@ -1,24 +1,31 @@
 <templates>
   <t t-name="o-spreadsheet-FontSizeEditor" owl="1">
-    <div class="o-dropdown o-font-size-editor" t-ref="FontSizeEditor">
-      <input
-        type="number"
-        min="1"
-        max="400"
-        class="o-font-size bg-transparent border-0 ps-1"
-        t-on-keydown="onInputKeydown"
-        t-on-click.stop=""
-        t-on-focus.stop="onInputFocused"
-        t-att-value="currentFontSize"
-        t-on-change="setSizeFromInput"
-        t-ref="inputFontSize"
-      />
-      <div title="Font Size" t-on-click="() => this.toggleFontList()">
-        <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
+    <div class="o-dropdown" t-ref="FontSizeEditor">
+      <div
+        class=" o-font-size-editor d-flex align-items-center"
+        t-att-class="props.class"
+        title="Font Size"
+        t-on-click="this.toggleFontList">
+        <input
+          type="number"
+          min="1"
+          max="400"
+          class="o-font-size bg-transparent border-0"
+          t-on-keydown="onInputKeydown"
+          t-on-click.stop=""
+          t-on-focus.stop="onInputFocused"
+          t-att-value="currentFontSize"
+          t-on-change="setSizeFromInput"
+          t-ref="inputFontSize"
+        />
+        <span>
+          <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
+        </span>
       </div>
       <div
         class="o-dropdown-content o-text-options"
         t-if="dropdown.isOpen"
+        t-on-click.stop=""
         t-att-style="props.dropdownStyle">
         <t t-foreach="fontSizes" t-as="fontSize" t-key="fontSize">
           <div

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -55,9 +55,11 @@
             />
 
             <div class="o-divider"/>
-
-            <FontSizeEditor onToggle="() => this.onClick()" dropdownStyle="this.dropdownStyle"/>
-
+            <FontSizeEditor
+              class="'o-hoverable-button'"
+              onToggle.bind="this.onClick"
+              dropdownStyle="this.dropdownStyle"
+            />
             <div class="o-divider"/>
 
             <ActionButton action="FORMAT.formatBold" class="'o-hoverable-button'"/>

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -235,26 +235,29 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
             class="o-divider"
           />
           <div
-            class="o-dropdown o-font-size-editor"
+            class="o-dropdown"
           >
-            <input
-              class="o-font-size bg-transparent border-0 ps-1"
-              max="400"
-              min="1"
-              type="number"
-            />
             <div
+              class="o-font-size-editor d-flex align-items-center o-hoverable-button"
               title="Font Size"
             >
-              <svg
-                class="o-icon"
-              >
-                <polygon
-                  fill="currentColor"
-                  points="0 0 4 4 8 0"
-                  transform="translate(5 7)"
-                />
-              </svg>
+              <input
+                class="o-font-size bg-transparent border-0"
+                max="400"
+                min="1"
+                type="number"
+              />
+              <span>
+                <svg
+                  class="o-icon"
+                >
+                  <polygon
+                    fill="currentColor"
+                    points="0 0 4 4 8 0"
+                    transform="translate(5 7)"
+                  />
+                </svg>
+              </span>
             </div>
             
           </div>

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -234,26 +234,29 @@ exports[`TopBar component can set cell format 1`] = `
               class="o-divider"
             />
             <div
-              class="o-dropdown o-font-size-editor"
+              class="o-dropdown"
             >
-              <input
-                class="o-font-size bg-transparent border-0 ps-1"
-                max="400"
-                min="1"
-                type="number"
-              />
               <div
+                class="o-font-size-editor d-flex align-items-center o-hoverable-button"
                 title="Font Size"
               >
-                <svg
-                  class="o-icon"
-                >
-                  <polygon
-                    fill="currentColor"
-                    points="0 0 4 4 8 0"
-                    transform="translate(5 7)"
-                  />
-                </svg>
+                <input
+                  class="o-font-size bg-transparent border-0"
+                  max="400"
+                  min="1"
+                  type="number"
+                />
+                <span>
+                  <svg
+                    class="o-icon"
+                  >
+                    <polygon
+                      fill="currentColor"
+                      points="0 0 4 4 8 0"
+                      transform="translate(5 7)"
+                    />
+                  </svg>
+                </span>
               </div>
               
             </div>
@@ -1098,26 +1101,29 @@ exports[`TopBar component simple rendering 1`] = `
           class="o-divider"
         />
         <div
-          class="o-dropdown o-font-size-editor"
+          class="o-dropdown"
         >
-          <input
-            class="o-font-size bg-transparent border-0 ps-1"
-            max="400"
-            min="1"
-            type="number"
-          />
           <div
+            class="o-font-size-editor d-flex align-items-center o-hoverable-button"
             title="Font Size"
           >
-            <svg
-              class="o-icon"
-            >
-              <polygon
-                fill="currentColor"
-                points="0 0 4 4 8 0"
-                transform="translate(5 7)"
-              />
-            </svg>
+            <input
+              class="o-font-size bg-transparent border-0"
+              max="400"
+              min="1"
+              type="number"
+            />
+            <span>
+              <svg
+                class="o-icon"
+              >
+                <polygon
+                  fill="currentColor"
+                  points="0 0 4 4 8 0"
+                  transform="translate(5 7)"
+                />
+              </svg>
+            </span>
           </div>
           
         </div>

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -292,14 +292,8 @@ describe("TopBar component", () => {
     const { model } = await mountParent();
     const fontSizeText = fixture.querySelector("input.o-font-size")! as HTMLInputElement;
     expect(fontSizeText.value.trim()).toBe(DEFAULT_FONT_SIZE.toString());
-    const fontSizeTool = fixture.querySelector('div[title="Font Size"]')!;
-    fontSizeTool.dispatchEvent(new Event("click"));
-    await nextTick();
-    const fontSizeList = fixture.querySelector(".o-font-size-editor div.o-dropdown-content")!;
-    fontSizeList
-      .querySelector('[data-size="8"]')!
-      .dispatchEvent(new Event("click", { bubbles: true }));
-    await nextTick();
+    await click(fixture, ".o-font-size-editor");
+    await click(fixture, '.o-dropdown-content [data-size="8"]');
     expect(fontSizeText.value.trim()).toBe("8");
     expect(getStyle(model, "A1").fontSize).toBe(8);
   });


### PR DESCRIPTION
The font size editor in the toolbar is missing hover effects.


Odoo task ID : [3360143](https://www.odoo.com/web#id=3360143&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo