### PR TITLE
[IMP] filter: select/clear all pre-filtered data

### DIFF
--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -194,11 +194,11 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
   }
 
   selectAll() {
-    this.state.values.forEach((value) => (value.checked = true));
+    this.displayedValues.forEach((value) => (value.checked = true));
   }
 
   clearAll() {
-    this.state.values.forEach((value) => (value.checked = false));
+    this.displayedValues.forEach((value) => (value.checked = false));
   }
 
   get filterTable() {

--- a/tests/components/filter_menu.test.ts
+++ b/tests/components/filter_menu.test.ts
@@ -7,7 +7,12 @@ import {
   setFormat,
   updateFilter,
 } from "../test_helpers/commands_helpers";
-import { focusAndKeyDown, keyDown, simulateClick } from "../test_helpers/dom_helper";
+import {
+  focusAndKeyDown,
+  keyDown,
+  setInputValueAndTrigger,
+  simulateClick,
+} from "../test_helpers/dom_helper";
 import { getCellsObject, mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
 
 async function openFilterMenu() {
@@ -187,6 +192,35 @@ describe("Filter menu component", () => {
       ]);
     });
 
+    test("Clear all work on the displayed values", async () => {
+      await openFilterMenu();
+      setInputValueAndTrigger(".o-filter-menu input", "1", "input");
+      await nextTick();
+      await simulateClick(".o-filter-menu-action-text:nth-of-type(2)");
+      setInputValueAndTrigger(".o-filter-menu input", "", "input");
+      await nextTick();
+      expect(getFilterMenuValues()).toEqual([
+        { value: "(Blanks)", isChecked: true },
+        { value: "1", isChecked: false },
+        { value: "2", isChecked: true },
+      ]);
+    });
+
+    test("Select all work on the displayed values", async () => {
+      await openFilterMenu();
+      await simulateClick(".o-filter-menu-action-text:nth-of-type(2)");
+      setInputValueAndTrigger(".o-filter-menu input", "1", "input");
+      await nextTick();
+      await simulateClick(".o-filter-menu-action-text:nth-of-type(1)");
+      setInputValueAndTrigger(".o-filter-menu input", "", "input");
+      await nextTick();
+      expect(getFilterMenuValues()).toEqual([
+        { value: "(Blanks)", isChecked: false },
+        { value: "1", isChecked: true },
+        { value: "2", isChecked: false },
+      ]);
+    });
+
     test("Hitting esc key correctly closes the filter menu", async () => {
       await openFilterMenu();
       expect(fixture.querySelectorAll(".o-filter-menu")).toHaveLength(1);
@@ -197,9 +231,7 @@ describe("Filter menu component", () => {
     describe("Search bar", () => {
       test("Can filter values with the search bar", async () => {
         await openFilterMenu();
-        const searchInput = fixture.querySelector(".o-filter-menu input") as HTMLInputElement;
-        searchInput.value = "1";
-        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        setInputValueAndTrigger(".o-filter-menu input", "1", "input");
         await nextTick();
         expect(getFilterMenuValues().map((v) => v.value)).toEqual(["1"]);
       });
@@ -219,9 +251,7 @@ describe("Filter menu component", () => {
         setCellContent(model, "A5", "Illinois");
 
         await openFilterMenu();
-        const searchInput = fixture.querySelector(".o-filter-menu input") as HTMLInputElement;
-        searchInput.value = "lo";
-        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        setInputValueAndTrigger(".o-filter-menu input", "lo", "input");
         await nextTick();
         expect(getFilterMenuValues().map((v) => v.value)).toEqual(["Florida", "Illinois"]);
       });


### PR DESCRIPTION
## Description:

This PR makes select/clear all functionality in filters work on the displayed values, not all values, which is the way in GSheets.

Odoo task ID : [3370645](https://www.odoo.com/web#id=3370645&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo