### PR TITLE
[IMP] Formatting: Change 'copy formatting' cursor

### DIFF
--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -14,7 +14,7 @@ import { useRefListener } from "../helpers/listener_hook";
 import { useInterval } from "../helpers/time_hooks";
 
 const CURSOR_SVG = /*xml*/ `
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="14" height="16"><path d="M6.5.4c1.3-.8 2.9-.1 3.8 1.4l2.9 5.1c.2.4.9 1.6-.4 2.3l-1.6.9 1.8 3.1c.2.4.1 1-.2 1.2l-1.6 1c-.3.1-.9 0-1.1-.4l-1.8-3.1-1.6 1c-.6.4-1.7 0-2.2-.8L0 4.3"/><path fill="#fff" d="M9.1 2a1.4 1.1 60 0 0-1.7-.6L5.5 2.5l.9 1.6-1 .6-.9-1.6-.6.4 1.8 3.1-1.3.7-1.8-3.1-1 .6 3.8 6.6 6.8-3.98M3.9 8.8 10.82 5l.795 1.4-6.81 3.96"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16"><path d="m7.5.6-6.9 4C.1 4.9 0 5.5.2 6l2 3.5c.3.5.9.6 1.4.4l6.9-4c.5-.3.6-.9.4-1.4l-.5-.9.9-.5 1.5 2.6-6.1 3.5 4 6.9 1.7-1-3-5.2 6.1-3.5L12 .3 9.4 1.8 8.9 1A1 1 0 0 0 7.5.6"/><path fill="#fff" d="M1.6 5.9a.5.5 0 0 1 .2-.7L7.4 2a.5.5 0 0 1 .7.2l1.2 2.2a.5.5 0 0 1-.2.7L3.6 8.4a.5.5 0 0 1-.7-.2"/></svg>
 `;
 
 css/* scss */ `


### PR DESCRIPTION
## Task Description

When copying the formatting of a cell to another with the "roller" button, the cursor of the mouse change. Currently, it look like a brush, which is more similar to the icon of the 'Conditionnal formatting' menu item than of the 'paint format' tool. This PR aims to change it to get a more logical cursor.