### PR TITLE
[IMP] model: don't dispatch local commands to core plugins

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -554,10 +554,17 @@ export class Model extends EventBus<any> implements CommandDispatcher {
    * It will call `beforeHandle` and `handle`
    */
   private dispatchToHandlers(handlers: CommandHandler<Command>[], command: Command) {
+    const isCommandCore = isCoreCommand(command);
     for (const handler of handlers) {
+      if (!isCommandCore && handler instanceof CorePlugin) {
+        continue;
+      }
       handler.beforeHandle(command);
     }
     for (const handler of handlers) {
+      if (!isCommandCore && handler instanceof CorePlugin) {
+        continue;
+      }
       handler.handle(command);
     }
   }

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -126,6 +126,19 @@ describe("Model", () => {
     expect(receivedCommands).not.toContain("COPY");
   });
 
+  test("Core plugins handle don't receive UI commands", () => {
+    const receivedCommands: CommandTypes[] = [];
+    class MyCorePlugin extends CorePlugin {
+      handle(cmd: CoreCommand) {
+        receivedCommands.push(cmd.type);
+      }
+    }
+    addTestPlugin(corePluginRegistry, MyCorePlugin);
+    const model = new Model();
+    model.dispatch("COPY");
+    expect(receivedCommands).not.toContain("COPY");
+  });
+
   test("canDispatch method is exposed and works", () => {
     class MyCorePlugin extends CorePlugin {
       allowDispatch(cmd: CoreCommand) {

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -13,6 +13,7 @@ import {
   renameSheet,
 } from "../test_helpers/commands_helpers";
 import { addTestPlugin } from "../test_helpers/helpers";
+import { coreTypes } from "./../../src/types/commands";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
 let m;
@@ -30,6 +31,10 @@ export interface UseTransientRange {
 }
 
 type TestCommands = Command | UseRange | UseTransientRange;
+//@ts-ignore
+coreTypes.add("USE_RANGE");
+//@ts-ignore
+coreTypes.add("USE_TRANSIENT_RANGE");
 
 class PluginTestRange extends CorePlugin {
   static getters = ["getUsedRanges", "getRanges"];


### PR DESCRIPTION
## Description

Before this commit, local commands were dispatched to core plugins. This made no sense from an architecture standpoint, as core plugins shouldn't be aware of UI commands.

Task:

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3184514](https://www.odoo.com/web#id=3184514&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo