### PR TITLE
[FIX] Filters: fix filter id on sheet duplication

### DIFF
--- a/src/plugins/core/filters.ts
+++ b/src/plugins/core/filters.ts
@@ -99,7 +99,14 @@ export class FiltersPlugin extends CorePlugin<FiltersState> implements FiltersSt
         this.history.update("tables", filterTables);
         break;
       case "DUPLICATE_SHEET":
-        this.history.update("tables", cmd.sheetIdTo, deepCopy(this.tables[cmd.sheetId]));
+        const tables: Record<FilterTableId, FilterTable | undefined> = {};
+        for (const filterTable of Object.values(this.tables[cmd.sheetId] || {})) {
+          if (filterTable) {
+            const newFilterTable = deepCopy(filterTable);
+            tables[newFilterTable.id] = newFilterTable;
+          }
+        }
+        this.history.update("tables", cmd.sheetIdTo, tables);
         break;
       case "ADD_COLUMNS_ROWS":
         this.onAddColumnsRows(cmd);

--- a/tests/plugins/filters.test.ts
+++ b/tests/plugins/filters.test.ts
@@ -148,6 +148,22 @@ describe("Filters plugin", () => {
       expect(getFilterValues(model, sheet2Id)).toMatchObject([{ zone: "A1:A3", value: ["D"] }]);
     });
 
+    test("Can delete row/columns on duplicated sheet with filters", () => {
+      createFilter(model, "B1:B3");
+      updateFilter(model, "B1", ["C"]);
+
+      const sheet2Id = "42";
+      model.dispatch("DUPLICATE_SHEET", {
+        sheetId: sheetId,
+        sheetIdTo: sheet2Id,
+      });
+      expect(getFilterValues(model, sheet2Id)).toMatchObject([{ zone: "B1:B3", value: ["C"] }]);
+      deleteColumns(model, ["A"], sheet2Id);
+
+      expect(getFilterValues(model, sheetId)).toMatchObject([{ zone: "B1:B3", value: ["C"] }]);
+      expect(getFilterValues(model, sheet2Id)).toMatchObject([{ zone: "A1:A3", value: ["C"] }]);
+    });
+
     test("Filter is disabled if its header row is hidden by the user", () => {
       createFilter(model, "A1:A3");
       setCellContent(model, "A2", "28");


### PR DESCRIPTION
The internal state of the filter plugin requires that the id in the table mapping matches the id of the related FilterTable object.

Task: 3384840

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3384840](https://www.odoo.com/web#id=3384840&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo