### PR TITLE
[ADD] functions: add TRUE and FALSE boolean functions

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -385,7 +385,12 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
   }
 
   showAutocomplete(searchTerm: string) {
-    if (!this.env.model.getters.getCurrentContent().startsWith("=")) {
+    const searchTermUpperCase = searchTerm.toUpperCase();
+    if (
+      !this.env.model.getters.getCurrentContent().startsWith("=") ||
+      searchTermUpperCase === "TRUE" ||
+      searchTermUpperCase === "FALSE"
+    ) {
       return;
     }
     this.autoCompleteState.showProvider = true;

--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -3,7 +3,7 @@ import { functionRegistry } from "../functions/index";
 import { concat, parseNumber, removeStringQuotes } from "../helpers";
 import { _lt } from "../translation";
 import { CompiledFormula, DEFAULT_LOCALE } from "../types";
-import { BadExpressionError } from "../types/errors";
+import { BadExpressionError, UnknownFunctionError } from "../types/errors";
 import { FunctionCode, FunctionCodeBuilder, Scope } from "./code_builder";
 import { AST, ASTFuncall, parseTokens } from "./parser";
 import { rangeTokenize } from "./range_tokenizer";
@@ -94,6 +94,10 @@ export function compile(formula: string): CompiledFormula {
       const { args } = ast;
       const functionName = ast.value.toUpperCase();
       const functionDefinition = functions[functionName];
+
+      if (!functionDefinition) {
+        throw new UnknownFunctionError(ast.value);
+      }
 
       assertEnoughArgs(ast);
 

--- a/src/formulas/composer_tokenizer.ts
+++ b/src/formulas/composer_tokenizer.ts
@@ -83,7 +83,7 @@ function mapParentFunction(tokens: EnrichedToken[]): EnrichedToken[] {
     }
 
     switch (token.type) {
-      case "FUNCTION":
+      case "SYMBOL":
         functionStarted = token.value;
         break;
       case "LEFT_PAREN":

--- a/src/formulas/helpers.ts
+++ b/src/formulas/helpers.ts
@@ -1,0 +1,22 @@
+import { functionRegistry } from "../functions";
+import { parseTokens, visitAst } from "./parser";
+import { Token } from "./tokenizer";
+
+const functions = functionRegistry.content;
+
+export function isExportableToExcel(tokens: Token[]): boolean {
+  try {
+    let isExported = true;
+    visitAst(parseTokens(tokens), (ast) => {
+      if (ast.type === "FUNCALL") {
+        const func = functions[ast.value.toUpperCase()];
+        if (!func?.isExported) {
+          isExported = false;
+        }
+      }
+    });
+    return isExported;
+  } catch (error) {
+    return false;
+  }
+}

--- a/src/formulas/index.ts
+++ b/src/formulas/index.ts
@@ -9,6 +9,7 @@
 
 export { compile } from "./compiler";
 export { composerTokenize, EnrichedToken } from "./composer_tokenizer";
+export * from "./helpers";
 export { parse } from "./parser";
 export { rangeTokenize } from "./range_tokenizer";
 export { Token, tokenize } from "./tokenizer";

--- a/src/formulas/tokenizer.ts
+++ b/src/formulas/tokenizer.ts
@@ -1,5 +1,4 @@
 import { INCORRECT_RANGE_STRING, NEWLINE } from "../constants";
-import { functionRegistry } from "../functions/index";
 import { getFormulaNumberRegex, rangeReference, replaceSpecialSpaces } from "../helpers/index";
 import { DEFAULT_LOCALE, Locale } from "../types";
 
@@ -20,7 +19,6 @@ import { DEFAULT_LOCALE, Locale } from "../types";
  * formulas.
  */
 
-const functions = functionRegistry.content;
 export const POSTFIX_UNARY_OPERATORS = ["%"];
 const OPERATORS = "+,-,*,/,:,=,<>,>=,>,<=,<,^,&".split(",").concat(POSTFIX_UNARY_OPERATORS);
 
@@ -28,8 +26,6 @@ type TokenType =
   | "OPERATOR"
   | "NUMBER"
   | "STRING"
-  | "BOOLEAN"
-  | "FUNCTION"
   | "SYMBOL"
   | "SPACE"
   | "DEBUGGER"
@@ -190,16 +186,11 @@ function tokenizeSymbol(chars: TokenizingChars): Token | null {
   }
   if (result.length) {
     const value = result;
-    const isFunction = value.toUpperCase() in functions;
-    if (isFunction) {
-      return { type: "FUNCTION", value };
-    }
     const isReference = rangeReference.test(value);
     if (isReference) {
       return { type: "REFERENCE", value };
-    } else {
-      return { type: "SYMBOL", value };
     }
+    return { type: "SYMBOL", value };
   }
   return null;
 }

--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -43,6 +43,19 @@ export const AND: AddFunctionDescription = {
 };
 
 // -----------------------------------------------------------------------------
+// FALSE
+// -----------------------------------------------------------------------------
+export const FALSE: AddFunctionDescription = {
+  description: _lt("Logical value `false`."),
+  args: [],
+  returns: ["BOOLEAN"],
+  compute: function (): boolean {
+    return false;
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
 // IF
 // -----------------------------------------------------------------------------
 export const IF: AddFunctionDescription = {
@@ -232,6 +245,19 @@ export const OR: AddFunctionDescription = {
     });
     assert(() => foundBoolean, _lt(`[[FUNCTION_NAME]] has no valid input data.`));
     return acc;
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// TRUE
+// -----------------------------------------------------------------------------
+export const TRUE: AddFunctionDescription = {
+  description: _lt("Logical value `true`."),
+  args: [],
+  returns: ["BOOLEAN"],
+  compute: function (): boolean {
+    return true;
   },
   isExported: true,
 };

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -1,5 +1,4 @@
-import { compile } from "../../../formulas/index";
-import { functionRegistry } from "../../../functions/index";
+import { compile, isExportableToExcel } from "../../../formulas/index";
 import { getItemId, positions, toXC } from "../../../helpers/index";
 import {
   CellPosition,
@@ -20,8 +19,6 @@ import { UIPlugin, UIPluginConfig } from "../../ui_plugin";
 import { CoreViewCommand } from "./../../../types/commands";
 import { buildCompilationParameters, CompilationParameters } from "./compilation_parameters";
 import { Evaluator } from "./evaluator";
-
-const functions = functionRegistry.content;
 
 //#region
 
@@ -285,10 +282,7 @@ export class EvaluationPlugin extends UIPlugin {
 
       const formulaCell = this.getCorrespondingFormulaCell(position);
       if (formulaCell) {
-        isExported = formulaCell.compiledFormula.tokens
-          .filter((tk) => tk.type === "FUNCTION")
-          .every((tk) => functions[tk.value.toUpperCase()].isExported);
-
+        isExported = isExportableToExcel(formulaCell.compiledFormula.tokens);
         isFormula = isExported;
 
         if (!isExported) {

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -364,3 +364,51 @@ describe("composer Assistant", () => {
     expect(assistantEL.style.transform).toBe("translate(0, -100%)");
   });
 });
+
+describe("autocomplete boolean functions", () => {
+  beforeEach(async () => {
+    clearFunctions();
+    functionRegistry.add("TRUE", {
+      description: "TRUE",
+      args: [],
+      compute: () => true,
+      returns: ["BOOLEAN"],
+    });
+    functionRegistry.add("FALSE", {
+      description: "FALSE",
+      args: [],
+      compute: () => false,
+      returns: ["BOOLEAN"],
+    });
+    ({ model, fixture, parent } = await mountComposerWrapper());
+    parent.startComposition();
+    await nextTick();
+  });
+
+  afterAll(() => {
+    restoreDefaultFunctions();
+  });
+
+  test("partial TRUE show autocomplete", async () => {
+    await typeInComposer("=TRU");
+    expect(fixture.querySelector(".o-autocomplete-value")?.textContent).toBe("TRUE");
+  });
+
+  test.each(["=TRUE", "=true"])("exact match TRUE does not show autocomplete", async (formula) => {
+    await typeInComposer(formula);
+    expect(fixture.querySelector(".o-autocomplete-value")).toBeNull();
+  });
+
+  test("partial FALSE show autocomplete", async () => {
+    await typeInComposer("=FAL");
+    expect(fixture.querySelector(".o-autocomplete-value")?.textContent).toBe("FALSE");
+  });
+
+  test.each(["=FALSE", "=false"])(
+    "exact match FALSE does not show autocomplete",
+    async (formula) => {
+      await typeInComposer(formula);
+      expect(fixture.querySelector(".o-autocomplete-value")).toBeNull();
+    }
+  );
+});

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -402,3 +402,33 @@ describe("formula assistant", () => {
     });
   });
 });
+
+describe("formula assistant for boolean functions", () => {
+  beforeAll(() => {
+    clearFunctions();
+    functionRegistry.add("TRUE", {
+      description: "TRUE",
+      args: [],
+      compute: () => true,
+      returns: ["BOOLEAN"],
+    });
+    functionRegistry.add("FALSE", {
+      description: "FALSE",
+      args: [],
+      compute: () => false,
+      returns: ["BOOLEAN"],
+    });
+  });
+
+  afterAll(() => {
+    restoreDefaultFunctions();
+  });
+
+  test.each(["=TRUE(", "=true(", "=FALSE(", "=false("])(
+    "show boolean formula assistant",
+    async () => {
+      await typeInComposer("=TRue(");
+      expect(fixture.querySelectorAll(".o-formula-assistant")).toHaveLength(1);
+    }
+  );
+});

--- a/tests/formulas/__snapshots__/composer_tokenizer.test.ts.snap
+++ b/tests/formulas/__snapshots__/composer_tokenizer.test.ts.snap
@@ -20,7 +20,7 @@ Array [
     "end": 5,
     "length": 3,
     "start": 2,
-    "type": "FUNCTION",
+    "type": "SYMBOL",
     "value": "SUM",
   },
   Object {
@@ -99,7 +99,7 @@ Array [
     "end": 4,
     "length": 3,
     "start": 1,
-    "type": "FUNCTION",
+    "type": "SYMBOL",
     "value": "AND",
   },
   Object {
@@ -171,7 +171,7 @@ Array [
     "end": 4,
     "length": 3,
     "start": 1,
-    "type": "FUNCTION",
+    "type": "SYMBOL",
     "value": "SUM",
   },
   Object {
@@ -279,7 +279,7 @@ Array [
     },
     "length": 3,
     "start": 14,
-    "type": "FUNCTION",
+    "type": "SYMBOL",
     "value": "ADD",
   },
   Object {

--- a/tests/formulas/composer_tokenizer.test.ts
+++ b/tests/formulas/composer_tokenizer.test.ts
@@ -117,10 +117,10 @@ describe("composerTokenizer base tests", () => {
 
   test("Function token", () => {
     expect(composerTokenize("SUM", DEFAULT_LOCALE)).toEqual([
-      { start: 0, end: 3, length: 3, type: "FUNCTION", value: "SUM" },
+      { start: 0, end: 3, length: 3, type: "SYMBOL", value: "SUM" },
     ]);
     expect(composerTokenize("RAND", DEFAULT_LOCALE)).toEqual([
-      { start: 0, end: 4, length: 4, type: "FUNCTION", value: "RAND" },
+      { start: 0, end: 4, length: 4, type: "SYMBOL", value: "RAND" },
     ]);
   });
   test("Boolean", () => {

--- a/tests/formulas/parser.test.ts
+++ b/tests/formulas/parser.test.ts
@@ -32,7 +32,7 @@ describe("parser", () => {
   });
 
   test("function without a opening parenthesis", () => {
-    expect(() => parse(`SUM 5`)).toThrow("Missing opening parenthesis");
+    expect(() => parse(`SUM 5`)).toThrow("Invalid formula");
   });
 
   test("function without closing parenthesis", () => {

--- a/tests/formulas/range_tokenizer.test.ts
+++ b/tests/formulas/range_tokenizer.test.ts
@@ -62,7 +62,7 @@ describe("rangeTokenizer", () => {
     expect(rangeTokenize("= SUM ( C4 : C5 )")).toEqual([
       { type: "OPERATOR", value: "=" },
       { type: "SPACE", value: " " },
-      { type: "FUNCTION", value: "SUM" },
+      { type: "SYMBOL", value: "SUM" },
       { type: "SPACE", value: " " },
       { type: "LEFT_PAREN", value: "(" },
       { type: "SPACE", value: " " },
@@ -82,7 +82,7 @@ describe("rangeTokenizer", () => {
   test.each(["A:A", "A1:A"])("formula with full column", (xc) => {
     expect(rangeTokenize(`=SUM(${xc})`)).toEqual([
       { type: "OPERATOR", value: "=" },
-      { type: "FUNCTION", value: "SUM" },
+      { type: "SYMBOL", value: "SUM" },
       { type: "LEFT_PAREN", value: "(" },
       { type: "REFERENCE", value: xc },
       { type: "RIGHT_PAREN", value: ")" },
@@ -99,7 +99,7 @@ describe("rangeTokenizer", () => {
   test.each(["1:1", "A1:1"])("formula with full row", (xc) => {
     expect(rangeTokenize(`=SUM(${xc})`)).toEqual([
       { type: "OPERATOR", value: "=" },
-      { type: "FUNCTION", value: "SUM" },
+      { type: "SYMBOL", value: "SUM" },
       { type: "LEFT_PAREN", value: "(" },
       { type: "REFERENCE", value: xc },
       { type: "RIGHT_PAREN", value: ")" },

--- a/tests/formulas/tokenizer.test.ts
+++ b/tests/formulas/tokenizer.test.ts
@@ -137,14 +137,14 @@ describe("tokenizer", () => {
   });
 
   test("Function token", () => {
-    expect(tokenize("SUM")).toEqual([{ type: "FUNCTION", value: "SUM" }]);
-    expect(tokenize("RAND")).toEqual([{ type: "FUNCTION", value: "RAND" }]);
-    expect(tokenize("rand")).toEqual([{ type: "FUNCTION", value: "rand" }]);
+    expect(tokenize("SUM")).toEqual([{ type: "SYMBOL", value: "SUM" }]);
+    expect(tokenize("RAND")).toEqual([{ type: "SYMBOL", value: "RAND" }]);
+    expect(tokenize("rand")).toEqual([{ type: "SYMBOL", value: "rand" }]);
   });
 
   test("Function token with point", () => {
-    expect(tokenize("CEILING.MATH")).toEqual([{ type: "FUNCTION", value: "CEILING.MATH" }]);
-    expect(tokenize("ceiling.math")).toEqual([{ type: "FUNCTION", value: "ceiling.math" }]);
+    expect(tokenize("CEILING.MATH")).toEqual([{ type: "SYMBOL", value: "CEILING.MATH" }]);
+    expect(tokenize("ceiling.math")).toEqual([{ type: "SYMBOL", value: "ceiling.math" }]);
   });
 
   test("Boolean", () => {
@@ -171,7 +171,7 @@ describe("tokenizer", () => {
     ]);
     expect(tokenize("=AND(true,false)")).toEqual([
       { type: "OPERATOR", value: "=" },
-      { type: "FUNCTION", value: "AND" },
+      { type: "SYMBOL", value: "AND" },
       { type: "LEFT_PAREN", value: "(" },
       { type: "SYMBOL", value: "true" },
       { type: "ARG_SEPARATOR", value: "," },
@@ -301,7 +301,7 @@ describe("Localized tokenizer", () => {
     const locale = { ...DEFAULT_LOCALE, decimalSeparator: "¤" };
     expect(tokenize("=SUM(5¤9, 8¤1)", locale)).toEqual([
       { type: "OPERATOR", value: "=" },
-      { type: "FUNCTION", value: "SUM" },
+      { type: "SYMBOL", value: "SUM" },
       { type: "LEFT_PAREN", value: "(" },
       { type: "NUMBER", value: "5¤9" },
       { type: "ARG_SEPARATOR", value: "," },
@@ -315,7 +315,7 @@ describe("Localized tokenizer", () => {
     const locale = { ...DEFAULT_LOCALE, formulaArgSeparator: "空" };
     expect(tokenize("=SUM(5空 8.5)", locale)).toEqual([
       { type: "OPERATOR", value: "=" },
-      { type: "FUNCTION", value: "SUM" },
+      { type: "SYMBOL", value: "SUM" },
       { type: "LEFT_PAREN", value: "(" },
       { type: "NUMBER", value: "5" },
       { type: "ARG_SEPARATOR", value: "空" },

--- a/tests/functions/module_logical.test.ts
+++ b/tests/functions/module_logical.test.ts
@@ -44,6 +44,18 @@ describe("AND formula", () => {
   });
 });
 
+describe("FALSE formula", () => {
+  test("does not accept argument", () => {
+    expect(evaluateCell("A1", { A1: "=FALSE(45)" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
+  });
+  test("return false", () => {
+    expect(evaluateCell("A1", { A1: "=FALSE()" })).toBe(false);
+  });
+  test("equals the false boolean value", () => {
+    expect(evaluateCell("A1", { A1: "=FALSE()=FALSE" })).toBe(true);
+  });
+});
+
 describe("IF formula", () => {
   test("functional tests on simple arguments", () => {
     expect(evaluateCell("A1", { A1: "=IF( ,  ,  )" })).toBe("");
@@ -353,6 +365,18 @@ describe("OR formula", () => {
     expect(evaluateCell("A1", { A1: "=OR(A2:A5)", A3: '="TRUE"' })).toBe("#ERROR"); // @compatibility: on google sheets, return #VALUE!
     expect(evaluateCell("A1", { A1: "=OR(A2:A5)", A3: "42" })).toBe(true);
     expect(evaluateCell("A1", { A1: "=OR(A2:A5)", A3: '="42"' })).toBe("#ERROR"); // @compatibility: on google sheets, return #VALUE!
+  });
+});
+
+describe("TRUE formula", () => {
+  test("does not accept argument", () => {
+    expect(evaluateCell("A1", { A1: "=TRUE(45)" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
+  });
+  test("return true", () => {
+    expect(evaluateCell("A1", { A1: "=TRUE()" })).toBe(true);
+  });
+  test("equals the true boolean value", () => {
+    expect(evaluateCell("A1", { A1: "=TRUE()=TRUE" })).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Description:

This commit adds the TRUE() and FALSE() functions.

Note: when typing the exact match TRUE or FALSE, the autocomplete
dropdown should not propose to autocomplete them to TRUE( or FALSE(

Odoo task ID : [3360232](https://www.odoo.com/web#id=3360232&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo