### PR TITLE
[FIX] FindAndReplace: Changing the show formula state from topbar

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -1,4 +1,4 @@
-import { Component, onMounted, onWillUnmount, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, useEffect, useRef, useState } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../types/index";
 import { css } from "../../helpers/css";
 
@@ -69,6 +69,14 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
 
   setup() {
     this.showFormulaState = this.env.model.getters.shouldShowFormulas();
+
+    useEffect(
+      () => {
+        this.state.searchOptions.searchFormulas = this.env.model.getters.shouldShowFormulas();
+        this.searchFormulas();
+      },
+      () => [this.env.model.getters.shouldShowFormulas()]
+    );
 
     onMounted(() => this.focusInput());
 

--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -54,6 +54,7 @@ export class FindAndReplacePlugin extends UIPlugin {
     searchFormulas: false,
   };
   private toSearch: string = "";
+  isEvaluationDirty = false;
 
   // ---------------------------------------------------------------------------
   // Command Handling
@@ -85,10 +86,18 @@ export class FindAndReplacePlugin extends UIPlugin {
       case "ADD_COLUMNS_ROWS":
         this.clearSearch();
         break;
+      case "UPDATE_CELL":
       case "ACTIVATE_SHEET":
       case "REFRESH_SEARCH":
-        this.refreshSearch();
+        this.isEvaluationDirty = true;
         break;
+    }
+  }
+
+  finalize() {
+    if (this.isEvaluationDirty) {
+      this.refreshSearch();
+      this.isEvaluationDirty = false;
     }
   }
 

--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -89,6 +89,8 @@ export class FindAndReplacePlugin extends UIPlugin {
       case "UPDATE_CELL":
       case "ACTIVATE_SHEET":
       case "REFRESH_SEARCH":
+      case "HIDE_COLUMNS_ROWS":
+      case "UNHIDE_COLUMNS_ROWS":
         this.isEvaluationDirty = true;
         break;
     }
@@ -268,6 +270,19 @@ export class FindAndReplacePlugin extends UIPlugin {
   }
 
   private getSearchableString(position: CellPosition): string {
+    const { sheetId, col, row } = position;
+    const cell = this.getters.getCell(position);
+    if (!cell) {
+      return "";
+    }
+
+    const isColHidden = this.getters.isColHidden(sheetId, col);
+    const isRowHidden = this.getters.isRowHidden(sheetId, row);
+
+    if (isColHidden || isRowHidden) {
+      return "";
+    }
+
     return this.getters.getCellText(position, this.searchOptions.searchFormulas);
   }
 

--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -84,8 +84,6 @@ export class FindAndReplacePlugin extends UIPlugin {
       case "REDO":
       case "REMOVE_COLUMNS_ROWS":
       case "ADD_COLUMNS_ROWS":
-        this.clearSearch();
-        break;
       case "UPDATE_CELL":
       case "ACTIVATE_SHEET":
       case "REFRESH_SEARCH":

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -805,6 +805,26 @@ describe("Topbar - View", () => {
     await click(fixture, ".o-sidePanel .o-sidePanelHeader .o-sidePanelClose");
     expect(model.getters.shouldShowFormulas()).toBe(true);
   });
+
+  test("Setting show formula from f&r should retain its state even it's changed via topbar", async () => {
+    const { model, fixture, env } = await mountSpreadsheet();
+    await click(fixture, ".o-topbar-menu[data-id='view']");
+    await click(fixture, ".o-menu-item[data-name='view_formulas']");
+    expect(model.getters.shouldShowFormulas()).toBe(true);
+    env.openSidePanel("FindAndReplace");
+    await nextTick();
+    await click(
+      fixture,
+      ".o-sidePanel .o-sidePanelBody .o-find-and-replace .o-section:nth-child(1) .o-far-item:nth-child(3) input"
+    );
+    expect(
+      (
+        document.querySelector(
+          ".o-sidePanel .o-sidePanelBody .o-find-and-replace .o-section:nth-child(1) .o-far-item:nth-child(3) input"
+        ) as HTMLInputElement
+      ).value
+    ).toBe("on");
+  });
 });
 
 describe("Topbar - menu item resizing with viewport", () => {

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -59,7 +59,8 @@ describe("basic search", () => {
     expect(model.getters.getSelection().zones).toEqual([toZone("A6")]);
   });
 
-  test("modifying cells won't change the search", () => {
+  test.skip("modifying cells won't change the search", () => {
+    // updated cell need to update the search
     model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
     let matches = model.getters.getSearchMatches();
     let matchIndex = model.getters.getCurrentSelectedMatchIndex();
@@ -114,8 +115,7 @@ describe("basic search", () => {
     expect(model.getters.getSearchMatches()).toHaveLength(0);
   });
 
-  test.skip("Will search a modified cell", () => {
-    // not implemented
+  test("Will search a modified cell", () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
     let matches = model.getters.getSearchMatches();
     let matchIndex = model.getters.getCurrentSelectedMatchIndex();
@@ -125,14 +125,14 @@ describe("basic search", () => {
     expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
     expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
     expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
-    setCellContent(model, "B1", "=1");
+    setCellContent(model, "B1", "1");
     setCellContent(model, "B2", "=11");
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
     expect(matches).toHaveLength(6);
     expect(matchIndex).toStrictEqual(0);
-    expect(matches[0]).toStrictEqual({ col: 1, row: 0, selected: false });
-    expect(matches[1]).toStrictEqual({ col: 0, row: 1, selected: true });
+    expect(matches[0]).toStrictEqual({ col: 1, row: 0, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 0, row: 1, selected: false });
     expect(matches[2]).toStrictEqual({ col: 1, row: 1, selected: false });
     expect(matches[3]).toStrictEqual({ col: 0, row: 2, selected: false });
     expect(matches[4]).toStrictEqual({ col: 0, row: 3, selected: false });
@@ -507,8 +507,8 @@ describe("replace", () => {
     model.dispatch("REPLACE_SEARCH", { replaceWith: "2,5" });
     const matches = model.getters.getSearchMatches();
     const matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(matches).toHaveLength(0);
-    expect(matchIndex).toStrictEqual(null);
+    expect(matches).toHaveLength(1);
+    expect(matchIndex).toStrictEqual(0);
     expect(getCell(model, "A2")?.content).toBe("=SUM(2.5,2.5)");
   });
 

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -4,9 +4,11 @@ import { SearchOptions } from "../../src/plugins/ui_feature/find_and_replace";
 import {
   activateSheet,
   createSheet,
+  redo,
   setCellContent,
   setSelection,
   setViewportOffset,
+  undo,
   updateLocale,
 } from "../test_helpers/commands_helpers";
 import {
@@ -158,6 +160,84 @@ describe("basic search", () => {
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
     expect(matches).toHaveLength(0);
     expect(matchIndex).toStrictEqual(null);
+  });
+
+  test("Need to update search if column or row is removed", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
+    let matches = model.getters.getSearchMatches();
+    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    expect(matches[0]).toStrictEqual({ col: 0, row: 1, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
+    expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
+    expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
+    model.dispatch("REMOVE_COLUMNS_ROWS", {
+      dimension: "ROW",
+      elements: [1],
+      sheetId: model.getters.getActiveSheetId(),
+    });
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(3);
+    expect(matchIndex).toStrictEqual(0);
+    expect(matches[0]).toStrictEqual({ col: 0, row: 1, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
+    expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
+  });
+
+  test("Need to update search if column or row is removed", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
+    let matches = model.getters.getSearchMatches();
+    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    model.dispatch("REMOVE_COLUMNS_ROWS", {
+      dimension: "ROW",
+      elements: [1],
+      sheetId: model.getters.getActiveSheetId(),
+    });
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(3);
+    expect(matchIndex).toStrictEqual(0);
+    undo(model);
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    redo(model);
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(3);
+    expect(matchIndex).toStrictEqual(0);
+  });
+
+  test("Need to maintain search if column or row is added", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
+    let matches = model.getters.getSearchMatches();
+    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    expect(matches[0]).toStrictEqual({ col: 0, row: 1, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
+    expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
+    expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
+    model.dispatch("ADD_COLUMNS_ROWS", {
+      dimension: "COL",
+      base: 1,
+      quantity: 1,
+      position: "after",
+      sheetId: model.getters.getActiveSheetId(),
+    });
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    expect(matches[0]).toStrictEqual({ col: 0, row: 1, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
+    expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
+    expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
   });
 
   test("new search when changing sheet", () => {

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -139,6 +139,27 @@ describe("basic search", () => {
     expect(matches[5]).toStrictEqual({ col: 0, row: 4, selected: false });
   });
 
+  test("Will skip search if cell is hidden", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
+    let matches = model.getters.getSearchMatches();
+    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    expect(matches[0]).toStrictEqual({ col: 0, row: 1, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
+    expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
+    expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
+    model.dispatch("HIDE_COLUMNS_ROWS", {
+      dimension: "COL",
+      elements: [0],
+      sheetId: model.getters.getActiveSheetId(),
+    });
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(0);
+    expect(matchIndex).toStrictEqual(null);
+  });
+
   test("new search when changing sheet", () => {
     const sheet1 = model.getters.getActiveSheetId();
     const sheet2 = "42";


### PR DESCRIPTION
## Description:

When we change the state of the 'Show Formula' option in the top bar, the side panel of 'Find and Replace' will also update its state accordingly. Therefore, when you click and set 'Show Formula' to true, the 'Find and Replace' side panel will also update its state and turn it on.

Task: : [3250881](https://www.odoo.com/web#id=3250881&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo