### PR TITLE
[IMP] LineChart: cumulative chart

### DIFF
--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
@@ -23,4 +23,10 @@ export class LineConfigPanel extends LineBarPieConfigPanel {
       stacked: ev.target.checked,
     });
   }
+
+  onUpdateCumulative(ev) {
+    this.props.updateChart(this.props.figureId, {
+      cumulative: ev.target.checked,
+    });
+  }
 }

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -14,6 +14,18 @@
             Stacked linechart
           </label>
         </div>
+        <div class="o-checkbox">
+          <label>
+            <input
+              type="checkbox"
+              name="cumulative"
+              t-att-checked="props.definition.cumulative"
+              t-on-change="onUpdateCumulative"
+              class="align-middle"
+            />
+            Cumulative data
+          </label>
+        </div>
       </div>
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -77,6 +77,7 @@ export class LineChart extends AbstractChart {
   readonly labelsAsText: boolean;
   readonly stacked: boolean;
   readonly type = "line";
+  readonly cumulative: boolean;
 
   constructor(definition: LineChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -92,6 +93,7 @@ export class LineChart extends AbstractChart {
     this.legendPosition = definition.legendPosition;
     this.labelsAsText = definition.labelsAsText;
     this.stacked = definition.stacked;
+    this.cumulative = definition.cumulative;
   }
 
   static validateChartDefinition(
@@ -120,6 +122,7 @@ export class LineChart extends AbstractChart {
       verticalAxisPosition: "left",
       labelRange: context.auxiliaryRange || undefined,
       stacked: false,
+      cumulative: false,
     };
   }
 
@@ -147,6 +150,7 @@ export class LineChart extends AbstractChart {
       title: this.title,
       labelsAsText: this.labelsAsText,
       stacked: this.stacked,
+      cumulative: this.cumulative,
     };
   }
 
@@ -364,6 +368,17 @@ function createLineChartRuntime(chart: LineChart, getters: Getters): LineChartRu
     if (chart.stacked) {
       backgroundRGBA.a = LINE_FILL_TRANSPARENCY;
     }
+    if (chart.cumulative) {
+      let accumulator = 0;
+      data = data.map((value) => {
+        if (!isNaN(value)) {
+          accumulator += parseFloat(value);
+          return accumulator;
+        }
+        return value;
+      });
+    }
+
     const backgroundColor = rgbaToHex(backgroundRGBA);
 
     const dataset: ChartDataSets = {

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -57,6 +57,7 @@ export interface ExcelChartDefinition {
   readonly verticalAxisPosition: VerticalAxisPosition;
   readonly legendPosition: LegendPosition;
   readonly stacked?: boolean;
+  readonly cumulative?: boolean;
 }
 
 export interface ChartCreationContext {

--- a/src/types/chart/line_chart.ts
+++ b/src/types/chart/line_chart.ts
@@ -13,6 +13,7 @@ export interface LineChartDefinition {
   readonly legendPosition: LegendPosition;
   readonly labelsAsText: boolean;
   readonly stacked: boolean;
+  readonly cumulative: boolean;
 }
 
 export type LineChartRuntime = {

--- a/src/xlsx/conversion/figure_conversion.ts
+++ b/src/xlsx/conversion/figure_conversion.ts
@@ -63,6 +63,7 @@ function convertChartData(chartData: ExcelChartDefinition): ChartDefinition | un
     verticalAxisPosition: chartData.verticalAxisPosition,
     legendPosition: chartData.legendPosition,
     stacked: chartData.stacked || false,
+    cumulative: chartData.cumulative || false,
     labelsAsText: false,
   };
 }

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -456,6 +456,7 @@ describe("Collaborative local history", () => {
                 verticalAxisPosition: "left",
                 title: "Line",
                 stacked: false,
+                cumulative: false,
               },
             },
           ],

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -1723,6 +1723,36 @@ describe("Chart evaluation", () => {
     ).toBe("#REF");
   });
 });
+
+describe("Cumulative Data line chart", () => {
+  test("Chart to display cumulative data", () => {
+    createChart(
+      model,
+      {
+        dataSets: ["B2:B8"],
+        dataSetsHaveTitle: true,
+        labelRange: "A2",
+        type: "line",
+        cumulative: false,
+      },
+      "1"
+    );
+
+    const chartData = (model.getters.getChartRuntime("1") as LineChartRuntime).chartJsConfig.data!
+      .datasets![0].data;
+    const initialData = [11, 12, 13, "P4", 30];
+    const expectedCumulativeData = [11, 23, 36, "P4", 66];
+
+    expect(chartData).toEqual(initialData);
+
+    updateChart(model, "1", { cumulative: true });
+    const updatedChartData = (model.getters.getChartRuntime("1") as LineChartRuntime).chartJsConfig
+      .data!.datasets![0].data;
+
+    expect(updatedChartData).toEqual(expectedCumulativeData);
+  });
+});
+
 test("creating chart with single dataset should have legend position set as none, followed by changing it to top", async () => {
   createChart(
     model,

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -113,6 +113,7 @@ export function createChart(
       legendPosition: data.legendPosition || "top",
       stacked: ("stacked" in data && data.stacked) || false,
       labelsAsText: ("labelsAsText" in data && data.labelsAsText) || false,
+      cumulative: ("cumulative" in data && data.cumulative) || false,
     },
   });
 }


### PR DESCRIPTION
## Description:

Added a checkbox to the LineChart side panel, enabling users to easily switch between cumulative and non-cumulative display modes. When the cumulative mode is selected, the chart shows cumulative data,
providing a comprehensive view of data progression.

Task: : [3420844](https://www.odoo.com/web#id=3420844&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo