### PR TITLE
[REL] 16.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.1.14",
+  "version": "16.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.1.14",
+      "version": "16.1.15",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.1.14",
+  "version": "16.1.15",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/80b14dde [FIX] Filters: fix filter id on sheet duplication Task: 3384840
https://github.com/odoo/o-spreadsheet/commit/a2ce50ef [FIX] rendering: cache text width
https://github.com/odoo/o-spreadsheet/commit/0493a3ae [IMP] dependencies: update owl to 2.1.3
https://github.com/odoo/o-spreadsheet/commit/5da9f489 [IMP] dependencies: update Typescript to 4.9
https://github.com/odoo/o-spreadsheet/commit/aafbfacf [FIX] filters: export xlsx of empty cells
