### PR TITLE
[FIX] *: unify to strict equality operator

### DIFF
--- a/src/components/composer/content_editable_helper.ts
+++ b/src/components/composer/content_editable_helper.ts
@@ -33,7 +33,7 @@ export class ContentEditableHelper {
       selection.removeAllRanges();
       selection.addRange(range);
     }
-    if (start == end && start === 0) {
+    if (start === end && start === 0) {
       range.setStart(this.el, 0);
       range.setEnd(this.el, 0);
     } else {
@@ -295,7 +295,7 @@ export class ContentEditableHelper {
         }, 0);
       }
     }
-    if (nodeToFind.nodeName === "P" && !isFirstParagraph && nodeToFind.textContent == "") {
+    if (nodeToFind.nodeName === "P" && !isFirstParagraph && nodeToFind.textContent === "") {
       usedCharacters++;
     }
     return usedCharacters;

--- a/src/functions/helper_matrices.ts
+++ b/src/functions/helper_matrices.ts
@@ -46,7 +46,7 @@ export function invertMatrix(M: Matrix<number>): {
     let diagonalElement = C[pivot][pivot];
 
     // if we have a 0 on the diagonal we'll need to swap with a lower row
-    if (diagonalElement == 0) {
+    if (diagonalElement === 0) {
       //look through every row below the i'th row
       for (let row = pivot + 1; row < dim; row++) {
         //if the ii'th row has a non-0 in the i'th col, swap it with that row
@@ -75,7 +75,7 @@ export function invertMatrix(M: Matrix<number>): {
     // the other rows so that there will be 0's in this column in the
     // rows above and below this one
     for (let row = 0; row < dim; row++) {
-      if (row == pivot) {
+      if (row === pivot) {
         continue;
       }
 

--- a/src/functions/module_info.ts
+++ b/src/functions/module_info.ts
@@ -68,7 +68,7 @@ export const ISNA: AddFunctionDescription = {
       value();
       return false;
     } catch (e) {
-      return e?.errorType == CellErrorType.NotAvailable;
+      return e?.errorType === CellErrorType.NotAvailable;
     }
   },
   isExported: true,

--- a/src/helpers/chart_date.ts
+++ b/src/helpers/chart_date.ts
@@ -75,7 +75,7 @@ function convertDateFormatForMoment(format: Format): MomentJSFormat {
   format = format.replace(/y/g, "Y");
   format = format.replace(/d/g, "D");
 
-  // "m" before "h" == month, "m" after "h" == minute
+  // "m" before "h" === month, "m" after "h" === minute
   const indexH = format.indexOf("h");
   if (indexH >= 0) {
     format = format.slice(0, indexH).replace(/m/g, "M") + format.slice(indexH);

--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -498,7 +498,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
   }
 
   private getHTMLContent(): string {
-    if (this.cells.length == 1 && this.cells[0].length == 1) {
+    if (this.cells.length === 1 && this.cells[0].length === 1) {
       return this.getters.getCellText(this.cells[0][0].position);
     }
 

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -150,10 +150,10 @@ export function rgbaToHex(rgba: RGBA): Color {
   let b = rgba.b.toString(16);
   let a = Math.round(rgba.a * 255).toString(16);
 
-  if (r.length == 1) r = "0" + r;
-  if (g.length == 1) g = "0" + g;
-  if (b.length == 1) b = "0" + b;
-  if (a.length == 1) a = "0" + a;
+  if (r.length === 1) r = "0" + r;
+  if (g.length === 1) g = "0" + g;
+  if (b.length === 1) b = "0" + b;
+  if (a.length === 1) a = "0" + a;
   if (a === "ff") a = "";
 
   return ("#" + r + g + b + a).toUpperCase();
@@ -258,11 +258,11 @@ export function rgbaToHSLA(rgba: RGBA): HSLA {
 
   // Calculate hue
   // No difference
-  if (delta == 0) h = 0;
+  if (delta === 0) h = 0;
   // Red is max
-  else if (cMax == r) h = ((g - b) / delta) % 6;
+  else if (cMax === r) h = ((g - b) / delta) % 6;
   // Green is max
-  else if (cMax == g) h = (b - r) / delta + 2;
+  else if (cMax === g) h = (b - r) / delta + 2;
   // Blue is max
   else h = (r - g) / delta + 4;
 
@@ -274,7 +274,7 @@ export function rgbaToHSLA(rgba: RGBA): HSLA {
   l = (cMax + cMin) / 2;
 
   // Calculate saturation
-  s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+  s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
 
   // Multiply l and s by 100
   s = +(s * 100).toFixed(1);

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -362,7 +362,7 @@ export function addMonthsToDate(date: Date, months: number, keepEndOfMonth: bool
 
 function isLeapYear(year: number): boolean {
   const _year = Math.trunc(year);
-  return (_year % 4 === 0 && _year % 100 != 0) || _year % 400 == 0;
+  return (_year % 4 === 0 && _year % 100 != 0) || _year % 400 === 0;
 }
 
 export function getYearFrac(startDate: number, endDate: number, _dayCountConvention: number) {

--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -25,7 +25,7 @@ export class UuidGenerator {
       // mainly for jest and other browsers that do not have the crypto functionality
       return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
         var r = (Math.random() * 16) | 0,
-          v = c == "x" ? r : (r & 0x3) | 0x8;
+          v = c === "x" ? r : (r & 0x3) | 0x8;
         return v.toString(16);
       });
     }

--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -392,7 +392,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
 
   /**
    * Set the borders of a cell.
-   * It overrides the current border if override == true.
+   * It overrides the current border if override === true.
    */
   private setBorder(
     sheetId: UID,

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -412,7 +412,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
         case "ContainsText":
           return cell.value.toString().indexOf(values[0].toString()) > -1;
         case "NotContains":
-          return !cell.value || cell.value.toString().indexOf(values[0].toString()) == -1;
+          return !cell.value || cell.value.toString().indexOf(values[0].toString()) === -1;
         case "GreaterThan":
           return cell.value > values[0];
         case "GreaterThanOrEqual":

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -603,7 +603,7 @@ export class SelectionStreamProcessorImpl implements SelectionStreamProcessor {
 
     while (true) {
       const nextCellPosition = this.getNextCellPosition(currentPosition, dim, dir);
-      // Break if nextPosition == currentPosition, which happens if there's no next valid position
+      // Break if nextPosition === currentPosition, which happens if there's no next valid position
       if (
         currentPosition.col === nextCellPosition.col &&
         currentPosition.row === nextCellPosition.row

--- a/src/xlsx/conversion/format_conversion.ts
+++ b/src/xlsx/conversion/format_conversion.ts
@@ -37,8 +37,8 @@ export function convertXlsxFormat(
       }
       convertedFormat = convertedFormat.replace(/"(.*)"/g, "[$$$1]"); // replace '"..."' by '[$...]'
 
-      convertedFormat = convertedFormat.replace(/_.{1}/g, ""); // _ == ignore width of next char for align purposes. Not supported ATM
-      convertedFormat = convertedFormat.replace(/\*.{1}/g, ""); // * == repeat next character enough to fill the line. Not supported ATM
+      convertedFormat = convertedFormat.replace(/_.{1}/g, ""); // _ === ignore width of next char for align purposes. Not supported ATM
+      convertedFormat = convertedFormat.replace(/\*.{1}/g, ""); // * === repeat next character enough to fill the line. Not supported ATM
 
       convertedFormat = convertedFormat.replace(/\\ /g, " "); // unescape spaces
 

--- a/src/xlsx/extraction/base_extractor.ts
+++ b/src/xlsx/extraction/base_extractor.ts
@@ -365,8 +365,8 @@ export class XlsxBaseExtractor {
    *
    * Why we need to do this :
    *  - For an XML "<t:test />"
-   *  - on Jest(jsdom) : xml.querySelector("test") == null, xml.querySelector("t\\:test") == <t:test />
-   *  - on Browser : xml.querySelector("test") == <t:test />, xml.querySelector("t\\:test") == null
+   *  - on Jest(jsdom) : xml.querySelector("test") === null, xml.querySelector("t\\:test") === <t:test />
+   *  - on Browser : xml.querySelector("test") === <t:test />, xml.querySelector("t\\:test") === null
    */
   protected querySelector(element: Element | Document, query: string) {
     query = this.areNamespaceIgnored ? removeNamespaces(query) : escapeNamespaces(query);
@@ -378,8 +378,8 @@ export class XlsxBaseExtractor {
    *
    * Why we need to do this :
    *  - For an XML "<t:test />"
-   *  - on Jest(jsdom) : xml.querySelectorAll("test") == [], xml.querySelectorAll("t\\:test") == [<t:test />]
-   *  - on Browser : xml.querySelectorAll("test") == [<t:test />], xml.querySelectorAll("t\\:test") == []
+   *  - on Jest(jsdom) : xml.querySelectorAll("test") === [], xml.querySelectorAll("t\\:test") === [<t:test />]
+   *  - on Browser : xml.querySelectorAll("test") === [<t:test />], xml.querySelectorAll("t\\:test") === []
    */
   protected querySelectorAll(element: Element | Document, query: string) {
     query = this.areNamespaceIgnored ? removeNamespaces(query) : escapeNamespaces(query);

--- a/tests/plugins/renderer.test.ts
+++ b/tests/plugins/renderer.test.ts
@@ -1422,9 +1422,9 @@ describe("renderer", () => {
 
     let ctx = new MockGridRenderingContext(model, 1000, 1000, {
       onFunctionCall: (val, args) => {
-        if (val == "moveTo") {
+        if (val === "moveTo") {
           current = [args[0], args[1]];
-        } else if (val == "fill") {
+        } else if (val === "fill") {
           filled.push([current[0], current[1]]);
         }
       },
@@ -1801,9 +1801,9 @@ describe("renderer", () => {
         }
       },
       onFunctionCall: (val, args) => {
-        if (currentColor !== "" && val == "moveTo") {
+        if (currentColor !== "" && val === "moveTo") {
           renderedBorders[currentColor] = { start: args };
-        } else if (currentColor !== "" && val == "lineTo") {
+        } else if (currentColor !== "" && val === "lineTo") {
           renderedBorders[currentColor].end = args;
           currentColor = "";
         }

--- a/tools/server/main.js
+++ b/tools/server/main.js
@@ -14,7 +14,7 @@ app.use(cors());
 app.use(express.json());
 // parse data with connect-multiparty.
 app.use(formData.parse(/* options */));
-// delete from the request all empty files (size == 0)
+// delete from the request all empty files (size === 0)
 app.use(formData.format());
 // change the file objects to fs.ReadStream
 app.use(formData.stream());


### PR DESCRIPTION
We have a common ground to use the strict equality operator to compare values. This commit removes the 'loose' equality leftovers. Note that the latter were comparing primitve variables of the same type.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo