### PR TITLE
[REL] 16.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.2.8",
+  "version": "16.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.2.8",
+      "version": "16.2.9",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.2.8",
+  "version": "16.2.9",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/eb91e1599 [FIX] formatting: round floats with leading zeroes Task: 3327899
https://github.com/odoo/o-spreadsheet/commit/625e984b9 [FIX] composer: do not autocomplete boolean values
https://github.com/odoo/o-spreadsheet/commit/5005d08f1 [FIX] Composer: autocomplete in topbar composer
https://github.com/odoo/o-spreadsheet/commit/fd2380d48 [FIX] misc: type of isCloneable interface
https://github.com/odoo/o-spreadsheet/commit/31d8d5de4 [FIX] color_picker: added missing snapshot
https://github.com/odoo/o-spreadsheet/commit/e7045516f [FIX] ColorPicker: fix `+` sign position
https://github.com/odoo/o-spreadsheet/commit/b04fd2135 [IMP] config: enables type checking for binded functions
https://github.com/odoo/o-spreadsheet/commit/4ed68a147 [FIX] github: remove makeLatest tag in 16.2
