### PR TITLE
[FIX] formatting: round floats with leading zeroes

### DIFF
--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -240,6 +240,8 @@ function removeTrailingZeroes(numberString: string): string | undefined {
   return numberString.slice(0, i + 1) || undefined;
 }
 
+const leadingZeroesRegexp = /^0+/;
+
 /**
  * Limit the size of the decimal part of a number to the given number of digits.
  */
@@ -258,17 +260,23 @@ function limitDecimalDigits(
   let slicedDecimalDigits = decimalDigits.slice(0, maxDecimals);
   const i = maxDecimals;
 
-  if (Number(Number(decimalDigits[i]) < 5)) {
+  if (Number(decimalDigits[i]) < 5) {
     return { integerDigits, decimalDigits: slicedDecimalDigits };
   }
 
   // round up
+  const leadingZeroes = slicedDecimalDigits.match(leadingZeroesRegexp)?.[0] || "";
   const slicedRoundedUp = (Number(slicedDecimalDigits) + 1).toString();
-  if (slicedRoundedUp.length > slicedDecimalDigits.length) {
-    integerDigits = (Number(integerDigits) + 1).toString();
+  const withoutLeadingZeroes = slicedDecimalDigits.slice(leadingZeroes.length);
+  // e.g. carry over from 99 to 100
+  const carryOver = slicedRoundedUp.length > withoutLeadingZeroes.length;
+  if (carryOver && !leadingZeroes) {
+    integerDigits = "1";
     resultDecimalDigits = undefined;
+  } else if (carryOver) {
+    resultDecimalDigits = leadingZeroes.slice(0, -1) + slicedRoundedUp;
   } else {
-    resultDecimalDigits = slicedRoundedUp;
+    resultDecimalDigits = leadingZeroes + slicedRoundedUp;
   }
 
   return { integerDigits, decimalDigits: resultDecimalDigits };

--- a/tests/helpers/format.test.ts
+++ b/tests/helpers/format.test.ts
@@ -166,6 +166,33 @@ describe("formatValue on number", () => {
     expect(formatValue(0.456789, "0.00000")).toBe("0.45679");
   });
 
+  test("apply decimal with a leading 0 in the decimal part rounded up", () => {
+    expect(formatValue(0.0695, "0.0")).toBe("0.1");
+    expect(formatValue(0.0695, "0.00")).toBe("0.07");
+    expect(formatValue(0.0695, "0.000")).toBe("0.070");
+    expect(formatValue(0.0695, "0.0000")).toBe("0.0695");
+  });
+
+  test("apply decimal with two leading 0 in the decimal part rounded up", () => {
+    expect(formatValue(0.00695, "0.0")).toBe("0.0");
+    expect(formatValue(0.00695, "0.00")).toBe("0.01");
+    expect(formatValue(0.00695, "0.000")).toBe("0.007");
+    expect(formatValue(0.00695, "0.0000")).toBe("0.0070");
+    expect(formatValue(0.00695, "0.00000")).toBe("0.00695");
+  });
+
+  test("apply decimal with a leading 0 in the decimal part rounded down", () => {
+    expect(formatValue(0.064, "0.00")).toBe("0.06");
+    expect(formatValue(0.0694, "0.000")).toBe("0.069");
+    expect(formatValue(0.0694, "0.0000")).toBe("0.0694");
+  });
+
+  test("apply decimal with two leading 0 in the decimal part rounded down", () => {
+    expect(formatValue(0.0064, "0.000")).toBe("0.006");
+    expect(formatValue(0.00694, "0.0000")).toBe("0.0069");
+    expect(formatValue(0.00694, "0.00000")).toBe("0.00694");
+  });
+
   test("apply format with thousand separator", () => {
     expect(formatValue(100, "000")).toBe("100");
     expect(formatValue(100, ",000")).toBe("100");


### PR DESCRIPTION


## Description:

Floats with leading zeroes aren't rounded correctly. Leading zeroes are dropped.

Hence 0.0695 is rounded to 0.70 with format "0.00" instead of 0.07

opw : [3327899](https://www.odoo.com/web#id=3327899&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo