### PR TITLE
[FIX] find_and_replace: update search undo/redo & add/delete header

### DIFF
--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -79,16 +79,14 @@ export class FindAndReplacePlugin extends UIPlugin {
       case "REPLACE_ALL_SEARCH":
         this.replaceAll(cmd.replaceWith);
         break;
-      case "UNDO":
-      case "REDO":
-      case "REMOVE_COLUMNS_ROWS":
-      case "ADD_COLUMNS_ROWS":
-        this.clearSearch();
-        break;
       case "EVALUATE_CELLS":
       case "UPDATE_CELL":
         this.isSearchDirty = true;
         break;
+      case "UNDO":
+      case "REDO":
+      case "REMOVE_COLUMNS_ROWS":
+      case "ADD_COLUMNS_ROWS":
       case "ACTIVATE_SHEET":
         this.refreshSearch();
         break;


### PR DESCRIPTION
## Description:

1. Identified the issue where undo or redo operations would result in the removal of all matches, requiring a fresh search.

2. Noted a similar issue where adding or removing rows/columns did not update the search accordingly.

This PR addresses these issues by updating the search functionality whenever any of the mentioned operations are executed. The search results will be automatically updated to reflect the changes

Task: : [3422484](https://www.odoo.com/web#id=3422484&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo