### PR TITLE
[FIX] sheet: duplicate sheet name problem when renaming

### DIFF
--- a/src/helpers/ui/sheet_interactive.ts
+++ b/src/helpers/ui/sheet_interactive.ts
@@ -8,9 +8,6 @@ export function interactiveRenameSheet(
   name: string,
   errorCallback: () => void
 ) {
-  const originalSheetName = env.model.getters.getSheetName(sheetId);
-  if (name === null || name === originalSheetName) return;
-
   const result = env.model.dispatch("RENAME_SHEET", { sheetId, name });
   if (result.reasons.includes(CommandResult.MissingSheetName)) {
     env.raiseError(_lt("The sheet name cannot be empty."), errorCallback);

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1096,6 +1096,7 @@ export const enum CommandResult {
   NotEnoughElements,
   NotEnoughSheets,
   MissingSheetName,
+  UnchangedSheetName,
   DuplicatedSheetName,
   DuplicatedSheetId,
   ForbiddenCharactersInSheetName,

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -321,6 +321,17 @@ describe("BottomBar component", () => {
       expect(window.getSelection()?.toString()).toEqual("ThisIsASheet");
       expect(document.activeElement).toEqual(sheetName);
     });
+
+    test("Sheet name is case insensitive", async () => {
+      const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
+      expect(sheetName.textContent).toEqual("Sheet1");
+      triggerMouseEvent(sheetName, "dblclick");
+      await nextTick();
+      sheetName.textContent = "SHEET1";
+      await keyDown({ key: "Enter" });
+      expect(raiseError).not.toHaveBeenCalled();
+      expect(sheetName.textContent).toEqual("SHEET1");
+    });
   });
 
   test("Can duplicate a sheet", async () => {

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -154,6 +154,21 @@ describe("sheets", () => {
     );
   });
 
+  test("Rename command won't be dispatched if the name is unchanged (case sensitive)", () => {
+    const model = new Model({ sheets: [{ id: "11", name: "Sheet1" }] });
+    expect(renameSheet(model, "11", "Sheet1")).toBeCancelledBecause(
+      CommandResult.UnchangedSheetName
+    );
+  });
+
+  test("Can change sheet name case", () => {
+    const sheetId = "11";
+    const model = new Model({ sheets: [{ id: sheetId, name: "Sheet1" }] });
+    expect(model.getters.getSheetName(sheetId)).toBe("Sheet1");
+    renameSheet(model, "11", "SHEET1");
+    expect(model.getters.getSheetName(sheetId)).toBe("SHEET1");
+  });
+
   test("Cannot create a sheet with a position > length of sheets", () => {
     const model = new Model();
     expect(model.dispatch("CREATE_SHEET", { sheetId: "42", position: 54 })).toBeCancelledBecause(


### PR DESCRIPTION
## Description:

This PR fixes the problem that when editing sheet name and the new sheet name is the same as the old one, but the case is different, an error will occur. The sheet name should be case insensitive.

If after converting names into lower cases, two names are the same, then the renaming process will stop.

Odoo task ID : [3370632](https://www.odoo.com/web#id=3370632&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo