### PR TITLE
[IMP] TopBarComposer: allow selection in readonly mode

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -71,10 +71,6 @@ css/* scss */ `
       padding-right: 3px;
       outline: none;
 
-      &.unfocusable {
-        pointer-events: none;
-      }
-
       p {
         margin-bottom: 0px;
 

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -3,7 +3,7 @@
     <div class="o-composer-container w-100 h-100">
       <div
         class="o-composer w-100 text-start"
-        t-att-class="{ 'text-muted': env.model.getters.isReadonly(), 'unfocusable': env.model.getters.isReadonly(), 'active': props.focus !== 'inactive' }"
+        t-att-class="{ 'text-muted': env.model.getters.isReadonly(), 'active': props.focus !== 'inactive' }"
         t-att-style="props.inputStyle"
         t-ref="o_composer"
         tabindex="1"

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -33,6 +33,10 @@ css/* scss */ `
       top: 20%;
     }
   }
+
+  .user-select-text {
+    user-select: text;
+  }
 `;
 
 interface Props {

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -1,6 +1,9 @@
 <templates>
   <t t-name="o-spreadsheet-TopBarComposer" owl="1">
-    <div class="o-topbar-composer bg-white" t-att-style="containerStyle">
+    <div
+      class="o-topbar-composer bg-white user-select-text"
+      t-on-click.stop=""
+      t-att-style="containerStyle">
       <Composer
         focus="props.focus"
         inputStyle="composerStyle"

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -559,7 +559,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
       </div>
       <div
-        class="o-topbar-composer bg-white"
+        class="o-topbar-composer bg-white user-select-text"
         style="border-color:#E0E2E4; border-right:none;"
       >
         <div

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -558,7 +558,7 @@ exports[`TopBar component can set cell format 1`] = `
           
         </div>
         <div
-          class="o-topbar-composer bg-white"
+          class="o-topbar-composer bg-white user-select-text"
           style="border-color:#E0E2E4; border-right:none;"
         >
           <div
@@ -1430,7 +1430,7 @@ exports[`TopBar component simple rendering 1`] = `
       
     </div>
     <div
-      class="o-topbar-composer bg-white"
+      class="o-topbar-composer bg-white user-select-text"
       style="border-color:#E0E2E4; border-right:none;"
     >
       <div

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -19,8 +19,19 @@ export async function simulateClick(
     (document.activeElement as HTMLElement | null)?.dispatchEvent(
       new FocusEvent("blur", { relatedTarget: target })
     );
-
-    target.dispatchEvent(new FocusEvent("focus", { relatedTarget: oldActiveEl }));
+    /** Dispatching a crafted FocusEvent does not actually focus the target.
+     * JSDom pretty much requires us to rely on Element.focus()
+     * Because of the problematic behavior addressed in 71a9c8c2,
+     * we have to check a posteriori if the target has been properly focused
+     * and if not, dispatch a FocusEvent with the relatedTarget to ensure a proper
+     * fallback behaviour.
+     */
+    if (target instanceof HTMLElement) {
+      target.focus();
+    }
+    if (document.activeElement !== target) {
+      target.dispatchEvent(new FocusEvent("focus", { relatedTarget: oldActiveEl }));
+    }
   }
   triggerMouseEvent(selector, "mouseup", x, y, extra);
   triggerMouseEvent(selector, "click", x, y, extra);


### PR DESCRIPTION
## Description:

Previously, users were unable to select specific portions within cell content in readonly mode.

To achieve this, Added the 'user-select-text' class to enable selection. Additionally, encountered an issue where the focus was shifted to the hiddenInput when users made a selection, resulting in the removal of the selection. To resolve this issue, Added `t-on-click.stop=""`  in TopBarComposer.


Odoo task ID : [3378521](https://www.odoo.com/web#id=3378521&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo