### PR TITLE
[FIX] SheetPlugin: Prevent deletion of all non-frozen headers

### DIFF
--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -365,6 +365,9 @@ export class InternalViewport {
       this.boundaries.right,
       this.searchHeaderIndex("COL", this.viewportWidth, this.left)
     );
+    if (this.left === -1) {
+      this.left = this.boundaries.left;
+    }
     if (this.right === -1) {
       this.right = this.getters.getNumberCols(sheetId) - 1;
     }
@@ -382,6 +385,9 @@ export class InternalViewport {
       this.boundaries.bottom,
       this.searchHeaderIndex("ROW", this.viewportHeight, this.top)
     );
+    if (this.top === -1) {
+      this.top = this.boundaries.top;
+    }
     if (this.bottom === -1) {
       this.bottom = this.getters.getNumberRows(sheetId) - 1;
     }

--- a/src/plugins/core/header_visibility.ts
+++ b/src/plugins/core/header_visibility.ts
@@ -5,7 +5,7 @@ import { CorePlugin } from "../core_plugin";
 
 export class HeaderVisibilityPlugin extends CorePlugin {
   static getters = [
-    "canRemoveHeaders",
+    "checkElementsIncludeAllVisibleHeaders",
     "getHiddenColsGroups",
     "getHiddenRowsGroups",
     "isRowHiddenByUser",
@@ -41,7 +41,7 @@ export class HeaderVisibilityPlugin extends CorePlugin {
         if (!this.getters.tryGetSheet(cmd.sheetId)) {
           return CommandResult.InvalidSheetId;
         }
-        if (!this.canRemoveHeaders(cmd.sheetId, cmd.dimension, cmd.elements)) {
+        if (this.checkElementsIncludeAllVisibleHeaders(cmd.sheetId, cmd.dimension, cmd.elements)) {
           return CommandResult.NotEnoughElements;
         }
         return CommandResult.Success;
@@ -97,9 +97,13 @@ export class HeaderVisibilityPlugin extends CorePlugin {
     return;
   }
 
-  canRemoveHeaders(sheetId: UID, dimension: Dimension, elements: HeaderIndex[]): boolean {
+  checkElementsIncludeAllVisibleHeaders(
+    sheetId: UID,
+    dimension: Dimension,
+    elements: HeaderIndex[]
+  ): boolean {
     const visibleHeaders = this.getAllVisibleHeaders(sheetId, dimension);
-    return !includesAll(elements, visibleHeaders);
+    return includesAll(elements, visibleHeaders);
   }
 
   isRowHiddenByUser(sheetId: UID, index: HeaderIndex): boolean {

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -4,10 +4,12 @@ import {
   deepCopy,
   getUnquotedSheetName,
   groupConsecutive,
+  includesAll,
   isDefined,
   isZoneInside,
   isZoneValid,
   positions,
+  range,
   toCartesian,
 } from "../../helpers/index";
 import { _lt, _t } from "../../translation";
@@ -71,6 +73,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "getSheetSize",
     "getSheetZone",
     "getPaneDivisions",
+    "checkElementsIncludeAllNonFrozenHeaders",
   ] as const;
 
   readonly sheetIdsMapName: Record<string, UID | undefined> = {};
@@ -138,6 +141,10 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
             : this.getNumberRows(cmd.sheetId);
         if (Math.min(...cmd.elements) < 0 || Math.max(...cmd.elements) > elements) {
           return CommandResult.InvalidHeaderIndex;
+        } else if (
+          this.checkElementsIncludeAllNonFrozenHeaders(cmd.sheetId, cmd.dimension, cmd.elements)
+        ) {
+          return CommandResult.NotEnoughElements;
         } else {
           return CommandResult.Success;
         }
@@ -481,6 +488,27 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
       panes.ySplit = base;
     }
     this.history.update("sheets", sheetId, "panes", panes);
+  }
+
+  /**
+   * Checks if all non-frozen header indices are present in the provided elements of selected rows/columns.
+   * This validation ensures that all rows or columns cannot be deleted when frozen panes exist.
+   */
+  checkElementsIncludeAllNonFrozenHeaders(
+    sheetId: UID,
+    dimension: Dimension,
+    elements: HeaderIndex[]
+  ): boolean {
+    const paneDivisions = this.getters.getPaneDivisions(sheetId);
+    const startIndex = dimension === "ROW" ? paneDivisions.ySplit : paneDivisions.xSplit;
+    const endIndex = this.getters.getNumberHeaders(sheetId, dimension);
+
+    if (!startIndex) {
+      return false;
+    }
+
+    const indicesToCheck = range(startIndex, endIndex);
+    return includesAll(elements, indicesToCheck);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/registries/menus/col_menu_registry.ts
+++ b/src/registries/menus/col_menu_registry.ts
@@ -72,11 +72,7 @@ colMenuRegistry
     name: ACTIONS.REMOVE_COLUMNS_NAME,
     sequence: 90,
     action: ACTIONS.REMOVE_COLUMNS_ACTION,
-    isVisible: (env: SpreadsheetChildEnv) => {
-      const sheetId = env.model.getters.getActiveSheetId();
-      const selectedCols = env.model.getters.getElementsFromSelection("COL");
-      return env.model.getters.canRemoveHeaders(sheetId, "COL", selectedCols);
-    },
+    isVisible: (env: SpreadsheetChildEnv) => ACTIONS.CAN_REMOVE_COLUMNS_ROWS("COL", env),
   })
   .add("clear_column", {
     name: ACTIONS.DELETE_CONTENT_COLUMNS_NAME,
@@ -90,7 +86,7 @@ colMenuRegistry
     isVisible: (env: SpreadsheetChildEnv) => {
       const sheetId = env.model.getters.getActiveSheetId();
       const selectedCols = env.model.getters.getElementsFromSelection("COL");
-      return env.model.getters.canRemoveHeaders(sheetId, "COL", selectedCols);
+      return !env.model.getters.checkElementsIncludeAllVisibleHeaders(sheetId, "COL", selectedCols);
     },
     separator: true,
   })

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -9,7 +9,7 @@ import {
   interactivePasteFromOS,
 } from "../../helpers/ui/paste_interactive";
 import { _lt } from "../../translation";
-import { CellValueType, Format, SpreadsheetChildEnv, Style } from "../../types/index";
+import { CellValueType, Dimension, Format, SpreadsheetChildEnv, Style } from "../../types/index";
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -234,6 +234,27 @@ export const REMOVE_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
     dimension: "ROW",
     elements: rows,
   });
+};
+
+export const CAN_REMOVE_COLUMNS_ROWS = (
+  dimension: Dimension,
+  env: SpreadsheetChildEnv
+): boolean => {
+  const sheetId = env.model.getters.getActiveSheetId();
+  const selectedElements = env.model.getters.getElementsFromSelection(dimension);
+
+  const includesAllVisibleHeaders = env.model.getters.checkElementsIncludeAllVisibleHeaders(
+    sheetId,
+    dimension,
+    selectedElements
+  );
+  const includesAllNonFrozenHeaders = env.model.getters.checkElementsIncludeAllNonFrozenHeaders(
+    sheetId,
+    dimension,
+    selectedElements
+  );
+
+  return !includesAllVisibleHeaders && !includesAllNonFrozenHeaders;
 };
 
 export const REMOVE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {

--- a/src/registries/menus/row_menu_registry.ts
+++ b/src/registries/menus/row_menu_registry.ts
@@ -55,11 +55,7 @@ rowMenuRegistry
     name: ACTIONS.REMOVE_ROWS_NAME,
     sequence: 70,
     action: ACTIONS.REMOVE_ROWS_ACTION,
-    isVisible: (env: SpreadsheetChildEnv) => {
-      const sheetId = env.model.getters.getActiveSheetId();
-      const selectedRows = env.model.getters.getElementsFromSelection("ROW");
-      return env.model.getters.canRemoveHeaders(sheetId, "ROW", selectedRows);
-    },
+    isVisible: (env: SpreadsheetChildEnv) => ACTIONS.CAN_REMOVE_COLUMNS_ROWS("ROW", env),
   })
   .add("clear_row", {
     name: ACTIONS.DELETE_CONTENT_ROWS_NAME,
@@ -73,7 +69,7 @@ rowMenuRegistry
     isVisible: (env: SpreadsheetChildEnv) => {
       const sheetId = env.model.getters.getActiveSheetId();
       const selectedRows = env.model.getters.getElementsFromSelection("ROW");
-      return env.model.getters.canRemoveHeaders(sheetId, "ROW", selectedRows);
+      return !env.model.getters.checkElementsIncludeAllVisibleHeaders(sheetId, "ROW", selectedRows);
     },
     separator: true,
   })

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -103,11 +103,13 @@ topbarMenuRegistry
     name: ACTIONS.REMOVE_ROWS_NAME,
     sequence: 80,
     action: ACTIONS.REMOVE_ROWS_ACTION,
+    isVisible: (env: SpreadsheetChildEnv) => ACTIONS.CAN_REMOVE_COLUMNS_ROWS("ROW", env),
   })
   .addChild("edit_delete_column", ["edit"], {
     name: ACTIONS.REMOVE_COLUMNS_NAME,
     sequence: 90,
     action: ACTIONS.REMOVE_COLUMNS_ACTION,
+    isVisible: (env: SpreadsheetChildEnv) => ACTIONS.CAN_REMOVE_COLUMNS_ROWS("COL", env),
   })
   .addChild("edit_delete_cell_shift_up", ["edit"], {
     name: _lt("Delete cell and shift up"),

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -301,6 +301,17 @@ describe("Menu Item actions", () => {
         elements: [3, 4],
       });
     });
+
+    test("selecting all non-frozen rows should hide the option for deletion", async () => {
+      const sheetId = model.getters.getActiveSheetId();
+      const lastRow = model.getters.getNumberRows(sheetId) - 1;
+
+      freezeRows(model, 4, sheetId);
+      selectRow(model, 4, "newAnchor");
+      selectRow(model, lastRow, "updateAnchor");
+
+      expect(getNode(path).isVisible(env)).toBeFalsy();
+    });
   });
 
   describe("Edit -> edit_delete_column", () => {
@@ -362,6 +373,17 @@ describe("Menu Item actions", () => {
         dimension: "COL",
         elements: [3, 4],
       });
+    });
+
+    test("selecting all non-frozen columns should hide the option for deletion", async () => {
+      const sheetId = model.getters.getActiveSheetId();
+      const lastColumn = model.getters.getNumberCols(sheetId) - 1;
+
+      freezeColumns(model, 3, sheetId);
+      selectColumn(model, 3, "newAnchor");
+      selectColumn(model, lastColumn, "updateAnchor");
+
+      expect(getNode(path).isVisible(env)).toBeFalsy();
     });
   });
 

--- a/tests/plugins/sheets.test.ts
+++ b/tests/plugins/sheets.test.ts
@@ -1015,6 +1015,21 @@ describe("sheets", () => {
     expect(freezeRows(model, 12)).toBeCancelledBecause(CommandResult.InvalidFreezeQuantity);
   });
 
+  test("Cannot delete all non-frozen columns/rows when frozen columns/rows exist", () => {
+    const model = new Model({ sheets: [{ colNumber: 10, rowNumber: 10 }] });
+    const sheetId = model.getters.getActiveSheetId();
+    freezeColumns(model, 5, sheetId);
+    freezeRows(model, 5, sheetId);
+
+    expect(deleteRows(model, [5, 6, 7, 8, 9])).toBeCancelledBecause(
+      CommandResult.NotEnoughElements
+    );
+
+    expect(deleteColumns(model, ["F", "G", "H", "I", "J"])).toBeCancelledBecause(
+      CommandResult.NotEnoughElements
+    );
+  });
+
   test("Cannot delete unexisting columns", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -1037,6 +1037,37 @@ describe("Multi Panes viewport", () => {
       CommandResult.InvalidScrollingDirection
     );
   });
+
+  test("Viewport remains unaffected when hiding all rows below frozen pane or columns right to frozen panes", () => {
+    const model = new Model({ sheets: [{ colNumber: 8, rowNumber: 8 }] });
+    const sheetId = model.getters.getActiveSheetId();
+
+    freezeRows(model, 4, sheetId);
+    let originalActiveMainViewport = model.getters.getActiveMainViewport();
+    hideRows(model, [4, 5, 6, 7]);
+    expect(model.getters.getActiveMainViewport()).toEqual(originalActiveMainViewport);
+
+    freezeColumns(model, 4, sheetId);
+    originalActiveMainViewport = model.getters.getActiveMainViewport();
+    hideColumns(model, ["E", "F", "G", "H"]);
+    expect(model.getters.getActiveMainViewport()).toEqual(originalActiveMainViewport);
+  });
+
+  test("Viewport remains unaffected when hiding all rows below frozen panes by data filter", () => {
+    const model = new Model({ sheets: [{ colNumber: 3, rowNumber: 3 }] });
+    const sheetId = model.getters.getActiveSheetId();
+
+    setCellContent(model, "A2", "2808");
+    setCellContent(model, "A3", "2808");
+
+    createFilter(model, "A1:A3");
+    freezeRows(model, 2, sheetId);
+
+    const originalActiveMainViewport = model.getters.getActiveMainViewport();
+    updateFilter(model, "A1", ["2808"]);
+
+    expect(model.getters.getActiveMainViewport()).toEqual(originalActiveMainViewport);
+  });
 });
 
 describe("multi sheet with different sizes", () => {


### PR DESCRIPTION
## Description:

This PR contains two commits that tackle the following issues:

***Commit 1:***

Issue: Deleting rows/columns, except the frozen ones, would break the spreadsheet. Hiding some rows and then deleting all rows, except the frozen ones, or using a data filter to hide some rows and then deleting all rows, would also cause issues.

Solution: Implemented a validation mechanism in the `SheetPlugin.` The `allowDispatch` function now checks for attempts to delete all rows or columns when frozen panes are present. If such actions are detected, the corresponding command will be rejected.

***Commit 2:***

Issue: The `searchHeaderIndex` function returned `-1` when trying to hide all rows/cols, leading to a broken sheet. This occurred because the `adjustViewportZoneY` function used this value as top.

Solution: Modified the `searchHeaderIndex` function to handle `top` and `left` `-1` cases correctly. Now, when trying to hide all rows or columns, the function reassigns the value of `boundaries.top` and `boundaries.left` respectively, resolving the issue.

Task: [3414127](https://www.odoo.com/web#id=3414127&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo