### PR TITLE
[FIX] functions: translate argument description

### DIFF
--- a/src/functions/arguments.ts
+++ b/src/functions/arguments.ts
@@ -21,10 +21,10 @@ const ARG_TYPES: ArgType[] = [
 ];
 
 export function arg(definition: string, description: string = ""): ArgDefinition {
-  return makeArg(`${definition} ${description}`);
+  return makeArg(definition, description);
 }
 
-function makeArg(str: string): ArgDefinition {
+function makeArg(str: string, description: string): ArgDefinition {
   let parts = str.match(ARG_REGEXP)!;
   let name = parts[1].trim();
   let types: ArgType[] = [];
@@ -50,7 +50,6 @@ function makeArg(str: string): ArgDefinition {
       defaultValue = param.trim().slice(8);
     }
   }
-  let description = parts[3].trim();
   const result: ArgDefinition = {
     name,
     description,

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -1,5 +1,8 @@
+import { setTranslationMethod } from "../../src";
 import { arg, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
+import { _lt } from "../../src/translation";
+import { registerCleanup } from "../setup/jest.setup";
 import { keyDown, keyUp } from "../test_helpers/dom_helper";
 import {
   clearFunctions,
@@ -34,7 +37,7 @@ describe("formula assistant", () => {
     });
     functionRegistry.add("FUNC1", {
       description: "func1 def",
-      args: [arg("f1Arg1 (any)", "f1 Arg1 def"), arg("f1Arg2 (any)", "f1 Arg2 def")],
+      args: [arg("f1Arg1 (any)", "f1 Arg1 def"), arg("f1Arg2 (any)", _lt("f1 Arg2 def"))],
       compute: () => 1,
       returns: ["ANY"],
     });
@@ -251,6 +254,23 @@ describe("formula assistant", () => {
         );
         expect(fixture.querySelectorAll(".o-formula-assistant-arg div")[3].textContent).toBe(
           "f1 Arg2 def"
+        );
+      });
+
+      test("argument description is translated", async () => {
+        // set the translation method after creating the argument.
+        // This is what actually happens because translations are
+        // loaded after the function definition
+        setTranslationMethod((str, ...values) => {
+          if (str === "f1 Arg2 def") {
+            return "translated description";
+          }
+          return str;
+        });
+        await typeInComposerGrid("=FUNC1(");
+        registerCleanup(() => setTranslationMethod((str, ...values) => str));
+        expect(fixture.querySelectorAll(".o-formula-assistant-arg div")[3].textContent).toBe(
+          "translated description"
         );
       });
 

--- a/tests/functions/arguments.test.ts
+++ b/tests/functions/arguments.test.ts
@@ -1,5 +1,7 @@
 import { addMetaInfoFromArg, arg, validateArguments } from "../../src/functions/arguments";
+import { setTranslationMethod, _lt } from "../../src/translation";
 import { AddFunctionDescription } from "../../src/types";
+import { registerCleanup } from "../setup/jest.setup";
 
 describe("args", () => {
   test("various", () => {
@@ -42,6 +44,22 @@ describe("args", () => {
       default: true,
       defaultValue: "10",
     });
+  });
+
+  test("argument description is translated", () => {
+    const description = _lt("description");
+    const argDefinition = arg("test (number)", description);
+    // set the translation method after creating the argument.
+    // This is what actually happens because translations are
+    // loaded after the function definition
+    setTranslationMethod((str, ...values) => {
+      if (str === "description") {
+        return "translated description";
+      }
+      return str;
+    });
+    registerCleanup(() => setTranslationMethod((str, ...values) => str));
+    expect(argDefinition.description.toString()).toEqual("translated description");
   });
 
   test("default string value", () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -10,6 +10,7 @@ import { Model } from "../../src/model";
 import { MergePlugin } from "../../src/plugins/core/merge";
 import { topbarMenuRegistry } from "../../src/registries";
 import { MenuItemRegistry } from "../../src/registries/menu_items_registry";
+import { _t } from "../../src/translation";
 import {
   ChartDefinition,
   ColorScaleMidPointThreshold,
@@ -146,7 +147,7 @@ export async function mountComponent<Props extends { [key: string]: any }>(
   model.drawGrid = () => {};
   const env = makeTestEnv({ ...optionalArgs.env, model: model });
   const props = optionalArgs.props || ({} as Props);
-  const app = new App(component, { props, env, test: true });
+  const app = new App(component, { props, env, test: true, translateFn: _t });
   app.addTemplates(OWL_TEMPLATES);
   const fixture = optionalArgs?.fixture || makeTestFixture();
   const parent = await app.mount(fixture);


### PR DESCRIPTION

## Description:

This commit fixes https://github.com/odoo/o-spreadsheet/commit/a815a1675431aa15d3b4e9ea252f8a5e444a164c

Argument descriptions were still eagerly interpolated in a template string, before the translation had a chance to be loaded.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo