### PR TITLE
[IMP] Demo: Add an uncaught error catcher

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -111,7 +111,7 @@ class Demo extends Component {
     });
 
     topbarMenuRegistry.add("notify", {
-      name: "Notify?",
+      name: "Dummy notifications",
       sequence: 1000,
       isReadonlyAllowed: true,
     });
@@ -121,6 +121,12 @@ class Demo extends Component {
       sequence: 13,
       isReadonlyAllowed: true,
       execute: () => this.notifyUser({ text: "This is a notification", tag: "notif" }),
+    });
+
+    topbarMenuRegistry.addChild("throw error", ["notify"], {
+      name: "Uncaught error",
+      sequence: 11,
+      execute: () => a / 0,
     });
 
     topbarMenuRegistry.addChild("xlsxImport", ["file"], {
@@ -179,14 +185,17 @@ class Demo extends Component {
       editText: this.editText,
     });
     useExternalListener(window, "beforeunload", this.leaveCollaborativeSession.bind(this));
+    useExternalListener(window, "unhandledrejection", () => {
+      this.raiseError("An unexpected error occurred. Open the developer console for details.");
+    });
 
     onWillStart(() => this.initiateConnection());
 
     onMounted(() => console.log("Mounted: ", Date.now() - start));
     onWillUnmount(this.leaveCollaborativeSession.bind(this));
     onError((error) => {
-      console.error(error);
       console.error(error.cause);
+      this.raiseError("An unexpected error occurred. Open the developer console for details.");
     });
   }
 


### PR DESCRIPTION
Adding an unhandled error catcher in demo to stop missing issues when we don'thave the dev tools opened.

Task: 3392372

## Description:

description of this task, what is implemented and why it is implemented that way.

Odoo task ID : [3392372](https://www.odoo.com/web#id=3392372&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo