### PR TITLE
[FIX] menus: dynamically add all functions

### DIFF
--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -168,7 +168,7 @@ export const insertFunctionMin: ActionSpec = {
 
 export const categorieFunctionAll: ActionSpec = {
   name: _lt("All"),
-  children: allFunctionListMenuBuilder(),
+  children: [allFunctionListMenuBuilder],
 };
 
 function allFunctionListMenuBuilder(): ActionSpec[] {

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -1,5 +1,6 @@
 import { Model } from "../src";
 import { FONT_SIZES } from "../src/constants";
+import { functionRegistry } from "../src/functions";
 import { zoneToXc } from "../src/helpers";
 import { interactivePaste } from "../src/helpers/ui/paste_interactive";
 import { colMenuRegistry, rowMenuRegistry, topbarMenuRegistry } from "../src/registries/index";
@@ -26,6 +27,7 @@ import {
   makeTestEnv,
   mockUuidV4To,
   nextTick,
+  restoreDefaultFunctions,
   spyModelDispatch,
   target,
 } from "./test_helpers/helpers";
@@ -797,6 +799,21 @@ describe("Menu Item actions", () => {
     const spyStartCell = jest.spyOn(env, "startCellEdition");
     doAction(["insert", "insert_function", "insert_function_sum"], env);
     expect(spyStartCell).toHaveBeenCalled();
+  });
+
+  test("Insert -> Function -> All includes new functions", () => {
+    functionRegistry.add("TEST.FUNC", {
+      args: [],
+      compute: () => 42,
+      description: "Test function",
+      returns: ["NUMBER"],
+    });
+    const env = makeTestEnv();
+    const allFunctions = getNode(["insert", "insert_function", "categorie_function_all"]).children(
+      env
+    );
+    expect(allFunctions.map((f) => f.name(env))).toContain("TEST.FUNC");
+    restoreDefaultFunctions();
   });
 
   describe("Format -> numbers", () => {


### PR DESCRIPTION

## Description:

Since https://github.com/odoo/o-spreadsheet/commit/950abc45d379a4d0ccec31e944c11efa50cc6dac, newly defined functions are not dynamically added in menu
"Insert > Function > All".

For example, functions added in odoo are not to be found there.

That's because the menu item children are eagerly created once, when the
menu is declared (when the js file is parsed and executed), which is before
other functions are added to the registry.

Now all function menu items are computed dynamically
Odoo task ID : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo