### PR TITLE
[FIX] find_and_replace: Update cell don't update the search

### DIFF
--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -53,6 +53,7 @@ export class FindAndReplacePlugin extends UIPlugin {
     searchFormulas: false,
   };
   private toSearch: string = "";
+  private isSearchDirty = false;
 
   // ---------------------------------------------------------------------------
   // Command Handling
@@ -84,10 +85,21 @@ export class FindAndReplacePlugin extends UIPlugin {
       case "ADD_COLUMNS_ROWS":
         this.clearSearch();
         break;
+      case "EVALUATE_CELLS":
+      case "UPDATE_CELL":
+        this.isSearchDirty = true;
+        break;
       case "ACTIVATE_SHEET":
       case "REFRESH_SEARCH":
         this.refreshSearch();
         break;
+    }
+  }
+
+  finalize() {
+    if (this.isSearchDirty) {
+      this.refreshSearch();
+      this.isSearchDirty = false;
     }
   }
 

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../src";
+import { args, functionRegistry } from "../../src/functions";
 import { toZone } from "../../src/helpers";
 import { SearchOptions } from "../../src/plugins/ui/find_and_replace";
 import { activateSheet, createSheet, setCellContent } from "../test_helpers/commands_helpers";
@@ -46,28 +47,6 @@ describe("basic search", () => {
     expect(model.getters.getSelection().zones).toEqual([toZone("A6")]);
   });
 
-  test("modifying cells won't change the search", () => {
-    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
-    let matches = model.getters.getSearchMatches();
-    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(matches.length).toBe(4);
-    expect(matchIndex).toStrictEqual(0);
-    expect(matches[0]).toStrictEqual({ col: 0, row: 1, selected: true });
-    expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
-    expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
-    expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
-    setCellContent(model, "A2", "hello");
-    setCellContent(model, "B1", "1");
-    matches = model.getters.getSearchMatches();
-    matchIndex = model.getters.getCurrentSelectedMatchIndex();
-    expect(matches.length).toBe(4);
-    expect(matchIndex).toStrictEqual(0);
-    expect(matches[0]).toStrictEqual({ col: 0, row: 1, selected: true });
-    expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
-    expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
-    expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
-  });
-
   test("change the search", async () => {
     model.dispatch("UPDATE_SEARCH", { toSearch: "hello", searchOptions });
     model.dispatch("SELECT_SEARCH_NEXT_MATCH");
@@ -87,6 +66,54 @@ describe("basic search", () => {
     expect(matches[1]).toStrictEqual({ col: 0, row: 2, selected: false });
     expect(matches[2]).toStrictEqual({ col: 0, row: 3, selected: false });
     expect(matches[3]).toStrictEqual({ col: 0, row: 4, selected: false });
+  });
+
+  test("refresh search when cell is updated", async () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "hello", searchOptions });
+    let matches = model.getters.getSearchMatches();
+    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(2);
+    expect(matchIndex).toStrictEqual(0);
+    expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 0, row: 1, selected: false });
+    setCellContent(model, "B1", "hello");
+    setCellContent(model, "B2", '="hello"');
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 1, row: 0, selected: false });
+    expect(matches[2]).toStrictEqual({ col: 0, row: 1, selected: false });
+    expect(matches[3]).toStrictEqual({ col: 1, row: 1, selected: false });
+  });
+
+  test("refresh search when cell is update with EVALUATE_CELLS", async () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "hello", searchOptions });
+    let matches = model.getters.getSearchMatches();
+    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(2);
+    expect(matchIndex).toStrictEqual(0);
+    expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 0, row: 1, selected: false });
+    let value = "3";
+    functionRegistry.add("GETVALUE", {
+      description: "Get value",
+      compute: () => value,
+      args: args(``),
+      returns: ["NUMBER"],
+    });
+    setCellContent(model, "B1", "=GETVALUE()");
+    value = '="hello"';
+    model.dispatch("EVALUATE_CELLS", { sheetId: model.getters.getActiveSheetId() });
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(getCellContent(model, "B1")).toBe('="hello"');
+    expect(matches).toHaveLength(3);
+    expect(matchIndex).toStrictEqual(0);
+    expect(matches[0]).toStrictEqual({ col: 0, row: 0, selected: true });
+    expect(matches[1]).toStrictEqual({ col: 1, row: 0, selected: false });
+    expect(matches[2]).toStrictEqual({ col: 0, row: 1, selected: false });
   });
 
   test("search on empty string does not match anything", () => {


### PR DESCRIPTION
## Description:

Previously, when we updated a cell that content was already searched in the Find and Replace, it wouldn't be considered a match. However, this PR aims to solve that issue. With this update, whenever a cell is updated, the search will also update and include the cell if it matches

Task: : [3422481](https://www.odoo.com/web#id=3422481&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo