### PR TITLE
[IMP] dates: detect mm/yyyy strings as dates

### DIFF
--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -41,7 +41,7 @@ export const mdyDateRegexp = /^\d{1,2}(\/|-|\s)\d{1,2}((\/|-|\s)\d{1,4})?$/;
 export const ymdDateRegexp = /^\d{3,4}(\/|-|\s)\d{1,2}(\/|-|\s)\d{1,2}$/;
 
 const dateSeparatorsRegex = /\/|-|\s/;
-export const dateRegexp = /^(\d{1,4})[\/-\s](\d{1,2})([\/-\s](\d{1,4}))?$/;
+const dateRegexp = /^(\d{1,4})[\/-\s](\d{1,4})([\/-\s](\d{1,4}))?$/;
 
 export const timeRegexp = /((\d+(:\d+)?(:\d+)?\s*(AM|PM))|(\d+:\d+(:\d+)?))$/;
 
@@ -122,6 +122,10 @@ function getDateParts(dateString: string, locale: Locale): DateParts | null {
 
   const localeDateType = getLocaleDateFormatType(locale);
   if (!part3) {
+    if (part2.length > 2) {
+      // e.g. 11/2023
+      return { month: part1, year: part2, day: undefined, dateString, type: localeDateType };
+    }
     if (localeDateType === "dmy") {
       return { day: part1, month: part2, year: part3, dateString, type: "dmy" };
     }

--- a/tests/functions/dates.test.ts
+++ b/tests/functions/dates.test.ts
@@ -98,6 +98,16 @@ describe("date helpers: can detect and parse various dates", () => {
     expect(d2.format).toBe("mm/dd");
   });
 
+  test("can detect and parse m/yyyy and mm/yyy dates ", () => {
+    const d1 = parseDateTime("3/2023", locale)!;
+    expect(d1.jsDate!).toEqual(new Date(2023, 2, 1));
+    expect(d1.format).toBe("m/yyyy");
+
+    const d2 = parseDateTime("03/2023", locale)!;
+    expect(d2.jsDate!).toEqual(new Date(2023, 2, 1));
+    expect(d2.format).toBe("mm/yyyy");
+  });
+
   test("can detect and parse m-d-yyyy dates ", () => {
     expect(parseDateTime("3-2-2010", locale)).toEqual({
       value: 40239,
@@ -147,6 +157,16 @@ describe("date helpers: can detect and parse various dates", () => {
     expect(d2.format).toBe("mm-dd");
   });
 
+  test("can detect and parse m-yyyy and mm-yyy dates ", () => {
+    const d1 = parseDateTime("3-2023", locale)!;
+    expect(d1.jsDate!).toEqual(new Date(2023, 2, 1));
+    expect(d1.format).toBe("m-yyyy");
+
+    const d2 = parseDateTime("03-2023", locale)!;
+    expect(d2.jsDate!).toEqual(new Date(2023, 2, 1));
+    expect(d2.format).toBe("mm-yyyy");
+  });
+
   test('can detect and parse "mm dd yyyy" dates ', () => {
     expect(parseDateTime("03 20 2010", locale)).toEqual({
       value: 40257,
@@ -183,6 +203,16 @@ describe("date helpers: can detect and parse various dates", () => {
     expect(d2.format).toBe("mm dd");
   });
 
+  test("can detect and parse 'm yyyy' and 'mm yyyy' dates ", () => {
+    const d1 = parseDateTime("3 2023", locale)!;
+    expect(d1.jsDate!).toEqual(new Date(2023, 2, 1));
+    expect(d1.format).toBe("m yyyy");
+
+    const d2 = parseDateTime("03 2023", locale)!;
+    expect(d2.jsDate!).toEqual(new Date(2023, 2, 1));
+    expect(d2.format).toBe("mm yyyy");
+  });
+
   test("does not parse invalid dates", () => {
     expect(parseDateTime("100/100/2099", locale)).toBeNull();
     expect(parseDateTime("20/10/2020", locale)).toBeNull(); // 20 is not a valid month
@@ -191,6 +221,11 @@ describe("date helpers: can detect and parse various dates", () => {
     expect(parseDateTime("02/28/2021", locale)).not.toBeNull();
     expect(parseDateTime("02/29/2021", locale)).toBeNull();
     expect(parseDateTime("01/33/2021", locale)).toBeNull();
+    expect(parseDateTime("01/2023/01", locale)).toBeNull();
+    expect(parseDateTime("01/2023/2023", locale)).toBeNull();
+    expect(parseDateTime("13/2023", locale)).toBeNull();
+    expect(parseDateTime("0/2023", locale)).toBeNull();
+    expect(parseDateTime("-1/2023", locale)).toBeNull();
   });
 
   test("can infer a year if not given completely", () => {


### PR DESCRIPTION
## Description:

With this commits, typing "12/2023", "12-2023" in a cell is detected as a date: the 1st December 2023

Odoo task ID : [3413243](https://www.odoo.com/web#id=3413243&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo