### PR TITLE
[REF] *: Remove env._t

### DIFF
--- a/src/components/border_editor/border_editor.xml
+++ b/src/components/border_editor/border_editor.xml
@@ -1,5 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-BorderEditor" owl="1">
+    <t t-set="border_color">Border Color</t>
     <Popover t-props="popoverProps">
       <div
         class="d-flex bg-white o-border-selector"
@@ -34,7 +35,7 @@
               toggleColorPicker="(ev) => this.toggleDropdownTool('borderColorTool')"
               showColorPicker="state.activeTool === 'borderColorTool'"
               onColorPicked="(color) => this.setBorderColor(color)"
-              title="env._t('Border Color')"
+              title="border_color"
               icon="props.currentBorderColor === '' ? 'o-spreadsheet-Icon.BORDER_NO_COLOR' : 'o-spreadsheet-Icon.BORDER_COLOR'"
               dropdownMaxHeight="this.props.dropdownMaxHeight"
               class="'o-dropdown-button o-border-picker-button'"

--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -2,6 +2,7 @@ import { Component, onWillUnmount, onWillUpdateProps, useRef, useState } from "@
 import { BACKGROUND_GRAY_COLOR, HEADER_WIDTH, TEXT_HEADER_COLOR } from "../../constants";
 import { deepEquals } from "../../helpers";
 import { MenuItemRegistry } from "../../registries/menu_items_registry";
+import { _t } from "../../translation";
 import { MenuMouseEvent, Pixel, Rect, SpreadsheetChildEnv, UID } from "../../types";
 import { Ripple } from "../animation/ripple";
 import { BottomBarSheet } from "../bottom_bar_sheet/bottom_bar_sheet";
@@ -132,7 +133,7 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
     const position =
       this.env.model.getters.getSheetIds().findIndex((sheetId) => sheetId === activeSheetId) + 1;
     const sheetId = this.env.model.uuidGenerator.uuidv4();
-    const name = this.env.model.getters.getNextSheetName(this.env._t("Sheet"));
+    const name = this.env.model.getters.getNextSheetName(_t("Sheet"));
     this.env.model.dispatch("CREATE_SHEET", { sheetId, position, name });
     this.env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: activeSheetId, sheetIdTo: sheetId });
   }

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,6 +1,7 @@
 import { Component } from "@odoo/owl";
 import { DEFAULT_FONT } from "../../../../constants";
 import { getFontSizeMatchingWidth, relativeLuminance } from "../../../../helpers";
+import { _t } from "../../../../translation";
 import { Color, Figure, Pixel, SpreadsheetChildEnv, Style } from "../../../../types";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
 import { cellTextStyleToCss, cssPropertiesToCss } from "../../../helpers";
@@ -140,6 +141,10 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
 
   get chartPadding() {
     return this.props.figure.width * CHART_PADDING_RATIO;
+  }
+
+  translate(term) {
+    return _t(term);
   }
 
   getTextStyles() {

--- a/src/components/figures/chart/scorecard/chart_scorecard.xml
+++ b/src/components/figures/chart/scorecard/chart_scorecard.xml
@@ -23,7 +23,7 @@
               </span>
             </t>
             <span t-att-style="textStyles.baselineDescrStyle" class="o-baseline-text-description">
-              <t t-esc="env._t(baselineDescr)"/>
+              <t t-esc="translate(baselineDescr)"/>
             </span>
           </div>
         </t>

--- a/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
@@ -1,5 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-BarChartDesignPanel" owl="1">
+    <t t-set="background_color">Background Color</t>
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
@@ -9,7 +10,7 @@
           toggleColorPicker="() => this.toggleColorPicker()"
           showColorPicker="state.fillColorTool"
           onColorPicked="(color) => this.updateBackgroundColor(color)"
-          title="env._t('Background Color')"
+          title="background_color"
           icon="'o-spreadsheet-Icon.FILL_COLOR'"
         />
       </div>

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
@@ -1,5 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-GaugeChartDesignPanel" owl="1">
+    <t t-set="background_color">Background Color</t>
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
@@ -9,7 +10,7 @@
           toggleColorPicker="() => this.toggleMenu('backgroundColor', ev)"
           showColorPicker="state.openedMenu === 'backgroundColor'"
           onColorPicked="(color) => this.updateBackgroundColor(color)"
-          title="env._t('Background Color')"
+          title="background_color"
           icon="'o-spreadsheet-Icon.FILL_COLOR'"
         />
       </div>

--- a/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
@@ -1,5 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-LineBarPieDesignPanel" owl="1">
+    <t t-set="background_color">Background Color</t>
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
@@ -9,7 +10,7 @@
           toggleColorPicker="() => this.toggleColorPicker()"
           showColorPicker="state.fillColorTool"
           onColorPicked="(color) => this.updateBackgroundColor(color)"
-          title="env._t('Background Color')"
+          title="background_color"
           icon="'o-spreadsheet-Icon.FILL_COLOR'"
         />
       </div>

--- a/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
@@ -1,5 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-LineChartDesignPanel" owl="1">
+    <t t-set="background_color">Background Color</t>
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
@@ -9,7 +10,7 @@
           toggleColorPicker="() => this.toggleColorPicker()"
           showColorPicker="state.fillColorTool"
           onColorPicked="(color) => this.updateBackgroundColor(color)"
-          title="env._t('Background Color')"
+          title="background_color"
           icon="'o-spreadsheet-Icon.FILL_COLOR'"
         />
       </div>

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
@@ -38,6 +38,10 @@ export class ScorecardChartDesignPanel extends Component<Props, SpreadsheetChild
     });
   }
 
+  translate(term) {
+    return _t(term);
+  }
+
   updateBaselineDescr(ev) {
     this.props.updateChart(this.props.figureId, { baselineDescr: ev.target.value });
   }

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
@@ -1,5 +1,8 @@
 <templates>
   <t t-name="o-spreadsheet-ScorecardChartDesignPanel" owl="1">
+    <t t-set="background_color">Background Color</t>
+    <t t-set="color_up">Color Up</t>
+    <t t-set="color_down">Color Down</t>
     <div>
       <div class="o-section o-chart-background-color">
         <div class="o-section-title">Background color</div>
@@ -9,7 +12,7 @@
           toggleColorPicker="() => this.toggleColorPicker('backgroundColor')"
           showColorPicker="state.openedColorPicker === 'backgroundColor'"
           onColorPicked="(color) => this.setColor(color, 'backgroundColor')"
-          title="env._t('Background Color')"
+          title="background_color"
           icon="'o-spreadsheet-Icon.FILL_COLOR'"
         />
       </div>
@@ -28,7 +31,7 @@
         <div class="o-section-title">Baseline description</div>
         <input
           type="text"
-          t-att-value="env._t(props.definition.baselineDescr)"
+          t-att-value="translate(props.definition.baselineDescr)"
           t-on-change="updateBaselineDescr"
           class="o-input o-optional"
         />
@@ -42,7 +45,7 @@
         toggleColorPicker="() => this.toggleColorPicker('baselineColorUp')"
         showColorPicker="state.openedColorPicker === 'baselineColorUp'"
         onColorPicked="(color) => this.setColor(color, 'baselineColorUp')"
-        title="env._t('Color Up')"
+        title="color_up"
         icon="'o-spreadsheet-Icon.FILL_COLOR'"
       />
       <br/>
@@ -52,7 +55,7 @@
         toggleColorPicker="() => this.toggleColorPicker('baselineColorDown')"
         showColorPicker="state.openedColorPicker === 'baselineColorDown'"
         onColorPicked="(color) => this.setColor(color, 'baselineColorDown')"
-        title="env._t('Color Down')"
+        title="color_down"
         icon="'o-spreadsheet-Icon.FILL_COLOR'"
       />
     </div>

--- a/src/components/side_panel/conditional_formatting/cell_is_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cell_is_rule_editor.xml
@@ -14,6 +14,8 @@
   </t>
 
   <t t-name="o-spreadsheet-CellIsRuleEditor" owl="1">
+    <t t-set="fill_color">Fill Color</t>
+    <t t-set="text_color">Text Color</t>
     <div class="o-cf-cell-is-rule">
       <div class="o-section-subtitle">Format cells if...</div>
       <select t-model="rule.operator" class="o-input o-cell-is-operator">
@@ -80,7 +82,7 @@
           toggleColorPicker="(ev) => this.toggleMenu('cellIsRule-textColor', ev)"
           showColorPicker="state.openedMenu === 'cellIsRule-textColor'"
           onColorPicked="(color) => this.setColor('textColor', color)"
-          title="env._t('Text Color')"
+          title="text_color"
           icon="'o-spreadsheet-Icon.TEXT_COLOR'"
           class="'o-tool'"
         />
@@ -90,7 +92,7 @@
           toggleColorPicker="(ev) => this.toggleMenu('cellIsRule-fillColor', ev)"
           showColorPicker="state.openedMenu === 'cellIsRule-fillColor'"
           onColorPicked="(color) => this.setColor('fillColor', color)"
-          title="env._t('Fill Color')"
+          title="fill_color"
           icon="'o-spreadsheet-Icon.FILL_COLOR'"
           class="'o-tool'"
         />

--- a/src/components/side_panel/conditional_formatting/color_scale_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/color_scale_rule_editor.xml
@@ -4,6 +4,7 @@
   </t>
 
   <t t-name="o-spreadsheet-ColorScaleRuleEditorThreshold" owl="1">
+    <t t-set="fill_color">Fill Color</t>
     <div t-attf-class="o-threshold o-threshold-{{thresholdType}}">
       <t t-if="thresholdType === 'midpoint'">
         <t t-set="type" t-value="threshold and threshold.type"/>
@@ -41,7 +42,7 @@
         toggleColorPicker="(ev) => this.toggleMenu('colorScale-'+thresholdType+'Color', ev)"
         showColorPicker="state.openedMenu === 'colorScale-'+thresholdType+'Color'"
         onColorPicked="(color) => this.setColorScaleColor(thresholdType, color)"
-        title="env._t('Fill Color')"
+        title="fill_color"
         icon="'o-spreadsheet-Icon.FILL_COLOR'"
         disabled="threshold === undefined"
       />

--- a/src/components/side_panel/custom_currency/custom_currency.ts
+++ b/src/components/side_panel/custom_currency/custom_currency.ts
@@ -1,6 +1,7 @@
 import { Component, onWillStart, useState } from "@odoo/owl";
 import { createCurrencyFormat, formatValue, roundFormat } from "../../../helpers";
 import { currenciesRegistry } from "../../../registries/currencies_registry";
+import { _t } from "../../../translation";
 import { Currency, Format, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
 import { CustomCurrencyTerms } from "../../translations_terms";
@@ -102,7 +103,7 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
     }
 
     const emptyCurrency: Currency = {
-      name: this.env._t(CustomCurrencyTerms.Custom),
+      name: _t(CustomCurrencyTerms.Custom),
       code: "",
       symbol: "",
       decimalPlaces: 2,

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -1,5 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-TopBar" owl="1">
+    <t t-set="text_color">Text Color</t>
+    <t t-set="fill_color">Fill Color</t>
     <div
       class="o-spreadsheet-topbar o-two-columns bg-white d-flex flex-column user-select-none"
       t-on-click="props.onClick">
@@ -71,7 +73,7 @@
               toggleColorPicker="(ev) => this.toggleDropdownTool('textColorTool', ev)"
               showColorPicker="state.activeTool === 'textColorTool'"
               onColorPicked="(color) => this.setColor('textColor', color)"
-              title="env._t('Text Color')"
+              title="text_color"
               icon="'o-spreadsheet-Icon.TEXT_COLOR'"
               dropdownMaxHeight="this.props.dropdownMaxHeight"
               class="'o-hoverable-button o-menu-item-button'"
@@ -84,7 +86,7 @@
               toggleColorPicker="(ev) => this.toggleDropdownTool('fillColorTool', ev)"
               showColorPicker="state.activeTool === 'fillColorTool'"
               onColorPicked="(color) => this.setColor('fillColor', color)"
-              title="env._t('Fill Color')"
+              title="fill_color"
               icon="'o-spreadsheet-Icon.FILL_COLOR'"
               dropdownMaxHeight="this.props.dropdownMaxHeight"
               class="'o-hoverable-button o-menu-item-button'"


### PR DESCRIPTION
In this commit, all usages of env._t() are replaced by _t(). 
In templates files, env._t() didn't work because terms used 
in attributes where not extracted into the translation files. 
Only string are exported from .xml files to translation files. 
So, to make it works, we set a variable that is then used 
in attributes. 
For example : 
```
<t t-set="string_to_translate">String to translate</t>
<Dialog title="string_to_translate>...</Dialog>
```

task-3292454