### PR TITLE
[FIX] toolbar: no hover effect on font size editor

### DIFF
--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -13,13 +13,12 @@ interface State {
 interface Props {
   onToggle: () => void;
   dropdownStyle: string;
+  class: string;
 }
 
-// -----------------------------------------------------------------------------
-// TopBar
-// -----------------------------------------------------------------------------
 css/* scss */ `
   .o-font-size-editor {
+    height: calc(100% - 4px);
     input.o-font-size {
       height: 20px;
       width: 23px;
@@ -107,4 +106,5 @@ export class FontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
 FontSizeEditor.props = {
   onToggle: Function,
   dropdownStyle: String,
+  class: String,
 };

--- a/src/components/font_size_editor/font_size_editor.xml
+++ b/src/components/font_size_editor/font_size_editor.xml
@@ -1,24 +1,31 @@
 <templates>
   <t t-name="o-spreadsheet-FontSizeEditor" owl="1">
-    <div class="o-dropdown o-font-size-editor" t-ref="FontSizeEditor">
-      <input
-        type="number"
-        min="1"
-        max="400"
-        class="o-font-size bg-transparent border-0"
-        t-on-keydown="onInputKeydown"
-        t-on-click.stop=""
-        t-on-focus.stop="onInputFocused"
-        t-att-value="currentFontSize"
-        t-on-change="setSizeFromInput"
-        t-ref="inputFontSize"
-      />
-      <span title="Font Size" t-on-click="() => this.toggleFontList()">
-        <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
-      </span>
+    <div class="o-dropdown" t-ref="FontSizeEditor">
+      <div
+        class=" o-font-size-editor"
+        t-att-class="props.class"
+        title="Font Size"
+        t-on-click="this.toggleFontList">
+        <input
+          type="number"
+          min="1"
+          max="400"
+          class="o-font-size bg-transparent border-0"
+          t-on-keydown="onInputKeydown"
+          t-on-click.stop=""
+          t-on-focus.stop="onInputFocused"
+          t-att-value="currentFontSize"
+          t-on-change="setSizeFromInput"
+          t-ref="inputFontSize"
+        />
+        <span>
+          <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
+        </span>
+      </div>
       <div
         class="o-dropdown-content o-text-options"
         t-if="dropdown.isOpen"
+        t-on-click.stop=""
         t-att-style="props.dropdownStyle">
         <t t-foreach="fontSizes" t-as="fontSize" t-key="fontSize">
           <div

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -116,7 +116,11 @@
               </div>
             </div>
             <div class="o-divider"/>
-            <FontSizeEditor onToggle="() => this.onClick()" dropdownStyle="this.dropdownStyle"/>
+            <FontSizeEditor
+              class="'o-tool'"
+              onToggle.bind="this.onClick"
+              dropdownStyle="this.dropdownStyle"
+            />
             <div class="o-divider"/>
             <div
               class="o-tool"

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -176,27 +176,30 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
             class="o-divider"
           />
           <div
-            class="o-dropdown o-font-size-editor"
+            class="o-dropdown"
           >
-            <input
-              class="o-font-size bg-transparent border-0"
-              max="400"
-              min="1"
-              type="number"
-            />
-            <span
+            <div
+              class="o-font-size-editor o-tool"
               title="Font Size"
             >
-              <svg
-                class="o-icon"
-              >
-                <polygon
-                  fill="#000000"
-                  points="0 0 4 4 8 0"
-                  transform="translate(5 7)"
-                />
-              </svg>
-            </span>
+              <input
+                class="o-font-size bg-transparent border-0"
+                max="400"
+                min="1"
+                type="number"
+              />
+              <span>
+                <svg
+                  class="o-icon"
+                >
+                  <polygon
+                    fill="#000000"
+                    points="0 0 4 4 8 0"
+                    transform="translate(5 7)"
+                  />
+                </svg>
+              </span>
+            </div>
             
           </div>
           

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -289,27 +289,30 @@ exports[`TopBar component can set cell format 1`] = `
               class="o-divider"
             />
             <div
-              class="o-dropdown o-font-size-editor"
+              class="o-dropdown"
             >
-              <input
-                class="o-font-size bg-transparent border-0"
-                max="400"
-                min="1"
-                type="number"
-              />
-              <span
+              <div
+                class="o-font-size-editor o-tool"
                 title="Font Size"
               >
-                <svg
-                  class="o-icon"
-                >
-                  <polygon
-                    fill="#000000"
-                    points="0 0 4 4 8 0"
-                    transform="translate(5 7)"
-                  />
-                </svg>
-              </span>
+                <input
+                  class="o-font-size bg-transparent border-0"
+                  max="400"
+                  min="1"
+                  type="number"
+                />
+                <span>
+                  <svg
+                    class="o-icon"
+                  >
+                    <polygon
+                      fill="#000000"
+                      points="0 0 4 4 8 0"
+                      transform="translate(5 7)"
+                    />
+                  </svg>
+                </span>
+              </div>
               
             </div>
             
@@ -803,27 +806,30 @@ exports[`TopBar component simple rendering 1`] = `
           class="o-divider"
         />
         <div
-          class="o-dropdown o-font-size-editor"
+          class="o-dropdown"
         >
-          <input
-            class="o-font-size bg-transparent border-0"
-            max="400"
-            min="1"
-            type="number"
-          />
-          <span
+          <div
+            class="o-font-size-editor o-tool"
             title="Font Size"
           >
-            <svg
-              class="o-icon"
-            >
-              <polygon
-                fill="#000000"
-                points="0 0 4 4 8 0"
-                transform="translate(5 7)"
-              />
-            </svg>
-          </span>
+            <input
+              class="o-font-size bg-transparent border-0"
+              max="400"
+              min="1"
+              type="number"
+            />
+            <span>
+              <svg
+                class="o-icon"
+              >
+                <polygon
+                  fill="#000000"
+                  points="0 0 4 4 8 0"
+                  transform="translate(5 7)"
+                />
+              </svg>
+            </span>
+          </div>
           
         </div>
         

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -290,14 +290,8 @@ describe("TopBar component", () => {
     const { model } = await mountParent();
     const fontSizeText = fixture.querySelector("input.o-font-size")! as HTMLInputElement;
     expect(fontSizeText.value.trim()).toBe(DEFAULT_FONT_SIZE.toString());
-    const fontSizeTool = fixture.querySelector('span[title="Font Size"]')!;
-    fontSizeTool.dispatchEvent(new Event("click"));
-    await nextTick();
-    const fontSizeList = fixture.querySelector(".o-font-size-editor div.o-dropdown-content")!;
-    fontSizeList
-      .querySelector('[data-size="8"]')!
-      .dispatchEvent(new Event("click", { bubbles: true }));
-    await nextTick();
+    await click(fixture, ".o-font-size-editor");
+    await click(fixture, '.o-dropdown-content [data-size="8"]');
     expect(fontSizeText.value.trim()).toBe("8");
     expect(getStyle(model, "A1").fontSize).toBe(8);
   });


### PR DESCRIPTION
The font size editor in the toolbar is missing hover effects.


Odoo task ID : [3360143](https://www.odoo.com/web#id=3360143&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo