### PR TITLE
[IMP] notify: change behavior

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -28,10 +28,9 @@ setTranslationMethod(
 
 const uuidGenerator = new o_spreadsheet.helpers.UuidGenerator();
 
-const tags = new Set();
-
 const NOTIFICATION_STYLE =
   "position:absolute;\
+  right:0px;\
   border:2px solid black;\
   background:#F5F5DCD5;\
   padding:20px;\
@@ -121,11 +120,28 @@ class Demo extends Component {
       isReadonlyAllowed: true,
     });
 
-    topbarMenuRegistry.addChild("fakenotify", ["notify"], {
-      name: "click me",
+    topbarMenuRegistry.addChild("fake_notify_sticky", ["notify"], {
+      name: "fake notify (sticky)",
       sequence: 13,
       isReadonlyAllowed: true,
-      execute: () => this.notifyUser({ text: "This is a notification", tag: "notif" }),
+      execute: () =>
+        this.notifyUser({
+          text: "I'm a sticky notification ! You want me to leave ? COME FIGHT WITH ME !!!",
+          sticky: true,
+          type: "warning",
+        }),
+    });
+
+    topbarMenuRegistry.addChild("fake_notify_no_sticky", ["notify"], {
+      name: "fake notify (no sticky)",
+      sequence: 14,
+      isReadonlyAllowed: true,
+      execute: () =>
+        this.notifyUser({
+          text: "I'm not a sticky notification, Just a simple notification. So... CiaoByeBye, see you in another universe...",
+          sticky: false,
+          type: "warning",
+        }),
     });
 
     topbarMenuRegistry.addChild("throw error", ["notify"], {
@@ -266,18 +282,23 @@ class Demo extends Component {
   }
 
   notifyUser(notification) {
-    if (tags.has(notification.tag)) return;
     const div = document.createElement("div");
     const text = document.createTextNode(notification.text);
     div.appendChild(text);
     div.style = NOTIFICATION_STYLE;
     const element = document.querySelector(".o-spreadsheet");
     div.onclick = () => {
-      tags.delete(notification.tag);
       element.removeChild(div);
     };
     element.appendChild(div);
-    tags.add(notification.tag);
+
+    if (!notification.sticky) {
+      setTimeout(() => {
+        if (document.body.contains(div)) {
+          element.removeChild(div);
+        }
+      }, 5000);
+    }
   }
 
   raiseError(content, callback) {

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -27,8 +27,7 @@ import { ImageProvider } from "../../helpers/figures/images/image_provider";
 import { Model } from "../../model";
 import { ComposerSelection } from "../../plugins/ui_stateful/edition";
 import { _t } from "../../translation";
-import { Pixel, SpreadsheetChildEnv } from "../../types";
-import { NotifyUIEvent } from "../../types/ui";
+import { InformationNotification, Pixel, SpreadsheetChildEnv } from "../../types";
 import { BottomBar } from "../bottom_bar/bottom_bar";
 import { SpreadsheetDashboard } from "../dashboard/dashboard";
 import { Grid } from "../grid/grid";
@@ -253,12 +252,16 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
 
   private bindModelEvents() {
     this.model.on("update", this, () => this.render(true));
-    this.model.on("notify-ui", this, this.onNotifyUI);
+    this.model.on("notify-ui", this, (notification: InformationNotification) =>
+      this.env.notifyUser(notification)
+    );
+    this.model.on("raise-error-ui", this, ({ text }) => this.env.raiseError(text));
   }
 
   private unbindModelEvents() {
     this.model.off("update", this);
     this.model.off("notify-ui", this);
+    this.model.off("raise-error-ui", this);
   }
 
   private checkViewportSize() {
@@ -279,19 +282,12 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
         text: _t(
           "The current window is too small to display this sheet properly. Consider resizing your browser window or adjusting frozen rows and columns."
         ),
-        tag: "viewportTooSmall",
+        type: "warning",
+        sticky: false,
       });
       this.isViewportTooSmall = true;
     } else {
       this.isViewportTooSmall = false;
-    }
-  }
-
-  private onNotifyUI(payload: NotifyUIEvent) {
-    switch (payload.type) {
-      case "ERROR":
-        this.env.raiseError(payload.text);
-        break;
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -46,13 +46,13 @@ import {
   Format,
   Getters,
   GridRenderingContext,
+  InformationNotification,
   isCoreCommand,
   LAYERS,
   LocalCommand,
   Locale,
   UID,
 } from "./types/index";
-import { NotifyUIEvent } from "./types/ui";
 import { WorkbookData } from "./types/workbook_data";
 import { XLSXExport } from "./types/xlsx";
 import { getXLSX } from "./xlsx/xlsx_writer";
@@ -104,7 +104,8 @@ export interface ModelConfig {
   readonly transportService: TransportService;
   readonly client: Client;
   readonly snapshotRequested: boolean;
-  readonly notifyUI: (payload: NotifyUIEvent) => void;
+  readonly notifyUI: (payload: InformationNotification) => void;
+  readonly raiseBlockingErrorUI: (text: string) => void;
 }
 
 export interface ModelExternalConfig {
@@ -395,7 +396,8 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       client,
       moveClient: () => {},
       snapshotRequested: false,
-      notifyUI: (payload: NotifyUIEvent) => this.trigger("notify-ui", payload),
+      notifyUI: (payload) => this.trigger("notify-ui", payload),
+      raiseBlockingErrorUI: (text) => this.trigger("raise-error-ui", { text }),
     };
   }
 

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -12,7 +12,7 @@ import {
 } from "../types/index";
 import { BasePlugin } from "./base_plugin";
 
-type UIActions = Pick<ModelConfig, "notifyUI">;
+type UIActions = Pick<ModelConfig, "notifyUI" | "raiseBlockingErrorUI">;
 
 export interface UIPluginConfig {
   readonly getters: Getters;

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -205,10 +205,7 @@ export class EditionPlugin extends UIPlugin {
           this.sheetId = this.getters.getActiveSheetId();
           this.cancelEditionAndActivateSheet();
           this.resetContent();
-          this.ui.notifyUI({
-            type: "ERROR",
-            text: CELL_DELETED_MESSAGE,
-          });
+          this.ui.raiseBlockingErrorUI(CELL_DELETED_MESSAGE);
         }
         break;
       case "CYCLE_EDITION_REFERENCES":
@@ -337,10 +334,7 @@ export class EditionPlugin extends UIPlugin {
   private onColumnsRemoved(cmd: RemoveColumnsRowsCommand) {
     if (cmd.elements.includes(this.col) && this.mode !== "inactive") {
       this.dispatch("STOP_EDITION", { cancel: true });
-      this.ui.notifyUI({
-        type: "ERROR",
-        text: CELL_DELETED_MESSAGE,
-      });
+      this.ui.raiseBlockingErrorUI(CELL_DELETED_MESSAGE);
       return;
     }
     const { top, left } = updateSelectionOnDeletion(
@@ -355,10 +349,7 @@ export class EditionPlugin extends UIPlugin {
   private onRowsRemoved(cmd: RemoveColumnsRowsCommand) {
     if (cmd.elements.includes(this.row) && this.mode !== "inactive") {
       this.dispatch("STOP_EDITION", { cancel: true });
-      this.ui.notifyUI({
-        type: "ERROR",
-        text: CELL_DELETED_MESSAGE,
-      });
+      this.ui.raiseBlockingErrorUI(CELL_DELETED_MESSAGE);
       return;
     }
     const { top, left } = updateSelectionOnDeletion(
@@ -543,12 +534,11 @@ export class EditionPlugin extends UIPlugin {
       this.currentTokens = text.startsWith("=") ? composerTokenize(text, locale) : [];
       if (this.currentTokens.length > 100) {
         if (raise) {
-          this.ui.notifyUI({
-            type: "ERROR",
-            text: _t(
+          this.ui.raiseBlockingErrorUI(
+            _t(
               "This formula has over 100 parts. It can't be processed properly, consider splitting it into multiple cells"
-            ),
-          });
+            )
+          );
         }
       }
     }

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -10,11 +10,12 @@ export interface EditTextOptions {
   placeholder?: string;
 }
 
-export type notificationType = "ERROR" | "INFORMATION";
+export type NotificationType = "danger" | "info" | "success" | "warning";
 
 export interface InformationNotification {
   text: string;
-  tag: string;
+  type: NotificationType;
+  sticky: boolean;
 }
 
 export interface SpreadsheetEnv {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,4 +1,0 @@
-export interface NotifyUIEvent {
-  type: "ERROR";
-  text: string;
-}

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -558,7 +558,7 @@ describe("Multi users synchronisation", () => {
 
   test("Composer is moved when column is removed on it", () => {
     selectCell(alice, "D2");
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     alice.dispatch("START_EDITION", { text: "hello" });
     deleteColumns(bob, ["D"]);
     expect(spy).toHaveBeenCalled();
@@ -612,7 +612,7 @@ describe("Multi users synchronisation", () => {
   test("Delete row & Don't notify cell is deleted when composer is active", () => {
     selectCell(alice, "A4");
     alice.dispatch("START_EDITION", { text: "hello" });
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     deleteRows(bob, [3]);
     expect(spy).toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
@@ -621,7 +621,7 @@ describe("Multi users synchronisation", () => {
   test("Delete col & Don't notify cell is deleted when composer is active", () => {
     selectCell(alice, "A4");
     alice.dispatch("START_EDITION", { text: "hello" });
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     deleteColumns(bob, ["A"]);
     expect(spy).toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
@@ -632,7 +632,7 @@ describe("Multi users synchronisation", () => {
     createSheet(alice, { sheetId: "42" });
     selectCell(alice, "A4");
     alice.dispatch("START_EDITION", { text: "hello" });
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     alice.dispatch("DELETE_SHEET", { sheetId: activeSheetId });
     expect(spy).toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
@@ -642,7 +642,7 @@ describe("Multi users synchronisation", () => {
     selectCell(alice, "A4");
     alice.dispatch("START_EDITION", { text: "hello" });
     alice.dispatch("STOP_EDITION");
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     deleteRows(bob, [3]);
     expect(spy).not.toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
@@ -652,7 +652,7 @@ describe("Multi users synchronisation", () => {
     selectCell(alice, "A4");
     alice.dispatch("START_EDITION", { text: "hello" });
     alice.dispatch("STOP_EDITION");
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     deleteColumns(bob, ["A"]);
     expect(spy).not.toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
@@ -664,7 +664,7 @@ describe("Multi users synchronisation", () => {
     selectCell(alice, "A4");
     alice.dispatch("START_EDITION", { text: "hello" });
     alice.dispatch("STOP_EDITION");
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     alice.dispatch("DELETE_SHEET", { sheetId: activeSheetId });
     expect(spy).not.toHaveBeenCalled();
     expect(alice.getters.getEditionMode()).toBe("inactive");
@@ -702,7 +702,7 @@ describe("Multi users synchronisation", () => {
     createSheet(alice, { sheetId: "42" });
     activateSheet(alice, "42");
     selectCell(alice, "A4");
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     alice.dispatch("START_EDITION", { text: "hello" });
     bob.dispatch("DELETE_SHEET", { sheetId: "42" });
     expect(spy).toHaveBeenCalled();
@@ -712,7 +712,7 @@ describe("Multi users synchronisation", () => {
   test("Composing in a sheet when a sheet deletion is redone", () => {
     createSheet(alice, { sheetId: "42" });
     selectCell(alice, "A4");
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     bob.dispatch("DELETE_SHEET", { sheetId: "42" });
     undo(bob);
     activateSheet(alice, "42");
@@ -725,7 +725,7 @@ describe("Multi users synchronisation", () => {
   test("Composing in a sheet when a sheet creation is undone", () => {
     createSheet(bob, { sheetId: "42" });
     selectCell(alice, "A4");
-    const spy = jest.spyOn(alice["config"], "notifyUI");
+    const spy = jest.spyOn(alice["config"], "raiseBlockingErrorUI");
     activateSheet(alice, "42");
     alice.dispatch("START_EDITION", { text: "hello" });
     undo(bob);

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -293,11 +293,28 @@ test("Warn user only once when the viewport is too small for its frozen panes", 
   expect(notifyUser).toHaveBeenCalledTimes(2);
 });
 
-test("Notify ui correctly with type notification correctly use notifyUser in the env", async () => {
+test("Raise error to ui use 'raiseError' in the env", async () => {
   const raiseError = jest.fn();
   ({ model, fixture } = await mountSpreadsheet(undefined, { raiseError }));
-  model["config"].notifyUI({ type: "ERROR", text: "hello" });
-  expect(raiseError).toHaveBeenCalledWith("hello");
+  model["config"].raiseBlockingErrorUI("windows has detected that your monitor is not plugged in");
+  expect(raiseError).toHaveBeenCalledWith(
+    "windows has detected that your monitor is not plugged in"
+  );
+});
+
+test("Notify ui correctly, with type notification correctly use notifyUser in the env", async () => {
+  const notifyUser = jest.fn();
+  ({ model, fixture } = await mountSpreadsheet(undefined, { notifyUser }));
+  model["config"].notifyUI({
+    text: "hello",
+    type: "info",
+    sticky: false,
+  });
+  expect(notifyUser).toHaveBeenCalledWith({
+    text: "hello",
+    type: "info",
+    sticky: false,
+  });
 });
 
 test("grid should regain focus after a topbar menu option is selected", async () => {

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -824,7 +824,7 @@ describe("edition", () => {
 
   test("write too long formulas raises an error", async () => {
     const model = new Model({});
-    const spyNotify = jest.spyOn(model["config"], "notifyUI");
+    const spyNotify = jest.spyOn(model["config"], "raiseBlockingErrorUI");
     model.dispatch("START_EDITION");
     const content = // 101 tokens
       "=1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1";


### PR DESCRIPTION
## Description:

This commit improves the notifications that can be sent to the user interface in three ways

1 - change responsibilities

Spreadsheet has been developed so that it isn't possible to notify several times with the same message.
We believe that this feature should not be general but specific to each notifying element.
Technically, this means no longer using "tag" on the notifyUser payload

2 - Have different notification categories.

The spreadsheet integration currently allows having only one level of notification. We would like to have several such as:
- danger
- warning
- info
- success

3 - Notify user with sticky and no sticky notifications


Task: : [3414653](https://www.odoo.com/web#id=3414653&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo