### PR TITLE
[FIX] selection_input: add missing test

### DIFF
--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -617,6 +617,16 @@ describe("charts", () => {
       "C1:C4",
       "D1:D4",
     ]);
+    expect(fixture.querySelectorAll(".o-selection-input input").length).toEqual(4);
+    expect(
+      (fixture.querySelectorAll(".o-selection-input input")[0] as HTMLInputElement).value
+    ).toBe("B1:B4");
+    expect(
+      (fixture.querySelectorAll(".o-selection-input input")[1] as HTMLInputElement).value
+    ).toBe("C1:C4");
+    expect(
+      (fixture.querySelectorAll(".o-selection-input input")[2] as HTMLInputElement).value
+    ).toBe("D1:D4");
   });
 
   test("Can add multiple ranges all in once with fullRow range", async () => {


### PR DESCRIPTION
## Description:

This PR aims to add a missing test for the selection input of the chart. When adding a multi-columns/rows zone as input, we expect the ranges to be adapted (e.g. "A1:B7" should be changed to ["A1:A7", "B1:B7"]. Unfortunately, while we are correctly testing this change, we are not testing the fact the config pannel updates correctly its ranges when clicking on the "confirm" button. This is now fixed by completing a test in the Charts' tests

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo