### PR TITLE
[FIX] translation: fix sprintf() for String objects

### DIFF
--- a/tests/helpers/translation.test.ts
+++ b/tests/helpers/translation.test.ts
@@ -1,0 +1,16 @@
+import { _t } from "../../src/translation";
+
+describe("Translations", () => {
+  test("placeholders in string translation are replaced with their given value", () => {
+    expect(_t("Hello %s", "World")).toBe("Hello World");
+  });
+
+  test("placeholder can be string Object instead of primitive", () => {
+    expect(_t("Hello %s", new String("World"))).toBe("Hello World");
+    expect(_t("Hello %s", _t("World"))).toBe("Hello World");
+  });
+
+  test("can have named placeholders", () => {
+    expect(_t("%(x1)s %(thing)s", { x1: "Hello", thing: "World" })).toBe("Hello World");
+  });
+});


### PR DESCRIPTION
The function sprintf() used in translations didn't handle String objects. This was a problem for translation, when the values of the string placeholder were also a result of a translation.

For example this code `_t('Hello %s', _t('World'))` would result in `Hello %s` instead of `Hello World`. (when the translations aren't loaded and LazyTranslatedString are used).

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo