### PR TITLE
[IMP] Translation: remove _lt function

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&
 - [ ] multiuser-able commands (has inverse commands and transformations where needed)
 - [ ] new/updated/removed commands are documented
 - [ ] exportable in excel
-- [ ] translations (\_lt("qmsdf %s", abc))
+- [ ] translations (\_t("qmsdf %s", abc))
 - [ ] unit tested
 - [ ] clean commented code
 - [ ] track breaking changes

--- a/demo/main.js
+++ b/demo/main.js
@@ -18,8 +18,13 @@ const {
   onError,
 } = owl;
 
-const { Spreadsheet, Model } = o_spreadsheet;
+const { Spreadsheet, Model, setTranslationMethod } = o_spreadsheet;
 const { topbarMenuRegistry } = o_spreadsheet.registries;
+
+setTranslationMethod(
+  (str, ...values) => str,
+  () => true
+);
 
 const uuidGenerator = new o_spreadsheet.helpers.UuidGenerator();
 

--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -1,18 +1,18 @@
 import { areZonesContinuous } from "../helpers/index";
 import { interactiveSortSelection } from "../helpers/sort";
 import { interactiveAddFilter } from "../helpers/ui/filter_interactive";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 
 export const sortRange: ActionSpec = {
-  name: _lt("Sort range"),
+  name: _t("Sort range"),
   isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
   icon: "o-spreadsheet-Icon.SORT_RANGE",
 };
 
 export const sortAscending: ActionSpec = {
-  name: _lt("Ascending (A ⟶ Z)"),
+  name: _t("Ascending (A ⟶ Z)"),
   execute: (env) => {
     const { anchor, zones } = env.model.getters.getSelection();
     const sheetId = env.model.getters.getActiveSheetId();
@@ -22,7 +22,7 @@ export const sortAscending: ActionSpec = {
 };
 
 export const sortDescending: ActionSpec = {
-  name: _lt("Descending (Z ⟶ A)"),
+  name: _t("Descending (Z ⟶ A)"),
   execute: (env) => {
     const { anchor, zones } = env.model.getters.getSelection();
     const sheetId = env.model.getters.getActiveSheetId();
@@ -32,7 +32,7 @@ export const sortDescending: ActionSpec = {
 };
 
 export const addDataFilter: ActionSpec = {
-  name: _lt("Create filter"),
+  name: _t("Create filter"),
   execute: (env) => {
     const sheetId = env.model.getters.getActiveSheetId();
     const selection = env.model.getters.getSelection().zones;
@@ -47,7 +47,7 @@ export const addDataFilter: ActionSpec = {
 };
 
 export const removeDataFilter: ActionSpec = {
-  name: _lt("Remove filter"),
+  name: _t("Remove filter"),
   execute: (env) => {
     const sheetId = env.model.getters.getActiveSheetId();
     env.model.dispatch("REMOVE_FILTER_TABLE", {
@@ -60,7 +60,7 @@ export const removeDataFilter: ActionSpec = {
 };
 
 export const splitToColumns: ActionSpec = {
-  name: _lt("Split text to columns"),
+  name: _t("Split text to columns"),
   sequence: 1,
   execute: (env) => env.openSidePanel("SplitToColumns", {}),
   isEnabled: (env) => env.model.getters.isSingleColSelected(),

--- a/src/actions/edit_actions.ts
+++ b/src/actions/edit_actions.ts
@@ -2,13 +2,13 @@ import { isEqual, positionToZone } from "../helpers";
 import { interactiveCut } from "../helpers/ui/cut_interactive";
 import { interactiveAddMerge } from "../helpers/ui/merge_interactive";
 import { handlePasteResult } from "../helpers/ui/paste_interactive";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { SpreadsheetChildEnv } from "../types";
 import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 
 export const undo: ActionSpec = {
-  name: _lt("Undo"),
+  name: _t("Undo"),
   description: "Ctrl+Z",
   execute: (env) => env.model.dispatch("REQUEST_UNDO"),
   isEnabled: (env) => env.model.getters.canUndo(),
@@ -16,7 +16,7 @@ export const undo: ActionSpec = {
 };
 
 export const redo: ActionSpec = {
-  name: _lt("Redo"),
+  name: _t("Redo"),
   description: "Ctrl+Y",
   execute: (env) => env.model.dispatch("REQUEST_REDO"),
   isEnabled: (env) => env.model.getters.canRedo(),
@@ -24,7 +24,7 @@ export const redo: ActionSpec = {
 };
 
 export const copy: ActionSpec = {
-  name: _lt("Copy"),
+  name: _t("Copy"),
   description: "Ctrl+C",
   isReadonlyAllowed: true,
   execute: async (env) => {
@@ -35,7 +35,7 @@ export const copy: ActionSpec = {
 };
 
 export const cut: ActionSpec = {
-  name: _lt("Cut"),
+  name: _t("Cut"),
   description: "Ctrl+X",
   execute: async (env) => {
     interactiveCut(env);
@@ -45,14 +45,14 @@ export const cut: ActionSpec = {
 };
 
 export const paste: ActionSpec = {
-  name: _lt("Paste"),
+  name: _t("Paste"),
   description: "Ctrl+V",
   execute: ACTIONS.PASTE_ACTION,
   icon: "o-spreadsheet-Icon.PASTE",
 };
 
 export const pasteSpecial: ActionSpec = {
-  name: _lt("Paste special"),
+  name: _t("Paste special"),
   isVisible: (env): boolean => {
     return !env.model.getters.isCutOperation();
   },
@@ -60,18 +60,18 @@ export const pasteSpecial: ActionSpec = {
 };
 
 export const pasteSpecialValue: ActionSpec = {
-  name: _lt("Paste value only"),
+  name: _t("Paste value only"),
   description: "Ctrl+Shift+V",
   execute: ACTIONS.PASTE_VALUE_ACTION,
 };
 
 export const pasteSpecialFormat: ActionSpec = {
-  name: _lt("Paste format only"),
+  name: _t("Paste format only"),
   execute: ACTIONS.PASTE_FORMAT_ACTION,
 };
 
 export const findAndReplace: ActionSpec = {
-  name: _lt("Find and replace"),
+  name: _t("Find and replace"),
   description: "Ctrl+H",
   isReadonlyAllowed: true,
   execute: (env) => {
@@ -81,7 +81,7 @@ export const findAndReplace: ActionSpec = {
 };
 
 export const deleteValues: ActionSpec = {
-  name: _lt("Delete values"),
+  name: _t("Delete values"),
   execute: (env) =>
     env.model.dispatch("DELETE_CONTENT", {
       sheetId: env.model.getters.getActiveSheetId(),
@@ -122,12 +122,12 @@ export const clearCols: ActionSpec = {
 };
 
 export const deleteCells: ActionSpec = {
-  name: _lt("Delete cells"),
+  name: _t("Delete cells"),
   isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
 };
 
 export const deleteCellShiftUp: ActionSpec = {
-  name: _lt("Delete cell and shift up"),
+  name: _t("Delete cell and shift up"),
   execute: (env) => {
     const zone = env.model.getters.getSelectedZone();
     const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "ROW" });
@@ -136,7 +136,7 @@ export const deleteCellShiftUp: ActionSpec = {
 };
 
 export const deleteCellShiftLeft: ActionSpec = {
-  name: _lt("Delete cell and shift left"),
+  name: _t("Delete cell and shift left"),
   execute: (env) => {
     const zone = env.model.getters.getSelectedZone();
     const result = env.model.dispatch("DELETE_CELL", { zone, shiftDimension: "COL" });
@@ -145,7 +145,7 @@ export const deleteCellShiftLeft: ActionSpec = {
 };
 
 export const mergeCells: ActionSpec = {
-  name: _lt("Merge cells"),
+  name: _t("Merge cells"),
   isEnabled: (env) => !cannotMerge(env),
   isActive: (env) => isInMerge(env),
   execute: (env) => toggleMerge(env),

--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -6,20 +6,20 @@ import {
 } from "../constants";
 import { formatValue, roundFormat } from "../helpers";
 import { parseLiteral } from "../helpers/cells";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { Align, DEFAULT_LOCALE, SpreadsheetChildEnv, VerticalAlign, Wrapping } from "../types";
 import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 import { setFormatter, setStyle } from "./menu_items_actions";
 
 export const formatNumberAutomatic: ActionSpec = {
-  name: _lt("Automatic"),
+  name: _t("Automatic"),
   execute: (env) => setFormatter(env, ""),
   isActive: (env) => isAutomaticFormatSelected(env),
 };
 
 export const formatNumberNumber: ActionSpec = {
-  name: _lt("Number"),
+  name: _t("Number"),
   description: (env) =>
     formatValue(1000.12, {
       format: "#,##0.00",
@@ -30,13 +30,13 @@ export const formatNumberNumber: ActionSpec = {
 };
 
 export const formatPercent: ActionSpec = {
-  name: _lt("Format as percent"),
+  name: _t("Format as percent"),
   execute: ACTIONS.FORMAT_PERCENT_ACTION,
   icon: "o-spreadsheet-Icon.PERCENT",
 };
 
 export const formatNumberPercent: ActionSpec = {
-  name: _lt("Percent"),
+  name: _t("Percent"),
   description: (env) =>
     formatValue(0.1012, {
       format: "0.00%",
@@ -47,7 +47,7 @@ export const formatNumberPercent: ActionSpec = {
 };
 
 export const formatNumberCurrency: ActionSpec = {
-  name: _lt("Currency"),
+  name: _t("Currency"),
   description: (env) =>
     formatValue(1000.12, {
       format: env.model.config.defaultCurrencyFormat,
@@ -58,7 +58,7 @@ export const formatNumberCurrency: ActionSpec = {
 };
 
 export const formatNumberCurrencyRounded: ActionSpec = {
-  name: _lt("Currency rounded"),
+  name: _t("Currency rounded"),
   description: (env) =>
     formatValue(1000, {
       format: roundFormat(env.model.config.defaultCurrencyFormat),
@@ -73,13 +73,13 @@ export const formatNumberCurrencyRounded: ActionSpec = {
 };
 
 export const formatCustomCurrency: ActionSpec = {
-  name: _lt("Custom currency"),
+  name: _t("Custom currency"),
   isVisible: (env) => env.loadCurrencies !== undefined,
   execute: (env) => env.openSidePanel("CustomCurrency", {}),
 };
 
 export const formatNumberDate: ActionSpec = {
-  name: _lt("Date"),
+  name: _t("Date"),
   description: (env) => {
     const locale = env.model.getters.getLocale();
     return formatValue(parseLiteral("9/26/2023", DEFAULT_LOCALE), {
@@ -92,7 +92,7 @@ export const formatNumberDate: ActionSpec = {
 };
 
 export const formatNumberTime: ActionSpec = {
-  name: _lt("Time"),
+  name: _t("Time"),
   description: (env) => {
     const locale = env.model.getters.getLocale();
     return formatValue(parseLiteral("9/26/2023 10:43:00 PM", DEFAULT_LOCALE), {
@@ -105,7 +105,7 @@ export const formatNumberTime: ActionSpec = {
 };
 
 export const formatNumberDateTime: ActionSpec = {
-  name: _lt("Date time"),
+  name: _t("Date time"),
   description: (env) => {
     const locale = env.model.getters.getLocale();
     return formatValue(parseLiteral("9/26/2023 22:43:00", DEFAULT_LOCALE), {
@@ -124,14 +124,14 @@ export const formatNumberDateTime: ActionSpec = {
 };
 
 export const formatNumberDuration: ActionSpec = {
-  name: _lt("Duration"),
+  name: _t("Duration"),
   description: "27:51:38",
   execute: (env) => setFormatter(env, "hhhh:mm:ss"),
   isActive: (env) => isFormatSelected(env, "hhhh:mm:ss"),
 };
 
 export const incraseDecimalPlaces: ActionSpec = {
-  name: _lt("Increase decimal places"),
+  name: _t("Increase decimal places"),
   icon: "o-spreadsheet-Icon.INCREASE_DECIMAL",
   execute: (env) =>
     env.model.dispatch("SET_DECIMAL", {
@@ -142,7 +142,7 @@ export const incraseDecimalPlaces: ActionSpec = {
 };
 
 export const decraseDecimalPlaces: ActionSpec = {
-  name: _lt("Decrease decimal places"),
+  name: _t("Decrease decimal places"),
   icon: "o-spreadsheet-Icon.DECRASE_DECIMAL",
   execute: (env) =>
     env.model.dispatch("SET_DECIMAL", {
@@ -153,7 +153,7 @@ export const decraseDecimalPlaces: ActionSpec = {
 };
 
 export const formatBold: ActionSpec = {
-  name: _lt("Bold"),
+  name: _t("Bold"),
   description: "Ctrl+B",
   execute: (env) => setStyle(env, { bold: !env.model.getters.getCurrentStyle().bold }),
   icon: "o-spreadsheet-Icon.BOLD",
@@ -161,7 +161,7 @@ export const formatBold: ActionSpec = {
 };
 
 export const formatItalic: ActionSpec = {
-  name: _lt("Italic"),
+  name: _t("Italic"),
   description: "Ctrl+I",
   execute: (env) => setStyle(env, { italic: !env.model.getters.getCurrentStyle().italic }),
   icon: "o-spreadsheet-Icon.ITALIC",
@@ -169,7 +169,7 @@ export const formatItalic: ActionSpec = {
 };
 
 export const formatUnderline: ActionSpec = {
-  name: _lt("Underline"),
+  name: _t("Underline"),
   description: "Ctrl+U",
   execute: (env) => setStyle(env, { underline: !env.model.getters.getCurrentStyle().underline }),
   icon: "o-spreadsheet-Icon.UNDERLINE",
@@ -177,7 +177,7 @@ export const formatUnderline: ActionSpec = {
 };
 
 export const formatStrikethrough: ActionSpec = {
-  name: _lt("Strikethrough"),
+  name: _t("Strikethrough"),
   execute: (env) =>
     setStyle(env, { strikethrough: !env.model.getters.getCurrentStyle().strikethrough }),
   icon: "o-spreadsheet-Icon.STRIKE",
@@ -185,23 +185,23 @@ export const formatStrikethrough: ActionSpec = {
 };
 
 export const formatFontSize: ActionSpec = {
-  name: _lt("Font size"),
+  name: _t("Font size"),
   children: fontSizeMenuBuilder(),
   icon: "o-spreadsheet-Icon.FONT_SIZE",
 };
 
 export const formatAlignment: ActionSpec = {
-  name: _lt("Alignment"),
+  name: _t("Alignment"),
   icon: "o-spreadsheet-Icon.ALIGN_LEFT",
 };
 
 export const formatAlignmentHorizontal: ActionSpec = {
-  name: _lt("Horizontal align"),
+  name: _t("Horizontal align"),
   icon: (env) => getHorizontalAlignmentIcon(env),
 };
 
 export const formatAlignmentLeft: ActionSpec = {
-  name: _lt("Left"),
+  name: _t("Left"),
   description: "Ctrl+Shift+L",
   execute: (env) => ACTIONS.setStyle(env, { align: "left" }),
   isActive: (env) => getHorizontalAlign(env) === "left",
@@ -209,7 +209,7 @@ export const formatAlignmentLeft: ActionSpec = {
 };
 
 export const formatAlignmentCenter: ActionSpec = {
-  name: _lt("Center"),
+  name: _t("Center"),
   description: "Ctrl+Shift+E",
   execute: (env) => ACTIONS.setStyle(env, { align: "center" }),
   isActive: (env) => getHorizontalAlign(env) === "center",
@@ -217,7 +217,7 @@ export const formatAlignmentCenter: ActionSpec = {
 };
 
 export const formatAlignmentRight: ActionSpec = {
-  name: _lt("Right"),
+  name: _t("Right"),
   description: "Ctrl+Shift+R",
   execute: (env) => ACTIONS.setStyle(env, { align: "right" }),
   isActive: (env) => getHorizontalAlign(env) === "right",
@@ -225,80 +225,80 @@ export const formatAlignmentRight: ActionSpec = {
 };
 
 export const formatAlignmentVertical: ActionSpec = {
-  name: _lt("Vertical align"),
+  name: _t("Vertical align"),
   icon: (env) => getVerticalAlignmentIcon(env),
 };
 
 export const formatAlignmentTop: ActionSpec = {
-  name: _lt("Top"),
+  name: _t("Top"),
   execute: (env) => ACTIONS.setStyle(env, { verticalAlign: "top" }),
   isActive: (env) => getVerticalAlign(env) === "top",
   icon: "o-spreadsheet-Icon.ALIGN_TOP",
 };
 
 export const formatAlignmentMiddle: ActionSpec = {
-  name: _lt("Middle"),
+  name: _t("Middle"),
   execute: (env) => ACTIONS.setStyle(env, { verticalAlign: "middle" }),
   isActive: (env) => getVerticalAlign(env) === "middle",
   icon: "o-spreadsheet-Icon.ALIGN_MIDDLE",
 };
 
 export const formatAlignmentBottom: ActionSpec = {
-  name: _lt("Bottom"),
+  name: _t("Bottom"),
   execute: (env) => ACTIONS.setStyle(env, { verticalAlign: "bottom" }),
   isActive: (env) => getVerticalAlign(env) === "bottom",
   icon: "o-spreadsheet-Icon.ALIGN_BOTTOM",
 };
 
 export const formatWrappingIcon: ActionSpec = {
-  name: _lt("Wrapping"),
+  name: _t("Wrapping"),
   icon: "o-spreadsheet-Icon.WRAPPING_OVERFLOW",
 };
 
 export const formatWrapping: ActionSpec = {
-  name: _lt("Wrapping"),
+  name: _t("Wrapping"),
   icon: (env) => getWrapModeIcon(env),
 };
 
 export const formatWrappingOverflow: ActionSpec = {
-  name: _lt("Overflow"),
+  name: _t("Overflow"),
   execute: (env) => ACTIONS.setStyle(env, { wrapping: "overflow" }),
   isActive: (env) => getWrappingMode(env) === "overflow",
   icon: "o-spreadsheet-Icon.WRAPPING_OVERFLOW",
 };
 
 export const formatWrappingWrap: ActionSpec = {
-  name: _lt("Wrap"),
+  name: _t("Wrap"),
   execute: (env) => ACTIONS.setStyle(env, { wrapping: "wrap" }),
   isActive: (env) => getWrappingMode(env) === "wrap",
   icon: "o-spreadsheet-Icon.WRAPPING_WRAP",
 };
 
 export const formatWrappingClip: ActionSpec = {
-  name: _lt("Clip"),
+  name: _t("Clip"),
   execute: (env) => ACTIONS.setStyle(env, { wrapping: "clip" }),
   isActive: (env) => getWrappingMode(env) === "clip",
   icon: "o-spreadsheet-Icon.WRAPPING_CLIP",
 };
 
 export const textColor: ActionSpec = {
-  name: _lt("Text Color"),
+  name: _t("Text Color"),
   icon: "o-spreadsheet-Icon.TEXT_COLOR",
 };
 
 export const fillColor: ActionSpec = {
-  name: _lt("Fill Color"),
+  name: _t("Fill Color"),
   icon: "o-spreadsheet-Icon.FILL_COLOR",
 };
 
 export const formatCF: ActionSpec = {
-  name: _lt("Conditional formatting"),
+  name: _t("Conditional formatting"),
   execute: ACTIONS.OPEN_CF_SIDEPANEL_ACTION,
   icon: "o-spreadsheet-Icon.CONDITIONAL_FORMAT",
 };
 
 export const clearFormat: ActionSpec = {
-  name: _lt("Clear formatting"),
+  name: _t("Clear formatting"),
   description: "Ctrl+<",
   execute: (env) =>
     env.model.dispatch("CLEAR_FORMATTING", {

--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -1,14 +1,14 @@
 import { functionRegistry } from "../functions";
 import { isConsecutive, isDefined } from "../helpers";
 import { handlePasteResult } from "../helpers/ui/paste_interactive";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { ActionBuilder, ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 
 export const insertRow: ActionSpec = {
   name: (env) => {
     const number = getRowsNumber(env);
-    return number === 1 ? _lt("Insert row") : _lt("Insert %s rows", number.toString());
+    return number === 1 ? _t("Insert row") : _t("Insert %s rows", number.toString());
   },
   isVisible: (env) =>
     isConsecutive(env.model.getters.getActiveRows()) &&
@@ -20,7 +20,7 @@ export const insertRow: ActionSpec = {
 export const rowInsertRowBefore: ActionSpec = {
   name: (env) => {
     const number = getRowsNumber(env);
-    return number === 1 ? _lt("Insert row above") : _lt("Insert %s rows above", number.toString());
+    return number === 1 ? _t("Insert row above") : _t("Insert %s rows above", number.toString());
   },
   execute: ACTIONS.INSERT_ROWS_BEFORE_ACTION,
   isVisible: (env) =>
@@ -35,9 +35,9 @@ export const topBarInsertRowsBefore: ActionSpec = {
   name: (env) => {
     const number = getRowsNumber(env);
     if (number === 1) {
-      return _lt("Row above");
+      return _t("Row above");
     }
-    return _lt("%s Rows above", number.toString());
+    return _t("%s Rows above", number.toString());
   },
 };
 
@@ -46,9 +46,9 @@ export const cellInsertRowsBefore: ActionSpec = {
   name: (env) => {
     const number = getRowsNumber(env);
     if (number === 1) {
-      return _lt("Insert row");
+      return _t("Insert row");
     }
-    return _lt("Insert %s rows", number.toString());
+    return _t("Insert %s rows", number.toString());
   },
   isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
   icon: "o-spreadsheet-Icon.INSERT_ROW_BEFORE",
@@ -58,7 +58,7 @@ export const rowInsertRowsAfter: ActionSpec = {
   execute: ACTIONS.INSERT_ROWS_AFTER_ACTION,
   name: (env) => {
     const number = getRowsNumber(env);
-    return number === 1 ? _lt("Insert row below") : _lt("Insert %s rows below", number.toString());
+    return number === 1 ? _t("Insert row below") : _t("Insert %s rows below", number.toString());
   },
   isVisible: (env) =>
     isConsecutive(env.model.getters.getActiveRows()) &&
@@ -72,16 +72,16 @@ export const topBarInsertRowsAfter: ActionSpec = {
   name: (env) => {
     const number = getRowsNumber(env);
     if (number === 1) {
-      return _lt("Row below");
+      return _t("Row below");
     }
-    return _lt("%s Rows below", number.toString());
+    return _t("%s Rows below", number.toString());
   },
 };
 
 export const insertCol: ActionSpec = {
   name: (env) => {
     const number = getColumnsNumber(env);
-    return number === 1 ? _lt("Insert column") : _lt("Insert %s columns", number.toString());
+    return number === 1 ? _t("Insert column") : _t("Insert %s columns", number.toString());
   },
   isVisible: (env) =>
     isConsecutive(env.model.getters.getActiveCols()) &&
@@ -94,8 +94,8 @@ export const colInsertColsBefore: ActionSpec = {
   name: (env) => {
     const number = getColumnsNumber(env);
     return number === 1
-      ? _lt("Insert column left")
-      : _lt("Insert %s columns left", number.toString());
+      ? _t("Insert column left")
+      : _t("Insert %s columns left", number.toString());
   },
   execute: ACTIONS.INSERT_COLUMNS_BEFORE_ACTION,
   isVisible: (env) =>
@@ -110,9 +110,9 @@ export const topBarInsertColsBefore: ActionSpec = {
   name: (env) => {
     const number = getColumnsNumber(env);
     if (number === 1) {
-      return _lt("Column left");
+      return _t("Column left");
     }
-    return _lt("%s Columns left", number.toString());
+    return _t("%s Columns left", number.toString());
   },
 };
 
@@ -121,9 +121,9 @@ export const cellInsertColsBefore: ActionSpec = {
   name: (env) => {
     const number = getColumnsNumber(env);
     if (number === 1) {
-      return _lt("Insert column");
+      return _t("Insert column");
     }
-    return _lt("Insert %s columns", number.toString());
+    return _t("Insert %s columns", number.toString());
   },
   isVisible: ACTIONS.IS_ONLY_ONE_RANGE,
   icon: "o-spreadsheet-Icon.INSERT_COL_BEFORE",
@@ -133,8 +133,8 @@ export const colInsertColsAfter: ActionSpec = {
   name: (env) => {
     const number = getColumnsNumber(env);
     return number === 1
-      ? _lt("Insert column right")
-      : _lt("Insert %s columns right", number.toString());
+      ? _t("Insert column right")
+      : _t("Insert %s columns right", number.toString());
   },
   execute: ACTIONS.INSERT_COLUMNS_AFTER_ACTION,
   isVisible: (env) =>
@@ -149,15 +149,15 @@ export const topBarInsertColsAfter: ActionSpec = {
   name: (env) => {
     const number = getColumnsNumber(env);
     if (number === 1) {
-      return _lt("Column right");
+      return _t("Column right");
     }
-    return _lt("%s Columns right", number.toString());
+    return _t("%s Columns right", number.toString());
   },
   execute: ACTIONS.INSERT_COLUMNS_AFTER_ACTION,
 };
 
 export const insertCell: ActionSpec = {
-  name: _lt("Insert cells"),
+  name: _t("Insert cells"),
   isVisible: (env) =>
     ACTIONS.IS_ONLY_ONE_RANGE(env) &&
     env.model.getters.getActiveCols().size === 0 &&
@@ -166,7 +166,7 @@ export const insertCell: ActionSpec = {
 };
 
 export const insertCellShiftDown: ActionSpec = {
-  name: _lt("Insert cells and shift down"),
+  name: _t("Insert cells and shift down"),
   execute: (env) => {
     const zone = env.model.getters.getSelectedZone();
     const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "ROW" });
@@ -178,7 +178,7 @@ export const insertCellShiftDown: ActionSpec = {
 };
 
 export const insertCellShiftRight: ActionSpec = {
-  name: _lt("Insert cells and shift right"),
+  name: _t("Insert cells and shift right"),
   execute: (env) => {
     const zone = env.model.getters.getSelectedZone();
     const result = env.model.dispatch("INSERT_CELL", { zone, shiftDimension: "COL" });
@@ -190,13 +190,13 @@ export const insertCellShiftRight: ActionSpec = {
 };
 
 export const insertChart: ActionSpec = {
-  name: _lt("Chart"),
+  name: _t("Chart"),
   execute: ACTIONS.CREATE_CHART,
   icon: "o-spreadsheet-Icon.INSERT_CHART",
 };
 
 export const insertImage: ActionSpec = {
-  name: _lt("Image"),
+  name: _t("Image"),
   description: "Ctrl+O",
   execute: ACTIONS.CREATE_IMAGE,
   isVisible: (env) => env.imageProvider !== undefined,
@@ -204,37 +204,37 @@ export const insertImage: ActionSpec = {
 };
 
 export const insertFunction: ActionSpec = {
-  name: _lt("Function"),
+  name: _t("Function"),
   icon: "o-spreadsheet-Icon.SHOW_HIDE_FORMULA",
 };
 
 export const insertFunctionSum: ActionSpec = {
-  name: _lt("SUM"),
+  name: _t("SUM"),
   execute: (env) => env.startCellEdition(`=SUM(`),
 };
 
 export const insertFunctionAverage: ActionSpec = {
-  name: _lt("AVERAGE"),
+  name: _t("AVERAGE"),
   execute: (env) => env.startCellEdition(`=AVERAGE(`),
 };
 
 export const insertFunctionCount: ActionSpec = {
-  name: _lt("COUNT"),
+  name: _t("COUNT"),
   execute: (env) => env.startCellEdition(`=COUNT(`),
 };
 
 export const insertFunctionMax: ActionSpec = {
-  name: _lt("MAX"),
+  name: _t("MAX"),
   execute: (env) => env.startCellEdition(`=MAX(`),
 };
 
 export const insertFunctionMin: ActionSpec = {
-  name: _lt("MIN"),
+  name: _t("MIN"),
   execute: (env) => env.startCellEdition(`=MIN(`),
 };
 
 export const categorieFunctionAll: ActionSpec = {
-  name: _lt("All"),
+  name: _t("All"),
   children: [allFunctionListMenuBuilder],
 };
 
@@ -261,13 +261,13 @@ export const categoriesFunctionListMenuBuilder: ActionBuilder = () => {
 };
 
 export const insertLink: ActionSpec = {
-  name: _lt("Link"),
+  name: _t("Link"),
   execute: ACTIONS.INSERT_LINK,
   icon: "o-spreadsheet-Icon.INSERT_LINK",
 };
 
 export const insertSheet: ActionSpec = {
-  name: _lt("Insert sheet"),
+  name: _t("Insert sheet"),
   execute: (env) => {
     const activeSheetId = env.model.getters.getActiveSheetId();
     const position = env.model.getters.getSheetIds().indexOf(activeSheetId) + 1;

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -6,7 +6,7 @@ import {
 import { centerFigurePosition, getMaxFigureSize } from "../helpers/figures/figure/figure";
 import { getZoneArea, numberToLetters } from "../helpers/index";
 import { interactivePaste, interactivePasteFromOS } from "../helpers/ui/paste_interactive";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { ClipboardMIMEType, ClipboardPasteOptions } from "../types/clipboard";
 import { Image } from "../types/image";
 import { Format, SpreadsheetChildEnv, Style } from "../types/index";
@@ -56,14 +56,14 @@ async function paste(env: SpreadsheetChildEnv, pasteOption?: ClipboardPasteOptio
       break;
     case "notImplemented":
       env.raiseError(
-        _lt(
+        _t(
           "Pasting from the context menu is not supported in this browser. Use keyboard shortcuts ctrl+c / ctrl+v instead."
         )
       );
       break;
     case "permissionDenied":
       env.raiseError(
-        _lt(
+        _t(
           "Access to the clipboard denied by the browser. Please enable clipboard permission for this page in your browser settings."
         )
       );
@@ -79,7 +79,7 @@ export const PASTE_FORMAT_ACTION = (env: SpreadsheetChildEnv) => paste(env, "onl
 
 export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetChildEnv) => {
   if (env.model.getters.getSelectedZones().length > 1) {
-    return _lt("Clear rows");
+    return _t("Clear rows");
   }
   let first: number;
   let last: number;
@@ -93,9 +93,9 @@ export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetChildEnv) => {
     last = zone.bottom;
   }
   if (first === last) {
-    return _lt("Clear row %s", (first + 1).toString());
+    return _t("Clear row %s", (first + 1).toString());
   }
-  return _lt("Clear rows %s - %s", (first + 1).toString(), (last + 1).toString());
+  return _t("Clear rows %s - %s", (first + 1).toString(), (last + 1).toString());
 };
 
 export const DELETE_CONTENT_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
@@ -111,7 +111,7 @@ export const DELETE_CONTENT_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
 
 export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
   if (env.model.getters.getSelectedZones().length > 1) {
-    return _lt("Clear columns");
+    return _t("Clear columns");
   }
   let first: number;
   let last: number;
@@ -125,9 +125,9 @@ export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
     last = zone.right;
   }
   if (first === last) {
-    return _lt("Clear column %s", numberToLetters(first));
+    return _t("Clear column %s", numberToLetters(first));
   }
-  return _lt("Clear columns %s - %s", numberToLetters(first), numberToLetters(last));
+  return _t("Clear columns %s - %s", numberToLetters(first), numberToLetters(last));
 };
 
 export const DELETE_CONTENT_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
@@ -143,7 +143,7 @@ export const DELETE_CONTENT_COLUMNS_ACTION = (env: SpreadsheetChildEnv) => {
 
 export const REMOVE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
   if (env.model.getters.getSelectedZones().length > 1) {
-    return _lt("Delete rows");
+    return _t("Delete rows");
   }
   let first: number;
   let last: number;
@@ -157,9 +157,9 @@ export const REMOVE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
     last = zone.bottom;
   }
   if (first === last) {
-    return _lt("Delete row %s", (first + 1).toString());
+    return _t("Delete row %s", (first + 1).toString());
   }
-  return _lt("Delete rows %s - %s", (first + 1).toString(), (last + 1).toString());
+  return _t("Delete rows %s - %s", (first + 1).toString(), (last + 1).toString());
 };
 
 export const REMOVE_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
@@ -179,7 +179,7 @@ export const REMOVE_ROWS_ACTION = (env: SpreadsheetChildEnv) => {
 
 export const REMOVE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
   if (env.model.getters.getSelectedZones().length > 1) {
-    return _lt("Delete columns");
+    return _t("Delete columns");
   }
   let first: number;
   let last: number;
@@ -193,9 +193,9 @@ export const REMOVE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
     last = zone.right;
   }
   if (first === last) {
-    return _lt("Delete column %s", numberToLetters(first));
+    return _t("Delete column %s", numberToLetters(first));
   }
-  return _lt("Delete columns %s - %s", numberToLetters(first), numberToLetters(last));
+  return _t("Delete columns %s - %s", numberToLetters(first), numberToLetters(last));
 };
 
 export const NOT_ALL_VISIBLE_ROWS_SELECTED = (env: SpreadsheetChildEnv) => {
@@ -314,15 +314,15 @@ export const HIDE_COLUMNS_NAME = (env: SpreadsheetChildEnv) => {
   let first = cols[0];
   let last = cols[cols.length - 1];
   if (cols.length === 1) {
-    return _lt("Hide column %s", numberToLetters(first).toString());
+    return _t("Hide column %s", numberToLetters(first).toString());
   } else if (last - first + 1 === cols.length) {
-    return _lt(
+    return _t(
       "Hide columns %s - %s",
       numberToLetters(first).toString(),
       numberToLetters(last).toString()
     );
   } else {
-    return _lt("Hide columns");
+    return _t("Hide columns");
   }
 };
 
@@ -331,11 +331,11 @@ export const HIDE_ROWS_NAME = (env: SpreadsheetChildEnv) => {
   let first = rows[0];
   let last = rows[rows.length - 1];
   if (rows.length === 1) {
-    return _lt("Hide row %s", (first + 1).toString());
+    return _t("Hide row %s", (first + 1).toString());
   } else if (last - first + 1 === rows.length) {
-    return _lt("Hide rows %s - %s", (first + 1).toString(), (last + 1).toString());
+    return _t("Hide rows %s - %s", (first + 1).toString(), (last + 1).toString());
   } else {
-    return _lt("Hide rows");
+    return _t("Hide rows");
   }
 };
 
@@ -375,7 +375,7 @@ async function requestImage(env: SpreadsheetChildEnv): Promise<Image | undefined
   try {
     return await env.imageProvider!.requestImage();
   } catch {
-    env.raiseError(_lt("An unexpected error occurred during the image transfer"));
+    env.raiseError(_t("An unexpected error occurred during the image transfer"));
     return undefined;
   }
 }

--- a/src/actions/sheet_actions.ts
+++ b/src/actions/sheet_actions.ts
@@ -1,9 +1,9 @@
 import { buildSheetLink, markdownLink } from "../helpers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { ActionSpec } from "./action";
 
 export const linkSheet: ActionSpec = {
-  name: _lt("Link sheet"),
+  name: _t("Link sheet"),
   children: [
     (env) => {
       const sheets = env.model.getters
@@ -19,18 +19,18 @@ export const linkSheet: ActionSpec = {
 };
 
 export const deleteSheet: ActionSpec = {
-  name: _lt("Delete"),
+  name: _t("Delete"),
   isVisible: (env) => {
     return env.model.getters.getSheetIds().length > 1;
   },
   execute: (env) =>
-    env.askConfirmation(_lt("Are you sure you want to delete this sheet?"), () => {
+    env.askConfirmation(_t("Are you sure you want to delete this sheet?"), () => {
       env.model.dispatch("DELETE_SHEET", { sheetId: env.model.getters.getActiveSheetId() });
     }),
 };
 
 export const duplicateSheet: ActionSpec = {
-  name: _lt("Duplicate"),
+  name: _t("Duplicate"),
   execute: (env) => {
     const sheetIdFrom = env.model.getters.getActiveSheetId();
     const sheetIdTo = env.model.uuidGenerator.uuidv4();
@@ -44,13 +44,13 @@ export const duplicateSheet: ActionSpec = {
 
 export const renameSheet = (args: { renameSheetCallback: () => void }): ActionSpec => {
   return {
-    name: _lt("Rename"),
+    name: _t("Rename"),
     execute: args.renameSheetCallback,
   };
 };
 
 export const sheetMoveRight: ActionSpec = {
-  name: _lt("Move right"),
+  name: _t("Move right"),
   isVisible: (env) => {
     const sheetId = env.model.getters.getActiveSheetId();
     const sheetIds = env.model.getters.getVisibleSheetIds();
@@ -64,7 +64,7 @@ export const sheetMoveRight: ActionSpec = {
 };
 
 export const sheetMoveLeft: ActionSpec = {
-  name: _lt("Move left"),
+  name: _t("Move left"),
   isVisible: (env) => {
     const sheetId = env.model.getters.getActiveSheetId();
     return env.model.getters.getVisibleSheetIds()[0] !== sheetId;
@@ -77,7 +77,7 @@ export const sheetMoveLeft: ActionSpec = {
 };
 
 export const hideSheet: ActionSpec = {
-  name: _lt("Hide sheet"),
+  name: _t("Hide sheet"),
   isVisible: (env) => env.model.getters.getVisibleSheetIds().length !== 1,
   execute: (env) =>
     env.model.dispatch("HIDE_SHEET", { sheetId: env.model.getters.getActiveSheetId() }),

--- a/src/actions/view_actions.ts
+++ b/src/actions/view_actions.ts
@@ -1,7 +1,7 @@
 import { areZonesContinuous } from "../helpers";
 import { interactiveAddFilter } from "../helpers/ui/filter_interactive";
 import { interactiveFreezeColumnsRows } from "../helpers/ui/freeze_interactive";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { SpreadsheetChildEnv } from "../types";
 import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
@@ -21,7 +21,7 @@ export const hideCols: ActionSpec = {
 };
 
 export const unhideCols: ActionSpec = {
-  name: _lt("Unhide columns"),
+  name: _t("Unhide columns"),
   execute: (env) => {
     const columns = env.model.getters.getElementsFromSelection("COL");
     env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
@@ -40,7 +40,7 @@ export const unhideCols: ActionSpec = {
 };
 
 export const unhideAllCols: ActionSpec = {
-  name: _lt("Unhide all columns"),
+  name: _t("Unhide all columns"),
   execute: (env) => {
     const sheetId = env.model.getters.getActiveSheetId();
     env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
@@ -68,7 +68,7 @@ export const hideRows: ActionSpec = {
 };
 
 export const unhideRows: ActionSpec = {
-  name: _lt("Unhide rows"),
+  name: _t("Unhide rows"),
   execute: (env) => {
     const columns = env.model.getters.getElementsFromSelection("ROW");
     env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
@@ -87,7 +87,7 @@ export const unhideRows: ActionSpec = {
 };
 
 export const unhideAllRows: ActionSpec = {
-  name: _lt("Unhide all rows"),
+  name: _t("Unhide all rows"),
   execute: (env) => {
     const sheetId = env.model.getters.getActiveSheetId();
     env.model.dispatch("UNHIDE_COLUMNS_ROWS", {
@@ -101,7 +101,7 @@ export const unhideAllRows: ActionSpec = {
 };
 
 export const unFreezePane: ActionSpec = {
-  name: _lt("Unfreeze"),
+  name: _t("Unfreeze"),
   isVisible: (env) => {
     const { xSplit, ySplit } = env.model.getters.getPaneDivisions(
       env.model.getters.getActiveSheetId()
@@ -116,12 +116,12 @@ export const unFreezePane: ActionSpec = {
 };
 
 export const freezePane: ActionSpec = {
-  name: _lt("Freeze"),
+  name: _t("Freeze"),
   icon: "o-spreadsheet-Icon.FREEZE",
 };
 
 export const unFreezeRows: ActionSpec = {
-  name: _lt("No rows"),
+  name: _t("No rows"),
   execute: (env) =>
     env.model.dispatch("UNFREEZE_ROWS", {
       sheetId: env.model.getters.getActiveSheetId(),
@@ -132,19 +132,19 @@ export const unFreezeRows: ActionSpec = {
 };
 
 export const freezeFirstRow: ActionSpec = {
-  name: _lt("1 row"),
+  name: _t("1 row"),
   execute: (env) => interactiveFreezeColumnsRows(env, "ROW", 1),
   isReadonlyAllowed: true,
 };
 
 export const freezeSecondRow: ActionSpec = {
-  name: _lt("2 rows"),
+  name: _t("2 rows"),
   execute: (env) => interactiveFreezeColumnsRows(env, "ROW", 2),
   isReadonlyAllowed: true,
 };
 
 export const freezeCurrentRow: ActionSpec = {
-  name: _lt("Up to current row"),
+  name: _t("Up to current row"),
   execute: (env) => {
     const { bottom } = env.model.getters.getSelectedZone();
     interactiveFreezeColumnsRows(env, "ROW", bottom + 1);
@@ -153,7 +153,7 @@ export const freezeCurrentRow: ActionSpec = {
 };
 
 export const unFreezeCols: ActionSpec = {
-  name: _lt("No columns"),
+  name: _t("No columns"),
   execute: (env) =>
     env.model.dispatch("UNFREEZE_COLUMNS", {
       sheetId: env.model.getters.getActiveSheetId(),
@@ -164,19 +164,19 @@ export const unFreezeCols: ActionSpec = {
 };
 
 export const freezeFirstCol: ActionSpec = {
-  name: _lt("1 column"),
+  name: _t("1 column"),
   execute: (env) => interactiveFreezeColumnsRows(env, "COL", 1),
   isReadonlyAllowed: true,
 };
 
 export const freezeSecondCol: ActionSpec = {
-  name: _lt("2 columns"),
+  name: _t("2 columns"),
   execute: (env) => interactiveFreezeColumnsRows(env, "COL", 2),
   isReadonlyAllowed: true,
 };
 
 export const freezeCurrentCol: ActionSpec = {
-  name: _lt("Up to current column"),
+  name: _t("Up to current column"),
   execute: (env) => {
     const { right } = env.model.getters.getSelectedZone();
     interactiveFreezeColumnsRows(env, "COL", right + 1);
@@ -187,8 +187,8 @@ export const freezeCurrentCol: ActionSpec = {
 export const viewGridlines: ActionSpec = {
   name: (env: SpreadsheetChildEnv) =>
     env.model.getters.getGridLinesVisibility(env.model.getters.getActiveSheetId())
-      ? _lt("Hide gridlines")
-      : _lt("Show gridlines"),
+      ? _t("Hide gridlines")
+      : _t("Show gridlines"),
   execute: (env) => {
     const sheetId = env.model.getters.getActiveSheetId();
     env.model.dispatch("SET_GRID_LINES_VISIBILITY", {
@@ -201,7 +201,7 @@ export const viewGridlines: ActionSpec = {
 
 export const viewFormulas: ActionSpec = {
   name: (env: SpreadsheetChildEnv) =>
-    env.model.getters.shouldShowFormulas() ? _lt("Hide formulas") : _lt("Show formulas"),
+    env.model.getters.shouldShowFormulas() ? "Hide formulas" : _t("Show formulas"),
   execute: (env) =>
     env.model.dispatch("SET_FORMULA_VISIBILITY", { show: !env.model.getters.shouldShowFormulas() }),
   isReadonlyAllowed: true,
@@ -210,7 +210,7 @@ export const viewFormulas: ActionSpec = {
 
 export const createRemoveFilter: ActionSpec = {
   name: (env) =>
-    selectionContainsFilter(env) ? _lt("Remove selected filters") : _lt("Create filter"),
+    selectionContainsFilter(env) ? _t("Remove selected filters") : _t("Create filter"),
   isActive: (env) => selectionContainsFilter(env),
   isEnabled: (env) => !cannotCreateFilter(env),
   execute: (env) => createRemoveFilterAction(env),

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -28,7 +28,7 @@ import { ComposerSelection } from "../../plugins/ui_stateful/edition";
 import { cellMenuRegistry } from "../../registries/menus/cell_menu_registry";
 import { colMenuRegistry } from "../../registries/menus/col_menu_registry";
 import { rowMenuRegistry } from "../../registries/menus/row_menu_registry";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import {
   Align,
   CellValueType,
@@ -635,7 +635,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private displayWarningCopyPasteNotSupported() {
-    this.env.raiseError(_lt("Copy/Paste is not supported in this browser."));
+    this.env.raiseError(_t("Copy/Paste is not supported in this browser."));
   }
 
   private clearFormatting() {

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -1,7 +1,7 @@
 import { Component, onMounted, onWillUpdateProps, useState } from "@odoo/owl";
 import { NEWLINE } from "../../../constants";
 import { interactiveSplitToColumns } from "../../../helpers/ui/split_to_columns_interactive";
-import { _lt } from "../../../translation";
+import { _t } from "../../../translation";
 import { CommandResult, SpreadsheetChildEnv } from "../../../types/index";
 import { SplitToColumnsTerms } from "../../translations_terms";
 import { SidePanelErrors } from "../side_panel_errors/side_panel_errors";
@@ -14,12 +14,12 @@ interface Separator {
 }
 
 const SEPARATORS: Separator[] = [
-  { name: _lt("Detect automatically"), value: "auto" },
-  { name: _lt("Custom separator"), value: "custom" },
-  { name: _lt("Space"), value: " " },
-  { name: _lt("Comma"), value: "," },
-  { name: _lt("Semicolon"), value: ";" },
-  { name: _lt("Line Break"), value: NEWLINE },
+  { name: _t("Detect automatically"), value: "auto" },
+  { name: _t("Custom separator"), value: "custom" },
+  { name: _t("Space"), value: " " },
+  { name: _t("Comma"), value: "," },
+  { name: _t("Semicolon"), value: ";" },
+  { name: _t("Line Break"), value: NEWLINE },
 ];
 
 interface Props {

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -26,7 +26,7 @@ import {
 import { ImageProvider } from "../../helpers/figures/images/image_provider";
 import { Model } from "../../model";
 import { ComposerSelection } from "../../plugins/ui_stateful/edition";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { Pixel, SpreadsheetChildEnv } from "../../types";
 import { NotifyUIEvent } from "../../types/ui";
 import { BottomBar } from "../bottom_bar/bottom_bar";
@@ -276,7 +276,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
         return;
       }
       this.env.notifyUser({
-        text: _lt(
+        text: _t(
           "The current window is too small to display this sheet properly. Consider resizing your browser window or adjusting frozen rows and columns."
         ),
         tag: "viewportTooSmall",

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -1,96 +1,96 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { CommandResult } from "../types/index";
 
 export const CfTerms = {
   Errors: {
-    [CommandResult.InvalidRange]: _lt("The range is invalid"),
-    [CommandResult.FirstArgMissing]: _lt("The argument is missing. Please provide a value"),
-    [CommandResult.SecondArgMissing]: _lt("The second argument is missing. Please provide a value"),
-    [CommandResult.MinNaN]: _lt("The minpoint must be a number"),
-    [CommandResult.MidNaN]: _lt("The midpoint must be a number"),
-    [CommandResult.MaxNaN]: _lt("The maxpoint must be a number"),
-    [CommandResult.ValueUpperInflectionNaN]: _lt("The first value must be a number"),
-    [CommandResult.ValueLowerInflectionNaN]: _lt("The second value must be a number"),
-    [CommandResult.MinBiggerThanMax]: _lt("Minimum must be smaller then Maximum"),
-    [CommandResult.MinBiggerThanMid]: _lt("Minimum must be smaller then Midpoint"),
-    [CommandResult.MidBiggerThanMax]: _lt("Midpoint must be smaller then Maximum"),
-    [CommandResult.LowerBiggerThanUpper]: _lt(
+    [CommandResult.InvalidRange]: _t("The range is invalid"),
+    [CommandResult.FirstArgMissing]: _t("The argument is missing. Please provide a value"),
+    [CommandResult.SecondArgMissing]: _t("The second argument is missing. Please provide a value"),
+    [CommandResult.MinNaN]: _t("The minpoint must be a number"),
+    [CommandResult.MidNaN]: _t("The midpoint must be a number"),
+    [CommandResult.MaxNaN]: _t("The maxpoint must be a number"),
+    [CommandResult.ValueUpperInflectionNaN]: _t("The first value must be a number"),
+    [CommandResult.ValueLowerInflectionNaN]: _t("The second value must be a number"),
+    [CommandResult.MinBiggerThanMax]: _t("Minimum must be smaller then Maximum"),
+    [CommandResult.MinBiggerThanMid]: _t("Minimum must be smaller then Midpoint"),
+    [CommandResult.MidBiggerThanMax]: _t("Midpoint must be smaller then Maximum"),
+    [CommandResult.LowerBiggerThanUpper]: _t(
       "Lower inflection point must be smaller than upper inflection point"
     ),
-    [CommandResult.MinInvalidFormula]: _lt("Invalid Minpoint formula"),
-    [CommandResult.MaxInvalidFormula]: _lt("Invalid Maxpoint formula"),
-    [CommandResult.MidInvalidFormula]: _lt("Invalid Midpoint formula"),
-    [CommandResult.ValueUpperInvalidFormula]: _lt("Invalid upper inflection point formula"),
-    [CommandResult.ValueLowerInvalidFormula]: _lt("Invalid lower inflection point formula"),
-    [CommandResult.EmptyRange]: _lt("A range needs to be defined"),
-    Unexpected: _lt("The rule is invalid for an unknown reason"),
+    [CommandResult.MinInvalidFormula]: _t("Invalid Minpoint formula"),
+    [CommandResult.MaxInvalidFormula]: _t("Invalid Maxpoint formula"),
+    [CommandResult.MidInvalidFormula]: _t("Invalid Midpoint formula"),
+    [CommandResult.ValueUpperInvalidFormula]: _t("Invalid upper inflection point formula"),
+    [CommandResult.ValueLowerInvalidFormula]: _t("Invalid lower inflection point formula"),
+    [CommandResult.EmptyRange]: _t("A range needs to be defined"),
+    Unexpected: _t("The rule is invalid for an unknown reason"),
   },
-  ColorScale: _lt("Color scale"),
-  IconSet: _lt("Icon set"),
+  ColorScale: _t("Color scale"),
+  IconSet: _t("Icon set"),
 };
 
 export const CellIsOperators = {
-  IsEmpty: _lt("Is empty"),
-  IsNotEmpty: _lt("Is not empty"),
-  ContainsText: _lt("Contains"),
-  NotContains: _lt("Does not contain"),
-  BeginsWith: _lt("Starts with"),
-  EndsWith: _lt("Ends with"),
-  Equal: _lt("Is equal to"),
-  NotEqual: _lt("Is not equal to"),
-  GreaterThan: _lt("Is greater than"),
-  GreaterThanOrEqual: _lt("Is greater than or equal to"),
-  LessThan: _lt("Is less than"),
-  LessThanOrEqual: _lt("Is less than or equal to"),
-  Between: _lt("Is between"),
-  NotBetween: _lt("Is not between"),
+  IsEmpty: _t("Is empty"),
+  IsNotEmpty: _t("Is not empty"),
+  ContainsText: _t("Contains"),
+  NotContains: _t("Does not contain"),
+  BeginsWith: _t("Starts with"),
+  EndsWith: _t("Ends with"),
+  Equal: _t("Is equal to"),
+  NotEqual: _t("Is not equal to"),
+  GreaterThan: _t("Is greater than"),
+  GreaterThanOrEqual: _t("Is greater than or equal to"),
+  LessThan: _t("Is less than"),
+  LessThanOrEqual: _t("Is less than or equal to"),
+  Between: _t("Is between"),
+  NotBetween: _t("Is not between"),
 };
 
 export const ChartTerms = {
-  Series: _lt("Series"),
+  Series: _t("Series"),
   Errors: {
-    Unexpected: _lt("The chart definition is invalid for an unknown reason"),
+    Unexpected: _t("The chart definition is invalid for an unknown reason"),
     // BASIC CHART ERRORS (LINE | BAR | PIE)
-    [CommandResult.InvalidDataSet]: _lt("The dataset is invalid"),
-    [CommandResult.InvalidLabelRange]: _lt("Labels are invalid"),
+    [CommandResult.InvalidDataSet]: _t("The dataset is invalid"),
+    [CommandResult.InvalidLabelRange]: _t("Labels are invalid"),
     // SCORECARD CHART ERRORS
-    [CommandResult.InvalidScorecardKeyValue]: _lt("The key value is invalid"),
-    [CommandResult.InvalidScorecardBaseline]: _lt("The baseline value is invalid"),
+    [CommandResult.InvalidScorecardKeyValue]: _t("The key value is invalid"),
+    [CommandResult.InvalidScorecardBaseline]: _t("The baseline value is invalid"),
     // GAUGE CHART ERRORS
-    [CommandResult.InvalidGaugeDataRange]: _lt("The data range is invalid"),
-    [CommandResult.EmptyGaugeRangeMin]: _lt("A minimum range limit value is needed"),
-    [CommandResult.GaugeRangeMinNaN]: _lt("The minimum range limit value must be a number"),
-    [CommandResult.EmptyGaugeRangeMax]: _lt("A maximum range limit value is needed"),
-    [CommandResult.GaugeRangeMaxNaN]: _lt("The maximum range limit value must be a number"),
-    [CommandResult.GaugeRangeMinBiggerThanRangeMax]: _lt(
+    [CommandResult.InvalidGaugeDataRange]: _t("The data range is invalid"),
+    [CommandResult.EmptyGaugeRangeMin]: _t("A minimum range limit value is needed"),
+    [CommandResult.GaugeRangeMinNaN]: _t("The minimum range limit value must be a number"),
+    [CommandResult.EmptyGaugeRangeMax]: _t("A maximum range limit value is needed"),
+    [CommandResult.GaugeRangeMaxNaN]: _t("The maximum range limit value must be a number"),
+    [CommandResult.GaugeRangeMinBiggerThanRangeMax]: _t(
       "Minimum range limit must be smaller than maximum range limit"
     ),
-    [CommandResult.GaugeLowerInflectionPointNaN]: _lt(
+    [CommandResult.GaugeLowerInflectionPointNaN]: _t(
       "The lower inflection point value must be a number"
     ),
-    [CommandResult.GaugeUpperInflectionPointNaN]: _lt(
+    [CommandResult.GaugeUpperInflectionPointNaN]: _t(
       "The upper inflection point value must be a number"
     ),
   },
 };
 
 export const CustomCurrencyTerms = {
-  Custom: _lt("Custom"),
+  Custom: _t("Custom"),
 };
 
-export const MergeErrorMessage = _lt(
+export const MergeErrorMessage = _t(
   "Merged cells are preventing this operation. Unmerge those cells and try again."
 );
 
 export const SplitToColumnsTerms = {
   Errors: {
-    Unexpected: _lt("Cannot split the selection for an unknown reason"),
-    [CommandResult.NoSplitSeparatorInSelection]: _lt(
+    Unexpected: _t("Cannot split the selection for an unknown reason"),
+    [CommandResult.NoSplitSeparatorInSelection]: _t(
       "There is no match for the selected separator in the selection"
     ),
-    [CommandResult.MoreThanOneColumnSelected]: _lt(
+    [CommandResult.MoreThanOneColumnSelected]: _t(
       "Only a selection from a single column can be split"
     ),
-    [CommandResult.SplitWillOverwriteContent]: _lt("Splitting will overwrite existing content"),
+    [CommandResult.SplitWillOverwriteContent]: _t("Splitting will overwrite existing content"),
   },
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { _lt } from "./translation";
+import { _t } from "./translation";
 import { BorderDescr, Color } from "./types";
 import { CellErrorType } from "./types/errors";
 
@@ -195,7 +195,7 @@ export const FORBIDDEN_IN_EXCEL_REGEX = /'|\*|\?|\/|\\|\[|\]/;
 // Cells
 export const FORMULA_REF_IDENTIFIER = "|";
 export const LOADING = "Loading...";
-export const DEFAULT_ERROR_MESSAGE = _lt("Invalid expression");
+export const DEFAULT_ERROR_MESSAGE = _t("Invalid expression");
 
 // Components
 export enum ComponentsImportance {

--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -1,7 +1,7 @@
 import { Token } from ".";
 import { functionRegistry } from "../functions/index";
 import { concat, parseNumber, removeStringQuotes } from "../helpers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { CompiledFormula, DEFAULT_LOCALE } from "../types";
 import { BadExpressionError, UnknownFunctionError } from "../types/errors";
 import { FunctionCode, FunctionCodeBuilder, Scope } from "./code_builder";
@@ -60,10 +60,10 @@ export function compile(formula: string): CompiledFormula {
     const scope = new Scope();
 
     if (ast.type === "BIN_OPERATION" && ast.value === ":") {
-      throw new BadExpressionError(_lt("Invalid formula"));
+      throw new BadExpressionError(_t("Invalid formula"));
     }
     if (ast.type === "EMPTY") {
-      throw new BadExpressionError(_lt("Invalid formula"));
+      throw new BadExpressionError(_t("Invalid formula"));
     }
     const compiledAST = compileAST(ast);
     const code = new FunctionCodeBuilder();
@@ -120,7 +120,7 @@ export function compile(formula: string): CompiledFormula {
         if (isRangeOnly) {
           if (!isRangeInput(currentArg)) {
             throw new BadExpressionError(
-              _lt(
+              _t(
                 "Function %s expects the parameter %s to be reference to a cell or range, not a %s.",
                 functionName,
                 (i + 1).toString(),
@@ -164,7 +164,7 @@ export function compile(formula: string): CompiledFormula {
       const code = new FunctionCodeBuilder(scope);
       if (ast.type !== "REFERENCE" && !(ast.type === "BIN_OPERATION" && ast.value === ":")) {
         if (isMeta) {
-          throw new BadExpressionError(_lt(`Argument must be a reference to a cell or range.`));
+          throw new BadExpressionError(_t(`Argument must be a reference to a cell or range.`));
         }
       }
       if (ast.debug) {
@@ -317,7 +317,7 @@ function assertEnoughArgs(ast: ASTFuncall) {
 
   if (nbrArg < functionDefinition.minArgRequired) {
     throw new BadExpressionError(
-      _lt(
+      _t(
         "Invalid number of arguments for the %s function. Expected %s minimum, but got %s instead.",
         functionName,
         functionDefinition.minArgRequired.toString(),
@@ -328,7 +328,7 @@ function assertEnoughArgs(ast: ASTFuncall) {
 
   if (nbrArg > functionDefinition.maxArgPossible) {
     throw new BadExpressionError(
-      _lt(
+      _t(
         "Invalid number of arguments for the %s function. Expected %s maximum, but got %s instead.",
         functionName,
         functionDefinition.maxArgPossible.toString(),
@@ -343,7 +343,7 @@ function assertEnoughArgs(ast: ASTFuncall) {
     const repeatingArgs = nbrArg - unrepeatableArgs;
     if (repeatingArgs % repeatableArgs !== 0) {
       throw new BadExpressionError(
-        _lt(
+        _t(
           "Invalid number of arguments for the %s function. Expected all arguments after position %s to be supplied by groups of %s arguments",
           functionName,
           unrepeatableArgs.toString(),

--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_ERROR_MESSAGE } from "../constants";
 import { parseNumber, removeStringQuotes } from "../helpers/index";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { DEFAULT_LOCALE } from "../types";
 import { BadExpressionError, InvalidReferenceError } from "../types/errors";
 import { Token, tokenize } from "./tokenizer";
@@ -137,11 +137,11 @@ function parseOperand(tokens: Token[]): AST {
       if (upperCaseValue === "TRUE" || upperCaseValue === "FALSE") {
         return { type: "BOOLEAN", value: upperCaseValue === "TRUE" };
       }
-      throw new BadExpressionError(_lt("Invalid formula"));
+      throw new BadExpressionError(_t("Invalid formula"));
 
     case "LEFT_PAREN":
       const result = parseExpression(tokens);
-      consumeOrThrow(tokens, "RIGHT_PAREN", _lt("Missing closing parenthesis"));
+      consumeOrThrow(tokens, "RIGHT_PAREN", _t("Missing closing parenthesis"));
       return result;
     case "OPERATOR":
       const operator = current.value;
@@ -152,14 +152,14 @@ function parseOperand(tokens: Token[]): AST {
           operand: parseExpression(tokens, OP_PRIORITY[operator]),
         };
       }
-      throw new BadExpressionError(_lt("Unexpected token: %s", current.value));
+      throw new BadExpressionError(_t("Unexpected token: %s", current.value));
     default:
-      throw new BadExpressionError(_lt("Unexpected token: %s", current.value));
+      throw new BadExpressionError(_t("Unexpected token: %s", current.value));
   }
 }
 
 function parseFunctionArgs(tokens: Token[]): AST[] {
-  consumeOrThrow(tokens, "LEFT_PAREN", _lt("Missing opening parenthesis"));
+  consumeOrThrow(tokens, "LEFT_PAREN", _t("Missing opening parenthesis"));
   const nextToken = tokens[0];
   if (nextToken?.type === "RIGHT_PAREN") {
     consumeOrThrow(tokens, "RIGHT_PAREN");
@@ -168,7 +168,7 @@ function parseFunctionArgs(tokens: Token[]): AST[] {
   const args: AST[] = [];
   args.push(parseOneFunctionArg(tokens));
   while (tokens[0]?.type !== "RIGHT_PAREN") {
-    consumeOrThrow(tokens, "ARG_SEPARATOR", _lt("Wrong function call"));
+    consumeOrThrow(tokens, "ARG_SEPARATOR", _t("Wrong function call"));
     args.push(parseOneFunctionArg(tokens));
   }
   consumeOrThrow(tokens, "RIGHT_PAREN");

--- a/src/functions/arguments.ts
+++ b/src/functions/arguments.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { AddFunctionDescription, ArgDefinition, ArgType, FunctionDescription } from "../types";
 
 //------------------------------------------------------------------------------
@@ -153,7 +153,7 @@ export function validateArguments(args: ArgDefinition[]) {
   for (let current of args) {
     if (current.type.includes("META") && current.type.length > 1) {
       throw new Error(
-        _lt(
+        _t(
           "Function ${name} has an argument that has been declared with more than one type whose type 'META'. The 'META' type can only be declared alone."
         )
       );
@@ -161,7 +161,7 @@ export function validateArguments(args: ArgDefinition[]) {
 
     if (previousArgRepeating && !current.repeating) {
       throw new Error(
-        _lt(
+        _t(
           "Function ${name} has no-repeatable arguments declared after repeatable ones. All repeatable arguments must be declared last."
         )
       );
@@ -170,7 +170,7 @@ export function validateArguments(args: ArgDefinition[]) {
     const currentIsntOptional = !(current.optional || current.repeating || current.default);
     if (previousIsOptional && currentIsntOptional) {
       throw new Error(
-        _lt(
+        _t(
           "Function ${name} has at mandatory arguments declared after optional ones. All optional arguments must be after all mandatory arguments."
         )
       );

--- a/src/functions/helper_financial.ts
+++ b/src/functions/helper_financial.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { Locale } from "../types";
 import { assert, toJsDate } from "./helpers";
 
@@ -6,7 +6,7 @@ import { assert, toJsDate } from "./helpers";
 export function assertMaturityAndSettlementDatesAreValid(settlement: number, maturity: number) {
   assert(
     () => settlement < maturity,
-    _lt(
+    _t(
       "The maturity (%s) must be strictly greater than the settlement (%s).",
       maturity.toString(),
       settlement.toString()
@@ -18,7 +18,7 @@ export function assertMaturityAndSettlementDatesAreValid(settlement: number, mat
 export function assertSettlementAndIssueDatesAreValid(settlement: number, issue: number) {
   assert(
     () => issue < settlement,
-    _lt(
+    _t(
       "The settlement date (%s) must be strictly greater than the issue date (%s).",
       settlement.toString(),
       issue.toString()
@@ -30,7 +30,7 @@ export function assertSettlementAndIssueDatesAreValid(settlement: number, issue:
 export function assertCouponFrequencyIsValid(frequency: number) {
   assert(
     () => [1, 2, 4].includes(frequency),
-    _lt("The frequency (%s) must be one of %s", frequency.toString(), [1, 2, 4].toString())
+    _t("The frequency (%s) must be one of %s", frequency.toString(), [1, 2, 4].toString())
   );
 }
 
@@ -38,7 +38,7 @@ export function assertCouponFrequencyIsValid(frequency: number) {
 export function assertDayCountConventionIsValid(dayCountConvention: number) {
   assert(
     () => 0 <= dayCountConvention && dayCountConvention <= 4,
-    _lt(
+    _t(
       "The day_count_convention (%s) must be between 0 and 4 inclusive.",
       dayCountConvention.toString()
     )
@@ -48,53 +48,53 @@ export function assertDayCountConventionIsValid(dayCountConvention: number) {
 export function assertRedemptionStrictlyPositive(redemption: number) {
   assert(
     () => redemption > 0,
-    _lt("The redemption (%s) must be strictly positive.", redemption.toString())
+    _t("The redemption (%s) must be strictly positive.", redemption.toString())
   );
 }
 
 export function assertPriceStrictlyPositive(price: number) {
-  assert(() => price > 0, _lt("The price (%s) must be strictly positive.", price.toString()));
+  assert(() => price > 0, _t("The price (%s) must be strictly positive.", price.toString()));
 }
 
 export function assertNumberOfPeriodsStrictlyPositive(nPeriods: number) {
   assert(
     () => nPeriods > 0,
-    _lt("The number_of_periods (%s) must be greater than 0.", nPeriods.toString())
+    _t("The number_of_periods (%s) must be greater than 0.", nPeriods.toString())
   );
 }
 
 export function assertRateStrictlyPositive(rate: number) {
-  assert(() => rate > 0, _lt("The rate (%s) must be strictly positive.", rate.toString()));
+  assert(() => rate > 0, _t("The rate (%s) must be strictly positive.", rate.toString()));
 }
 
 export function assertLifeStrictlyPositive(life: number) {
-  assert(() => life > 0, _lt("The life (%s) must be strictly positive.", life.toString()));
+  assert(() => life > 0, _t("The life (%s) must be strictly positive.", life.toString()));
 }
 
 export function assertCostStrictlyPositive(cost: number) {
-  assert(() => cost > 0, _lt("The cost (%s) must be strictly positive.", cost.toString()));
+  assert(() => cost > 0, _t("The cost (%s) must be strictly positive.", cost.toString()));
 }
 
 export function assertCostPositiveOrZero(cost: number) {
-  assert(() => cost >= 0, _lt("The cost (%s) must be positive or null.", cost.toString()));
+  assert(() => cost >= 0, _t("The cost (%s) must be positive or null.", cost.toString()));
 }
 
 export function assertPeriodStrictlyPositive(period: number) {
-  assert(() => period > 0, _lt("The period (%s) must be strictly positive.", period.toString()));
+  assert(() => period > 0, _t("The period (%s) must be strictly positive.", period.toString()));
 }
 
 export function assertPeriodPositiveOrZero(period: number) {
-  assert(() => period >= 0, _lt("The period (%s) must be positive or null.", period.toString()));
+  assert(() => period >= 0, _t("The period (%s) must be positive or null.", period.toString()));
 }
 
 export function assertSalvagePositiveOrZero(salvage: number) {
-  assert(() => salvage >= 0, _lt("The salvage (%s) must be positive or null.", salvage.toString()));
+  assert(() => salvage >= 0, _t("The salvage (%s) must be positive or null.", salvage.toString()));
 }
 
 export function assertSalvageSmallerOrEqualThanCost(salvage: number, cost: number) {
   assert(
     () => salvage <= cost,
-    _lt(
+    _t(
       "The salvage (%s) must be smaller or equal than the cost (%s).",
       salvage.toString(),
       cost.toString()
@@ -103,38 +103,38 @@ export function assertSalvageSmallerOrEqualThanCost(salvage: number, cost: numbe
 }
 
 export function assertPresentValueStrictlyPositive(pv: number) {
-  assert(() => pv > 0, _lt("The present value (%s) must be strictly positive.", pv.toString()));
+  assert(() => pv > 0, _t("The present value (%s) must be strictly positive.", pv.toString()));
 }
 
 export function assertPeriodSmallerOrEqualToLife(period: number, life: number) {
   assert(
     () => period <= life,
-    _lt("The period (%s) must be less than or equal life (%s).", period.toString(), life.toString())
+    _t("The period (%s) must be less than or equal life (%s).", period.toString(), life.toString())
   );
 }
 
 export function assertInvestmentStrictlyPositive(investment: number) {
   assert(
     () => investment > 0,
-    _lt("The investment (%s) must be strictly positive.", investment.toString())
+    _t("The investment (%s) must be strictly positive.", investment.toString())
   );
 }
 
 export function assertDiscountStrictlyPositive(discount: number) {
   assert(
     () => discount > 0,
-    _lt("The discount (%s) must be strictly positive.", discount.toString())
+    _t("The discount (%s) must be strictly positive.", discount.toString())
   );
 }
 
 export function assertDiscountStrictlySmallerThanOne(discount: number) {
-  assert(() => discount < 1, _lt("The discount (%s) must be smaller than 1.", discount.toString()));
+  assert(() => discount < 1, _t("The discount (%s) must be smaller than 1.", discount.toString()));
 }
 
 export function assertDeprecationFactorStrictlyPositive(factor: number) {
   assert(
     () => factor > 0,
-    _lt("The depreciation factor (%s) must be strictly positive.", factor.toString())
+    _t("The depreciation factor (%s) must be strictly positive.", factor.toString())
   );
 }
 
@@ -151,7 +151,7 @@ export function assertSettlementLessThanOneYearBeforeMaturity(
 
   assert(
     () => endDate.getTime() <= startDatePlusOneYear.getTime(),
-    _lt(
+    _t(
       "The settlement date (%s) must at most one year after the maturity date (%s).",
       settlement.toString(),
       maturity.toString()
@@ -174,15 +174,15 @@ export function assertFirstAndLastPeriodsAreValid(
   assertNumberOfPeriodsStrictlyPositive(numberOfPeriods);
   assert(
     () => firstPeriod > 0,
-    _lt("The first_period (%s) must be strictly positive.", firstPeriod.toString())
+    _t("The first_period (%s) must be strictly positive.", firstPeriod.toString())
   );
   assert(
     () => lastPeriod > 0,
-    _lt("The last_period (%s) must be strictly positive.", lastPeriod.toString())
+    _t("The last_period (%s) must be strictly positive.", lastPeriod.toString())
   );
   assert(
     () => firstPeriod <= lastPeriod,
-    _lt(
+    _t(
       "The first_period (%s) must be smaller or equal to the last_period (%s).",
       firstPeriod.toString(),
       lastPeriod.toString()
@@ -190,7 +190,7 @@ export function assertFirstAndLastPeriodsAreValid(
   );
   assert(
     () => lastPeriod <= numberOfPeriods,
-    _lt(
+    _t(
       "The last_period (%s) must be smaller or equal to the number_of_periods (%s).",
       firstPeriod.toString(),
       numberOfPeriods.toString()
@@ -214,15 +214,15 @@ export function assertStartAndEndPeriodAreValid(
   assertLifeStrictlyPositive(life);
   assert(
     () => startPeriod >= 0,
-    _lt("The start_period (%s) must be greater or equal than 0.", startPeriod.toString())
+    _t("The start_period (%s) must be greater or equal than 0.", startPeriod.toString())
   );
   assert(
     () => endPeriod >= 0,
-    _lt("The end_period (%s) must be greater or equal than 0.", endPeriod.toString())
+    _t("The end_period (%s) must be greater or equal than 0.", endPeriod.toString())
   );
   assert(
     () => startPeriod <= endPeriod,
-    _lt(
+    _t(
       "The start_period (%s) must be smaller or equal to the end_period (%s).",
       startPeriod.toString(),
       endPeriod.toString()
@@ -230,7 +230,7 @@ export function assertStartAndEndPeriodAreValid(
   );
   assert(
     () => endPeriod <= life,
-    _lt(
+    _t(
       "The end_period (%s) must be smaller or equal to the life (%s).",
       startPeriod.toString(),
       life.toString()
@@ -241,28 +241,28 @@ export function assertStartAndEndPeriodAreValid(
 export function assertRateGuessStrictlyGreaterThanMinusOne(guess: number) {
   assert(
     () => guess > -1,
-    _lt("The rate_guess (%s) must be strictly greater than -1.", guess.toString())
+    _t("The rate_guess (%s) must be strictly greater than -1.", guess.toString())
   );
 }
 
 export function assertCashFlowsAndDatesHaveSameDimension(cashFlows: any[][], dates: any[][]) {
   assert(
     () => cashFlows.length === dates.length && cashFlows[0].length === dates[0].length,
-    _lt("The cashflow_amounts and cashflow_dates ranges must have the same dimensions.")
+    _t("The cashflow_amounts and cashflow_dates ranges must have the same dimensions.")
   );
 }
 
 export function assertCashFlowsHavePositiveAndNegativesValues(cashFlow: number[]) {
   assert(
     () => cashFlow.some((val) => val > 0) && cashFlow.some((val) => val < 0),
-    _lt("There must be both positive and negative values in cashflow_amounts.")
+    _t("There must be both positive and negative values in cashflow_amounts.")
   );
 }
 
 export function assertEveryDateGreaterThanFirstDateOfCashFlowDates(dates: number[]) {
   assert(
     () => dates.every((date) => date >= dates[0]),
-    _lt(
+    _t(
       "All the dates should be greater or equal to the first date in cashflow_dates (%s).",
       dates[0].toString()
     )

--- a/src/functions/helper_matrices.ts
+++ b/src/functions/helper_matrices.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { Matrix } from "../types";
 
 export function getUnitMatrix(n: number): Matrix<number> {
@@ -114,7 +114,7 @@ function swapMatrixRows(matrix: number[][], row1: number, row2: number) {
  */
 export function multiplyMatrices(matrix1: Matrix<number>, matrix2: Matrix<number>): Matrix<number> {
   if (matrix1.length !== matrix2[0].length) {
-    throw new Error(_lt("Cannot multiply matrices : incompatible matrices size."));
+    throw new Error(_t("Cannot multiply matrices : incompatible matrices size."));
   }
 
   const rowsM1 = matrix1[0].length;

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -1,7 +1,7 @@
 // HELPERS
 import { numberToJsDate, parseDateTime } from "../helpers/dates";
 import { isNumber, parseNumber } from "../helpers/numbers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   ArgValue,
   CellValue,
@@ -24,13 +24,13 @@ export function assert(condition: () => boolean, message: string): void {
 // -----------------------------------------------------------------------------
 
 const expectNumberValueError = (value: string) =>
-  _lt(
+  _t(
     "The function [[FUNCTION_NAME]] expects a number value, but '%s' is a string, and cannot be coerced to a number.",
     value
   );
 
 export const expectNumberRangeError = (lowerBound: number, upperBound: number, value: number) =>
-  _lt(
+  _t(
     "The function [[FUNCTION_NAME]] expects a number value between %s and %s inclusive, but receives %s.",
     lowerBound.toString(),
     upperBound.toString(),
@@ -39,7 +39,7 @@ export const expectNumberRangeError = (lowerBound: number, upperBound: number, v
 
 export const expectStringSetError = (stringSet: string[], value: string) => {
   const stringSetString = stringSet.map((str) => `'${str}'`).join(", ");
-  return _lt(
+  return _t(
     "The function [[FUNCTION_NAME]] has an argument with value '%s'. It should be one of: %s.",
     value,
     stringSetString
@@ -93,7 +93,7 @@ export function strictToInteger(
 export function assertNumberGreaterThanOrEqualToOne(value: number) {
   assert(
     () => value >= 1,
-    _lt(
+    _t(
       "The function [[FUNCTION_NAME]] expects a number value to be greater than or equal to 1, but receives %s.",
       value.toString()
     )
@@ -138,7 +138,7 @@ export function normalizeValue<T>(value: T): T | string {
 }
 
 const expectBooleanValueError = (value: string) =>
-  _lt(
+  _t(
     "The function [[FUNCTION_NAME]] expects a boolean value, but '%s' is a text, and cannot be coerced to a number.",
     value
   );
@@ -517,7 +517,7 @@ export function visitMatchingRanges(
 
   if (countArg % 2 === 1) {
     throw new Error(
-      _lt(`Function [[FUNCTION_NAME]] expects criteria_range and criterion to be in pairs.`)
+      _t(`Function [[FUNCTION_NAME]] expects criteria_range and criterion to be in pairs.`)
     );
   }
 
@@ -535,7 +535,7 @@ export function visitMatchingRanges(
       criteriaRange[0].length !== dimCol
     ) {
       throw new Error(
-        _lt(`Function [[FUNCTION_NAME]] expects criteria_range to have the same dimension`)
+        _t(`Function [[FUNCTION_NAME]] expects criteria_range to have the same dimension`)
       );
     }
 

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,5 +1,5 @@
 import { Registry } from "../registries/registry";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   Arg,
@@ -33,21 +33,21 @@ export { arg } from "./arguments";
 type Functions = { [functionName: string]: AddFunctionDescription };
 type Category = { name: string; functions: Functions };
 const categories: Category[] = [
-  { name: _lt("Array"), functions: array },
-  { name: _lt("Database"), functions: database },
-  { name: _lt("Date"), functions: date },
-  { name: _lt("Filter"), functions: filter },
-  { name: _lt("Financial"), functions: financial },
-  { name: _lt("Info"), functions: info },
-  { name: _lt("Lookup"), functions: lookup },
-  { name: _lt("Logical"), functions: logical },
-  { name: _lt("Math"), functions: math },
-  { name: _lt("Misc"), functions: misc },
-  { name: _lt("Operator"), functions: operators },
-  { name: _lt("Statistical"), functions: statistical },
-  { name: _lt("Text"), functions: text },
-  { name: _lt("Engineering"), functions: engineering },
-  { name: _lt("Web"), functions: web },
+  { name: _t("Array"), functions: array },
+  { name: _t("Database"), functions: database },
+  { name: _t("Date"), functions: date },
+  { name: _t("Filter"), functions: filter },
+  { name: _t("Financial"), functions: financial },
+  { name: _t("Info"), functions: info },
+  { name: _t("Lookup"), functions: lookup },
+  { name: _t("Logical"), functions: logical },
+  { name: _t("Math"), functions: math },
+  { name: _t("Misc"), functions: misc },
+  { name: _t("Operator"), functions: operators },
+  { name: _t("Statistical"), functions: statistical },
+  { name: _t("Text"), functions: text },
+  { name: _t("Engineering"), functions: engineering },
+  { name: _t("Web"), functions: web },
 ];
 
 const functionNameRegex = /^[A-Z0-9\_\.]+$/;
@@ -64,7 +64,7 @@ class FunctionRegistry extends Registry<FunctionDescription> {
     name = name.toUpperCase();
     if (!functionNameRegex.test(name)) {
       throw new Error(
-        _lt(
+        _t(
           "Invalid function name %s. Function names can exclusively contain alphanumerical values separated by dots (.) or underscore (_)",
           name
         )

--- a/src/functions/module_array.ts
+++ b/src/functions/module_array.ts
@@ -1,5 +1,5 @@
 import { transpose2dArray } from "../helpers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   Arg,
@@ -36,11 +36,11 @@ import { invertMatrix, multiplyMatrices } from "./helper_matrices";
 // ARRAY_CONSTRAIN
 // -----------------------------------------------------------------------------
 export const ARRAY_CONSTRAIN: AddFunctionDescription = {
-  description: _lt("Returns a result array constrained to a specific width and height."),
+  description: _t("Returns a result array constrained to a specific width and height."),
   args: [
-    arg("input_range (any, range<any>)", _lt("The range to constrain.")),
-    arg("rows (number)", _lt("The number of rows in the constrained array.")),
-    arg("columns (number)", _lt("The number of columns in the constrained array.")),
+    arg("input_range (any, range<any>)", _t("The range to constrain.")),
+    arg("rows (number)", _t("The number of rows in the constrained array.")),
+    arg("columns (number)", _t("The number of columns in the constrained array.")),
   ],
   returns: ["RANGE<ANY>"],
   //TODO computeFormat
@@ -54,11 +54,11 @@ export const ARRAY_CONSTRAIN: AddFunctionDescription = {
     const _columnsArg = toInteger(columns, this.locale);
 
     assertPositive(
-      _lt("The rows argument (%s) must be strictly positive.", _rowsArg.toString()),
+      _t("The rows argument (%s) must be strictly positive.", _rowsArg.toString()),
       _rowsArg
     );
     assertPositive(
-      _lt("The columns argument (%s) must be strictly positive.", _rowsArg.toString()),
+      _t("The columns argument (%s) must be strictly positive.", _rowsArg.toString()),
       _columnsArg
     );
 
@@ -81,16 +81,16 @@ export const ARRAY_CONSTRAIN: AddFunctionDescription = {
 // CHOOSECOLS
 // -----------------------------------------------------------------------------
 export const CHOOSECOLS: AddFunctionDescription = {
-  description: _lt("Creates a new array from the selected columns in the existing range."),
+  description: _t("Creates a new array from the selected columns in the existing range."),
   args: [
-    arg("array (any, range<any>)", _lt("The array that contains the columns to be returned.")),
+    arg("array (any, range<any>)", _t("The array that contains the columns to be returned.")),
     arg(
       "col_num (number, range<number>)",
-      _lt("The first column index of the columns to be returned.")
+      _t("The first column index of the columns to be returned.")
     ),
     arg(
       "col_num2 (number, range<number>, repeating)",
-      _lt("The columns indexes of the columns to be returned.")
+      _t("The columns indexes of the columns to be returned.")
     ),
   ],
   returns: ["RANGE<ANY>"],
@@ -100,7 +100,7 @@ export const CHOOSECOLS: AddFunctionDescription = {
     const _columns = flattenRowFirst(columns, (val) => toInteger(val, this.locale));
     assert(
       () => _columns.every((col) => col > 0 && col <= _array.length),
-      _lt(
+      _t(
         "The columns arguments must be between 1 and %s (got %s).",
         _array.length.toString(),
         (_columns.find((col) => col <= 0 || col > _array.length) || 0).toString()
@@ -122,13 +122,13 @@ export const CHOOSECOLS: AddFunctionDescription = {
 // CHOOSEROWS
 // -----------------------------------------------------------------------------
 export const CHOOSEROWS: AddFunctionDescription = {
-  description: _lt("Creates a new array from the selected rows in the existing range."),
+  description: _t("Creates a new array from the selected rows in the existing range."),
   args: [
-    arg("array (any, range<any>)", _lt("The array that contains the rows to be returned.")),
-    arg("row_num (number, range<number>)", _lt("The first row index of the rows to be returned.")),
+    arg("array (any, range<any>)", _t("The array that contains the rows to be returned.")),
+    arg("row_num (number, range<number>)", _t("The first row index of the rows to be returned.")),
     arg(
       "row_num2 (number, range<number>, repeating)",
-      _lt("The rows indexes of the rows to be returned.")
+      _t("The rows indexes of the rows to be returned.")
     ),
   ],
   returns: ["RANGE<ANY>"],
@@ -138,7 +138,7 @@ export const CHOOSEROWS: AddFunctionDescription = {
     const _rows = flattenRowFirst(rows, (val) => toInteger(val, this.locale));
     assert(
       () => _rows.every((row) => row > 0 && row <= _array[0].length),
-      _lt(
+      _t(
         "The rows arguments must be between 1 and %s (got %s).",
         _array[0].length.toString(),
         (_rows.find((row) => row <= 0 || row > _array[0].length) || 0).toString()
@@ -163,18 +163,18 @@ export const CHOOSEROWS: AddFunctionDescription = {
 // EXPAND
 // -----------------------------------------------------------------------------
 export const EXPAND: AddFunctionDescription = {
-  description: _lt("Expands or pads an array to specified row and column dimensions."),
+  description: _t("Expands or pads an array to specified row and column dimensions."),
   args: [
-    arg("array (any, range<any>)", _lt("The array to expand.")),
+    arg("array (any, range<any>)", _t("The array to expand.")),
     arg(
       "rows (number)",
-      _lt("The number of rows in the expanded array. If missing, rows will not be expanded.")
+      _t("The number of rows in the expanded array. If missing, rows will not be expanded.")
     ),
     arg(
       "columns (number, optional)",
-      _lt("The number of columns in the expanded array. If missing, columns will not be expanded.")
+      _t("The number of columns in the expanded array. If missing, columns will not be expanded.")
     ),
-    arg("pad_with (any, default=0)", _lt("The value with which to pad.")), // @compatibility: on Excel, pad with #N/A
+    arg("pad_with (any, default=0)", _t("The value with which to pad.")), // @compatibility: on Excel, pad with #N/A
   ],
   returns: ["RANGE<ANY>"],
   //TODO computeFormat
@@ -191,14 +191,14 @@ export const EXPAND: AddFunctionDescription = {
 
     assert(
       () => _rows >= _array[0].length,
-      _lt(
+      _t(
         "The rows arguments (%s) must be greater or equal than the number of rows of the array.",
         _rows.toString()
       )
     );
     assert(
       () => _columns >= _array.length,
-      _lt(
+      _t(
         "The columns arguments (%s) must be greater or equal than the number of columns of the array.",
         _columns.toString()
       )
@@ -224,10 +224,10 @@ export const EXPAND: AddFunctionDescription = {
 // FLATTEN
 // -----------------------------------------------------------------------------
 export const FLATTEN: AddFunctionDescription = {
-  description: _lt("Flattens all the values from one or more ranges into a single column."),
+  description: _t("Flattens all the values from one or more ranges into a single column."),
   args: [
-    arg("range (any, range<any>)", _lt("The first range to flatten.")),
-    arg("range2 (any, range<any>, repeating)", _lt("Additional ranges to flatten.")),
+    arg("range (any, range<any>)", _t("The first range to flatten.")),
+    arg("range2 (any, range<any>, repeating)", _t("Additional ranges to flatten.")),
   ],
   returns: ["RANGE<ANY>"],
   compute: function (...ranges: ArgValue[]): Matrix<CellValue> {
@@ -240,10 +240,10 @@ export const FLATTEN: AddFunctionDescription = {
 // FREQUENCY
 // -----------------------------------------------------------------------------
 export const FREQUENCY: AddFunctionDescription = {
-  description: _lt("Calculates the frequency distribution of a range."),
+  description: _t("Calculates the frequency distribution of a range."),
   args: [
-    arg("data (range<number>)", _lt("The array of ranges containing the values to be counted.")),
-    arg("classes (number, range<number>)", _lt("The range containing the set of classes.")),
+    arg("data (range<number>)", _t("The array of ranges containing the values to be counted.")),
+    arg("classes (number, range<number>)", _t("The range containing the set of classes.")),
   ],
   returns: ["RANGE<NUMBER>"],
   compute: function (data: MatrixArgValue, classes: MatrixArgValue): CellValue[][] {
@@ -298,10 +298,10 @@ export const FREQUENCY: AddFunctionDescription = {
 // HSTACK
 // -----------------------------------------------------------------------------
 export const HSTACK: AddFunctionDescription = {
-  description: _lt("Appends ranges horizontally and in sequence to return a larger array."),
+  description: _t("Appends ranges horizontally and in sequence to return a larger array."),
   args: [
-    arg("range1 (any, range<any>)", _lt("The first range to be appended.")),
-    arg("range2 (any, range<any>, repeating)", _lt("Additional ranges to add to range1.")),
+    arg("range1 (any, range<any>)", _t("The first range to be appended.")),
+    arg("range2 (any, range<any>, repeating)", _t("Additional ranges to add to range1.")),
   ],
   returns: ["RANGE<ANY>"],
   //TODO computeFormat
@@ -330,11 +330,11 @@ export const HSTACK: AddFunctionDescription = {
 // MDETERM
 // -----------------------------------------------------------------------------
 export const MDETERM: AddFunctionDescription = {
-  description: _lt("Returns the matrix determinant of a square matrix."),
+  description: _t("Returns the matrix determinant of a square matrix."),
   args: [
     arg(
       "square_matrix (number, range<number>)",
-      _lt(
+      _t(
         "An range with an equal number of rows and columns representing a matrix whose determinant will be calculated."
       )
     ),
@@ -344,11 +344,11 @@ export const MDETERM: AddFunctionDescription = {
     const _matrix = toMatrixArgValue(matrix);
 
     assertSquareMatrix(
-      _lt("The argument square_matrix must have the same number of columns and rows."),
+      _t("The argument square_matrix must have the same number of columns and rows."),
       _matrix
     );
     if (!isNumberMatrix(_matrix)) {
-      throw new Error(_lt("The argument square_matrix must be a matrix of numbers."));
+      throw new Error(_t("The argument square_matrix must be a matrix of numbers."));
     }
     const { determinant } = invertMatrix(_matrix);
 
@@ -361,11 +361,11 @@ export const MDETERM: AddFunctionDescription = {
 // MINVERSE
 // -----------------------------------------------------------------------------
 export const MINVERSE: AddFunctionDescription = {
-  description: _lt("Returns the multiplicative inverse of a square matrix."),
+  description: _t("Returns the multiplicative inverse of a square matrix."),
   args: [
     arg(
       "square_matrix (number, range<number>)",
-      _lt(
+      _t(
         "An range with an equal number of rows and columns representing a matrix whose multiplicative inverse will be calculated."
       )
     ),
@@ -375,16 +375,16 @@ export const MINVERSE: AddFunctionDescription = {
     const _matrix = toMatrixArgValue(matrix);
 
     assertSquareMatrix(
-      _lt("The argument square_matrix must have the same number of columns and rows."),
+      _t("The argument square_matrix must have the same number of columns and rows."),
       _matrix
     );
     if (!isNumberMatrix(_matrix)) {
-      throw new Error(_lt("The argument square_matrix must be a matrix of numbers."));
+      throw new Error(_t("The argument square_matrix must be a matrix of numbers."));
     }
 
     const { inverted } = invertMatrix(_matrix);
     if (!inverted) {
-      throw new Error(_lt("The matrix is not invertible."));
+      throw new Error(_t("The matrix is not invertible."));
     }
 
     return inverted;
@@ -396,15 +396,15 @@ export const MINVERSE: AddFunctionDescription = {
 // MMULT
 // -----------------------------------------------------------------------------
 export const MMULT: AddFunctionDescription = {
-  description: _lt("Calculates the matrix product of two matrices."),
+  description: _t("Calculates the matrix product of two matrices."),
   args: [
     arg(
       "matrix1 (number, range<number>)",
-      _lt("The first matrix in the matrix multiplication operation.")
+      _t("The first matrix in the matrix multiplication operation.")
     ),
     arg(
       "matrix2 (number, range<number>)",
-      _lt("The second matrix in the matrix multiplication operation.")
+      _t("The second matrix in the matrix multiplication operation.")
     ),
   ],
   returns: ["RANGE<NUMBER>"],
@@ -414,7 +414,7 @@ export const MMULT: AddFunctionDescription = {
 
     assert(
       () => _matrix1.length === _matrix2[0].length,
-      _lt(
+      _t(
         "In [[FUNCTION_NAME]], the number of columns of the first matrix (%s) must be equal to the \
         number of rows of the second matrix (%s).",
         _matrix1.length.toString(),
@@ -422,7 +422,7 @@ export const MMULT: AddFunctionDescription = {
       )
     );
     if (!isNumberMatrix(_matrix1) || !isNumberMatrix(_matrix2)) {
-      throw new Error(_lt("The arguments matrix1 and matrix2 must be matrices of numbers."));
+      throw new Error(_t("The arguments matrix1 and matrix2 must be matrices of numbers."));
     }
 
     return multiplyMatrices(_matrix1, _matrix2);
@@ -434,26 +434,26 @@ export const MMULT: AddFunctionDescription = {
 // SUMPRODUCT
 // -----------------------------------------------------------------------------
 export const SUMPRODUCT: AddFunctionDescription = {
-  description: _lt(
+  description: _t(
     "Calculates the sum of the products of corresponding entries in equal-sized ranges."
   ),
   args: [
     arg(
       "range1 (number, range<number>)",
-      _lt(
+      _t(
         "The first range whose entries will be multiplied with corresponding entries in the other ranges."
       )
     ),
     arg(
       "range2 (number, range<number>, repeating)",
-      _lt(
+      _t(
         "The other range whose entries will be multiplied with corresponding entries in the other ranges."
       )
     ),
   ],
   returns: ["NUMBER"],
   compute: function (...args: ArgValue[]): number {
-    assertSameDimensions(_lt("All the ranges must have the same dimensions."), ...args);
+    assertSameDimensions(_t("All the ranges must have the same dimensions."), ...args);
     const _args = args.map(toMatrixArgValue);
     let result = 0;
     for (let i = 0; i < _args[0].length; i++) {
@@ -517,19 +517,19 @@ function getSumXAndY(
 }
 
 export const SUMX2MY2: AddFunctionDescription = {
-  description: _lt(
+  description: _t(
     "Calculates the sum of the difference of the squares of the values in two array."
   ),
   args: [
     arg(
       "array_x (number, range<number>)",
-      _lt(
+      _t(
         "The array or range of values whose squares will be reduced by the squares of corresponding entries in array_y and added together."
       )
     ),
     arg(
       "array_y (number, range<number>)",
-      _lt(
+      _t(
         "The array or range of values whose squares will be subtracted from the squares of corresponding entries in array_x and added together."
       )
     ),
@@ -545,17 +545,17 @@ export const SUMX2MY2: AddFunctionDescription = {
 // SUMX2PY2
 // -----------------------------------------------------------------------------
 export const SUMX2PY2: AddFunctionDescription = {
-  description: _lt("Calculates the sum of the sum of the squares of the values in two array."),
+  description: _t("Calculates the sum of the sum of the squares of the values in two array."),
   args: [
     arg(
       "array_x (number, range<number>)",
-      _lt(
+      _t(
         "The array or range of values whose squares will be added to the squares of corresponding entries in array_y and added together."
       )
     ),
     arg(
       "array_y (number, range<number>)",
-      _lt(
+      _t(
         "The array or range of values whose squares will be added to the squares of corresponding entries in array_x and added together."
       )
     ),
@@ -571,17 +571,17 @@ export const SUMX2PY2: AddFunctionDescription = {
 // SUMXMY2
 // -----------------------------------------------------------------------------
 export const SUMXMY2: AddFunctionDescription = {
-  description: _lt("Calculates the sum of squares of the differences of values in two array."),
+  description: _t("Calculates the sum of squares of the differences of values in two array."),
   args: [
     arg(
       "array_x (number, range<number>)",
-      _lt(
+      _t(
         "The array or range of values that will be reduced by corresponding entries in array_y, squared, and added together."
       )
     ),
     arg(
       "array_y (number, range<number>)",
-      _lt(
+      _t(
         "The array or range of values that will be subtracted from corresponding entries in array_x, the result squared, and all such results added together."
       )
     ),
@@ -599,16 +599,16 @@ export const SUMXMY2: AddFunctionDescription = {
 const TO_COL_ROW_DEFAULT_IGNORE = 0;
 const TO_COL_ROW_DEFAULT_SCAN = false;
 const TO_COL_ROW_ARGS = [
-  arg("array (any, range<any>)", _lt("The array which will be transformed.")),
+  arg("array (any, range<any>)", _t("The array which will be transformed.")),
   arg(
     `ignore (number, default=${TO_COL_ROW_DEFAULT_IGNORE})`,
-    _lt(
+    _t(
       "The control to ignore blanks and errors. 0 (default) is to keep all values, 1 is to ignore blanks, 2 is to ignore errors, and 3 is to ignore blanks and errors."
     )
   ),
   arg(
     `scan_by_column (number, default=${TO_COL_ROW_DEFAULT_SCAN})`,
-    _lt(
+    _t(
       "Whether the array should be scanned by column. True scans the array by column and false (default) \
       scans the array by row."
     )
@@ -616,7 +616,7 @@ const TO_COL_ROW_ARGS = [
 ];
 
 export const TOCOL: AddFunctionDescription = {
-  description: _lt("Transforms a range of cells into a single column."),
+  description: _t("Transforms a range of cells into a single column."),
   args: TO_COL_ROW_ARGS,
   returns: ["RANGE<ANY>"],
   //TODO compute format
@@ -629,7 +629,7 @@ export const TOCOL: AddFunctionDescription = {
     const _ignore = toInteger(ignore, this.locale);
     const _scanByColumn = toBoolean(scanByColumn);
 
-    assert(() => _ignore >= 0 && _ignore <= 3, _lt("Argument ignore must be between 0 and 3"));
+    assert(() => _ignore >= 0 && _ignore <= 3, _t("Argument ignore must be between 0 and 3"));
 
     const mappedFn = (acc: CellValue[], item: CellValue | undefined) => {
       // TODO : implement ignore value 2 (ignore error) & 3 (ignore blanks and errors) once we can have errors in
@@ -645,7 +645,7 @@ export const TOCOL: AddFunctionDescription = {
     const result = reduceAny([_array], mappedFn, [], _scanByColumn ? "colFirst" : "rowFirst");
 
     if (result.length === 0) {
-      throw new NotAvailableError(_lt("No results for the given arguments of TOCOL."));
+      throw new NotAvailableError(_t("No results for the given arguments of TOCOL."));
     }
     return [result];
   },
@@ -656,7 +656,7 @@ export const TOCOL: AddFunctionDescription = {
 // TOROW
 // -----------------------------------------------------------------------------
 export const TOROW: AddFunctionDescription = {
-  description: _lt("Transforms a range of cells into a single row."),
+  description: _t("Transforms a range of cells into a single row."),
   args: TO_COL_ROW_ARGS,
   returns: ["RANGE<ANY>"],
   //TODO compute format
@@ -669,7 +669,7 @@ export const TOROW: AddFunctionDescription = {
     const _ignore = toInteger(ignore, this.locale);
     const _scanByColumn = toBoolean(scanByColumn);
 
-    assert(() => _ignore >= 0 && _ignore <= 3, _lt("Argument ignore must be between 0 and 3"));
+    assert(() => _ignore >= 0 && _ignore <= 3, _t("Argument ignore must be between 0 and 3"));
 
     const mappedFn = (acc: Matrix<CellValue>, item: CellValue | undefined) => {
       // TODO : implement ignore value 2 (ignore error) & 3 (ignore blanks and errors) once we can have errors in
@@ -685,7 +685,7 @@ export const TOROW: AddFunctionDescription = {
     const result = reduceAny([_array], mappedFn, [], _scanByColumn ? "colFirst" : "rowFirst");
 
     if (result.length === 0 || result[0].length === 0) {
-      throw new NotAvailableError(_lt("No results for the given arguments of TOROW."));
+      throw new NotAvailableError(_t("No results for the given arguments of TOROW."));
     }
     return result;
   },
@@ -696,8 +696,8 @@ export const TOROW: AddFunctionDescription = {
 // TRANSPOSE
 // -----------------------------------------------------------------------------
 export const TRANSPOSE: AddFunctionDescription = {
-  description: _lt("Transposes the rows and columns of a range."),
-  args: [arg("range (any, range<any>)", _lt("The range to be transposed."))],
+  description: _t("Transposes the rows and columns of a range."),
+  args: [arg("range (any, range<any>)", _t("The range to be transposed."))],
   returns: ["RANGE<ANY>"],
   computeFormat: (values: Arg) => {
     if (!values.format) {
@@ -719,10 +719,10 @@ export const TRANSPOSE: AddFunctionDescription = {
 // VSTACK
 // -----------------------------------------------------------------------------
 export const VSTACK: AddFunctionDescription = {
-  description: _lt("Appends ranges vertically and in sequence to return a larger array."),
+  description: _t("Appends ranges vertically and in sequence to return a larger array."),
   args: [
-    arg("range1 (any, range<any>)", _lt("The first range to be appended.")),
-    arg("range2 (any, range<any>, repeating)", _lt("Additional ranges to add to range1.")),
+    arg("range1 (any, range<any>)", _t("The first range to be appended.")),
+    arg("range2 (any, range<any>, repeating)", _t("Additional ranges to add to range1.")),
   ],
   returns: ["RANGE<ANY>"],
   //TODO computeFormat
@@ -755,18 +755,18 @@ export const VSTACK: AddFunctionDescription = {
 // WRAPCOLS
 // -----------------------------------------------------------------------------
 export const WRAPCOLS: AddFunctionDescription = {
-  description: _lt(
+  description: _t(
     "Wraps the provided row or column of cells by columns after a specified number of elements to form a new array."
   ),
   args: [
-    arg("range (any, range<any>)", _lt("The range to wrap.")),
+    arg("range (any, range<any>)", _t("The range to wrap.")),
     arg(
       "wrap_count (number)",
-      _lt("The maximum number of cells for each column, rounded down to the nearest whole number.")
+      _t("The maximum number of cells for each column, rounded down to the nearest whole number.")
     ),
     arg(
       "pad_with  (any, default=0)", // TODO : replace with #N/A
-      _lt("The value with which to fill the extra cells in the range.")
+      _t("The value with which to fill the extra cells in the range.")
     ),
   ],
   returns: ["RANGE<ANY>"],
@@ -780,7 +780,7 @@ export const WRAPCOLS: AddFunctionDescription = {
     const nOfRows = toInteger(wrapCount, this.locale);
     const _padWith = padWith === null ? 0 : padWith;
 
-    assertSingleColOrRow(_lt("Argument range must be a single row or column."), _range);
+    assertSingleColOrRow(_t("Argument range must be a single row or column."), _range);
 
     const values = _range.flat();
     const nOfCols = Math.ceil(values.length / nOfRows);
@@ -805,18 +805,18 @@ export const WRAPCOLS: AddFunctionDescription = {
 // WRAPROWS
 // -----------------------------------------------------------------------------
 export const WRAPROWS: AddFunctionDescription = {
-  description: _lt(
+  description: _t(
     "Wraps the provided row or column of cells by rows after a specified number of elements to form a new array."
   ),
   args: [
-    arg("range (any, range<any>)", _lt("The range to wrap.")),
+    arg("range (any, range<any>)", _t("The range to wrap.")),
     arg(
       "wrap_count (number)",
-      _lt("The maximum number of cells for each row, rounded down to the nearest whole number.")
+      _t("The maximum number of cells for each row, rounded down to the nearest whole number.")
     ),
     arg(
       "pad_with  (any, default=0)", // TODO : replace with #N/A
-      _lt("The value with which to fill the extra cells in the range.")
+      _t("The value with which to fill the extra cells in the range.")
     ),
   ],
   returns: ["RANGE<ANY>"],
@@ -830,7 +830,7 @@ export const WRAPROWS: AddFunctionDescription = {
     const nOfCols = toInteger(wrapCount, this.locale);
     const _padWith = padWith === null ? 0 : padWith;
 
-    assertSingleColOrRow(_lt("Argument range must be a single row or column."), _range);
+    assertSingleColOrRow(_t("Argument range must be a single row or column."), _range);
 
     const values = _range.flat();
     const nOfRows = Math.ceil(values.length / nOfCols);

--- a/src/functions/module_custom.ts
+++ b/src/functions/module_custom.ts
@@ -1,5 +1,5 @@
 import { createLargeNumberFormat } from "../helpers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { AddFunctionDescription, PrimitiveArg, PrimitiveArgValue } from "../types";
 import { arg } from "./arguments";
 import { toNumber } from "./helpers";
@@ -8,12 +8,12 @@ import { toNumber } from "./helpers";
 // FORMAT.LARGE.NUMBER
 // -----------------------------------------------------------------------------
 export const FORMAT_LARGE_NUMBER: AddFunctionDescription = {
-  description: _lt(`Apply a large number format`),
+  description: _t(`Apply a large number format`),
   args: [
-    arg("value (number)", _lt("The number.")),
+    arg("value (number)", _t("The number.")),
     arg(
       "unit (string, optional)",
-      _lt("The formatting unit. Use 'k', 'm', or 'b' to force the unit")
+      _t("The formatting unit. Use 'k', 'm', or 'b' to force the unit")
     ),
   ],
   returns: ["NUMBER"],
@@ -30,7 +30,7 @@ export const FORMAT_LARGE_NUMBER: AddFunctionDescription = {
         case "b":
           return createLargeNumberFormat(format, 1e9, "b", this.locale);
         default:
-          throw new Error(_lt("The formatting unit should be 'k', 'm' or 'b'."));
+          throw new Error(_t("The formatting unit should be 'k', 'm' or 'b'."));
       }
     }
     if (value < 1e5) {

--- a/src/functions/module_database.ts
+++ b/src/functions/module_database.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   ArgValue,
@@ -46,7 +46,7 @@ function getMatchingCells(
   // where the first column has the value 1.
 
   if (typeof field !== "number" && typeof field !== "string") {
-    throw new Error(_lt("The field must be a number or a string"));
+    throw new Error(_t("The field must be a number or a string"));
   }
 
   let index: number;
@@ -54,7 +54,7 @@ function getMatchingCells(
     index = Math.trunc(field) - 1;
     if (index < 0 || dimRowDB - 1 < index) {
       throw new Error(
-        _lt(
+        _t(
           "The field (%s) must be one of %s or must be a number between 1 and %s inclusive.",
           field.toString(),
           dimRowDB.toString()
@@ -66,7 +66,7 @@ function getMatchingCells(
     index = indexColNameDB.get(colName) ?? -1;
     if (index === -1) {
       throw new Error(
-        _lt(
+        _t(
           "The field (%s) must be one of %s.",
           toString(field),
           [...indexColNameDB.keys()].toString()
@@ -83,7 +83,7 @@ function getMatchingCells(
 
   if (dimColCriteria < 2) {
     throw new Error(
-      _lt(
+      _t(
         "The criteria range contains %s row, it must be at least 2 rows.",
         dimColCriteria.toString()
       )
@@ -145,17 +145,17 @@ function getMatchingCells(
 const databaseArgs = [
   arg(
     "database (range)",
-    _lt(
+    _t(
       "The array or range containing the data to consider, structured in such a way that the first row contains the labels for each column's values."
     )
   ),
   arg(
     "field (any)",
-    _lt("Indicates which column in database contains the values to be extracted and operated on.")
+    _t("Indicates which column in database contains the values to be extracted and operated on.")
   ),
   arg(
     "criteria (range)",
-    _lt(
+    _t(
       "An array or range containing zero or more criteria to filter the database values by before operating."
     )
   ),
@@ -165,7 +165,7 @@ const databaseArgs = [
 // DAVERAGE
 // -----------------------------------------------------------------------------
 export const DAVERAGE: AddFunctionDescription = {
-  description: _lt("Average of a set of values from a table-like range."),
+  description: _t("Average of a set of values from a table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -183,7 +183,7 @@ export const DAVERAGE: AddFunctionDescription = {
 // DCOUNT
 // -----------------------------------------------------------------------------
 export const DCOUNT: AddFunctionDescription = {
-  description: _lt("Counts values from a table-like range."),
+  description: _t("Counts values from a table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -201,7 +201,7 @@ export const DCOUNT: AddFunctionDescription = {
 // DCOUNTA
 // -----------------------------------------------------------------------------
 export const DCOUNTA: AddFunctionDescription = {
-  description: _lt("Counts values and text from a table-like range."),
+  description: _t("Counts values and text from a table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -219,7 +219,7 @@ export const DCOUNTA: AddFunctionDescription = {
 // DGET
 // -----------------------------------------------------------------------------
 export const DGET: AddFunctionDescription = {
-  description: _lt("Single value from a table-like range."),
+  description: _t("Single value from a table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -228,7 +228,7 @@ export const DGET: AddFunctionDescription = {
     criteria: MatrixArgValue
   ): FunctionReturnValue {
     const cells = getMatchingCells(database, field, criteria, this.locale);
-    assert(() => cells.length === 1, _lt("More than one match found in DGET evaluation."));
+    assert(() => cells.length === 1, _t("More than one match found in DGET evaluation."));
     return cells[0];
   },
   isExported: true,
@@ -238,7 +238,7 @@ export const DGET: AddFunctionDescription = {
 // DMAX
 // -----------------------------------------------------------------------------
 export const DMAX: AddFunctionDescription = {
-  description: _lt("Maximum of values from a table-like range."),
+  description: _t("Maximum of values from a table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -256,7 +256,7 @@ export const DMAX: AddFunctionDescription = {
 // DMIN
 // -----------------------------------------------------------------------------
 export const DMIN: AddFunctionDescription = {
-  description: _lt("Minimum of values from a table-like range."),
+  description: _t("Minimum of values from a table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -274,7 +274,7 @@ export const DMIN: AddFunctionDescription = {
 // DPRODUCT
 // -----------------------------------------------------------------------------
 export const DPRODUCT: AddFunctionDescription = {
-  description: _lt("Product of values from a table-like range."),
+  description: _t("Product of values from a table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -292,7 +292,7 @@ export const DPRODUCT: AddFunctionDescription = {
 // DSTDEV
 // -----------------------------------------------------------------------------
 export const DSTDEV: AddFunctionDescription = {
-  description: _lt("Standard deviation of population sample from table."),
+  description: _t("Standard deviation of population sample from table."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -310,7 +310,7 @@ export const DSTDEV: AddFunctionDescription = {
 // DSTDEVP
 // -----------------------------------------------------------------------------
 export const DSTDEVP: AddFunctionDescription = {
-  description: _lt("Standard deviation of entire population from table."),
+  description: _t("Standard deviation of entire population from table."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -328,7 +328,7 @@ export const DSTDEVP: AddFunctionDescription = {
 // DSUM
 // -----------------------------------------------------------------------------
 export const DSUM: AddFunctionDescription = {
-  description: _lt("Sum of values from a table-like range."),
+  description: _t("Sum of values from a table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -346,7 +346,7 @@ export const DSUM: AddFunctionDescription = {
 // DVAR
 // -----------------------------------------------------------------------------
 export const DVAR: AddFunctionDescription = {
-  description: _lt("Variance of population sample from table-like range."),
+  description: _t("Variance of population sample from table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (
@@ -364,7 +364,7 @@ export const DVAR: AddFunctionDescription = {
 // DVARP
 // -----------------------------------------------------------------------------
 export const DVARP: AddFunctionDescription = {
-  description: _lt("Variance of a population from a table-like range."),
+  description: _t("Variance of a population from a table-like range."),
   args: databaseArgs,
   returns: ["NUMBER"],
   compute: function (

--- a/src/functions/module_date.ts
+++ b/src/functions/module_date.ts
@@ -12,7 +12,7 @@ import {
   numberToJsDate,
   parseDateTime,
 } from "../helpers/dates";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { AddFunctionDescription, ArgValue, PrimitiveArgValue } from "../types";
 import { arg } from "./arguments";
 import {
@@ -40,11 +40,11 @@ enum TIME_UNIT {
 // DATE
 // -----------------------------------------------------------------------------
 export const DATE: AddFunctionDescription = {
-  description: _lt("Converts year/month/day into a date."),
+  description: _t("Converts year/month/day into a date."),
   args: [
-    arg("year (number)", _lt("The year component of the date.")),
-    arg("month (number)", _lt("The month component of the date.")),
-    arg("day (number)", _lt("The day component of the date.")),
+    arg("year (number)", _t("The year component of the date.")),
+    arg("month (number)", _t("The month component of the date.")),
+    arg("day (number)", _t("The day component of the date.")),
   ],
   returns: ["DATE"],
   computeFormat: function () {
@@ -62,7 +62,7 @@ export const DATE: AddFunctionDescription = {
     // For years less than 0 or greater than 10000, return #ERROR.
     assert(
       () => 0 <= _year && _year <= 9999,
-      _lt("The year (%s) must be between 0 and 9999 inclusive.", _year.toString())
+      _t("The year (%s) must be between 0 and 9999 inclusive.", _year.toString())
     );
 
     // Between 0 and 1899, we add that value to 1900 to calculate the year
@@ -75,7 +75,7 @@ export const DATE: AddFunctionDescription = {
 
     assert(
       () => result >= 0,
-      _lt(`The function [[FUNCTION_NAME]] result must be greater than or equal 01/01/1900.`)
+      _t(`The function [[FUNCTION_NAME]] result must be greater than or equal 01/01/1900.`)
     );
 
     return result;
@@ -87,23 +87,23 @@ export const DATE: AddFunctionDescription = {
 // DATEDIF
 // -----------------------------------------------------------------------------
 export const DATEDIF: AddFunctionDescription = {
-  description: _lt("Calculates the number of days, months, or years between two dates."),
+  description: _t("Calculates the number of days, months, or years between two dates."),
   args: [
     arg(
       "start_date (date)",
-      _lt(
+      _t(
         "The start date to consider in the calculation. Must be a reference to a cell containing a DATE, a function returning a DATE type, or a number."
       )
     ),
     arg(
       "end_date (date)",
-      _lt(
+      _t(
         "The end date to consider in the calculation. Must be a reference to a cell containing a DATE, a function returning a DATE type, or a number."
       )
     ),
     arg(
       "unit (string)",
-      _lt(
+      _t(
         `A text abbreviation for unit of time. Accepted values are "Y" (the number of whole years between start_date and end_date), "M" (the number of whole months between start_date and end_date), "D" (the number of days between start_date and end_date), "MD" (the number of days between start_date and end_date after subtracting whole months), "YM" (the number of whole months between start_date and end_date after subtracting whole years), "YD" (the number of days between start_date and end_date, assuming start_date and end_date were no more than one year apart).`
       )
     ),
@@ -125,7 +125,7 @@ export const DATEDIF: AddFunctionDescription = {
     const jsEndDate = numberToJsDate(_endDate);
     assert(
       () => _endDate >= _startDate,
-      _lt(
+      _t(
         "start_date (%s) should be on or before end_date (%s).",
         jsStartDate.toLocaleDateString(),
         jsEndDate.toLocaleDateString()
@@ -184,8 +184,8 @@ export const DATEDIF: AddFunctionDescription = {
 // DATEVALUE
 // -----------------------------------------------------------------------------
 export const DATEVALUE: AddFunctionDescription = {
-  description: _lt("Converts a date string to a date value."),
-  args: [arg("date_string (string)", _lt("The string representing the date."))],
+  description: _t("Converts a date string to a date value."),
+  args: [arg("date_string (string)", _t("The string representing the date."))],
   returns: ["NUMBER"],
   compute: function (dateString: PrimitiveArgValue): number {
     const _dateString = toString(dateString);
@@ -193,7 +193,7 @@ export const DATEVALUE: AddFunctionDescription = {
 
     assert(
       () => internalDate !== null,
-      _lt("The date_string (%s) cannot be parsed to date/time.", _dateString.toString())
+      _t("The date_string (%s) cannot be parsed to date/time.", _dateString.toString())
     );
 
     return Math.trunc(internalDate!.value);
@@ -205,8 +205,8 @@ export const DATEVALUE: AddFunctionDescription = {
 // DAY
 // -----------------------------------------------------------------------------
 export const DAY: AddFunctionDescription = {
-  description: _lt("Day of the month that a specific date falls on."),
-  args: [arg("date (string)", _lt("The date from which to extract the day."))],
+  description: _t("Day of the month that a specific date falls on."),
+  args: [arg("date (string)", _t("The date from which to extract the day."))],
   returns: ["NUMBER"],
   compute: function (date: PrimitiveArgValue): number {
     return toJsDate(date, this.locale).getDate();
@@ -218,10 +218,10 @@ export const DAY: AddFunctionDescription = {
 // DAYS
 // -----------------------------------------------------------------------------
 export const DAYS: AddFunctionDescription = {
-  description: _lt("Number of days between two dates."),
+  description: _t("Number of days between two dates."),
   args: [
-    arg("end_date (date)", _lt("The end of the date range.")),
-    arg("start_date (date)", _lt("The start of the date range.")),
+    arg("end_date (date)", _t("The end of the date range.")),
+    arg("start_date (date)", _t("The start of the date range.")),
   ],
   returns: ["NUMBER"],
   compute: function (endDate: PrimitiveArgValue, startDate: PrimitiveArgValue): number {
@@ -238,13 +238,13 @@ export const DAYS: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 const DEFAULT_DAY_COUNT_METHOD = 0;
 export const DAYS360: AddFunctionDescription = {
-  description: _lt("Number of days between two dates on a 360-day year (months of 30 days)."),
+  description: _t("Number of days between two dates on a 360-day year (months of 30 days)."),
   args: [
-    arg("start_date (date)", _lt("The start date to consider in the calculation.")),
-    arg("end_date (date)", _lt("The end date to consider in the calculation.")),
+    arg("start_date (date)", _t("The start date to consider in the calculation.")),
+    arg("end_date (date)", _t("The end date to consider in the calculation.")),
     arg(
       `method (number, default=${DEFAULT_DAY_COUNT_METHOD})`,
-      _lt("An indicator of what day count method to use. (0) US NASD method (1) European method")
+      _t("An indicator of what day count method to use. (0) US NASD method (1) European method")
     ),
   ],
   returns: ["NUMBER"],
@@ -267,12 +267,12 @@ export const DAYS360: AddFunctionDescription = {
 // EDATE
 // -----------------------------------------------------------------------------
 export const EDATE: AddFunctionDescription = {
-  description: _lt("Date a number of months before/after another date."),
+  description: _t("Date a number of months before/after another date."),
   args: [
-    arg("start_date (date)", _lt("The date from which to calculate the result.")),
+    arg("start_date (date)", _t("The date from which to calculate the result.")),
     arg(
       "months (number)",
-      _lt("The number of months before (negative) or after (positive) 'start_date' to calculate.")
+      _t("The number of months before (negative) or after (positive) 'start_date' to calculate.")
     ),
   ],
   returns: ["DATE"],
@@ -293,12 +293,12 @@ export const EDATE: AddFunctionDescription = {
 // EOMONTH
 // -----------------------------------------------------------------------------
 export const EOMONTH: AddFunctionDescription = {
-  description: _lt("Last day of a month before or after a date."),
+  description: _t("Last day of a month before or after a date."),
   args: [
-    arg("start_date (date)", _lt("The date from which to calculate the result.")),
+    arg("start_date (date)", _t("The date from which to calculate the result.")),
     arg(
       "months (number)",
-      _lt("The number of months before (negative) or after (positive) 'start_date' to consider.")
+      _t("The number of months before (negative) or after (positive) 'start_date' to consider.")
     ),
   ],
   returns: ["DATE"],
@@ -321,8 +321,8 @@ export const EOMONTH: AddFunctionDescription = {
 // HOUR
 // -----------------------------------------------------------------------------
 export const HOUR: AddFunctionDescription = {
-  description: _lt("Hour component of a specific time."),
-  args: [arg("time (date)", _lt("The time from which to calculate the hour component."))],
+  description: _t("Hour component of a specific time."),
+  args: [arg("time (date)", _t("The time from which to calculate the hour component."))],
   returns: ["NUMBER"],
   compute: function (date: PrimitiveArgValue): number {
     return toJsDate(date, this.locale).getHours();
@@ -334,11 +334,11 @@ export const HOUR: AddFunctionDescription = {
 // ISOWEEKNUM
 // -----------------------------------------------------------------------------
 export const ISOWEEKNUM: AddFunctionDescription = {
-  description: _lt("ISO week number of the year."),
+  description: _t("ISO week number of the year."),
   args: [
     arg(
       "date (date)",
-      _lt(
+      _t(
         "The date for which to determine the ISO week number. Must be a reference to a cell containing a date, a function returning a date type, or a number."
       )
     ),
@@ -423,8 +423,8 @@ export const ISOWEEKNUM: AddFunctionDescription = {
 // MINUTE
 // -----------------------------------------------------------------------------
 export const MINUTE: AddFunctionDescription = {
-  description: _lt("Minute component of a specific time."),
-  args: [arg("time (date)", _lt("The time from which to calculate the minute component."))],
+  description: _t("Minute component of a specific time."),
+  args: [arg("time (date)", _t("The time from which to calculate the minute component."))],
   returns: ["NUMBER"],
   compute: function (date: PrimitiveArgValue): number {
     return toJsDate(date, this.locale).getMinutes();
@@ -436,8 +436,8 @@ export const MINUTE: AddFunctionDescription = {
 // MONTH
 // -----------------------------------------------------------------------------
 export const MONTH: AddFunctionDescription = {
-  description: _lt("Month of the year a specific date falls in"),
-  args: [arg("date (date)", _lt("The date from which to extract the month."))],
+  description: _t("Month of the year a specific date falls in"),
+  args: [arg("date (date)", _t("The date from which to extract the month."))],
   returns: ["NUMBER"],
   compute: function (date: PrimitiveArgValue): number {
     return toJsDate(date, this.locale).getMonth() + 1;
@@ -449,19 +449,19 @@ export const MONTH: AddFunctionDescription = {
 // NETWORKDAYS
 // -----------------------------------------------------------------------------
 export const NETWORKDAYS: AddFunctionDescription = {
-  description: _lt("Net working days between two provided days."),
+  description: _t("Net working days between two provided days."),
   args: [
     arg(
       "start_date (date)",
-      _lt("The start date of the period from which to calculate the number of net working days.")
+      _t("The start date of the period from which to calculate the number of net working days.")
     ),
     arg(
       "end_date (date)",
-      _lt("The end date of the period from which to calculate the number of net working days.")
+      _t("The end date of the period from which to calculate the number of net working days.")
     ),
     arg(
       "holidays (date, range<date>, optional)",
-      _lt("A range or array constant containing the date serial numbers to consider holidays.")
+      _t("A range or array constant containing the date serial numbers to consider holidays.")
     ),
   ],
   returns: ["NUMBER"],
@@ -513,7 +513,7 @@ function weekendToDayNumber(weekend: PrimitiveArgValue): number[] {
         }
       }
       return true;
-    }, _lt('When weekend is a string (%s) it must be composed of "0" or "1".', weekend));
+    }, _t('When weekend is a string (%s) it must be composed of "0" or "1".', weekend));
 
     let result: number[] = [];
     for (let i = 0; i < 7; i++) {
@@ -529,7 +529,7 @@ function weekendToDayNumber(weekend: PrimitiveArgValue): number[] {
   if (typeof weekend === "number") {
     assert(
       () => (1 <= weekend && weekend <= 7) || (11 <= weekend && weekend <= 17),
-      _lt(
+      _t(
         "The weekend (%s) must be a string or a number in the range 1-7 or 11-17.",
         weekend.toString()
       )
@@ -552,27 +552,27 @@ function weekendToDayNumber(weekend: PrimitiveArgValue): number[] {
     return [weekend - 11];
   }
 
-  throw Error(_lt("The weekend must be a number or a string."));
+  throw Error(_t("The weekend must be a number or a string."));
 }
 
 export const NETWORKDAYS_INTL: AddFunctionDescription = {
-  description: _lt("Net working days between two dates (specifying weekends)."),
+  description: _t("Net working days between two dates (specifying weekends)."),
   args: [
     arg(
       "start_date (date)",
-      _lt("The start date of the period from which to calculate the number of net working days.")
+      _t("The start date of the period from which to calculate the number of net working days.")
     ),
     arg(
       "end_date (date)",
-      _lt("The end date of the period from which to calculate the number of net working days.")
+      _t("The end date of the period from which to calculate the number of net working days.")
     ),
     arg(
       `weekend (any, default=${DEFAULT_WEEKEND})`,
-      _lt("A number or string representing which days of the week are considered weekends.")
+      _t("A number or string representing which days of the week are considered weekends.")
     ),
     arg(
       "holidays (date, range<date>, optional)",
-      _lt("A range or array constant containing the dates to consider as holidays.")
+      _t("A range or array constant containing the dates to consider as holidays.")
     ),
   ],
   returns: ["NUMBER"],
@@ -619,7 +619,7 @@ export const NETWORKDAYS_INTL: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const NOW: AddFunctionDescription = {
-  description: _lt("Current date and time as a date value."),
+  description: _t("Current date and time as a date value."),
   args: [],
   returns: ["DATE"],
   computeFormat: function () {
@@ -639,8 +639,8 @@ export const NOW: AddFunctionDescription = {
 // SECOND
 // -----------------------------------------------------------------------------
 export const SECOND: AddFunctionDescription = {
-  description: _lt("Minute component of a specific time."),
-  args: [arg("time (date)", _lt("The time from which to calculate the second component."))],
+  description: _t("Minute component of a specific time."),
+  args: [arg("time (date)", _t("The time from which to calculate the second component."))],
   returns: ["NUMBER"],
   compute: function (date: PrimitiveArgValue): number {
     return toJsDate(date, this.locale).getSeconds();
@@ -652,11 +652,11 @@ export const SECOND: AddFunctionDescription = {
 // TIME
 // -----------------------------------------------------------------------------
 export const TIME: AddFunctionDescription = {
-  description: _lt("Converts hour/minute/second into a time."),
+  description: _t("Converts hour/minute/second into a time."),
   args: [
-    arg("hour (number)", _lt("The hour component of the time.")),
-    arg("minute (number)", _lt("The minute component of the time.")),
-    arg("second (number)", _lt("The second component of the time.")),
+    arg("hour (number)", _t("The hour component of the time.")),
+    arg("minute (number)", _t("The minute component of the time.")),
+    arg("second (number)", _t("The second component of the time.")),
   ],
   returns: ["DATE"],
   computeFormat: function () {
@@ -679,7 +679,7 @@ export const TIME: AddFunctionDescription = {
 
     _hour %= 24;
 
-    assert(() => _hour >= 0, _lt(`The function [[FUNCTION_NAME]] result cannot be negative`));
+    assert(() => _hour >= 0, _t(`The function [[FUNCTION_NAME]] result cannot be negative`));
 
     return _hour / 24 + _minute / (24 * 60) + _second / (24 * 60 * 60);
   },
@@ -690,8 +690,8 @@ export const TIME: AddFunctionDescription = {
 // TIMEVALUE
 // -----------------------------------------------------------------------------
 export const TIMEVALUE: AddFunctionDescription = {
-  description: _lt("Converts a time string into its serial number representation."),
-  args: [arg("time_string (string)", _lt("The string that holds the time representation."))],
+  description: _t("Converts a time string into its serial number representation."),
+  args: [arg("time_string (string)", _t("The string that holds the time representation."))],
   returns: ["NUMBER"],
   compute: function (timeString: PrimitiveArgValue): number {
     const _timeString = toString(timeString);
@@ -699,7 +699,7 @@ export const TIMEVALUE: AddFunctionDescription = {
 
     assert(
       () => internalDate !== null,
-      _lt("The time_string (%s) cannot be parsed to date/time.", _timeString)
+      _t("The time_string (%s) cannot be parsed to date/time.", _timeString)
     );
     const result = internalDate!.value - Math.trunc(internalDate!.value);
 
@@ -712,7 +712,7 @@ export const TIMEVALUE: AddFunctionDescription = {
 // TODAY
 // -----------------------------------------------------------------------------
 export const TODAY: AddFunctionDescription = {
-  description: _lt("Current date as a date value."),
+  description: _t("Current date as a date value."),
   args: [],
   returns: ["DATE"],
   computeFormat: function () {
@@ -730,17 +730,17 @@ export const TODAY: AddFunctionDescription = {
 // WEEKDAY
 // -----------------------------------------------------------------------------
 export const WEEKDAY: AddFunctionDescription = {
-  description: _lt("Day of the week of the date provided (as number)."),
+  description: _t("Day of the week of the date provided (as number)."),
   args: [
     arg(
       "date (date)",
-      _lt(
+      _t(
         "The date for which to determine the day of the week. Must be a reference to a cell containing a date, a function returning a date type, or a number."
       )
     ),
     arg(
       `type (number, default=${DEFAULT_TYPE})`,
-      _lt(
+      _t(
         "A number indicating which numbering system to use to represent weekdays. By default, counts starting with Sunday = 1."
       )
     ),
@@ -752,7 +752,7 @@ export const WEEKDAY: AddFunctionDescription = {
     const m = _date.getDay();
     assert(
       () => [1, 2, 3].includes(_type),
-      _lt("The type (%s) must be 1, 2 or 3.", _type.toString())
+      _t("The type (%s) must be 1, 2 or 3.", _type.toString())
     );
 
     if (_type === 1) return m + 1;
@@ -766,17 +766,17 @@ export const WEEKDAY: AddFunctionDescription = {
 // WEEKNUM
 // -----------------------------------------------------------------------------
 export const WEEKNUM: AddFunctionDescription = {
-  description: _lt("Week number of the year."),
+  description: _t("Week number of the year."),
   args: [
     arg(
       "date (date)",
-      _lt(
+      _t(
         "The date for which to determine the week number. Must be a reference to a cell containing a date, a function returning a date type, or a number."
       )
     ),
     arg(
       `type (number, default=${DEFAULT_TYPE})`,
-      _lt("A number representing the day that a week starts on. Sunday = 1.")
+      _t("A number representing the day that a week starts on. Sunday = 1.")
     ),
   ],
   returns: ["NUMBER"],
@@ -785,7 +785,7 @@ export const WEEKNUM: AddFunctionDescription = {
     const _type = Math.round(toNumber(type, this.locale));
     assert(
       () => _type === 1 || _type === 2 || (11 <= _type && _type <= 17) || _type === 21,
-      _lt("The type (%s) is out of range.", _type.toString())
+      _t("The type (%s) is out of range.", _type.toString())
     );
 
     if (_type === 21) {
@@ -824,16 +824,16 @@ export const WEEKNUM: AddFunctionDescription = {
 // WORKDAY
 // -----------------------------------------------------------------------------
 export const WORKDAY: AddFunctionDescription = {
-  description: _lt("Date after a number of workdays."),
+  description: _t("Date after a number of workdays."),
   args: [
-    arg("start_date (date)", _lt("The date from which to begin counting.")),
+    arg("start_date (date)", _t("The date from which to begin counting.")),
     arg(
       "num_days (number)",
-      _lt("The number of working days to advance from start_date. If negative, counts backwards.")
+      _t("The number of working days to advance from start_date. If negative, counts backwards.")
     ),
     arg(
       "holidays (date, range<date>, optional)",
-      _lt("A range or array constant containing the dates to consider holidays.")
+      _t("A range or array constant containing the dates to consider holidays.")
     ),
   ],
   returns: ["NUMBER"],
@@ -854,20 +854,20 @@ export const WORKDAY: AddFunctionDescription = {
 // WORKDAY.INTL
 // -----------------------------------------------------------------------------
 export const WORKDAY_INTL: AddFunctionDescription = {
-  description: _lt("Date after a number of workdays (specifying weekends)."),
+  description: _t("Date after a number of workdays (specifying weekends)."),
   args: [
-    arg("start_date (date)", _lt("The date from which to begin counting.")),
+    arg("start_date (date)", _t("The date from which to begin counting.")),
     arg(
       "num_days (number)",
-      _lt("The number of working days to advance from start_date. If negative, counts backwards.")
+      _t("The number of working days to advance from start_date. If negative, counts backwards.")
     ),
     arg(
       `weekend (any, default=${DEFAULT_WEEKEND})`,
-      _lt("A number or string representing which days of the week are considered weekends.")
+      _t("A number or string representing which days of the week are considered weekends.")
     ),
     arg(
       "holidays (date, range<date>, optional)",
-      _lt("A range or array constant containing the dates to consider holidays.")
+      _t("A range or array constant containing the dates to consider holidays.")
     ),
   ],
   returns: ["DATE"],
@@ -885,7 +885,7 @@ export const WORKDAY_INTL: AddFunctionDescription = {
     if (typeof weekend === "string") {
       assert(
         () => weekend !== "1111111",
-        _lt("The weekend (%s) must be different from '1111111'.", weekend)
+        _t("The weekend (%s) must be different from '1111111'.", weekend)
       );
     }
 
@@ -924,8 +924,8 @@ export const WORKDAY_INTL: AddFunctionDescription = {
 // YEAR
 // -----------------------------------------------------------------------------
 export const YEAR: AddFunctionDescription = {
-  description: _lt("Year specified by a given date."),
-  args: [arg("date (date)", _lt("The date from which to extract the year."))],
+  description: _t("Year specified by a given date."),
+  args: [arg("date (date)", _t("The date from which to extract the year."))],
   returns: ["NUMBER"],
   compute: function (date: PrimitiveArgValue): number {
     return toJsDate(date, this.locale).getFullYear();
@@ -938,23 +938,23 @@ export const YEAR: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 const DEFAULT_DAY_COUNT_CONVENTION = 0;
 export const YEARFRAC: AddFunctionDescription = {
-  description: _lt("Exact number of years between two dates."),
+  description: _t("Exact number of years between two dates."),
   args: [
     arg(
       "start_date (date)",
-      _lt(
+      _t(
         "The start date to consider in the calculation. Must be a reference to a cell containing a date, a function returning a date type, or a number."
       )
     ),
     arg(
       "end_date (date)",
-      _lt(
+      _t(
         "The end date to consider in the calculation. Must be a reference to a cell containing a date, a function returning a date type, or a number."
       )
     ),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION})`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -969,15 +969,15 @@ export const YEARFRAC: AddFunctionDescription = {
 
     assert(
       () => _startDate >= 0,
-      _lt("The start_date (%s) must be positive or null.", _startDate.toString())
+      _t("The start_date (%s) must be positive or null.", _startDate.toString())
     );
     assert(
       () => _endDate >= 0,
-      _lt("The end_date (%s) must be positive or null.", _endDate.toString())
+      _t("The end_date (%s) must be positive or null.", _endDate.toString())
     );
     assert(
       () => 0 <= _dayCountConvention && _dayCountConvention <= 4,
-      _lt(
+      _t(
         "The day_count_convention (%s) must be between 0 and 4 inclusive.",
         _dayCountConvention.toString()
       )
@@ -991,8 +991,8 @@ export const YEARFRAC: AddFunctionDescription = {
 // MONTH.START
 // -----------------------------------------------------------------------------
 export const MONTH_START: AddFunctionDescription = {
-  description: _lt("First day of the month preceding a date."),
-  args: [arg("date (date)", _lt("The date from which to calculate the result."))],
+  description: _t("First day of the month preceding a date."),
+  args: [arg("date (date)", _t("The date from which to calculate the result."))],
   returns: ["DATE"],
   computeFormat: function () {
     return this.locale.dateFormat;
@@ -1010,8 +1010,8 @@ export const MONTH_START: AddFunctionDescription = {
 // MONTH.END
 // -----------------------------------------------------------------------------
 export const MONTH_END: AddFunctionDescription = {
-  description: _lt("Last day of the month following a date."),
-  args: [arg("date (date)", _lt("The date from which to calculate the result."))],
+  description: _t("Last day of the month following a date."),
+  args: [arg("date (date)", _t("The date from which to calculate the result."))],
   returns: ["DATE"],
   computeFormat: function () {
     return this.locale.dateFormat;
@@ -1025,8 +1025,8 @@ export const MONTH_END: AddFunctionDescription = {
 // QUARTER
 // -----------------------------------------------------------------------------
 export const QUARTER: AddFunctionDescription = {
-  description: _lt("Quarter of the year a specific date falls in"),
-  args: [arg("date (date)", _lt("The date from which to extract the quarter."))],
+  description: _t("Quarter of the year a specific date falls in"),
+  args: [arg("date (date)", _t("The date from which to extract the quarter."))],
   returns: ["NUMBER"],
   compute: function (date: PrimitiveArgValue): number {
     return Math.ceil((toJsDate(date, this.locale).getMonth() + 1) / 3);
@@ -1037,8 +1037,8 @@ export const QUARTER: AddFunctionDescription = {
 // QUARTER.START
 // -----------------------------------------------------------------------------
 export const QUARTER_START: AddFunctionDescription = {
-  description: _lt("First day of the quarter of the year a specific date falls in."),
-  args: [arg("date (date)", _lt("The date from which to calculate the start of quarter."))],
+  description: _t("First day of the quarter of the year a specific date falls in."),
+  args: [arg("date (date)", _t("The date from which to calculate the start of quarter."))],
   returns: ["DATE"],
   computeFormat: function () {
     return this.locale.dateFormat;
@@ -1055,8 +1055,8 @@ export const QUARTER_START: AddFunctionDescription = {
 // QUARTER.END
 // -----------------------------------------------------------------------------
 export const QUARTER_END: AddFunctionDescription = {
-  description: _lt("Last day of the quarter of the year a specific date falls in."),
-  args: [arg("date (date)", _lt("The date from which to calculate the end of quarter."))],
+  description: _t("Last day of the quarter of the year a specific date falls in."),
+  args: [arg("date (date)", _t("The date from which to calculate the end of quarter."))],
   returns: ["DATE"],
   computeFormat: function () {
     return this.locale.dateFormat;
@@ -1073,8 +1073,8 @@ export const QUARTER_END: AddFunctionDescription = {
 // YEAR.START
 // -----------------------------------------------------------------------------
 export const YEAR_START: AddFunctionDescription = {
-  description: _lt("First day of the year a specific date falls in."),
-  args: [arg("date (date)", _lt("The date from which to calculate the start of the year."))],
+  description: _t("First day of the year a specific date falls in."),
+  args: [arg("date (date)", _t("The date from which to calculate the start of the year."))],
   returns: ["DATE"],
   computeFormat: function () {
     return this.locale.dateFormat;
@@ -1090,8 +1090,8 @@ export const YEAR_START: AddFunctionDescription = {
 // YEAR.END
 // -----------------------------------------------------------------------------
 export const YEAR_END: AddFunctionDescription = {
-  description: _lt("Last day of the year a specific date falls in."),
-  args: [arg("date (date)", _lt("The date from which to calculate the end of the year."))],
+  description: _t("Last day of the year a specific date falls in."),
+  args: [arg("date (date)", _t("The date from which to calculate the end of the year."))],
   returns: ["DATE"],
   computeFormat: function () {
     return this.locale.dateFormat;

--- a/src/functions/module_engineering.ts
+++ b/src/functions/module_engineering.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { AddFunctionDescription, PrimitiveArgValue } from "../types";
 import { arg } from "./arguments";
 import { toNumber } from "./helpers";
@@ -9,10 +9,10 @@ const DEFAULT_DELTA_ARG = 0;
 // DELTA
 // -----------------------------------------------------------------------------
 export const DELTA: AddFunctionDescription = {
-  description: _lt("Compare two numeric values, returning 1 if they're equal."),
+  description: _t("Compare two numeric values, returning 1 if they're equal."),
   args: [
-    arg(" (number)", _lt("The first number to compare.")),
-    arg(` (number, default=${DEFAULT_DELTA_ARG})`, _lt("The second number to compare.")),
+    arg(" (number)", _t("The first number to compare.")),
+    arg(` (number, default=${DEFAULT_DELTA_ARG})`, _t("The second number to compare.")),
   ],
   returns: ["NUMBER"],
   compute: function (

--- a/src/functions/module_filter.ts
+++ b/src/functions/module_filter.ts
@@ -1,5 +1,5 @@
 import { transpose2dArray } from "../helpers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   ArgValue,
@@ -18,21 +18,21 @@ import { assertSameDimensions, assertSingleColOrRow } from "./helper_assert";
 // FILTER
 // -----------------------------------------------------------------------------
 export const FILTER: AddFunctionDescription = {
-  description: _lt(
+  description: _t(
     "Returns a filtered version of the source range, returning only rows or columns that meet the specified conditions."
   ),
   // TODO modify args description when vectorization on formulas is available
   args: [
-    arg("range (any, range<any>)", _lt("The data to be filtered.")),
+    arg("range (any, range<any>)", _t("The data to be filtered.")),
     arg(
       "condition1 (boolean, range<boolean>)",
-      _lt(
+      _t(
         "A column or row containing true or false values corresponding to the first column or row of range."
       )
     ),
     arg(
       "condition2 (boolean, range<boolean>, repeating)",
-      _lt("Additional column or row containing true or false values.")
+      _t("Additional column or row containing true or false values.")
     ),
   ],
   returns: ["RANGE<ANY>"],
@@ -41,10 +41,10 @@ export const FILTER: AddFunctionDescription = {
     let _range = toMatrixArgValue(range);
     const _conditionsMatrices = conditions.map((cond) => toMatrixArgValue(cond));
     _conditionsMatrices.map((c) =>
-      assertSingleColOrRow(_lt("The arguments condition must be a single column or row."), c)
+      assertSingleColOrRow(_t("The arguments condition must be a single column or row."), c)
     );
     assertSameDimensions(
-      _lt("The arguments conditions must have the same dimensions."),
+      _t("The arguments conditions must have the same dimensions."),
       ..._conditionsMatrices
     );
     const _conditions = _conditionsMatrices.map((c) => c.flat());
@@ -54,7 +54,7 @@ export const FILTER: AddFunctionDescription = {
 
     assert(
       () => _conditions.every((cond) => cond.length === _range.length),
-      _lt(`FILTER has mismatched sizes on the range and conditions.`)
+      _t(`FILTER has mismatched sizes on the range and conditions.`)
     );
 
     const results: MatrixArgValue = [];
@@ -67,7 +67,7 @@ export const FILTER: AddFunctionDescription = {
     }
 
     if (!results.length) {
-      throw new NotAvailableError(_lt("No match found in FILTER evaluation"));
+      throw new NotAvailableError(_t("No match found in FILTER evaluation"));
     }
 
     return toCellValueMatrix(mode === "row" ? transpose2dArray(results) : results);
@@ -79,16 +79,16 @@ export const FILTER: AddFunctionDescription = {
 // UNIQUE
 // -----------------------------------------------------------------------------
 export const UNIQUE: AddFunctionDescription = {
-  description: _lt("Unique rows in the provided source range."),
+  description: _t("Unique rows in the provided source range."),
   args: [
-    arg("range (any, range<any>)", _lt("The data to filter by unique entries.")),
+    arg("range (any, range<any>)", _t("The data to filter by unique entries.")),
     arg(
       "by_column (boolean, default=FALSE)",
-      _lt("Whether to filter the data by columns or by rows.")
+      _t("Whether to filter the data by columns or by rows.")
     ),
     arg(
       "exactly_once (boolean, default=FALSE)",
-      _lt("Whether to return only entries with no duplicates.")
+      _t("Whether to return only entries with no duplicates.")
     ),
   ],
   returns: ["RANGE<NUMBER>"],
@@ -121,7 +121,7 @@ export const UNIQUE: AddFunctionDescription = {
       ? [...map.values()].filter((v) => v.count === 1).map((v) => v.val)
       : [...map.values()].map((v) => v.val);
 
-    if (!results.length) throw new Error(_lt("No unique values found"));
+    if (!results.length) throw new Error(_t("No unique values found"));
 
     return toCellValueMatrix(_byColumn ? results : transpose2dArray(results));
   },

--- a/src/functions/module_financial.ts
+++ b/src/functions/module_financial.ts
@@ -7,7 +7,7 @@ import {
   range,
   transpose2dArray,
 } from "../helpers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   ArgValue,
@@ -65,21 +65,18 @@ const DEFAULT_FUTURE_VALUE = 0;
 const COUPON_FUNCTION_ARGS = [
   arg(
     "settlement (date)",
-    _lt(
+    _t(
       "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
     )
   ),
   arg(
     "maturity (date)",
-    _lt("The maturity or end date of the security, when it can be redeemed at face, or par value.")
+    _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
   ),
-  arg(
-    "frequency (number)",
-    _lt("The number of interest or coupon payments per year (1, 2, or 4).")
-  ),
+  arg("frequency (number)", _t("The number of interest or coupon payments per year (1, 2, or 4).")),
   arg(
     `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-    _lt("An indicator of what day count method to use.")
+    _t("An indicator of what day count method to use.")
   ),
 ];
 
@@ -115,7 +112,7 @@ function newtonMethod(
     if (isNaN(y)) {
       assert(
         () => count < maxIterations && nanFallback !== undefined,
-        _lt(`Function [[FUNCTION_NAME]] didn't find any result.`)
+        _t(`Function [[FUNCTION_NAME]] didn't find any result.`)
       );
       count++;
       x = nanFallback!(previousFallback);
@@ -126,7 +123,7 @@ function newtonMethod(
     xDelta = Math.abs(newX - x);
     x = newX;
     yEqual0 = xDelta < epsMax || Math.abs(y) < epsMax;
-    assert(() => count < maxIterations, _lt(`Function [[FUNCTION_NAME]] didn't find any result.`));
+    assert(() => count < maxIterations, _t(`Function [[FUNCTION_NAME]] didn't find any result.`));
     count++;
   } while (!yEqual0);
   return x;
@@ -136,15 +133,15 @@ function newtonMethod(
 // ACCRINTM
 // -----------------------------------------------------------------------------
 export const ACCRINTM: AddFunctionDescription = {
-  description: _lt("Accrued interest of security paying at maturity."),
+  description: _t("Accrued interest of security paying at maturity."),
   args: [
-    arg("issue (date)", _lt("The date the security was initially issued.")),
-    arg("maturity (date)", _lt("The maturity date of the security.")),
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("redemption (number)", _lt("The redemption amount per 100 face value, or par.")),
+    arg("issue (date)", _t("The date the security was initially issued.")),
+    arg("maturity (date)", _t("The maturity date of the security.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("redemption (number)", _t("The redemption amount per 100 face value, or par.")),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -177,18 +174,18 @@ export const ACCRINTM: AddFunctionDescription = {
 // AMORLINC
 // -----------------------------------------------------------------------------
 export const AMORLINC: AddFunctionDescription = {
-  description: _lt("Depreciation for an accounting period."),
+  description: _t("Depreciation for an accounting period."),
   args: [
-    arg("cost (number)", _lt("The initial cost of the asset.")),
-    arg("purchase_date (date)", _lt("The date the asset was purchased.")),
-    arg("first_period_end (date)", _lt("The date the first period ended.")),
-    arg("salvage (number)", _lt("The value of the asset at the end of depreciation.")),
+    arg("cost (number)", _t("The initial cost of the asset.")),
+    arg("purchase_date (date)", _t("The date the asset was purchased.")),
+    arg("first_period_end (date)", _t("The date the first period ended.")),
+    arg("salvage (number)", _t("The value of the asset at the end of depreciation.")),
     arg(
       "period (number)",
-      _lt("The single period within life for which to calculate depreciation.")
+      _t("The single period within life for which to calculate depreciation.")
     ),
-    arg("rate (number)", _lt("The deprecation rate.")),
-    arg(" (number, optional)", _lt("An indicator of what day count method to use.")),
+    arg("rate (number)", _t("The deprecation rate.")),
+    arg(" (number, optional)", _t("An indicator of what day count method to use.")),
   ],
   returns: ["NUMBER"],
   compute: function (
@@ -217,7 +214,7 @@ export const AMORLINC: AddFunctionDescription = {
     assertDayCountConventionIsValid(_dayCountConvention);
     assert(
       () => _purchaseDate <= _firstPeriodEnd,
-      _lt(
+      _t(
         "The purchase_date (%s) must be before the first_period_end (%s).",
         _purchaseDate.toString(),
         _firstPeriodEnd.toString()
@@ -262,7 +259,7 @@ export const AMORLINC: AddFunctionDescription = {
 // COUPDAYS
 // -----------------------------------------------------------------------------
 export const COUPDAYS: AddFunctionDescription = {
-  description: _lt("Days in coupon period containing settlement date."),
+  description: _t("Days in coupon period containing settlement date."),
   args: COUPON_FUNCTION_ARGS,
   returns: ["NUMBER"],
   compute: function (
@@ -308,7 +305,7 @@ export const COUPDAYS: AddFunctionDescription = {
 // COUPDAYBS
 // -----------------------------------------------------------------------------
 export const COUPDAYBS: AddFunctionDescription = {
-  description: _lt("Days from settlement until next coupon."),
+  description: _t("Days from settlement until next coupon."),
   args: COUPON_FUNCTION_ARGS,
   returns: ["NUMBER"],
   compute: function (
@@ -385,7 +382,7 @@ export const COUPDAYBS: AddFunctionDescription = {
 // COUPDAYSNC
 // -----------------------------------------------------------------------------
 export const COUPDAYSNC: AddFunctionDescription = {
-  description: _lt("Days from settlement until next coupon."),
+  description: _t("Days from settlement until next coupon."),
   args: COUPON_FUNCTION_ARGS,
   returns: ["NUMBER"],
   compute: function (
@@ -440,7 +437,7 @@ export const COUPDAYSNC: AddFunctionDescription = {
 // COUPNCD
 // -----------------------------------------------------------------------------
 export const COUPNCD: AddFunctionDescription = {
-  description: _lt("Next coupon date after the settlement date."),
+  description: _t("Next coupon date after the settlement date."),
   args: COUPON_FUNCTION_ARGS,
   returns: ["NUMBER"],
   computeFormat: function () {
@@ -484,7 +481,7 @@ export const COUPNCD: AddFunctionDescription = {
 // COUPNUM
 // -----------------------------------------------------------------------------
 export const COUPNUM: AddFunctionDescription = {
-  description: _lt("Number of coupons between settlement and maturity."),
+  description: _t("Number of coupons between settlement and maturity."),
   args: COUPON_FUNCTION_ARGS,
   returns: ["NUMBER"],
   compute: function (
@@ -522,7 +519,7 @@ export const COUPNUM: AddFunctionDescription = {
 // COUPPCD
 // -----------------------------------------------------------------------------
 export const COUPPCD: AddFunctionDescription = {
-  description: _lt("Last coupon date prior to or on the settlement date."),
+  description: _t("Last coupon date prior to or on the settlement date."),
   args: COUPON_FUNCTION_ARGS,
   returns: ["NUMBER"],
   computeFormat: function () {
@@ -562,22 +559,22 @@ export const COUPPCD: AddFunctionDescription = {
 // CUMIPMT
 // -----------------------------------------------------------------------------
 export const CUMIPMT: AddFunctionDescription = {
-  description: _lt("Cumulative interest paid over a set of periods."),
+  description: _t("Cumulative interest paid over a set of periods."),
   args: [
-    arg("rate (number)", _lt("The interest rate.")),
-    arg("number_of_periods (number)", _lt("The number of payments to be made.")),
-    arg("present_value (number)", _lt("The current value of the annuity.")),
+    arg("rate (number)", _t("The interest rate.")),
+    arg("number_of_periods (number)", _t("The number of payments to be made.")),
+    arg("present_value (number)", _t("The current value of the annuity.")),
     arg(
       "first_period (number)",
-      _lt("The number of the payment period to begin the cumulative calculation.")
+      _t("The number of the payment period to begin the cumulative calculation.")
     ),
     arg(
       "last_period (number)",
-      _lt("The number of the payment period to end the cumulative calculation.")
+      _t("The number of the payment period to end the cumulative calculation.")
     ),
     arg(
       `end_or_beginning (number, default=${DEFAULT_END_OR_BEGINNING})`,
-      _lt("Whether payments are due at the end (0) or beginning (1) of each period.")
+      _t("Whether payments are due at the end (0) or beginning (1) of each period.")
     ),
   ],
   returns: ["NUMBER"],
@@ -621,22 +618,22 @@ export const CUMIPMT: AddFunctionDescription = {
 // CUMPRINC
 // -----------------------------------------------------------------------------
 export const CUMPRINC: AddFunctionDescription = {
-  description: _lt("Cumulative principal paid over a set of periods."),
+  description: _t("Cumulative principal paid over a set of periods."),
   args: [
-    arg("rate (number)", _lt("The interest rate.")),
-    arg("number_of_periods (number)", _lt("The number of payments to be made.")),
-    arg("present_value (number)", _lt("The current value of the annuity.")),
+    arg("rate (number)", _t("The interest rate.")),
+    arg("number_of_periods (number)", _t("The number of payments to be made.")),
+    arg("present_value (number)", _t("The current value of the annuity.")),
     arg(
       "first_period (number)",
-      _lt("The number of the payment period to begin the cumulative calculation.")
+      _t("The number of the payment period to begin the cumulative calculation.")
     ),
     arg(
       "last_period (number)",
-      _lt("The number of the payment period to end the cumulative calculation.")
+      _t("The number of the payment period to end the cumulative calculation.")
     ),
     arg(
       `end_or_beginning (number, default=${DEFAULT_END_OR_BEGINNING})`,
-      _lt("Whether payments are due at the end (0) or beginning (1) of each period.")
+      _t("Whether payments are due at the end (0) or beginning (1) of each period.")
     ),
   ],
   returns: ["NUMBER"],
@@ -680,16 +677,16 @@ export const CUMPRINC: AddFunctionDescription = {
 // DB
 // -----------------------------------------------------------------------------
 export const DB: AddFunctionDescription = {
-  description: _lt("Depreciation via declining balance method."),
+  description: _t("Depreciation via declining balance method."),
   args: [
-    arg("cost (number)", _lt("The initial cost of the asset.")),
-    arg("salvage (number)", _lt("The value of the asset at the end of depreciation.")),
-    arg("life (number)", _lt("The number of periods over which the asset is depreciated.")),
+    arg("cost (number)", _t("The initial cost of the asset.")),
+    arg("salvage (number)", _t("The value of the asset at the end of depreciation.")),
+    arg("life (number)", _t("The number of periods over which the asset is depreciated.")),
     arg(
       "period (number)",
-      _lt("The single period within life for which to calculate depreciation.")
+      _t("The single period within life for which to calculate depreciation.")
     ),
-    arg("month (number, optional)", _lt("The number of months in the first year of depreciation.")),
+    arg("month (number, optional)", _t("The number of months in the first year of depreciation.")),
   ],
   returns: ["NUMBER"],
   // to do: replace by dollar format
@@ -714,11 +711,11 @@ export const DB: AddFunctionDescription = {
     assertLifeStrictlyPositive(_life);
     assert(
       () => 1 <= _month && _month <= 12,
-      _lt("The month (%s) must be between 1 and 12 inclusive.", _month.toString())
+      _t("The month (%s) must be between 1 and 12 inclusive.", _month.toString())
     );
     assert(
       () => _period <= lifeLimit,
-      _lt(
+      _t(
         "The period (%s) must be less than or equal to %s.",
         _period.toString(),
         lifeLimit.toString()
@@ -752,18 +749,18 @@ export const DB: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 const DEFAULT_DDB_DEPRECIATION_FACTOR = 2;
 export const DDB: AddFunctionDescription = {
-  description: _lt("Depreciation via double-declining balance method."),
+  description: _t("Depreciation via double-declining balance method."),
   args: [
-    arg("cost (number)", _lt("The initial cost of the asset.")),
-    arg("salvage (number)", _lt("The value of the asset at the end of depreciation.")),
-    arg("life (number)", _lt("The number of periods over which the asset is depreciated.")),
+    arg("cost (number)", _t("The initial cost of the asset.")),
+    arg("salvage (number)", _t("The value of the asset at the end of depreciation.")),
+    arg("life (number)", _t("The number of periods over which the asset is depreciated.")),
     arg(
       "period (number)",
-      _lt("The single period within life for which to calculate depreciation.")
+      _t("The single period within life for which to calculate depreciation.")
     ),
     arg(
       `factor (number, default=${DEFAULT_DDB_DEPRECIATION_FACTOR})`,
-      _lt("The factor by which depreciation decreases.")
+      _t("The factor by which depreciation decreases.")
     ),
   ],
   returns: ["NUMBER"],
@@ -813,25 +810,23 @@ export const DDB: AddFunctionDescription = {
 // DISC
 // -----------------------------------------------------------------------------
 export const DISC: AddFunctionDescription = {
-  description: _lt("Discount rate of a security based on price."),
+  description: _t("Discount rate of a security based on price."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("price (number)", _lt("The price at which the security is bought per 100 face value.")),
-    arg("redemption (number)", _lt("The redemption amount per 100 face value, or par.")),
+    arg("price (number)", _t("The price at which the security is bought per 100 face value.")),
+    arg("redemption (number)", _t("The redemption amount per 100 face value, or par.")),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -878,20 +873,20 @@ export const DISC: AddFunctionDescription = {
 // DOLLARDE
 // -----------------------------------------------------------------------------
 export const DOLLARDE: AddFunctionDescription = {
-  description: _lt("Convert a decimal fraction to decimal value."),
+  description: _t("Convert a decimal fraction to decimal value."),
   args: [
     arg(
       "fractional_price (number)",
-      _lt("The price quotation given using fractional decimal conventions.")
+      _t("The price quotation given using fractional decimal conventions.")
     ),
-    arg("unit (number)", _lt("The units of the fraction, e.g. 8 for 1/8ths or 32 for 1/32nds.")),
+    arg("unit (number)", _t("The units of the fraction, e.g. 8 for 1/8ths or 32 for 1/32nds.")),
   ],
   returns: ["NUMBER"],
   compute: function (fractionalPrice: PrimitiveArgValue, unit: PrimitiveArgValue): number {
     const price = toNumber(fractionalPrice, this.locale);
     const _unit = Math.trunc(toNumber(unit, this.locale));
 
-    assert(() => _unit > 0, _lt("The unit (%s) must be strictly positive.", _unit.toString()));
+    assert(() => _unit > 0, _t("The unit (%s) must be strictly positive.", _unit.toString()));
 
     const truncatedPrice = Math.trunc(price);
     const priceFractionalPart = price - truncatedPrice;
@@ -907,12 +902,12 @@ export const DOLLARDE: AddFunctionDescription = {
 // DOLLARFR
 // -----------------------------------------------------------------------------
 export const DOLLARFR: AddFunctionDescription = {
-  description: _lt("Convert a decimal value to decimal fraction."),
+  description: _t("Convert a decimal value to decimal fraction."),
   args: [
-    arg("decimal_price (number)", _lt("The price quotation given as a decimal value.")),
+    arg("decimal_price (number)", _t("The price quotation given as a decimal value.")),
     arg(
       "unit (number)",
-      _lt("The units of the desired fraction, e.g. 8 for 1/8ths or 32 for 1/32nds.")
+      _t("The units of the desired fraction, e.g. 8 for 1/8ths or 32 for 1/32nds.")
     ),
   ],
   returns: ["NUMBER"],
@@ -920,7 +915,7 @@ export const DOLLARFR: AddFunctionDescription = {
     const price = toNumber(decimalPrice, this.locale);
     const _unit = Math.trunc(toNumber(unit, this.locale));
 
-    assert(() => _unit > 0, _lt("The unit (%s) must be strictly positive.", _unit.toString()));
+    assert(() => _unit > 0, _t("The unit (%s) must be strictly positive.", _unit.toString()));
 
     const truncatedPrice = Math.trunc(price);
     const priceFractionalPart = price - truncatedPrice;
@@ -936,29 +931,27 @@ export const DOLLARFR: AddFunctionDescription = {
 // DURATION
 // -----------------------------------------------------------------------------
 export const DURATION: AddFunctionDescription = {
-  description: _lt("Number of periods for an investment to reach a value."),
+  description: _t("Number of periods for an investment to reach a value."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("yield (number)", _lt("The expected annual yield of the security.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("yield (number)", _t("The expected annual yield of the security.")),
     arg(
       "frequency (number)",
-      _lt("The number of interest or coupon payments per year (1, 2, or 4).")
+      _t("The number of interest or coupon payments per year (1, 2, or 4).")
     ),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -982,8 +975,8 @@ export const DURATION: AddFunctionDescription = {
     assertCouponFrequencyIsValid(_frequency);
     assertDayCountConventionIsValid(_dayCountConvention);
 
-    assert(() => _rate >= 0, _lt("The rate (%s) must be positive or null.", _rate.toString()));
-    assert(() => _yield >= 0, _lt("The yield (%s) must be positive or null.", _yield.toString()));
+    assert(() => _rate >= 0, _t("The rate (%s) must be positive or null.", _rate.toString()));
+    assert(() => _yield >= 0, _t("The yield (%s) must be positive or null.", _yield.toString()));
 
     const years = YEARFRAC.compute.bind(this)(start, end, _dayCountConvention) as number;
     const timeFirstYear = years - Math.trunc(years) || 1 / _frequency;
@@ -1014,10 +1007,10 @@ export const DURATION: AddFunctionDescription = {
 // EFFECT
 // -----------------------------------------------------------------------------
 export const EFFECT: AddFunctionDescription = {
-  description: _lt("Annual effective interest rate."),
+  description: _t("Annual effective interest rate."),
   args: [
-    arg("nominal_rate (number)", _lt("The nominal interest rate per year.")),
-    arg("periods_per_year (number)", _lt("The number of compounding periods per year.")),
+    arg("nominal_rate (number)", _t("The nominal interest rate per year.")),
+    arg("periods_per_year (number)", _t("The number of compounding periods per year.")),
   ],
   returns: ["NUMBER"],
   compute: function (nominal_rate: PrimitiveArgValue, periods_per_year: PrimitiveArgValue): number {
@@ -1026,11 +1019,11 @@ export const EFFECT: AddFunctionDescription = {
 
     assert(
       () => nominal > 0,
-      _lt("The nominal rate (%s) must be strictly greater than 0.", nominal.toString())
+      _t("The nominal rate (%s) must be strictly greater than 0.", nominal.toString())
     );
     assert(
       () => periods > 0,
-      _lt("The number of periods by year (%s) must strictly greater than 0.", periods.toString())
+      _t("The number of periods by year (%s) must strictly greater than 0.", periods.toString())
     );
 
     // https://en.wikipedia.org/wiki/Nominal_interest_rate#Nominal_versus_effective_interest_rate
@@ -1044,18 +1037,18 @@ export const EFFECT: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 const DEFAULT_PRESENT_VALUE = 0;
 export const FV: AddFunctionDescription = {
-  description: _lt("Future value of an annuity investment."),
+  description: _t("Future value of an annuity investment."),
   args: [
-    arg("rate (number)", _lt("The interest rate.")),
-    arg("number_of_periods (number)", _lt("The number of payments to be made.")),
-    arg("payment_amount (number)", _lt("The amount per period to be paid.")),
+    arg("rate (number)", _t("The interest rate.")),
+    arg("number_of_periods (number)", _t("The number of payments to be made.")),
+    arg("payment_amount (number)", _t("The amount per period to be paid.")),
     arg(
       `present_value (number, default=${DEFAULT_PRESENT_VALUE})`,
-      _lt("The current value of the annuity.")
+      _t("The current value of the annuity.")
     ),
     arg(
       `end_or_beginning (number, default=${DEFAULT_END_OR_BEGINNING})`,
-      _lt("Whether payments are due at the end (0) or beginning (1) of each period.")
+      _t("Whether payments are due at the end (0) or beginning (1) of each period.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1084,12 +1077,12 @@ export const FV: AddFunctionDescription = {
 // FVSCHEDULE
 // -----------------------------------------------------------------------------
 export const FVSCHEDULE: AddFunctionDescription = {
-  description: _lt("Future value of principal from series of rates."),
+  description: _t("Future value of principal from series of rates."),
   args: [
-    arg("principal (number)", _lt("The amount of initial capital or value to compound against.")),
+    arg("principal (number)", _t("The amount of initial capital or value to compound against.")),
     arg(
       "rate_schedule (number, range<number>)",
-      _lt("A series of interest rates to compound against the principal.")
+      _t("A series of interest rates to compound against the principal.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1108,25 +1101,23 @@ export const FVSCHEDULE: AddFunctionDescription = {
 // INTRATE
 // -----------------------------------------------------------------------------
 export const INTRATE: AddFunctionDescription = {
-  description: _lt("Calculates effective interest rate."),
+  description: _t("Calculates effective interest rate."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("investment (number)", _lt("The amount invested in the security.")),
-    arg("redemption (number)", _lt("The amount to be received at maturity.")),
+    arg("investment (number)", _t("The amount invested in the security.")),
+    arg("redemption (number)", _t("The amount to be received at maturity.")),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1167,19 +1158,19 @@ export const INTRATE: AddFunctionDescription = {
 // IPMT
 // -----------------------------------------------------------------------------
 export const IPMT: AddFunctionDescription = {
-  description: _lt("Payment on the principal of an investment."),
+  description: _t("Payment on the principal of an investment."),
   args: [
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("period (number)", _lt("The amortization period, in terms of number of periods.")),
-    arg("number_of_periods (number)", _lt("The number of payments to be made.")),
-    arg("present_value (number)", _lt("The current value of the annuity.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("period (number)", _t("The amortization period, in terms of number of periods.")),
+    arg("number_of_periods (number)", _t("The number of payments to be made.")),
+    arg("present_value (number)", _t("The current value of the annuity.")),
     arg(
       `future_value (number, default=${DEFAULT_FUTURE_VALUE})`,
-      _lt("The future value remaining after the final payment has been made.")
+      _t("The future value remaining after the final payment has been made.")
     ),
     arg(
       `end_or_beginning (number, default=${DEFAULT_END_OR_BEGINNING})`,
-      _lt("Whether payments are due at the end (0) or beginning (1) of each period.")
+      _t("Whether payments are due at the end (0) or beginning (1) of each period.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1217,15 +1208,15 @@ export const IPMT: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 const DEFAULT_RATE_GUESS = 0.1;
 export const IRR: AddFunctionDescription = {
-  description: _lt("Internal rate of return given periodic cashflows."),
+  description: _t("Internal rate of return given periodic cashflows."),
   args: [
     arg(
       "cashflow_amounts (number, range<number>)",
-      _lt("An array or range containing the income or payments associated with the investment.")
+      _t("An array or range containing the income or payments associated with the investment.")
     ),
     arg(
       `rate_guess (number, default=${DEFAULT_RATE_GUESS})`,
-      _lt("An estimate for what the internal rate of return will be.")
+      _t("An estimate for what the internal rate of return will be.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1257,7 +1248,7 @@ export const IRR: AddFunctionDescription = {
 
     assert(
       () => positive && negative,
-      _lt("The cashflow_amounts must include negative and positive values.")
+      _t("The cashflow_amounts must include negative and positive values.")
     );
 
     const firstAmount = amounts.shift();
@@ -1302,12 +1293,12 @@ export const IRR: AddFunctionDescription = {
 // ISPMT
 // -----------------------------------------------------------------------------
 export const ISPMT: AddFunctionDescription = {
-  description: _lt("Returns the interest paid at a particular period of an investment."),
+  description: _t("Returns the interest paid at a particular period of an investment."),
   args: [
-    arg("rate (number)", _lt("The interest rate.")),
-    arg("period (number)", _lt("The period for which you want to view the interest payment.")),
-    arg("number_of_periods (number)", _lt("The number of payments to be made.")),
-    arg("present_value (number)", _lt("The current value of the annuity.")),
+    arg("rate (number)", _t("The interest rate.")),
+    arg("period (number)", _t("The period for which you want to view the interest payment.")),
+    arg("number_of_periods (number)", _t("The number of payments to be made.")),
+    arg("present_value (number)", _t("The current value of the annuity.")),
   ],
   returns: ["NUMBER"],
   compute: function (
@@ -1323,7 +1314,7 @@ export const ISPMT: AddFunctionDescription = {
 
     assert(
       () => nOfPeriods !== 0,
-      _lt("The number of periods must be different than 0.", nOfPeriods.toString())
+      _t("The number of periods must be different than 0.", nOfPeriods.toString())
     );
 
     const currentInvestment = investment - investment * (period / nOfPeriods);
@@ -1336,29 +1327,27 @@ export const ISPMT: AddFunctionDescription = {
 // MDURATION
 // -----------------------------------------------------------------------------
 export const MDURATION: AddFunctionDescription = {
-  description: _lt("Modified Macaulay duration."),
+  description: _t("Modified Macaulay duration."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("yield (number)", _lt("The expected annual yield of the security.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("yield (number)", _t("The expected annual yield of the security.")),
     arg(
       "frequency (number)",
-      _lt("The number of interest or coupon payments per year (1, 2, or 4).")
+      _t("The number of interest or coupon payments per year (1, 2, or 4).")
     ),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1389,18 +1378,18 @@ export const MDURATION: AddFunctionDescription = {
 // MIRR
 // -----------------------------------------------------------------------------
 export const MIRR: AddFunctionDescription = {
-  description: _lt("Modified internal rate of return."),
+  description: _t("Modified internal rate of return."),
   args: [
     arg(
       "cashflow_amounts (range<number>)",
-      _lt(
+      _t(
         "A range containing the income or payments associated with the investment. The array should contain bot payments and incomes."
       )
     ),
-    arg("financing_rate (number)", _lt("The interest rate paid on funds invested.")),
+    arg("financing_rate (number)", _t("The interest rate paid on funds invested.")),
     arg(
       "reinvestment_return_rate (number)",
-      _lt(
+      _t(
         "The return (as a percentage) earned on reinvestment of income received from the investment."
       )
     ),
@@ -1450,7 +1439,7 @@ export const MIRR: AddFunctionDescription = {
 
     assert(
       () => pv !== 0 && fv !== 0,
-      _lt("There must be both positive and negative values in cashflow_amounts.")
+      _t("There must be both positive and negative values in cashflow_amounts.")
     );
 
     const exponent = 1 / (n - 1);
@@ -1464,10 +1453,10 @@ export const MIRR: AddFunctionDescription = {
 // NOMINAL
 // -----------------------------------------------------------------------------
 export const NOMINAL: AddFunctionDescription = {
-  description: _lt("Annual nominal interest rate."),
+  description: _t("Annual nominal interest rate."),
   args: [
-    arg("effective_rate (number)", _lt("The effective interest rate per year.")),
-    arg("periods_per_year (number)", _lt("The number of compounding periods per year.")),
+    arg("effective_rate (number)", _t("The effective interest rate per year.")),
+    arg("periods_per_year (number)", _t("The number of compounding periods per year.")),
   ],
   returns: ["NUMBER"],
   compute: function (
@@ -1479,11 +1468,11 @@ export const NOMINAL: AddFunctionDescription = {
 
     assert(
       () => effective > 0,
-      _lt("The effective rate (%s) must must strictly greater than 0.", effective.toString())
+      _t("The effective rate (%s) must must strictly greater than 0.", effective.toString())
     );
     assert(
       () => periods > 0,
-      _lt("The number of periods by year (%s) must strictly greater than 0.", periods.toString())
+      _t("The number of periods by year (%s) must strictly greater than 0.", periods.toString())
     );
 
     // https://en.wikipedia.org/wiki/Nominal_interest_rate#Nominal_versus_effective_interest_rate
@@ -1496,18 +1485,18 @@ export const NOMINAL: AddFunctionDescription = {
 // NPER
 // -----------------------------------------------------------------------------
 export const NPER: AddFunctionDescription = {
-  description: _lt("Number of payment periods for an investment."),
+  description: _t("Number of payment periods for an investment."),
   args: [
-    arg("rate (number)", _lt("The interest rate.")),
-    arg("payment_amount (number)", _lt("The amount of each payment made.")),
-    arg("present_value (number)", _lt("The current value of the annuity.")),
+    arg("rate (number)", _t("The interest rate.")),
+    arg("payment_amount (number)", _t("The amount of each payment made.")),
+    arg("present_value (number)", _t("The current value of the annuity.")),
     arg(
       `future_value (number, default=${DEFAULT_FUTURE_VALUE})`,
-      _lt("The future value remaining after the final payment has been made.")
+      _t("The future value remaining after the final payment has been made.")
     ),
     arg(
       `end_or_beginning (number, default=${DEFAULT_END_OR_BEGINNING})`,
-      _lt("Whether payments are due at the end (0) or beginning (1) of each period.")
+      _t("Whether payments are due at the end (0) or beginning (1) of each period.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1567,13 +1556,13 @@ function npvResult(r: number, startValue: number, values: ArgValue[], locale: Lo
 }
 
 export const NPV: AddFunctionDescription = {
-  description: _lt(
+  description: _t(
     "The net present value of an investment based on a series of periodic cash flows and a discount rate."
   ),
   args: [
-    arg("discount (number)", _lt("The discount rate of the investment over one period.")),
-    arg("cashflow1 (number, range<number>)", _lt("The first future cash flow.")),
-    arg("cashflow2 (number, range<number>, repeating)", _lt("Additional future cash flows.")),
+    arg("discount (number)", _t("The discount rate of the investment over one period.")),
+    arg("cashflow1 (number, range<number>)", _t("The first future cash flow.")),
+    arg("cashflow2 (number, range<number>, repeating)", _t("Additional future cash flows.")),
   ],
   returns: ["NUMBER"],
   // to do: replace by dollar format
@@ -1583,7 +1572,7 @@ export const NPV: AddFunctionDescription = {
 
     assert(
       () => _discount !== -1,
-      _lt("The discount (%s) must be different from -1.", _discount.toString())
+      _t("The discount (%s) must be different from -1.", _discount.toString())
     );
 
     return npvResult(_discount, 0, values, this.locale);
@@ -1595,11 +1584,11 @@ export const NPV: AddFunctionDescription = {
 // PDURATION
 // -----------------------------------------------------------------------------
 export const PDURATION: AddFunctionDescription = {
-  description: _lt("Computes the number of periods needed for an investment to reach a value."),
+  description: _t("Computes the number of periods needed for an investment to reach a value."),
   args: [
-    arg("rate (number)", _lt("The rate at which the investment grows each period.")),
-    arg("present_value (number)", _lt("The investment's current value.")),
-    arg("future_value (number)", _lt("The investment's desired future value.")),
+    arg("rate (number)", _t("The rate at which the investment grows each period.")),
+    arg("present_value (number)", _t("The investment's current value.")),
+    arg("future_value (number)", _t("The investment's desired future value.")),
   ],
   returns: ["NUMBER"],
   compute: function (
@@ -1614,11 +1603,11 @@ export const PDURATION: AddFunctionDescription = {
     assertRateStrictlyPositive(_rate);
     assert(
       () => _presentValue > 0,
-      _lt("The present_value (%s) must be strictly positive.", _presentValue.toString())
+      _t("The present_value (%s) must be strictly positive.", _presentValue.toString())
     );
     assert(
       () => _futureValue > 0,
-      _lt("The future_value (%s) must be strictly positive.", _futureValue.toString())
+      _t("The future_value (%s) must be strictly positive.", _futureValue.toString())
     );
 
     return (Math.log(_futureValue) - Math.log(_presentValue)) / Math.log(1 + _rate);
@@ -1630,18 +1619,18 @@ export const PDURATION: AddFunctionDescription = {
 // PMT
 // -----------------------------------------------------------------------------
 export const PMT: AddFunctionDescription = {
-  description: _lt("Periodic payment for an annuity investment."),
+  description: _t("Periodic payment for an annuity investment."),
   args: [
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("number_of_periods (number)", _lt("The number of payments to be made.")),
-    arg("present_value (number)", _lt("The current value of the annuity.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("number_of_periods (number)", _t("The number of payments to be made.")),
+    arg("present_value (number)", _t("The current value of the annuity.")),
     arg(
       `future_value (number, default=${DEFAULT_FUTURE_VALUE})`,
-      _lt("The future value remaining after the final payment has been made.")
+      _t("The future value remaining after the final payment has been made.")
     ),
     arg(
       `end_or_beginning (number, default=${DEFAULT_END_OR_BEGINNING})`,
-      _lt("Whether payments are due at the end (0) or beginning (1) of each period.")
+      _t("Whether payments are due at the end (0) or beginning (1) of each period.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1685,19 +1674,19 @@ export const PMT: AddFunctionDescription = {
 // PPMT
 // -----------------------------------------------------------------------------
 export const PPMT: AddFunctionDescription = {
-  description: _lt("Payment on the principal of an investment."),
+  description: _t("Payment on the principal of an investment."),
   args: [
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("period (number)", _lt("The amortization period, in terms of number of periods.")),
-    arg("number_of_periods (number)", _lt("The number of payments to be made.")),
-    arg("present_value (number)", _lt("The current value of the annuity.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("period (number)", _t("The amortization period, in terms of number of periods.")),
+    arg("number_of_periods (number)", _t("The number of payments to be made.")),
+    arg("present_value (number)", _t("The current value of the annuity.")),
     arg(
       `future_value (number, default=${DEFAULT_FUTURE_VALUE})`,
-      _lt("The future value remaining after the final payment has been made.")
+      _t("The future value remaining after the final payment has been made.")
     ),
     arg(
       `end_or_beginning (number, default=${DEFAULT_END_OR_BEGINNING})`,
-      _lt("Whether payments are due at the end (0) or beginning (1) of each period.")
+      _t("Whether payments are due at the end (0) or beginning (1) of each period.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1722,7 +1711,7 @@ export const PPMT: AddFunctionDescription = {
     assertNumberOfPeriodsStrictlyPositive(n);
     assert(
       () => period > 0 && period <= n,
-      _lt("The period must be between 1 and number_of_periods", n.toString())
+      _t("The period must be between 1 and number_of_periods", n.toString())
     );
 
     const payment = PMT.compute.bind(this)(r, n, pv, fv, endOrBeginning) as number;
@@ -1742,18 +1731,18 @@ export const PPMT: AddFunctionDescription = {
 // PV
 // -----------------------------------------------------------------------------
 export const PV: AddFunctionDescription = {
-  description: _lt("Present value of an annuity investment."),
+  description: _t("Present value of an annuity investment."),
   args: [
-    arg("rate (number)", _lt("The interest rate.")),
-    arg("number_of_periods (number)", _lt("The number of payments to be made.")),
-    arg("payment_amount (number)", _lt("The amount per period to be paid.")),
+    arg("rate (number)", _t("The interest rate.")),
+    arg("number_of_periods (number)", _t("The number of payments to be made.")),
+    arg("payment_amount (number)", _t("The amount per period to be paid.")),
     arg(
       `future_value (number, default=${DEFAULT_FUTURE_VALUE})`,
-      _lt("The future value remaining after the final payment has been made.")
+      _t("The future value remaining after the final payment has been made.")
     ),
     arg(
       `end_or_beginning (number, default=${DEFAULT_END_OR_BEGINNING})`,
-      _lt("Whether payments are due at the end (0) or beginning (1) of each period.")
+      _t("Whether payments are due at the end (0) or beginning (1) of each period.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1783,30 +1772,28 @@ export const PV: AddFunctionDescription = {
 // PRICE
 // -----------------------------------------------------------------------------
 export const PRICE: AddFunctionDescription = {
-  description: _lt("Price of a security paying periodic interest."),
+  description: _t("Price of a security paying periodic interest."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("yield (number)", _lt("The expected annual yield of the security.")),
-    arg("redemption (number)", _lt("The redemption amount per 100 face value, or par.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("yield (number)", _t("The expected annual yield of the security.")),
+    arg("redemption (number)", _t("The redemption amount per 100 face value, or par.")),
     arg(
       "frequency (number)",
-      _lt("The number of interest or coupon payments per year (1, 2, or 4).")
+      _t("The number of interest or coupon payments per year (1, 2, or 4).")
     ),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1832,8 +1819,8 @@ export const PRICE: AddFunctionDescription = {
     assertCouponFrequencyIsValid(_frequency);
     assertDayCountConventionIsValid(_dayCountConvention);
 
-    assert(() => _rate >= 0, _lt("The rate (%s) must be positive or null.", _rate.toString()));
-    assert(() => _yield >= 0, _lt("The yield (%s) must be positive or null.", _yield.toString()));
+    assert(() => _rate >= 0, _t("The rate (%s) must be positive or null.", _rate.toString()));
+    assert(() => _yield >= 0, _t("The yield (%s) must be positive or null.", _yield.toString()));
     assertRedemptionStrictlyPositive(_redemption);
 
     const years = YEARFRAC.compute.bind(this)(
@@ -1875,25 +1862,23 @@ export const PRICE: AddFunctionDescription = {
 // PRICEDISC
 // -----------------------------------------------------------------------------
 export const PRICEDISC: AddFunctionDescription = {
-  description: _lt("Price of a discount security."),
+  description: _t("Price of a discount security."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("discount (number)", _lt("The discount rate of the security at time of purchase.")),
-    arg("redemption (number)", _lt("The redemption amount per 100 face value, or par.")),
+    arg("discount (number)", _t("The discount rate of the security at time of purchase.")),
+    arg("redemption (number)", _t("The redemption amount per 100 face value, or par.")),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1939,28 +1924,26 @@ export const PRICEDISC: AddFunctionDescription = {
 // PRICEMAT
 // -----------------------------------------------------------------------------
 export const PRICEMAT: AddFunctionDescription = {
-  description: _lt(
+  description: _t(
     "Calculates the price of a security paying interest at maturity, based on expected yield."
   ),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("issue (date)", _lt("The date the security was initially issued.")),
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("yield (number)", _lt("The expected annual yield of the security.")),
+    arg("issue (date)", _t("The date the security was initially issued.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("yield (number)", _t("The expected annual yield of the security.")),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1984,8 +1967,8 @@ export const PRICEMAT: AddFunctionDescription = {
     assertMaturityAndSettlementDatesAreValid(_settlement, _maturity);
     assertDayCountConventionIsValid(_dayCount);
 
-    assert(() => _rate >= 0, _lt("The rate (%s) must be positive or null.", _rate.toString()));
-    assert(() => _yield >= 0, _lt("The yield (%s) must be positive or null.", _yield.toString()));
+    assert(() => _rate >= 0, _t("The rate (%s) must be positive or null.", _rate.toString()));
+    assert(() => _yield >= 0, _t("The yield (%s) must be positive or null.", _yield.toString()));
 
     /**
      * https://support.microsoft.com/en-us/office/pricemat-function-52c3b4da-bc7e-476a-989f-a95f675cae77
@@ -2034,22 +2017,22 @@ export const PRICEMAT: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 const RATE_GUESS_DEFAULT = 0.1;
 export const RATE: AddFunctionDescription = {
-  description: _lt("Interest rate of an annuity investment."),
+  description: _t("Interest rate of an annuity investment."),
   args: [
-    arg("number_of_periods (number)", _lt("The number of payments to be made.")),
-    arg("payment_per_period (number)", _lt("The amount per period to be paid.")),
-    arg("present_value (number)", _lt("The current value of the annuity.")),
+    arg("number_of_periods (number)", _t("The number of payments to be made.")),
+    arg("payment_per_period (number)", _t("The amount per period to be paid.")),
+    arg("present_value (number)", _t("The current value of the annuity.")),
     arg(
       `future_value (number, default=${DEFAULT_FUTURE_VALUE})`,
-      _lt("The future value remaining after the final payment has been made.")
+      _t("The future value remaining after the final payment has been made.")
     ),
     arg(
       `end_or_beginning (number, default=${DEFAULT_END_OR_BEGINNING})`,
-      _lt("Whether payments are due at the end (0) or beginning (1) of each period.")
+      _t("Whether payments are due at the end (0) or beginning (1) of each period.")
     ),
     arg(
       `rate_guess (number, default=${RATE_GUESS_DEFAULT})`,
-      _lt("An estimate for what the interest rate will be.")
+      _t("An estimate for what the interest rate will be.")
     ),
   ],
   returns: ["NUMBER"],
@@ -2075,7 +2058,7 @@ export const RATE: AddFunctionDescription = {
     assertNumberOfPeriodsStrictlyPositive(n);
     assert(
       () => [payment, pv, fv].some((val) => val > 0) && [payment, pv, fv].some((val) => val < 0),
-      _lt(
+      _t(
         "There must be both positive and negative values in [payment_amount, present_value, future_value].",
         n.toString()
       )
@@ -2109,28 +2092,26 @@ export const RATE: AddFunctionDescription = {
 // RECEIVED
 // -----------------------------------------------------------------------------
 export const RECEIVED: AddFunctionDescription = {
-  description: _lt("Amount received at maturity for a security."),
+  description: _t("Amount received at maturity for a security."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
     arg(
       "investment (number)",
-      _lt("The amount invested (irrespective of face value of each security).")
+      _t("The amount invested (irrespective of face value of each security).")
     ),
-    arg("discount (number)", _lt("The discount rate of the security invested in.")),
+    arg("discount (number)", _t("The discount rate of the security invested in.")),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -2178,13 +2159,13 @@ export const RECEIVED: AddFunctionDescription = {
 // RRI
 // -----------------------------------------------------------------------------
 export const RRI: AddFunctionDescription = {
-  description: _lt(
+  description: _t(
     "Computes the rate needed for an investment to reach a specific value within a specific number of periods."
   ),
   args: [
-    arg("number_of_periods (number)", _lt("The number of periods.")),
-    arg("present_value (number)", _lt("The present value of the investment.")),
-    arg("future_value (number)", _lt("The future value of the investment.")),
+    arg("number_of_periods (number)", _t("The number of periods.")),
+    arg("present_value (number)", _t("The present value of the investment.")),
+    arg("future_value (number)", _t("The future value of the investment.")),
   ],
   returns: ["NUMBER"],
   compute: function (
@@ -2212,11 +2193,11 @@ export const RRI: AddFunctionDescription = {
 // SLN
 // -----------------------------------------------------------------------------
 export const SLN: AddFunctionDescription = {
-  description: _lt("Depreciation of an asset using the straight-line method."),
+  description: _t("Depreciation of an asset using the straight-line method."),
   args: [
-    arg("cost (number)", _lt("The initial cost of the asset.")),
-    arg("salvage (number)", _lt("The value of the asset at the end of depreciation.")),
-    arg("life (number)", _lt("The number of periods over which the asset is depreciated.")),
+    arg("cost (number)", _t("The initial cost of the asset.")),
+    arg("salvage (number)", _t("The value of the asset at the end of depreciation.")),
+    arg("life (number)", _t("The number of periods over which the asset is depreciated.")),
   ],
   returns: ["NUMBER"],
   computeFormat: () => "#,##0.00",
@@ -2241,14 +2222,14 @@ export const SLN: AddFunctionDescription = {
 // SYD
 // -----------------------------------------------------------------------------
 export const SYD: AddFunctionDescription = {
-  description: _lt("Depreciation via sum of years digit method."),
+  description: _t("Depreciation via sum of years digit method."),
   args: [
-    arg("cost (number)", _lt("The initial cost of the asset.")),
-    arg("salvage (number)", _lt("The value of the asset at the end of depreciation.")),
-    arg("life (number)", _lt("The number of periods over which the asset is depreciated.")),
+    arg("cost (number)", _t("The initial cost of the asset.")),
+    arg("salvage (number)", _t("The value of the asset at the end of depreciation.")),
+    arg("life (number)", _t("The number of periods over which the asset is depreciated.")),
     arg(
       "period (number)",
-      _lt("The single period within life for which to calculate depreciation.")
+      _t("The single period within life for which to calculate depreciation.")
     ),
   ],
   returns: ["NUMBER"],
@@ -2289,21 +2270,19 @@ export const SYD: AddFunctionDescription = {
 // TBILLPRICE
 // -----------------------------------------------------------------------------
 export const TBILLPRICE: AddFunctionDescription = {
-  description: _lt("Price of a US Treasury bill."),
+  description: _t("Price of a US Treasury bill."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("discount (number)", _lt("The discount rate of the bill at time of purchase.")),
+    arg("discount (number)", _t("The discount rate of the bill at time of purchase.")),
   ],
   returns: ["NUMBER"],
   compute: function (
@@ -2339,21 +2318,19 @@ export const TBILLPRICE: AddFunctionDescription = {
 // TBILLEQ
 // -----------------------------------------------------------------------------
 export const TBILLEQ: AddFunctionDescription = {
-  description: _lt("Equivalent rate of return for a US Treasury bill."),
+  description: _t("Equivalent rate of return for a US Treasury bill."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("discount (number)", _lt("The discount rate of the bill at time of purchase.")),
+    arg("discount (number)", _t("The discount rate of the bill at time of purchase.")),
   ],
   returns: ["NUMBER"],
   compute: function (
@@ -2418,21 +2395,19 @@ export const TBILLEQ: AddFunctionDescription = {
 // TBILLYIELD
 // -----------------------------------------------------------------------------
 export const TBILLYIELD: AddFunctionDescription = {
-  description: _lt("The yield of a US Treasury bill based on price."),
+  description: _t("The yield of a US Treasury bill based on price."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("price (number)", _lt("The price at which the security is bought per 100 face value.")),
+    arg("price (number)", _t("The price at which the security is bought per 100 face value.")),
   ],
   returns: ["NUMBER"],
   compute: function (
@@ -2472,20 +2447,20 @@ export const TBILLYIELD: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 const DEFAULT_VDB_NO_SWITCH = false;
 export const VDB: AddFunctionDescription = {
-  description: _lt("Variable declining balance. WARNING : does not handle decimal periods."),
+  description: _t("Variable declining balance. WARNING : does not handle decimal periods."),
   args: [
-    arg("cost (number)", _lt("The initial cost of the asset.")),
-    arg("salvage (number)", _lt("The value of the asset at the end of depreciation.")),
-    arg("life (number)", _lt("The number of periods over which the asset is depreciated.")),
-    arg("start (number)", _lt("Starting period to calculate depreciation.")),
-    arg("end (number)", _lt("Ending period to calculate depreciation.")),
+    arg("cost (number)", _t("The initial cost of the asset.")),
+    arg("salvage (number)", _t("The value of the asset at the end of depreciation.")),
+    arg("life (number)", _t("The number of periods over which the asset is depreciated.")),
+    arg("start (number)", _t("Starting period to calculate depreciation.")),
+    arg("end (number)", _t("Ending period to calculate depreciation.")),
     arg(
       `factor (number, default=${DEFAULT_DDB_DEPRECIATION_FACTOR})`,
-      _lt("The number of months in the first year of depreciation.")
+      _t("The number of months in the first year of depreciation.")
     ),
     arg(
       `no_switch (number, default=${DEFAULT_VDB_NO_SWITCH})`,
-      _lt(
+      _t(
         "Whether to switch to straight-line depreciation when the depreciation is greater than the declining balance calculation."
       )
     ),
@@ -2564,19 +2539,19 @@ export const VDB: AddFunctionDescription = {
 // XIRR
 // -----------------------------------------------------------------------------
 export const XIRR: AddFunctionDescription = {
-  description: _lt("Internal rate of return given non-periodic cash flows."),
+  description: _t("Internal rate of return given non-periodic cash flows."),
   args: [
     arg(
       "cashflow_amounts (range<number>)",
-      _lt("An range containing the income or payments associated with the investment.")
+      _t("An range containing the income or payments associated with the investment.")
     ),
     arg(
       "cashflow_dates (range<number>)",
-      _lt("An range with dates corresponding to the cash flows in cashflow_amounts.")
+      _t("An range with dates corresponding to the cash flows in cashflow_amounts.")
     ),
     arg(
       `rate_guess (number, default=${RATE_GUESS_DEFAULT})`,
-      _lt("An estimate for what the internal rate of return will be.")
+      _t("An estimate for what the internal rate of return will be.")
     ),
   ],
   returns: ["NUMBER"],
@@ -2652,16 +2627,16 @@ export const XIRR: AddFunctionDescription = {
 // XNPV
 // -----------------------------------------------------------------------------
 export const XNPV: AddFunctionDescription = {
-  description: _lt("Net present value given to non-periodic cash flows.."),
+  description: _t("Net present value given to non-periodic cash flows.."),
   args: [
-    arg("discount (number)", _lt("The discount rate of the investment over one period.")),
+    arg("discount (number)", _t("The discount rate of the investment over one period.")),
     arg(
       "cashflow_amounts (number, range<number>)",
-      _lt("An range containing the income or payments associated with the investment.")
+      _t("An range containing the income or payments associated with the investment.")
     ),
     arg(
       "cashflow_dates (number, range<number>)",
-      _lt("An range with dates corresponding to the cash flows in cashflow_amounts.")
+      _t("An range with dates corresponding to the cash flows in cashflow_amounts.")
     ),
   ],
   returns: ["NUMBER"],
@@ -2684,7 +2659,7 @@ export const XNPV: AddFunctionDescription = {
     } else {
       assert(
         () => _cashFlows.length === _dates.length,
-        _lt("There must be the same number of values in cashflow_amounts and cashflow_dates.")
+        _t("There must be the same number of values in cashflow_amounts and cashflow_dates.")
       );
     }
     assertEveryDateGreaterThanFirstDateOfCashFlowDates(_dates);
@@ -2731,30 +2706,28 @@ export const XNPV: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const YIELD: AddFunctionDescription = {
-  description: _lt("Annual yield of a security paying periodic interest."),
+  description: _t("Annual yield of a security paying periodic interest."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("price (number)", _lt("The price at which the security is bought per 100 face value.")),
-    arg("redemption (number)", _lt("The redemption amount per 100 face value, or par.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("price (number)", _t("The price at which the security is bought per 100 face value.")),
+    arg("redemption (number)", _t("The redemption amount per 100 face value, or par.")),
     arg(
       "frequency (number)",
-      _lt("The number of interest or coupon payments per year (1, 2, or 4).")
+      _t("The number of interest or coupon payments per year (1, 2, or 4).")
     ),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -2780,7 +2753,7 @@ export const YIELD: AddFunctionDescription = {
     assertCouponFrequencyIsValid(_frequency);
     assertDayCountConventionIsValid(_dayCountConvention);
 
-    assert(() => _rate >= 0, _lt("The rate (%s) must be positive or null.", _rate.toString()));
+    assert(() => _rate >= 0, _t("The rate (%s) must be positive or null.", _rate.toString()));
     assertPriceStrictlyPositive(_price);
     assertRedemptionStrictlyPositive(_redemption);
 
@@ -2874,25 +2847,23 @@ export const YIELD: AddFunctionDescription = {
 // YIELDDISC
 // -----------------------------------------------------------------------------
 export const YIELDDISC: AddFunctionDescription = {
-  description: _lt("Annual yield of a discount security."),
+  description: _t("Annual yield of a discount security."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("price (number)", _lt("The price at which the security is bought per 100 face value.")),
-    arg("redemption (number)", _lt("The redemption amount per 100 face value, or par.")),
+    arg("price (number)", _t("The price at which the security is bought per 100 face value.")),
+    arg("redemption (number)", _t("The redemption amount per 100 face value, or par.")),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -2937,26 +2908,24 @@ export const YIELDDISC: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const YIELDMAT: AddFunctionDescription = {
-  description: _lt("Annual yield of a security paying interest at maturity."),
+  description: _t("Annual yield of a security paying interest at maturity."),
   args: [
     arg(
       "settlement (date)",
-      _lt(
+      _t(
         "The settlement date of the security, the date after issuance when the security is delivered to the buyer."
       )
     ),
     arg(
       "maturity (date)",
-      _lt(
-        "The maturity or end date of the security, when it can be redeemed at face, or par value."
-      )
+      _t("The maturity or end date of the security, when it can be redeemed at face, or par value.")
     ),
-    arg("issue (date)", _lt("The date the security was initially issued.")),
-    arg("rate (number)", _lt("The annualized rate of interest.")),
-    arg("price (number)", _lt("The price at which the security is bought.")),
+    arg("issue (date)", _t("The date the security was initially issued.")),
+    arg("rate (number)", _t("The annualized rate of interest.")),
+    arg("price (number)", _t("The price at which the security is bought.")),
     arg(
       `day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} )`,
-      _lt("An indicator of what day count method to use.")
+      _t("An indicator of what day count method to use.")
     ),
   ],
   returns: ["NUMBER"],
@@ -2981,13 +2950,13 @@ export const YIELDMAT: AddFunctionDescription = {
 
     assert(
       () => _settlement >= _issue,
-      _lt(
+      _t(
         "The settlement (%s) must be greater than or equal to the issue (%s).",
         _settlement.toString(),
         _issue.toString()
       )
     );
-    assert(() => _rate >= 0, _lt("The rate (%s) must be positive or null.", _rate.toString()));
+    assert(() => _rate >= 0, _t("The rate (%s) must be positive or null.", _rate.toString()));
     assertPriceStrictlyPositive(_price);
 
     const issueToMaturity = YEARFRAC.compute.bind(this)(

--- a/src/functions/module_info.ts
+++ b/src/functions/module_info.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { AddFunctionDescription, PrimitiveArgValue } from "../types";
 import { CellErrorType, NotAvailableError } from "../types/errors";
 import { arg } from "./arguments";
@@ -7,8 +7,8 @@ import { arg } from "./arguments";
 // ISERR
 // -----------------------------------------------------------------------------
 export const ISERR: AddFunctionDescription = {
-  description: _lt("Whether a value is an error other than #N/A."),
-  args: [arg("value (any, lazy)", _lt("The value to be verified as an error type."))],
+  description: _t("Whether a value is an error other than #N/A."),
+  args: [arg("value (any, lazy)", _t("The value to be verified as an error type."))],
   returns: ["BOOLEAN"],
   compute: function (value: () => PrimitiveArgValue): boolean {
     try {
@@ -25,8 +25,8 @@ export const ISERR: AddFunctionDescription = {
 // ISERROR
 // -----------------------------------------------------------------------------
 export const ISERROR: AddFunctionDescription = {
-  description: _lt("Whether a value is an error."),
-  args: [arg("value (any, lazy)", _lt("The value to be verified as an error type."))],
+  description: _t("Whether a value is an error."),
+  args: [arg("value (any, lazy)", _t("The value to be verified as an error type."))],
   returns: ["BOOLEAN"],
   compute: function (value: () => PrimitiveArgValue): boolean {
     try {
@@ -43,8 +43,8 @@ export const ISERROR: AddFunctionDescription = {
 // ISLOGICAL
 // -----------------------------------------------------------------------------
 export const ISLOGICAL: AddFunctionDescription = {
-  description: _lt("Whether a value is `true` or `false`."),
-  args: [arg("value (any, lazy)", _lt("The value to be verified as a logical TRUE or FALSE."))],
+  description: _t("Whether a value is `true` or `false`."),
+  args: [arg("value (any, lazy)", _t("The value to be verified as a logical TRUE or FALSE."))],
   returns: ["BOOLEAN"],
   compute: function (value: () => PrimitiveArgValue): boolean {
     try {
@@ -60,8 +60,8 @@ export const ISLOGICAL: AddFunctionDescription = {
 // ISNA
 // -----------------------------------------------------------------------------
 export const ISNA: AddFunctionDescription = {
-  description: _lt("Whether a value is the error #N/A."),
-  args: [arg("value (any, lazy)", _lt("The value to be verified as an error type."))],
+  description: _t("Whether a value is the error #N/A."),
+  args: [arg("value (any, lazy)", _t("The value to be verified as an error type."))],
   returns: ["BOOLEAN"],
   compute: function (value: () => PrimitiveArgValue): boolean {
     try {
@@ -78,8 +78,8 @@ export const ISNA: AddFunctionDescription = {
 // ISNONTEXT
 // -----------------------------------------------------------------------------
 export const ISNONTEXT: AddFunctionDescription = {
-  description: _lt("Whether a value is non-textual."),
-  args: [arg("value (any, lazy)", _lt("The value to be checked."))],
+  description: _t("Whether a value is non-textual."),
+  args: [arg("value (any, lazy)", _t("The value to be checked."))],
   returns: ["BOOLEAN"],
   compute: function (value: () => PrimitiveArgValue): boolean {
     try {
@@ -96,8 +96,8 @@ export const ISNONTEXT: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const ISNUMBER: AddFunctionDescription = {
-  description: _lt("Whether a value is a number."),
-  args: [arg("value (any, lazy)", _lt("The value to be verified as a number."))],
+  description: _t("Whether a value is a number."),
+  args: [arg("value (any, lazy)", _t("The value to be verified as a number."))],
   returns: ["BOOLEAN"],
   compute: function (value: () => PrimitiveArgValue): boolean {
     try {
@@ -113,8 +113,8 @@ export const ISNUMBER: AddFunctionDescription = {
 // ISTEXT
 // -----------------------------------------------------------------------------
 export const ISTEXT: AddFunctionDescription = {
-  description: _lt("Whether a value is text."),
-  args: [arg("value (any, lazy)", _lt("The value to be verified as text."))],
+  description: _t("Whether a value is text."),
+  args: [arg("value (any, lazy)", _t("The value to be verified as text."))],
   returns: ["BOOLEAN"],
   compute: function (value: () => PrimitiveArgValue): boolean {
     try {
@@ -130,10 +130,8 @@ export const ISTEXT: AddFunctionDescription = {
 // ISBLANK
 // -----------------------------------------------------------------------------
 export const ISBLANK: AddFunctionDescription = {
-  description: _lt("Whether the referenced cell is empty"),
-  args: [
-    arg("value (any, lazy)", _lt("Reference to the cell that will be checked for emptiness.")),
-  ],
+  description: _t("Whether the referenced cell is empty"),
+  args: [arg("value (any, lazy)", _t("Reference to the cell that will be checked for emptiness."))],
   returns: ["BOOLEAN"],
   compute: function (value: () => PrimitiveArgValue): boolean {
     try {
@@ -150,7 +148,7 @@ export const ISBLANK: AddFunctionDescription = {
 // NA
 // -----------------------------------------------------------------------------
 export const NA: AddFunctionDescription = {
-  description: _lt("Returns the error value #N/A."),
+  description: _t("Returns the error value #N/A."),
   args: [],
   returns: ["BOOLEAN"],
   compute: function (value: PrimitiveArgValue): boolean {

--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   ArgValue,
@@ -14,17 +14,17 @@ import { assert, conditionalVisitBoolean, toBoolean } from "./helpers";
 // AND
 // -----------------------------------------------------------------------------
 export const AND: AddFunctionDescription = {
-  description: _lt("Logical `and` operator."),
+  description: _t("Logical `and` operator."),
   args: [
     arg(
       "logical_expression1 (boolean, range<boolean>)",
-      _lt(
+      _t(
         "An expression or reference to a cell containing an expression that represents some logical value, i.e. TRUE or FALSE, or an expression that can be coerced to a logical value."
       )
     ),
     arg(
       "logical_expression2 (boolean, range<boolean>, repeating)",
-      _lt("More expressions that represent logical values.")
+      _t("More expressions that represent logical values.")
     ),
   ],
   returns: ["BOOLEAN"],
@@ -36,7 +36,7 @@ export const AND: AddFunctionDescription = {
       acc = acc && arg;
       return acc;
     });
-    assert(() => foundBoolean, _lt(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => foundBoolean, _t(`[[FUNCTION_NAME]] has no valid input data.`));
     return acc;
   },
   isExported: true,
@@ -46,7 +46,7 @@ export const AND: AddFunctionDescription = {
 // FALSE
 // -----------------------------------------------------------------------------
 export const FALSE: AddFunctionDescription = {
-  description: _lt("Logical value `false`."),
+  description: _t("Logical value `false`."),
   args: [],
   returns: ["BOOLEAN"],
   compute: function (): boolean {
@@ -59,21 +59,21 @@ export const FALSE: AddFunctionDescription = {
 // IF
 // -----------------------------------------------------------------------------
 export const IF: AddFunctionDescription = {
-  description: _lt("Returns value depending on logical expression."),
+  description: _t("Returns value depending on logical expression."),
   args: [
     arg(
       "logical_expression (boolean)",
-      _lt(
+      _t(
         "An expression or reference to a cell containing an expression that represents some logical value, i.e. TRUE or FALSE."
       )
     ),
     arg(
       "value_if_true (any, lazy)",
-      _lt("The value the function returns if logical_expression is TRUE.")
+      _t("The value the function returns if logical_expression is TRUE.")
     ),
     arg(
       "value_if_false (any, lazy, default=FALSE)",
-      _lt("The value the function returns if logical_expression is FALSE.")
+      _t("The value the function returns if logical_expression is FALSE.")
     ),
   ],
   returns: ["ANY"],
@@ -92,12 +92,12 @@ export const IF: AddFunctionDescription = {
 // IFERROR
 // -----------------------------------------------------------------------------
 export const IFERROR: AddFunctionDescription = {
-  description: _lt("Value if it is not an error, otherwise 2nd argument."),
+  description: _t("Value if it is not an error, otherwise 2nd argument."),
   args: [
-    arg("value (any, lazy)", _lt("The value to return if value itself is not an error.")),
+    arg("value (any, lazy)", _t("The value to return if value itself is not an error.")),
     arg(
       `value_if_error (any, lazy, default="empty")`,
-      _lt("The value the function returns if value is an error.")
+      _t("The value the function returns if value is an error.")
     ),
   ],
   returns: ["ANY"],
@@ -130,12 +130,12 @@ export const IFERROR: AddFunctionDescription = {
 // IFNA
 // -----------------------------------------------------------------------------
 export const IFNA: AddFunctionDescription = {
-  description: _lt("Value if it is not an #N/A error, otherwise 2nd argument."),
+  description: _t("Value if it is not an #N/A error, otherwise 2nd argument."),
   args: [
-    arg("value (any, lazy)", _lt("The value to return if value itself is not #N/A an error.")),
+    arg("value (any, lazy)", _t("The value to return if value itself is not #N/A an error.")),
     arg(
       `value_if_error (any, lazy, default="empty")`,
-      _lt("The value the function returns if value is an #N/A error.")
+      _t("The value the function returns if value is an #N/A error.")
     ),
   ],
   returns: ["ANY"],
@@ -162,29 +162,29 @@ export const IFNA: AddFunctionDescription = {
 // IFS
 // -----------------------------------------------------------------------------
 export const IFS: AddFunctionDescription = {
-  description: _lt("Returns a value depending on multiple logical expressions."),
+  description: _t("Returns a value depending on multiple logical expressions."),
   args: [
     arg(
       "condition1 (boolean, lazy)",
-      _lt(
+      _t(
         "The first condition to be evaluated. This can be a boolean, a number, an array, or a reference to any of those."
       )
     ),
-    arg("value1 (any, lazy)", _lt("The returned value if condition1 is TRUE.")),
+    arg("value1 (any, lazy)", _t("The returned value if condition1 is TRUE.")),
     arg(
       "condition2 (boolean, lazy, repeating)",
-      _lt("Additional conditions to be evaluated if the previous ones are FALSE.")
+      _t("Additional conditions to be evaluated if the previous ones are FALSE.")
     ),
     arg(
       "value2 (any, lazy, repeating)",
-      _lt("Additional values to be returned if their corresponding conditions are TRUE.")
+      _t("Additional values to be returned if their corresponding conditions are TRUE.")
     ),
   ],
   returns: ["ANY"],
   compute: function (...values: (() => PrimitiveArgValue)[]): FunctionReturnValue {
     assert(
       () => values.length % 2 === 0,
-      _lt(`Wrong number of arguments. Expected an even number of arguments.`)
+      _t(`Wrong number of arguments. Expected an even number of arguments.`)
     );
     for (let n = 0; n < values.length - 1; n += 2) {
       if (toBoolean(values[n]())) {
@@ -192,7 +192,7 @@ export const IFS: AddFunctionDescription = {
         return returnValue !== null ? returnValue : "";
       }
     }
-    throw new Error(_lt(`No match.`));
+    throw new Error(_t(`No match.`));
   },
   isExported: true,
 };
@@ -201,11 +201,11 @@ export const IFS: AddFunctionDescription = {
 // NOT
 // -----------------------------------------------------------------------------
 export const NOT: AddFunctionDescription = {
-  description: _lt("Returns opposite of provided logical value."),
+  description: _t("Returns opposite of provided logical value."),
   args: [
     arg(
       "logical_expression (boolean)",
-      _lt(
+      _t(
         "An expression or reference to a cell holding an expression that represents some logical value."
       )
     ),
@@ -221,17 +221,17 @@ export const NOT: AddFunctionDescription = {
 // OR
 // -----------------------------------------------------------------------------
 export const OR: AddFunctionDescription = {
-  description: _lt("Logical `or` operator."),
+  description: _t("Logical `or` operator."),
   args: [
     arg(
       "logical_expression1 (boolean, range<boolean>)",
-      _lt(
+      _t(
         "An expression or reference to a cell containing an expression that represents some logical value, i.e. TRUE or FALSE, or an expression that can be coerced to a logical value."
       )
     ),
     arg(
       "logical_expression2 (boolean, range<boolean>, repeating)",
-      _lt("More expressions that evaluate to logical values.")
+      _t("More expressions that evaluate to logical values.")
     ),
   ],
   returns: ["BOOLEAN"],
@@ -243,7 +243,7 @@ export const OR: AddFunctionDescription = {
       acc = acc || arg;
       return !acc;
     });
-    assert(() => foundBoolean, _lt(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => foundBoolean, _t(`[[FUNCTION_NAME]] has no valid input data.`));
     return acc;
   },
   isExported: true,
@@ -253,7 +253,7 @@ export const OR: AddFunctionDescription = {
 // TRUE
 // -----------------------------------------------------------------------------
 export const TRUE: AddFunctionDescription = {
-  description: _lt("Logical value `true`."),
+  description: _t("Logical value `true`."),
   args: [],
   returns: ["BOOLEAN"],
   compute: function (): boolean {
@@ -266,17 +266,17 @@ export const TRUE: AddFunctionDescription = {
 // XOR
 // -----------------------------------------------------------------------------
 export const XOR: AddFunctionDescription = {
-  description: _lt("Logical `xor` operator."),
+  description: _t("Logical `xor` operator."),
   args: [
     arg(
       "logical_expression1 (boolean, range<boolean>)",
-      _lt(
+      _t(
         "An expression or reference to a cell containing an expression that represents some logical value, i.e. TRUE or FALSE, or an expression that can be coerced to a logical value."
       )
     ),
     arg(
       "logical_expression2 (boolean, range<boolean>, repeating)",
-      _lt("More expressions that evaluate to logical values.")
+      _t("More expressions that evaluate to logical values.")
     ),
   ],
   returns: ["BOOLEAN"],
@@ -288,7 +288,7 @@ export const XOR: AddFunctionDescription = {
       acc = acc ? !arg : arg;
       return true; // no stop condition
     });
-    assert(() => foundBoolean, _lt(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => foundBoolean, _t(`[[FUNCTION_NAME]] has no valid input data.`));
     return acc;
   },
   isExported: true,

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1,5 +1,5 @@
 import { getCanonicalSheetName, toXC, toZone } from "../helpers/index";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   FunctionReturnValue,
@@ -32,7 +32,7 @@ const DEFAULT_ABSOLUTE_RELATIVE_MODE = 1;
 function assertAvailable(variable, searchKey) {
   if (variable === undefined) {
     throw new NotAvailableError(
-      _lt("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
+      _t("Did not find value '%s' in [[FUNCTION_NAME]] evaluation.", toString(searchKey))
     );
   }
 }
@@ -42,28 +42,28 @@ function assertAvailable(variable, searchKey) {
 // -----------------------------------------------------------------------------
 
 export const ADDRESS: AddFunctionDescription = {
-  description: _lt("Returns a cell reference as a string. "),
+  description: _t("Returns a cell reference as a string. "),
   args: [
-    arg("row (number)", _lt("The row number of the cell reference. ")),
+    arg("row (number)", _t("The row number of the cell reference. ")),
     arg(
       "column (number)",
-      _lt("The column number (not name) of the cell reference. A is column number 1. ")
+      _t("The column number (not name) of the cell reference. A is column number 1. ")
     ),
     arg(
       `absolute_relative_mode (number, default=${DEFAULT_ABSOLUTE_RELATIVE_MODE})`,
-      _lt(
+      _t(
         "An indicator of whether the reference is row/column absolute. 1 is row and column absolute (e.g. $A$1), 2 is row absolute and column relative (e.g. A$1), 3 is row relative and column absolute (e.g. $A1), and 4 is row and column relative (e.g. A1)."
       )
     ),
     arg(
       "use_a1_notation (boolean, default=TRUE)",
-      _lt(
+      _t(
         "A boolean indicating whether to use A1 style notation (TRUE) or R1C1 style notation (FALSE)."
       )
     ),
     arg(
       "sheet (string, optional)",
-      _lt("A string indicating the name of the sheet into which the address points.")
+      _t("A string indicating the name of the sheet into which the address points.")
     ),
   ],
   returns: ["STRING"],
@@ -109,11 +109,11 @@ export const ADDRESS: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const COLUMN: AddFunctionDescription = {
-  description: _lt("Column number of a specified cell."),
+  description: _t("Column number of a specified cell."),
   args: [
     arg(
       "cell_reference (meta, default='this cell')",
-      _lt(
+      _t(
         "The cell whose column number will be returned. Column A corresponds to 1. By default, the function use the cell in which the formula is entered."
       )
     ),
@@ -136,8 +136,8 @@ export const COLUMN: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const COLUMNS: AddFunctionDescription = {
-  description: _lt("Number of columns in a specified array or range."),
-  args: [arg("range (meta)", _lt("The range whose column count will be returned."))],
+  description: _t("Number of columns in a specified array or range."),
+  args: [arg("range (meta)", _t("The range whose column count will be returned."))],
   returns: ["NUMBER"],
   compute: function (range: string): number {
     const zone = toZone(range);
@@ -151,22 +151,22 @@ export const COLUMNS: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const HLOOKUP: AddFunctionDescription = {
-  description: _lt(`Horizontal lookup`),
+  description: _t(`Horizontal lookup`),
   args: [
-    arg("search_key (any)", _lt("The value to search for. For example, 42, 'Cats', or I24.")),
+    arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
     arg(
       "range (range)",
-      _lt(
+      _t(
         "The range to consider for the search. The first row in the range is searched for the key specified in search_key."
       )
     ),
     arg(
       "index (number)",
-      _lt("The row index of the value to be returned, where the first row in range is numbered 1.")
+      _t("The row index of the value to be returned, where the first row in range is numbered 1.")
     ),
     arg(
       `is_sorted (boolean, default=${DEFAULT_IS_SORTED})`,
-      _lt(
+      _t(
         "Indicates whether the row to be searched (the first row of the specified range) is sorted, in which case the closest match for search_key will be returned."
       )
     ),
@@ -183,7 +183,7 @@ export const HLOOKUP: AddFunctionDescription = {
 
     assert(
       () => 1 <= _index && _index <= range[0].length,
-      _lt("[[FUNCTION_NAME]] evaluates to an out of bounds range.")
+      _t("[[FUNCTION_NAME]] evaluates to an out of bounds range.")
     );
 
     const _isSorted = toBoolean(isSorted);
@@ -218,18 +218,18 @@ export const HLOOKUP: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const LOOKUP: AddFunctionDescription = {
-  description: _lt(`Look up a value.`),
+  description: _t(`Look up a value.`),
   args: [
-    arg("search_key (any)", _lt("The value to search for. For example, 42, 'Cats', or I24.")),
+    arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
     arg(
       "search_array (range)",
-      _lt(
+      _t(
         "One method of using this function is to provide a single sorted row or column search_array to look through for the search_key with a second argument result_range. The other way is to combine these two arguments into one search_array where the first row or column is searched and a value is returned from the last row or column in the array. If search_key is not found, a non-exact match may be returned."
       )
     ),
     arg(
       "result_range (range, optional)",
-      _lt(
+      _t(
         "The range from which to return a result. The value returned corresponds to the location where search_key is found in search_range. This range must be only a single row or column and should not be used if using the search_result_array method."
       )
     ),
@@ -274,20 +274,20 @@ export const LOOKUP: AddFunctionDescription = {
     nbRow = resultRange[0].length;
     assert(
       () => nbCol === 1 || nbRow === 1,
-      _lt("The result_range must be a single row or a single column.")
+      _t("The result_range must be a single row or a single column.")
     );
 
     if (nbCol > 1) {
       assert(
         () => index <= nbCol - 1,
-        _lt("[[FUNCTION_NAME]] evaluates to an out of range row value %s.", (index + 1).toString())
+        _t("[[FUNCTION_NAME]] evaluates to an out of range row value %s.", (index + 1).toString())
       );
       return resultRange[index][0] as FunctionReturnValue;
     }
 
     assert(
       () => index <= nbRow - 1,
-      _lt("[[FUNCTION_NAME]] evaluates to an out of range column value %s.", (index + 1).toString())
+      _t("[[FUNCTION_NAME]] evaluates to an out of range column value %s.", (index + 1).toString())
     );
 
     return resultRange[0][index] as FunctionReturnValue;
@@ -300,13 +300,13 @@ export const LOOKUP: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 const DEFAULT_SEARCH_TYPE = 1;
 export const MATCH: AddFunctionDescription = {
-  description: _lt(`Position of item in range that matches value.`),
+  description: _t(`Position of item in range that matches value.`),
   args: [
-    arg("search_key (any)", _lt("The value to search for. For example, 42, 'Cats', or I24.")),
-    arg("range (any, range)", _lt("The one-dimensional array to be searched.")),
+    arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
+    arg("range (any, range)", _t("The one-dimensional array to be searched.")),
     arg(
       `search_type (number, default=${DEFAULT_SEARCH_TYPE})`,
-      _lt(
+      _t(
         "The search method. 1 (default) finds the largest value less than or equal to search_key when range is sorted in ascending order. 0 finds the exact value when range is unsorted. -1 finds the smallest value greater than or equal to search_key when range is sorted in descending order."
       )
     ),
@@ -324,7 +324,7 @@ export const MATCH: AddFunctionDescription = {
 
     assert(
       () => nbCol === 1 || nbRow === 1,
-      _lt("The range must be a single row or a single column.")
+      _t("The range must be a single row or a single column.")
     );
 
     let index = -1;
@@ -356,11 +356,11 @@ export const MATCH: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const ROW: AddFunctionDescription = {
-  description: _lt("Row number of a specified cell."),
+  description: _t("Row number of a specified cell."),
   args: [
     arg(
       "cell_reference (meta, default='this cell')",
-      _lt(
+      _t(
         "The cell whose row number will be returned. By default, this function uses the cell in which the formula is entered."
       )
     ),
@@ -383,8 +383,8 @@ export const ROW: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const ROWS: AddFunctionDescription = {
-  description: _lt("Number of rows in a specified array or range."),
-  args: [arg("range (meta)", _lt("The range whose row count will be returned."))],
+  description: _t("Number of rows in a specified array or range."),
+  args: [arg("range (meta)", _t("The range whose row count will be returned."))],
   returns: ["NUMBER"],
   compute: function (range: string): number {
     const zone = toZone(range);
@@ -398,24 +398,24 @@ export const ROWS: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const VLOOKUP: AddFunctionDescription = {
-  description: _lt(`Vertical lookup.`),
+  description: _t(`Vertical lookup.`),
   args: [
-    arg("search_key (any)", _lt("The value to search for. For example, 42, 'Cats', or I24.")),
+    arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
     arg(
       "range (any, range)",
-      _lt(
+      _t(
         "The range to consider for the search. The first column in the range is searched for the key specified in search_key."
       )
     ),
     arg(
       "index (number)",
-      _lt(
+      _t(
         "The column index of the value to be returned, where the first column in range is numbered 1."
       )
     ),
     arg(
       `is_sorted (boolean, default=${DEFAULT_IS_SORTED})`,
-      _lt(
+      _t(
         "Indicates whether the column to be searched (the first column of the specified range) is sorted, in which case the closest match for search_key will be returned."
       )
     ),
@@ -431,7 +431,7 @@ export const VLOOKUP: AddFunctionDescription = {
     const _searchKey = normalizeValue(searchKey);
     assert(
       () => 1 <= _index && _index <= range.length,
-      _lt("[[FUNCTION_NAME]] evaluates to an out of bounds range.")
+      _t("[[FUNCTION_NAME]] evaluates to an out of bounds range.")
     );
 
     const _isSorted = toBoolean(isSorted);
@@ -466,32 +466,32 @@ export const VLOOKUP: AddFunctionDescription = {
 // XLOOKUP
 // -----------------------------------------------------------------------------
 export const XLOOKUP: AddFunctionDescription = {
-  description: _lt(
+  description: _t(
     `Search a range for a match and return the corresponding item from a second range.`
   ),
   args: [
-    arg("search_key (any)", _lt("The value to search for.")),
+    arg("search_key (any)", _t("The value to search for.")),
     arg(
       "lookup_range (any, range)",
-      _lt("The range to consider for the search. Should be a single column or a single row.")
+      _t("The range to consider for the search. Should be a single column or a single row.")
     ),
     arg(
       "return_range (any, range)",
-      _lt("The range containing the return value. Should have the same dimensions as lookup_range.")
+      _t("The range containing the return value. Should have the same dimensions as lookup_range.")
     ),
     arg(
       "if_not_found (any, lazy, optional)",
-      _lt("If a valid match is not found, return this value.")
+      _t("If a valid match is not found, return this value.")
     ),
     arg(
       `match_mode (any, default=${DEFAULT_MATCH_MODE})`,
-      _lt(
+      _t(
         "(0) Exact match. (-1) Return next smaller item if no match. (1) Return next greater item if no match."
       )
     ),
     arg(
       `search_mode (any, default=${DEFAULT_SEARCH_MODE})`,
-      _lt(
+      _t(
         "(1) Search starting at first item. \
       (-1) Search starting at last item. \
       (2) Perform a binary search that relies on lookup_array being sorted in ascending order. If not sorted, invalid results will be returned. \
@@ -515,16 +515,13 @@ export const XLOOKUP: AddFunctionDescription = {
 
     assert(
       () => lookupRange.length === 1 || lookupRange[0].length === 1,
-      _lt("lookup_range should be either a single row or single column.")
+      _t("lookup_range should be either a single row or single column.")
     );
     assert(
       () => [-1, 1, -2, 2].includes(_searchMode),
-      _lt("searchMode should be a value in [-1, 1, -2, 2].")
+      _t("searchMode should be a value in [-1, 1, -2, 2].")
     );
-    assert(
-      () => [-1, 0, 1].includes(_matchMode),
-      _lt("matchMode should be a value in [-1, 0, 1].")
-    );
+    assert(() => [-1, 0, 1].includes(_matchMode), _t("matchMode should be a value in [-1, 0, 1]."));
 
     const lookupDirection = lookupRange.length === 1 ? "col" : "row";
 
@@ -533,7 +530,7 @@ export const XLOOKUP: AddFunctionDescription = {
         lookupDirection === "col"
           ? returnRange[0].length === lookupRange[0].length
           : returnRange.length === lookupRange.length,
-      _lt("return_range should have the same dimensions as lookup_range.")
+      _t("return_range should have the same dimensions as lookup_range.")
     );
 
     const getElement =

--- a/src/functions/module_math.ts
+++ b/src/functions/module_math.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   Arg,
@@ -33,8 +33,8 @@ const DECIMAL_REPRESENTATION = /^-?[a-z0-9]+$/i;
 // ABS
 // -----------------------------------------------------------------------------
 export const ABS: AddFunctionDescription = {
-  description: _lt("Absolute value of a number."),
-  args: [arg("value (number)", _lt("The number of which to return the absolute value."))],
+  description: _t("Absolute value of a number."),
+  args: [arg("value (number)", _t("The number of which to return the absolute value."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     return Math.abs(toNumber(value, this.locale));
@@ -46,11 +46,11 @@ export const ABS: AddFunctionDescription = {
 // ACOS
 // -----------------------------------------------------------------------------
 export const ACOS: AddFunctionDescription = {
-  description: _lt("Inverse cosine of a value, in radians."),
+  description: _t("Inverse cosine of a value, in radians."),
   args: [
     arg(
       "value (number)",
-      _lt(
+      _t(
         "The value for which to calculate the inverse cosine. Must be between -1 and 1, inclusive."
       )
     ),
@@ -60,7 +60,7 @@ export const ACOS: AddFunctionDescription = {
     const _value = toNumber(value, this.locale);
     assert(
       () => Math.abs(_value) <= 1,
-      _lt("The value (%s) must be between -1 and 1 inclusive.", _value.toString())
+      _t("The value (%s) must be between -1 and 1 inclusive.", _value.toString())
     );
     return Math.acos(_value);
   },
@@ -71,11 +71,11 @@ export const ACOS: AddFunctionDescription = {
 // ACOSH
 // -----------------------------------------------------------------------------
 export const ACOSH: AddFunctionDescription = {
-  description: _lt("Inverse hyperbolic cosine of a number."),
+  description: _t("Inverse hyperbolic cosine of a number."),
   args: [
     arg(
       "value (number)",
-      _lt(
+      _t(
         "The value for which to calculate the inverse hyperbolic cosine. Must be greater than or equal to 1."
       )
     ),
@@ -85,7 +85,7 @@ export const ACOSH: AddFunctionDescription = {
     const _value = toNumber(value, this.locale);
     assert(
       () => _value >= 1,
-      _lt("The value (%s) must be greater than or equal to 1.", _value.toString())
+      _t("The value (%s) must be greater than or equal to 1.", _value.toString())
     );
     return Math.acosh(_value);
   },
@@ -96,8 +96,8 @@ export const ACOSH: AddFunctionDescription = {
 // ACOT
 // -----------------------------------------------------------------------------
 export const ACOT: AddFunctionDescription = {
-  description: _lt("Inverse cotangent of a value."),
-  args: [arg("value (number)", _lt("The value for which to calculate the inverse cotangent."))],
+  description: _t("Inverse cotangent of a value."),
+  args: [arg("value (number)", _t("The value for which to calculate the inverse cotangent."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     const _value = toNumber(value, this.locale);
@@ -114,11 +114,11 @@ export const ACOT: AddFunctionDescription = {
 // ACOTH
 // -----------------------------------------------------------------------------
 export const ACOTH: AddFunctionDescription = {
-  description: _lt("Inverse hyperbolic cotangent of a value."),
+  description: _t("Inverse hyperbolic cotangent of a value."),
   args: [
     arg(
       "value (number)",
-      _lt(
+      _t(
         "The value for which to calculate the inverse hyperbolic cotangent. Must not be between -1 and 1, inclusive."
       )
     ),
@@ -128,7 +128,7 @@ export const ACOTH: AddFunctionDescription = {
     const _value = toNumber(value, this.locale);
     assert(
       () => Math.abs(_value) > 1,
-      _lt("The value (%s) cannot be between -1 and 1 inclusive.", _value.toString())
+      _t("The value (%s) cannot be between -1 and 1 inclusive.", _value.toString())
     );
     return Math.log((_value + 1) / (_value - 1)) / 2;
   },
@@ -139,11 +139,11 @@ export const ACOTH: AddFunctionDescription = {
 // ASIN
 // -----------------------------------------------------------------------------
 export const ASIN: AddFunctionDescription = {
-  description: _lt("Inverse sine of a value, in radians."),
+  description: _t("Inverse sine of a value, in radians."),
   args: [
     arg(
       "value (number)",
-      _lt("The value for which to calculate the inverse sine. Must be between -1 and 1, inclusive.")
+      _t("The value for which to calculate the inverse sine. Must be between -1 and 1, inclusive.")
     ),
   ],
   returns: ["NUMBER"],
@@ -151,7 +151,7 @@ export const ASIN: AddFunctionDescription = {
     const _value = toNumber(value, this.locale);
     assert(
       () => Math.abs(_value) <= 1,
-      _lt("The value (%s) must be between -1 and 1 inclusive.", _value.toString())
+      _t("The value (%s) must be between -1 and 1 inclusive.", _value.toString())
     );
     return Math.asin(_value);
   },
@@ -162,9 +162,9 @@ export const ASIN: AddFunctionDescription = {
 // ASINH
 // -----------------------------------------------------------------------------
 export const ASINH: AddFunctionDescription = {
-  description: _lt("Inverse hyperbolic sine of a number."),
+  description: _t("Inverse hyperbolic sine of a number."),
   args: [
-    arg("value (number)", _lt("The value for which to calculate the inverse hyperbolic sine.")),
+    arg("value (number)", _t("The value for which to calculate the inverse hyperbolic sine.")),
   ],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
@@ -177,8 +177,8 @@ export const ASINH: AddFunctionDescription = {
 // ATAN
 // -----------------------------------------------------------------------------
 export const ATAN: AddFunctionDescription = {
-  description: _lt("Inverse tangent of a value, in radians."),
-  args: [arg("value (number)", _lt("The value for which to calculate the inverse tangent."))],
+  description: _t("Inverse tangent of a value, in radians."),
+  args: [arg("value (number)", _t("The value for which to calculate the inverse tangent."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     return Math.atan(toNumber(value, this.locale));
@@ -190,17 +190,17 @@ export const ATAN: AddFunctionDescription = {
 // ATAN2
 // -----------------------------------------------------------------------------
 export const ATAN2: AddFunctionDescription = {
-  description: _lt("Angle from the X axis to a point (x,y), in radians."),
+  description: _t("Angle from the X axis to a point (x,y), in radians."),
   args: [
     arg(
       "x (number)",
-      _lt(
+      _t(
         "The x coordinate of the endpoint of the line segment for which to calculate the angle from the x-axis."
       )
     ),
     arg(
       "y (number)",
-      _lt(
+      _t(
         "The y coordinate of the endpoint of the line segment for which to calculate the angle from the x-axis."
       )
     ),
@@ -211,7 +211,7 @@ export const ATAN2: AddFunctionDescription = {
     const _y = toNumber(y, this.locale);
     assert(
       () => _x !== 0 || _y !== 0,
-      _lt(`Function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
     return Math.atan2(_y, _x);
   },
@@ -222,11 +222,11 @@ export const ATAN2: AddFunctionDescription = {
 // ATANH
 // -----------------------------------------------------------------------------
 export const ATANH: AddFunctionDescription = {
-  description: _lt("Inverse hyperbolic tangent of a number."),
+  description: _t("Inverse hyperbolic tangent of a number."),
   args: [
     arg(
       "value (number)",
-      _lt(
+      _t(
         "The value for which to calculate the inverse hyperbolic tangent. Must be between -1 and 1, exclusive."
       )
     ),
@@ -236,7 +236,7 @@ export const ATANH: AddFunctionDescription = {
     const _value = toNumber(value, this.locale);
     assert(
       () => Math.abs(_value) < 1,
-      _lt("The value (%s) must be between -1 and 1 exclusive.", _value.toString())
+      _t("The value (%s) must be between -1 and 1 exclusive.", _value.toString())
     );
     return Math.atanh(_value);
   },
@@ -247,12 +247,12 @@ export const ATANH: AddFunctionDescription = {
 // CEILING
 // -----------------------------------------------------------------------------
 export const CEILING: AddFunctionDescription = {
-  description: _lt(`Rounds number up to nearest multiple of factor.`),
+  description: _t(`Rounds number up to nearest multiple of factor.`),
   args: [
-    arg("value (number)", _lt("The value to round up to the nearest integer multiple of factor.")),
+    arg("value (number)", _t("The value to round up to the nearest integer multiple of factor.")),
     arg(
       `factor (number, default=${DEFAULT_FACTOR})`,
-      _lt("The number to whose multiples value will be rounded.")
+      _t("The number to whose multiples value will be rounded.")
     ),
   ],
   returns: ["NUMBER"],
@@ -262,7 +262,7 @@ export const CEILING: AddFunctionDescription = {
     const _factor = toNumber(factor, this.locale);
     assert(
       () => _factor >= 0 || _value <= 0,
-      _lt(
+      _t(
         "The factor (%s) must be positive when the value (%s) is positive.",
         _factor.toString(),
         _value.toString()
@@ -277,21 +277,21 @@ export const CEILING: AddFunctionDescription = {
 // CEILING.MATH
 // -----------------------------------------------------------------------------
 export const CEILING_MATH: AddFunctionDescription = {
-  description: _lt(`Rounds number up to nearest multiple of factor.`),
+  description: _t(`Rounds number up to nearest multiple of factor.`),
   args: [
     arg(
       "number (number)",
-      _lt("The value to round up to the nearest integer multiple of significance.")
+      _t("The value to round up to the nearest integer multiple of significance.")
     ),
     arg(
       `significance (number, default=${DEFAULT_SIGNIFICANCE})`,
-      _lt(
+      _t(
         "The number to whose multiples number will be rounded. The sign of significance will be ignored."
       )
     ),
     arg(
       `mode (number, default=${DEFAULT_MODE})`,
-      _lt(
+      _t(
         "If number is negative, specifies the rounding direction. If 0 or blank, it is rounded towards zero. Otherwise, it is rounded away from zero."
       )
     ),
@@ -328,15 +328,15 @@ export const CEILING_MATH: AddFunctionDescription = {
 // CEILING.PRECISE
 // -----------------------------------------------------------------------------
 export const CEILING_PRECISE: AddFunctionDescription = {
-  description: _lt(`Rounds number up to nearest multiple of factor.`),
+  description: _t(`Rounds number up to nearest multiple of factor.`),
   args: [
     arg(
       "number (number)",
-      _lt("The value to round up to the nearest integer multiple of significance.")
+      _t("The value to round up to the nearest integer multiple of significance.")
     ),
     arg(
       `significance (number, default=${DEFAULT_SIGNIFICANCE})`,
-      _lt("The number to whose multiples number will be rounded.")
+      _t("The number to whose multiples number will be rounded.")
     ),
   ],
   returns: ["NUMBER"],
@@ -351,8 +351,8 @@ export const CEILING_PRECISE: AddFunctionDescription = {
 // COS
 // -----------------------------------------------------------------------------
 export const COS: AddFunctionDescription = {
-  description: _lt("Cosine of an angle provided in radians."),
-  args: [arg("angle (number)", _lt("The angle to find the cosine of, in radians."))],
+  description: _t("Cosine of an angle provided in radians."),
+  args: [arg("angle (number)", _t("The angle to find the cosine of, in radians."))],
   returns: ["NUMBER"],
   compute: function (angle: PrimitiveArgValue): number {
     return Math.cos(toNumber(angle, this.locale));
@@ -364,8 +364,8 @@ export const COS: AddFunctionDescription = {
 // COSH
 // -----------------------------------------------------------------------------
 export const COSH: AddFunctionDescription = {
-  description: _lt("Hyperbolic cosine of any real number."),
-  args: [arg("value (number)", _lt("Any real value to calculate the hyperbolic cosine of."))],
+  description: _t("Hyperbolic cosine of any real number."),
+  args: [arg("value (number)", _t("Any real value to calculate the hyperbolic cosine of."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     return Math.cosh(toNumber(value, this.locale));
@@ -377,14 +377,14 @@ export const COSH: AddFunctionDescription = {
 // COT
 // -----------------------------------------------------------------------------
 export const COT: AddFunctionDescription = {
-  description: _lt("Cotangent of an angle provided in radians."),
-  args: [arg("angle (number)", _lt("The angle to find the cotangent of, in radians."))],
+  description: _t("Cotangent of an angle provided in radians."),
+  args: [arg("angle (number)", _t("The angle to find the cotangent of, in radians."))],
   returns: ["NUMBER"],
   compute: function (angle: PrimitiveArgValue): number {
     const _angle = toNumber(angle, this.locale);
     assert(
       () => _angle !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
     return 1 / Math.tan(_angle);
   },
@@ -395,14 +395,14 @@ export const COT: AddFunctionDescription = {
 // COTH
 // -----------------------------------------------------------------------------
 export const COTH: AddFunctionDescription = {
-  description: _lt("Hyperbolic cotangent of any real number."),
-  args: [arg("value (number)", _lt("Any real value to calculate the hyperbolic cotangent of."))],
+  description: _t("Hyperbolic cotangent of any real number."),
+  args: [arg("value (number)", _t("Any real value to calculate the hyperbolic cotangent of."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     const _value = toNumber(value, this.locale);
     assert(
       () => _value !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
     return 1 / Math.tanh(_value);
   },
@@ -413,15 +413,15 @@ export const COTH: AddFunctionDescription = {
 // COUNTBLANK
 // -----------------------------------------------------------------------------
 export const COUNTBLANK: AddFunctionDescription = {
-  description: _lt("Number of empty values."),
+  description: _t("Number of empty values."),
   args: [
     arg(
       "value1 (any, range)",
-      _lt("The first value or range in which to count the number of blanks.")
+      _t("The first value or range in which to count the number of blanks.")
     ),
     arg(
       "value2 (any, range, repeating)",
-      _lt("Additional values or ranges in which to count the number of blanks.")
+      _t("Additional values or ranges in which to count the number of blanks.")
     ),
   ],
   returns: ["NUMBER"],
@@ -439,10 +439,10 @@ export const COUNTBLANK: AddFunctionDescription = {
 // COUNTIF
 // -----------------------------------------------------------------------------
 export const COUNTIF: AddFunctionDescription = {
-  description: _lt("A conditional count across a range."),
+  description: _t("A conditional count across a range."),
   args: [
-    arg("range (range)", _lt("The range that is tested against criterion.")),
-    arg("criterion (string)", _lt("The pattern or test to apply to range.")),
+    arg("range (range)", _t("The range that is tested against criterion.")),
+    arg("criterion (string)", _t("The pattern or test to apply to range.")),
   ],
   returns: ["NUMBER"],
   compute: function (...argsValues: ArgValue[]): number {
@@ -463,17 +463,17 @@ export const COUNTIF: AddFunctionDescription = {
 // COUNTIFS
 // -----------------------------------------------------------------------------
 export const COUNTIFS: AddFunctionDescription = {
-  description: _lt("Count values depending on multiple criteria."),
+  description: _t("Count values depending on multiple criteria."),
   args: [
-    arg("criteria_range1 (range)", _lt("The range to check against criterion1.")),
-    arg("criterion1 (string)", _lt("The pattern or test to apply to criteria_range1.")),
+    arg("criteria_range1 (range)", _t("The range to check against criterion1.")),
+    arg("criterion1 (string)", _t("The pattern or test to apply to criteria_range1.")),
     arg(
       "criteria_range2 (any, range, repeating)",
-      _lt(
+      _t(
         "Additional ranges over which to evaluate the additional criteria. The filtered set will be the intersection of the sets produced by each criterion-range pair."
       )
     ),
-    arg("criterion2 (string, repeating)", _lt("Additional criteria to check.")),
+    arg("criterion2 (string, repeating)", _t("Additional criteria to check.")),
   ],
   returns: ["NUMBER"],
   compute: function (...argsValues: ArgValue[]): number {
@@ -508,12 +508,12 @@ function isDefined(value: any): boolean {
 }
 
 export const COUNTUNIQUE: AddFunctionDescription = {
-  description: _lt("Counts number of unique values in a range."),
+  description: _t("Counts number of unique values in a range."),
   args: [
-    arg("value1 (any, range)", _lt("The first value or range to consider for uniqueness.")),
+    arg("value1 (any, range)", _t("The first value or range to consider for uniqueness.")),
     arg(
       "value2 (any, range, repeating)",
-      _lt("Additional values or ranges to consider for uniqueness.")
+      _t("Additional values or ranges to consider for uniqueness.")
     ),
   ],
   returns: ["NUMBER"],
@@ -527,26 +527,26 @@ export const COUNTUNIQUE: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const COUNTUNIQUEIFS: AddFunctionDescription = {
-  description: _lt("Counts number of unique values in a range, filtered by a set of criteria."),
+  description: _t("Counts number of unique values in a range, filtered by a set of criteria."),
   args: [
     arg(
       "range (range)",
-      _lt("The range of cells from which the number of unique values will be counted.")
+      _t("The range of cells from which the number of unique values will be counted.")
     ),
-    arg("criteria_range1 (range)", _lt("The range of cells over which to evaluate criterion1.")),
+    arg("criteria_range1 (range)", _t("The range of cells over which to evaluate criterion1.")),
     arg(
       "criterion1 (string)",
-      _lt(
+      _t(
         "The pattern or test to apply to criteria_range1, such that each cell that evaluates to TRUE will be included in the filtered set."
       )
     ),
     arg(
       "criteria_range2 (any, range, repeating)",
-      _lt(
+      _t(
         "Additional ranges over which to evaluate the additional criteria. The filtered set will be the intersection of the sets produced by each criterion-range pair."
       )
     ),
-    arg("criterion2 (string, repeating)", _lt("The pattern or test to apply to criteria_range2.")),
+    arg("criterion2 (string, repeating)", _t("The pattern or test to apply to criteria_range2.")),
   ],
   returns: ["NUMBER"],
   compute: function (range: MatrixArgValue, ...argsValues: ArgValue[]): number {
@@ -569,14 +569,14 @@ export const COUNTUNIQUEIFS: AddFunctionDescription = {
 // CSC
 // -----------------------------------------------------------------------------
 export const CSC: AddFunctionDescription = {
-  description: _lt("Cosecant of an angle provided in radians."),
-  args: [arg("angle (number)", _lt("The angle to find the cosecant of, in radians."))],
+  description: _t("Cosecant of an angle provided in radians."),
+  args: [arg("angle (number)", _t("The angle to find the cosecant of, in radians."))],
   returns: ["NUMBER"],
   compute: function (angle: PrimitiveArgValue): number {
     const _angle = toNumber(angle, this.locale);
     assert(
       () => _angle !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
     return 1 / Math.sin(_angle);
   },
@@ -587,14 +587,14 @@ export const CSC: AddFunctionDescription = {
 // CSCH
 // -----------------------------------------------------------------------------
 export const CSCH: AddFunctionDescription = {
-  description: _lt("Hyperbolic cosecant of any real number."),
-  args: [arg("value (number)", _lt("Any real value to calculate the hyperbolic cosecant of."))],
+  description: _t("Hyperbolic cosecant of any real number."),
+  args: [arg("value (number)", _t("Any real value to calculate the hyperbolic cosecant of."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     const _value = toNumber(value, this.locale);
     assert(
       () => _value !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
     return 1 / Math.sinh(_value);
   },
@@ -605,10 +605,10 @@ export const CSCH: AddFunctionDescription = {
 // DECIMAL
 // -----------------------------------------------------------------------------
 export const DECIMAL: AddFunctionDescription = {
-  description: _lt("Converts from another base to decimal."),
+  description: _t("Converts from another base to decimal."),
   args: [
-    arg("value (string)", _lt("The number to convert.")),
-    arg(",base (number)", _lt("The base to convert the value from.")),
+    arg("value (string)", _t("The number to convert.")),
+    arg(",base (number)", _t("The base to convert the value from.")),
   ],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue, base: PrimitiveArgValue): number {
@@ -617,7 +617,7 @@ export const DECIMAL: AddFunctionDescription = {
 
     assert(
       () => 2 <= _base && _base <= 36,
-      _lt("The base (%s) must be between 2 and 36 inclusive.", _base.toString())
+      _t("The base (%s) must be between 2 and 36 inclusive.", _base.toString())
     );
 
     const _value = toString(value);
@@ -632,13 +632,13 @@ export const DECIMAL: AddFunctionDescription = {
      */
     assert(
       () => !!DECIMAL_REPRESENTATION.test(_value),
-      _lt("The value (%s) must be a valid base %s representation.", _value, _base.toString())
+      _t("The value (%s) must be a valid base %s representation.", _value, _base.toString())
     );
 
     const deci = parseInt(_value, _base);
     assert(
       () => !isNaN(deci),
-      _lt("The value (%s) must be a valid base %s representation.", _value, _base.toString())
+      _t("The value (%s) must be a valid base %s representation.", _value, _base.toString())
     );
     return deci;
   },
@@ -649,8 +649,8 @@ export const DECIMAL: AddFunctionDescription = {
 // DEGREES
 // -----------------------------------------------------------------------------
 export const DEGREES: AddFunctionDescription = {
-  description: _lt(`Converts an angle value in radians to degrees.`),
-  args: [arg("angle (number)", _lt("The angle to convert from radians to degrees."))],
+  description: _t(`Converts an angle value in radians to degrees.`),
+  args: [arg("angle (number)", _t("The angle to convert from radians to degrees."))],
   returns: ["NUMBER"],
   compute: function (angle: PrimitiveArgValue): number {
     return (toNumber(angle, this.locale) * 180) / Math.PI;
@@ -662,8 +662,8 @@ export const DEGREES: AddFunctionDescription = {
 // EXP
 // -----------------------------------------------------------------------------
 export const EXP: AddFunctionDescription = {
-  description: _lt(`Euler's number, e (~2.718) raised to a power.`),
-  args: [arg("value (number)", _lt("The exponent to raise e."))],
+  description: _t(`Euler's number, e (~2.718) raised to a power.`),
+  args: [arg("value (number)", _t("The exponent to raise e."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     return Math.exp(toNumber(value, this.locale));
@@ -675,15 +675,12 @@ export const EXP: AddFunctionDescription = {
 // FLOOR
 // -----------------------------------------------------------------------------
 export const FLOOR: AddFunctionDescription = {
-  description: _lt(`Rounds number down to nearest multiple of factor.`),
+  description: _t(`Rounds number down to nearest multiple of factor.`),
   args: [
-    arg(
-      "value (number)",
-      _lt("The value to round down to the nearest integer multiple of factor.")
-    ),
+    arg("value (number)", _t("The value to round down to the nearest integer multiple of factor.")),
     arg(
       `factor (number, default=${DEFAULT_FACTOR})`,
-      _lt("The number to whose multiples value will be rounded.")
+      _t("The number to whose multiples value will be rounded.")
     ),
   ],
   returns: ["NUMBER"],
@@ -693,7 +690,7 @@ export const FLOOR: AddFunctionDescription = {
     const _factor = toNumber(factor, this.locale);
     assert(
       () => _factor >= 0 || _value <= 0,
-      _lt(
+      _t(
         "The factor (%s) must be positive when the value (%s) is positive.",
         _factor.toString(),
         _value.toString()
@@ -708,21 +705,21 @@ export const FLOOR: AddFunctionDescription = {
 // FLOOR.MATH
 // -----------------------------------------------------------------------------
 export const FLOOR_MATH: AddFunctionDescription = {
-  description: _lt(`Rounds number down to nearest multiple of factor.`),
+  description: _t(`Rounds number down to nearest multiple of factor.`),
   args: [
     arg(
       "number (number)",
-      _lt("The value to round down to the nearest integer multiple of significance.")
+      _t("The value to round down to the nearest integer multiple of significance.")
     ),
     arg(
       `significance (number, default=${DEFAULT_SIGNIFICANCE})`,
-      _lt(
+      _t(
         "The number to whose multiples number will be rounded. The sign of significance will be ignored."
       )
     ),
     arg(
       `mode (number, default=${DEFAULT_MODE})`,
-      _lt(
+      _t(
         "If number is negative, specifies the rounding direction. If 0 or blank, it is rounded away from zero. Otherwise, it is rounded towards zero."
       )
     ),
@@ -758,15 +755,15 @@ export const FLOOR_MATH: AddFunctionDescription = {
 // FLOOR.PRECISE
 // -----------------------------------------------------------------------------
 export const FLOOR_PRECISE: AddFunctionDescription = {
-  description: _lt(`Rounds number down to nearest multiple of factor.`),
+  description: _t(`Rounds number down to nearest multiple of factor.`),
   args: [
     arg(
       "number (number)",
-      _lt("The value to round down to the nearest integer multiple of significance.")
+      _t("The value to round down to the nearest integer multiple of significance.")
     ),
     arg(
       `significance (number, default=${DEFAULT_SIGNIFICANCE})`,
-      _lt("The number to whose multiples number will be rounded.")
+      _t("The number to whose multiples number will be rounded.")
     ),
   ],
   returns: ["NUMBER"],
@@ -784,8 +781,8 @@ export const FLOOR_PRECISE: AddFunctionDescription = {
 // ISEVEN
 // -----------------------------------------------------------------------------
 export const ISEVEN: AddFunctionDescription = {
-  description: _lt(`Whether the provided value is even.`),
-  args: [arg("value (number)", _lt("The value to be verified as even."))],
+  description: _t(`Whether the provided value is even.`),
+  args: [arg("value (number)", _t("The value to be verified as even."))],
   returns: ["BOOLEAN"],
   compute: function (value: PrimitiveArgValue): boolean {
     const _value = strictToNumber(value, this.locale);
@@ -799,15 +796,15 @@ export const ISEVEN: AddFunctionDescription = {
 // ISO.CEILING
 // -----------------------------------------------------------------------------
 export const ISO_CEILING: AddFunctionDescription = {
-  description: _lt(`Rounds number up to nearest multiple of factor.`),
+  description: _t(`Rounds number up to nearest multiple of factor.`),
   args: [
     arg(
       "number (number)",
-      _lt("The value to round up to the nearest integer multiple of significance.")
+      _t("The value to round up to the nearest integer multiple of significance.")
     ),
     arg(
       `significance (number, default=${DEFAULT_SIGNIFICANCE})`,
-      _lt("The number to whose multiples number will be rounded.")
+      _t("The number to whose multiples number will be rounded.")
     ),
   ],
   returns: ["NUMBER"],
@@ -825,8 +822,8 @@ export const ISO_CEILING: AddFunctionDescription = {
 // ISODD
 // -----------------------------------------------------------------------------
 export const ISODD: AddFunctionDescription = {
-  description: _lt(`Whether the provided value is even.`),
-  args: [arg("value (number)", _lt("The value to be verified as even."))],
+  description: _t(`Whether the provided value is even.`),
+  args: [arg("value (number)", _t("The value to be verified as even."))],
   returns: ["BOOLEAN"],
   compute: function (value: PrimitiveArgValue): boolean {
     const _value = strictToNumber(value, this.locale);
@@ -840,12 +837,12 @@ export const ISODD: AddFunctionDescription = {
 // LN
 // -----------------------------------------------------------------------------
 export const LN: AddFunctionDescription = {
-  description: _lt(`The logarithm of a number, base e (euler's number).`),
-  args: [arg("value (number)", _lt("The value for which to calculate the logarithm, base e."))],
+  description: _t(`The logarithm of a number, base e (euler's number).`),
+  args: [arg("value (number)", _t("The value for which to calculate the logarithm, base e."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     const _value = toNumber(value, this.locale);
-    assert(() => _value > 0, _lt("The value (%s) must be strictly positive.", _value.toString()));
+    assert(() => _value > 0, _t("The value (%s) must be strictly positive.", _value.toString()));
     return Math.log(_value);
   },
   isExported: true,
@@ -855,17 +852,17 @@ export const LN: AddFunctionDescription = {
 // MOD
 // -----------------------------------------------------------------------------
 export const MOD: AddFunctionDescription = {
-  description: _lt(`Modulo (remainder) operator.`),
+  description: _t(`Modulo (remainder) operator.`),
   args: [
-    arg("dividend (number)", _lt("The number to be divided to find the remainder.")),
-    arg("divisor (number)", _lt("The number to divide by.")),
+    arg("dividend (number)", _t("The number to be divided to find the remainder.")),
+    arg("divisor (number)", _t("The number to divide by.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (dividend: PrimitiveArg) => dividend?.format,
   compute: function (dividend: PrimitiveArgValue, divisor: PrimitiveArgValue): number {
     const _divisor = toNumber(divisor, this.locale);
 
-    assert(() => _divisor !== 0, _lt("The divisor must be different from 0."));
+    assert(() => _divisor !== 0, _t("The divisor must be different from 0."));
 
     const _dividend = toNumber(dividend, this.locale);
     const modulus = _dividend % _divisor;
@@ -882,17 +879,17 @@ export const MOD: AddFunctionDescription = {
 // MUNIT
 // -----------------------------------------------------------------------------
 export const MUNIT: AddFunctionDescription = {
-  description: _lt("Returns a n x n unit matrix, where n is the input dimension."),
+  description: _t("Returns a n x n unit matrix, where n is the input dimension."),
   args: [
     arg(
       "dimension (number)",
-      _lt("An integer specifying the dimension size of the unit matrix. It must be positive.")
+      _t("An integer specifying the dimension size of the unit matrix. It must be positive.")
     ),
   ],
   returns: ["RANGE<NUMBER>"],
   compute: function (n: PrimitiveArgValue): number[][] {
     const _n = toInteger(n, this.locale);
-    assertPositive(_lt("The argument dimension must be positive"), _n);
+    assertPositive(_t("The argument dimension must be positive"), _n);
     return getUnitMatrix(_n);
   },
   isExported: true,
@@ -902,8 +899,8 @@ export const MUNIT: AddFunctionDescription = {
 // ODD
 // -----------------------------------------------------------------------------
 export const ODD: AddFunctionDescription = {
-  description: _lt(`Rounds a number up to the nearest odd integer.`),
-  args: [arg("value (number)", _lt("The value to round to the next greatest odd number."))],
+  description: _t(`Rounds a number up to the nearest odd integer.`),
+  args: [arg("value (number)", _t("The value to round to the next greatest odd number."))],
   returns: ["NUMBER"],
   computeFormat: (number: PrimitiveArg) => number?.format,
   compute: function (value: PrimitiveArgValue): number {
@@ -920,7 +917,7 @@ export const ODD: AddFunctionDescription = {
 // PI
 // -----------------------------------------------------------------------------
 export const PI: AddFunctionDescription = {
-  description: _lt(`The number pi.`),
+  description: _t(`The number pi.`),
   args: [],
   returns: ["NUMBER"],
   compute: function (): number {
@@ -933,10 +930,10 @@ export const PI: AddFunctionDescription = {
 // POWER
 // -----------------------------------------------------------------------------
 export const POWER: AddFunctionDescription = {
-  description: _lt(`A number raised to a power.`),
+  description: _t(`A number raised to a power.`),
   args: [
-    arg("base (number)", _lt("The number to raise to the exponent power.")),
-    arg("exponent (number)", _lt("The exponent to raise base to.")),
+    arg("base (number)", _t("The number to raise to the exponent power.")),
+    arg("exponent (number)", _t("The exponent to raise base to.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (base: PrimitiveArg) => base?.format,
@@ -945,7 +942,7 @@ export const POWER: AddFunctionDescription = {
     const _exponent = toNumber(exponent, this.locale);
     assert(
       () => _base >= 0 || Number.isInteger(_exponent),
-      _lt("The exponent (%s) must be an integer when the base is negative.", _exponent.toString())
+      _t("The exponent (%s) must be an integer when the base is negative.", _exponent.toString())
     );
     return Math.pow(_base, _exponent);
   },
@@ -956,15 +953,15 @@ export const POWER: AddFunctionDescription = {
 // PRODUCT
 // -----------------------------------------------------------------------------
 export const PRODUCT: AddFunctionDescription = {
-  description: _lt("Result of multiplying a series of numbers together."),
+  description: _t("Result of multiplying a series of numbers together."),
   args: [
     arg(
       "factor1 (number, range<number>)",
-      _lt("The first number or range to calculate for the product.")
+      _t("The first number or range to calculate for the product.")
     ),
     arg(
       "factor2 (number, range<number>, repeating)",
-      _lt("More numbers or ranges to calculate for the product.")
+      _t("More numbers or ranges to calculate for the product.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1001,7 +998,7 @@ export const PRODUCT: AddFunctionDescription = {
 // RAND
 // -----------------------------------------------------------------------------
 export const RAND: AddFunctionDescription = {
-  description: _lt("A random number between 0 inclusive and 1 exclusive."),
+  description: _t("A random number between 0 inclusive and 1 exclusive."),
   args: [],
   returns: ["NUMBER"],
   compute: function (): number {
@@ -1014,13 +1011,13 @@ export const RAND: AddFunctionDescription = {
 // RANDARRAY
 // -----------------------------------------------------------------------------
 export const RANDARRAY: AddFunctionDescription = {
-  description: _lt("Returns a grid of random numbers between 0 inclusive and 1 exclusive."),
+  description: _t("Returns a grid of random numbers between 0 inclusive and 1 exclusive."),
   args: [
-    arg("rows (number, default=1)", _lt("The number of rows to be returned.")),
-    arg("columns (number, default=1)", _lt("The number of columns to be returned.")),
-    arg("min (number, default=0)", _lt("The minimum number you would like returned.")),
-    arg("max (number, default=1)", _lt("The maximum number you would like returned.")),
-    arg("whole_number (number, default=FALSE)", _lt("Return a whole number or a decimal value.")),
+    arg("rows (number, default=1)", _t("The number of rows to be returned.")),
+    arg("columns (number, default=1)", _t("The number of columns to be returned.")),
+    arg("min (number, default=0)", _t("The minimum number you would like returned.")),
+    arg("max (number, default=1)", _t("The maximum number you would like returned.")),
+    arg("whole_number (number, default=FALSE)", _t("Return a whole number or a decimal value.")),
   ],
   returns: ["RANGE<NUMBER>"],
   compute: function (
@@ -1036,11 +1033,11 @@ export const RANDARRAY: AddFunctionDescription = {
     const _max = toNumber(max, this.locale);
     const _whole_number = toBoolean(whole_number);
 
-    assertPositive(_lt("The number columns (%s) must be positive.", _cols.toString()), _cols);
-    assertPositive(_lt("The number rows (%s) must be positive.", _rows.toString()), _rows);
+    assertPositive(_t("The number columns (%s) must be positive.", _cols.toString()), _cols);
+    assertPositive(_t("The number rows (%s) must be positive.", _rows.toString()), _rows);
     assert(
       () => _min <= _max,
-      _lt(
+      _t(
         "The maximum (%s) must be greater than or equal to the minimum (%s).",
         _max.toString(),
         _min.toString()
@@ -1049,7 +1046,7 @@ export const RANDARRAY: AddFunctionDescription = {
     if (_whole_number) {
       assert(
         () => Number.isInteger(_min) && Number.isInteger(_max),
-        _lt(
+        _t(
           "The maximum (%s) and minimum (%s) must be integers when whole_number is TRUE.",
           _max.toString(),
           _min.toString()
@@ -1077,10 +1074,10 @@ export const RANDARRAY: AddFunctionDescription = {
 // RANDBETWEEN
 // -----------------------------------------------------------------------------
 export const RANDBETWEEN: AddFunctionDescription = {
-  description: _lt("Random integer between two values, inclusive."),
+  description: _t("Random integer between two values, inclusive."),
   args: [
-    arg("low (number)", _lt("The low end of the random range.")),
-    arg("high (number)", _lt("The high end of the random range.")),
+    arg("low (number)", _t("The low end of the random range.")),
+    arg("high (number)", _t("The high end of the random range.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (low: PrimitiveArg) => low?.format,
@@ -1097,7 +1094,7 @@ export const RANDBETWEEN: AddFunctionDescription = {
 
     assert(
       () => _low <= _high,
-      _lt(
+      _t(
         "The high (%s) must be greater than or equal to the low (%s).",
         _high.toString(),
         _low.toString()
@@ -1112,12 +1109,12 @@ export const RANDBETWEEN: AddFunctionDescription = {
 // ROUND
 // -----------------------------------------------------------------------------
 export const ROUND: AddFunctionDescription = {
-  description: _lt("Rounds a number according to standard rules."),
+  description: _t("Rounds a number according to standard rules."),
   args: [
-    arg("value (number)", _lt("The value to round to places number of places.")),
+    arg("value (number)", _t("The value to round to places number of places.")),
     arg(
       `places (number, default=${DEFAULT_PLACES})`,
-      _lt("The number of decimal places to which to round.")
+      _t("The number of decimal places to which to round.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1145,15 +1142,15 @@ export const ROUND: AddFunctionDescription = {
 // ROUNDDOWN
 // -----------------------------------------------------------------------------
 export const ROUNDDOWN: AddFunctionDescription = {
-  description: _lt(`Rounds down a number.`),
+  description: _t(`Rounds down a number.`),
   args: [
     arg(
       "value (number)",
-      _lt("The value to round to places number of places, always rounding down.")
+      _t("The value to round to places number of places, always rounding down.")
     ),
     arg(
       `places (number, default=${DEFAULT_PLACES})`,
-      _lt("The number of decimal places to which to round.")
+      _t("The number of decimal places to which to round.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1181,15 +1178,12 @@ export const ROUNDDOWN: AddFunctionDescription = {
 // ROUNDUP
 // -----------------------------------------------------------------------------
 export const ROUNDUP: AddFunctionDescription = {
-  description: _lt(`Rounds up a number.`),
+  description: _t(`Rounds up a number.`),
   args: [
-    arg(
-      "value (number)",
-      _lt("The value to round to places number of places, always rounding up.")
-    ),
+    arg("value (number)", _t("The value to round to places number of places, always rounding up.")),
     arg(
       `places (number, default=${DEFAULT_PLACES})`,
-      _lt("The number of decimal places to which to round.")
+      _t("The number of decimal places to which to round.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1217,8 +1211,8 @@ export const ROUNDUP: AddFunctionDescription = {
 // SEC
 // -----------------------------------------------------------------------------
 export const SEC: AddFunctionDescription = {
-  description: _lt("Secant of an angle provided in radians."),
-  args: [arg("angle (number)", _lt("The angle to find the secant of, in radians."))],
+  description: _t("Secant of an angle provided in radians."),
+  args: [arg("angle (number)", _t("The angle to find the secant of, in radians."))],
   returns: ["NUMBER"],
   compute: function (angle: PrimitiveArgValue): number {
     return 1 / Math.cos(toNumber(angle, this.locale));
@@ -1230,8 +1224,8 @@ export const SEC: AddFunctionDescription = {
 // SECH
 // -----------------------------------------------------------------------------
 export const SECH: AddFunctionDescription = {
-  description: _lt("Hyperbolic secant of any real number."),
-  args: [arg("value (number)", _lt("Any real value to calculate the hyperbolic secant of."))],
+  description: _t("Hyperbolic secant of any real number."),
+  args: [arg("value (number)", _t("Any real value to calculate the hyperbolic secant of."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     return 1 / Math.cosh(toNumber(value, this.locale));
@@ -1243,8 +1237,8 @@ export const SECH: AddFunctionDescription = {
 // SIN
 // -----------------------------------------------------------------------------
 export const SIN: AddFunctionDescription = {
-  description: _lt("Sine of an angle provided in radians."),
-  args: [arg("angle (number)", _lt("The angle to find the sine of, in radians."))],
+  description: _t("Sine of an angle provided in radians."),
+  args: [arg("angle (number)", _t("The angle to find the sine of, in radians."))],
   returns: ["NUMBER"],
   compute: function (angle: PrimitiveArgValue): number {
     return Math.sin(toNumber(angle, this.locale));
@@ -1256,8 +1250,8 @@ export const SIN: AddFunctionDescription = {
 // SINH
 // -----------------------------------------------------------------------------
 export const SINH: AddFunctionDescription = {
-  description: _lt("Hyperbolic sine of any real number."),
-  args: [arg("value (number)", _lt("Any real value to calculate the hyperbolic sine of."))],
+  description: _t("Hyperbolic sine of any real number."),
+  args: [arg("value (number)", _t("Any real value to calculate the hyperbolic sine of."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     return Math.sinh(toNumber(value, this.locale));
@@ -1269,13 +1263,13 @@ export const SINH: AddFunctionDescription = {
 // SQRT
 // -----------------------------------------------------------------------------
 export const SQRT: AddFunctionDescription = {
-  description: _lt("Positive square root of a positive number."),
-  args: [arg("value (number)", _lt("The number for which to calculate the positive square root."))],
+  description: _t("Positive square root of a positive number."),
+  args: [arg("value (number)", _t("The number for which to calculate the positive square root."))],
   returns: ["NUMBER"],
   computeFormat: (value: PrimitiveArg) => value?.format,
   compute: function (value: PrimitiveArgValue): number {
     const _value = toNumber(value, this.locale);
-    assert(() => _value >= 0, _lt("The value (%s) must be positive or null.", _value.toString()));
+    assert(() => _value >= 0, _t("The value (%s) must be positive or null.", _value.toString()));
     return Math.sqrt(_value);
   },
   isExported: true,
@@ -1285,12 +1279,12 @@ export const SQRT: AddFunctionDescription = {
 // SUM
 // -----------------------------------------------------------------------------
 export const SUM: AddFunctionDescription = {
-  description: _lt("Sum of a series of numbers and/or cells."),
+  description: _t("Sum of a series of numbers and/or cells."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first number or range to add together.")),
+    arg("value1 (number, range<number>)", _t("The first number or range to add together.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional numbers or ranges to add to value1.")
+      _t("Additional numbers or ranges to add to value1.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1307,13 +1301,13 @@ export const SUM: AddFunctionDescription = {
 // SUMIF
 // -----------------------------------------------------------------------------
 export const SUMIF: AddFunctionDescription = {
-  description: _lt("A conditional sum across a range."),
+  description: _t("A conditional sum across a range."),
   args: [
-    arg("criteria_range (range)", _lt("The range which is tested against criterion.")),
-    arg("criterion (string)", _lt("The pattern or test to apply to range.")),
+    arg("criteria_range (range)", _t("The range which is tested against criterion.")),
+    arg("criterion (string)", _t("The pattern or test to apply to range.")),
     arg(
       "sum_range (range, default=criteria_range)",
-      _lt("The range to be summed, if different from range.")
+      _t("The range to be summed, if different from range.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1346,13 +1340,13 @@ export const SUMIF: AddFunctionDescription = {
 // SUMIFS
 // -----------------------------------------------------------------------------
 export const SUMIFS: AddFunctionDescription = {
-  description: _lt("Sums a range depending on multiple criteria."),
+  description: _t("Sums a range depending on multiple criteria."),
   args: [
-    arg("sum_range (range)", _lt("The range to sum.")),
-    arg("criteria_range1 (range)", _lt("The range to check against criterion1.")),
-    arg("criterion1 (string)", _lt("The pattern or test to apply to criteria_range1.")),
-    arg("criteria_range2 (any, range, repeating)", _lt("Additional ranges to check.")),
-    arg("criterion2 (string, repeating)", _lt("Additional criteria to check.")),
+    arg("sum_range (range)", _t("The range to sum.")),
+    arg("criteria_range1 (range)", _t("The range to check against criterion1.")),
+    arg("criterion1 (string)", _t("The pattern or test to apply to criteria_range1.")),
+    arg("criteria_range2 (any, range, repeating)", _t("Additional ranges to check.")),
+    arg("criterion2 (string, repeating)", _t("Additional criteria to check.")),
   ],
   returns: ["NUMBER"],
   compute: function (sumRange: MatrixArgValue, ...criters: ArgValue[]): number {
@@ -1376,8 +1370,8 @@ export const SUMIFS: AddFunctionDescription = {
 // TAN
 // -----------------------------------------------------------------------------
 export const TAN: AddFunctionDescription = {
-  description: _lt("Tangent of an angle provided in radians."),
-  args: [arg("angle (number)", _lt("The angle to find the tangent of, in radians."))],
+  description: _t("Tangent of an angle provided in radians."),
+  args: [arg("angle (number)", _t("The angle to find the tangent of, in radians."))],
   returns: ["NUMBER"],
   compute: function (angle: PrimitiveArgValue): number {
     return Math.tan(toNumber(angle, this.locale));
@@ -1389,8 +1383,8 @@ export const TAN: AddFunctionDescription = {
 // TANH
 // -----------------------------------------------------------------------------
 export const TANH: AddFunctionDescription = {
-  description: _lt("Hyperbolic tangent of any real number."),
-  args: [arg("value (number)", _lt("Any real value to calculate the hyperbolic tangent of."))],
+  description: _t("Hyperbolic tangent of any real number."),
+  args: [arg("value (number)", _t("Any real value to calculate the hyperbolic tangent of."))],
   returns: ["NUMBER"],
   compute: function (value: PrimitiveArgValue): number {
     return Math.tanh(toNumber(value, this.locale));
@@ -1402,12 +1396,12 @@ export const TANH: AddFunctionDescription = {
 // TRUNC
 // -----------------------------------------------------------------------------
 export const TRUNC: AddFunctionDescription = {
-  description: _lt("Truncates a number."),
+  description: _t("Truncates a number."),
   args: [
-    arg("value (number)", _lt("The value to be truncated.")),
+    arg("value (number)", _t("The value to be truncated.")),
     arg(
       `places (number, default=${DEFAULT_PLACES})`,
-      _lt("The number of significant digits to the right of the decimal point to retain.")
+      _t("The number of significant digits to the right of the decimal point to retain.")
     ),
   ],
   returns: ["NUMBER"],

--- a/src/functions/module_operators.ts
+++ b/src/functions/module_operators.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   FunctionReturnValue,
@@ -13,10 +13,10 @@ import { POWER } from "./module_math";
 // ADD
 // -----------------------------------------------------------------------------
 export const ADD: AddFunctionDescription = {
-  description: _lt(`Sum of two numbers.`),
+  description: _t(`Sum of two numbers.`),
   args: [
-    arg("value1 (number)", _lt("The first addend.")),
-    arg("value2 (number)", _lt("The second addend.")),
+    arg("value1 (number)", _t("The first addend.")),
+    arg("value2 (number)", _t("The second addend.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (value1: PrimitiveArg, value2: PrimitiveArg) => value1?.format || value2?.format,
@@ -29,10 +29,10 @@ export const ADD: AddFunctionDescription = {
 // CONCAT
 // -----------------------------------------------------------------------------
 export const CONCAT: AddFunctionDescription = {
-  description: _lt(`Concatenation of two values.`),
+  description: _t(`Concatenation of two values.`),
   args: [
-    arg("value1 (string)", _lt("The value to which value2 will be appended.")),
-    arg("value2 (string)", _lt("The value to append to value1.")),
+    arg("value1 (string)", _t("The value to which value2 will be appended.")),
+    arg("value2 (string)", _t("The value to append to value1.")),
   ],
   returns: ["STRING"],
   compute: function (value1: PrimitiveArgValue, value2: PrimitiveArgValue): string {
@@ -45,17 +45,17 @@ export const CONCAT: AddFunctionDescription = {
 // DIVIDE
 // -----------------------------------------------------------------------------
 export const DIVIDE: AddFunctionDescription = {
-  description: _lt(`One number divided by another.`),
+  description: _t(`One number divided by another.`),
   args: [
-    arg("dividend (number)", _lt("The number to be divided.")),
-    arg("divisor (number)", _lt("The number to divide by.")),
+    arg("dividend (number)", _t("The number to be divided.")),
+    arg("divisor (number)", _t("The number to divide by.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (dividend: PrimitiveArg, divisor: PrimitiveArg) =>
     dividend?.format || divisor?.format,
   compute: function (dividend: PrimitiveArgValue, divisor: PrimitiveArgValue): number {
     const _divisor = toNumber(divisor, this.locale);
-    assert(() => _divisor !== 0, _lt("The divisor must be different from zero."));
+    assert(() => _divisor !== 0, _t("The divisor must be different from zero."));
     return toNumber(dividend, this.locale) / _divisor;
   },
 };
@@ -70,10 +70,10 @@ function isEmpty(value: PrimitiveArgValue): boolean {
 const getNeutral = { number: 0, string: "", boolean: false };
 
 export const EQ: AddFunctionDescription = {
-  description: _lt(`Equal.`),
+  description: _t(`Equal.`),
   args: [
-    arg("value1 (any)", _lt("The first value.")),
-    arg("value2 (any)", _lt("The value to test against value1 for equality.")),
+    arg("value1 (any)", _t("The first value.")),
+    arg("value2 (any)", _t("The value to test against value1 for equality.")),
   ],
   returns: ["BOOLEAN"],
   compute: function (value1: PrimitiveArgValue, value2: PrimitiveArgValue): boolean {
@@ -117,10 +117,10 @@ function applyRelationalOperator(
 }
 
 export const GT: AddFunctionDescription = {
-  description: _lt(`Strictly greater than.`),
+  description: _t(`Strictly greater than.`),
   args: [
-    arg("value1 (any)", _lt("The value to test as being greater than value2.")),
-    arg("value2 (any)", _lt("The second value.")),
+    arg("value1 (any)", _t("The value to test as being greater than value2.")),
+    arg("value2 (any)", _t("The second value.")),
   ],
   returns: ["BOOLEAN"],
   compute: function (value1: PrimitiveArgValue, value2: PrimitiveArgValue): boolean {
@@ -134,10 +134,10 @@ export const GT: AddFunctionDescription = {
 // GTE
 // -----------------------------------------------------------------------------
 export const GTE: AddFunctionDescription = {
-  description: _lt(`Greater than or equal to.`),
+  description: _t(`Greater than or equal to.`),
   args: [
-    arg("value1 (any)", _lt("The value to test as being greater than or equal to value2.")),
-    arg("value2 (any)", _lt("The second value.")),
+    arg("value1 (any)", _t("The value to test as being greater than or equal to value2.")),
+    arg("value2 (any)", _t("The second value.")),
   ],
   returns: ["BOOLEAN"],
   compute: function (value1: PrimitiveArgValue, value2: PrimitiveArgValue): boolean {
@@ -151,10 +151,10 @@ export const GTE: AddFunctionDescription = {
 // LT
 // -----------------------------------------------------------------------------
 export const LT: AddFunctionDescription = {
-  description: _lt(`Less than.`),
+  description: _t(`Less than.`),
   args: [
-    arg("value1 (any)", _lt("The value to test as being less than value2.")),
-    arg("value2 (any)", _lt("The second value.")),
+    arg("value1 (any)", _t("The value to test as being less than value2.")),
+    arg("value2 (any)", _t("The second value.")),
   ],
   returns: ["BOOLEAN"],
   compute: function (value1: PrimitiveArgValue, value2: PrimitiveArgValue): boolean {
@@ -166,10 +166,10 @@ export const LT: AddFunctionDescription = {
 // LTE
 // -----------------------------------------------------------------------------
 export const LTE: AddFunctionDescription = {
-  description: _lt(`Less than or equal to.`),
+  description: _t(`Less than or equal to.`),
   args: [
-    arg("value1 (any)", _lt("The value to test as being less than or equal to value2.")),
-    arg("value2 (any)", _lt("The second value.")),
+    arg("value1 (any)", _t("The value to test as being less than or equal to value2.")),
+    arg("value2 (any)", _t("The second value.")),
   ],
   returns: ["BOOLEAN"],
   compute: function (value1: PrimitiveArgValue, value2: PrimitiveArgValue): boolean {
@@ -181,10 +181,10 @@ export const LTE: AddFunctionDescription = {
 // MINUS
 // -----------------------------------------------------------------------------
 export const MINUS: AddFunctionDescription = {
-  description: _lt(`Difference of two numbers.`),
+  description: _t(`Difference of two numbers.`),
   args: [
-    arg("value1 (number)", _lt("The minuend, or number to be subtracted from.")),
-    arg("value2 (number)", _lt("The subtrahend, or number to subtract from value1.")),
+    arg("value1 (number)", _t("The minuend, or number to be subtracted from.")),
+    arg("value2 (number)", _t("The subtrahend, or number to subtract from value1.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (value1: PrimitiveArg, value2: PrimitiveArg) => value1?.format || value2?.format,
@@ -197,10 +197,10 @@ export const MINUS: AddFunctionDescription = {
 // MULTIPLY
 // -----------------------------------------------------------------------------
 export const MULTIPLY: AddFunctionDescription = {
-  description: _lt(`Product of two numbers`),
+  description: _t(`Product of two numbers`),
   args: [
-    arg("factor1 (number)", _lt("The first multiplicand.")),
-    arg("factor2 (number)", _lt("The second multiplicand.")),
+    arg("factor1 (number)", _t("The first multiplicand.")),
+    arg("factor2 (number)", _t("The second multiplicand.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (factor1: PrimitiveArg, factor2: PrimitiveArg) =>
@@ -214,10 +214,10 @@ export const MULTIPLY: AddFunctionDescription = {
 // NE
 // -----------------------------------------------------------------------------
 export const NE: AddFunctionDescription = {
-  description: _lt(`Not equal.`),
+  description: _t(`Not equal.`),
   args: [
-    arg("value1 (any)", _lt("The first value.")),
-    arg("value2 (any)", _lt("The value to test against value1 for inequality.")),
+    arg("value1 (any)", _t("The first value.")),
+    arg("value2 (any)", _t("The value to test against value1 for inequality.")),
   ],
   returns: ["BOOLEAN"],
   compute: function (value1: PrimitiveArgValue, value2: PrimitiveArgValue): boolean {
@@ -229,10 +229,10 @@ export const NE: AddFunctionDescription = {
 // POW
 // -----------------------------------------------------------------------------
 export const POW: AddFunctionDescription = {
-  description: _lt(`A number raised to a power.`),
+  description: _t(`A number raised to a power.`),
   args: [
-    arg("base (number)", _lt("The number to raise to the exponent power.")),
-    arg("exponent (number)", _lt("The exponent to raise base to.")),
+    arg("base (number)", _t("The number to raise to the exponent power.")),
+    arg("exponent (number)", _t("The exponent to raise base to.")),
   ],
   returns: ["NUMBER"],
   compute: function (base: PrimitiveArgValue, exponent: PrimitiveArgValue): number {
@@ -244,11 +244,11 @@ export const POW: AddFunctionDescription = {
 // UMINUS
 // -----------------------------------------------------------------------------
 export const UMINUS: AddFunctionDescription = {
-  description: _lt(`A number with the sign reversed.`),
+  description: _t(`A number with the sign reversed.`),
   args: [
     arg(
       "value (number)",
-      _lt("The number to have its sign reversed. Equivalently, the number to multiply by -1.")
+      _t("The number to have its sign reversed. Equivalently, the number to multiply by -1.")
     ),
   ],
   computeFormat: (value: PrimitiveArg) => value?.format,
@@ -262,8 +262,8 @@ export const UMINUS: AddFunctionDescription = {
 // UNARY_PERCENT
 // -----------------------------------------------------------------------------
 export const UNARY_PERCENT: AddFunctionDescription = {
-  description: _lt(`Value interpreted as a percentage.`),
-  args: [arg("percentage (number)", _lt("The value to interpret as a percentage."))],
+  description: _t(`Value interpreted as a percentage.`),
+  args: [arg("percentage (number)", _t("The value to interpret as a percentage."))],
   returns: ["NUMBER"],
   compute: function (percentage: PrimitiveArgValue): number {
     return toNumber(percentage, this.locale) / 100;
@@ -274,8 +274,8 @@ export const UNARY_PERCENT: AddFunctionDescription = {
 // UPLUS
 // -----------------------------------------------------------------------------
 export const UPLUS: AddFunctionDescription = {
-  description: _lt(`A specified number, unchanged.`),
-  args: [arg("value (any)", _lt("The number to return."))],
+  description: _t(`A specified number, unchanged.`),
+  args: [arg("value (any)", _t("The number to return."))],
   returns: ["ANY"],
   computeFormat: (value: PrimitiveArg) => value?.format,
   compute: function (value: PrimitiveArgValue): FunctionReturnValue {

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -1,6 +1,6 @@
 import { parseDateTime } from "../helpers/dates";
 import { isNumber, percentile } from "../helpers/numbers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddFunctionDescription,
   Arg,
@@ -41,7 +41,7 @@ function covariance(dataY: ArgValue, dataX: ArgValue, isSample: boolean): number
 
   assert(
     () => lenY === lenX,
-    _lt(
+    _t(
       "[[FUNCTION_NAME]] has mismatched argument count %s vs %s.",
       lenY.toString(),
       lenX.toString()
@@ -63,7 +63,7 @@ function covariance(dataY: ArgValue, dataX: ArgValue, isSample: boolean): number
 
   assert(
     () => count !== 0 && (!isSample || count !== 1),
-    _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+    _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
   );
 
   const averageY = sumY / count;
@@ -98,7 +98,7 @@ function variance(args: ArgValue[], isSample: boolean, textAs0: boolean, locale:
 
   assert(
     () => count !== 0 && (!isSample || count !== 1),
-    _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+    _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
   );
 
   const average = sum / count;
@@ -117,7 +117,7 @@ function centile(
   const _percent = toNumber(percent, locale);
   assert(
     () => (isInclusive ? 0 <= _percent && _percent <= 1 : 0 < _percent && _percent < 1),
-    _lt(`Function [[FUNCTION_NAME]] parameter 2 value is out of range.`)
+    _t(`Function [[FUNCTION_NAME]] parameter 2 value is out of range.`)
   );
   let sortedArray: number[] = [];
   let index: number;
@@ -136,13 +136,13 @@ function centile(
       count++;
     }
   });
-  assert(() => count !== 0, _lt(`[[FUNCTION_NAME]] has no valid input data.`));
+  assert(() => count !== 0, _t(`[[FUNCTION_NAME]] has no valid input data.`));
 
   if (!isInclusive) {
     // 2nd argument must be between 1/(n+1) and n/(n+1) with n the number of data
     assert(
       () => 1 / (count + 1) <= _percent && _percent <= count / (count + 1),
-      _lt(`Function [[FUNCTION_NAME]] parameter 2 value is out of range.`)
+      _t(`Function [[FUNCTION_NAME]] parameter 2 value is out of range.`)
     );
   }
 
@@ -153,12 +153,12 @@ function centile(
 // AVEDEV
 // -----------------------------------------------------------------------------
 export const AVEDEV: AddFunctionDescription = {
-  description: _lt("Average magnitude of deviations from mean."),
+  description: _t("Average magnitude of deviations from mean."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the sample.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the sample.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the sample.")
+      _t("Additional values or ranges to include in the sample.")
     ),
   ],
   returns: ["NUMBER"],
@@ -175,7 +175,7 @@ export const AVEDEV: AddFunctionDescription = {
     );
     assert(
       () => count !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
     const average = sum / count;
     return reduceNumbers(values, (acc, a) => acc + Math.abs(average - a), 0, this.locale) / count;
@@ -187,15 +187,15 @@ export const AVEDEV: AddFunctionDescription = {
 // AVERAGE
 // -----------------------------------------------------------------------------
 export const AVERAGE: AddFunctionDescription = {
-  description: _lt(`Numerical average value in a dataset, ignoring text.`),
+  description: _t(`Numerical average value in a dataset, ignoring text.`),
   args: [
     arg(
       "value1 (number, range<number>)",
-      _lt("The first value or range to consider when calculating the average value.")
+      _t("The first value or range to consider when calculating the average value.")
     ),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to consider when calculating the average value.")
+      _t("Additional values or ranges to consider when calculating the average value.")
     ),
   ],
   returns: ["NUMBER"],
@@ -215,7 +215,7 @@ export const AVERAGE: AddFunctionDescription = {
     );
     assert(
       () => count !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
     return sum / count;
   },
@@ -225,21 +225,21 @@ export const AVERAGE: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 // AVERAGE.WEIGHTED
 // -----------------------------------------------------------------------------
-const rangeError = _lt(`[[FUNCTION_NAME]] has mismatched range sizes.`);
-const negativeWeightError = _lt(
+const rangeError = _t(`[[FUNCTION_NAME]] has mismatched range sizes.`);
+const negativeWeightError = _t(
   `[[FUNCTION_NAME]] expects the weight to be positive or equal to 0.`
 );
 
 export const AVERAGE_WEIGHTED: AddFunctionDescription = {
-  description: _lt(`Weighted average.`),
+  description: _t(`Weighted average.`),
   args: [
-    arg("values (number, range<number>)", _lt("Values to average.")),
-    arg("weights (number, range<number>)", _lt("Weights for each corresponding value.")),
+    arg("values (number, range<number>)", _t("Values to average.")),
+    arg("weights (number, range<number>)", _t("Weights for each corresponding value.")),
     arg(
       "additional_values (number, range<number>, repeating)",
-      _lt("Additional values to average.")
+      _t("Additional values to average.")
     ),
-    arg("additional_weights (number, range<number>, repeating)", _lt("Additional weights.")),
+    arg("additional_weights (number, range<number>, repeating)", _t("Additional weights.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (values: Arg) => {
@@ -252,7 +252,7 @@ export const AVERAGE_WEIGHTED: AddFunctionDescription = {
     let weight;
     assert(
       () => values.length % 2 === 0,
-      _lt(`Wrong number of Argument[]. Expected an even number of Argument[].`)
+      _t(`Wrong number of Argument[]. Expected an even number of Argument[].`)
     );
     for (let n = 0; n < values.length - 1; n += 2) {
       value = values[n];
@@ -276,7 +276,7 @@ export const AVERAGE_WEIGHTED: AddFunctionDescription = {
             // typeof subValue or subWeight can be 'number' or 'undefined'
             assert(
               () => subValueIsNumber === subWeightIsNumber,
-              _lt(`[[FUNCTION_NAME]] expects number values.`)
+              _t(`[[FUNCTION_NAME]] expects number values.`)
             );
 
             if (subWeightIsNumber) {
@@ -299,7 +299,7 @@ export const AVERAGE_WEIGHTED: AddFunctionDescription = {
 
     assert(
       () => count !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
 
     return sum / count;
@@ -310,15 +310,15 @@ export const AVERAGE_WEIGHTED: AddFunctionDescription = {
 // AVERAGEA
 // -----------------------------------------------------------------------------
 export const AVERAGEA: AddFunctionDescription = {
-  description: _lt(`Numerical average value in a dataset.`),
+  description: _t(`Numerical average value in a dataset.`),
   args: [
     arg(
       "value1 (number, range<number>)",
-      _lt("The first value or range to consider when calculating the average value.")
+      _t("The first value or range to consider when calculating the average value.")
     ),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to consider when calculating the average value.")
+      _t("Additional values or ranges to consider when calculating the average value.")
     ),
   ],
   returns: ["NUMBER"],
@@ -338,7 +338,7 @@ export const AVERAGEA: AddFunctionDescription = {
     );
     assert(
       () => count !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
     return sum / count;
   },
@@ -349,13 +349,13 @@ export const AVERAGEA: AddFunctionDescription = {
 // AVERAGEIF
 // -----------------------------------------------------------------------------
 export const AVERAGEIF: AddFunctionDescription = {
-  description: _lt(`Average of values depending on criteria.`),
+  description: _t(`Average of values depending on criteria.`),
   args: [
-    arg("criteria_range (range)", _lt("The range to check against criterion.")),
-    arg("criterion (string)", _lt("The pattern or test to apply to criteria_range.")),
+    arg("criteria_range (range)", _t("The range to check against criterion.")),
+    arg("criterion (string)", _t("The pattern or test to apply to criteria_range.")),
     arg(
       "average_range (range, default=criteria_range)",
-      _lt("The range to average. If not included, criteria_range is used for the average instead.")
+      _t("The range to average. If not included, criteria_range is used for the average instead.")
     ),
   ],
   returns: ["NUMBER"],
@@ -385,7 +385,7 @@ export const AVERAGEIF: AddFunctionDescription = {
 
     assert(
       () => count !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
 
     return sum / count;
@@ -397,16 +397,16 @@ export const AVERAGEIF: AddFunctionDescription = {
 // AVERAGEIFS
 // -----------------------------------------------------------------------------
 export const AVERAGEIFS: AddFunctionDescription = {
-  description: _lt(`Average of values depending on multiple criteria.`),
+  description: _t(`Average of values depending on multiple criteria.`),
   args: [
-    arg("average_range (range)", _lt("The range to average.")),
-    arg("criteria_range1 (range)", _lt("The range to check against criterion1.")),
-    arg("criterion1 (string)", _lt("The pattern or test to apply to criteria_range1.")),
+    arg("average_range (range)", _t("The range to average.")),
+    arg("criteria_range1 (range)", _t("The range to check against criterion1.")),
+    arg("criterion1 (string)", _t("The pattern or test to apply to criteria_range1.")),
     arg(
       "criteria_range2 (any, range, repeating)",
-      _lt("Additional criteria_range and criterion to check.")
+      _t("Additional criteria_range and criterion to check.")
     ),
-    arg("criterion2 (string, repeating)", _lt("The pattern or test to apply to criteria_range2.")),
+    arg("criterion2 (string, repeating)", _t("The pattern or test to apply to criteria_range2.")),
   ],
   returns: ["NUMBER"],
   compute: function (averageRange: MatrixArgValue, ...values: ArgValue[]): number {
@@ -425,7 +425,7 @@ export const AVERAGEIFS: AddFunctionDescription = {
     );
     assert(
       () => count !== 0,
-      _lt(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
     );
     return sum / count;
   },
@@ -436,15 +436,15 @@ export const AVERAGEIFS: AddFunctionDescription = {
 // COUNT
 // -----------------------------------------------------------------------------
 export const COUNT: AddFunctionDescription = {
-  description: _lt(`The number of numeric values in dataset.`),
+  description: _t(`The number of numeric values in dataset.`),
   args: [
     arg(
       "value1 (number, range<number>)",
-      _lt("The first value or range to consider when counting.")
+      _t("The first value or range to consider when counting.")
     ),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to consider when counting.")
+      _t("Additional values or ranges to consider when counting.")
     ),
   ],
   returns: ["NUMBER"],
@@ -476,12 +476,12 @@ export const COUNT: AddFunctionDescription = {
 // COUNTA
 // -----------------------------------------------------------------------------
 export const COUNTA: AddFunctionDescription = {
-  description: _lt(`The number of values in a dataset.`),
+  description: _t(`The number of values in a dataset.`),
   args: [
-    arg("value1 (any, range)", _lt("The first value or range to consider when counting.")),
+    arg("value1 (any, range)", _t("The first value or range to consider when counting.")),
     arg(
       "value2 (any, range, repeating)",
-      _lt("Additional values or ranges to consider when counting.")
+      _t("Additional values or ranges to consider when counting.")
     ),
   ],
   returns: ["NUMBER"],
@@ -498,15 +498,12 @@ export const COUNTA: AddFunctionDescription = {
 // Note: Unlike the VAR function which corresponds to the variance over a sample (VAR.S),
 // the COVAR function corresponds to the covariance over an entire population (COVAR.P)
 export const COVAR: AddFunctionDescription = {
-  description: _lt(`The covariance of a dataset.`),
+  description: _t(`The covariance of a dataset.`),
   args: [
-    arg(
-      "data_y (any, range)",
-      _lt("The range representing the array or matrix of dependent data.")
-    ),
+    arg("data_y (any, range)", _t("The range representing the array or matrix of dependent data.")),
     arg(
       "data_x (any, range)",
-      _lt("The range representing the array or matrix of independent data.")
+      _t("The range representing the array or matrix of independent data.")
     ),
   ],
   returns: ["NUMBER"],
@@ -520,15 +517,12 @@ export const COVAR: AddFunctionDescription = {
 // COVARIANCE.P
 // -----------------------------------------------------------------------------
 export const COVARIANCE_P: AddFunctionDescription = {
-  description: _lt(`The covariance of a dataset.`),
+  description: _t(`The covariance of a dataset.`),
   args: [
-    arg(
-      "data_y (any, range)",
-      _lt("The range representing the array or matrix of dependent data.")
-    ),
+    arg("data_y (any, range)", _t("The range representing the array or matrix of dependent data.")),
     arg(
       "data_x (any, range)",
-      _lt("The range representing the array or matrix of independent data.")
+      _t("The range representing the array or matrix of independent data.")
     ),
   ],
   returns: ["NUMBER"],
@@ -542,15 +536,12 @@ export const COVARIANCE_P: AddFunctionDescription = {
 // COVARIANCE.S
 // -----------------------------------------------------------------------------
 export const COVARIANCE_S: AddFunctionDescription = {
-  description: _lt(`The sample covariance of a dataset.`),
+  description: _t(`The sample covariance of a dataset.`),
   args: [
-    arg(
-      "data_y (any, range)",
-      _lt("The range representing the array or matrix of dependent data.")
-    ),
+    arg("data_y (any, range)", _t("The range representing the array or matrix of dependent data.")),
     arg(
       "data_x (any, range)",
-      _lt("The range representing the array or matrix of independent data.")
+      _t("The range representing the array or matrix of independent data.")
     ),
   ],
   returns: ["NUMBER"],
@@ -564,10 +555,10 @@ export const COVARIANCE_S: AddFunctionDescription = {
 // LARGE
 // -----------------------------------------------------------------------------
 export const LARGE: AddFunctionDescription = {
-  description: _lt("Nth largest element from a data set."),
+  description: _t("Nth largest element from a data set."),
   args: [
-    arg("data (any, range)", _lt("Array or range containing the dataset to consider.")),
-    arg("n (number)", _lt("The rank from largest to smallest of the element to return.")),
+    arg("data (any, range)", _t("Array or range containing the dataset to consider.")),
+    arg("n (number)", _t("The rank from largest to smallest of the element to return.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (data: Arg) => {
@@ -597,10 +588,10 @@ export const LARGE: AddFunctionDescription = {
       }
     });
     const result = largests.shift();
-    assert(() => result !== undefined, _lt(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => result !== undefined, _t(`[[FUNCTION_NAME]] has no valid input data.`));
     assert(
       () => count >= _n,
-      _lt("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n.toString())
+      _t("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n.toString())
     );
     return result!;
   },
@@ -611,15 +602,15 @@ export const LARGE: AddFunctionDescription = {
 // MAX
 // -----------------------------------------------------------------------------
 export const MAX: AddFunctionDescription = {
-  description: _lt("Maximum value in a numeric dataset."),
+  description: _t("Maximum value in a numeric dataset."),
   args: [
     arg(
       "value1 (number, range<number>)",
-      _lt("The first value or range to consider when calculating the maximum value.")
+      _t("The first value or range to consider when calculating the maximum value.")
     ),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to consider when calculating the maximum value.")
+      _t("Additional values or ranges to consider when calculating the maximum value.")
     ),
   ],
   returns: ["NUMBER"],
@@ -637,15 +628,15 @@ export const MAX: AddFunctionDescription = {
 // MAXA
 // -----------------------------------------------------------------------------
 export const MAXA: AddFunctionDescription = {
-  description: _lt("Maximum numeric value in a dataset."),
+  description: _t("Maximum numeric value in a dataset."),
   args: [
     arg(
       "value1 (any, range)",
-      _lt("The first value or range to consider when calculating the maximum value.")
+      _t("The first value or range to consider when calculating the maximum value.")
     ),
     arg(
       "value2 (any, range, repeating)",
-      _lt("Additional values or ranges to consider when calculating the maximum value.")
+      _t("Additional values or ranges to consider when calculating the maximum value.")
     ),
   ],
   returns: ["NUMBER"],
@@ -670,23 +661,23 @@ export const MAXA: AddFunctionDescription = {
 // MAXIFS
 // -----------------------------------------------------------------------------
 export const MAXIFS: AddFunctionDescription = {
-  description: _lt("Returns the maximum value in a range of cells, filtered by a set of criteria."),
+  description: _t("Returns the maximum value in a range of cells, filtered by a set of criteria."),
   args: [
-    arg("range (range)", _lt("The range of cells from which the maximum will be determined.")),
-    arg("criteria_range1 (range)", _lt("The range of cells over which to evaluate criterion1.")),
+    arg("range (range)", _t("The range of cells from which the maximum will be determined.")),
+    arg("criteria_range1 (range)", _t("The range of cells over which to evaluate criterion1.")),
     arg(
       "criterion1 (string)",
-      _lt(
+      _t(
         "The pattern or test to apply to criteria_range1, such that each cell that evaluates to TRUE will be included in the filtered set."
       )
     ),
     arg(
       "criteria_range2 (any, range, repeating)",
-      _lt(
+      _t(
         "Additional ranges over which to evaluate the additional criteria. The filtered set will be the intersection of the sets produced by each criterion-range pair."
       )
     ),
-    arg("criterion2 (string, repeating)", _lt("The pattern or test to apply to criteria_range2.")),
+    arg("criterion2 (string, repeating)", _t("The pattern or test to apply to criteria_range2.")),
   ],
   returns: ["NUMBER"],
   compute: function (range: MatrixArgValue, ...args: ArgValue[]): number {
@@ -710,15 +701,15 @@ export const MAXIFS: AddFunctionDescription = {
 // MEDIAN
 // -----------------------------------------------------------------------------
 export const MEDIAN: AddFunctionDescription = {
-  description: _lt("Median value in a numeric dataset."),
+  description: _t("Median value in a numeric dataset."),
   args: [
     arg(
       "value1 (any, range)",
-      _lt("The first value or range to consider when calculating the median value.")
+      _t("The first value or range to consider when calculating the median value.")
     ),
     arg(
       "value2 (any, range, repeating)",
-      _lt("Additional values or ranges to consider when calculating the median value.")
+      _t("Additional values or ranges to consider when calculating the median value.")
     ),
   ],
   returns: ["NUMBER"],
@@ -743,15 +734,15 @@ export const MEDIAN: AddFunctionDescription = {
 // MIN
 // -----------------------------------------------------------------------------
 export const MIN: AddFunctionDescription = {
-  description: _lt("Minimum value in a numeric dataset."),
+  description: _t("Minimum value in a numeric dataset."),
   args: [
     arg(
       "value1 (number, range<number>)",
-      _lt("The first value or range to consider when calculating the minimum value.")
+      _t("The first value or range to consider when calculating the minimum value.")
     ),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to consider when calculating the minimum value.")
+      _t("Additional values or ranges to consider when calculating the minimum value.")
     ),
   ],
   returns: ["NUMBER"],
@@ -769,15 +760,15 @@ export const MIN: AddFunctionDescription = {
 // MINA
 // -----------------------------------------------------------------------------
 export const MINA: AddFunctionDescription = {
-  description: _lt("Minimum numeric value in a dataset."),
+  description: _t("Minimum numeric value in a dataset."),
   args: [
     arg(
       "value1 (number, range<number>)",
-      _lt("The first value or range to consider when calculating the minimum value.")
+      _t("The first value or range to consider when calculating the minimum value.")
     ),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to consider when calculating the minimum value.")
+      _t("Additional values or ranges to consider when calculating the minimum value.")
     ),
   ],
   returns: ["NUMBER"],
@@ -802,23 +793,23 @@ export const MINA: AddFunctionDescription = {
 // MINIFS
 // -----------------------------------------------------------------------------
 export const MINIFS: AddFunctionDescription = {
-  description: _lt("Returns the minimum value in a range of cells, filtered by a set of criteria."),
+  description: _t("Returns the minimum value in a range of cells, filtered by a set of criteria."),
   args: [
-    arg("range (range)", _lt("The range of cells from which the minimum will be determined.")),
-    arg("criteria_range1 (range)", _lt("The range of cells over which to evaluate criterion1.")),
+    arg("range (range)", _t("The range of cells from which the minimum will be determined.")),
+    arg("criteria_range1 (range)", _t("The range of cells over which to evaluate criterion1.")),
     arg(
       "criterion1 (string)",
-      _lt(
+      _t(
         "The pattern or test to apply to criteria_range1, such that each cell that evaluates to TRUE will be included in the filtered set."
       )
     ),
     arg(
       "criteria_range2 (any, range, repeating)",
-      _lt(
+      _t(
         "Additional ranges over which to evaluate the additional criteria. The filtered set will be the intersection of the sets produced by each criterion-range pair."
       )
     ),
-    arg("criterion2 (string, repeating)", _lt("The pattern or test to apply to criteria_range2.")),
+    arg("criterion2 (string, repeating)", _t("The pattern or test to apply to criteria_range2.")),
   ],
   returns: ["NUMBER"],
   compute: function (range: MatrixArgValue, ...args: ArgValue[]): number {
@@ -842,12 +833,12 @@ export const MINIFS: AddFunctionDescription = {
 // PERCENTILE
 // -----------------------------------------------------------------------------
 export const PERCENTILE: AddFunctionDescription = {
-  description: _lt("Value at a given percentile of a dataset."),
+  description: _t("Value at a given percentile of a dataset."),
   args: [
-    arg("data (any, range)", _lt("The array or range containing the dataset to consider.")),
+    arg("data (any, range)", _t("The array or range containing the dataset to consider.")),
     arg(
       "percentile (number)",
-      _lt("The percentile whose value within data will be calculated and returned.")
+      _t("The percentile whose value within data will be calculated and returned.")
     ),
   ],
   returns: ["NUMBER"],
@@ -864,12 +855,12 @@ export const PERCENTILE: AddFunctionDescription = {
 // PERCENTILE.EXC
 // -----------------------------------------------------------------------------
 export const PERCENTILE_EXC: AddFunctionDescription = {
-  description: _lt("Value at a given percentile of a dataset exclusive of 0 and 1."),
+  description: _t("Value at a given percentile of a dataset exclusive of 0 and 1."),
   args: [
-    arg("data (any, range)", _lt("The array or range containing the dataset to consider.")),
+    arg("data (any, range)", _t("The array or range containing the dataset to consider.")),
     arg(
       "percentile (number)",
-      _lt(
+      _t(
         "The percentile, exclusive of 0 and 1, whose value within 'data' will be calculated and returned."
       )
     ),
@@ -888,12 +879,12 @@ export const PERCENTILE_EXC: AddFunctionDescription = {
 // PERCENTILE.INC
 // -----------------------------------------------------------------------------
 export const PERCENTILE_INC: AddFunctionDescription = {
-  description: _lt("Value at a given percentile of a dataset."),
+  description: _t("Value at a given percentile of a dataset."),
   args: [
-    arg("data (any, range)", _lt("The array or range containing the dataset to consider.")),
+    arg("data (any, range)", _t("The array or range containing the dataset to consider.")),
     arg(
       "percentile (number)",
-      _lt("The percentile whose value within data will be calculated and returned.")
+      _t("The percentile whose value within data will be calculated and returned.")
     ),
   ],
   returns: ["NUMBER"],
@@ -910,10 +901,10 @@ export const PERCENTILE_INC: AddFunctionDescription = {
 // QUARTILE
 // -----------------------------------------------------------------------------
 export const QUARTILE: AddFunctionDescription = {
-  description: _lt("Value nearest to a specific quartile of a dataset."),
+  description: _t("Value nearest to a specific quartile of a dataset."),
   args: [
-    arg("data (any, range)", _lt("The array or range containing the dataset to consider.")),
-    arg("quartile_number (number)", _lt("Which quartile value to return.")),
+    arg("data (any, range)", _t("The array or range containing the dataset to consider.")),
+    arg("quartile_number (number)", _t("Which quartile value to return.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (data: Arg) => {
@@ -929,10 +920,10 @@ export const QUARTILE: AddFunctionDescription = {
 // QUARTILE.EXC
 // -----------------------------------------------------------------------------
 export const QUARTILE_EXC: AddFunctionDescription = {
-  description: _lt("Value nearest to a specific quartile of a dataset exclusive of 0 and 4."),
+  description: _t("Value nearest to a specific quartile of a dataset exclusive of 0 and 4."),
   args: [
-    arg("data (any, range)", _lt("The array or range containing the dataset to consider.")),
-    arg("quartile_number (number)", _lt("Which quartile value, exclusive of 0 and 4, to return.")),
+    arg("data (any, range)", _t("The array or range containing the dataset to consider.")),
+    arg("quartile_number (number)", _t("Which quartile value, exclusive of 0 and 4, to return.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (data: Arg) => {
@@ -949,10 +940,10 @@ export const QUARTILE_EXC: AddFunctionDescription = {
 // QUARTILE.INC
 // -----------------------------------------------------------------------------
 export const QUARTILE_INC: AddFunctionDescription = {
-  description: _lt("Value nearest to a specific quartile of a dataset."),
+  description: _t("Value nearest to a specific quartile of a dataset."),
   args: [
-    arg("data (any, range)", _lt("The array or range containing the dataset to consider.")),
-    arg("quartile_number (number)", _lt("Which quartile value to return.")),
+    arg("data (any, range)", _t("The array or range containing the dataset to consider.")),
+    arg("quartile_number (number)", _t("Which quartile value to return.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (data: Arg) => {
@@ -969,10 +960,10 @@ export const QUARTILE_INC: AddFunctionDescription = {
 // SMALL
 // -----------------------------------------------------------------------------
 export const SMALL: AddFunctionDescription = {
-  description: _lt("Nth smallest element in a data set."),
+  description: _t("Nth smallest element in a data set."),
   args: [
-    arg("data (any, range)", _lt("The array or range containing the dataset to consider.")),
-    arg("n (number)", _lt("The rank from smallest to largest of the element to return.")),
+    arg("data (any, range)", _t("The array or range containing the dataset to consider.")),
+    arg("n (number)", _t("The rank from smallest to largest of the element to return.")),
   ],
   returns: ["NUMBER"],
   computeFormat: (data: Arg) => {
@@ -1002,10 +993,10 @@ export const SMALL: AddFunctionDescription = {
       }
     });
     const result = largests.pop();
-    assert(() => result !== undefined, _lt(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => result !== undefined, _t(`[[FUNCTION_NAME]] has no valid input data.`));
     assert(
       () => count >= _n,
-      _lt("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n.toString())
+      _t("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n.toString())
     );
     return result!;
   },
@@ -1016,12 +1007,12 @@ export const SMALL: AddFunctionDescription = {
 // STDEV
 // -----------------------------------------------------------------------------
 export const STDEV: AddFunctionDescription = {
-  description: _lt("Standard deviation."),
+  description: _t("Standard deviation."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the sample.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the sample.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the sample.")
+      _t("Additional values or ranges to include in the sample.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1035,12 +1026,12 @@ export const STDEV: AddFunctionDescription = {
 // STDEV.P
 // -----------------------------------------------------------------------------
 export const STDEV_P: AddFunctionDescription = {
-  description: _lt("Standard deviation of entire population."),
+  description: _t("Standard deviation of entire population."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the population.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the population.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the population.")
+      _t("Additional values or ranges to include in the population.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1054,12 +1045,12 @@ export const STDEV_P: AddFunctionDescription = {
 // STDEV.S
 // -----------------------------------------------------------------------------
 export const STDEV_S: AddFunctionDescription = {
-  description: _lt("Standard deviation."),
+  description: _t("Standard deviation."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the sample.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the sample.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the sample.")
+      _t("Additional values or ranges to include in the sample.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1073,12 +1064,12 @@ export const STDEV_S: AddFunctionDescription = {
 // STDEVA
 // -----------------------------------------------------------------------------
 export const STDEVA: AddFunctionDescription = {
-  description: _lt("Standard deviation of sample (text as 0)."),
+  description: _t("Standard deviation of sample (text as 0)."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the sample.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the sample.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the sample.")
+      _t("Additional values or ranges to include in the sample.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1092,12 +1083,12 @@ export const STDEVA: AddFunctionDescription = {
 // STDEVP
 // -----------------------------------------------------------------------------
 export const STDEVP: AddFunctionDescription = {
-  description: _lt("Standard deviation of entire population."),
+  description: _t("Standard deviation of entire population."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the population.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the population.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the population.")
+      _t("Additional values or ranges to include in the population.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1111,12 +1102,12 @@ export const STDEVP: AddFunctionDescription = {
 // STDEVPA
 // -----------------------------------------------------------------------------
 export const STDEVPA: AddFunctionDescription = {
-  description: _lt("Standard deviation of entire population (text as 0)."),
+  description: _t("Standard deviation of entire population (text as 0)."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the population.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the population.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the population.")
+      _t("Additional values or ranges to include in the population.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1130,12 +1121,12 @@ export const STDEVPA: AddFunctionDescription = {
 // VAR
 // -----------------------------------------------------------------------------
 export const VAR: AddFunctionDescription = {
-  description: _lt("Variance."),
+  description: _t("Variance."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the sample.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the sample.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the sample.")
+      _t("Additional values or ranges to include in the sample.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1149,12 +1140,12 @@ export const VAR: AddFunctionDescription = {
 // VAR.P
 // -----------------------------------------------------------------------------
 export const VAR_P: AddFunctionDescription = {
-  description: _lt("Variance of entire population."),
+  description: _t("Variance of entire population."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the population.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the population.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the population.")
+      _t("Additional values or ranges to include in the population.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1168,12 +1159,12 @@ export const VAR_P: AddFunctionDescription = {
 // VAR.S
 // -----------------------------------------------------------------------------
 export const VAR_S: AddFunctionDescription = {
-  description: _lt("Variance."),
+  description: _t("Variance."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the sample.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the sample.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the sample.")
+      _t("Additional values or ranges to include in the sample.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1187,12 +1178,12 @@ export const VAR_S: AddFunctionDescription = {
 // VARA
 // -----------------------------------------------------------------------------
 export const VARA: AddFunctionDescription = {
-  description: _lt("Variance of sample (text as 0)."),
+  description: _t("Variance of sample (text as 0)."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the sample.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the sample.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the sample.")
+      _t("Additional values or ranges to include in the sample.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1206,12 +1197,12 @@ export const VARA: AddFunctionDescription = {
 // VARP
 // -----------------------------------------------------------------------------
 export const VARP: AddFunctionDescription = {
-  description: _lt("Variance of entire population."),
+  description: _t("Variance of entire population."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the population.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the population.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the population.")
+      _t("Additional values or ranges to include in the population.")
     ),
   ],
   returns: ["NUMBER"],
@@ -1225,12 +1216,12 @@ export const VARP: AddFunctionDescription = {
 // VARPA
 // -----------------------------------------------------------------------------
 export const VARPA: AddFunctionDescription = {
-  description: _lt("Variance of entire population (text as 0)."),
+  description: _t("Variance of entire population (text as 0)."),
   args: [
-    arg("value1 (number, range<number>)", _lt("The first value or range of the population.")),
+    arg("value1 (number, range<number>)", _t("The first value or range of the population.")),
     arg(
       "value2 (number, range<number>, repeating)",
-      _lt("Additional values or ranges to include in the population.")
+      _t("Additional values or ranges to include in the population.")
     ),
   ],
   returns: ["NUMBER"],

--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -1,5 +1,5 @@
 import { escapeRegExp, formatValue, transpose2dArray } from "../helpers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { AddFunctionDescription, ArgValue, PrimitiveArgValue } from "../types";
 import { arg } from "./arguments";
 import { assert, reduceAny, toBoolean, toNumber, toString } from "./helpers";
@@ -13,13 +13,11 @@ const wordRegex = /[A-Za-zÀ-ÖØ-öø-ÿ]+/g;
 // CHAR
 // -----------------------------------------------------------------------------
 export const CHAR: AddFunctionDescription = {
-  description: _lt("Gets character associated with number."),
+  description: _t("Gets character associated with number."),
   args: [
     arg(
       "table_number (number)",
-      _lt(
-        "The number of the character to look up from the current Unicode table in decimal format."
-      )
+      _t("The number of the character to look up from the current Unicode table in decimal format.")
     ),
   ],
   returns: ["STRING"],
@@ -27,7 +25,7 @@ export const CHAR: AddFunctionDescription = {
     const _tableNumber = Math.trunc(toNumber(tableNumber, this.locale));
     assert(
       () => _tableNumber >= 1,
-      _lt("The table_number (%s) is out of range.", _tableNumber.toString())
+      _t("The table_number (%s) is out of range.", _tableNumber.toString())
     );
     return String.fromCharCode(_tableNumber);
   },
@@ -38,8 +36,8 @@ export const CHAR: AddFunctionDescription = {
 // CLEAN
 // -----------------------------------------------------------------------------
 export const CLEAN: AddFunctionDescription = {
-  description: _lt("Remove non-printable characters from a piece of text."),
-  args: [arg("text (string)", _lt("The text whose non-printable characters are to be removed."))],
+  description: _t("Remove non-printable characters from a piece of text."),
+  args: [arg("text (string)", _t("The text whose non-printable characters are to be removed."))],
   returns: ["STRING"],
   compute: function (text: PrimitiveArgValue): string {
     const _text = toString(text);
@@ -58,10 +56,10 @@ export const CLEAN: AddFunctionDescription = {
 // CONCATENATE
 // -----------------------------------------------------------------------------
 export const CONCATENATE: AddFunctionDescription = {
-  description: _lt("Appends strings to one another."),
+  description: _t("Appends strings to one another."),
   args: [
-    arg("string1 (string, range<string>)", _lt("The initial string.")),
-    arg("string2 (string, range<string>, repeating)", _lt("More strings to append in sequence.")),
+    arg("string1 (string, range<string>)", _t("The initial string.")),
+    arg("string2 (string, range<string>, repeating)", _t("More strings to append in sequence.")),
   ],
   returns: ["STRING"],
   compute: function (...values: ArgValue[]): string {
@@ -74,10 +72,10 @@ export const CONCATENATE: AddFunctionDescription = {
 // EXACT
 // -----------------------------------------------------------------------------
 export const EXACT: AddFunctionDescription = {
-  description: _lt("Tests whether two strings are identical."),
+  description: _t("Tests whether two strings are identical."),
   args: [
-    arg("string1 (string)", _lt("The first string to compare.")),
-    arg("string2 (string)", _lt("The second string to compare.")),
+    arg("string1 (string)", _t("The first string to compare.")),
+    arg("string2 (string)", _t("The second string to compare.")),
   ],
   returns: ["BOOLEAN"],
   compute: function (string1: PrimitiveArgValue, string2: PrimitiveArgValue): boolean {
@@ -90,16 +88,16 @@ export const EXACT: AddFunctionDescription = {
 // FIND
 // -----------------------------------------------------------------------------
 export const FIND: AddFunctionDescription = {
-  description: _lt("First position of string found in text, case-sensitive."),
+  description: _t("First position of string found in text, case-sensitive."),
   args: [
-    arg("search_for (string)", _lt("The string to look for within text_to_search.")),
+    arg("search_for (string)", _t("The string to look for within text_to_search.")),
     arg(
       "text_to_search (string)",
-      _lt("The text to search for the first occurrence of search_for.")
+      _t("The text to search for the first occurrence of search_for.")
     ),
     arg(
       `starting_at (number, default=${DEFAULT_STARTING_AT})`,
-      _lt("The character within text_to_search at which to start the search.")
+      _t("The character within text_to_search at which to start the search.")
     ),
   ],
   returns: ["NUMBER"],
@@ -112,17 +110,17 @@ export const FIND: AddFunctionDescription = {
     const _textToSearch = toString(textToSearch);
     const _startingAt = toNumber(startingAt, this.locale);
 
-    assert(() => _textToSearch !== "", _lt(`The text_to_search must be non-empty.`));
+    assert(() => _textToSearch !== "", _t(`The text_to_search must be non-empty.`));
     assert(
       () => _startingAt >= 1,
-      _lt("The starting_at (%s) must be greater than or equal to 1.", _startingAt.toString())
+      _t("The starting_at (%s) must be greater than or equal to 1.", _startingAt.toString())
     );
 
     const result = _textToSearch.indexOf(_searchFor, _startingAt - 1);
 
     assert(
       () => result >= 0,
-      _lt(
+      _t(
         "In [[FUNCTION_NAME]] evaluation, cannot find '%s' within '%s'.",
         _searchFor.toString(),
         _textToSearch
@@ -138,19 +136,19 @@ export const FIND: AddFunctionDescription = {
 // JOIN
 // -----------------------------------------------------------------------------
 export const JOIN: AddFunctionDescription = {
-  description: _lt("Concatenates elements of arrays with delimiter."),
+  description: _t("Concatenates elements of arrays with delimiter."),
   args: [
     arg(
       "delimiter (string)",
-      _lt("The character or string to place between each concatenated value.")
+      _t("The character or string to place between each concatenated value.")
     ),
     arg(
       "value_or_array1 (string, range<string>)",
-      _lt("The value or values to be appended using delimiter.")
+      _t("The value or values to be appended using delimiter.")
     ),
     arg(
       "value_or_array2 (string, range<string>, repeating)",
-      _lt("More values to be appended using delimiter.")
+      _t("More values to be appended using delimiter.")
     ),
   ],
   returns: ["STRING"],
@@ -164,12 +162,12 @@ export const JOIN: AddFunctionDescription = {
 // LEFT
 // -----------------------------------------------------------------------------
 export const LEFT: AddFunctionDescription = {
-  description: _lt("Substring from beginning of specified string."),
+  description: _t("Substring from beginning of specified string."),
   args: [
-    arg("text (string)", _lt("The string from which the left portion will be returned.")),
+    arg("text (string)", _t("The string from which the left portion will be returned.")),
     arg(
       "number_of_characters (number, optional)",
-      _lt("The number of characters to return from the left side of string.")
+      _t("The number of characters to return from the left side of string.")
     ),
   ],
   returns: ["STRING"],
@@ -177,7 +175,7 @@ export const LEFT: AddFunctionDescription = {
     const _numberOfCharacters = args.length ? toNumber(args[0], this.locale) : 1;
     assert(
       () => _numberOfCharacters >= 0,
-      _lt("The number_of_characters (%s) must be positive or null.", _numberOfCharacters.toString())
+      _t("The number_of_characters (%s) must be positive or null.", _numberOfCharacters.toString())
     );
     return toString(text).substring(0, _numberOfCharacters);
   },
@@ -188,8 +186,8 @@ export const LEFT: AddFunctionDescription = {
 // LEN
 // -----------------------------------------------------------------------------
 export const LEN: AddFunctionDescription = {
-  description: _lt("Length of a string."),
-  args: [arg("text (string)", _lt("The string whose length will be returned."))],
+  description: _t("Length of a string."),
+  args: [arg("text (string)", _t("The string whose length will be returned."))],
   returns: ["NUMBER"],
   compute: function (text: PrimitiveArgValue): number {
     return toString(text).length;
@@ -201,8 +199,8 @@ export const LEN: AddFunctionDescription = {
 // LOWER
 // -----------------------------------------------------------------------------
 export const LOWER: AddFunctionDescription = {
-  description: _lt("Converts a specified string to lowercase."),
-  args: [arg("text (string)", _lt("The string to convert to lowercase."))],
+  description: _t("Converts a specified string to lowercase."),
+  args: [arg("text (string)", _t("The string to convert to lowercase."))],
   returns: ["STRING"],
   compute: function (text: PrimitiveArgValue): string {
     return toString(text).toLowerCase();
@@ -214,16 +212,16 @@ export const LOWER: AddFunctionDescription = {
 // MID
 // -----------------------------------------------------------------------------
 export const MID: AddFunctionDescription = {
-  description: _lt("A segment of a string."),
+  description: _t("A segment of a string."),
   args: [
-    arg("text (string)", _lt("The string to extract a segment from.")),
+    arg("text (string)", _t("The string to extract a segment from.")),
     arg(
       " (number)",
-      _lt(
+      _t(
         "The index from the left of string from which to begin extracting. The first character in string has the index 1."
       )
     ),
-    arg(" (number)", _lt("The length of the segment to extract.")),
+    arg(" (number)", _t("The length of the segment to extract.")),
   ],
   returns: ["STRING"],
   compute: function (
@@ -237,14 +235,14 @@ export const MID: AddFunctionDescription = {
 
     assert(
       () => _starting_at >= 1,
-      _lt(
+      _t(
         "The starting_at argument (%s) must be positive greater than one.",
         _starting_at.toString()
       )
     );
     assert(
       () => _extract_length >= 0,
-      _lt("The extract_length argument (%s) must be positive or null.", _extract_length.toString())
+      _t("The extract_length argument (%s) must be positive or null.", _extract_length.toString())
     );
 
     return _text.slice(_starting_at - 1, _starting_at + _extract_length - 1);
@@ -256,11 +254,11 @@ export const MID: AddFunctionDescription = {
 // PROPER
 // -----------------------------------------------------------------------------
 export const PROPER: AddFunctionDescription = {
-  description: _lt("Capitalizes each word in a specified string."),
+  description: _t("Capitalizes each word in a specified string."),
   args: [
     arg(
       "text_to_capitalize (string)",
-      _lt(
+      _t(
         "The text which will be returned with the first letter of each word in uppercase and all other letters in lowercase."
       )
     ),
@@ -279,15 +277,15 @@ export const PROPER: AddFunctionDescription = {
 // REPLACE
 // -----------------------------------------------------------------------------
 export const REPLACE: AddFunctionDescription = {
-  description: _lt("Replaces part of a text string with different text."),
+  description: _t("Replaces part of a text string with different text."),
   args: [
-    arg("text (string)", _lt("The text, a part of which will be replaced.")),
+    arg("text (string)", _t("The text, a part of which will be replaced.")),
     arg(
       "position (number)",
-      _lt("The position where the replacement will begin (starting from 1).")
+      _t("The position where the replacement will begin (starting from 1).")
     ),
-    arg("length (number)", _lt("The number of characters in the text to be replaced.")),
-    arg("new_text (string)", _lt("The text which will be inserted into the original text.")),
+    arg("length (number)", _t("The number of characters in the text to be replaced.")),
+    arg("new_text (string)", _t("The text which will be inserted into the original text.")),
   ],
   returns: ["STRING"],
   compute: function (
@@ -299,7 +297,7 @@ export const REPLACE: AddFunctionDescription = {
     const _position = toNumber(position, this.locale);
     assert(
       () => _position >= 1,
-      _lt("The position (%s) must be greater than or equal to 1.", _position.toString())
+      _t("The position (%s) must be greater than or equal to 1.", _position.toString())
     );
 
     const _text = toString(text);
@@ -314,12 +312,12 @@ export const REPLACE: AddFunctionDescription = {
 // RIGHT
 // -----------------------------------------------------------------------------
 export const RIGHT: AddFunctionDescription = {
-  description: _lt("A substring from the end of a specified string."),
+  description: _t("A substring from the end of a specified string."),
   args: [
-    arg("text (string)", _lt("The string from which the right portion will be returned.")),
+    arg("text (string)", _t("The string from which the right portion will be returned.")),
     arg(
       "number_of_characters (number, optional)",
-      _lt("The number of characters to return from the right side of string.")
+      _t("The number of characters to return from the right side of string.")
     ),
   ],
   returns: ["STRING"],
@@ -327,7 +325,7 @@ export const RIGHT: AddFunctionDescription = {
     const _numberOfCharacters = args.length ? toNumber(args[0], this.locale) : 1;
     assert(
       () => _numberOfCharacters >= 0,
-      _lt("The number_of_characters (%s) must be positive or null.", _numberOfCharacters.toString())
+      _t("The number_of_characters (%s) must be positive or null.", _numberOfCharacters.toString())
     );
     const _text = toString(text);
     const stringLength = _text.length;
@@ -340,16 +338,16 @@ export const RIGHT: AddFunctionDescription = {
 // SEARCH
 // -----------------------------------------------------------------------------
 export const SEARCH: AddFunctionDescription = {
-  description: _lt("First position of string found in text, ignoring case."),
+  description: _t("First position of string found in text, ignoring case."),
   args: [
-    arg("search_for (string)", _lt("The string to look for within text_to_search.")),
+    arg("search_for (string)", _t("The string to look for within text_to_search.")),
     arg(
       "text_to_search (string)",
-      _lt("The text to search for the first occurrence of search_for.")
+      _t("The text to search for the first occurrence of search_for.")
     ),
     arg(
       `starting_at (number, default=${DEFAULT_STARTING_AT})`,
-      _lt("The character within text_to_search at which to start the search.")
+      _t("The character within text_to_search at which to start the search.")
     ),
   ],
   returns: ["NUMBER"],
@@ -362,17 +360,17 @@ export const SEARCH: AddFunctionDescription = {
     const _textToSearch = toString(textToSearch).toLowerCase();
     const _startingAt = toNumber(startingAt, this.locale);
 
-    assert(() => _textToSearch !== "", _lt(`The text_to_search must be non-empty.`));
+    assert(() => _textToSearch !== "", _t(`The text_to_search must be non-empty.`));
     assert(
       () => _startingAt >= 1,
-      _lt("The starting_at (%s) must be greater than or equal to 1.", _startingAt.toString())
+      _t("The starting_at (%s) must be greater than or equal to 1.", _startingAt.toString())
     );
 
     const result = _textToSearch.indexOf(_searchFor, _startingAt - 1);
 
     assert(
       () => result >= 0,
-      _lt(
+      _t(
         "In [[FUNCTION_NAME]] evaluation, cannot find '%s' within '%s'.",
         _searchFor,
         _textToSearch
@@ -390,17 +388,17 @@ export const SEARCH: AddFunctionDescription = {
 const SPLIT_DEFAULT_SPLIT_BY_EACH = true;
 const SPLIT_DEFAULT_REMOVE_EMPTY_TEXT = true;
 export const SPLIT: AddFunctionDescription = {
-  description: _lt("Split text by specific character delimiter(s)."),
+  description: _t("Split text by specific character delimiter(s)."),
   args: [
-    arg("text (string)", _lt("The text to divide.")),
-    arg("delimiter (string)", _lt("The character or characters to use to split text.")),
+    arg("text (string)", _t("The text to divide.")),
+    arg("delimiter (string)", _t("The character or characters to use to split text.")),
     arg(
       `split_by_each (boolean, default=${SPLIT_DEFAULT_SPLIT_BY_EACH}})`,
-      _lt("Whether or not to divide text around each character contained in delimiter.")
+      _t("Whether or not to divide text around each character contained in delimiter.")
     ),
     arg(
       `remove_empty_text (boolean, default=${SPLIT_DEFAULT_REMOVE_EMPTY_TEXT})`,
-      _lt(
+      _t(
         "Whether or not to remove empty text messages from the split results. The default behavior is to treat \
         consecutive delimiters as one (if TRUE). If FALSE, empty cells values are added between consecutive delimiters."
       )
@@ -420,7 +418,7 @@ export const SPLIT: AddFunctionDescription = {
 
     assert(
       () => _delimiter.length > 0,
-      _lt("The _delimiter (%s) must be not be empty.", _delimiter)
+      _t("The _delimiter (%s) must be not be empty.", _delimiter)
     );
 
     const regex = _splitByEach ? new RegExp(`[${_delimiter}]`, "g") : new RegExp(_delimiter, "g");
@@ -439,14 +437,14 @@ export const SPLIT: AddFunctionDescription = {
 // SUBSTITUTE
 // -----------------------------------------------------------------------------
 export const SUBSTITUTE: AddFunctionDescription = {
-  description: _lt("Replaces existing text with new text in a string."),
+  description: _t("Replaces existing text with new text in a string."),
   args: [
-    arg("text_to_search (string)", _lt("The text within which to search and replace.")),
-    arg("search_for (string)", _lt("The string to search for within text_to_search.")),
-    arg("replace_with (string)", _lt("The string that will replace search_for.")),
+    arg("text_to_search (string)", _t("The text within which to search and replace.")),
+    arg("search_for (string)", _t("The string to search for within text_to_search.")),
+    arg("replace_with (string)", _t("The string that will replace search_for.")),
     arg(
       "occurrence_number (number, optional)",
-      _lt(
+      _t(
         "The instance of search_for within text_to_search to replace with replace_with. By default, all occurrences of search_for are replaced; however, if occurrence_number is specified, only the indicated instance of search_for is replaced."
       )
     ),
@@ -462,7 +460,7 @@ export const SUBSTITUTE: AddFunctionDescription = {
 
     assert(
       () => _occurrenceNumber >= 0,
-      _lt("The occurrenceNumber (%s) must be positive or null.", _occurrenceNumber.toString())
+      _t("The occurrenceNumber (%s) must be positive or null.", _occurrenceNumber.toString())
     );
 
     const _textToSearch = toString(textToSearch);
@@ -487,25 +485,25 @@ export const SUBSTITUTE: AddFunctionDescription = {
 // TEXTJOIN
 // -----------------------------------------------------------------------------
 export const TEXTJOIN: AddFunctionDescription = {
-  description: _lt("Combines text from multiple strings and/or arrays."),
+  description: _t("Combines text from multiple strings and/or arrays."),
   args: [
     arg(
       "delimiter (string)",
-      _lt(
+      _t(
         " A string, possible empty, or a reference to a valid string. If empty, the text will be simply concatenated."
       )
     ),
     arg(
       "ignore_empty (boolean)",
-      _lt(
+      _t(
         "A boolean; if TRUE, empty cells selected in the text arguments won't be included in the result."
       )
     ),
     arg(
       "text1 (string, range<string>)",
-      _lt("Any text item. This could be a string, or an array of strings in a range.")
+      _t("Any text item. This could be a string, or an array of strings in a range.")
     ),
-    arg("text2 (string, range<string>, repeating)", _lt("Additional text item(s).")),
+    arg("text2 (string, range<string>, repeating)", _t("Additional text item(s).")),
   ],
   returns: ["STRING"],
   compute: function (
@@ -530,9 +528,9 @@ export const TEXTJOIN: AddFunctionDescription = {
 // TRIM
 // -----------------------------------------------------------------------------
 export const TRIM: AddFunctionDescription = {
-  description: _lt("Removes space characters."),
+  description: _t("Removes space characters."),
   args: [
-    arg("text (string)", _lt("The text or reference to a cell containing text to be trimmed.")),
+    arg("text (string)", _t("The text or reference to a cell containing text to be trimmed.")),
   ],
   returns: ["STRING"],
   compute: function (text: PrimitiveArgValue): string {
@@ -545,8 +543,8 @@ export const TRIM: AddFunctionDescription = {
 // UPPER
 // -----------------------------------------------------------------------------
 export const UPPER: AddFunctionDescription = {
-  description: _lt("Converts a specified string to uppercase."),
-  args: [arg("text (string)", _lt("The string to convert to uppercase."))],
+  description: _t("Converts a specified string to uppercase."),
+  args: [arg("text (string)", _t("The string to convert to uppercase."))],
   returns: ["STRING"],
   compute: function (text: PrimitiveArgValue): string {
     return toString(text).toUpperCase();
@@ -558,12 +556,12 @@ export const UPPER: AddFunctionDescription = {
 // TEXT
 // -----------------------------------------------------------------------------
 export const TEXT: AddFunctionDescription = {
-  description: _lt("Converts a number to text according to a specified format."),
+  description: _t("Converts a number to text according to a specified format."),
   args: [
-    arg("number (number)", _lt("The number, date or time to format.")),
+    arg("number (number)", _t("The number, date or time to format.")),
     arg(
       "format (string)",
-      _lt("The pattern by which to format the number, enclosed in quotation marks.")
+      _t("The pattern by which to format the number, enclosed in quotation marks.")
     ),
   ],
   returns: ["STRING"],

--- a/src/functions/module_web.ts
+++ b/src/functions/module_web.ts
@@ -1,5 +1,5 @@
 import { markdownLink } from "../helpers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { AddFunctionDescription, PrimitiveArgValue } from "../types";
 import { arg } from "./arguments";
 import { toString } from "./helpers";
@@ -8,12 +8,12 @@ import { toString } from "./helpers";
 // HYPERLINK
 // -----------------------------------------------------------------------------
 export const HYPERLINK: AddFunctionDescription = {
-  description: _lt("Creates a hyperlink in a cell."),
+  description: _t("Creates a hyperlink in a cell."),
   args: [
-    arg("url (string)", _lt("The full URL of the link enclosed in quotation marks.")),
+    arg("url (string)", _t("The full URL of the link enclosed in quotation marks.")),
     arg(
       "link_label (string, optional)",
-      _lt("The text to display in the cell, enclosed in quotation marks.")
+      _t("The text to display in the cell, enclosed in quotation marks.")
     ),
   ],
   returns: ["STRING"],

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { CellValue, Currency, Format, FormattedValue, Locale, LocaleFormat } from "../types";
 import { DEFAULT_LOCALE } from "./../types/locale";
 import { INITIAL_1900_DAY, isDateTime, numberToJsDate, parseDateTime } from "./dates";
@@ -52,28 +52,28 @@ type InternalFormat = (
 // TODO in the future : remove these constants MONTHS/DAYS, and use a library such as luxon to handle it
 // + possibly handle automatic translation of day/month
 const MONTHS: Readonly<Record<number, string>> = {
-  0: _lt("January"),
-  1: _lt("February"),
-  2: _lt("March"),
-  3: _lt("April"),
-  4: _lt("May"),
-  5: _lt("June"),
-  6: _lt("July"),
-  7: _lt("August"),
-  8: _lt("September"),
-  9: _lt("October"),
-  10: _lt("November"),
-  11: _lt("December"),
+  0: _t("January"),
+  1: _t("February"),
+  2: _t("March"),
+  3: _t("April"),
+  4: _t("May"),
+  5: _t("June"),
+  6: _t("July"),
+  7: _t("August"),
+  8: _t("September"),
+  9: _t("October"),
+  10: _t("November"),
+  11: _t("December"),
 };
 
 const DAYS: Readonly<Record<number, string>> = {
-  0: _lt("Sunday"),
-  1: _lt("Monday"),
-  2: _lt("Tuesday"),
-  3: _lt("Wednesday"),
-  4: _lt("Thursday"),
-  5: _lt("Friday"),
-  6: _lt("Saturday"),
+  0: _t("Sunday"),
+  1: _t("Monday"),
+  2: _t("Tuesday"),
+  3: _t("Wednesday"),
+  4: _t("Thursday"),
+  5: _t("Friday"),
+  6: _t("Saturday"),
 };
 
 interface InternalNumberFormat {

--- a/src/helpers/links.ts
+++ b/src/helpers/links.ts
@@ -1,5 +1,5 @@
 import { Registry } from "../registries/registry";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { CellValue, Getters, Link, SpreadsheetChildEnv } from "../types";
 import { isMarkdownLink, isSheetUrl, isWebLink, parseMarkdownLink, parseSheetUrl } from "./misc";
 
@@ -52,7 +52,7 @@ urlRegistry.add("sheet_URL", {
   },
   urlRepresentation(url, getters) {
     const sheetId = parseSheetUrl(url);
-    return getters.tryGetSheetName(sheetId) || _lt("Invalid sheet");
+    return getters.tryGetSheetName(sheetId) || _t("Invalid sheet");
   },
   open(url, env) {
     const sheetId = parseSheetUrl(url);

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   CoreGetters,
   Getters,
@@ -62,7 +62,7 @@ export class RangeImpl implements Range {
     } else if (right === undefined && bottom !== undefined) {
       return { bottom, left, top, right: this.getSheetSize(this.sheetId).numberOfCols - 1 };
     }
-    throw new Error(_lt("Bad zone format"));
+    throw new Error(_t("Bad zone format"));
   }
 
   static getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {

--- a/src/helpers/sort.ts
+++ b/src/helpers/sort.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   CellValueType,
   CommandResult,
@@ -101,7 +101,7 @@ export function interactiveSortSelection(
       });
     } else {
       env.askConfirmation(
-        _lt(
+        _t(
           "We found data next to your selection. Since this data was not selected, it will not be sorted. Do you want to extend your selection?"
         ),
         () => {
@@ -130,7 +130,7 @@ export function interactiveSortSelection(
     const { col, row } = anchor;
     env.model.selection.selectZone({ cell: { col, row }, zone });
     env.raiseError(
-      _lt("Cannot sort. To sort, select only cells or only merges that have the same size.")
+      _t("Cannot sort. To sort, select only cells or only merges that have the same size.")
     );
   }
 }

--- a/src/helpers/ui/cut_interactive.ts
+++ b/src/helpers/ui/cut_interactive.ts
@@ -1,5 +1,5 @@
 import { CommandResult } from "../..";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { SpreadsheetChildEnv } from "../../types";
 
 export function interactiveCut(env: SpreadsheetChildEnv) {
@@ -7,7 +7,7 @@ export function interactiveCut(env: SpreadsheetChildEnv) {
 
   if (!result.isSuccessful) {
     if (result.isCancelledBecause(CommandResult.WrongCutSelection)) {
-      env.raiseError(_lt("This operation is not allowed with multiple selections."));
+      env.raiseError(_t("This operation is not allowed with multiple selections."));
     }
   }
 }

--- a/src/helpers/ui/filter_interactive.ts
+++ b/src/helpers/ui/filter_interactive.ts
@@ -1,10 +1,10 @@
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { CommandResult, SpreadsheetChildEnv, UID, Zone } from "../../types";
 
 export const AddFilterInteractiveContent = {
-  filterOverlap: _lt("You cannot create overlapping filters."),
-  nonContinuousTargets: _lt("A filter can only be created on a continuous selection."),
-  mergeInFilter: _lt("You can't create a filter over a range that contains a merge."),
+  filterOverlap: _t("You cannot create overlapping filters."),
+  nonContinuousTargets: _t("A filter can only be created on a continuous selection."),
+  mergeInFilter: _t("You can't create a filter over a range that contains a merge."),
 };
 
 export function interactiveAddFilter(env: SpreadsheetChildEnv, sheetId: UID, target: Zone[]) {

--- a/src/helpers/ui/merge_interactive.ts
+++ b/src/helpers/ui/merge_interactive.ts
@@ -1,11 +1,11 @@
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { CommandResult, SpreadsheetChildEnv, UID, Zone } from "../../types";
 
 export const AddMergeInteractiveContent = {
-  MergeIsDestructive: _lt(
+  MergeIsDestructive: _t(
     "Merging these cells will only preserve the top-leftmost value. Merge anyway?"
   ),
-  MergeInFilter: _lt("You can't merge cells inside of an existing filter."),
+  MergeInFilter: _t("You can't merge cells inside of an existing filter."),
 };
 
 export function interactiveAddMerge(env: SpreadsheetChildEnv, sheetId: UID, target: Zone[]) {

--- a/src/helpers/ui/paste_interactive.ts
+++ b/src/helpers/ui/paste_interactive.ts
@@ -1,14 +1,14 @@
 import { CommandResult, DispatchResult } from "../..";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { ClipboardPasteOptions, SpreadsheetChildEnv, Zone } from "../../types";
 
 export const PasteInteractiveContent = {
-  wrongPasteSelection: _lt("This operation is not allowed with multiple selections."),
-  willRemoveExistingMerge: _lt(
+  wrongPasteSelection: _t("This operation is not allowed with multiple selections."),
+  willRemoveExistingMerge: _t(
     "This operation is not possible due to a merge. Please remove the merges first than try again."
   ),
-  wrongFigurePasteOption: _lt("Cannot do a special paste of a figure."),
-  frozenPaneOverlap: _lt("Cannot paste merged cells over a frozen pane."),
+  wrongFigurePasteOption: _t("Cannot do a special paste of a figure."),
+  frozenPaneOverlap: _t("Cannot paste merged cells over a frozen pane."),
 };
 
 export function handlePasteResult(env: SpreadsheetChildEnv, result: DispatchResult) {

--- a/src/helpers/ui/sheet_interactive.ts
+++ b/src/helpers/ui/sheet_interactive.ts
@@ -1,5 +1,5 @@
 import { FORBIDDEN_SHEET_CHARS } from "../../constants";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { CommandResult, SpreadsheetChildEnv, UID } from "../../types";
 
 export function interactiveRenameSheet(
@@ -10,15 +10,15 @@ export function interactiveRenameSheet(
 ) {
   const result = env.model.dispatch("RENAME_SHEET", { sheetId, name });
   if (result.reasons.includes(CommandResult.MissingSheetName)) {
-    env.raiseError(_lt("The sheet name cannot be empty."), errorCallback);
+    env.raiseError(_t("The sheet name cannot be empty."), errorCallback);
   } else if (result.reasons.includes(CommandResult.DuplicatedSheetName)) {
     env.raiseError(
-      _lt("A sheet with the name %s already exists. Please select another name.", name),
+      _t("A sheet with the name %s already exists. Please select another name.", name),
       errorCallback
     );
   } else if (result.reasons.includes(CommandResult.ForbiddenCharactersInSheetName)) {
     env.raiseError(
-      _lt(
+      _t(
         "Some used characters are not allowed in a sheet name (Forbidden characters are %s).",
         FORBIDDEN_SHEET_CHARS.join(" ")
       ),

--- a/src/helpers/ui/split_to_columns_interactive.ts
+++ b/src/helpers/ui/split_to_columns_interactive.ts
@@ -1,10 +1,10 @@
 import { CommandResult } from "../..";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { SpreadsheetChildEnv } from "../../types";
 import { DispatchResult } from "./../../types/commands";
 
 export const SplitToColumnsInteractiveContent = {
-  SplitIsDestructive: _lt("This will overwrite data in the subsequent columns. Split anyway?"),
+  SplitIsDestructive: _t("This will overwrite data in the subsequent columns. Split anyway?"),
 };
 
 export function interactiveSplitToColumns(

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { Position, UnboundedZone, Zone, ZoneDimension } from "../types";
 import { lettersToNumber, numberToLetters, toCartesian, toXC } from "./coordinates";
 import { range } from "./misc";
@@ -192,7 +192,7 @@ export function zoneToXc(zone: Zone | UnboundedZone): string {
     return isOneCell ? toXC(left, top) : `${toXC(left, top)}:${toXC(right, bottom)}`;
   }
 
-  throw new Error(_lt("Bad zone format"));
+  throw new Error(_t("Bad zone format"));
 }
 
 /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -26,7 +26,7 @@ import {
   SelectionStreamProcessorImpl,
 } from "./selection_stream/selection_stream_processor";
 import { StateObserver } from "./state_observer";
-import { _lt } from "./translation";
+import { _t } from "./translation";
 import { StateUpdateMessage, TransportService } from "./types/collaborative/transport_service";
 import { CommandTypes } from "./types/commands";
 import { FileStore } from "./types/files";
@@ -382,7 +382,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
   private setupConfig(config: Partial<ModelConfig>): ModelConfig {
     const client = config.client || {
       id: this.uuidGenerator.uuidv4(),
-      name: _lt("Anonymous").toString(),
+      name: _t("Anonymous").toString(),
     };
     const transportService = config.transportService || new LocalTransportService();
     return {

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -10,7 +10,7 @@ import {
   positions,
   toCartesian,
 } from "../../helpers/index";
-import { _lt, _t } from "../../translation";
+import { _t } from "../../translation";
 import {
   Cell,
   CellPosition,
@@ -635,7 +635,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     if (deltaIndex === 0) {
       return currentIndex;
     }
-    throw new Error(_lt("There is not enough visible sheets"));
+    throw new Error(_t("There is not enough visible sheets"));
   }
 
   private checkSheetName(cmd: RenameSheetCommand | CreateSheetCommand): CommandResult {
@@ -761,7 +761,7 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   private getDuplicateSheetName(sheetName: string) {
     let i = 1;
     const names = this.orderedSheetIds.map(this.getSheetName.bind(this));
-    const baseName = _lt("Copy of %s", sheetName);
+    const baseName = _t("Copy of %s", sheetName);
     let name = baseName.toString();
     while (names.includes(name)) {
       name = `${baseName} (${i})`;

--- a/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
@@ -1,7 +1,7 @@
 import { functionRegistry } from "../../../functions";
 import { intersection, isZoneValid, zoneToXc } from "../../../helpers";
 import { ModelConfig } from "../../../model";
-import { _lt } from "../../../translation";
+import { _t } from "../../../translation";
 import {
   CellPosition,
   CellValue,
@@ -81,19 +81,19 @@ class CompilationParametersBuilder {
     if (range.zone.bottom !== range.zone.top || range.zone.left !== range.zone.right) {
       throw new Error(
         paramNumber
-          ? _lt(
+          ? _t(
               "Function %s expects the parameter %s to be a single value or a single cell reference, not a range.",
               functionName.toString(),
               paramNumber.toString()
             )
-          : _lt(
+          : _t(
               "Function %s expects its parameters to be single values or single cell references, not ranges.",
               functionName.toString()
             )
       );
     }
     if (range.invalidSheetName) {
-      throw new Error(_lt("Invalid sheet name: %s", range.invalidSheetName));
+      throw new Error(_t("Invalid sheet name: %s", range.invalidSheetName));
     }
 
     return this.readCell(range);
@@ -101,7 +101,7 @@ class CompilationParametersBuilder {
 
   private readCell(range: Range): PrimitiveArg {
     if (!this.getters.tryGetSheet(range.sheetId)) {
-      throw new Error(_lt("Invalid sheet name"));
+      throw new Error(_t("Invalid sheet name"));
     }
     const position = { sheetId: range.sheetId, col: range.zone.left, row: range.zone.top };
     const evaluatedCell = this.getEvaluatedCellIfNotEmpty(position);

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -1,7 +1,7 @@
 import { forEachPositionsInZone, JetSet, lazy, toXC } from "../../../helpers";
 import { createEvaluatedCell, errorCell, evaluateLiteral } from "../../../helpers/cells";
 import { ModelConfig } from "../../../model";
-import { _lt } from "../../../translation";
+import { _t } from "../../../translation";
 import {
   Cell,
   CellPosition,
@@ -296,17 +296,15 @@ export class Evaluator {
     }
 
     if (enoughCols) {
-      throw new Error(_lt("Result couldn't be automatically expanded. Please insert more rows."));
+      throw new Error(_t("Result couldn't be automatically expanded. Please insert more rows."));
     }
 
     if (enoughRows) {
-      throw new Error(
-        _lt("Result couldn't be automatically expanded. Please insert more columns.")
-      );
+      throw new Error(_t("Result couldn't be automatically expanded. Please insert more columns."));
     }
 
     throw new Error(
-      _lt("Result couldn't be automatically expanded. Please insert more columns and rows.")
+      _t("Result couldn't be automatically expanded. Please insert more columns and rows.")
     );
   }
 
@@ -334,7 +332,7 @@ export class Evaluator {
       ) {
         this.blockedArrayFormulas.add(formulaPositionId);
         throw new Error(
-          _lt(
+          _t(
             "Array result was not expanded because it would overwrite data in %s.",
             toXC(position.col, position.row)
           )

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -3,7 +3,7 @@ import { compile } from "../../formulas";
 import { parseLiteral } from "../../helpers/cells";
 import { colorNumberString, percentile } from "../../helpers/index";
 import { clip, lazy } from "../../helpers/misc";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import {
   CellIsRule,
   CellPosition,
@@ -458,7 +458,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
           return cell.value === values[0];
         default:
           console.warn(
-            _lt(
+            _t(
               "Not implemented operator %s for kind of conditional formatting:  %s",
               rule.operator,
               rule.type

--- a/src/plugins/ui_feature/sort.ts
+++ b/src/plugins/ui_feature/sort.ts
@@ -1,6 +1,6 @@
 import { isInside, overlap, positions, range, zoneToDimension } from "../../helpers/index";
 import { sortCells } from "../../helpers/sort";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import {
   CellPosition,
   CellValueType,
@@ -26,7 +26,7 @@ export class SortPlugin extends UIPlugin {
     switch (cmd.type) {
       case "SORT_CELLS":
         if (!isInside(cmd.col, cmd.row, cmd.zone)) {
-          throw new Error(_lt("The anchor must be part of the provided zone"));
+          throw new Error(_t("The anchor must be part of the provided zone"));
         }
         return this.checkValidations(cmd, this.checkMerge, this.checkMergeSizes);
     }

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -16,7 +16,7 @@ import {
 } from "../../helpers/index";
 import { canonicalizeContent, localizeFormula } from "../../helpers/locale";
 import { loopThroughReferenceType } from "../../helpers/reference_type";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import {
   AddColumnsRowsCommand,
   CellPosition,
@@ -42,7 +42,7 @@ export type EditionMode =
   | "selecting" // should tell if you need to underline the current range selected.
   | "inactive";
 
-const CELL_DELETED_MESSAGE = _lt("The cell you are trying to edit has been deleted.");
+const CELL_DELETED_MESSAGE = _t("The cell you are trying to edit has been deleted.");
 
 export interface ComposerSelection {
   start: number;
@@ -572,7 +572,7 @@ export class EditionPlugin extends UIPlugin {
         if (raise) {
           this.ui.notifyUI({
             type: "ERROR",
-            text: _lt(
+            text: _t(
               "This formula has over 100 parts. It can't be processed properly, consider splitting it into multiple cells"
             ),
           });

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -12,7 +12,7 @@ import {
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
 } from "../../helpers/index";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { SelectionEvent } from "../../types/event_stream";
 import {
   AddColumnsRowsCommand,
@@ -51,32 +51,32 @@ interface SelectionStatisticFunction {
 
 const selectionStatisticFunctions: SelectionStatisticFunction[] = [
   {
-    name: _lt("Sum"),
+    name: _t("Sum"),
     types: [CellValueType.number],
     compute: (values, locale) => SUM.compute.bind({ locale })([values]) as number,
   },
   {
-    name: _lt("Avg"),
+    name: _t("Avg"),
     types: [CellValueType.number],
     compute: (values, locale) => AVERAGE.compute.bind({ locale })([values]) as number,
   },
   {
-    name: _lt("Min"),
+    name: _t("Min"),
     types: [CellValueType.number],
     compute: (values, locale) => MIN.compute.bind({ locale })([values]) as number,
   },
   {
-    name: _lt("Max"),
+    name: _t("Max"),
     types: [CellValueType.number],
     compute: (values, locale) => MAX.compute.bind({ locale })([values]) as number,
   },
   {
-    name: _lt("Count"),
+    name: _t("Count"),
     types: [CellValueType.number, CellValueType.text, CellValueType.boolean, CellValueType.error],
     compute: (values, locale) => COUNTA.compute.bind({ locale })([values]) as number,
   },
   {
-    name: _lt("Count Numbers"),
+    name: _t("Count Numbers"),
     types: [CellValueType.number, CellValueType.text, CellValueType.boolean, CellValueType.error],
     compute: (values, locale) => COUNT.compute.bind({ locale })([values]) as number,
   },

--- a/src/registries/chart_types.ts
+++ b/src/registries/chart_types.ts
@@ -10,7 +10,7 @@ import {
   createScorecardChartRuntime,
   ScorecardChart,
 } from "../helpers/figures/charts/scorecard_chart";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   AddColumnsRowsCommand,
   CommandResult,
@@ -80,7 +80,7 @@ chartRegistry.add("bar", {
   ) => BarChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     BarChart.getDefinitionFromContextCreation(context),
-  name: _lt("Bar"),
+  name: _t("Bar"),
   sequence: 10,
 });
 chartRegistry.add("line", {
@@ -96,7 +96,7 @@ chartRegistry.add("line", {
   ) => LineChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     LineChart.getDefinitionFromContextCreation(context),
-  name: _lt("Line"),
+  name: _t("Line"),
   sequence: 20,
 });
 chartRegistry.add("pie", {
@@ -112,7 +112,7 @@ chartRegistry.add("pie", {
   ) => PieChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     PieChart.getDefinitionFromContextCreation(context),
-  name: _lt("Pie"),
+  name: _t("Pie"),
   sequence: 30,
 });
 chartRegistry.add("scorecard", {
@@ -128,7 +128,7 @@ chartRegistry.add("scorecard", {
   ) => ScorecardChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     ScorecardChart.getDefinitionFromContextCreation(context),
-  name: _lt("Scorecard"),
+  name: _t("Scorecard"),
   sequence: 40,
 });
 chartRegistry.add("gauge", {
@@ -144,7 +144,7 @@ chartRegistry.add("gauge", {
   ) => GaugeChart.transformDefinition(definition, executed),
   getChartDefinitionFromContextCreation: (context: ChartCreationContext) =>
     GaugeChart.getDefinitionFromContextCreation(context),
-  name: _lt("Gauge"),
+  name: _t("Gauge"),
   sequence: 50,
 });
 

--- a/src/registries/figure_registry.ts
+++ b/src/registries/figure_registry.ts
@@ -2,7 +2,7 @@ import { Action, ActionSpec, createActions } from "../actions/action";
 import { ChartFigure } from "../components/figures/figure_chart/figure_chart";
 import { ImageFigure } from "../components/figures/figure_image/figure_image";
 import { getMaxFigureSize } from "../helpers/figures/figure/figure";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { SpreadsheetChildEnv, UID } from "../types";
 import { Registry } from "./registry";
 
@@ -48,7 +48,7 @@ function getChartMenu(
   const menuItemSpecs: ActionSpec[] = [
     {
       id: "edit",
-      name: _lt("Edit"),
+      name: _t("Edit"),
       sequence: 1,
       execute: () => {
         env.model.dispatch("SELECT_FIGURE", { id: figureId });
@@ -73,7 +73,7 @@ function getImageMenuRegistry(
     getCutMenuItem(figureId, env),
     {
       id: "reset_size",
-      name: _lt("Reset size"),
+      name: _t("Reset size"),
       sequence: 4,
       execute: async () => {
         const imagePath = env.model.getters.getImagePath(figureId);
@@ -102,7 +102,7 @@ function getImageMenuRegistry(
 function getCopyMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
   return {
     id: "copy",
-    name: _lt("Copy"),
+    name: _t("Copy"),
     sequence: 2,
     description: "Ctrl+C",
     execute: async () => {
@@ -117,7 +117,7 @@ function getCopyMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
 function getCutMenuItem(figureId: UID, env: SpreadsheetChildEnv): ActionSpec {
   return {
     id: "cut",
-    name: _lt("Cut"),
+    name: _t("Cut"),
     sequence: 3,
     description: "Ctrl+X",
     execute: async () => {
@@ -136,7 +136,7 @@ function getDeleteMenuItem(
 ): ActionSpec {
   return {
     id: "delete",
-    name: _lt("Delete"),
+    name: _t("Delete"),
     sequence: 10,
     execute: () => {
       env.model.dispatch("DELETE_FIGURE", {

--- a/src/registries/menus/cell_menu_registry.ts
+++ b/src/registries/menus/cell_menu_registry.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { MenuItemRegistry } from "../menu_items_registry";
 
 import * as ACTION_EDIT from "../../actions/edit_actions";
@@ -51,12 +51,12 @@ cellMenuRegistry
   })
   .addChild("insert_cell_down", ["insert_cell"], {
     ...ACTION_INSERT.insertCellShiftDown,
-    name: _lt("Shift down"),
+    name: _t("Shift down"),
     sequence: 10,
   })
   .addChild("insert_cell_right", ["insert_cell"], {
     ...ACTION_INSERT.insertCellShiftRight,
-    name: _lt("Shift right"),
+    name: _t("Shift right"),
     sequence: 20,
   })
   .add("delete_row", {
@@ -77,19 +77,19 @@ cellMenuRegistry
   })
   .addChild("delete_cell_up", ["delete_cell"], {
     ...ACTION_EDIT.deleteCellShiftUp,
-    name: _lt("Shift up"),
+    name: _t("Shift up"),
     sequence: 10,
     icon: "o-spreadsheet-Icon.DELETE_CELL_SHIFT_UP",
   })
   .addChild("delete_cell_left", ["delete_cell"], {
     ...ACTION_EDIT.deleteCellShiftLeft,
-    name: _lt("Shift left"),
+    name: _t("Shift left"),
     sequence: 20,
     icon: "o-spreadsheet-Icon.DELETE_CELL_SHIFT_LEFT",
   })
   .add("insert_link", {
     ...ACTION_INSERT.insertLink,
-    name: _lt("Insert link"),
+    name: _t("Insert link"),
     sequence: 150,
     separator: true,
   });

--- a/src/registries/menus/col_menu_registry.ts
+++ b/src/registries/menus/col_menu_registry.ts
@@ -3,7 +3,7 @@ import * as ACTION_EDIT from "../../actions/edit_actions";
 import * as ACTION_FORMAT from "../../actions/format_actions";
 import * as ACTION_INSERT from "../../actions/insert_actions";
 import * as ACTION_VIEW from "../../actions/view_actions";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { MenuItemRegistry } from "../menu_items_registry";
 
 export const colMenuRegistry = new MenuItemRegistry();
@@ -37,7 +37,7 @@ colMenuRegistry
   .add("sort_columns", {
     ...ACTION_DATA.sortRange,
     name: (env) =>
-      env.model.getters.getActiveCols().size > 1 ? _lt("Sort columns") : _lt("Sort column"),
+      env.model.getters.getActiveCols().size > 1 ? _t("Sort columns") : _t("Sort column"),
     sequence: 50,
     separator: true,
   })

--- a/src/registries/menus/number_format_menu_registry.ts
+++ b/src/registries/menus/number_format_menu_registry.ts
@@ -1,6 +1,6 @@
 import { ActionSpec } from "../../actions/action";
 import * as ACTION_FORMAT from "../../actions/format_actions";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { MenuItemRegistry } from "../menu_items_registry";
 
 export const numberFormatMenuRegistry = new MenuItemRegistry();
@@ -52,7 +52,7 @@ numberFormatMenuRegistry
   });
 
 export const formatNumberMenuItemSpec: ActionSpec = {
-  name: _lt("More formats"),
+  name: _t("More formats"),
   icon: "o-spreadsheet-Icon.NUMBER_FORMATS",
   children: [() => numberFormatMenuRegistry.getAll()],
 };

--- a/src/registries/menus/topbar_menu_registry.ts
+++ b/src/registries/menus/topbar_menu_registry.ts
@@ -3,7 +3,7 @@ import * as ACTION_EDIT from "../../actions/edit_actions";
 import * as ACTION_FORMAT from "../../actions/format_actions";
 import * as ACTION_INSERT from "../../actions/insert_actions";
 import * as ACTION_VIEW from "../../actions/view_actions";
-import { _lt } from "../../translation";
+import { _t } from "../../translation";
 import { MenuItemRegistry } from "../menu_items_registry";
 import { formatNumberMenuItemSpec } from "./number_format_menu_registry";
 
@@ -16,11 +16,11 @@ topbarMenuRegistry
   // ---------------------------------------------------------------------
 
   .add("file", {
-    name: _lt("File"),
+    name: _t("File"),
     sequence: 10,
   })
   .addChild("settings", ["file"], {
-    name: _lt("Settings"),
+    name: _t("Settings"),
     sequence: 100,
     execute: (env) => env.openSidePanel("Settings"),
     icon: "o-spreadsheet-Icon.COG",
@@ -31,7 +31,7 @@ topbarMenuRegistry
   // ---------------------------------------------------------------------
 
   .add("edit", {
-    name: _lt("Edit"),
+    name: _t("Edit"),
     sequence: 20,
   })
   .addChild("undo", ["edit"], {
@@ -74,7 +74,7 @@ topbarMenuRegistry
     separator: true,
   })
   .addChild("delete", ["edit"], {
-    name: _lt("Delete"),
+    name: _t("Delete"),
     icon: "o-spreadsheet-Icon.DELETE",
     sequence: 70,
   })
@@ -112,7 +112,7 @@ topbarMenuRegistry
   // ---------------------------------------------------------------------
 
   .add("view", {
-    name: _lt("View"),
+    name: _t("View"),
     sequence: 30,
   })
   .addChild("unfreeze_panes", ["view"], {
@@ -171,7 +171,7 @@ topbarMenuRegistry
   // ---------------------------------------------------------------------
 
   .add("insert", {
-    name: _lt("Insert"),
+    name: _t("Insert"),
     sequence: 40,
   })
   .addChild("insert_row", ["insert"], {
@@ -204,12 +204,12 @@ topbarMenuRegistry
   })
   .addChild("insert_cell_down", ["insert", "insert_cell"], {
     ...ACTION_INSERT.insertCellShiftDown,
-    name: _lt("Shift down"),
+    name: _t("Shift down"),
     sequence: 10,
   })
   .addChild("insert_cell_right", ["insert", "insert_cell"], {
     ...ACTION_INSERT.insertCellShiftRight,
-    name: _lt("Shift right"),
+    name: _t("Shift right"),
     sequence: 20,
   })
   .addChild("insert_sheet", ["insert"], {
@@ -269,10 +269,10 @@ topbarMenuRegistry
   // FORMAT MENU ITEMS
   // ---------------------------------------------------------------------
 
-  .add("format", { name: _lt("Format"), sequence: 50 })
+  .add("format", { name: _t("Format"), sequence: 50 })
   .addChild("format_number", ["format"], {
     ...formatNumberMenuItemSpec,
-    name: _lt("Number"),
+    name: _t("Number"),
     sequence: 10,
     separator: true,
   })
@@ -361,7 +361,7 @@ topbarMenuRegistry
   // ---------------------------------------------------------------------
 
   .add("data", {
-    name: _lt("Data"),
+    name: _t("Data"),
     sequence: 60,
   })
   .addChild("sort_range", ["data"], {

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -4,7 +4,7 @@ import { CustomCurrencyPanel } from "../components/side_panel/custom_currency/cu
 import { FindAndReplacePanel } from "../components/side_panel/find_and_replace/find_and_replace";
 import { SettingsPanel } from "../components/side_panel/settings/settings_panel";
 import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns_panel/split_to_columns_panel";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import { SpreadsheetChildEnv } from "../types";
 import { Registry } from "./registry";
 
@@ -20,31 +20,31 @@ export interface SidePanelContent {
 export const sidePanelRegistry = new Registry<SidePanelContent>();
 
 sidePanelRegistry.add("ConditionalFormatting", {
-  title: _lt("Conditional formatting"),
+  title: _t("Conditional formatting"),
   Body: ConditionalFormattingPanel,
 });
 
 sidePanelRegistry.add("ChartPanel", {
-  title: _lt("Chart"),
+  title: _t("Chart"),
   Body: ChartPanel,
 });
 
 sidePanelRegistry.add("FindAndReplace", {
-  title: _lt("Find and Replace"),
+  title: _t("Find and Replace"),
   Body: FindAndReplacePanel,
 });
 
 sidePanelRegistry.add("CustomCurrency", {
-  title: _lt("Custom currency format"),
+  title: _t("Custom currency format"),
   Body: CustomCurrencyPanel,
 });
 
 sidePanelRegistry.add("SplitToColumns", {
-  title: _lt("Split text into columns"),
+  title: _t("Split text into columns"),
   Body: SplitIntoColumnsPanel,
 });
 
 sidePanelRegistry.add("Settings", {
-  title: _lt("Spreadsheet settings"),
+  title: _t("Spreadsheet settings"),
   Body: SettingsPanel,
 });

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -1,6 +1,5 @@
 /*
- * usage: every string should be translated either with _lt if they are registered with a registry at
- *  the load of the app or with Spreadsheet._t in the templates. Spreadsheet._t is exposed in the
+ * usage: every string should be translated with Spreadsheet._t in the templates. Spreadsheet._t is exposed in the
  *  sub-env of Spreadsheet components as _t
  * */
 
@@ -11,6 +10,7 @@ export type TranslationFunction = (
 
 // define a mock translation function, when o-spreadsheet runs in standalone it doesn't translate any string
 let _translate: TranslationFunction = (s) => s;
+let _loaded: () => boolean = () => false;
 
 function sprintf(s: string, ...values: string[] | [{ [key: string]: string }]): string {
   if (values.length === 1 && typeof values[0] === "object") {
@@ -25,25 +25,21 @@ function sprintf(s: string, ...values: string[] | [{ [key: string]: string }]): 
 /***
  * Allow to inject a translation function from outside o-spreadsheet.
  * @param tfn the function that will do the translation
+ * @param loaded a function that returns true when the translation is loaded
  */
-export function setTranslationMethod(tfn: TranslationFunction) {
+export function setTranslationMethod(tfn: TranslationFunction, loaded: () => boolean = () => true) {
   _translate = tfn;
+  _loaded = loaded;
 }
 
 export const _t: TranslationFunction = function (
   s: string,
   ...values: string[] | [{ [key: string]: string }]
 ) {
+  if (!_loaded()) {
+    return new LazyTranslatedString(s, values) as unknown as string;
+  }
   return sprintf(_translate(s), ...values);
-};
-
-export const _lt: TranslationFunction = function (
-  str: string,
-  ...values: string[] | [{ [key: string]: string }]
-) {
-  // casts the object to unknown then to string to trick typescript into thinking that the object it receives is actually a string
-  // this way it will be typed correctly (behaves like a string) but tests like typeof _lt("whatever") will be object and not string !
-  return new LazyTranslatedString(str, values) as unknown as string;
 };
 
 class LazyTranslatedString extends String {
@@ -53,7 +49,7 @@ class LazyTranslatedString extends String {
 
   valueOf() {
     const str = super.valueOf();
-    return sprintf(_translate(str), ...this.values);
+    return _loaded() ? sprintf(_translate(str), ...this.values) : str;
   }
   toString() {
     return this.valueOf();

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,4 +1,4 @@
-import { _lt } from "../translation";
+import { _t } from "../translation";
 
 export enum CellErrorType {
   NotAvailable = "#N/A",
@@ -32,13 +32,13 @@ export class BadExpressionError extends EvaluationError {
 
 export class CircularDependencyError extends EvaluationError {
   constructor() {
-    super(CellErrorType.CircularDependency, _lt("Circular reference"));
+    super(CellErrorType.CircularDependency, _t("Circular reference"));
   }
 }
 
 export class InvalidReferenceError extends EvaluationError {
   constructor() {
-    super(CellErrorType.InvalidReference, _lt("Invalid reference"));
+    super(CellErrorType.InvalidReference, _t("Invalid reference"));
   }
 }
 
@@ -46,7 +46,7 @@ export class NotAvailableError extends EvaluationError {
   constructor(errorMessage: string | undefined = undefined) {
     super(
       CellErrorType.NotAvailable,
-      errorMessage || _lt("Data not available"),
+      errorMessage || _t("Data not available"),
       errorMessage ? CellErrorLevel.error : CellErrorLevel.silent
     );
   }
@@ -54,6 +54,6 @@ export class NotAvailableError extends EvaluationError {
 
 export class UnknownFunctionError extends EvaluationError {
   constructor(fctName: string) {
-    super(CellErrorType.UnknownFunction, _lt('Unknown function: "%s"', fctName));
+    super(CellErrorType.UnknownFunction, _t('Unknown function: "%s"', fctName));
   }
 }

--- a/src/xlsx/xlsx_reader.ts
+++ b/src/xlsx/xlsx_reader.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_REVISION_ID } from "../constants";
 import { removeFalsyAttributes } from "../helpers";
-import { _lt } from "../translation";
+import { _t } from "../translation";
 import {
   ImportedFiles,
   XLSXExternalBook,
@@ -135,7 +135,7 @@ export class XlsxReader {
     };
 
     if (!xlsxFileStructure.workbook.rels) {
-      throw Error(_lt("Cannot find workbook relations file"));
+      throw Error(_t("Cannot find workbook relations file"));
     }
 
     return xlsxFileStructure;

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -1,7 +1,7 @@
 import { setTranslationMethod } from "../../src";
 import { arg, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
-import { _lt } from "../../src/translation";
+import { _t } from "../../src/translation";
 import { registerCleanup } from "../setup/jest.setup";
 import { keyDown, keyUp } from "../test_helpers/dom_helper";
 import {
@@ -45,12 +45,17 @@ describe("formula assistant", () => {
       compute: () => 1,
       returns: ["ANY"],
     });
+    setTranslationMethod(
+      (str, ...values) => str,
+      () => false
+    );
     functionRegistry.add("FUNC1", {
       description: "func1 def",
-      args: [arg("f1Arg1 (any)", "f1 Arg1 def"), arg("f1Arg2 (any)", _lt("f1 Arg2 def"))],
+      args: [arg("f1Arg1 (any)", "f1 Arg1 def"), arg("f1Arg2 (any)", _t("f1 Arg2 def"))],
       compute: () => 1,
       returns: ["ANY"],
     });
+    setTranslationMethod((str, ...values) => str);
     functionRegistry.add("FUNC2", {
       description: "func2 def",
       args: [

--- a/tests/functions/arguments.test.ts
+++ b/tests/functions/arguments.test.ts
@@ -1,7 +1,5 @@
 import { addMetaInfoFromArg, arg, validateArguments } from "../../src/functions/arguments";
-import { setTranslationMethod, _lt } from "../../src/translation";
 import { AddFunctionDescription } from "../../src/types";
-import { registerCleanup } from "../setup/jest.setup";
 
 describe("args", () => {
   test("various", () => {
@@ -44,22 +42,6 @@ describe("args", () => {
       default: true,
       defaultValue: "10",
     });
-  });
-
-  test("argument description is translated", () => {
-    const description = _lt("description");
-    const argDefinition = arg("test (number)", description);
-    // set the translation method after creating the argument.
-    // This is what actually happens because translations are
-    // loaded after the function definition
-    setTranslationMethod((str, ...values) => {
-      if (str === "description") {
-        return "translated description";
-      }
-      return str;
-    });
-    registerCleanup(() => setTranslationMethod((str, ...values) => str));
-    expect(argDefinition.description.toString()).toEqual("translated description");
   });
 
   test("default string value", () => {

--- a/tests/helpers/ui.test.ts
+++ b/tests/helpers/ui.test.ts
@@ -97,11 +97,11 @@ describe("Interactive rename sheet", () => {
 });
 
 describe("Interactive Freeze columns/rows", () => {
-  const model = new Model();
   test.each([
     ["column", "COL"],
     ["row", "ROW"],
   ])("freeze %s through a merge", (name, dimension) => {
+    const model = new Model();
     merge(model, "A1:D4");
     const raiseError = jest.fn();
     const env = makeInteractiveTestEnv(model, { raiseError });

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -45,6 +45,8 @@ import {
 } from "../test_helpers/getters_helpers";
 import { createEqualCF, getGrid, target, toRangesData } from "../test_helpers/helpers";
 
+let model: Model;
+
 describe("clipboard", () => {
   test("can copy and paste a cell", () => {
     const model = new Model();
@@ -837,9 +839,8 @@ describe("clipboard", () => {
   });
 
   describe("copy/paste several zones", () => {
-    const model = new Model();
-
     beforeEach(() => {
+      model = new Model();
       setCellContent(model, "A1", "a1");
       setCellContent(model, "A2", "a2");
       setCellContent(model, "A3", "a3");

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../test_helpers/getters_helpers";
 import { toRangesData } from "../test_helpers/helpers";
 
+let model: Model;
 describe("core", () => {
   describe("statistic functions", () => {
     test("functions are applied on deduplicated cells in zones", () => {
@@ -51,13 +52,15 @@ describe("core", () => {
     });
 
     describe("return undefined if the types handled by the function are not present among the types of the selected cells", () => {
-      const model = new Model();
-      setCellContent(model, "A1", "24");
-      setCellContent(model, "A2", "=42");
-      setCellContent(model, "A3", "107% of people don't get statistics");
-      setCellContent(model, "A4", "TRUE");
-      setCellContent(model, "A5", "=A5");
-      setCellContent(model, "A6", "=A7");
+      beforeEach(() => {
+        model = new Model();
+        setCellContent(model, "A1", "24");
+        setCellContent(model, "A2", "=42");
+        setCellContent(model, "A3", "107% of people don't get statistics");
+        setCellContent(model, "A4", "TRUE");
+        setCellContent(model, "A5", "=A5");
+        setCellContent(model, "A6", "=A7");
+      });
 
       test('return the "SUM" value only on cells interpreted as number', () => {
         // select the range A1:A7
@@ -148,7 +151,7 @@ describe("core", () => {
       });
     });
 
-    describe("raise error from compilation with specific error message", () => {
+    test("raise error from compilation with specific error message", () => {
       functionRegistry.add("TWOARGSNEEDED", {
         description: "any function",
         compute: () => {

--- a/tests/plugins/evaluation_formula_array.test.ts
+++ b/tests/plugins/evaluation_formula_array.test.ts
@@ -27,9 +27,8 @@ import {
 import { getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import { restoreDefaultFunctions, target } from "../test_helpers/helpers";
 
+let model: Model;
 describe("evaluate formulas that return an array", () => {
-  let model: Model = new Model();
-
   beforeEach(() => {
     model = new Model();
     functionRegistry.add("MFILL", {

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -871,8 +871,10 @@ describe("Alter Selection with content in selection", () => {
 });
 
 describe("move elements(s)", () => {
-  const model = new Model({
-    sheets: [{ id: "1", colNumber: 10, rowNumber: 10, merges: ["C3:D4", "G7:H8"] }],
+  beforeEach(() => {
+    model = new Model({
+      sheets: [{ id: "1", colNumber: 10, rowNumber: 10, merges: ["C3:D4", "G7:H8"] }],
+    });
   });
   test("can't move columns whose merges overflow from the selection", () => {
     const result = moveColumns(model, "F", ["B", "C"]);

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -2,6 +2,7 @@
  * This file will be run before each test file
  */
 import { setDefaultSheetViewSize } from "../../src/constants";
+import { setTranslationMethod } from "../../src/translation";
 import { getParsedOwlTemplateBundle } from "../../tools/bundle_xml/bundle_xml_templates";
 import "./canvas.mock";
 import "./jest_extend";
@@ -12,6 +13,10 @@ export let OWL_TEMPLATES: Document;
 beforeAll(() => {
   OWL_TEMPLATES = getParsedOwlTemplateBundle();
   setDefaultSheetViewSize(1000);
+  setTranslationMethod(
+    (str, ...values) => str,
+    () => true
+  );
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Task Description

Following https://github.com/odoo/odoo/pull/130179, this PR aims to remove the use of _lt function, using now _t instead. To be able to take translations loading into account, a new function _loaded has been added to the setTranslationFunction method, indicating wether the translation has been loaded or not.

By default, we then have _t returning only lazy string, and once a translation has been loaded, it will return translated string directly.

## Related Task

- Task: : [3446734](https://www.odoo.com/web#id=3446734&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo