### PR TITLE
[FIX] FilterEvaluationPlugin:  enable filtered rows when unhiding rows

### DIFF
--- a/src/plugins/ui/filter_evaluation.ts
+++ b/src/plugins/ui/filter_evaluation.ts
@@ -73,6 +73,7 @@ export class FilterEvaluationPlugin extends UIPlugin {
         this.filterValues[cmd.sheetId] = {};
         break;
       case "HIDE_COLUMNS_ROWS":
+      case "UNHIDE_COLUMNS_ROWS":
         this.updateHiddenRows();
         break;
       case "UPDATE_FILTER":

--- a/tests/plugins/filters.test.ts
+++ b/tests/plugins/filters.test.ts
@@ -18,6 +18,7 @@ import {
   setCellContent,
   setStyle,
   undo,
+  unhideRows,
   updateFilter,
 } from "../test_helpers/commands_helpers";
 import { getCellContent } from "../test_helpers/getters_helpers";
@@ -185,6 +186,19 @@ describe("Filters plugin", () => {
       updateFilter(model, "B1", ["28"]);
       expect(model.getters.isRowHidden(sheetId, 1)).toBe(true);
       expect(model.getters.isRowHidden(sheetId, 2)).toBe(false);
+    });
+
+    test("Filtered rows should persist after hiding and unhiding multiple rows", () => {
+      const model = new Model();
+
+      setCellContent(model, "A4", "D");
+
+      createFilter(model, "A3:A4");
+      updateFilter(model, "A3", ["D"]);
+      expect(model.getters.isRowFiltered(sheetId, 3)).toEqual(true);
+      hideRows(model, [2, 3]);
+      unhideRows(model, [2, 3]);
+      expect(model.getters.isRowFiltered(sheetId, 3)).toEqual(true);
     });
   });
 


### PR DESCRIPTION
## Description:

Previously, when selecting multiple rows containing filters with some rows filtered, hiding and then unhiding the rows would disable the filter.

To address this issue, the commit enables filtered rows upon unhiding rows in `filter_evaluation.ts`. This is achieved by handling the `UNHIDE_COLUMNS_ROWS` action and updating the `hiddenRows` accordingly.

Task: : [3435119](https://www.odoo.com/web#id=3435119&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo