### PR TITLE
[IMP] Figure: add icons to figure context menu

### DIFF
--- a/src/registries/figure_registry.ts
+++ b/src/registries/figure_registry.ts
@@ -54,6 +54,7 @@ function getChartMenu(
         env.model.dispatch("SELECT_FIGURE", { id: figureId });
         env.openSidePanel("ChartPanel");
       },
+      icon: "o-spreadsheet-Icon.EDIT",
     },
     getCopyMenuItem(figureId, env),
     getCutMenuItem(figureId, env),
@@ -91,6 +92,7 @@ function getImageMenuRegistry(
           width,
         });
       },
+      icon: "o-spreadsheet-Icon.REFRESH",
     },
     getDeleteMenuItem(figureId, onFigureDeleted, env),
   ];
@@ -108,6 +110,7 @@ function getCopyMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
       env.model.dispatch("COPY");
       await env.clipboard.write(env.model.getters.getClipboardContent());
     },
+    icon: "o-spreadsheet-Icon.COPY",
   };
 }
 
@@ -122,6 +125,7 @@ function getCutMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
       env.model.dispatch("CUT");
       await env.clipboard.write(env.model.getters.getClipboardContent());
     },
+    icon: "o-spreadsheet-Icon.CUT",
   };
 }
 
@@ -141,5 +145,6 @@ function getDeleteMenuItem(
       });
       onFigureDeleted();
     },
+    icon: "o-spreadsheet-Icon.DELETE",
   };
 }


### PR DESCRIPTION
## Description:

Previously, the figure context menu(s) lacked icons while other context menus had them.

This commit addresses the issue by adding icons for Copy, Cut, Edit, Delete, and
Reset Size options to the figures context menu.

Odoo task ID : [3391903](https://www.odoo.com/web#id=3391903&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo