### PR TITLE
[REF] module_database: remove useless map

### DIFF
--- a/src/functions/module_database.ts
+++ b/src/functions/module_database.ts
@@ -133,7 +133,7 @@ function getMatchingCells(
 
   // 4 - return for each database row corresponding, the cells corresponding to the field parameter
 
-  const fieldCol: (CellValue | null)[] = database[index].map((col) => col);
+  const fieldCol = database[index];
   // Example continuation:: fieldCol = ["C", "j", "k", 7]
   const matchingCells = [...matchingRows].map((x) => fieldCol[x + 1]);
   // Example continuation:: matchingCells = ["j", 7]


### PR DESCRIPTION

## Description:

The map is useless and we can let Typescript infer the type

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo