### PR TITLE
[FIX] find_and_replace: hidden cell should not be considered 

### DIFF
--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -154,12 +154,17 @@ export class FindAndReplacePlugin extends UIPlugin {
    * Find matches using the current regex
    */
   private findMatches() {
-    const activeSheetId = this.getters.getActiveSheetId();
-    const cells = this.getters.getCells(activeSheetId);
+    const sheetId = this.getters.getActiveSheetId();
+    const cells = this.getters.getCells(sheetId);
     const matches: SearchMatch[] = [];
-
     if (this.toSearch) {
       for (const cell of Object.values(cells)) {
+        const { col, row } = this.getters.getCellPosition(cell.id);
+        const isColHidden = this.getters.isColHidden(sheetId, col);
+        const isRowHidden = this.getters.isRowHidden(sheetId, row);
+        if (isColHidden || isRowHidden) {
+          continue;
+        }
         if (
           cell &&
           this.currentSearchRegex &&

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -2,7 +2,12 @@ import { Model } from "../../src";
 import { args, functionRegistry } from "../../src/functions";
 import { toZone } from "../../src/helpers";
 import { SearchOptions } from "../../src/plugins/ui/find_and_replace";
-import { activateSheet, createSheet, setCellContent } from "../test_helpers/commands_helpers";
+import {
+  activateSheet,
+  createSheet,
+  hideRows,
+  setCellContent,
+} from "../test_helpers/commands_helpers";
 import { getCellContent, getCellText } from "../test_helpers/getters_helpers";
 
 let model: Model;
@@ -175,6 +180,20 @@ describe("basic search", () => {
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
     expect(matches).toHaveLength(2);
+    expect(matchIndex).toStrictEqual(0);
+  });
+
+  test("hidden cells should not be included in match", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
+    let matches = model.getters.getSearchMatches();
+    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    hideRows(model, [1]);
+    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(3);
     expect(matchIndex).toStrictEqual(0);
   });
 });


### PR DESCRIPTION
## Description:

Previously, when we are hiding row or column, f&r include that values in search. But if column or row is hidden, we need to make sure that cell will not consider in searched match

Task: : [3422479](https://www.odoo.com/web#id=3422479&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo