### PR TITLE
[IMP] icons: add display header icon

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -102,10 +102,12 @@ class Demo extends Component {
       icon: "o-spreadsheet-Icon.OPEN_READ_WRITE",
     });
 
-    topbarMenuRegistry.addChild("display_header", ["file"], {
+    topbarMenuRegistry.addChild("display_header", ["view"], {
       name: () => (this.state.displayHeader ? "Hide header" : "Show header"),
       isReadonlyAllowed: true,
       execute: () => (this.state.displayHeader = !this.state.displayHeader),
+      icon: "o-spreadsheet-Icon.DISPLAY_HEADER",
+      sequence: 1000,
     });
 
     topbarMenuRegistry.add("notify", {

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -847,4 +847,12 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.DISPLAY_HEADER" owl="1">
+    <svg class="o-icon" width="18" height="18">
+      <path
+        fill="currentColor"
+        d="M.75.5h16.5v17H.75m1.5-12H.75V7h1.5v1.5H.75V10h1.5v1.5H.75V13h1.5v1.5H.75V16h1.5v1.5h1.5V16h1.5v1.5h1.5V16h1.5v1.5h1.5V16h1.5v1.5h1.5V16h1.5v1.5h1.5V16h1.5v-1.5h-1.5V13h1.5v-1.5h-1.5V10h1.5V8.5h-1.5V7h1.5V5.5M2.75 2.25v1.5h2v-1.5m2.5 0v1.5h7v-1.5"
+      />
+    </svg>
+  </t>
 </templates>


### PR DESCRIPTION
## Description:

This PR aims to add a missing icon for the "Show/Hide header" menu item. Moreover, as this is more like a "view" thing, this menu item has been moved from the File menu to the View menu

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo