### PR TITLE
[IMP] helpers: add ast iteration helper

### DIFF
--- a/src/formulas/helpers.ts
+++ b/src/formulas/helpers.ts
@@ -1,21 +1,15 @@
 import { functionRegistry } from "../functions";
-import { parseTokens, visitAst } from "./parser";
+import { iterateAstNodes, parseTokens } from "./parser";
 import { Token } from "./tokenizer";
 
 const functions = functionRegistry.content;
 
 export function isExportableToExcel(tokens: Token[]): boolean {
   try {
-    let isExported = true;
-    visitAst(parseTokens(tokens), (ast) => {
-      if (ast.type === "FUNCALL") {
-        const func = functions[ast.value.toUpperCase()];
-        if (!func?.isExported) {
-          isExported = false;
-        }
-      }
-    });
-    return isExported;
+    const nonExportableFunctions = iterateAstNodes(parseTokens(tokens)).filter(
+      (ast) => ast.type === "FUNCALL" && !functions[ast.value.toUpperCase()]?.isExported
+    );
+    return nonExportableFunctions.length === 0;
   } catch (error) {
     return false;
   }

--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -239,13 +239,6 @@ export function parseTokens(tokens: Token[]): AST {
   return result;
 }
 
-export function visitAst(ast: AST, fn: (ast: AST) => void) {
-  mapAst(ast, (ast) => {
-    fn(ast);
-    return ast;
-  });
-}
-
 /**
  * Allows to visit all nodes of an AST and apply a mapping function
  * to nodes of a specific type.
@@ -270,6 +263,28 @@ export function convertAstNodes<T extends AST["type"]>(
     }
     return ast;
   });
+}
+
+export function iterateAstNodes(ast: AST): AST[] {
+  return Array.from(astIterator(ast));
+}
+
+function* astIterator(ast: AST): Iterable<AST> {
+  yield ast;
+  switch (ast.type) {
+    case "FUNCALL":
+      for (const arg of ast.args) {
+        yield* astIterator(arg);
+      }
+      break;
+    case "UNARY_OPERATION":
+      yield* astIterator(ast.operand);
+      break;
+    case "BIN_OPERATION":
+      yield* astIterator(ast.left);
+      yield* astIterator(ast.right);
+      break;
+  }
 }
 
 export function mapAst<T extends AST["type"]>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export { Revision } from "./collaborative/revisions";
 export { Spreadsheet } from "./components/index";
 export { setDefaultSheetViewSize } from "./constants";
 export { compile, functionCache } from "./formulas/compiler";
-export { astToFormula, convertAstNodes, parse } from "./formulas/parser";
+export { astToFormula, convertAstNodes, iterateAstNodes, parse } from "./formulas/parser";
 export { tokenize } from "./formulas/tokenizer";
 export { AbstractChart } from "./helpers/figures/charts";
 export { findCellInNewZone } from "./helpers/zones";


### PR DESCRIPTION
## Description:
[IMP] helpers: add ast iteration helper

This commit introduces a new helper to iterate over all nodes of an
AST: `iterateAstNodes`.
This is helpful to explore and inspect an AST, for example to find
particular functions.

The helper returns an array, allowing to use all regular
array methods (filter, map, reduce, etc.). It's more versatile than
the current `visitAst` helper. Therefore, `visitAst` is removed.

The helper is also exposed in the public index API to be used in
odoo to find odoo specific functions.

Odoo task ID : [3360232](https://www.odoo.com/web#id=3360232&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo