### PR TITLE
[FIX] xlsx: export array formula

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -1,5 +1,5 @@
 import { compile, isExportableToExcel } from "../../../formulas/index";
-import { getItemId, positions, toXC } from "../../../helpers/index";
+import { getItemId, positions, toXC, toZone, zoneToXc } from "../../../helpers/index";
 import {
   CellPosition,
   CellValue,
@@ -279,12 +279,12 @@ export class EvaluationPlugin extends UIPlugin {
       let newContent: string | undefined = undefined;
       let newFormat: string | undefined = undefined;
       let isExported: boolean = true;
-
+      let resultSpanningCells: Zone = toZone(xc);
       const formulaCell = this.getCorrespondingFormulaCell(position);
       if (formulaCell) {
         isExported = isExportableToExcel(formulaCell.compiledFormula.tokens);
         isFormula = isExported;
-
+        resultSpanningCells = this.evaluator.getResultZone(position);
         if (!isExported) {
           newContent = value.toString();
           newFormat = evaluatedCell.format;
@@ -298,7 +298,15 @@ export class EvaluationPlugin extends UIPlugin {
         ? getItemId<Format>(newFormat, data.formats)
         : exportedCellData.format;
       const content = !isExported ? newContent : exportedCellData.content;
-      exportedSheetData.cells[xc] = { ...exportedCellData, value, isFormula, content, format };
+      // OpenXml §18.17.6.3
+      exportedSheetData.cells[xc] = {
+        ...exportedCellData,
+        value,
+        isFormula,
+        content,
+        format,
+        resultSpanningCells: zoneToXc(resultSpanningCells),
+      };
     }
   }
 

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -18,6 +18,7 @@ import {
   MatrixFunctionReturn,
   PrimitiveFormat,
   UID,
+  Zone,
 } from "../../../types";
 import {
   CellErrorLevel,
@@ -70,6 +71,24 @@ export class Evaluator {
 
   getEvaluatedPositions(): CellPosition[] {
     return [...this.evaluatedCells.keys()].map(this.decodePosition.bind(this));
+  }
+
+  getResultZone(position: CellPosition): Zone {
+    const arrayFormulaPositionId = this.encodePosition(position);
+    let top = position.row;
+    let bottom = position.row;
+    let left = position.col;
+    let right = position.col;
+    for (const positionId of this.spreadingRelations.getArrayResultPositionIds(
+      arrayFormulaPositionId
+    )) {
+      const position = this.decodePosition(positionId);
+      bottom = Math.max(bottom, position.row);
+      top = Math.min(top, position.row);
+      left = Math.min(left, position.col);
+      right = Math.max(right, position.col);
+    }
+    return { top, bottom, left, right };
   }
 
   private getArrayFormulaSpreadingOnId(positionId: PositionId): PositionId | undefined {

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -69,11 +69,20 @@ export interface ExcelWorkbookData extends WorkbookData {
   sheets: ExcelSheetData[];
 }
 
-export interface ExcelCellData extends CellData {
+interface LiteralExcelCellData extends CellData {
   value: CellValue;
-  isFormula: Boolean;
+  isFormula: false;
+}
+
+export interface FormulaExcelCellData extends CellData {
+  value: CellValue;
+  isFormula: true;
+  resultSpanningCells: string;
   computedFormat?: Format;
 }
+
+export type ExcelCellData = LiteralExcelCellData | FormulaExcelCellData;
+
 export interface ExcelSheetData extends Omit<SheetData, "figureTables"> {
   cells: { [key: string]: ExcelCellData | undefined };
   charts: FigureData<ExcelChartDefinition>[];

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -14650,7 +14650,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
         </row>
         <row r="168" ht="17.25" customHeight="1" hidden="0">
             <c r="A168" s="1">
-                <f>
+                <f t="array" ref="A168:B169">
                     RANDARRAY(2,2)
                 </f>
             </c>
@@ -17133,7 +17133,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
         </row>
         <row r="168" ht="17.25" customHeight="1" hidden="0">
             <c r="A168" s="1">
-                <f>
+                <f t="array" ref="A168:B169">
                     RANDARRAY(2,2)
                 </f>
             </c>


### PR DESCRIPTION
Strange Excel Online behavior: =TRANSPOSE(A1:A10) seem to be exported as {=TRANSPOSE(A1:A10)} and the array can't be modified. Same behavior if exporting from GSheet and importing to excel online

When exporting from Excel Online, the cell has properties in a `futureMetadata` tag, looks like they are using a more recent file format version.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo