### PR TITLE
[FIX] Composer: Allow to unselect fully selected composer content

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -386,6 +386,22 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     this.autoCompleteState.selectedIndex = 0;
   }
 
+  /**
+   * This is required to ensure the content helper selection is
+   * properly updated on "onclick" events. Depending on the browser,
+   * the callback onClick from the composer will be executed before
+   * the selection was updated in the dom, which means we capture an
+   * wrong selection which is then forced upon the content helper on
+   * patchContent.
+   */
+  onMousedown(ev: MouseEvent) {
+    if (ev.button > 0) {
+      // not main button, probably a context menu
+      return;
+    }
+    this.contentHelper.removeSelection();
+  }
+
   onClick() {
     if (this.env.model.getters.isReadonly()) {
       return;

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -12,6 +12,7 @@
         t-on-keydown="onKeydown"
         t-on-mousewheel.stop=""
         t-on-input="onInput"
+        t-on-mousedown="onMousedown"
         t-on-click="onClick"
         t-on-keyup="onKeyup"
         t-on-paste.stop=""

--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -193,6 +193,14 @@ export class ContentEditableHelper {
     element?.scrollIntoView({ block: "nearest" });
   }
 
+  /**
+   * remove the current selection of the user
+   * */
+  removeSelection() {
+    let selection = window.getSelection()!;
+    selection.removeAllRanges();
+  }
+
   private removeAll() {
     if (this.el) {
       while (this.el.firstChild) {

--- a/tests/components/__mocks__/content_editable_helper.ts
+++ b/tests/components/__mocks__/content_editable_helper.ts
@@ -79,6 +79,11 @@ export class ContentEditableHelper {
     }
   }
 
+  removeSelection() {
+    this.currentState.cursorStart = 0;
+    this.currentState.cursorEnd = 0;
+  }
+
   removeAll() {
     this.selectionState = initialSelectionState;
     this.currentState.cursorStart = 0;


### PR DESCRIPTION
In Chrome, when the content of the composer is completely selected (after a Ctrl-A for instance) and a user clicks on the text, the 'onCLick' callback of the composer is called before the selection is updated in the contentEditableHelper. Since the onClick callback captures that selection and sets it back on the CEH at the next `onPatched`, we cannot unselect that text.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo