### PR TITLE
[FIX] xlsx: use FormatAttributes to export filters

### DIFF
--- a/src/xlsx/functions/table.ts
+++ b/src/xlsx/functions/table.ts
@@ -4,7 +4,16 @@ import { XMLAttributes, XMLString } from "../../types/xlsx";
 import { NAMESPACE } from "../constants";
 import { escapeXml, formatAttributes, joinXmlNodes, parseXML } from "../helpers/xml_helpers";
 
-const TABLE_DEFAULT_STYLE = escapeXml/*xml*/ `<tableStyleInfo name="TableStyleLight8" showFirstColumn="0" showLastColumn="0" showRowStripes="0" showColumnStripes="0"/>`;
+const TABLE_DEFAULT_ATTRS: XMLAttributes = [
+  ["name", "TableStyleLight8"],
+  ["showFirstColumn", "0"],
+  ["showLastColumn", "0"],
+  ["showRowStripes", "0"],
+  ["showColumnStripes", "0"],
+];
+const TABLE_DEFAULT_STYLE = escapeXml/*xml*/ `<tableStyleInfo ${formatAttributes(
+  TABLE_DEFAULT_ATTRS
+)}/>`;
 
 export function createTable(
   table: ExcelFilterTableData,


### PR DESCRIPTION
THe minification process inside Odoo tends to ignore the spaces in template strings. this is the third occurence of that issue [1] that we notice, hopefully we fix every potential source of issue.

[1] See 1a2c6bec and 2df8b138

Task: 3460544

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo