### PR TITLE
[IMP] Composer: Select autocomplete results on mouseover

### DIFF
--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
@@ -5,13 +5,12 @@ import { AutocompleteValue } from "../composer/composer";
 css/* scss */ `
   .o-autocomplete-dropdown {
     pointer-events: auto;
+    cursor: pointer;
     background-color: #fff;
     max-width: 400px;
-    & > div:hover {
-      background-color: #f2f2f2;
-    }
+
     .o-autocomplete-value-focus {
-      background-color: rgba(0, 0, 0, 0.08);
+      background-color: #f2f2f2;
     }
 
     & > div {
@@ -28,6 +27,7 @@ interface Props {
   values: AutocompleteValue[];
   selectedIndex: number | undefined;
   onValueSelected: (value: string) => void;
+  onValueHovered: (index: string) => void;
 }
 
 export class TextValueProvider extends Component<Props> {
@@ -38,4 +38,5 @@ TextValueProvider.props = {
   values: Array,
   selectedIndex: { type: Number, optional: true },
   onValueSelected: Function,
+  onValueHovered: Function,
 };

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
@@ -26,6 +26,7 @@ css/* scss */ `
 interface Props {
   values: AutocompleteValue[];
   selectedIndex: number | undefined;
+  getHtmlContent: (value: string) => string;
   onValueSelected: (value: string) => void;
   onValueHovered: (index: string) => void;
 }
@@ -37,6 +38,7 @@ export class TextValueProvider extends Component<Props> {
 TextValueProvider.props = {
   values: Array,
   selectedIndex: { type: Number, optional: true },
+  getHtmlContent: Function,
   onValueSelected: Function,
   onValueHovered: Function,
 };

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -10,7 +10,17 @@
           t-att-class="{'o-autocomplete-value-focus': props.selectedIndex === v_index}"
           t-on-click="() => this.props.onValueSelected(v.text)"
           t-on-mousemove="() => this.props.onValueHovered(v_index)">
-          <div class="o-autocomplete-value text-truncate" t-esc="v.text"/>
+          <div class="o-autocomplete-value text-truncate">
+            <t t-set="htmlContent" t-value="props.getHtmlContent(v.text)"/>
+            <span
+              t-foreach="htmlContent"
+              t-as="content"
+              t-key="content_index"
+              t-att-class="content.class"
+              t-attf-style="color: {{content.color || 'inherit'}};"
+              t-esc="content.value"
+            />
+          </div>
           <div
             class="o-autocomplete-description text-truncate"
             t-esc="v.description"

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -8,7 +8,8 @@
         <div
           class="d-flex flex-column text-start"
           t-att-class="{'o-autocomplete-value-focus': props.selectedIndex === v_index}"
-          t-on-click="() => this.props.onValueSelected(v.text)">
+          t-on-click="() => this.props.onValueSelected(v.text)"
+          t-on-mousemove="() => this.props.onValueHovered(v_index)">
           <div class="o-autocomplete-value text-truncate" t-esc="v.text"/>
           <div
             class="o-autocomplete-description text-truncate"

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -420,12 +420,12 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
           text,
           description,
         };
+      })
+      .sort((a, b) => {
+        return a.text.length - b.text.length || a.text.localeCompare(b.text);
       });
     if (searchTerm) {
       values = fuzzyLookup(searchTerm, values, (t) => t.text);
-    } else {
-      // alphabetical order
-      values = values.sort((a, b) => a.text.localeCompare(b.text));
     }
     this.autoCompleteState.values = values.slice(0, 10);
     this.autoCompleteState.selectedIndex = 0;

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -2,7 +2,7 @@ import { Component, onMounted, onWillUnmount, useEffect, useRef, useState } from
 import { DEFAULT_FONT, NEWLINE } from "../../../constants";
 import { EnrichedToken } from "../../../formulas/index";
 import { functionRegistry } from "../../../functions/index";
-import { fuzzyLookup, getZoneArea, isEqual, splitReference } from "../../../helpers/index";
+import { clip, fuzzyLookup, getZoneArea, isEqual, splitReference } from "../../../helpers/index";
 import { interactiveStopEdition } from "../../../helpers/ui/stop_edition_interactive";
 import { ComposerSelection } from "../../../plugins/ui_stateful/edition";
 
@@ -429,6 +429,10 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     }
     this.autoCompleteState.values = values.slice(0, 10);
     this.autoCompleteState.selectedIndex = 0;
+  }
+
+  updateAutoCompleteIndex(index: number) {
+    this.autoCompleteState.selectedIndex = clip(0, index, 10);
   }
 
   /**

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -34,6 +34,7 @@
           selectedIndex="autoCompleteState.selectedIndex"
           onValueSelected.bind="this.autoComplete"
           onValueHovered.bind="this.updateAutoCompleteIndex"
+          getHtmlContent="autoCompleteState.getHtmlContent"
         />
         <FunctionDescriptionProvider
           t-if="functionDescriptionState.showDescription"

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -33,6 +33,7 @@
           values="autoCompleteState.values"
           selectedIndex="autoCompleteState.selectedIndex"
           onValueSelected.bind="this.autoComplete"
+          onValueHovered.bind="this.updateAutoCompleteIndex"
         />
         <FunctionDescriptionProvider
           t-if="functionDescriptionState.showDescription"

--- a/src/components/composer/formula_assistant/formula_assistant.ts
+++ b/src/components/composer/formula_assistant/formula_assistant.ts
@@ -1,4 +1,5 @@
 import { Component, onWillUnmount, useState } from "@odoo/owl";
+import { COMPOSER_ASSISTANT_COLOR } from "../../../constants";
 import { FunctionDescription } from "../../../types";
 import { css } from "../../helpers/css";
 
@@ -21,8 +22,8 @@ css/* scss */ `
     .o-formula-assistant-focus {
       div:first-child,
       span {
-        color: purple;
-        text-shadow: 0px 0px 1px purple;
+        color: ${COMPOSER_ASSISTANT_COLOR};
+        text-shadow: 0px 0px 1px ${COMPOSER_ASSISTANT_COLOR};
       }
       div:last-child {
         color: black;

--- a/src/components/helpers/html_content_helpers.ts
+++ b/src/components/helpers/html_content_helpers.ts
@@ -1,0 +1,28 @@
+import { HtmlContent } from "../composer/composer/composer";
+
+export function getHtmlContentFromPattern(
+  pattern: string,
+  value: string,
+  highlightColor: string,
+  className: string
+): HtmlContent[] {
+  const pendingHtmlContent: HtmlContent[] = [];
+  pattern = pattern.toLowerCase();
+
+  for (const patternChar of pattern) {
+    const index = value.toLocaleLowerCase().indexOf(patternChar);
+    if (index === -1) {
+      continue;
+    }
+    pendingHtmlContent.push(
+      { value: value.slice(0, index), color: "" },
+      { value: value[index], color: highlightColor, class: className }
+    );
+    value = value.slice(index + 1);
+  }
+
+  pendingHtmlContent.push({ value });
+  const htmlContent = pendingHtmlContent.filter((content) => content.value);
+
+  return htmlContent;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,7 @@ export const HEADER_GROUPING_BORDER_COLOR = "#999";
 export const GRID_BORDER_COLOR = "#E2E3E3";
 export const FROZEN_PANE_HEADER_BORDER_COLOR = "#BCBCBC";
 export const FROZEN_PANE_BORDER_COLOR = "#DADFE8";
+export const COMPOSER_ASSISTANT_COLOR = "#9B359B";
 
 // Color picker defaults as upper case HEX to match `toHex`helper
 export const COLOR_PICKER_DEFAULTS: Color[] = [

--- a/tests/components/__snapshots__/autocomplete_dropdown.test.ts.snap
+++ b/tests/components/__snapshots__/autocomplete_dropdown.test.ts.snap
@@ -10,7 +10,18 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
     <div
       class="o-autocomplete-value text-truncate"
     >
-      SUM
+      <span
+        class="o-semi-bold"
+        style="color: #9B359B;"
+      >
+        S
+      </span>
+      <span
+        style="color: inherit;"
+      >
+        UM
+      </span>
+      
     </div>
     <div
       class="o-autocomplete-description text-truncate"
@@ -25,7 +36,18 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
     <div
       class="o-autocomplete-value text-truncate"
     >
-      SZZ
+      <span
+        class="o-semi-bold"
+        style="color: #9B359B;"
+      >
+        S
+      </span>
+      <span
+        style="color: inherit;"
+      >
+        ZZ
+      </span>
+      
     </div>
     
   </div>
@@ -47,7 +69,18 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       <div
         class="o-autocomplete-value text-truncate"
       >
-        SUM
+        <span
+          class="o-semi-bold"
+          style="color: #9B359B;"
+        >
+          S
+        </span>
+        <span
+          style="color: inherit;"
+        >
+          UM
+        </span>
+        
       </div>
       <div
         class="o-autocomplete-description text-truncate"
@@ -62,7 +95,18 @@ exports[`composer Assistant render above the cell when not enough place below 1`
       <div
         class="o-autocomplete-value text-truncate"
       >
-        SZZ
+        <span
+          class="o-semi-bold"
+          style="color: #9B359B;"
+        >
+          S
+        </span>
+        <span
+          style="color: inherit;"
+        >
+          ZZ
+        </span>
+        
       </div>
       
     </div>
@@ -87,7 +131,18 @@ exports[`composer Assistant render below the cell by default 1`] = `
       <div
         class="o-autocomplete-value text-truncate"
       >
-        SUM
+        <span
+          class="o-semi-bold"
+          style="color: #9B359B;"
+        >
+          S
+        </span>
+        <span
+          style="color: inherit;"
+        >
+          UM
+        </span>
+        
       </div>
       <div
         class="o-autocomplete-description text-truncate"
@@ -102,7 +157,18 @@ exports[`composer Assistant render below the cell by default 1`] = `
       <div
         class="o-autocomplete-value text-truncate"
       >
-        SZZ
+        <span
+          class="o-semi-bold"
+          style="color: #9B359B;"
+        >
+          S
+        </span>
+        <span
+          style="color: inherit;"
+        >
+          ZZ
+        </span>
+        
       </div>
       
     </div>

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -41,31 +41,36 @@ async function typeInComposer(text: string, fromScratch: boolean = true) {
 
 beforeEach(() => {
   clearFunctions();
-  functionRegistry.add("IF", {
-    description: "do if",
-    args: [],
-    compute: () => 1,
-    returns: ["ANY"],
-  });
-  functionRegistry.add("SUM", {
-    description: "do sum",
-    args: [],
-    compute: () => 1,
-    returns: ["ANY"],
-  });
-  functionRegistry.add("SZZ", {
-    description: "do something",
-    args: [],
-    compute: () => 1,
-    returns: ["ANY"],
-  });
-  functionRegistry.add("HIDDEN", {
-    description: "do something",
-    args: [],
-    compute: () => 1,
-    returns: ["ANY"],
-    hidden: true,
-  });
+  functionRegistry
+    .add("IF", {
+      description: "do if",
+      args: [],
+      compute: () => 1,
+      returns: ["ANY"],
+    })
+    .add("SUM", {
+      description: "do sum",
+      args: [],
+      compute: () => 1,
+      returns: ["ANY"],
+    })
+    .add("SZZ", {
+      description: "do something",
+      args: [],
+      compute: () => 1,
+      returns: ["ANY"],
+    })
+    .add("HIDDEN", {
+      description: "do something",
+      args: [],
+      compute: () => 1,
+      returns: ["ANY"],
+      hidden: true,
+    });
+});
+
+afterEach(() => {
+  restoreDefaultFunctions();
 });
 
 describe("Functions autocomplete", () => {
@@ -75,10 +80,6 @@ describe("Functions autocomplete", () => {
     parent.startComposition();
     await nextTick();
     composerEl = fixture.querySelector("div.o-composer")!;
-  });
-
-  afterAll(() => {
-    restoreDefaultFunctions();
   });
 
   describe("autocomplete", () => {
@@ -413,7 +414,7 @@ describe("autocomplete boolean functions", () => {
     await nextTick();
   });
 
-  afterAll(() => {
+  afterEach(() => {
     restoreDefaultFunctions();
   });
 
@@ -439,4 +440,64 @@ describe("autocomplete boolean functions", () => {
       expect(fixture.querySelector(".o-autocomplete-value")).toBeNull();
     }
   );
+});
+describe("composer entries", () => {
+  beforeEach(() => {
+    clearFunctions();
+    functionRegistry
+      .add("SEC", {
+        description: "",
+        args: [],
+        compute: () => 1,
+        returns: ["ANY"],
+      })
+      .add("SUPER", {
+        description: "",
+        args: [],
+        compute: () => 1,
+        returns: ["ANY"],
+      })
+      .add("SIN", {
+        description: "",
+        args: [],
+        compute: () => 1,
+        returns: ["ANY"],
+      })
+      .add("SLNT", {
+        description: "",
+        args: [],
+        compute: () => 1,
+        returns: ["ANY"],
+      })
+      .add("SECQ", {
+        description: "",
+        args: [],
+        compute: () => 1,
+        returns: ["ANY"],
+      })
+      .add("SAPER", {
+        description: "",
+        args: [],
+        compute: () => 1,
+        returns: ["ANY"],
+      })
+      .add("SLN", {
+        description: "",
+        args: [],
+        compute: () => 1,
+        returns: ["ANY"],
+      });
+  });
+  test("Autocomplente entries are sorted by length and then alphanumerically", async () => {
+    ({ fixture, parent } = await mountComposerWrapper());
+    await typeInComposer("=S");
+    const entries = fixture.querySelectorAll(".o-autocomplete-value");
+    expect(entries[0].textContent).toBe("SEC");
+    expect(entries[1].textContent).toBe("SIN");
+    expect(entries[2].textContent).toBe("SLN");
+    expect(entries[3].textContent).toBe("SECQ");
+    expect(entries[4].textContent).toBe("SLNT");
+    expect(entries[5].textContent).toBe("SAPER");
+    expect(entries[6].textContent).toBe("SUPER");
+  });
 });

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -2,7 +2,13 @@ import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import { selectCell } from "../test_helpers/commands_helpers";
-import { click, keyDown, keyUp, simulateClick } from "../test_helpers/dom_helper";
+import {
+  click,
+  keyDown,
+  keyUp,
+  simulateClick,
+  triggerMouseEvent,
+} from "../test_helpers/dom_helper";
 import { getCellText } from "../test_helpers/getters_helpers";
 import {
   ComposerWrapper,
@@ -225,6 +231,26 @@ describe("Functions autocomplete", () => {
 
       await simulateClick(dropDownEl);
       expect(document.activeElement).toEqual(activeElement);
+    });
+
+    test("Hovering over an autocomplete entry highlights it as the current choice", async () => {
+      await typeInComposer("=S");
+      expect(
+        fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
+      ).toBe("SUM");
+      const entries = fixture.querySelectorAll(".o-autocomplete-value");
+      const firstEntry = entries[0];
+      const secondEntry = entries[1];
+      triggerMouseEvent(secondEntry, "mousemove");
+      await nextTick();
+      expect(
+        fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
+      ).toBe("SZZ");
+      triggerMouseEvent(firstEntry, "mousemove");
+      await nextTick();
+      expect(
+        fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
+      ).toBe("SUM");
     });
   });
 

--- a/tests/components/composer_integration.test.ts
+++ b/tests/components/composer_integration.test.ts
@@ -635,9 +635,9 @@ describe("TopBar composer", () => {
     ({ model, fixture } = await mountSpreadsheet());
     const composerEl = await typeInComposerTopBar("=\nS");
     await click(fixture, ".o-autocomplete-dropdown > div:nth-child(2)");
-    expect(composerEl.textContent).toBe("=\nSUMX2MY2(");
+    expect(composerEl.textContent).toBe("=\nSIN(");
     expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
-    expect(cehMock.selectionState.position).toBe(11);
+    expect(cehMock.selectionState.position).toBe(6);
     expect(document.activeElement).toBe(composerEl);
     expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(0);
   });


### PR DESCRIPTION
the current behaviour of the composer formula autocompletion is somehow limited as the function description can only be seen on the currently selected entry, which can only be modified via keyboard navigation. This revision allows the selection to be updated by hovering on one of the entries of the dropdown.

Task: 3387413

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3387413](https://www.odoo.com/web#id=3387413&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo