### PR TITLE
[IMP] data: remove key `entities` in exported data

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -536,7 +536,6 @@ export function createEmptyWorkbookData(sheetName = "Sheet1"): WorkbookData {
   const data = {
     version: CURRENT_VERSION,
     sheets: [createEmptySheet(INITIAL_SHEET_ID, sheetName)],
-    entities: {},
     styles: {},
     formats: {},
     borders: {},

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -61,7 +61,6 @@ export interface WorkbookData {
   styles: { [key: number]: Style };
   formats: { [key: number]: Format };
   borders: { [key: number]: Border };
-  entities: { [key: string]: { [key: string]: any } };
   revisionId: UID;
   uniqueFigureIds: boolean;
   settings: WorkbookSettings;

--- a/src/xlsx/xlsx_reader.ts
+++ b/src/xlsx/xlsx_reader.ts
@@ -152,7 +152,6 @@ export class XlsxReader {
       styles: convertStyles(data, this.warningManager),
       formats: convertFormats(data, this.warningManager),
       borders: convertBorders(data, this.warningManager),
-      entities: {},
       revisionId: DEFAULT_REVISION_ID,
     } as WorkbookData;
 

--- a/tests/model/data.test.ts
+++ b/tests/model/data.test.ts
@@ -11,7 +11,6 @@ describe("load data", () => {
       borders: {},
       styles: {},
       formats: {},
-      entities: {},
       settings: { locale: DEFAULT_LOCALE },
       revisionId: DEFAULT_REVISION_ID,
       sheets: [
@@ -46,7 +45,6 @@ describe("load data", () => {
       borders: {},
       styles: {},
       formats: {},
-      entities: {},
       revisionId: DEFAULT_REVISION_ID,
       sheets: [
         {
@@ -78,7 +76,6 @@ describe("load data", () => {
       borders: {},
       styles: {},
       formats: {},
-      entities: {},
       revisionId: DEFAULT_REVISION_ID,
       sheets: [
         {
@@ -151,7 +148,6 @@ describe("load data", () => {
       borders: {},
       styles: {},
       formats: {},
-      entities: {},
       revisionId: DEFAULT_REVISION_ID,
       sheets: [
         {

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -591,7 +591,6 @@ test("complete import, then export", () => {
       },
     ],
     settings: { locale: DEFAULT_LOCALE },
-    entities: {},
     styles: {
       1: { bold: true, textColor: "#3A3791", fontSize: 12 },
     },
@@ -675,7 +674,6 @@ test("import then export (figures)", () => {
         headerGroups: { COL: [], ROW: [] },
       },
     ],
-    entities: {},
     styles: {},
     formats: {},
     borders: {},


### PR DESCRIPTION
The very early versions of o_spreadsheet used a `entities` key in the data, but it isn't used anymore. Remove mentions of it.

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo