### PR TITLE
[REM] translation: remove _t from env

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -163,8 +163,6 @@ export interface SpreadsheetProps {
   model: Model;
 }
 
-const t = (s: string): string => s;
-
 interface SidePanelState {
   isOpen: boolean;
   component?: string;
@@ -179,7 +177,6 @@ interface ComposerState {
 export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Spreadsheet";
   static components = { TopBar, Grid, BottomBar, SidePanel, SpreadsheetDashboard };
-  static _t = t;
 
   sidePanel!: SidePanelState;
   composer!: ComposerState;
@@ -220,7 +217,6 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       isDashboard: () => this.model.getters.isDashboard(),
       openSidePanel: this.openSidePanel.bind(this),
       toggleSidePanel: this.toggleSidePanel.bind(this),
-      _t: Spreadsheet._t,
       clipboard: this.env.clipboard || instantiateClipboard(),
       startCellEdition: (content: string) => this.onGridComposerCellFocused(content),
     });

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -1,8 +1,3 @@
-/*
- * usage: every string should be translated with Spreadsheet._t in the templates. Spreadsheet._t is exposed in the
- *  sub-env of Spreadsheet components as _t
- * */
-
 export type TranslationFunction = (
   string: string,
   ...values: string[] | [{ [key: string]: string }]

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -1,6 +1,5 @@
 import { Model } from "..";
 import { ClipboardInterface } from "../helpers/clipboard/navigator_clipboard_wrapper";
-import { TranslationFunction } from "../translation";
 import { Currency } from "./currency";
 import { ImageProviderInterface } from "./files";
 import { Locale } from "./locale";
@@ -36,7 +35,6 @@ export interface SpreadsheetChildEnv extends SpreadsheetEnv {
   openSidePanel: (panel: string, panelProps?: any) => void;
   toggleSidePanel: (panel: string, panelProps?: any) => void;
   clipboard: ClipboardInterface;
-  _t: TranslationFunction;
   startCellEdition: (content: string) => void;
   loadCurrencies?: () => Promise<Currency[]>;
   loadLocales: () => Promise<Locale[]>;

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -134,7 +134,6 @@ export function makeTestEnv(mockEnv: Partial<SpreadsheetChildEnv> = {}): Spreads
     //FIXME : image provider is not built on top of the file store of the model if provided
     // and imageProvider is defined even when there is no file store on the model
     imageProvider: new ImageProvider(new FileStore()),
-    _t: mockEnv._t || ((str: string, ...values: any) => str),
     notifyUser: mockEnv.notifyUser || (() => {}),
     raiseError: mockEnv.raiseError || (() => {}),
     askConfirmation: mockEnv.askConfirmation || (() => {}),


### PR DESCRIPTION
## Description:

Commit 09dd17f removed all usage of `env._t`
This commit completely removes `_t` from the env.

You must now always use the standalone `_t` function from `translation.ts`

Task: [3292454](https://www.odoo.com/web#id=3292454&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo