### PR TITLE
[FIX] Composer: formula autocomplete navigation with arrow keys

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -371,8 +371,11 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
 
   onKeyup(ev: KeyboardEvent) {
     if (this.contentHelper.el === document.activeElement) {
-      const isSelectingForComposer = this.env.model.getters.isSelectingForComposer();
-      if (isSelectingForComposer && ev.key?.startsWith("Arrow")) {
+      if (this.autoCompleteState.showProvider && ["ArrowUp", "ArrowDown"].includes(ev.key)) {
+        return;
+      }
+
+      if (this.env.model.getters.isSelectingForComposer() && ev.key?.startsWith("Arrow")) {
         return;
       }
 

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import { selectCell } from "../test_helpers/commands_helpers";
-import { click, keyDown, simulateClick } from "../test_helpers/dom_helper";
+import { click, keyDown, keyUp, simulateClick } from "../test_helpers/dom_helper";
 import { getCellText } from "../test_helpers/getters_helpers";
 import {
   clearFunctions,
@@ -146,10 +146,12 @@ describe("Functions autocomplete", () => {
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SUM");
       await keyDown({ key: "ArrowDown" });
+      await keyUp({ key: "ArrowDown" });
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SZZ");
       await keyDown({ key: "ArrowUp" });
+      await keyUp({ key: "ArrowUp" });
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SUM");


### PR DESCRIPTION
## Description:

Resolving a minor bug introduced in PR#2744

When using arrow keys to navigate the formula autocomplete, the navigation behavior was not functioning as intended.

To rectify this problem, an early return from the `onKeyup` function has been implemented for cases where users are navigating through the formula autocomplete.

Task: : [3461828](https://www.odoo.com/web#id=3461828&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo