### PR TITLE
[IMP] data: add the trim whitespace feature

### DIFF
--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -36,6 +36,13 @@ export const removeDuplicates: ActionSpec = {
   },
 };
 
+export const trimWhitespace: ActionSpec = {
+  name: _t("Trim whitespace"),
+  execute: (env) => {
+    env.model.dispatch("TRIM_WHITESPACE");
+  },
+};
+
 export const sortDescending: ActionSpec = {
   name: _t("Descending (Z ⟶ A)"),
   execute: (env) => {

--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -1,4 +1,4 @@
-import { escapeRegExp, formatValue } from "../helpers";
+import { escapeRegExp, formatValue, trimContent } from "../helpers";
 import { _t } from "../translation";
 import { AddFunctionDescription, ArgValue, CellValue, Matrix, Maybe } from "../types";
 import { arg } from "./arguments";
@@ -534,7 +534,7 @@ export const TRIM = {
   ],
   returns: ["STRING"],
   compute: function (text: Maybe<CellValue>): string {
-    return toString(text).trim();
+    return trimContent(toString(text));
   },
   isExported: true,
 } satisfies AddFunctionDescription;

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -489,3 +489,8 @@ export function insertItemsAtIndex<T>(array: readonly T[], items: T[], index: nu
   newArray.splice(index, 0, ...items);
   return newArray;
 }
+
+export function trimContent(content: string): string {
+  const contentLines = content.split("\n");
+  return contentLines.map((line) => line.replace(/\s+/g, " ").trim()).join("\n");
+}

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -410,6 +410,10 @@ topbarMenuRegistry
     ...ACTION_DATA.removeDuplicates,
     sequence: 10,
   })
+  .addChild("trim_whitespace", ["data", "data_cleanup"], {
+    ...ACTION_DATA.trimWhitespace,
+    sequence: 20,
+  })
   .addChild("split_to_columns", ["data"], {
     ...ACTION_DATA.splitToColumns,
     sequence: 20,

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -525,6 +525,10 @@ export interface RemoveDuplicatesCommand {
   hasHeader: boolean;
 }
 
+export interface TrimWhitespaceCommand {
+  type: "TRIM_WHITESPACE";
+}
+
 export interface GroupHeadersCommand extends SheetDependentCommand {
   type: "GROUP_HEADERS";
   dimension: Dimension;
@@ -1108,7 +1112,8 @@ export type LocalCommand =
   | ActivatePreviousSheetCommand
   | UpdateFilterCommand
   | SplitTextIntoColumnsCommand
-  | RemoveDuplicatesCommand;
+  | RemoveDuplicatesCommand
+  | TrimWhitespaceCommand;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/tests/functions/module_text.test.ts
+++ b/tests/functions/module_text.test.ts
@@ -734,6 +734,9 @@ describe("TRIM formula", () => {
     );
     expect(evaluateCell("A1", { A1: '=TRIM(" A ")' })).toBe("A");
     expect(evaluateCell("A1", { A1: '=TRIM("  A     ")' })).toBe("A");
+    expect(evaluateCell("A1", { A1: '=TRIM("  A    B  ")' })).toBe("A B");
+    expect(evaluateCell("A1", { A1: '=TRIM("  A   \n B   \n  \n C  ")' })).toBe("A\nB\n\nC"); // @compatibility: the TRIM Excel function does not keep line breaks
+    expect(evaluateCell("A1", { A1: '=TRIM(" \t  A   \t B\tC  \t")' })).toBe("A B C");
   });
 
   test("casting tests on simple arguments", () => {
@@ -744,7 +747,7 @@ describe("TRIM formula", () => {
   test("functional tests on cell arguments", () => {
     expect(evaluateCell("A1", { A1: "=TRIM(A2)" })).toBe("");
     expect(evaluateCell("A1", { A1: "=TRIM(A2)", A2: " Kikou  " })).toBe("Kikou");
-    expect(evaluateCell("A1", { A1: "=TRIM(A2)", A2: '" Kikou  "' })).toBe('" Kikou  "');
+    expect(evaluateCell("A1", { A1: "=TRIM(A2)", A2: '" Kikou  "' })).toBe('" Kikou "');
     expect(evaluateCell("A1", { A1: "=TRIM(A2)", A2: '=" Kikou  "' })).toBe("Kikou");
   });
 });

--- a/tests/plugins/trim_whitespace.test.ts
+++ b/tests/plugins/trim_whitespace.test.ts
@@ -1,0 +1,108 @@
+import { Model } from "../../src";
+import { getCellContent } from "../test_helpers";
+import { selectCell, setCellContent, setSelection } from "../test_helpers/commands_helpers";
+import { createModelFromGrid, getRangeValuesAsMatrix } from "../test_helpers/helpers";
+
+describe("trim whitespace", () => {
+  test("trim cell content", () => {
+    const model = new Model();
+    setCellContent(model, "A2", "   Alo         ");
+    selectCell(model, "A2");
+    model.dispatch("TRIM_WHITESPACE");
+    expect(getCellContent(model, "A2")).toBe("Alo");
+  });
+
+  test("remove duplicate spaces", () => {
+    const model = new Model();
+    setCellContent(model, "A2", "  Alo        salut     sunt  eu    un haiduc  ");
+    selectCell(model, "A2");
+    model.dispatch("TRIM_WHITESPACE");
+    expect(getCellContent(model, "A2")).toBe("Alo salut sunt eu un haiduc");
+  });
+
+  test("can trim on multiple selection", async () => {
+    const model = createModelFromGrid({
+      A1: "   Space   Opera",
+      A2: " Space  Marine",
+      A3: "  Space Cowboys   ",
+      A4: "   Space Cake  ???    ",
+    });
+    let notifyUserTextSpy = jest.fn();
+    jest.spyOn(model.config, "notifyUI").mockImplementation(notifyUserTextSpy);
+    setSelection(model, ["A1:A2", "A2:A3", "A4"]);
+    model.dispatch("TRIM_WHITESPACE");
+    expect(getCellContent(model, "A1")).toBe("Space Opera");
+    expect(getCellContent(model, "A2")).toBe("Space Marine");
+    expect(getCellContent(model, "A3")).toBe("Space Cowboys");
+    expect(getCellContent(model, "A4")).toBe("Space Cake ???");
+  });
+
+  test("remove tabulation", () => {
+    const model = new Model();
+    setCellContent(model, "A2", "\tAlo   \t     salut\tsunt eu \tun haiduc  \t");
+    selectCell(model, "A2");
+    model.dispatch("TRIM_WHITESPACE");
+    expect(getCellContent(model, "A2")).toBe("Alo salut sunt eu un haiduc");
+  });
+
+  test("keep lines break", () => {
+    // @compatibility: the TRIM Excel function does not keep line breaks
+    const model = new Model();
+    setCellContent(model, "A2", "  Alo        salut   \n   sunt  eu  \n  un haiduc  ");
+    selectCell(model, "A2");
+    model.dispatch("TRIM_WHITESPACE");
+    expect(getCellContent(model, "A2")).toBe("Alo salut\nsunt eu\nun haiduc");
+  });
+
+  test("keep empty lines break", () => {
+    // @compatibility: the TRIM Google Sheets feature does not keep empty line breaks bue the formula does
+    const model = new Model();
+    setCellContent(model, "A2", "  Alo        salut   \n\n   sunt  eu  \n     \n  un haiduc  ");
+    selectCell(model, "A2");
+    model.dispatch("TRIM_WHITESPACE");
+    expect(getCellContent(model, "A2")).toBe("Alo salut\n\nsunt eu\n\nun haiduc");
+  });
+
+  test("apply it on all selected cells", () => {
+    const model = createModelFromGrid({ A2: " a ", A3: " b ", A4: " c " });
+    setSelection(model, ["A2:A3", "A3:A4"]);
+    model.dispatch("TRIM_WHITESPACE");
+    expect(getRangeValuesAsMatrix(model, "A2:A4")).toEqual([["a"], ["b"], ["c"]]);
+  });
+});
+
+describe("notify user", () => {
+  test("notify when cells are trimmed", async () => {
+    const model = createModelFromGrid({
+      A1: " A B     B    A  ",
+      A2: "  SPACES   INVADERS   !  ",
+      A3: "NO SPACES INVADERS",
+    });
+    let notifyUserTextSpy = jest.fn();
+    jest.spyOn(model.config, "notifyUI").mockImplementation(notifyUserTextSpy);
+    setSelection(model, ["A1:A3"]);
+    model.dispatch("TRIM_WHITESPACE");
+    expect(notifyUserTextSpy).toHaveBeenCalledWith({
+      text: "Trimmed whitespace from 2 cells.",
+      type: "info",
+      sticky: false,
+    });
+  });
+
+  test("notify when no cells trimmed", async () => {
+    const model = createModelFromGrid({
+      A1: "Space Jam",
+      A2: "Space invaders",
+      A3: "Space mountain",
+    });
+    let notifyUserTextSpy = jest.fn();
+    jest.spyOn(model.config, "notifyUI").mockImplementation(notifyUserTextSpy);
+    setSelection(model, ["A1:A3"]);
+    model.dispatch("TRIM_WHITESPACE");
+    expect(notifyUserTextSpy).toHaveBeenCalledWith({
+      text: "No selected cells had whitespace trimmed.",
+      type: "info",
+      sticky: false,
+    });
+  });
+});


### PR DESCRIPTION
## Description:

Add a new feature in the data menu allowing to trim whitespace cells 
present in the selection

Odoo task ID : [3356367](https://www.odoo.com/web#id=3356367&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo