### PR TITLE
[FIX] find_and_replace: hiding and unhiding rows/cols refresh search

### DIFF
--- a/src/plugins/ui/find_and_replace.ts
+++ b/src/plugins/ui/find_and_replace.ts
@@ -81,11 +81,15 @@ export class FindAndReplacePlugin extends UIPlugin {
         break;
       case "EVALUATE_CELLS":
       case "UPDATE_CELL":
+      case "REMOVE_FILTER_TABLE":
+      case "UPDATE_FILTER":
         this.isSearchDirty = true;
         break;
       case "UNDO":
       case "REDO":
       case "REMOVE_COLUMNS_ROWS":
+      case "HIDE_COLUMNS_ROWS":
+      case "UNHIDE_COLUMNS_ROWS":
       case "ADD_COLUMNS_ROWS":
       case "ACTIVATE_SHEET":
         this.refreshSearch();

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -5,11 +5,16 @@ import { SearchOptions } from "../../src/plugins/ui/find_and_replace";
 import {
   activateSheet,
   addRows,
+  createFilter,
   createSheet,
+  deleteFilter,
   deleteRows,
+  hideRows,
   redo,
   setCellContent,
   undo,
+  unhideRows,
+  updateFilter,
 } from "../test_helpers/commands_helpers";
 import { getCellContent, getCellText } from "../test_helpers/getters_helpers";
 
@@ -226,6 +231,43 @@ describe("basic search", () => {
     matches = model.getters.getSearchMatches();
     matchIndex = model.getters.getCurrentSelectedMatchIndex();
     expect(matches).toHaveLength(3);
+    expect(matchIndex).toStrictEqual(0);
+  });
+
+  test("Need to update search when column or row is hiding and unhiding", () => {
+    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
+    let matches = model.getters.getSearchMatches();
+    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    hideRows(model, [1]);
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(3);
+    expect(matchIndex).toStrictEqual(0);
+    unhideRows(model, [1]);
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+  });
+
+  test("Need to update search if updating or removing the filter", () => {
+    createFilter(model, "A1:A6");
+    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions });
+    let matches = model.getters.getSearchMatches();
+    let matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
+    expect(matchIndex).toStrictEqual(0);
+    updateFilter(model, "A1", ["1"]);
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(2);
+    expect(matchIndex).toStrictEqual(0);
+    deleteFilter(model, "A1:A6");
+    matches = model.getters.getSearchMatches();
+    matchIndex = model.getters.getCurrentSelectedMatchIndex();
+    expect(matches).toHaveLength(4);
     expect(matchIndex).toStrictEqual(0);
   });
 


### PR DESCRIPTION
## Description:

Previously, when hide rows or columns and a match was present in that hidden row or column, include the cell in the matches. To address this, need to update the search when hiding or unhiding rows or columns.

Additionally, when hide rows or columns using filters, also needed to refresh the search.

Task: : [3442607](https://www.odoo.com/web#cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form&id=3442607)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo