### PR TITLE
[REF] filters: rename 'values' in command

### DIFF
--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -219,7 +219,7 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
     this.env.model.dispatch("UPDATE_FILTER", {
       ...position,
       sheetId: this.env.model.getters.getActiveSheetId(),
-      values: this.state.values.filter((val) => !val.checked).map((val) => val.string),
+      hiddenValues: this.state.values.filter((val) => !val.checked).map((val) => val.string),
     });
     this.props.onClosed?.();
   }

--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -457,7 +457,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
           sheetId,
           col: newTableZone.left + i,
           row: newTableZone.top,
-          values: table.filtersValues[i],
+          hiddenValues: table.filtersValues[i],
         });
       }
     }

--- a/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/src/plugins/ui_stateful/filter_evaluation.ts
@@ -155,11 +155,11 @@ export class FilterEvaluationPlugin extends UIPlugin {
     };
   }
 
-  private updateFilter({ col, row, values, sheetId }: UpdateFilterCommand) {
+  private updateFilter({ col, row, hiddenValues, sheetId }: UpdateFilterCommand) {
     const id = this.getters.getFilterId({ sheetId, col, row });
     if (!id) return;
     if (!this.filterValues[sheetId]) this.filterValues[sheetId] = {};
-    this.filterValues[sheetId][id] = values;
+    this.filterValues[sheetId][id] = hiddenValues;
   }
 
   private updateHiddenRows() {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -463,7 +463,7 @@ export interface RemoveFilterTableCommand extends TargetDependentCommand {
 
 export interface UpdateFilterCommand extends PositionDependentCommand {
   type: "UPDATE_FILTER";
-  values: string[];
+  hiddenValues: string[];
 }
 
 export interface SetFormattingCommand extends TargetDependentCommand {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -837,11 +837,11 @@ export function createFilter(
 export function updateFilter(
   model: Model,
   xc: string,
-  values: string[],
+  hiddenValues: string[],
   sheetId: UID = model.getters.getActiveSheetId()
 ): DispatchResult {
   const { col, row } = toCartesian(xc);
-  return model.dispatch("UPDATE_FILTER", { col, row, sheetId, values });
+  return model.dispatch("UPDATE_FILTER", { col, row, sheetId, hiddenValues });
 }
 
 export function deleteFilter(


### PR DESCRIPTION

## Description:

The property name `values` in the UPDATE_FILTER command is not self-explanatory You don't know if those values will be displayed or will be hidden.

This commit renames the property to `hiddenValues`

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo