### PR TITLE
[FIX]  registries: inline non-shared registry actions

### DIFF
--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -1,3 +1,6 @@
+import { areZonesContinuous } from "../helpers/index";
+import { interactiveSortSelection } from "../helpers/sort";
+import { interactiveAddFilter } from "../helpers/ui/filter_interactive";
 import { _lt } from "../translation";
 import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
@@ -10,27 +13,48 @@ export const sortRange: ActionSpec = {
 
 export const sortAscending: ActionSpec = {
   name: _lt("Ascending (A ⟶ Z)"),
-  execute: ACTIONS.SORT_CELLS_ASCENDING,
+  execute: (env) => {
+    const { anchor, zones } = env.model.getters.getSelection();
+    const sheetId = env.model.getters.getActiveSheetId();
+    interactiveSortSelection(env, sheetId, anchor.cell, zones[0], "ascending");
+  },
   icon: "o-spreadsheet-Icon.SORT_ASCENDING",
 };
 
 export const sortDescending: ActionSpec = {
   name: _lt("Descending (Z ⟶ A)"),
-  execute: ACTIONS.SORT_CELLS_DESCENDING,
+  execute: (env) => {
+    const { anchor, zones } = env.model.getters.getSelection();
+    const sheetId = env.model.getters.getActiveSheetId();
+    interactiveSortSelection(env, sheetId, anchor.cell, zones[0], "descending");
+  },
   icon: "o-spreadsheet-Icon.SORT_DESCENDING",
 };
 
 export const addDataFilter: ActionSpec = {
   name: _lt("Create filter"),
-  execute: ACTIONS.FILTERS_CREATE_FILTER_TABLE,
+  execute: (env) => {
+    const sheetId = env.model.getters.getActiveSheetId();
+    const selection = env.model.getters.getSelection().zones;
+    interactiveAddFilter(env, sheetId, selection);
+  },
   isVisible: (env) => !ACTIONS.SELECTION_CONTAINS_FILTER(env),
-  isEnabled: (env) => ACTIONS.SELECTION_IS_CONTINUOUS(env),
+  isEnabled: (env): boolean => {
+    const selectedZones = env.model.getters.getSelectedZones();
+    return areZonesContinuous(...selectedZones);
+  },
   icon: "o-spreadsheet-Icon.MENU_FILTER_ICON",
 };
 
 export const removeDataFilter: ActionSpec = {
   name: _lt("Remove filter"),
-  execute: ACTIONS.FILTERS_REMOVE_FILTER_TABLE,
+  execute: (env) => {
+    const sheetId = env.model.getters.getActiveSheetId();
+    env.model.dispatch("REMOVE_FILTER_TABLE", {
+      sheetId,
+      target: env.model.getters.getSelectedZones(),
+    });
+  },
   isVisible: ACTIONS.SELECTION_CONTAINS_FILTER,
   icon: "o-spreadsheet-Icon.MENU_FILTER_ICON",
 };

--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -3,17 +3,18 @@ import { _lt } from "../translation";
 import { Align, SpreadsheetChildEnv } from "../types";
 import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
+import { setFormatter, setStyle } from "./menu_items_actions";
 
 export const formatNumberAutomatic: ActionSpec = {
   name: _lt("Automatic"),
-  execute: ACTIONS.FORMAT_AUTOMATIC_ACTION,
+  execute: (env) => setFormatter(env, ""),
   isActive: (env) => isAutomaticFormatSelected(env),
 };
 
 export const formatNumberNumber: ActionSpec = {
   name: _lt("Number"),
   description: "1,000.12",
-  execute: ACTIONS.FORMAT_NUMBER_ACTION,
+  execute: (env) => setFormatter(env, "#,##0.00"),
   isActive: (env) => isFormatSelected(env, "#,##0.00"),
 };
 
@@ -33,48 +34,48 @@ export const formatNumberPercent: ActionSpec = {
 export const formatNumberCurrency: ActionSpec = {
   name: _lt("Currency"),
   description: "$1,000.12",
-  execute: ACTIONS.FORMAT_CURRENCY_ACTION,
+  execute: (env) => setFormatter(env, "[$$]#,##0.00"),
   isActive: (env) => isFormatSelected(env, "[$$]#,##0.00"),
 };
 
 export const formatNumberCurrencyRounded: ActionSpec = {
   name: _lt("Currency rounded"),
   description: "$1,000",
-  execute: ACTIONS.FORMAT_CURRENCY_ROUNDED_ACTION,
+  execute: (env) => setFormatter(env, "[$$]#,##0"),
   isActive: (env) => isFormatSelected(env, "[$$]#,##0"),
 };
 
 export const formatCustomCurrency: ActionSpec = {
   name: _lt("Custom currency"),
   isVisible: (env) => env.loadCurrencies !== undefined,
-  execute: ACTIONS.OPEN_CUSTOM_CURRENCY_SIDEPANEL_ACTION,
+  execute: (env) => env.openSidePanel("CustomCurrency", {}),
 };
 
 export const formatNumberDate: ActionSpec = {
   name: _lt("Date"),
   description: "9/26/2008",
-  execute: ACTIONS.FORMAT_DATE_ACTION,
+  execute: (env) => setFormatter(env, "m/d/yyyy"),
   isActive: (env) => isFormatSelected(env, "m/d/yyyy"),
 };
 
 export const formatNumberTime: ActionSpec = {
   name: _lt("Time"),
   description: "10:43:00 PM",
-  execute: ACTIONS.FORMAT_TIME_ACTION,
+  execute: (env) => setFormatter(env, "hh:mm:ss a"),
   isActive: (env) => isFormatSelected(env, "hh:mm:ss a"),
 };
 
 export const formatNumberDateTime: ActionSpec = {
   name: _lt("Date time"),
   description: "9/26/2008 22:43:00",
-  execute: ACTIONS.FORMAT_DATE_TIME_ACTION,
+  execute: (env) => setFormatter(env, "m/d/yyyy hh:mm:ss"),
   isActive: (env) => isFormatSelected(env, "m/d/yyyy hh:mm:ss"),
 };
 
 export const formatNumberDuration: ActionSpec = {
   name: _lt("Duration"),
   description: "27:51:38",
-  execute: ACTIONS.FORMAT_DURATION_ACTION,
+  execute: (env) => setFormatter(env, "hhhh:mm:ss"),
   isActive: (env) => isFormatSelected(env, "hhhh:mm:ss"),
 };
 
@@ -103,7 +104,7 @@ export const decraseDecimalPlaces: ActionSpec = {
 export const formatBold: ActionSpec = {
   name: _lt("Bold"),
   description: "Ctrl+B",
-  execute: ACTIONS.FORMAT_BOLD_ACTION,
+  execute: (env) => setStyle(env, { bold: !env.model.getters.getCurrentStyle().bold }),
   icon: "o-spreadsheet-Icon.BOLD",
   isActive: (env) => !!env.model.getters.getCurrentStyle().bold,
 };
@@ -111,7 +112,7 @@ export const formatBold: ActionSpec = {
 export const formatItalic: ActionSpec = {
   name: _lt("Italic"),
   description: "Ctrl+I",
-  execute: ACTIONS.FORMAT_ITALIC_ACTION,
+  execute: (env) => setStyle(env, { italic: !env.model.getters.getCurrentStyle().italic }),
   icon: "o-spreadsheet-Icon.ITALIC",
   isActive: (env) => !!env.model.getters.getCurrentStyle().italic,
 };
@@ -119,14 +120,15 @@ export const formatItalic: ActionSpec = {
 export const formatUnderline: ActionSpec = {
   name: _lt("Underline"),
   description: "Ctrl+U",
-  execute: ACTIONS.FORMAT_UNDERLINE_ACTION,
+  execute: (env) => setStyle(env, { underline: !env.model.getters.getCurrentStyle().underline }),
   icon: "o-spreadsheet-Icon.UNDERLINE",
   isActive: (env) => !!env.model.getters.getCurrentStyle().underline,
 };
 
 export const formatStrikethrough: ActionSpec = {
   name: _lt("Strikethrough"),
-  execute: ACTIONS.FORMAT_STRIKETHROUGH_ACTION,
+  execute: (env) =>
+    setStyle(env, { strikethrough: !env.model.getters.getCurrentStyle().strikethrough }),
   icon: "o-spreadsheet-Icon.STRIKE",
   isActive: (env) => !!env.model.getters.getCurrentStyle().strikethrough,
 };
@@ -255,7 +257,11 @@ export const paintFormat: ActionSpec = {
 export const clearFormat: ActionSpec = {
   name: _lt("Clear formatting"),
   description: "Ctrl+<",
-  execute: ACTIONS.FORMAT_CLEARFORMAT_ACTION,
+  execute: (env) =>
+    env.model.dispatch("CLEAR_FORMATTING", {
+      sheetId: env.model.getters.getActiveSheetId(),
+      target: env.model.getters.getSelectedZones(),
+    }),
   icon: "o-spreadsheet-Icon.CLEAR_FORMAT",
 };
 

--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -1,11 +1,15 @@
 import { functionRegistry } from "../functions";
 import { isConsecutive, isDefined } from "../helpers";
+import { handlePasteResult } from "../helpers/ui/paste_interactive";
 import { _lt } from "../translation";
 import { ActionBuilder, ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 
 export const insertRow: ActionSpec = {
-  name: ACTIONS.MENU_INSERT_ROWS_NAME,
+  name: (env) => {
+    const number = getRowsNumber(env);
+    return number === 1 ? _lt("Insert row") : _lt("Insert %s rows", number.toString());
+  },
   isVisible: (env) =>
     isConsecutive(env.model.getters.getActiveRows()) &&
     ACTIONS.IS_ONLY_ONE_RANGE(env) &&
@@ -14,7 +18,10 @@ export const insertRow: ActionSpec = {
 };
 
 export const rowInsertRowBefore: ActionSpec = {
-  name: ACTIONS.ROW_INSERT_ROWS_BEFORE_NAME,
+  name: (env) => {
+    const number = getRowsNumber(env);
+    return number === 1 ? _lt("Insert row above") : _lt("Insert %s rows above", number.toString());
+  },
   execute: ACTIONS.INSERT_ROWS_BEFORE_ACTION,
   isVisible: (env) =>
     isConsecutive(env.model.getters.getActiveRows()) &&
@@ -25,19 +32,34 @@ export const rowInsertRowBefore: ActionSpec = {
 
 export const topBarInsertRowsBefore: ActionSpec = {
   ...rowInsertRowBefore,
-  name: ACTIONS.MENU_INSERT_ROWS_BEFORE_NAME,
+  name: (env) => {
+    const number = getRowsNumber(env);
+    if (number === 1) {
+      return _lt("Row above");
+    }
+    return _lt("%s Rows above", number.toString());
+  },
 };
 
 export const cellInsertRowsBefore: ActionSpec = {
   ...rowInsertRowBefore,
-  name: ACTIONS.CELL_INSERT_ROWS_BEFORE_NAME,
+  name: (env) => {
+    const number = getRowsNumber(env);
+    if (number === 1) {
+      return _lt("Insert row");
+    }
+    return _lt("Insert %s rows", number.toString());
+  },
   isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
   icon: "o-spreadsheet-Icon.INSERT_ROW_BEFORE",
 };
 
 export const rowInsertRowsAfter: ActionSpec = {
   execute: ACTIONS.INSERT_ROWS_AFTER_ACTION,
-  name: ACTIONS.ROW_INSERT_ROWS_AFTER_NAME,
+  name: (env) => {
+    const number = getRowsNumber(env);
+    return number === 1 ? _lt("Insert row below") : _lt("Insert %s rows below", number.toString());
+  },
   isVisible: (env) =>
     isConsecutive(env.model.getters.getActiveRows()) &&
     ACTIONS.IS_ONLY_ONE_RANGE(env) &&
@@ -47,11 +69,20 @@ export const rowInsertRowsAfter: ActionSpec = {
 
 export const topBarInsertRowsAfter: ActionSpec = {
   ...rowInsertRowsAfter,
-  name: ACTIONS.MENU_INSERT_ROWS_AFTER_NAME,
+  name: (env) => {
+    const number = getRowsNumber(env);
+    if (number === 1) {
+      return _lt("Row below");
+    }
+    return _lt("%s Rows below", number.toString());
+  },
 };
 
 export const insertCol: ActionSpec = {
-  name: ACTIONS.MENU_INSERT_COLUMNS_NAME,
+  name: (env) => {
+    const number = getColumnsNumber(env);
+    return number === 1 ? _lt("Insert column") : _lt("Insert %s columns", number.toString());
+  },
   isVisible: (env) =>
     isConsecutive(env.model.getters.getActiveCols()) &&
     ACTIONS.IS_ONLY_ONE_RANGE(env) &&
@@ -60,7 +91,12 @@ export const insertCol: ActionSpec = {
 };
 
 export const colInsertColsBefore: ActionSpec = {
-  name: ACTIONS.COLUMN_INSERT_COLUMNS_BEFORE_NAME,
+  name: (env) => {
+    const number = getColumnsNumber(env);
+    return number === 1
+      ? _lt("Insert column left")
+      : _lt("Insert %s columns left", number.toString());
+  },
   execute: ACTIONS.INSERT_COLUMNS_BEFORE_ACTION,
   isVisible: (env) =>
     isConsecutive(env.model.getters.getActiveCols()) &&
@@ -71,18 +107,35 @@ export const colInsertColsBefore: ActionSpec = {
 
 export const topBarInsertColsBefore: ActionSpec = {
   ...colInsertColsBefore,
-  name: ACTIONS.MENU_INSERT_COLUMNS_BEFORE_NAME,
+  name: (env) => {
+    const number = getColumnsNumber(env);
+    if (number === 1) {
+      return _lt("Column left");
+    }
+    return _lt("%s Columns left", number.toString());
+  },
 };
 
 export const cellInsertColsBefore: ActionSpec = {
   ...colInsertColsBefore,
-  name: ACTIONS.CELL_INSERT_COLUMNS_BEFORE_NAME,
+  name: (env) => {
+    const number = getColumnsNumber(env);
+    if (number === 1) {
+      return _lt("Insert column");
+    }
+    return _lt("Insert %s columns", number.toString());
+  },
   isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
   icon: "o-spreadsheet-Icon.INSERT_COL_BEFORE",
 };
 
 export const colInsertColsAfter: ActionSpec = {
-  name: ACTIONS.COLUMN_INSERT_COLUMNS_AFTER_NAME,
+  name: (env) => {
+    const number = getColumnsNumber(env);
+    return number === 1
+      ? _lt("Insert column right")
+      : _lt("Insert %s columns right", number.toString());
+  },
   execute: ACTIONS.INSERT_COLUMNS_AFTER_ACTION,
   isVisible: (env) =>
     isConsecutive(env.model.getters.getActiveCols()) &&
@@ -93,7 +146,13 @@ export const colInsertColsAfter: ActionSpec = {
 
 export const topBarInsertColsAfter: ActionSpec = {
   ...colInsertColsAfter,
-  name: ACTIONS.MENU_INSERT_COLUMNS_AFTER_NAME,
+  name: (env) => {
+    const number = getColumnsNumber(env);
+    if (number === 1) {
+      return _lt("Column right");
+    }
+    return _lt("%s Columns right", number.toString());
+  },
   execute: ACTIONS.INSERT_COLUMNS_AFTER_ACTION,
 };
 
@@ -108,7 +167,11 @@ export const insertCell: ActionSpec = {
 
 export const insertCellShiftDown: ActionSpec = {
   name: _lt("Insert cells and shift down"),
-  execute: ACTIONS.INSERT_CELL_SHIFT_DOWN,
+  execute: (env) => {
+    const zone = env.model.getters.getSelectedZone();
+    const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "ROW" });
+    handlePasteResult(env, result);
+  },
   isVisible: (env) =>
     env.model.getters.getActiveRows().size === 0 && env.model.getters.getActiveCols().size === 0,
   icon: "o-spreadsheet-Icon.INSERT_CELL_SHIFT_DOWN",
@@ -116,7 +179,11 @@ export const insertCellShiftDown: ActionSpec = {
 
 export const insertCellShiftRight: ActionSpec = {
   name: _lt("Insert cells and shift right"),
-  execute: ACTIONS.INSERT_CELL_SHIFT_RIGHT,
+  execute: (env) => {
+    const zone = env.model.getters.getSelectedZone();
+    const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "COL" });
+    handlePasteResult(env, result);
+  },
   isVisible: (env) =>
     env.model.getters.getActiveRows().size === 0 && env.model.getters.getActiveCols().size === 0,
   icon: "o-spreadsheet-Icon.INSERT_CELL_SHIFT_RIGHT",
@@ -201,7 +268,13 @@ export const insertLink: ActionSpec = {
 
 export const insertSheet: ActionSpec = {
   name: _lt("Insert sheet"),
-  execute: ACTIONS.CREATE_SHEET_ACTION,
+  execute: (env) => {
+    const activeSheetId = env.model.getters.getActiveSheetId();
+    const position = env.model.getters.getSheetIds().indexOf(activeSheetId) + 1;
+    const sheetId = env.model.uuidGenerator.uuidv4();
+    env.model.dispatch("CREATE_SHEET", { sheetId, position });
+    env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
+  },
   icon: "o-spreadsheet-Icon.INSERT_SHEET",
 };
 
@@ -213,4 +286,24 @@ function createFormulaFunctions(fnNames: string[]): ActionSpec[] {
       execute: (env) => env.startCellEdition(`=${fnName}(`),
     };
   });
+}
+
+function getRowsNumber(env): number {
+  const activeRows = env.model.getters.getActiveRows();
+  if (activeRows.size) {
+    return activeRows.size;
+  } else {
+    const zone = env.model.getters.getSelectedZones()[0];
+    return zone.bottom - zone.top + 1;
+  }
+}
+
+function getColumnsNumber(env): number {
+  const activeCols = env.model.getters.getActiveCols();
+  if (activeCols.size) {
+    return activeCols.size;
+  } else {
+    const zone = env.model.getters.getSelectedZones()[0];
+    return zone.right - zone.left + 1;
+  }
 }

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -4,15 +4,8 @@ import {
   getSmartChartDefinition,
 } from "../helpers/figures/charts";
 import { centerFigurePosition, getMaxFigureSize } from "../helpers/figures/figure/figure";
-import { areZonesContinuous, getZoneArea, numberToLetters } from "../helpers/index";
-import { interactiveSortSelection } from "../helpers/sort";
-import { interactiveCut } from "../helpers/ui/cut_interactive";
-import { interactiveAddFilter } from "../helpers/ui/filter_interactive";
-import {
-  handlePasteResult,
-  interactivePaste,
-  interactivePasteFromOS,
-} from "../helpers/ui/paste_interactive";
+import { getZoneArea, numberToLetters } from "../helpers/index";
+import { interactivePaste, interactivePasteFromOS } from "../helpers/ui/paste_interactive";
 import { _lt } from "../translation";
 import { ClipboardMIMEType, ClipboardPasteOptions } from "../types/clipboard";
 import { Image } from "../types/image";
@@ -21,26 +14,6 @@ import { Format, SpreadsheetChildEnv, Style } from "../types/index";
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
-
-function getColumnsNumber(env: SpreadsheetChildEnv): number {
-  const activeCols = env.model.getters.getActiveCols();
-  if (activeCols.size) {
-    return activeCols.size;
-  } else {
-    const zone = env.model.getters.getSelectedZones()[0];
-    return zone.right - zone.left + 1;
-  }
-}
-
-function getRowsNumber(env: SpreadsheetChildEnv): number {
-  const activeRows = env.model.getters.getActiveRows();
-  if (activeRows.size) {
-    return activeRows.size;
-  } else {
-    const zone = env.model.getters.getSelectedZones()[0];
-    return zone.bottom - zone.top + 1;
-  }
-}
 
 export function setFormatter(env: SpreadsheetChildEnv, format: Format) {
   env.model.dispatch("SET_FORMATTING", {
@@ -61,20 +34,6 @@ export function setStyle(env: SpreadsheetChildEnv, style: Style) {
 //------------------------------------------------------------------------------
 // Simple actions
 //------------------------------------------------------------------------------
-
-export const UNDO_ACTION = (env: SpreadsheetChildEnv) => env.model.dispatch("REQUEST_UNDO");
-
-export const REDO_ACTION = (env: SpreadsheetChildEnv) => env.model.dispatch("REQUEST_REDO");
-
-export const COPY_ACTION = async (env: SpreadsheetChildEnv) => {
-  env.model.dispatch("COPY");
-  await env.clipboard.write(env.model.getters.getClipboardContent());
-};
-
-export const CUT_ACTION = async (env: SpreadsheetChildEnv) => {
-  interactiveCut(env);
-  await env.clipboard.write(env.model.getters.getClipboardContent());
-};
 
 export const PASTE_ACTION = async (env: SpreadsheetChildEnv) => paste(env);
 export const PASTE_VALUE_ACTION = async (env: SpreadsheetChildEnv) => paste(env, "onlyValue");
@@ -113,27 +72,6 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
 }
 
 export const PASTE_FORMAT_ACTION = (env: SpreadsheetChildEnv) => paste(env, "onlyFormat");
-
-export const DELETE_CONTENT_ACTION = (env: SpreadsheetChildEnv) =>
-  env.model.dispatch("DELETE_CONTENT", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    target: env.model.getters.getSelectedZones(),
-  });
-
-export const SET_FORMULA_VISIBILITY_ACTION = (env: SpreadsheetChildEnv) =>
-  env.model.dispatch("SET_FORMULA_VISIBILITY", { show: !env.model.getters.shouldShowFormulas() });
-
-export const SET_GRID_LINES_VISIBILITY_ACTION = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  env.model.dispatch("SET_GRID_LINES_VISIBILITY", {
-    sheetId,
-    areGridLinesVisible: !env.model.getters.getGridLinesVisibility(sheetId),
-  });
-};
-
-export const IS_NOT_CUT_OPERATION = (env: SpreadsheetChildEnv): boolean => {
-  return !env.model.getters.isCutOperation();
-};
 
 //------------------------------------------------------------------------------
 // Grid manipulations
@@ -287,56 +225,6 @@ export const NOT_ALL_VISIBLE_COLS_SELECTED = (env: SpreadsheetChildEnv) => {
   return env.model.getters.canRemoveHeaders(sheetId, "COL", selectedCols);
 };
 
-export const INSERT_CELL_SHIFT_DOWN = (env: SpreadsheetChildEnv) => {
-  const zone = env.model.getters.getSelectedZone();
-  const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "ROW" });
-  handlePasteResult(env, result);
-};
-
-export const INSERT_CELL_SHIFT_RIGHT = (env: SpreadsheetChildEnv) => {
-  const zone = env.model.getters.getSelectedZone();
-  const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "COL" });
-  handlePasteResult(env, result);
-};
-
-export const DELETE_CELL_SHIFT_UP = (env: SpreadsheetChildEnv) => {
-  const zone = env.model.getters.getSelectedZone();
-  const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "ROW" });
-  handlePasteResult(env, result);
-};
-
-export const DELETE_CELL_SHIFT_LEFT = (env: SpreadsheetChildEnv) => {
-  const zone = env.model.getters.getSelectedZone();
-  const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "COL" });
-  handlePasteResult(env, result);
-};
-
-export const MENU_INSERT_ROWS_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getRowsNumber(env);
-  return number === 1 ? _lt("Insert row") : _lt("Insert %s rows", number.toString());
-};
-
-export const MENU_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getRowsNumber(env);
-  if (number === 1) {
-    return _lt("Row above");
-  }
-  return _lt("%s Rows above", number.toString());
-};
-
-export const ROW_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getRowsNumber(env);
-  return number === 1 ? _lt("Insert row above") : _lt("Insert %s rows above", number.toString());
-};
-
-export const CELL_INSERT_ROWS_BEFORE_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getRowsNumber(env);
-  if (number === 1) {
-    return _lt("Insert row");
-  }
-  return _lt("Insert %s rows", number.toString());
-};
-
 export const INSERT_ROWS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
   const activeRows = env.model.getters.getActiveRows();
   let row: number;
@@ -356,19 +244,6 @@ export const INSERT_ROWS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
     quantity,
     dimension: "ROW",
   });
-};
-
-export const MENU_INSERT_ROWS_AFTER_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getRowsNumber(env);
-  if (number === 1) {
-    return _lt("Row below");
-  }
-  return _lt("%s Rows below", number.toString());
-};
-
-export const ROW_INSERT_ROWS_AFTER_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getRowsNumber(env);
-  return number === 1 ? _lt("Insert row below") : _lt("Insert %s rows below", number.toString());
 };
 
 export const INSERT_ROWS_AFTER_ACTION = (env: SpreadsheetChildEnv) => {
@@ -392,34 +267,6 @@ export const INSERT_ROWS_AFTER_ACTION = (env: SpreadsheetChildEnv) => {
   });
 };
 
-export const MENU_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getColumnsNumber(env);
-  if (number === 1) {
-    return _lt("Column left");
-  }
-  return _lt("%s Columns left", number.toString());
-};
-
-export const MENU_INSERT_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getColumnsNumber(env);
-  return number === 1 ? _lt("Insert column") : _lt("Insert %s columns", number.toString());
-};
-
-export const COLUMN_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getColumnsNumber(env);
-  return number === 1
-    ? _lt("Insert column left")
-    : _lt("Insert %s columns left", number.toString());
-};
-
-export const CELL_INSERT_COLUMNS_BEFORE_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getColumnsNumber(env);
-  if (number === 1) {
-    return _lt("Insert column");
-  }
-  return _lt("Insert %s columns", number.toString());
-};
-
 export const INSERT_COLUMNS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
   const activeCols = env.model.getters.getActiveCols();
   let column: number;
@@ -439,21 +286,6 @@ export const INSERT_COLUMNS_BEFORE_ACTION = (env: SpreadsheetChildEnv) => {
     base: column,
     quantity,
   });
-};
-
-export const MENU_INSERT_COLUMNS_AFTER_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getColumnsNumber(env);
-  if (number === 1) {
-    return _lt("Column right");
-  }
-  return _lt("%s Columns right", number.toString());
-};
-
-export const COLUMN_INSERT_COLUMNS_AFTER_NAME = (env: SpreadsheetChildEnv) => {
-  const number = getColumnsNumber(env);
-  return number === 1
-    ? _lt("Insert column right")
-    : _lt("Insert %s columns right", number.toString());
 };
 
 export const INSERT_COLUMNS_AFTER_ACTION = (env: SpreadsheetChildEnv) => {
@@ -494,33 +326,6 @@ export const HIDE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
   }
 };
 
-export const HIDE_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
-  const columns = env.model.getters.getElementsFromSelection("COL");
-  env.model.dispatch("HIDE_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    dimension: "COL",
-    elements: columns,
-  });
-};
-
-export const UNHIDE_ALL_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
-    sheetId,
-    dimension: "COL",
-    elements: Array.from(Array(env.model.getters.getNumberCols(sheetId)).keys()),
-  });
-};
-
-export const UNHIDE_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
-  const columns = env.model.getters.getElementsFromSelection("COL");
-  env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    dimension: "COL",
-    elements: columns,
-  });
-};
-
 export const HIDE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
   const rows = env.model.getters.getElementsFromSelection("ROW");
   let first = rows[0];
@@ -532,45 +337,6 @@ export const HIDE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
   } else {
     return _lt("Hide rows");
   }
-};
-
-export const HIDE_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
-  const rows = env.model.getters.getElementsFromSelection("ROW");
-  env.model.dispatch("HIDE_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    dimension: "ROW",
-    elements: rows,
-  });
-};
-
-export const UNHIDE_ALL_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
-    sheetId,
-    dimension: "ROW",
-    elements: Array.from(Array(env.model.getters.getNumberRows(sheetId)).keys()),
-  });
-};
-
-export const UNHIDE_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
-  const columns = env.model.getters.getElementsFromSelection("ROW");
-  env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    dimension: "ROW",
-    elements: columns,
-  });
-};
-
-//------------------------------------------------------------------------------
-// Sheets
-//------------------------------------------------------------------------------
-
-export const CREATE_SHEET_ACTION = (env: SpreadsheetChildEnv) => {
-  const activeSheetId = env.model.getters.getActiveSheetId();
-  const position = env.model.getters.getSheetIds().indexOf(activeSheetId) + 1;
-  const sheetId = env.model.uuidGenerator.uuidv4();
-  env.model.dispatch("CREATE_SHEET", { sheetId, position });
-  env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
 };
 
 //------------------------------------------------------------------------------
@@ -638,60 +404,13 @@ export const CREATE_IMAGE = async (env: SpreadsheetChildEnv) => {
 // Style/Format
 //------------------------------------------------------------------------------
 
-export const FORMAT_AUTOMATIC_ACTION = (env: SpreadsheetChildEnv) => setFormatter(env, "");
-
-export const FORMAT_NUMBER_ACTION = (env: SpreadsheetChildEnv) => setFormatter(env, "#,##0.00");
-
 export const FORMAT_PERCENT_ACTION = (env: SpreadsheetChildEnv) => setFormatter(env, "0.00%");
-
-export const FORMAT_CURRENCY_ACTION = (env: SpreadsheetChildEnv) =>
-  setFormatter(env, "[$$]#,##0.00");
-
-export const FORMAT_CURRENCY_ROUNDED_ACTION = (env: SpreadsheetChildEnv) =>
-  setFormatter(env, "[$$]#,##0");
-
-export const FORMAT_DATE_ACTION = (env: SpreadsheetChildEnv) => setFormatter(env, "m/d/yyyy");
-
-export const FORMAT_TIME_ACTION = (env: SpreadsheetChildEnv) => setFormatter(env, "hh:mm:ss a");
-
-export const FORMAT_DATE_TIME_ACTION = (env: SpreadsheetChildEnv) =>
-  setFormatter(env, "m/d/yyyy hh:mm:ss");
-
-export const FORMAT_DURATION_ACTION = (env: SpreadsheetChildEnv) => setFormatter(env, "hhhh:mm:ss");
-
-export const FORMAT_BOLD_ACTION = (env: SpreadsheetChildEnv) =>
-  setStyle(env, { bold: !env.model.getters.getCurrentStyle().bold });
-
-export const FORMAT_ITALIC_ACTION = (env: SpreadsheetChildEnv) =>
-  setStyle(env, { italic: !env.model.getters.getCurrentStyle().italic });
-
-export const FORMAT_STRIKETHROUGH_ACTION = (env: SpreadsheetChildEnv) =>
-  setStyle(env, { strikethrough: !env.model.getters.getCurrentStyle().strikethrough });
-
-export const FORMAT_UNDERLINE_ACTION = (env: SpreadsheetChildEnv) =>
-  setStyle(env, { underline: !env.model.getters.getCurrentStyle().underline });
-
-export const FORMAT_CLEARFORMAT_ACTION = (env: SpreadsheetChildEnv) => {
-  env.model.dispatch("CLEAR_FORMATTING", {
-    sheetId: env.model.getters.getActiveSheetId(),
-    target: env.model.getters.getSelectedZones(),
-  });
-};
 
 //------------------------------------------------------------------------------
 // Side panel
 //------------------------------------------------------------------------------
-
 export const OPEN_CF_SIDEPANEL_ACTION = (env: SpreadsheetChildEnv) => {
   env.openSidePanel("ConditionalFormatting", { selection: env.model.getters.getSelectedZones() });
-};
-
-export const OPEN_FAR_SIDEPANEL_ACTION = (env: SpreadsheetChildEnv) => {
-  env.openSidePanel("FindAndReplace", {});
-};
-
-export const OPEN_CUSTOM_CURRENCY_SIDEPANEL_ACTION = (env: SpreadsheetChildEnv) => {
-  env.openSidePanel("CustomCurrency", {});
 };
 
 export const INSERT_LINK = (env: SpreadsheetChildEnv) => {
@@ -703,46 +422,15 @@ export const INSERT_LINK = (env: SpreadsheetChildEnv) => {
 // Filters action
 //------------------------------------------------------------------------------
 
-export const FILTERS_CREATE_FILTER_TABLE = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  const selection = env.model.getters.getSelection().zones;
-  interactiveAddFilter(env, sheetId, selection);
-};
-
-export const FILTERS_REMOVE_FILTER_TABLE = (env: SpreadsheetChildEnv) => {
-  const sheetId = env.model.getters.getActiveSheetId();
-  env.model.dispatch("REMOVE_FILTER_TABLE", {
-    sheetId,
-    target: env.model.getters.getSelectedZones(),
-  });
-};
-
 export const SELECTION_CONTAINS_FILTER = (env: SpreadsheetChildEnv): boolean => {
   const sheetId = env.model.getters.getActiveSheetId();
   const selectedZones = env.model.getters.getSelectedZones();
   return env.model.getters.doesZonesContainFilter(sheetId, selectedZones);
 };
 
-export const SELECTION_IS_CONTINUOUS = (env: SpreadsheetChildEnv): boolean => {
-  const selectedZones = env.model.getters.getSelectedZones();
-  return areZonesContinuous(...selectedZones);
-};
-
 //------------------------------------------------------------------------------
 // Sorting action
 //------------------------------------------------------------------------------
-
-export const SORT_CELLS_ASCENDING = (env: SpreadsheetChildEnv) => {
-  const { anchor, zones } = env.model.getters.getSelection();
-  const sheetId = env.model.getters.getActiveSheetId();
-  interactiveSortSelection(env, sheetId, anchor.cell, zones[0], "ascending");
-};
-
-export const SORT_CELLS_DESCENDING = (env: SpreadsheetChildEnv) => {
-  const { anchor, zones } = env.model.getters.getSelection();
-  const sheetId = env.model.getters.getActiveSheetId();
-  interactiveSortSelection(env, sheetId, anchor.cell, zones[0], "descending");
-};
 
 export const IS_ONLY_ONE_RANGE = (env: SpreadsheetChildEnv): boolean => {
   return env.model.getters.getSelectedZones().length === 1;

--- a/src/actions/view_actions.ts
+++ b/src/actions/view_actions.ts
@@ -8,14 +8,28 @@ import * as ACTIONS from "./menu_items_actions";
 
 export const hideCols: ActionSpec = {
   name: ACTIONS.HIDE_COLUMNS_NAME,
-  execute: ACTIONS.HIDE_COLUMNS_ACTION,
+  execute: (env) => {
+    const columns = env.model.getters.getElementsFromSelection("COL");
+    env.model.dispatch("HIDE_COLUMNS_ROWS", {
+      sheetId: env.model.getters.getActiveSheetId(),
+      dimension: "COL",
+      elements: columns,
+    });
+  },
   isVisible: ACTIONS.NOT_ALL_VISIBLE_COLS_SELECTED,
   icon: "o-spreadsheet-Icon.HIDE_COL",
 };
 
 export const unhideCols: ActionSpec = {
   name: _lt("Unhide columns"),
-  execute: ACTIONS.UNHIDE_COLUMNS_ACTION,
+  execute: (env) => {
+    const columns = env.model.getters.getElementsFromSelection("COL");
+    env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
+      sheetId: env.model.getters.getActiveSheetId(),
+      dimension: "COL",
+      elements: columns,
+    });
+  },
   isVisible: (env: SpreadsheetChildEnv) => {
     const hiddenCols = env.model.getters
       .getHiddenColsGroups(env.model.getters.getActiveSheetId())
@@ -27,21 +41,42 @@ export const unhideCols: ActionSpec = {
 
 export const unhideAllCols: ActionSpec = {
   name: _lt("Unhide all columns"),
-  execute: ACTIONS.UNHIDE_ALL_COLUMNS_ACTION,
+  execute: (env) => {
+    const sheetId = env.model.getters.getActiveSheetId();
+    env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
+      sheetId,
+      dimension: "COL",
+      elements: Array.from(Array(env.model.getters.getNumberCols(sheetId)).keys()),
+    });
+  },
   isVisible: (env: SpreadsheetChildEnv) =>
     env.model.getters.getHiddenColsGroups(env.model.getters.getActiveSheetId()).length > 0,
 };
 
 export const hideRows: ActionSpec = {
   name: ACTIONS.HIDE_ROWS_NAME,
-  execute: ACTIONS.HIDE_ROWS_ACTION,
+  execute: (env) => {
+    const rows = env.model.getters.getElementsFromSelection("ROW");
+    env.model.dispatch("HIDE_COLUMNS_ROWS", {
+      sheetId: env.model.getters.getActiveSheetId(),
+      dimension: "ROW",
+      elements: rows,
+    });
+  },
   isVisible: ACTIONS.NOT_ALL_VISIBLE_ROWS_SELECTED,
   icon: "o-spreadsheet-Icon.HIDE_ROW",
 };
 
 export const unhideRows: ActionSpec = {
   name: _lt("Unhide rows"),
-  execute: ACTIONS.UNHIDE_ROWS_ACTION,
+  execute: (env) => {
+    const columns = env.model.getters.getElementsFromSelection("ROW");
+    env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
+      sheetId: env.model.getters.getActiveSheetId(),
+      dimension: "ROW",
+      elements: columns,
+    });
+  },
   isVisible: (env: SpreadsheetChildEnv) => {
     const hiddenRows = env.model.getters
       .getHiddenRowsGroups(env.model.getters.getActiveSheetId())
@@ -53,7 +88,14 @@ export const unhideRows: ActionSpec = {
 
 export const unhideAllRows: ActionSpec = {
   name: _lt("Unhide all rows"),
-  execute: ACTIONS.UNHIDE_ALL_ROWS_ACTION,
+  execute: (env) => {
+    const sheetId = env.model.getters.getActiveSheetId();
+    env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
+      sheetId,
+      dimension: "ROW",
+      elements: Array.from(Array(env.model.getters.getNumberRows(sheetId)).keys()),
+    });
+  },
   isVisible: (env: SpreadsheetChildEnv) =>
     env.model.getters.getHiddenRowsGroups(env.model.getters.getActiveSheetId()).length > 0,
 };
@@ -147,14 +189,21 @@ export const viewGridlines: ActionSpec = {
     env.model.getters.getGridLinesVisibility(env.model.getters.getActiveSheetId())
       ? _lt("Hide gridlines")
       : _lt("Show gridlines"),
-  execute: ACTIONS.SET_GRID_LINES_VISIBILITY_ACTION,
+  execute: (env) => {
+    const sheetId = env.model.getters.getActiveSheetId();
+    env.model.dispatch("SET_GRID_LINES_VISIBILITY", {
+      sheetId,
+      areGridLinesVisible: !env.model.getters.getGridLinesVisibility(sheetId),
+    });
+  },
   icon: "o-spreadsheet-Icon.SHOW_HIDE_GRID",
 };
 
 export const viewFormulas: ActionSpec = {
   name: (env: SpreadsheetChildEnv) =>
     env.model.getters.shouldShowFormulas() ? _lt("Hide formulas") : _lt("Show formulas"),
-  execute: ACTIONS.SET_FORMULA_VISIBILITY_ACTION,
+  execute: (env) =>
+    env.model.dispatch("SET_FORMULA_VISIBILITY", { show: !env.model.getters.shouldShowFormulas() }),
   isReadonlyAllowed: true,
   icon: "o-spreadsheet-Icon.SHOW_HIDE_FORMULA",
 };


### PR DESCRIPTION
## Description:
Before:
The 'ActionSpec' items and their action's implementations are currently split in different files.

After:
The goal of this task is to inline the actions of `ActionSpec` that are only used once, and are well-readable when written inline.

Odoo task ID : [3377143](https://www.odoo.com/web#id=3377143&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo