### PR TITLE
[REF] selection input: ranges props is now an array

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -69,7 +69,7 @@ css/* scss */ `
 `;
 
 interface Props {
-  ranges: () => string[];
+  ranges: string[];
   hasSingleRange?: boolean;
   required?: boolean;
   isInvalid?: boolean;
@@ -101,7 +101,7 @@ interface SelectionRange extends Omit<RangeInputValue, "color"> {
 export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SelectionInput";
   private id = uuidGenerator.uuidv4();
-  private previousRanges: string[] = this.props.ranges() || [];
+  private previousRanges: string[] = this.props.ranges || [];
   private originSheet = this.env.model.getters.getActiveSheetId();
   private state: State = useState({
     isMissing: false,
@@ -113,8 +113,8 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     const existingSelectionRanges = this.env.model.getters.getSelectionInput(this.id);
     const ranges = existingSelectionRanges.length
       ? existingSelectionRanges
-      : this.props.ranges()
-      ? this.props.ranges().map((xc, id) => ({
+      : this.props.ranges
+      ? this.props.ranges.map((xc, id) => ({
           xc,
           id,
           isFocused: false,
@@ -159,7 +159,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
   enableNewSelectionInput() {
     this.env.model.dispatch("ENABLE_NEW_SELECTION_INPUT", {
       id: this.id,
-      initialRanges: this.props.ranges(),
+      initialRanges: this.props.ranges,
       hasSingleRange: this.props.hasSingleRange,
     });
   }
@@ -281,7 +281,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     }
     this.props.onSelectionChanged?.(existingSelectionXcs);
     this.props.onSelectionConfirmed?.();
-    this.previousRanges = this.props.ranges();
+    this.previousRanges = existingSelectionXcs;
     if (existingSelectionXcs.join() !== this.previousRanges.join()) {
       this.enableNewSelectionInput();
     }
@@ -290,7 +290,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
 }
 
 SelectionInput.props = {
-  ranges: Function,
+  ranges: Array,
   hasSingleRange: { type: Boolean, optional: true },
   required: { type: Boolean, optional: true },
   isInvalid: { type: Boolean, optional: true },

--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
@@ -18,7 +18,7 @@
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>
         <SelectionInput
-          ranges="() => this.getDataSeriesRanges()"
+          ranges="this.getDataSeriesRanges()"
           required="true"
           onSelectionChanged="(ranges) => this.onDataSeriesRangesChanged(ranges)"
           onSelectionConfirmed="() => this.onDataSeriesConfirmed()"
@@ -27,7 +27,7 @@
       <div class="o-section o-data-labels">
         <div class="o-section-title">Categories / Labels</div>
         <SelectionInput
-          ranges="() => [this.getLabelRange()]"
+          ranges="[this.getLabelRange()]"
           isInvalid="isLabelInvalid"
           hasSingleRange="true"
           onSelectionChanged="(ranges) => this.onLabelRangeChanged(ranges)"

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.xml
@@ -4,7 +4,7 @@
       <div class="o-section o-data-series">
         <div class="o-section-title">Data range</div>
         <SelectionInput
-          ranges="() => [this.getDataRange()]"
+          ranges="[this.getDataRange()]"
           isInvalid="isDataRangeInvalid"
           hasSingleRange="true"
           required="true"

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
@@ -4,7 +4,7 @@
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>
         <SelectionInput
-          ranges="() => this.getDataSeriesRanges()"
+          ranges="this.getDataSeriesRanges()"
           required="true"
           onSelectionChanged="(ranges) => this.onDataSeriesRangesChanged(ranges)"
           onSelectionConfirmed="() => this.onDataSeriesConfirmed()"
@@ -13,7 +13,7 @@
       <div class="o-section o-data-labels">
         <div class="o-section-title">Categories / Labels</div>
         <SelectionInput
-          ranges="() => [this.getLabelRange()]"
+          ranges="[this.getLabelRange()]"
           isInvalid="isLabelInvalid"
           hasSingleRange="true"
           onSelectionChanged="(ranges) => this.onLabelRangeChanged(ranges)"

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -18,7 +18,7 @@
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>
         <SelectionInput
-          ranges="() => this.getDataSeriesRanges()"
+          ranges="this.getDataSeriesRanges()"
           required="true"
           onSelectionChanged="(ranges) => this.onDataSeriesRangesChanged(ranges)"
           onSelectionConfirmed="() => this.onDataSeriesConfirmed()"
@@ -27,7 +27,7 @@
       <div class="o-section o-data-labels">
         <div class="o-section-title">Categories / Labels</div>
         <SelectionInput
-          ranges="() => [this.getLabelRange()]"
+          ranges="[this.getLabelRange()]"
           isInvalid="isLabelInvalid"
           hasSingleRange="true"
           onSelectionChanged="(ranges) => this.onLabelRangeChanged(ranges)"

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
@@ -4,7 +4,7 @@
       <div class="o-section o-data-series">
         <div class="o-section-title">Key value</div>
         <SelectionInput
-          ranges="() => [this.getKeyValueRange()]"
+          ranges="[this.getKeyValueRange()]"
           isInvalid="isKeyValueInvalid"
           hasSingleRange="true"
           required="true"
@@ -16,7 +16,7 @@
         <div class="o-section-title">Baseline configuration</div>
         <div class="o-section-subtitle">Baseline value</div>
         <SelectionInput
-          ranges="() => [this.getBaselineRange()]"
+          ranges="[this.getBaselineRange()]"
           isInvalid="isBaselineInvalid"
           hasSingleRange="true"
           onSelectionChanged="(ranges) => this.onBaselineRangeChanged(ranges)"

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.xml
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.xml
@@ -35,7 +35,7 @@
             <div class="o-section-title">Apply to range</div>
             <div class="o-selection-cf">
               <SelectionInput
-                ranges="() => state.currentCF.ranges"
+                ranges="state.currentCF.ranges"
                 class="'o-range'"
                 isInvalid="isRangeValid"
                 onSelectionChanged="(ranges) => this.onRangesChanged(ranges)"

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -50,7 +50,7 @@ interface SelectionInputTestConfig {
 class Parent extends Component<any> {
   static template = xml/* xml */ `
     <SelectionInput
-      ranges="() => initialRanges || []"
+      ranges="initialRanges || []"
       hasSingleRange="hasSingleRange"
       onSelectionChanged="(ranges) => this.onChanged(ranges)"
       onSelectionConfirmed="onConfirmed" />
@@ -88,10 +88,10 @@ class MultiParent extends Component<any> {
   static template = xml/* xml */ `
     <div>
       <div class="input-1">
-        <SelectionInput ranges="() => []"/>
+        <SelectionInput ranges="[]"/>
       </div>
       <div class="input-2">
-        <SelectionInput ranges="() => []"/>
+        <SelectionInput ranges="[]"/>
       </div>
     </div>
   `;


### PR DESCRIPTION
## Description:

Since dca78e3, the `ranges` props of the `SelectionInput` component is function.

The usual owl data flow is: 'parent to child' at rendering (through props)
and 'child to parent' at user events (with callbacks, which don't return
anything).
Here when `ranges` is called while handling a user event, it's getting
data from its parent (data from parent to child).
Also, when `ranges` is used at rendering, the `ranges` can simply be
given directly.

Since this is not the traditional way to give data from parent
to child and it might be unusual/confusing, this commit remove it.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo