### PR TITLE
[FIX] SortPlugin: fix crash whith empty-ish cells

### DIFF
--- a/src/plugins/ui/sort.ts
+++ b/src/plugins/ui/sort.ts
@@ -12,6 +12,7 @@ import {
   SortDirection,
   SortOptions,
   UID,
+  UpdateCellCommand,
   Zone,
 } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
@@ -280,18 +281,17 @@ export class SortPlugin extends UIPlugin {
     const sortedIndex: number[] = sortedIndexOfSortTypeCells.map((x) => x.index);
 
     const [width, height]: [number, number] = [cells.length, cells[0].length];
-
+    const cellUpdates: Omit<UpdateCellCommand, "type">[] = [];
     for (let c: HeaderIndex = 0; c < width; c++) {
       for (let r: HeaderIndex = 0; r < height; r++) {
         let cell = cells[c][sortedIndex[r]];
         let newCol: HeaderIndex = sortZone.left + c * stepX;
         let newRow: HeaderIndex = sortZone.top + r * stepY;
-        let newCellValues: any = {
+        let newCellValues: Omit<UpdateCellCommand, "type"> = {
           sheetId: sheetId,
           col: newCol,
           row: newRow,
           content: "",
-          value: "",
         };
         if (cell) {
           let content: string = cell.content;
@@ -305,11 +305,11 @@ export class SortPlugin extends UIPlugin {
           newCellValues.style = cell.style;
           newCellValues.content = content;
           newCellValues.format = cell.format;
-          newCellValues.value = cell.evaluated.value;
         }
-        this.dispatch("UPDATE_CELL", newCellValues);
+        cellUpdates.push(newCellValues);
       }
     }
+    cellUpdates.forEach((cmdPayload) => this.dispatch("UPDATE_CELL", cmdPayload));
   }
 
   /**

--- a/tests/plugins/sort.test.ts
+++ b/tests/plugins/sort.test.ts
@@ -337,6 +337,31 @@ describe("Basic Sorting", () => {
       A7: { content: "-33" },
     });
   });
+
+  test("Sort with a cell that will be removed because it is considered empty", () => {
+    model = new Model({
+      sheets: [
+        {
+          id: sheetId,
+          colNumber: 1,
+          rowNumber: 3,
+          cells: {
+            A1: { content: "a" },
+            A2: { content: '=""' },
+          },
+        },
+      ],
+    });
+    sort(model, {
+      zone: "A2:A3",
+      anchor: "A2",
+      direction: "ascending",
+      sortOptions: { emptyCellAsZero: true },
+    });
+    expect(getCellsObject(model, sheetId)).toMatchObject({
+      A1: { content: "a" },
+    });
+  });
 });
 
 describe("Trigger sort generic errors", () => {


### PR DESCRIPTION
**Current behavior before PR:**
When sorting the cells (in `sortZone` method), it is editing the cells directly inside the loop. When it dispatches the "UPDATE_CELL" command, the content of the cell can be considered as empty and the cell will be removed as well as the corresponding `cellId` from the `SheetPlugin.cellPosition` array.
Therefore, it won't be able to retrieve the position of the cell in a future iteration of the loop to retrieve its value (with `this.getters.getCellPosition`)

**Description of the fix:**
Store the cell updates in an array to apply them all at once at the end.

OPW: : [3422772](https://www.odoo.com/web#id=3422772&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo