### PR TITLE
[FIX] TopBar: fix focus lost in grid

### DIFF
--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -20,6 +20,7 @@
             position="state.menuState.position"
             menuItems="state.menuState.menuItems"
             onClose="() => this.closeMenus()"
+            onMenuClicked="() => this.props.onClick()"
           />
         </div>
         <div class="o-topbar-topright">

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -281,6 +281,15 @@ describe("Spreadsheet", () => {
     spreadsheetDiv.dispatchEvent(new KeyboardEvent("keydown", { key: "H", ctrlKey: true }));
     expect(spreadsheetKeyDown).not.toHaveBeenCalled();
   });
+
+  test("grid should regain focus after a topbar menu option is selected", async () => {
+    ({ parent, fixture } = await mountSpreadsheet());
+    expect(document.activeElement!.tagName).toEqual("INPUT");
+    triggerMouseEvent(".o-topbar-menu[data-id='format']", "click");
+    await nextTick();
+    await simulateClick(".o-menu-item[title='Bold']");
+    expect(document.activeElement!.tagName).toEqual("INPUT");
+  });
 });
 
 describe("Composer interactions", () => {


### PR DESCRIPTION
## Description:

Fixed the focus is lost in the grid when clicking a menu-item in the topbar. Previously clicking a topbar menu-item loses the focus in grid, Now the focus is maintained within the grid after interacting with the menu.

Task: [3419397](https://www.odoo.com/web#id=3419397&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo