### PR TITLE
[FIX] HeaderSizePlugin: Prevent state desynchronization

### DIFF
--- a/src/plugins/core/header_size.ts
+++ b/src/plugins/core/header_size.ts
@@ -105,7 +105,8 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
         }
         break;
       case "UPDATE_CELL":
-        if (!this.sizes[cmd.sheetId]?.["ROW"]?.[cmd.row]?.manualSize) {
+        const row = this.sizes[cmd.sheetId]?.["ROW"]?.[cmd.row];
+        if (row && !row.manualSize) {
           const { sheetId, row } = cmd;
           this.history.update(
             "sizes",

--- a/tests/plugins/header_visibility.test.ts
+++ b/tests/plugins/header_visibility.test.ts
@@ -1,6 +1,7 @@
 import { CommandResult, Model } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { numberToLetters, toZone } from "../../src/helpers";
+import { HeaderSizePlugin } from "../../src/plugins/core/header_size";
 import {
   addColumns,
   addRows,
@@ -11,10 +12,12 @@ import {
   merge,
   redo,
   setSelection,
+  setStyle,
   undo,
   unhideColumns,
   unhideRows,
 } from "../test_helpers/commands_helpers";
+import { getPlugin } from "../test_helpers/helpers";
 
 //------------------------------------------------------------------------------
 // Hide/unhide
@@ -333,5 +336,17 @@ describe("Hide Rows", () => {
     expect(result).toBeCancelledBecause(CommandResult.InvalidHeaderIndex);
     hideRows(model, [1, 2]);
     expect(model.getters.getHiddenRowsGroups(sheetId)).toEqual([[1, 2]]);
+  });
+
+  test("Do not compute row of empty cell", () => {
+    model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    // Will force an UPDATE_CELL subcommand upon addRows
+    setStyle(model, "A100", { fillColor: "red" });
+    addRows(model, "after", 99, 1);
+    const plugin = getPlugin(model, HeaderSizePlugin);
+    expect(plugin.sizes[sheetId].ROW.length).toEqual(101);
+    model.dispatch("DUPLICATE_SHEET", { sheetId, sheetIdTo: "sheet2" });
+    expect(plugin.sizes["sheet2"].ROW.length).toEqual(101);
   });
 });


### PR DESCRIPTION
HOW TO REPRODUCE
----------------
- Go to the last row of a sheet
- Make sure that at least one cell contains a style (fillColor for
  instance)
- Insert a row after the last row
- duplicate the sheet

-> crash

The issue is a combination of 2 commits https://github.com/odoo/o-spreadsheet/commit/61f1c527fa549f38896be586514facb175e64021 and https://github.com/odoo/o-spreadsheet/commit/9086ac9b79532ef74ec14588850575f44e5bedf6.
Because of the order of the plugins, the headerSizePlugin would handle
the command `ADD_COLUMNS_ROWS` weirdly. This could prove specifically
prove problematic when inserting a **ROW** after a header containing
cells with some style.

The command is processed as such:
- CellPlugin handles the original command. Because the header after which we
  insert contains a cell with some style, it dispatches a subcommand
  `UPDATE_CELL` to propagate the style in the newly created row/column
- HeaderSizePlugin handles `UPDATE_CELL` and adds an entry to its state
  for the new row/column index of the updated cell, therefore adding 1
  more row to the internal mapping.
- HeaderSizePlugin handles the original command but it mistakenly
  assumes that its internal state contains the old quantity of rows
  but it was already updated when handling the `UPDATE_CELL` subcommand.

Task: 3450174

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3450174](https://www.odoo.com/web#id=3450174&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo