### PR TITLE
[FIX] FiguresContainer: Restrict resizing if reaches header boundary

### DIFF
--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -283,6 +283,15 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
       if (dirY < 0) {
         this.dnd.y = dndInitialY - deltaY;
       }
+
+      if (this.dnd.x < 0) {
+        this.dnd.width += this.dnd.x;
+        this.dnd.x = 0;
+      }
+      if (this.dnd.y < 0) {
+        this.dnd.height += this.dnd.y;
+        this.dnd.y = 0;
+      }
     };
 
     const onMouseUp = (ev: MouseEvent) => {

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -222,6 +222,23 @@ describe("figures", () => {
   });
 
   test.each([
+    ["top", { mouseOffsetX: 0, mouseOffsetY: -100 }],
+    ["left", { mouseOffsetX: -100, mouseOffsetY: 0 }],
+    ["topLeft", { mouseOffsetX: -100, mouseOffsetY: -100 }],
+  ])(
+    "Resizing a figure through its top and left anchor does not change size beyond header boundaries",
+    async (anchor: string, mouseMove: { mouseOffsetX: number; mouseOffsetY: number }) => {
+      const figureId = "someuuid";
+      const figure = { width: 100, height: 100 };
+      createFigure(model, { id: figureId, y: 0, x: 0, ...figure });
+      await nextTick();
+      await simulateClick(".o-figure");
+      await dragAnchor(anchor, mouseMove.mouseOffsetX, mouseMove.mouseOffsetY, true);
+      expect(model.getters.getFigure(sheetId, figureId)).toMatchObject(figure);
+    }
+  );
+
+  test.each([
     [
       "topLeft",
       { mouseOffsetX: 200, mouseOffsetY: 200 },


### PR DESCRIPTION
## Description:

Resizing the graph previously allowed it to go beyond the header, causing the entire graph to be pushed to the right or bottom upon release. This PR addresses this issue by introducing a restriction that prevents resizing from extending into the header.

Changes made:
- Added conditional checks to restrict resizing if the x or y coordinate reaches the header boundaries.

Task: : [3414127](https://www.odoo.com/web#id=3414041&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo