### PR TITLE
[IMP] spreadsheet: Properly unbind model upon props change

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -3,6 +3,7 @@ import {
   onMounted,
   onPatched,
   onWillUnmount,
+  onWillUpdateProps,
   useExternalListener,
   useState,
   useSubEnv,
@@ -226,13 +227,19 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     });
 
     useExternalListener(window as any, "resize", () => this.render(true));
-    useExternalListener(window, "beforeunload", this.unbindModelEvents.bind(this));
+    useExternalListener(window, "beforeunload", () => this.unbindModelEvents(this.props.model));
 
-    this.bindModelEvents();
+    this.bindModelEvents(this.props.model);
     onMounted(() => {
       this.checkViewportSize();
     });
-    onWillUnmount(() => this.unbindModelEvents());
+    onWillUpdateProps((nextProps) => {
+      if (nextProps.model !== this.props.model) {
+        this.unbindModelEvents(this.props.model);
+        this.bindModelEvents(nextProps.model);
+      }
+    });
+    onWillUnmount(() => this.unbindModelEvents(this.props.model));
     onPatched(() => {
       this.checkViewportSize();
     });
@@ -250,18 +257,18 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       : this.composer.gridFocusMode;
   }
 
-  private bindModelEvents() {
-    this.model.on("update", this, () => this.render(true));
-    this.model.on("notify-ui", this, (notification: InformationNotification) =>
+  private bindModelEvents(model: Model) {
+    model.on("update", this, () => this.render(true));
+    model.on("notify-ui", this, (notification: InformationNotification) =>
       this.env.notifyUser(notification)
     );
-    this.model.on("raise-error-ui", this, ({ text }) => this.env.raiseError(text));
+    model.on("raise-error-ui", this, ({ text }) => this.env.raiseError(text));
   }
 
-  private unbindModelEvents() {
-    this.model.off("update", this);
-    this.model.off("notify-ui", this);
-    this.model.off("raise-error-ui", this);
+  private unbindModelEvents(model: Model) {
+    model.off("update", this);
+    model.off("notify-ui", this);
+    model.off("raise-error-ui", this);
   }
 
   private checkViewportSize() {

--- a/tests/components/integration.test.ts
+++ b/tests/components/integration.test.ts
@@ -1,0 +1,58 @@
+import { Component, useState, xml } from "@odoo/owl";
+import { Model, Spreadsheet } from "../../src";
+import { SpreadsheetChildEnv } from "../../src/types";
+import { createSheet, setCellContent } from "../test_helpers/commands_helpers";
+import { getChildFromComponent, mountComponent, nextTick } from "../test_helpers/helpers";
+
+class Parent extends Component<{}, SpreadsheetChildEnv> {
+  static template = xml/* xml */ `
+      <div class="integration-wrapper">
+        <Spreadsheet model="model"/>
+      </div>
+    `;
+  static components = { Spreadsheet };
+
+  state = useState({ model: new Model() });
+
+  setup() {}
+
+  get model() {
+    return this.state.model;
+  }
+
+  setModel(model: Model) {
+    this.state.model = model;
+  }
+}
+
+async function mountParent(
+  model: Model = new Model()
+): Promise<{ parent: Parent; model: Model; fixture: HTMLElement }> {
+  let parent: Component;
+  let fixture: HTMLElement;
+  ({ parent, fixture } = await mountComponent(Parent, { props: { model } }));
+  return { parent: parent as Parent, model, fixture };
+}
+
+describe("Integration of Spreadsheet component", () => {
+  test("Updates in old model of Spreadsheet should not impact the latter", async () => {
+    const { parent } = await mountParent();
+    const model1 = parent.model;
+    createSheet(model1, { name: "test", sheetId: "test" });
+    await nextTick();
+
+    const spreadsheetComponent = getChildFromComponent(parent, Spreadsheet);
+
+    const model2 = new Model();
+    parent.setModel(model2);
+    model1.leaveSession();
+    await nextTick();
+
+    // starting from here, any action on model1 should have 0 effect on Spreadsheet
+    const fn1 = jest.spyOn(spreadsheetComponent, "render");
+
+    setCellContent(model1, "A1", "test");
+    await nextTick();
+    expect(fn1).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
While model is passed as a props to `Spreadsheet`, we bind callbacks to the the model bus but we never remove them if this model changes.

Task: 3461955

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo