### PR TITLE
[FIX] worksheet: download issue with sheets containing array formulas

### DIFF
--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -21,7 +21,10 @@ export function addFormula(cell: ExcelCellData): {
   attrs: XMLAttributes;
   node: XMLString;
 } {
-  const formula = cell.content!;
+  const formula = cell.content;
+  if (!formula) {
+    return { attrs: [], node: escapeXml`` };
+  }
 
   const attrs: XMLAttributes = [];
   let node = escapeXml``;

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -14648,6 +14648,21 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </f>
             </c>
         </row>
+        <row r="168" ht="17.25" customHeight="1" hidden="0">
+            <c r="A168" s="1">
+                <f>
+                    RANDARRAY(2,2)
+                </f>
+            </c>
+            <c r="B168" s="1">
+            </c>
+        </row>
+        <row r="169" ht="17.25" customHeight="1" hidden="0">
+            <c r="A169" s="1">
+            </c>
+            <c r="B169" s="1">
+            </c>
+        </row>
     </sheetData>
 </worksheet>",
       "contentType": "sheet",
@@ -17114,6 +17129,21 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 <f>
                     DATEDIF("2002-01-01","2002-01-02","D")
                 </f>
+            </c>
+        </row>
+        <row r="168" ht="17.25" customHeight="1" hidden="0">
+            <c r="A168" s="1">
+                <f>
+                    RANDARRAY(2,2)
+                </f>
+            </c>
+            <c r="B168" s="1">
+            </c>
+        </row>
+        <row r="169" ht="17.25" customHeight="1" hidden="0">
+            <c r="A169" s="1">
+            </c>
+            <c r="B169" s="1">
             </c>
         </row>
     </sheetData>

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -302,6 +302,7 @@ const allExportableFormulasData = {
         A165: { content: '=HYPERLINK("https://www.odoo.com", "Odoo")' },
         A166: { content: '=ADDRESS(27,53,4,FALSE,"sheet!")' },
         A167: { content: '=DATEDIF("2002/01/01","2002/01/02","D")' },
+        A168: { content: "=RANDARRAY(2, 2)" },
 
         // DATA
         G1: { content: "Name", style: 8 },


### PR DESCRIPTION
## Description:

Previously, attempting to download a sheet with array formulas resulted in a traceback due to the `addRows` function within worksheet.ts trying to access the value of undefined cell content.

To resolve this, a conditional check has been added to skip the `addFormula` section when the cell content is undefined.

Task: : [3461417](https://www.odoo.com/web#id=3461417&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo