### PR TITLE
[FIX] find_and_replace: wrong active cell on replaceAll 

### DIFF
--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -225,39 +225,38 @@ export class FindAndReplacePlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
   // Replace
   // ---------------------------------------------------------------------------
+  private replaceMatch(selectedMatch: SearchMatch, replaceWith: string) {
+    if (!this.currentSearchRegex) {
+      return;
+    }
+
+    const sheetId = this.getters.getActiveSheetId();
+    const cell = this.getters.getCell({ sheetId, ...selectedMatch });
+    const { col, row } = selectedMatch;
+
+    if (cell?.isFormula && !this.searchOptions.searchFormulas) {
+      return;
+    }
+    const replaceRegex = new RegExp(
+      this.currentSearchRegex.source,
+      this.currentSearchRegex.flags + "g"
+    );
+    const toReplace: string | null = this.getSearchableString({ sheetId, col, row });
+    const content = toReplace.replace(replaceRegex, replaceWith);
+    this.dispatch("UPDATE_CELL", { sheetId, col, row, content });
+  }
+
   /**
    * Replace the value of the currently selected match
    */
   private replace(replaceWith: string) {
-    if (this.selectedMatchIndex === null || !this.currentSearchRegex) {
+    if (this.selectedMatchIndex === null) {
       return;
     }
-    const matches = this.searchMatches;
-    const selectedMatch = matches[this.selectedMatchIndex];
-    const sheetId = this.getters.getActiveSheetId();
-    const cell = this.getters.getCell({ sheetId, ...selectedMatch });
-    if (cell?.isFormula && !this.searchOptions.searchFormulas) {
-      this.selectNextCell(Direction.next);
-    } else {
-      const replaceRegex = new RegExp(
-        this.currentSearchRegex.source,
-        this.currentSearchRegex.flags + "g"
-      );
-      const toReplace: string | null = this.getSearchableString({
-        sheetId,
-        col: selectedMatch.col,
-        row: selectedMatch.row,
-      });
-      const newContent = toReplace.replace(replaceRegex, replaceWith);
-      this.dispatch("UPDATE_CELL", {
-        sheetId: this.getters.getActiveSheetId(),
-        col: selectedMatch.col,
-        row: selectedMatch.row,
-        content: newContent,
-      });
-      this.searchMatches.splice(this.selectedMatchIndex, 1);
-      this.selectNextCell(Direction.current);
-    }
+
+    const selectedMatch = this.searchMatches[this.selectedMatchIndex];
+    this.replaceMatch(selectedMatch, replaceWith);
+    this.selectNextCell(Direction.next);
   }
   /**
    * Apply the replace function to all the matches one time.
@@ -265,7 +264,7 @@ export class FindAndReplacePlugin extends UIPlugin {
   private replaceAll(replaceWith: string) {
     const matchCount = this.searchMatches.length;
     for (let i = 0; i < matchCount; i++) {
-      this.replace(replaceWith);
+      this.replaceMatch(this.searchMatches[i], replaceWith);
     }
   }
 

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -542,4 +542,15 @@ describe("replace", () => {
     expect(getCellContent(model, "A3")).toBe("kikou");
     expect(getCellContent(model, "A4")).toBe("kikou");
   });
+
+  test("replace all won't update the active cell", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "hell", searchOptions });
+    expect(getActivePosition(model)).toBe("A1");
+    model.dispatch("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
+    const matches = model.getters.getSearchMatches();
+    const matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(0);
+    expect(matchIndex).toStrictEqual(null);
+    expect(getActivePosition(model)).toBe("A1");
+  });
 });


### PR DESCRIPTION
## Description:

Previously, when we clicked on "Replace All", it updated the active cell position, making it the last matched find.

This commit will handle the cell position during "Replace All."

Task: : [3422486](https://www.odoo.com/web#id=3422486&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo