### PR TITLE
[IMP] tests: add utility to add test plugins

### DIFF
--- a/tests/plugins/history.test.ts
+++ b/tests/plugins/history.test.ts
@@ -21,7 +21,7 @@ import {
   getEvaluatedCell,
 } from "../test_helpers/getters_helpers"; // to have getcontext mocks
 import "../test_helpers/helpers";
-import { getPlugin } from "../test_helpers/helpers";
+import { addTestPlugin, getPlugin } from "../test_helpers/helpers";
 
 // we test here the undo/redo feature
 
@@ -308,7 +308,7 @@ describe("Model history", () => {
 
   test("undone & redone commands are part of the command", () => {
     class TestPlugin extends UIPlugin {}
-    featurePluginRegistry.add("test-plugin", TestPlugin);
+    addTestPlugin(featurePluginRegistry, TestPlugin);
     const model = new Model();
     const plugin = getPlugin(model, TestPlugin);
     plugin.handle = jest.fn((cmd) => {});
@@ -330,6 +330,5 @@ describe("Model history", () => {
       type: "REDO",
       commands: [command],
     });
-    featurePluginRegistry.remove("test-plugin");
   });
 });

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -12,6 +12,7 @@ import {
   deleteSheet,
   renameSheet,
 } from "../test_helpers/commands_helpers";
+import { addTestPlugin } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
 let m;
@@ -76,11 +77,8 @@ class PluginTestRange extends CorePlugin {
   }
 }
 
-beforeAll(() => {
-  corePluginRegistry.add("testRange", PluginTestRange);
-});
-afterAll(() => {
-  corePluginRegistry.remove("testRange");
+beforeEach(() => {
+  addTestPlugin(corePluginRegistry, PluginTestRange);
 });
 
 describe("range plugin", () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -22,9 +22,12 @@ import { ImageProvider } from "../../src/helpers/figures/images/image_provider";
 import { range, toCartesian, toUnboundedZone, toXC, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { MergePlugin } from "../../src/plugins/core/merge";
+import { CorePluginConstructor } from "../../src/plugins/core_plugin";
+import { UIPluginConstructor } from "../../src/plugins/ui_plugin";
 import { ComposerSelection } from "../../src/plugins/ui_stateful";
 import { topbarMenuRegistry } from "../../src/registries";
 import { MenuItemRegistry } from "../../src/registries/menu_items_registry";
+import { Registry } from "../../src/registries/registry";
 import { _t } from "../../src/translation";
 import {
   CellPosition,
@@ -73,6 +76,15 @@ export function getPlugin<T extends new (...args: any) => any>(
   cls: T
 ): InstanceType<T> {
   return model["handlers"].find((handler) => handler instanceof cls) as unknown as InstanceType<T>;
+}
+
+export function addTestPlugin(
+  registry: Registry<CorePluginConstructor | UIPluginConstructor>,
+  Plugin: CorePluginConstructor | UIPluginConstructor
+) {
+  const key = `test-plugin-${Plugin.name}`;
+  registry.add(key, Plugin);
+  registerCleanup(() => registry.remove(key));
 }
 
 const realTimeSetTimeout = window.setTimeout.bind(window);


### PR DESCRIPTION
## Description:

When adding a new test plugin, it is necessary to remove it after. Otherwise memory leaks could occur.

This commit adds a utility to add a test plugin and remove it automatically.
Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo