### PR TITLE
[REF] ot_tests: use TEST_COMMANDS for ot test files

### DIFF
--- a/tests/collaborative/ot/ot.test.ts
+++ b/tests/collaborative/ot/ot.test.ts
@@ -1,12 +1,7 @@
 import { transform } from "../../../src/collaborative/ot/ot";
-import {
-  AddMergeCommand,
-  CreateFilterTableCommand,
-  DeleteFigureCommand,
-  UpdateChartCommand,
-  UpdateFigureCommand,
-} from "../../../src/types";
+import { DeleteFigureCommand, UpdateChartCommand, UpdateFigureCommand } from "../../../src/types";
 import { LineChartDefinition } from "../../../src/types/chart/line_chart";
+import { TEST_COMMANDS } from "../../test_helpers/constants";
 import { target } from "../../test_helpers/helpers";
 
 describe("OT with DELETE_FIGURE", () => {
@@ -37,27 +32,18 @@ describe("OT with DELETE_FIGURE", () => {
 });
 
 describe("OT with CREATE_FILTER_TABLE", () => {
-  const createTable: Omit<CreateFilterTableCommand, "target"> = {
-    type: "CREATE_FILTER_TABLE",
-    sheetId: "42",
-  };
-  const addMerge: Omit<AddMergeCommand, "target"> = {
-    type: "ADD_MERGE",
-    sheetId: "42",
-  };
-
-  describe.each([createTable, addMerge])(
+  describe.each([TEST_COMMANDS.CREATE_FILTER_TABLE, TEST_COMMANDS.ADD_MERGE])(
     "CREATE_FILTER_TABLE with CREATE_FILTER_TABLE & ADD_MERGE",
     (cmd) => {
       test("Overlapping target", () => {
         const zones = target("A1");
-        const createTableCmd = { ...createTable, target: zones };
+        const createTableCmd = { ...TEST_COMMANDS.CREATE_FILTER_TABLE, target: zones };
         const executed = { ...cmd, target: zones };
         expect(transform(createTableCmd, executed)).toBeUndefined();
       });
 
       test("distinct targets", () => {
-        const createTableCommand = { ...createTable, target: target("A1") };
+        const createTableCommand = { ...TEST_COMMANDS.CREATE_FILTER_TABLE, target: target("A1") };
         const executed = { ...cmd, target: target("B2") };
         expect(transform(createTableCommand, executed)).toEqual(createTableCommand);
       });

--- a/tests/collaborative/ot/ot_merged.test.ts
+++ b/tests/collaborative/ot/ot_merged.test.ts
@@ -1,120 +1,73 @@
 import { transform } from "../../../src/collaborative/ot/ot";
 import { toZone } from "../../../src/helpers";
-import {
-  AddMergeCommand,
-  ClearCellCommand,
-  ClearFormattingCommand,
-  CreateFilterTableCommand,
-  DeleteContentCommand,
-  RemoveMergeCommand,
-  SetBorderCommand,
-  SetFormattingCommand,
-  UpdateCellCommand,
-  UpdateCellPositionCommand,
-} from "../../../src/types";
+import { AddMergeCommand, CreateFilterTableCommand } from "../../../src/types";
+import { OT_TESTS_SINGLE_CELL_COMMANDS, TEST_COMMANDS } from "../../test_helpers/constants";
 import { target } from "../../test_helpers/helpers";
 
 describe("OT with ADD_MERGE", () => {
   const sheetId = "Sheet1";
   const addMerge: AddMergeCommand = {
-    type: "ADD_MERGE",
+    ...TEST_COMMANDS.ADD_MERGE,
     target: target("B2:C3"),
     sheetId,
   };
 
-  const updateCell: Omit<UpdateCellCommand, "row" | "col"> = {
-    type: "UPDATE_CELL",
-    sheetId,
-    content: "test",
-  };
-  const updateCellPosition: Omit<UpdateCellPositionCommand, "row" | "col"> = {
-    type: "UPDATE_CELL_POSITION",
-    cellId: "Id",
-    sheetId,
-  };
-  const clearCell: Omit<ClearCellCommand, "row" | "col"> = {
-    type: "CLEAR_CELL",
-    sheetId,
-  };
-  const setBorder: Omit<SetBorderCommand, "row" | "col"> = {
-    type: "SET_BORDER",
-    sheetId,
-    border: { left: { style: "thin", color: "#000" } },
-  };
+  describe.each(OT_TESTS_SINGLE_CELL_COMMANDS)("single cell commands", (cmd) => {
+    test(`${cmd.type} inside the merge`, () => {
+      const command = { ...cmd, sheetId, col: 2, row: 2 };
+      const result = transform(command, addMerge);
+      expect(result).toBeUndefined();
+    });
+    test(`${cmd.type} = the top-left of the merge`, () => {
+      const command = { ...cmd, sheetId, col: 1, row: 1 };
+      const result = transform(command, addMerge);
+      expect(result).toEqual(command);
+    });
+    test(`${cmd.type} outside the merge`, () => {
+      const command = { ...cmd, sheetId, col: 10, row: 10 };
+      const result = transform(command, addMerge);
+      expect(result).toEqual(command);
+    });
 
-  describe.each([updateCell, updateCellPosition, clearCell, setBorder])(
-    "single cell commands",
+    test(`${cmd.type} in another sheet`, () => {
+      const command = { ...cmd, col: 2, row: 1, sheetId: "42" };
+      const result = transform(command, addMerge);
+      expect(result).toEqual(command);
+    });
+  });
+
+  describe.each([
+    TEST_COMMANDS.DELETE_CONTENT,
+    TEST_COMMANDS.SET_FORMATTING,
+    TEST_COMMANDS.CLEAR_FORMATTING,
+  ])("target commands", (cmd) => {
+    test(`${cmd.type} outside merge`, () => {
+      const command = { ...cmd, sheetId, target: [toZone("E1:F2")] };
+      const result = transform(command, addMerge);
+      expect(result).toEqual(command);
+    });
+  });
+
+  describe.each([TEST_COMMANDS.ADD_MERGE, TEST_COMMANDS.REMOVE_MERGE])(
+    `ADD_MERGE & AddMerge | RemoveMerge`,
     (cmd) => {
-      test(`${cmd.type} inside the merge`, () => {
-        const command = { ...cmd, col: 2, row: 2 };
+      test("two distinct merges", () => {
+        const command = { ...cmd, sheetId, target: target("E1:F2") };
+        const result = transform(command, addMerge);
+        expect(result).toEqual(command);
+      });
+      test("two overlapping merges", () => {
+        const command = { ...cmd, sheetId, target: target("C3:D5") };
         const result = transform(command, addMerge);
         expect(result).toBeUndefined();
       });
-      test(`${cmd.type} = the top-left of the merge`, () => {
-        const command = { ...cmd, col: 1, row: 1 };
-        const result = transform(command, addMerge);
-        expect(result).toEqual(command);
-      });
-      test(`${cmd.type} outside the merge`, () => {
-        const command = { ...cmd, col: 10, row: 10 };
-        const result = transform(command, addMerge);
-        expect(result).toEqual(command);
-      });
-
-      test(`${cmd.type} in another sheet`, () => {
-        const command = { ...cmd, col: 2, row: 1, sheetId: "42" };
+      test("two overlapping merges in different sheets", () => {
+        const command = { ...cmd, target: target("C3:D5"), sheetId: "another sheet" };
         const result = transform(command, addMerge);
         expect(result).toEqual(command);
       });
     }
   );
-
-  const deleteContent: Omit<DeleteContentCommand, "target"> = {
-    type: "DELETE_CONTENT",
-    sheetId,
-  };
-
-  const setFormatting: Omit<SetFormattingCommand, "target"> = {
-    type: "SET_FORMATTING",
-    sheetId,
-    style: { fillColor: "#000000" },
-  };
-
-  const clearFormatting: Omit<ClearFormattingCommand, "target"> = {
-    type: "CLEAR_FORMATTING",
-    sheetId,
-  };
-
-  describe.each([deleteContent, setFormatting, clearFormatting])("target commands", (cmd) => {
-    test(`${cmd.type} outside merge`, () => {
-      const command = { ...cmd, target: [toZone("E1:F2")] };
-      const result = transform(command, addMerge);
-      expect(result).toEqual(command);
-    });
-  });
-
-  const removeMerge: Omit<RemoveMergeCommand, "target"> = {
-    type: "REMOVE_MERGE",
-    sheetId,
-  };
-
-  describe.each([addMerge, removeMerge])(`ADD_MERGE & AddMerge | RemoveMerge`, (cmd) => {
-    test("two distinct merges", () => {
-      const command = { ...cmd, target: target("E1:F2") };
-      const result = transform(command, addMerge);
-      expect(result).toEqual(command);
-    });
-    test("two overlapping merges", () => {
-      const command = { ...cmd, target: target("C3:D5") };
-      const result = transform(command, addMerge);
-      expect(result).toBeUndefined();
-    });
-    test("two overlapping merges in different sheets", () => {
-      const command = { ...cmd, target: target("C3:D5"), sheetId: "another sheet" };
-      const result = transform(command, addMerge);
-      expect(result).toEqual(command);
-    });
-  });
 
   const createTable: Omit<CreateFilterTableCommand, "target"> = {
     type: "CREATE_FILTER_TABLE",
@@ -124,13 +77,13 @@ describe("OT with ADD_MERGE", () => {
   describe("ADD_MERGE with CREATE_FILTER_TABLE", () => {
     test("Merge overlapping filter table", () => {
       const zones = target("A1");
-      const addMergeCmd = { ...addMerge, target: zones };
+      const addMergeCmd = { ...TEST_COMMANDS.ADD_MERGE, sheetId, target: zones };
       const createTableCmd = { ...createTable, target: zones };
       expect(transform(addMergeCmd, createTableCmd)).toBeUndefined();
     });
 
     test("Merge not overlapping filter table", () => {
-      const addMergeCmd = { ...addMerge, target: target("A1") };
+      const addMergeCmd = { ...TEST_COMMANDS.ADD_MERGE, sheetId, target: target("A1") };
       const createTableCmd = { ...createTable, target: target("B2") };
       expect(transform(addMergeCmd, createTableCmd)).toEqual(addMergeCmd);
     });

--- a/tests/collaborative/ot/ot_rows_removed.test.ts
+++ b/tests/collaborative/ot/ot_rows_removed.test.ts
@@ -2,24 +2,18 @@ import { transform } from "../../../src/collaborative/ot/ot";
 import { toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
-  AddConditionalFormatCommand,
-  AddMergeCommand,
-  ClearCellCommand,
-  ClearFormattingCommand,
-  CreateFilterTableCommand,
-  DeleteContentCommand,
   FreezeColumnsCommand,
   FreezeRowsCommand,
   RemoveColumnsRowsCommand,
-  RemoveFilterTableCommand,
-  RemoveMergeCommand,
   ResizeColumnsRowsCommand,
-  SetBorderCommand,
-  SetFormattingCommand,
-  UpdateCellCommand,
-  UpdateCellPositionCommand,
 } from "../../../src/types";
-import { createEqualCF, target, toRangesData } from "../../test_helpers/helpers";
+import {
+  OT_TESTS_RANGE_DEPENDANT_COMMANDS,
+  OT_TESTS_SINGLE_CELL_COMMANDS,
+  OT_TESTS_TARGET_DEPENDANT_COMMANDS,
+  TEST_COMMANDS,
+} from "../../test_helpers/constants";
+import { target, toRangesData } from "../../test_helpers/helpers";
 
 describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
   const sheetId = "Sheet1";
@@ -30,163 +24,106 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
     sheetId,
   };
 
-  const updateCell: Omit<UpdateCellCommand, "row"> = {
-    type: "UPDATE_CELL",
-    sheetId,
-    content: "test",
-    col: 1,
-  };
-  const updateCellPosition: Omit<UpdateCellPositionCommand, "row"> = {
-    type: "UPDATE_CELL_POSITION",
-    cellId: "Id",
-    sheetId,
-    col: 1,
-  };
-  const clearCell: Omit<ClearCellCommand, "row"> = {
-    type: "CLEAR_CELL",
-    sheetId,
-    col: 1,
-  };
-  const setBorder: Omit<SetBorderCommand, "row"> = {
-    type: "SET_BORDER",
-    sheetId,
-    col: 1,
-    border: { left: { style: "thin", color: "#000" } },
-  };
-  describe.each([updateCell, updateCellPosition, clearCell, setBorder])(
-    "single cell commands",
-    (cmd) => {
-      test(`remove rows before ${cmd.type}`, () => {
-        const command = { ...cmd, row: 10 };
-        const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, row: 7 });
-      });
-      test(`remove rows after ${cmd.type}`, () => {
-        const command = { ...cmd, row: 1 };
-        const result = transform(command, removeRows);
-        expect(result).toEqual(command);
-      });
-      test(`remove rows before and after ${cmd.type}`, () => {
-        const command = { ...cmd, row: 4 };
-        const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, row: 2 });
-      });
-      test(`${cmd.type} in removed rows`, () => {
-        const command = { ...cmd, row: 2 };
-        const result = transform(command, removeRows);
-        expect(result).toBeUndefined();
-      });
-      test(`${cmd.type} and rows removed in different sheets`, () => {
-        const command = { ...cmd, row: 10, sheetId: "42" };
-        const result = transform(command, removeRows);
-        expect(result).toEqual(command);
-      });
-      test(`with many row elements in growing order`, () => {
-        const command = { ...cmd, row: 8 };
-        const result = transform(command, { ...removeRows, elements: [2, 3, 4, 5, 6] });
-        expect(result).toEqual({ ...cmd, row: 3 });
-      });
-    }
-  );
-
-  const deleteContent: Omit<DeleteContentCommand, "target"> = {
-    type: "DELETE_CONTENT",
-    sheetId,
-  };
-
-  const setFormatting: Omit<SetFormattingCommand, "target"> = {
-    type: "SET_FORMATTING",
-    sheetId,
-    style: { fillColor: "#000000" },
-  };
-
-  const clearFormatting: Omit<ClearFormattingCommand, "target"> = {
-    type: "CLEAR_FORMATTING",
-    sheetId,
-  };
-
-  const addConditionalFormat: Omit<AddConditionalFormatCommand, "ranges"> = {
-    type: "ADD_CONDITIONAL_FORMAT",
-    sheetId,
-    cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-  };
-
-  const createFilters: Omit<CreateFilterTableCommand, "target"> = {
-    type: "CREATE_FILTER_TABLE",
-    sheetId,
-  };
-
-  const removeFilters: Omit<RemoveFilterTableCommand, "target"> = {
-    type: "REMOVE_FILTER_TABLE",
-    sheetId,
-  };
-
-  describe.each([deleteContent, setFormatting, clearFormatting, createFilters, removeFilters])(
-    "target commands",
-    (cmd) => {
-      test(`remove rows after ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A1:C1")] };
-        const result = transform(command, removeRows);
-        expect(result).toEqual(command);
-      });
-      test(`remove rows before ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A12:B14")] };
-        const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, target: [toZone("A9:B11")] });
-      });
-      test(`remove rows before and after ${cmd.type}`, () => {
-        const command = { ...cmd, target: [toZone("A5:B5")] };
-        const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, target: [toZone("A3:B3")] });
-      });
-      test(`${cmd.type} in removed rows`, () => {
-        const command = { ...cmd, target: [toZone("A6:B7")] };
-        const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, target: [toZone("A4:B4")] });
-      });
-      test(`${cmd.type} and rows removed in different sheets`, () => {
-        const command = { ...cmd, target: [toZone("A1:C6")], sheetId: "42" };
-        const result = transform(command, removeRows);
-        expect(result).toEqual(command);
-      });
-      test(`${cmd.type} with a target removed`, () => {
-        const command = { ...cmd, target: [toZone("A3:B4")] };
-        const result = transform(command, removeRows);
-        expect(result).toBeUndefined();
-      });
-      test(`${cmd.type} with a target removed, but another valid`, () => {
-        const command = { ...cmd, target: [toZone("A3:B4"), toZone("A1")] };
-        const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, target: [toZone("A1")] });
-      });
-    }
-  );
-
-  describe.each([addConditionalFormat])("Range dependant commands", (cmd) => {
+  describe.each(OT_TESTS_SINGLE_CELL_COMMANDS)("single cell commands", (cmd) => {
+    test(`remove rows before ${cmd.type}`, () => {
+      const command = { ...cmd, sheetId, row: 10 };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, row: 7 });
+    });
     test(`remove rows after ${cmd.type}`, () => {
-      const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "A1:C1") };
+      const command = { ...cmd, sheetId, row: 1 };
+      const result = transform(command, removeRows);
+      expect(result).toEqual(command);
+    });
+    test(`remove rows before and after ${cmd.type}`, () => {
+      const command = { ...cmd, sheetId, row: 4 };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, row: 2 });
+    });
+    test(`${cmd.type} in removed rows`, () => {
+      const command = { ...cmd, sheetId, row: 2 };
+      const result = transform(command, removeRows);
+      expect(result).toBeUndefined();
+    });
+    test(`${cmd.type} and rows removed in different sheets`, () => {
+      const command = { ...cmd, row: 10, sheetId: "42" };
+      const result = transform(command, removeRows);
+      expect(result).toEqual(command);
+    });
+    test(`with many row elements in growing order`, () => {
+      const command = { ...cmd, sheetId, row: 8 };
+      const result = transform(command, { ...removeRows, elements: [2, 3, 4, 5, 6] });
+      expect(result).toEqual({ ...command, row: 3 });
+    });
+  });
+
+  describe.each(OT_TESTS_TARGET_DEPENDANT_COMMANDS)("target commands", (cmd) => {
+    test(`remove rows after ${cmd.type}`, () => {
+      const command = { ...cmd, sheetId, target: [toZone("A1:C1")] };
       const result = transform(command, removeRows);
       expect(result).toEqual(command);
     });
     test(`remove rows before ${cmd.type}`, () => {
-      const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "A12:B14") };
+      const command = { ...cmd, sheetId, target: [toZone("A12:B14")] };
       const result = transform(command, removeRows);
-      expect(result).toEqual({ ...command, ranges: toRangesData(cmd.sheetId, "A9:B11") });
-    });
-    test(`remove rows before ${cmd.type} in the sheet of the ranges`, () => {
-      const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "A12:B14"), sheetId: "42" };
-      const result = transform(command, removeRows);
-      expect(result).toEqual({ ...command, ranges: toRangesData(cmd.sheetId, "A9:B11") });
+      expect(result).toEqual({ ...command, target: [toZone("A9:B11")] });
     });
     test(`remove rows before and after ${cmd.type}`, () => {
-      const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "A5:B5") };
+      const command = { ...cmd, sheetId, target: [toZone("A5:B5")] };
       const result = transform(command, removeRows);
-      expect(result).toEqual({ ...command, ranges: toRangesData(cmd.sheetId, "A3:B3") });
+      expect(result).toEqual({ ...command, target: [toZone("A3:B3")] });
     });
     test(`${cmd.type} in removed rows`, () => {
-      const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "A6:B7") };
+      const command = { ...cmd, sheetId, target: [toZone("A6:B7")] };
       const result = transform(command, removeRows);
-      expect(result).toEqual({ ...command, ranges: toRangesData(cmd.sheetId, "A4:B4") });
+      expect(result).toEqual({ ...command, target: [toZone("A4:B4")] });
+    });
+    test(`${cmd.type} and rows removed in different sheets`, () => {
+      const command = { ...cmd, target: [toZone("A1:C6")], sheetId: "42" };
+      const result = transform(command, removeRows);
+      expect(result).toEqual(command);
+    });
+    test(`${cmd.type} with a target removed`, () => {
+      const command = { ...cmd, sheetId, target: [toZone("A3:B4")] };
+      const result = transform(command, removeRows);
+      expect(result).toBeUndefined();
+    });
+    test(`${cmd.type} with a target removed, but another valid`, () => {
+      const command = { ...cmd, sheetId, target: [toZone("A3:B4"), toZone("A1")] };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, target: [toZone("A1")] });
+    });
+  });
+
+  describe.each(OT_TESTS_RANGE_DEPENDANT_COMMANDS)("Range dependant commands", (cmd) => {
+    test(`remove rows after ${cmd.type}`, () => {
+      const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "A1:C1") };
+      const result = transform(command, removeRows);
+      expect(result).toEqual(command);
+    });
+    test(`remove rows before ${cmd.type}`, () => {
+      const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "A12:B14") };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "A9:B11") });
+    });
+    test(`remove rows before ${cmd.type} in the sheet of the ranges`, () => {
+      const command = {
+        ...cmd,
+        ranges: toRangesData(sheetId, "A12:B14"),
+        sheetId: "42",
+      };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "A9:B11") });
+    });
+    test(`remove rows before and after ${cmd.type}`, () => {
+      const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "A5:B5") };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "A3:B3") });
+    });
+    test(`${cmd.type} in removed rows`, () => {
+      const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "A6:B7") };
+      const result = transform(command, removeRows);
+      expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "A4:B4") });
     });
     test(`${cmd.type} and rows removed in different sheets`, () => {
       const command = { ...cmd, ranges: toRangesData("42", "A1:C6"), sheetId: "42" };
@@ -194,41 +131,41 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
       expect(result).toEqual(command);
     });
     test(`${cmd.type} with a target removed`, () => {
-      const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "A3:B4") };
+      const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "A3:B4") };
       const result = transform(command, removeRows);
       expect(result).toBeUndefined();
     });
     test(`${cmd.type} with a target removed, but another valid`, () => {
-      const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "A3:B4, A1") };
+      const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "A3:B4, A1") };
       const result = transform(command, removeRows);
-      expect(result).toEqual({ ...command, ranges: toRangesData(cmd.sheetId, "A1") });
+      expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "A1") });
     });
 
     describe("With unbounded ranges", () => {
       test(`remove rows after ${cmd.type}`, () => {
-        const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "1:1") };
+        const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "1:1") };
         const result = transform(command, removeRows);
         expect(result).toEqual(command);
       });
       test(`remove rows before ${cmd.type}`, () => {
-        const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "A12:14") };
+        const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "A12:14") };
         const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, ranges: toRangesData(cmd.sheetId, "A9:11") });
+        expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "A9:11") });
       });
       test(`${cmd.type} in removed rows`, () => {
-        const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "6:7") };
+        const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "6:7") };
         const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, ranges: toRangesData(cmd.sheetId, "4:4") });
+        expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "4:4") });
       });
       test(`${cmd.type} with a target removed`, () => {
-        const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "C3:4") };
+        const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "C3:4") };
         const result = transform(command, removeRows);
         expect(result).toBeUndefined();
       });
       test(`${cmd.type} with a target removed, but another valid`, () => {
-        const command = { ...cmd, ranges: toRangesData(cmd.sheetId, "3:4,1:1") };
+        const command = { ...cmd, sheetId, ranges: toRangesData(sheetId, "3:4,1:1") };
         const result = transform(command, removeRows);
-        expect(result).toEqual({ ...command, ranges: toRangesData(cmd.sheetId, "1:1") });
+        expect(result).toEqual({ ...command, ranges: toRangesData(sheetId, "1:1") });
       });
     });
   });
@@ -350,46 +287,41 @@ describe("OT with REMOVE_COLUMNS_ROWS with dimension ROW", () => {
     });
   });
 
-  const addMerge: Omit<AddMergeCommand, "target"> = {
-    type: "ADD_MERGE",
-    sheetId,
-  };
-  const removeMerge: Omit<RemoveMergeCommand, "target"> = {
-    type: "REMOVE_MERGE",
-    sheetId,
-  };
-  describe.each([addMerge, removeMerge])("Remove Columns - Merge", (cmd) => {
-    test(`remove rows before Merge`, () => {
-      const command = { ...cmd, target: target("A1:C1") };
-      const result = transform(command, removeRows);
-      expect(result).toEqual(command);
-    });
-    test(`remove rows after Merge`, () => {
-      const command = { ...cmd, target: target("A12:B14") };
-      const result = transform(command, removeRows);
-      expect(result).toEqual({ ...command, target: target("A9:B11") });
-    });
-    test(`remove rows before and after Merge`, () => {
-      const command = { ...cmd, target: target("A5:B5") };
-      const result = transform(command, removeRows);
-      expect(result).toEqual({ ...command, target: target("A3:B3") });
-    });
-    test(`Merge in removed rows`, () => {
-      const command = { ...cmd, target: target("A6:B7") };
-      const result = transform(command, removeRows);
-      expect(result).toEqual({ ...command, target: target("A4:B4") });
-    });
-    test(`Merge and rows removed in different sheets`, () => {
-      const command = { ...cmd, target: target("A1:C6"), sheetId: "42" };
-      const result = transform(command, removeRows);
-      expect(result).toEqual(command);
-    });
-    test(`Merge with a target removed`, () => {
-      const command = { ...cmd, target: target("A3:B4") };
-      const result = transform(command, removeRows);
-      expect(result).toBeUndefined();
-    });
-  });
+  describe.each([TEST_COMMANDS.ADD_MERGE, TEST_COMMANDS.REMOVE_MERGE])(
+    "Remove Columns - Merge",
+    (cmd) => {
+      test(`remove rows before Merge`, () => {
+        const command = { ...cmd, sheetId, target: target("A1:C1") };
+        const result = transform(command, removeRows);
+        expect(result).toEqual(command);
+      });
+      test(`remove rows after Merge`, () => {
+        const command = { ...cmd, sheetId, target: target("A12:B14") };
+        const result = transform(command, removeRows);
+        expect(result).toEqual({ ...command, target: target("A9:B11") });
+      });
+      test(`remove rows before and after Merge`, () => {
+        const command = { ...cmd, sheetId, target: target("A5:B5") };
+        const result = transform(command, removeRows);
+        expect(result).toEqual({ ...command, target: target("A3:B3") });
+      });
+      test(`Merge in removed rows`, () => {
+        const command = { ...cmd, sheetId, target: target("A6:B7") };
+        const result = transform(command, removeRows);
+        expect(result).toEqual({ ...command, target: target("A4:B4") });
+      });
+      test(`Merge and rows removed in different sheets`, () => {
+        const command = { ...cmd, target: target("A1:C6"), sheetId: "42" };
+        const result = transform(command, removeRows);
+        expect(result).toEqual(command);
+      });
+      test(`Merge with a target removed`, () => {
+        const command = { ...cmd, sheetId, target: target("A3:B4") };
+        const result = transform(command, removeRows);
+        expect(result).toBeUndefined();
+      });
+    }
+  );
 
   describe("Removing column does not transform commands in dimension 'ROW'", () => {
     const addColumnsAfter: AddColumnsRowsCommand = {

--- a/tests/collaborative/ot/ot_sheet_deleted.test.ts
+++ b/tests/collaborative/ot/ot_sheet_deleted.test.ts
@@ -3,177 +3,72 @@ import { toZone } from "../../../src/helpers";
 import {
   AddColumnsRowsCommand,
   AddConditionalFormatCommand,
-  AddMergeCommand,
-  ClearCellCommand,
-  ClearFormattingCommand,
-  CreateChartCommand,
-  CreateFigureCommand,
-  CreateFilterTableCommand,
-  DeleteContentCommand,
   DeleteSheetCommand,
   DuplicateSheetCommand,
-  Figure,
-  HideSheetCommand,
   MoveRangeCommand,
-  MoveSheetCommand,
   RemoveColumnsRowsCommand,
-  RemoveConditionalFormatCommand,
-  RemoveFilterTableCommand,
-  RemoveMergeCommand,
-  RenameSheetCommand,
   ResizeColumnsRowsCommand,
-  SetBorderCommand,
-  SetFormattingCommand,
-  ShowSheetCommand,
-  UpdateCellCommand,
-  UpdateCellPositionCommand,
 } from "../../../src/types";
-import { createEqualCF, target, toRangesData } from "../../test_helpers/helpers";
+import {
+  OT_TESTS_RANGE_DEPENDANT_COMMANDS,
+  OT_TESTS_SINGLE_CELL_COMMANDS,
+  OT_TESTS_TARGET_DEPENDANT_COMMANDS,
+  TEST_COMMANDS,
+} from "../../test_helpers/constants";
+import { toRangesData } from "../../test_helpers/helpers";
 
 describe("OT with DELETE_SHEET", () => {
   const deletedSheetId = "deletedSheet";
   const sheetId = "stillPresent";
   const deleteSheet: DeleteSheetCommand = { type: "DELETE_SHEET", sheetId: deletedSheetId };
 
-  const updateCell: Omit<UpdateCellCommand, "sheetId"> = { type: "UPDATE_CELL", col: 0, row: 0 };
-  const updateCellPosition: Omit<UpdateCellPositionCommand, "sheetId"> = {
-    type: "UPDATE_CELL_POSITION",
-    col: 0,
-    row: 0,
-    cellId: "ID",
-  };
-  const clearCell: Omit<ClearCellCommand, "sheetId"> = { type: "CLEAR_CELL", col: 0, row: 0 };
-  const deleteContent: Omit<DeleteContentCommand, "sheetId"> = {
-    type: "DELETE_CONTENT",
-    target: [toZone("A1")],
-  };
   const addColumns: Omit<AddColumnsRowsCommand, "sheetId"> = {
-    type: "ADD_COLUMNS_ROWS",
+    ...TEST_COMMANDS.ADD_COLUMNS_ROWS,
     dimension: "COL",
-    base: 0,
-    position: "after",
-    quantity: 1,
   };
   const addRows: Omit<AddColumnsRowsCommand, "sheetId"> = {
-    type: "ADD_COLUMNS_ROWS",
+    ...TEST_COMMANDS.ADD_COLUMNS_ROWS,
     dimension: "ROW",
-    base: 1,
-    position: "after",
-    quantity: 1,
   };
-  const removeColumn: Omit<RemoveColumnsRowsCommand, "sheetId"> = {
-    type: "REMOVE_COLUMNS_ROWS",
+  const removeColumn: RemoveColumnsRowsCommand = {
+    ...TEST_COMMANDS.REMOVE_COLUMNS_ROWS,
     dimension: "COL",
-    elements: [0],
   };
-  const removeRows: Omit<RemoveColumnsRowsCommand, "sheetId"> = {
-    type: "REMOVE_COLUMNS_ROWS",
-    elements: [0],
+  const removeRows: RemoveColumnsRowsCommand = {
+    ...TEST_COMMANDS.REMOVE_COLUMNS_ROWS,
     dimension: "ROW",
   };
-  const addMerge: Omit<AddMergeCommand, "sheetId"> = { type: "ADD_MERGE", target: target("A1:B1") };
-  const removeMerge: Omit<RemoveMergeCommand, "sheetId"> = {
-    type: "REMOVE_MERGE",
-    target: target("A1:B1"),
-  };
-  const moveSheet: Omit<MoveSheetCommand, "sheetId"> = { type: "MOVE_SHEET", delta: -1 };
-  const renameSheet: Omit<RenameSheetCommand, "sheetId"> = { type: "RENAME_SHEET", name: "test" };
-  const hideSheet: Omit<HideSheetCommand, "sheetId"> = { type: "HIDE_SHEET" };
-  const showSheet: Omit<ShowSheetCommand, "sheetId"> = { type: "SHOW_SHEET" };
-  const addCF: Omit<AddConditionalFormatCommand, "sheetId"> = {
-    type: "ADD_CONDITIONAL_FORMAT",
-    cf: createEqualCF("test", { fillColor: "orange" }, "id"),
-    ranges: toRangesData(sheetId, "A1:B1"),
-  };
-  const createFigure: Omit<CreateFigureCommand, "sheetId"> = {
-    type: "CREATE_FIGURE",
-    figure: {} as Figure,
-  };
-  const setFormatting: Omit<SetFormattingCommand, "sheetId"> = {
-    type: "SET_FORMATTING",
-    target: [toZone("A1")],
-  };
-  const clearFormatting: Omit<ClearFormattingCommand, "sheetId"> = {
-    type: "CLEAR_FORMATTING",
-    target: [toZone("A1")],
-  };
-  const setBorder: Omit<SetBorderCommand, "sheetId"> = {
-    type: "SET_BORDER",
-    col: 0,
-    row: 0,
-    border: undefined,
-  };
-  const createChart: Omit<CreateChartCommand, "sheetId"> = {
-    type: "CREATE_CHART",
-    id: "1",
-    definition: {} as any,
-  };
-  const resizeColumns: Omit<ResizeColumnsRowsCommand, "sheetId"> = {
-    type: "RESIZE_COLUMNS_ROWS",
+
+  const resizeColumns: ResizeColumnsRowsCommand = {
+    ...TEST_COMMANDS.RESIZE_COLUMNS_ROWS,
     dimension: "COL",
-    elements: [1],
-    size: 10,
   };
-  const resizeRows: Omit<ResizeColumnsRowsCommand, "sheetId"> = {
-    type: "RESIZE_COLUMNS_ROWS",
+  const resizeRows: ResizeColumnsRowsCommand = {
+    ...TEST_COMMANDS.RESIZE_COLUMNS_ROWS,
     dimension: "ROW",
-    elements: [1],
-    size: 10,
-  };
-  const removeConditionalFormatting: Omit<RemoveConditionalFormatCommand, "sheetId"> = {
-    type: "REMOVE_CONDITIONAL_FORMAT",
-    id: "789",
-  };
-  const otherDeleteSheet: Omit<DeleteSheetCommand, "sheetId"> = {
-    type: "DELETE_SHEET",
-  };
-
-  const moveRanges: Omit<MoveRangeCommand, "sheetId"> = {
-    type: "MOVE_RANGES",
-    targetSheetId: sheetId,
-    col: 0,
-    row: 0,
-    target: [toZone("A1")],
-  };
-
-  const createFilters: Omit<CreateFilterTableCommand, "sheetId"> = {
-    type: "CREATE_FILTER_TABLE",
-    target: [toZone("A1:A5")],
-  };
-
-  const removeFilters: Omit<RemoveFilterTableCommand, "sheetId"> = {
-    type: "REMOVE_FILTER_TABLE",
-    target: [toZone("A1:A5")],
   };
 
   describe.each([
-    updateCell,
-    updateCellPosition,
-    clearCell,
-    deleteContent,
+    ...OT_TESTS_SINGLE_CELL_COMMANDS,
+    ...OT_TESTS_TARGET_DEPENDANT_COMMANDS,
+    ...OT_TESTS_RANGE_DEPENDANT_COMMANDS,
     addColumns,
     addRows,
     removeColumn,
     removeRows,
-    addMerge,
-    removeMerge,
-    moveSheet,
-    hideSheet,
-    showSheet,
-    renameSheet,
-    addCF,
-    createFigure,
-    setFormatting,
-    clearFormatting,
-    setBorder,
-    createChart,
+    TEST_COMMANDS.ADD_MERGE,
+    TEST_COMMANDS.REMOVE_MERGE,
+    TEST_COMMANDS.MOVE_SHEET,
+    TEST_COMMANDS.HIDE_SHEET,
+    TEST_COMMANDS.SHOW_SHEET,
+    TEST_COMMANDS.RENAME_SHEET,
+    TEST_COMMANDS.CREATE_FIGURE,
+    TEST_COMMANDS.CREATE_CHART,
     resizeColumns,
     resizeRows,
-    removeConditionalFormatting,
-    otherDeleteSheet,
-    moveRanges,
-    createFilters,
-    removeFilters,
+    TEST_COMMANDS.REMOVE_CONDITIONAL_FORMAT,
+    TEST_COMMANDS.DELETE_SHEET,
+    TEST_COMMANDS.MOVE_RANGES,
   ])("Delete sheet", (cmd) => {
     test("Delete the sheet on which the command is triggered", () => {
       const result = transform({ ...cmd, sheetId: deletedSheetId }, deleteSheet);
@@ -199,7 +94,7 @@ describe("OT with DELETE_SHEET", () => {
     });
 
     test("Delete the sheet on which the command is triggered", () => {
-      const command = { ...cmd, sheetId: sheetId };
+      const command = { ...cmd, sheetId };
       const result = transform(command, deleteSheet);
       expect(result).toEqual(command);
     });
@@ -220,7 +115,7 @@ describe("OT with DELETE_SHEET", () => {
     });
 
     test("Delete another sheet", () => {
-      const command = { ...cmd, targetSheetId: sheetId };
+      const command = { ...cmd, sheetId, targetSheetId: sheetId };
       const result = transform(command, deleteSheet);
       expect(result).toEqual(command);
     });
@@ -235,10 +130,7 @@ describe("OT with DELETE_SHEET", () => {
   });
 
   describe("Delete sheet with range dependant command", () => {
-    const addCF: Omit<AddConditionalFormatCommand, "sheetId" | "ranges"> = {
-      type: "ADD_CONDITIONAL_FORMAT",
-      cf: createEqualCF("test", { fillColor: "orange" }, "id"),
-    };
+    const addCF: AddConditionalFormatCommand = { ...TEST_COMMANDS.ADD_CONDITIONAL_FORMAT };
 
     test("Delete the sheet of the command", () => {
       const cmd = { ...addCF, sheetId: deletedSheetId, ranges: toRangesData(sheetId, "A1:B1") };
@@ -259,7 +151,7 @@ describe("OT with DELETE_SHEET", () => {
         ranges: [...toRangesData(deletedSheetId, "A1:B1"), ...toRangesData(sheetId, "A1:B1")],
       };
       const result = transform(cmd, deleteSheet);
-      expect(result).toEqual({ ...cmd, ranges: toRangesData(cmd.sheetId, "A1:B1") });
+      expect(result).toEqual({ ...cmd, ranges: toRangesData(sheetId, "A1:B1") });
     });
   });
 });

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -50,14 +50,20 @@ type CommandMapping = {
   [key in CoreCommandTypes]: Extract<CoreCommand, { type: key }>;
 };
 
-// TODO : use this in ot_*.test.ts files. should be at least -400 lines of code
-const TEST_COMMANDS_PARTIAL: Partial<CommandMapping> = {
+export const TEST_COMMANDS: CommandMapping = {
   UPDATE_CELL: {
     type: "UPDATE_CELL",
     col: 0,
     row: 0,
     content: "hello",
     sheetId: "sheetId",
+  },
+  UPDATE_CELL_POSITION: {
+    type: "UPDATE_CELL_POSITION",
+    cellId: "Id",
+    sheetId: "sheetId",
+    row: 0,
+    col: 0,
   },
   CLEAR_CELL: {
     type: "CLEAR_CELL",
@@ -123,6 +129,24 @@ const TEST_COMMANDS_PARTIAL: Partial<CommandMapping> = {
     sheetId: "sheetId",
     sheetIdTo: "duplicateSheetId",
   },
+  MOVE_SHEET: {
+    type: "MOVE_SHEET",
+    sheetId: "sheetId",
+    delta: -1,
+  },
+  DELETE_SHEET: {
+    type: "DELETE_SHEET",
+    sheetId: "sheetId",
+  },
+  RENAME_SHEET: {
+    type: "RENAME_SHEET",
+    sheetId: "sheetId",
+    name: "newName",
+  },
+  SHOW_SHEET: {
+    type: "SHOW_SHEET",
+    sheetId: "sheetId",
+  },
   ADD_CONDITIONAL_FORMAT: {
     type: "ADD_CONDITIONAL_FORMAT",
     ranges: toRangesData("sheetId", "A1"),
@@ -137,6 +161,17 @@ const TEST_COMMANDS_PARTIAL: Partial<CommandMapping> = {
     },
     sheetId: "sheetId",
   },
+  REMOVE_CONDITIONAL_FORMAT: {
+    type: "REMOVE_CONDITIONAL_FORMAT",
+    id: "cfId",
+    sheetId: "sheetId",
+  },
+  MOVE_CONDITIONAL_FORMAT: {
+    type: "MOVE_CONDITIONAL_FORMAT",
+    sheetId: "sheetId",
+    cfId: "cfId",
+    direction: "up",
+  },
   CREATE_FIGURE: {
     type: "CREATE_FIGURE",
     figure: {
@@ -149,11 +184,27 @@ const TEST_COMMANDS_PARTIAL: Partial<CommandMapping> = {
     },
     sheetId: "sheetId",
   },
+  DELETE_FIGURE: {
+    type: "DELETE_FIGURE",
+    id: "figureId",
+    sheetId: "sheetId",
+  },
+  UPDATE_FIGURE: {
+    type: "UPDATE_FIGURE",
+    id: "figureId",
+    sheetId: "sheetId",
+  },
   CREATE_CHART: {
     type: "CREATE_CHART",
     definition: TEST_CHART_DATA.basicChart,
     position: { x: 0, y: 0 },
     size: { width: 200, height: 200 },
+    id: "figureId",
+    sheetId: "sheetId",
+  },
+  UPDATE_CHART: {
+    type: "UPDATE_CHART",
+    definition: TEST_CHART_DATA.basicChart,
     id: "figureId",
     sheetId: "sheetId",
   },
@@ -180,5 +231,80 @@ const TEST_COMMANDS_PARTIAL: Partial<CommandMapping> = {
     quantity: 1,
     sheetId: "sheetId",
   },
+  REMOVE_COLUMNS_ROWS: {
+    type: "REMOVE_COLUMNS_ROWS",
+    dimension: "ROW",
+    elements: [0],
+    sheetId: "sheetId",
+  },
+  FREEZE_COLUMNS: {
+    type: "FREEZE_COLUMNS",
+    sheetId: "sheetId",
+    quantity: 1,
+  },
+  FREEZE_ROWS: {
+    type: "FREEZE_ROWS",
+    sheetId: "sheetId",
+    quantity: 1,
+  },
+  UNFREEZE_COLUMNS: {
+    type: "UNFREEZE_COLUMNS",
+    sheetId: "sheetId",
+  },
+  UNFREEZE_ROWS: {
+    type: "UNFREEZE_ROWS",
+    sheetId: "sheetId",
+  },
+  UNFREEZE_COLUMNS_ROWS: {
+    type: "UNFREEZE_COLUMNS_ROWS",
+    sheetId: "sheetId",
+  },
+  HIDE_COLUMNS_ROWS: {
+    type: "HIDE_COLUMNS_ROWS",
+    dimension: "ROW",
+    elements: [0],
+    sheetId: "sheetId",
+  },
+  UNHIDE_COLUMNS_ROWS: {
+    type: "UNHIDE_COLUMNS_ROWS",
+    dimension: "ROW",
+    elements: [0],
+    sheetId: "sheetId",
+  },
+  SET_GRID_LINES_VISIBILITY: {
+    type: "SET_GRID_LINES_VISIBILITY",
+    sheetId: "sheetId",
+    areGridLinesVisible: true,
+  },
+  MOVE_RANGES: {
+    type: "MOVE_RANGES",
+    target: target("A1"),
+    sheetId: "sheetId",
+    targetSheetId: "sheetId",
+    col: 0,
+    row: 0,
+  },
+  SET_ZONE_BORDERS: {
+    type: "SET_ZONE_BORDERS",
+    sheetId: "sheetId",
+    target: target("A1"),
+    border: { position: "top", style: "thin", color: "#000000" },
+  },
 };
-export const TEST_COMMANDS = TEST_COMMANDS_PARTIAL as CommandMapping;
+
+export const OT_TESTS_SINGLE_CELL_COMMANDS = [
+  TEST_COMMANDS.UPDATE_CELL,
+  TEST_COMMANDS.UPDATE_CELL_POSITION,
+  TEST_COMMANDS.CLEAR_CELL,
+  TEST_COMMANDS.SET_BORDER,
+];
+
+export const OT_TESTS_TARGET_DEPENDANT_COMMANDS = [
+  TEST_COMMANDS.DELETE_CONTENT,
+  TEST_COMMANDS.SET_FORMATTING,
+  TEST_COMMANDS.CLEAR_FORMATTING,
+  TEST_COMMANDS.CREATE_FILTER_TABLE,
+  TEST_COMMANDS.REMOVE_FILTER_TABLE,
+];
+
+export const OT_TESTS_RANGE_DEPENDANT_COMMANDS = [TEST_COMMANDS.ADD_CONDITIONAL_FORMAT];


### PR DESCRIPTION
This commit makes use fo the TEST_COMMANDS variable for the ot tests, which avoid having the need to re-define every test command in each of the 6 ot_*.tests files.

This saves us ~300 lines of repeated constant declaration in the tests.


Odoo task ID : [3383455](https://www.odoo.com/web#id=3383455&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo