### PR TITLE
[FIX] grid: typo in component template

### DIFF
--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -178,7 +178,7 @@ const TEMPLATE = xml/* xml */ `
         focus="props.focusComposer"
         />
     </t>
-    <t else="1">
+    <t t-else="1">
       <input class="position-absolute"
         style="z-index:-1000;"
         t-on-input="onInput"


### PR DESCRIPTION
Commit 8a9217a8 introduced a nex input to partially support IME inputs with a typo in the template, making the preventing the input to be properly cleared when editing cell content.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo