### PR TITLE
[FIX] Composer: formula assistant not updating with arrow keys

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -369,14 +369,21 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     this.processTokenAtCursor();
   }
 
-  onKeyup() {
+  onKeyup(ev: KeyboardEvent) {
     if (this.contentHelper.el === document.activeElement) {
+      const isSelectingForComposer = this.env.model.getters.isSelectingForComposer();
+      if (isSelectingForComposer && ev.key?.startsWith("Arrow")) {
+        return;
+      }
+
       const { start: oldStart, end: oldEnd } = this.env.model.getters.getComposerSelection();
       const { start, end } = this.contentHelper.getCurrentSelection();
 
       if (start !== oldStart || end !== oldEnd) {
         this.env.model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start, end });
       }
+
+      this.processTokenAtCursor();
     }
   }
 

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -399,6 +399,22 @@ describe("formula assistant", () => {
             .textContent
         ).toBe("f4Arg2");
       });
+
+      test("Formula Helper updates when navigating with keyboard arrows", async () => {
+        await typeInComposer("=UPTOWNFUNC(1, 2, 3");
+        expect(
+          fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0]
+            .textContent
+        ).toBe("f4Arg3");
+        await keyDown({ key: "ArrowLeft" });
+        await keyDown({ key: "ArrowLeft" });
+        await keyDown({ key: "ArrowLeft" });
+        await keyUp({ key: "ArrowLeft" });
+        expect(
+          fixture.querySelectorAll(".o-formula-assistant-arg.o-formula-assistant-focus span")[0]
+            .textContent
+        ).toBe("f4Arg2");
+      });
     });
   });
 });


### PR DESCRIPTION
## Description:

In this PR, Addressed an issue in the Composer where the formula assistant wasn't updating properly when navigating with arrow keys.

To resolve this, Added a call to `processTokenAtCursor` within the `onKeyUp`.

Task: : [3436604](https://www.odoo.com/web#id=3436604&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo