### PR TITLE
[FIX] xlsx: space loss in XML when exporting hyperlink

### DIFF
--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -137,8 +137,13 @@ export function addHyperlinks(
         const sheetId = parseSheetUrl(url);
         const sheet = data.sheets.find((sheet) => sheet.id === sheetId);
         const location = sheet ? `${sheet.name}!A1` : INCORRECT_RANGE_STRING;
+        const hyperlinkAttributes: XMLAttributes = [
+          ["display", label],
+          ["location", location],
+          ["ref", xc],
+        ];
         linkNodes.push(escapeXml/*xml*/ `
-          <hyperlink display="${label}" location="${location}" ref="${xc}"/>
+          <hyperlink ${formatAttributes(hyperlinkAttributes)}/>
         `);
       } else {
         const linkRelId = addRelsToFile(
@@ -150,8 +155,12 @@ export function addHyperlinks(
             targetMode: "External",
           }
         );
+        const hyperlinkAttributes: XMLAttributes = [
+          ["r:id", linkRelId],
+          ["ref", xc],
+        ];
         linkNodes.push(escapeXml/*xml*/ `
-          <hyperlink r:id="${linkRelId}" ref="${xc}"/>
+          <hyperlink ${formatAttributes(hyperlinkAttributes)}/>
         `);
       }
     }


### PR DESCRIPTION
## Description:

This PR fixes the loss of space in XML when exporting hyperlink. The solution is to use existing `formatAttributes` to join attributes with space, instead of using space directly in the string.

The cause of problem is still unknown. See commit 1a2c6be.

Odoo task ID : [3371845](https://www.odoo.com/web#id=3371845&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo