### PR TITLE
[FIX] some chart side panel style issue

### DIFF
--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
@@ -2,18 +2,16 @@
   <t t-name="o-spreadsheet-BarConfigPanel" owl="1">
     <div>
       <div class="o-section pt-0">
-        <div class="o-checkbox">
-          <label>
-            <input
-              type="checkbox"
-              name="stacked"
-              t-att-checked="props.definition.stacked"
-              t-on-change="onUpdateStacked"
-              class="align-middle"
-            />
-            Stacked barchart
-          </label>
-        </div>
+        <label class="o-checkbox">
+          <input
+            type="checkbox"
+            name="stacked"
+            t-att-checked="props.definition.stacked"
+            t-on-change="onUpdateStacked"
+            class="align-middle"
+          />
+          Stacked barchart
+        </label>
       </div>
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>
@@ -33,7 +31,7 @@
           onSelectionChanged="(ranges) => this.onLabelRangeChanged(ranges)"
           onSelectionConfirmed="() => this.onLabelRangeConfirmed()"
         />
-        <label>
+        <label class="o-checkbox">
           <input
             type="checkbox"
             name="aggregated"
@@ -45,16 +43,18 @@
         </label>
       </div>
       <div class="o-section o-use-row-as-headers" t-if="calculateHeaderPosition()">
-        <label>
+        <label class="o-checkbox">
           <input
             type="checkbox"
             t-att-checked="props.definition.dataSetsHaveTitle"
             t-on-change="onUpdateDataSetsHaveTitle"
             class="align-middle"
           />
-          Use row
-          <span t-esc="calculateHeaderPosition()"/>
-          as headers
+          <span>
+            Use row
+            <t t-esc="calculateHeaderPosition()"/>
+            as headers
+          </span>
         </label>
       </div>
 

--- a/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
@@ -4,15 +4,17 @@
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
-        Select a color...
-        <ColorPickerWidget
-          currentColor="props.definition.background"
-          toggleColorPicker="() => this.toggleColorPicker()"
-          showColorPicker="state.fillColorTool"
-          onColorPicked="(color) => this.updateBackgroundColor(color)"
-          title="background_color"
-          icon="'o-spreadsheet-Icon.FILL_COLOR'"
-        />
+        <div class="d-flex align-items-center">
+          <span class="pe-1">Select a color...</span>
+          <ColorPickerWidget
+            currentColor="props.definition.background"
+            toggleColorPicker="() => this.toggleColorPicker()"
+            showColorPicker="state.fillColorTool"
+            onColorPicked="(color) => this.updateBackgroundColor(color)"
+            title="background_color"
+            icon="'o-spreadsheet-Icon.FILL_COLOR'"
+          />
+        </div>
       </div>
       <div class="o-section o-chart-title">
         <div class="o-section-title">Title</div>

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
@@ -4,15 +4,17 @@
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
-        Select a color...
-        <ColorPickerWidget
-          currentColor="props.definition.background"
-          toggleColorPicker="() => this.toggleMenu('backgroundColor', ev)"
-          showColorPicker="state.openedMenu === 'backgroundColor'"
-          onColorPicked="(color) => this.updateBackgroundColor(color)"
-          title="background_color"
-          icon="'o-spreadsheet-Icon.FILL_COLOR'"
-        />
+        <div class="d-flex align-items-center">
+          <span class="pe-1">Select a color...</span>
+          <ColorPickerWidget
+            currentColor="props.definition.background"
+            toggleColorPicker="() => this.toggleMenu('backgroundColor', ev)"
+            showColorPicker="state.openedMenu === 'backgroundColor'"
+            onColorPicked="(color) => this.updateBackgroundColor(color)"
+            title="background_color"
+            icon="'o-spreadsheet-Icon.FILL_COLOR'"
+          />
+        </div>
       </div>
 
       <div class="o-section o-chart-title">

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
@@ -19,7 +19,7 @@
           onSelectionChanged="(ranges) => this.onLabelRangeChanged(ranges)"
           onSelectionConfirmed="() => this.onLabelRangeConfirmed()"
         />
-        <label>
+        <label class="o-checkbox">
           <input
             type="checkbox"
             name="aggregated"
@@ -31,16 +31,18 @@
         </label>
       </div>
       <div class="o-section o-use-row-as-headers" t-if="calculateHeaderPosition()">
-        <label>
+        <label class="o-checkbox">
           <input
             type="checkbox"
             t-att-checked="props.definition.dataSetsHaveTitle"
             t-on-change="onUpdateDataSetsHaveTitle"
             class="align-middle"
           />
-          Use row
-          <span t-esc="calculateHeaderPosition()"/>
-          as headers
+          <span>
+            Use row
+            <t t-esc="calculateHeaderPosition()"/>
+            as headers
+          </span>
         </label>
       </div>
 

--- a/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
@@ -4,15 +4,17 @@
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
-        Select a color...
-        <ColorPickerWidget
-          currentColor="props.definition.background"
-          toggleColorPicker="() => this.toggleColorPicker()"
-          showColorPicker="state.fillColorTool"
-          onColorPicked="(color) => this.updateBackgroundColor(color)"
-          title="background_color"
-          icon="'o-spreadsheet-Icon.FILL_COLOR'"
-        />
+        <div class="d-flex align-items-center">
+          <span class="pe-1">Select a color...</span>
+          <ColorPickerWidget
+            currentColor="props.definition.background"
+            toggleColorPicker="() => this.toggleColorPicker()"
+            showColorPicker="state.fillColorTool"
+            onColorPicked="(color) => this.updateBackgroundColor(color)"
+            title="background_color"
+            icon="'o-spreadsheet-Icon.FILL_COLOR'"
+          />
+        </div>
       </div>
       <div class="o-section o-chart-title">
         <div class="o-section-title">Title</div>

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -2,18 +2,16 @@
   <t t-name="o-spreadsheet-LineConfigPanel" owl="1">
     <div>
       <div class="o-section pt-0">
-        <div class="o-checkbox">
-          <label>
-            <input
-              type="checkbox"
-              name="stacked"
-              t-att-checked="props.definition.stacked"
-              t-on-change="onUpdateStacked"
-              class="align-middle"
-            />
-            Stacked linechart
-          </label>
-        </div>
+        <label class="o-checkbox">
+          <input
+            type="checkbox"
+            name="stacked"
+            t-att-checked="props.definition.stacked"
+            t-on-change="onUpdateStacked"
+            class="align-middle"
+          />
+          Stacked linechart
+        </label>
       </div>
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>
@@ -33,7 +31,7 @@
           onSelectionChanged="(ranges) => this.onLabelRangeChanged(ranges)"
           onSelectionConfirmed="() => this.onLabelRangeConfirmed()"
         />
-        <label>
+        <label class="o-checkbox">
           <input
             type="checkbox"
             name="aggregated"
@@ -43,17 +41,15 @@
           />
           Aggregate
         </label>
-        <div t-if="canTreatLabelsAsText">
-          <label>
-            <input
-              type="checkbox"
-              name="labelsAsText"
-              t-att-checked="props.definition.labelsAsText"
-              t-on-change="onUpdateLabelsAsText"
-            />
-            Treat labels as text
-          </label>
-        </div>
+        <label t-if="canTreatLabelsAsText" class="o-checkbox">
+          <input
+            type="checkbox"
+            name="labelsAsText"
+            t-att-checked="props.definition.labelsAsText"
+            t-on-change="onUpdateLabelsAsText"
+          />
+          Treat labels as text
+        </label>
       </div>
       <div class="o-section o-use-row-as-headers" t-if="calculateHeaderPosition()">
         <label>
@@ -63,9 +59,11 @@
             t-on-change="onUpdateDataSetsHaveTitle"
             class="align-middle"
           />
-          Use row
-          <span t-esc="calculateHeaderPosition()"/>
-          as headers
+          <span>
+            Use row
+            <t t-esc="calculateHeaderPosition()"/>
+            as headers
+          </span>
         </label>
       </div>
 

--- a/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
@@ -4,15 +4,17 @@
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
-        Select a color...
-        <ColorPickerWidget
-          currentColor="props.definition.background"
-          toggleColorPicker="() => this.toggleColorPicker()"
-          showColorPicker="state.fillColorTool"
-          onColorPicked="(color) => this.updateBackgroundColor(color)"
-          title="background_color"
-          icon="'o-spreadsheet-Icon.FILL_COLOR'"
-        />
+        <div class="d-flex align-items-center">
+          <span class="pe-1">Select a color...</span>
+          <ColorPickerWidget
+            currentColor="props.definition.background"
+            toggleColorPicker="() => this.toggleColorPicker()"
+            showColorPicker="state.fillColorTool"
+            onColorPicked="(color) => this.updateBackgroundColor(color)"
+            title="background_color"
+            icon="'o-spreadsheet-Icon.FILL_COLOR'"
+          />
+        </div>
       </div>
       <div class="o-section o-chart-title">
         <div class="o-section-title">Title</div>

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
@@ -6,15 +6,17 @@
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
-        Select a color...
-        <ColorPickerWidget
-          currentColor="props.definition.background"
-          toggleColorPicker="() => this.toggleColorPicker('backgroundColor')"
-          showColorPicker="state.openedColorPicker === 'backgroundColor'"
-          onColorPicked="(color) => this.setColor(color, 'backgroundColor')"
-          title="background_color"
-          icon="'o-spreadsheet-Icon.FILL_COLOR'"
-        />
+        <div class="d-flex align-items-center">
+          <span class="pe-1">Select a color...</span>
+          <ColorPickerWidget
+            currentColor="props.definition.background"
+            toggleColorPicker="() => this.toggleColorPicker('backgroundColor')"
+            showColorPicker="state.openedColorPicker === 'backgroundColor'"
+            onColorPicked="(color) => this.setColor(color, 'backgroundColor')"
+            title="background_color"
+            icon="'o-spreadsheet-Icon.FILL_COLOR'"
+          />
+        </div>
       </div>
 
       <div class="o-section o-chart-title">
@@ -39,25 +41,28 @@
     </div>
     <div class="o-section o-chart-baseline-color">
       <div class="o-section-title">Baseline color</div>
-      Color on value increase
-      <ColorPickerWidget
-        currentColor="props.definition.baselineColorUp"
-        toggleColorPicker="() => this.toggleColorPicker('baselineColorUp')"
-        showColorPicker="state.openedColorPicker === 'baselineColorUp'"
-        onColorPicked="(color) => this.setColor(color, 'baselineColorUp')"
-        title="color_up"
-        icon="'o-spreadsheet-Icon.FILL_COLOR'"
-      />
-      <br/>
-      Color on value decrease
-      <ColorPickerWidget
-        currentColor="props.definition.baselineColorDown"
-        toggleColorPicker="() => this.toggleColorPicker('baselineColorDown')"
-        showColorPicker="state.openedColorPicker === 'baselineColorDown'"
-        onColorPicked="(color) => this.setColor(color, 'baselineColorDown')"
-        title="color_down"
-        icon="'o-spreadsheet-Icon.FILL_COLOR'"
-      />
+      <div class="d-flex align-items-center">
+        <span class="pe-1">Color on value increase</span>
+        <ColorPickerWidget
+          currentColor="props.definition.baselineColorUp"
+          toggleColorPicker="() => this.toggleColorPicker('baselineColorUp')"
+          showColorPicker="state.openedColorPicker === 'baselineColorUp'"
+          onColorPicked="(color) => this.setColor(color, 'baselineColorUp')"
+          title="color_up"
+          icon="'o-spreadsheet-Icon.FILL_COLOR'"
+        />
+      </div>
+      <div class="d-flex align-items-center">
+        <span class="pe-1">Color on value decrease</span>
+        <ColorPickerWidget
+          currentColor="props.definition.baselineColorDown"
+          toggleColorPicker="() => this.toggleColorPicker('baselineColorDown')"
+          showColorPicker="state.openedColorPicker === 'baselineColorDown'"
+          onColorPicked="(color) => this.setColor(color, 'baselineColorDown')"
+          title="color_down"
+          icon="'o-spreadsheet-Icon.FILL_COLOR'"
+        />
+      </div>
     </div>
   </t>
 </templates>

--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -5,20 +5,6 @@ import { css } from "../../helpers/css";
 
 css/* scss */ `
   .o-find-and-replace {
-    .o-far-item {
-      display: block;
-      .o-far-checkbox {
-        display: inline-block;
-        .o-far-input {
-          vertical-align: middle;
-        }
-        .o-far-label {
-          position: relative;
-          top: 1.5px;
-          padding-left: 4px;
-        }
-      }
-    }
     outline: none;
     height: 100%;
     .o-input-search-container {

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -19,39 +19,30 @@
         </div>
         <div>
           <!-- TODO: go through this css, the group misses a padding and could profit from BootStrap -->
-          <div class="o-far-item">
-            <label class="o-far-checkbox">
-              <input
-                t-model="state.searchOptions.matchCase"
-                t-on-change="updateSearch"
-                class="o-far-input"
-                type="checkbox"
-              />
-              <span class="o-far-label">Match case</span>
-            </label>
-          </div>
-          <div class="o-far-item">
-            <label class="o-far-checkbox">
-              <input
-                t-model="state.searchOptions.exactMatch"
-                t-on-change="updateSearch"
-                class="o-far-input"
-                type="checkbox"
-              />
-              <span class="o-far-label">Match entire cell content</span>
-            </label>
-          </div>
-          <div class="o-far-item">
-            <label class="o-far-checkbox">
-              <input
-                t-model="state.searchOptions.searchFormulas"
-                t-on-change="searchFormulas"
-                class="o-far-input"
-                type="checkbox"
-              />
-              <span class="o-far-label">Search in formulas</span>
-            </label>
-          </div>
+          <label class="o-checkbox mt-1">
+            <input
+              t-model="state.searchOptions.matchCase"
+              t-on-change="updateSearch"
+              type="checkbox"
+            />
+            <span>Match case</span>
+          </label>
+          <label class="o-checkbox">
+            <input
+              t-model="state.searchOptions.exactMatch"
+              t-on-change="updateSearch"
+              type="checkbox"
+            />
+            <span>Match entire cell content</span>
+          </label>
+          <label class="o-checkbox">
+            <input
+              t-model="state.searchOptions.searchFormulas"
+              t-on-change="searchFormulas"
+              type="checkbox"
+            />
+            <span>Search in formulas</span>
+          </label>
         </div>
       </div>
       <div class="o-sidePanelButtons">

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -132,12 +132,10 @@ css/* scss */ `
     }
 
     .o-checkbox {
-      label {
-        display: flex;
-        justify-items: center;
-        input {
-          margin-right: 5px;
-        }
+      display: flex;
+      justify-items: center;
+      input {
+        margin-right: 5px;
       }
     }
 

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.xml
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.xml
@@ -25,17 +25,15 @@
           placeholder="Add any characters or symbol"
         />
 
-        <div class="o-checkbox">
-          <label>
-            <input
-              type="checkbox"
-              name="add columns"
-              t-att-checked="state.addNewColumns"
-              t-on-change="updateAddNewColumnsCheckbox"
-            />
-            Add new columns to avoid overwriting cells
-          </label>
-        </div>
+        <label class="o-checkbox">
+          <input
+            type="checkbox"
+            name="add columns"
+            t-att-checked="state.addNewColumns"
+            t-on-change="updateAddNewColumnsCheckbox"
+          />
+          Add new columns to avoid overwriting cells
+        </label>
 
         <div class="o-sidePanelButtons">
           <button

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -20,13 +20,13 @@ const selectors = {
   replaceAllButton:
     ".o-sidePanel .o-find-and-replace .o-sidePanelButtons:nth-of-type(4) .o-sidePanelButton:nth-child(2)",
   checkBoxMatchingCase:
-    ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-far-item:nth-child(1) input",
+    ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-checkbox:nth-child(1) input",
   checkBoxExactMatch:
-    ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-far-item:nth-child(2) input",
+    ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-checkbox:nth-child(2) input",
   checkBoxSearchFormulas:
-    ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-far-item:nth-child(3) input",
+    ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-checkbox:nth-child(3) input",
   checkBoxReplaceFormulas:
-    ".o-sidePanel .o-find-and-replace .o-section:nth-child(3) .o-far-item:nth-child(3) input",
+    ".o-sidePanel .o-find-and-replace .o-section:nth-child(3) .o-checkbox:nth-child(3) input",
 };
 
 describe("find and replace sidePanel component", () => {

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -841,7 +841,7 @@ describe("Topbar - View", () => {
     await nextTick();
     await click(
       fixture,
-      ".o-sidePanel .o-sidePanelBody .o-find-and-replace .o-section:nth-child(1) .o-far-item:nth-child(3) input"
+      ".o-sidePanel .o-sidePanelBody .o-find-and-replace .o-section:nth-child(1) .o-checkbox:nth-child(3) input"
     );
     expect(model.getters.shouldShowFormulas()).toBe(false);
     await click(fixture, ".o-sidePanel .o-sidePanelHeader .o-sidePanelClose");


### PR DESCRIPTION
[FIX] chart panel: wrongly aligned ColorPicker

Since a component ColorPickerWidget was created, the color picker icon was
misaligned with its text in the chart side panels. Fix this issue.

[IMP] side-panels: use `o-checkbox` for all checkboxes

Some inputs din't use the `o-checkbox` class, and their labels and
checkboxes were sometime badly aligned. This commit uses the `o-checkbox`
class for all checkboxes.

Odoo task ID : [3380585](https://www.odoo.com/web#id=3380585&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo