### PR TITLE
[REF] o-spreadsheet: remove owl="1" from the templates

### DIFF
--- a/src/components/action_button/action_button.xml
+++ b/src/components/action_button/action_button.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ActionButton" owl="1">
+  <t t-name="o-spreadsheet-ActionButton">
     <span
       t-if="isVisible"
       class="o-menu-item-button"

--- a/src/components/animation/ripple.xml
+++ b/src/components/animation/ripple.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Ripple" owl="1">
+  <t t-name="o-spreadsheet-Ripple">
     <div
       class="o-ripple-container position-relative"
       t-att-class="props.class"
@@ -15,7 +15,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet-RippleEffect" owl="1">
+  <t t-name="o-spreadsheet-RippleEffect">
     <div
       class="position-absolute"
       t-att-class="{ 'overflow-hidden': !props.allowOverflow }"

--- a/src/components/autofill/autofill.xml
+++ b/src/components/autofill/autofill.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Autofill" owl="1">
+  <t t-name="o-spreadsheet-Autofill">
     <div class="o-autofill" t-att-style="style"/>
     <div
       class="o-autofill-handler"

--- a/src/components/border_editor/border_editor.xml
+++ b/src/components/border_editor/border_editor.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-BorderEditor" owl="1">
+  <t t-name="o-spreadsheet-BorderEditor">
     <t t-set="border_color">Border Color</t>
     <Popover t-props="popoverProps">
       <div

--- a/src/components/border_editor/border_editor_widget.xml
+++ b/src/components/border_editor/border_editor_widget.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-BorderEditorWidget" owl="1">
+  <t t-name="o-spreadsheet-BorderEditorWidget">
     <div class="d-flex position-relative" title="Borders">
       <span
         t-ref="borderEditorButton"

--- a/src/components/bottom_bar/bottom_bar.xml
+++ b/src/components/bottom_bar/bottom_bar.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-BottomBar" owl="1">
+  <t t-name="o-spreadsheet-BottomBar">
     <div
       class="o-spreadsheet-bottom-bar o-two-columns d-flex align-items-center overflow-hidden"
       t-on-click="props.onClick"

--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-BottomBarSheet" owl="1">
+  <t t-name="o-spreadsheet-BottomBarSheet">
     <Ripple>
       <div
         class="o-sheet d-flex align-items-center user-select-none text-nowrap "

--- a/src/components/bottom_bar_statistic/bottom_bar_statistic.xml
+++ b/src/components/bottom_bar_statistic/bottom_bar_statistic.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-BottomBarStatisic" owl="1">
+  <t t-name="o-spreadsheet-BottomBarStatisic">
     <t t-set="selectedStatistic" t-value="getSelectedStatistic()"/>
     <Ripple class="'ms-auto'" t-if="selectedStatistic !== undefined">
       <div

--- a/src/components/collaborative_client_tag/collaborative_client_tag.xml
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ClientTag" owl="1">
+  <t t-name="o-spreadsheet-ClientTag">
     <div>
       <div class="o-client-tag" t-att-style="tagStyle" t-esc="props.name"/>
     </div>

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ColorPicker" owl="1">
+  <t t-name="o-spreadsheet-ColorPicker">
     <Popover t-props="popoverProps">
       <div class="o-color-picker" t-on-click.stop="" t-att-style="colorPickerStyle">
         <div class="o-color-picker-section-name">Standard</div>

--- a/src/components/color_picker/color_picker_widget.xml
+++ b/src/components/color_picker/color_picker_widget.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ColorPickerWidget" owl="1">
+  <t t-name="o-spreadsheet-ColorPickerWidget">
     <div class="o-color-picker-widget">
       <span
         class="o-color-picker-button"

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-TextValueProvider" owl="1">
+  <t t-name="o-spreadsheet-TextValueProvider">
     <div
       t-att-class="{
           'o-autocomplete-dropdown':props.values.length,

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Composer" owl="1">
+  <t t-name="o-spreadsheet-Composer">
     <div class="o-composer-container w-100 h-100">
       <div
         class="o-composer w-100 text-start"

--- a/src/components/composer/formula_assistant/formula_assistant.xml
+++ b/src/components/composer/formula_assistant/formula_assistant.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-FunctionDescriptionProvider" owl="1">
+  <t t-name="o-spreadsheet-FunctionDescriptionProvider">
     <div
       class="o-formula-assistant-container user-select-none shadow"
       t-att-class="{

--- a/src/components/composer/grid_composer/grid_composer.xml
+++ b/src/components/composer/grid_composer/grid_composer.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-GridComposer" owl="1">
+  <t t-name="o-spreadsheet-GridComposer">
     <div
       class="o-cell-reference"
       t-if="shouldDisplayCellReference"

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-TopBarComposer" owl="1">
+  <t t-name="o-spreadsheet-TopBarComposer">
     <div
       class="o-topbar-composer bg-white user-select-text"
       t-on-click.stop=""

--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-SpreadsheetDashboard" owl="1">
+  <t t-name="o-spreadsheet-SpreadsheetDashboard">
     <div
       class="o-grid o-two-columns"
       tabindex="-1"

--- a/src/components/error_tooltip/error_tooltip.xml
+++ b/src/components/error_tooltip/error_tooltip.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ErrorToolTip" owl="1">
+  <t t-name="o-spreadsheet-ErrorToolTip">
     <div class="o-error-tooltip">
       <t t-esc="props.text"/>
     </div>

--- a/src/components/figures/chart/chartJs/chartjs.xml
+++ b/src/components/figures/chart/chartJs/chartjs.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ChartJsComponent" owl="1">
+  <t t-name="o-spreadsheet-ChartJsComponent">
     <canvas class="o-figure-canvas w-100 h-100" t-att-style="canvasStyle" t-ref="graphContainer"/>
   </t>
 </templates>

--- a/src/components/figures/chart/scorecard/chart_scorecard.xml
+++ b/src/components/figures/chart/scorecard/chart_scorecard.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ScorecardChart" owl="1">
+  <t t-name="o-spreadsheet-ScorecardChart">
     <div class="o-scorecard w-100 h-100" t-att-style="chartStyle" t-ref="chart">
       <t t-set="textStyles" t-value="getTextStyles()"/>
       <div t-if="title" class="o-title-text" t-esc="title" t-att-style="textStyles.titleStyle"/>

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-FigureComponent" owl="1">
+  <t t-name="o-spreadsheet-FigureComponent">
     <div class="o-figure-wrapper pe-auto" t-att-style="wrapperStyle">
       <div
         class="o-figure w-100 h-100"

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ChartFigure" owl="1">
+  <t t-name="o-spreadsheet-ChartFigure">
     <div class="o-chart-container w-100 h-100" t-on-dblclick="onDoubleClick">
       <t
         t-component="chartComponent"

--- a/src/components/figures/figure_container/figure_container.xml
+++ b/src/components/figures/figure_container/figure_container.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-FiguresContainer" owl="1">
+  <t t-name="o-spreadsheet-FiguresContainer">
     <div>
       <t t-foreach="containers" t-as="container" t-key="container.type">
         <div

--- a/src/components/figures/figure_image/figure_image.xml
+++ b/src/components/figures/figure_image/figure_image.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ImageFigure" owl="1">
+  <t t-name="o-spreadsheet-ImageFigure">
     <img t-att-src="getImagePath" class="w-100 h-100"/>
   </t>
 </templates>

--- a/src/components/filters/filter_icon/filter_icon.xml
+++ b/src/components/filters/filter_icon/filter_icon.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-FilterIcon" owl="1">
+  <t t-name="o-spreadsheet-FilterIcon">
     <div class="o-filter-icon" t-att-style="style" t-on-click.stop="props.onClick">
       <t t-if="props.isActive" t-call="o-spreadsheet-Icon.FILTER_ICON_ACTIVE"/>
       <t t-else="" t-call="o-spreadsheet-Icon.FILTER_ICON"/>

--- a/src/components/filters/filter_icons_overlay/filter_icons_overlay.xml
+++ b/src/components/filters/filter_icons_overlay/filter_icons_overlay.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-FilterIconsOverlay" owl="1">
+  <t t-name="o-spreadsheet-FilterIconsOverlay">
     <t
       t-foreach="getVisibleFilterHeaders()"
       t-as="header"

--- a/src/components/filters/filter_menu/filter_menu.xml
+++ b/src/components/filters/filter_menu/filter_menu.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-FilterMenu" owl="1">
+  <t t-name="o-spreadsheet-FilterMenu">
     <div class="o-filter-menu d-flex flex-column bg-white" t-on-wheel.stop="">
       <div>
         <div class="o-filter-menu-item" t-on-click="() => this.sortFilterZone('ascending')">

--- a/src/components/filters/filter_menu_item/filter_menu_value_item.xml
+++ b/src/components/filters/filter_menu_item/filter_menu_value_item.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-FilterMenuValueItem" owl="1">
+  <t t-name="o-spreadsheet-FilterMenuValueItem">
     <div
       t-on-click="this.props.onClick"
       t-on-mousemove="this.props.onMouseMove"

--- a/src/components/font_size_editor/font_size_editor.xml
+++ b/src/components/font_size_editor/font_size_editor.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-FontSizeEditor" owl="1">
+  <t t-name="o-spreadsheet-FontSizeEditor">
     <div class="o-dropdown" t-ref="FontSizeEditor">
       <div
         class=" o-font-size-editor d-flex align-items-center"

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Grid" owl="1">
+  <t t-name="o-spreadsheet-Grid">
     <div
       class="o-grid"
       tabindex="-1"

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-GridOverlay" owl="1">
+  <t t-name="o-spreadsheet-GridOverlay">
     <div
       t-ref="gridOverlay"
       class="o-grid-overlay overflow-hidden"

--- a/src/components/grid_popover/grid_popover.xml
+++ b/src/components/grid_popover/grid_popover.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-GridPopover" owl="1">
+  <t t-name="o-spreadsheet-GridPopover">
     <Popover
       t-if="cellPopover.isOpen"
       positioning="cellPopover.cellCorner"

--- a/src/components/headers_overlay/headers_overlay.xml
+++ b/src/components/headers_overlay/headers_overlay.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-HeadersOverlay" owl="1">
+  <t t-name="o-spreadsheet-HeadersOverlay">
     <div class="o-overlay">
       <ColResizer onOpenContextMenu="props.onOpenContextMenu"/>
       <RowResizer onOpenContextMenu="props.onOpenContextMenu"/>
@@ -7,7 +7,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet-RowResizer" owl="1">
+  <t t-name="o-spreadsheet-RowResizer">
     <div
       class="o-row-resizer"
       t-on-mousemove.self="onMouseMove"
@@ -64,7 +64,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet-ColResizer" owl="1">
+  <t t-name="o-spreadsheet-ColResizer">
     <div
       class="o-col-resizer"
       t-on-mousemove.self="onMouseMove"

--- a/src/components/highlight/border/border.xml
+++ b/src/components/highlight/border/border.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Border" owl="1">
+  <t t-name="o-spreadsheet-Border">
     <div
       class="o-border"
       t-on-mousedown="onMouseDown"

--- a/src/components/highlight/corner/corner.xml
+++ b/src/components/highlight/corner/corner.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Corner" owl="1">
+  <t t-name="o-spreadsheet-Corner">
     <div
       class="o-corner"
       t-on-mousedown="onMouseDown"

--- a/src/components/highlight/highlight/highlight.xml
+++ b/src/components/highlight/highlight/highlight.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Highlight" owl="1">
+  <t t-name="o-spreadsheet-Highlight">
     <div class="o-highlight" t-ref="highlight">
       <t t-foreach="['n', 's', 'w', 'e']" t-as="orientation" t-key="orientation">
         <Border

--- a/src/components/icon_picker/icon_picker.xml
+++ b/src/components/icon_picker/icon_picker.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-IconPicker" owl="1">
+  <t t-name="o-spreadsheet-IconPicker">
     <div class="o-icon-picker">
       <t t-foreach="iconSets" t-as="iconSet" t-key="iconSet">
         <div class="o-cf-icon-line">

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Icon.CLEAR_AND_RELOAD" owl="1">
+  <t t-name="o-spreadsheet-Icon.CLEAR_AND_RELOAD">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -8,7 +8,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.EXPORT_XLSX" owl="1">
+  <t t-name="o-spreadsheet-Icon.EXPORT_XLSX">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -16,7 +16,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.OPEN_READ_ONLY" owl="1">
+  <t t-name="o-spreadsheet-Icon.OPEN_READ_ONLY">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -24,7 +24,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.OPEN_DASHBOARD" owl="1">
+  <t t-name="o-spreadsheet-Icon.OPEN_DASHBOARD">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -32,7 +32,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.OPEN_READ_WRITE" owl="1">
+  <t t-name="o-spreadsheet-Icon.OPEN_READ_WRITE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -40,7 +40,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.IMPORT_XLSX" owl="1">
+  <t t-name="o-spreadsheet-Icon.IMPORT_XLSX">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -48,7 +48,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.UNDO" owl="1">
+  <t t-name="o-spreadsheet-Icon.UNDO">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -56,7 +56,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.REDO" owl="1">
+  <t t-name="o-spreadsheet-Icon.REDO">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -64,7 +64,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.COPY" owl="1">
+  <t t-name="o-spreadsheet-Icon.COPY">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -72,7 +72,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.CUT" owl="1">
+  <t t-name="o-spreadsheet-Icon.CUT">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -80,7 +80,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.PASTE" owl="1">
+  <t t-name="o-spreadsheet-Icon.PASTE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -88,7 +88,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.FIND_AND_REPLACE" owl="1">
+  <t t-name="o-spreadsheet-Icon.FIND_AND_REPLACE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -96,7 +96,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.DELETE" owl="1">
+  <t t-name="o-spreadsheet-Icon.DELETE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -104,14 +104,14 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.CLEAR" owl="1">
+  <t t-name="o-spreadsheet-Icon.CLEAR">
     <svg class="o-icon">
       <path
         d="M1.5 15a.75.75 0 0 0 0 1.5h15a.75.75 0 0 0 0-1.5M5.3 12.75c.1.1.3.2.5.2h4c.2 0 .4-.1.5-.2l5.5-5.5c.2-.3.2-.6 0-.8l-4.4-4.4c-.3-.2-.6-.2-.8 0l-4.8 4.8c-2.7 2.9-3.1 2.8-2.4 4M7 7.25l3.6 3.6-1 1-3.6.1-1.8-1.9"
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.FREEZE" owl="1">
+  <t t-name="o-spreadsheet-Icon.FREEZE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -119,7 +119,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.UNFREEZE" owl="1">
+  <t t-name="o-spreadsheet-Icon.UNFREEZE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -127,7 +127,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.SHOW_HIDE_GRID" owl="1">
+  <t t-name="o-spreadsheet-Icon.SHOW_HIDE_GRID">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -135,7 +135,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.SHOW_HIDE_FORMULA" owl="1">
+  <t t-name="o-spreadsheet-Icon.SHOW_HIDE_FORMULA">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -143,7 +143,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.HIDE_ROW" owl="1">
+  <t t-name="o-spreadsheet-Icon.HIDE_ROW">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -151,7 +151,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.HIDE_COL" owl="1">
+  <t t-name="o-spreadsheet-Icon.HIDE_COL">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -159,7 +159,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_ROW" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_ROW">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -167,7 +167,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_ROW_BEFORE" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_ROW_BEFORE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -175,7 +175,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_ROW_AFTER" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_ROW_AFTER">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -183,7 +183,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_COL" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_COL">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -191,7 +191,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_COL_AFTER" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_COL_AFTER">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -199,7 +199,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_COL_BEFORE" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_COL_BEFORE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -207,7 +207,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_CELL" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_CELL">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -215,7 +215,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_CELL_SHIFT_DOWN" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_CELL_SHIFT_DOWN">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -223,7 +223,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_CELL_SHIFT_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_CELL_SHIFT_RIGHT">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -231,7 +231,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.DELETE_CELL_SHIFT_UP" owl="1">
+  <t t-name="o-spreadsheet-Icon.DELETE_CELL_SHIFT_UP">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -239,7 +239,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.DELETE_CELL_SHIFT_LEFT" owl="1">
+  <t t-name="o-spreadsheet-Icon.DELETE_CELL_SHIFT_LEFT">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -247,7 +247,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_CHART" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_CHART">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -255,28 +255,28 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_IMAGE" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_IMAGE">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M.5 2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2H2v14h14V2H2m10 4.5L10 11 8.5 9.5l-2 2.5L5 10.5l-2 3h12M3.5,5a1.5,1.5,0,0,1,3,0a1.5,1.5,0,0,1,-3,0"
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_LINK" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_LINK">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M6.88 13.69c.19-.19.41-.28.68-.28.27 0 .51.09.72.28.43.45.43.92 0 1.4l-.84.8c-.75.75-1.63 1.12-2.64 1.12-1.04 0-1.93-.37-2.68-1.12C1.37 15.14 1 14.26 1 13.25c0-1.04.37-1.93 1.12-2.68l2.96-2.96c.93-.9 1.89-1.42 2.88-1.54.98-.12 1.84.17 2.56.86.21.21.32.45.32.72 0 .26-.1.51-.32.72-.48.43-.95.43-1.4 0-.67-.64-1.55-.41-2.67.68l-2.93 2.92c-.35.35-.52.77-.52 1.28s.17.92.52 1.24c.35.35.76.52 1.26.52.49 0 .91-.17 1.26-.52l.84-.8m9-11.48c.75.75 1.12 1.63 1.12 2.64 0 1.04-.37 1.94-1.12 2.68l-3.16 3.16c-.99.96-1.99 1.44-3 1.44-.83 0-1.57-.33-2.24-1a.913.913 0 0 1-.28-.68c0-.27.09-.5.27-.72.19-.19.43-.28.71-.28.28 0 .51.09.7.28.66.64 1.48.48 2.44-.48l3.16-3.12c.37-.37.56-.8.56-1.28 0-.51-.19-.92-.56-1.24-.32-.35-.7-.56-1.12-.62-.43-.07-.83.07-1.2.42l-1 1c-.22.19-.45.28-.72.28-.26 0-.5-.09-.68-.28-.46-.45-.46-.92 0-1.4l1-1c.72-.72 1.56-1.06 2.54-1.02.97.04 1.83.45 2.58 1.22"
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.INSERT_SHEET" owl="1">
+  <t t-name="o-spreadsheet-Icon.INSERT_SHEET">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M17.5 5.5V16a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2A1.5 1.5 0 0 1 2 .5h10.5M2 5.5h3.5V2H2m5.25 3.5h3.5V2h-3.5M2 10.75h3.5v-3.5H2m5.25 3.5h3.5v-3.5h-3.5m5.25 3.5H16v-3.5h-3.5M2 16h3.5v-3.5H2M7.25 16h3.5v-3.5h-3.5M12.5 16H16v-3.5h-3.5"
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.PAINT_FORMAT" owl="1">
+  <t t-name="o-spreadsheet-Icon.PAINT_FORMAT">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -285,7 +285,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.CONDITIONAL_FORMAT" owl="1">
+  <t t-name="o-spreadsheet-Icon.CONDITIONAL_FORMAT">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -293,7 +293,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.CLEAR_FORMAT" owl="1">
+  <t t-name="o-spreadsheet-Icon.CLEAR_FORMAT">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -301,27 +301,27 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.TRIANGLE_DOWN" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_DOWN">
     <svg class="o-icon">
       <polygon fill="currentColor" points="0 0 4 4 8 0" transform="translate(5 7)"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.TRIANGLE_UP" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_UP">
     <svg class="o-icon">
       <polygon fill="currentColor" points="4 0 0 4 8 4" transform="translate(5 7)"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.TRIANGLE_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_RIGHT">
     <svg class="o-icon">
       <polygon fill="currentColor" points="0 0 4 4 0 8" transform="translate(5 5)"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.TRIANGLE_LEFT" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_LEFT">
     <svg class="o-icon">
       <polygon fill="currentColor" points="4 0 0 4 4 8" transform="translate(5 5)"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BOLD" owl="1">
+  <t t-name="o-spreadsheet-Icon.BOLD">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -329,12 +329,12 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ITALIC" owl="1">
+  <t t-name="o-spreadsheet-Icon.ITALIC">
     <svg class="o-icon">
       <path fill="currentColor" d="M7 3v2h2.58l-3.66 8H3v2h8v-2H8.42l3.66-8H15V3"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.UNDERLINE" owl="1">
+  <t t-name="o-spreadsheet-Icon.UNDERLINE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -342,7 +342,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.STRIKE" owl="1">
+  <t t-name="o-spreadsheet-Icon.STRIKE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -350,7 +350,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.TEXT_COLOR" owl="1">
+  <t t-name="o-spreadsheet-Icon.TEXT_COLOR">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -358,7 +358,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.FILL_COLOR" owl="1">
+  <t t-name="o-spreadsheet-Icon.FILL_COLOR">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -366,7 +366,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.MERGE_CELL" owl="1">
+  <t t-name="o-spreadsheet-Icon.MERGE_CELL">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -374,27 +374,27 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ALIGN_LEFT" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_LEFT">
     <svg class="o-icon align-left">
       <path fill="currentColor" d="M2 16h10v-2H2v2M12 6H2v2h10V6M2 2v2h14V2H2m0 10h14v-2H2v2"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ALIGN_CENTER" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_CENTER">
     <svg class="o-icon align-center">
       <path fill="currentColor" d="M4 14v2h10v-2H4m0-8v2h10V6H4m-2 6h14v-2H2v2M2 2v2h14V2H2"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ALIGN_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_RIGHT">
     <svg class="o-icon align-right">
       <path fill="currentColor" d="M6 16h10v-2H6v2m-4-4h14v-2H2v2M2 2v2h14V2H2m4 6h10V6H6v2"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ALIGN_TOP" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_TOP">
     <svg class="o-icon align-top">
       <path d="M3 2h12v2H3m2.5 5H8v7h2V9h2.5L9 5.5" fill="currentColor"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ALIGN_MIDDLE" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_MIDDLE">
     <svg class="o-icon align-middle">
       <path
         d="M12.5 3H10V0H8v3H5.5L9 6.5M5.5 15H8v3h2v-3h2.5L9 11.5M3 8v2h12V8"
@@ -402,17 +402,17 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ALIGN_BOTTOM" owl="1">
+  <t t-name="o-spreadsheet-Icon.ALIGN_BOTTOM">
     <svg class="o-icon align-bottom">
       <path d="M5.5 9H8V2h2v7h2.5L9 12.5M3 14v2h12v-2" fill="currentColor"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.WRAPPING_OVERFLOW" owl="1">
+  <t t-name="o-spreadsheet-Icon.WRAPPING_OVERFLOW">
     <svg class="o-icon wrapping-overflow">
       <path d="M13 8H6v2h7v2l3-3-3-3M2 2h2v14H2M9 2h2v4H9m0 6h2v4H9" fill="currentColor"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.WRAPPING_WRAP" owl="1">
+  <t t-name="o-spreadsheet-Icon.WRAPPING_WRAP">
     <svg class="o-icon wrapping-wrap">
       <path
         fill="currentColor"
@@ -420,12 +420,12 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.WRAPPING_CLIP" owl="1">
+  <t t-name="o-spreadsheet-Icon.WRAPPING_CLIP">
     <svg class="o-icon wrapping-clip">
       <path fill="currentColor" d="M2 2h2v14H2M14 2h2v14h-2v-6H6V8h8"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDERS" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDERS">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -433,7 +433,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_HV" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_HV">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M2 16h2v-2H2v2M4 5H2v2h2V5m1 11h2v-2H5v2m8-14h-2v2h2V2M4 2H2v2h2V2m3 0H5v2h2V2M2 13h2v-2H2v2m9 3h2v-2h-2v2m3-14v2h2V2h-2m0 5h2V5h-2v2m0 9h2v-2h-2v2m0-3h2v-2h-2v2"
@@ -442,7 +442,7 @@
       <path d="M10 2H8v6H2v2h6v6h2v-6h6V8h-6"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_H" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_H">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M8 16h2v-2H8v2M5 4h2V2H5v2m3 9h2v-2H8v2m-3 3h2v-2H5v2M2 7h2V5H2v2m0 9h2v-2H2v2M2 4h2V2H2v2m0 9h2v-2H2v2m12 0h2v-2h-2v2m0 3h2v-2h-2v2m0-9h2V5h-2v2m0-5v2h2V2h-2M8 4h2V2H8v2m3 0h2V2h-2v2M8 7h2V5H8v2m3 9h2v-2h-2v2"
@@ -451,7 +451,7 @@
       <path d="M2 10h14V8H2"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_V" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_V">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M5 16h2v-2H5v2M2 7h2V5H2v2m0-3h2V2H2v2m3 6h2V8H5v2m0-6h2V2H5v2M2 16h2v-2H2v2m0-6h2V8H2v2m0 3h2v-2H2v2M14 2v2h2V2h-2m0 8h2V8h-2v2m0 6h2v-2h-2v2m0-9h2V5h-2v2m0 6h2v-2h-2v2m-3 3h2v-2h-2v2m0-6h2V8h-2v2m0-6h2V2h-2v2"
@@ -460,13 +460,13 @@
       <path d="M8 16h2V2H8"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_EXTERNAL" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_EXTERNAL">
     <svg class="o-icon" fill="currentColor">
       <path d="M10 5H8v2h2V5m3 3h-2v2h2V8m-3 0H8v2h2V8m0 3H8v2h2v-2M7 8H5v2h2V8" opacity=".54"/>
       <path d="M2 2h14v14H2V2m12 12V4H4v10h10"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_LEFT" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_LEFT">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M8 10h2V8H8v2m0-3h2V5H8v2m0 6h2v-2H8v2m0 3h2v-2H8v2m-3 0h2v-2H5v2M5 4h2V2H5v2m0 6h2V8H5v2m9 6h2v-2h-2v2m0-6h2V8h-2v2m0 3h2v-2h-2v2m0-6h2V5h-2v2M8 4h2V2H8v2m6-2v2h2V2h-2m-3 14h2v-2h-2v2m0-6h2V8h-2v2m0-6h2V2h-2v2"
@@ -475,7 +475,7 @@
       <path d="M2 16h2V2H2"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_TOP" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_TOP">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M5 10h2V8H5v2m-3 6h2v-2H2v2m6 0h2v-2H8v2m0-3h2v-2H8v2m-3 3h2v-2H5v2m-3-3h2v-2H2v2m6-3h2V8H8v2M2 7h2V5H2v2m0 3h2V8H2v2m12 0h2V8h-2v2m0 3h2v-2h-2v2m0-6h2V5h-2v2M8 7h2V5H8v2m3 9h2v-2h-2v2m0-6h2V8h-2v2m3 6h2v-2h-2v2"
@@ -484,7 +484,7 @@
       <path d="M2 2v2h14V2"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_RIGHT">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M2 4h2V2H2v2m3 0h2V2H5v2m0 6h2V8H5v2m0 6h2v-2H5v2M2 7h2V5H2v2m0 3h2V8H2v2m0 6h2v-2H2v2m0-3h2v-2H2v2m9-3h2V8h-2v2m-3 6h2v-2H8v2m3 0h2v-2h-2v2M8 4h2V2H8v2m3 0h2V2h-2v2m-3 9h2v-2H8v2m0-6h2V5H8v2m0 3h2V8H8v2"
@@ -493,7 +493,7 @@
       <path d="M14 2v14h2V2"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_BOTTOM" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_BOTTOM">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M7 2H5v2h2V2m3 6H8v2h2V8m0 3H8v2h2v-2m3-3h-2v2h2V8M7 8H5v2h2V8m6-6h-2v2h2V2m-3 3H8v2h2V5m0-3H8v2h2V2m-6 9H2v2h2v-2m10 2h2v-2h-2v2m0-6h2V5h-2v2m0 3h2V8h-2v2m0-8v2h2V2h-2M4 2H2v2h2V2m0 3H2v2h2V5m0 3H2v2h2V8"
@@ -502,7 +502,7 @@
       <path d="M2 16h14v-2H2"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_CLEAR" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_CLEAR">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -511,7 +511,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_TYPE" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_TYPE">
     <svg class="o-icon">
       <g fill="#000000" transform="translate(2 2)">
         <polygon points="0 0 0 2 14 2 14 0"/>
@@ -524,7 +524,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_COLOR" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_COLOR">
     <svg class="o-icon">
       <g fill="#000000" transform="translate(4 2)">
         <polygon points="0 12 0 9 7 2 10 5 3 12"/>
@@ -532,7 +532,7 @@
       </g>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.BORDER_NO_COLOR" owl="1">
+  <t t-name="o-spreadsheet-Icon.BORDER_NO_COLOR">
     <svg class="o-icon">
       <g fill="#000000">
         <polygon points="4 12 4 9 11 2 14 5 7 12"/>
@@ -544,12 +544,12 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet-Icon.PLUS" owl="1">
+  <t t-name="o-spreadsheet-Icon.PLUS">
     <svg class="o-icon" viewBox="0 0 18 18">
       <path fill="currentColor" d="M8 0h2v8h8v2h-8v8H8v-8H0V8h8"/>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.LIST" owl="1">
+  <t t-name="o-spreadsheet-Icon.LIST">
     <svg class="o-icon" viewBox="0 0 384 384">
       <rect x="0" y="277.333" width="384" height="42.667" fill="currentColor"/>
       <rect x="0" y="170.667" width="384" height="42.667" fill="currentColor"/>
@@ -557,7 +557,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet-Icon.EDIT" owl="1">
+  <t t-name="o-spreadsheet-Icon.EDIT">
     <svg class="o-icon" viewBox="0 0 576 512">
       <path
         fill="currentColor"
@@ -565,7 +565,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.UNLINK" owl="1">
+  <t t-name="o-spreadsheet-Icon.UNLINK">
     <svg class="o-icon" viewBox="0 0 512 512">
       <path
         fill="currentColor"
@@ -577,7 +577,7 @@
  *  http://fontawesome.io/
  *  https://fontawesome.com/license
  */
-  <t t-name="o-spreadsheet-Icon.CARET_UP" owl="1">
+  <t t-name="o-spreadsheet-Icon.CARET_UP">
     <svg class="caret-up" viewBox="0 0 320 512">
       <path
         fill="currentColor"
@@ -585,7 +585,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.CARET_DOWN" owl="1">
+  <t t-name="o-spreadsheet-Icon.CARET_DOWN">
     <svg class="caret-down" viewBox="0 0 320 512">
       <path
         fill="currentColor"
@@ -593,14 +593,14 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.CARET_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.CARET_RIGHT">
     <svg class="o-icon caret-right" viewBox="0 0 192 512">
       <path
         d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.CARET_LEFT" owl="1">
+  <t t-name="o-spreadsheet-Icon.CARET_LEFT">
     <svg class="o-icon caret-left" viewBox="0 0 192 512">
       <path
         d="M192 127.338v257.324c0 17.818-21.543 26.741-34.142 14.142L29.196 270.142c-7.81-7.81-7.81-20.474 0-28.284l128.662-128.662c12.599-12.6 34.142-3.676 34.142 14.142z"
@@ -608,7 +608,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet-Icon.TRASH" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRASH">
     <svg class="o-cf-icon trash" viewBox="0 0 448 512">
       <path
         fill="currentColor"
@@ -616,7 +616,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.REFRESH" owl="1">
+  <t t-name="o-spreadsheet-Icon.REFRESH">
     <svg class="o-cf-icon refresh" viewBox="0 0 512 512">
       <path
         fill="currentColor"
@@ -625,7 +625,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet-Icon.ARROW_DOWN" owl="1">
+  <t t-name="o-spreadsheet-Icon.ARROW_DOWN">
     <svg
       class="o-cf-icon arrow-down"
       width="10"
@@ -639,7 +639,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ARROW_UP" owl="1">
+  <t t-name="o-spreadsheet-Icon.ARROW_UP">
     <svg class="o-cf-icon arrow-up" width="10" height="10" focusable="false" viewBox="0 0 448 512">
       <path
         fill="#00A04A"
@@ -648,7 +648,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ARROW_RIGHT" owl="1">
+  <t t-name="o-spreadsheet-Icon.ARROW_RIGHT">
     <svg
       class="o-cf-icon arrow-right"
       width="10"
@@ -662,7 +662,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet-Icon.SMILE" owl="1">
+  <t t-name="o-spreadsheet-Icon.SMILE">
     <svg class="o-cf-icon smile" width="10" height="10" focusable="false" viewBox="0 0 496 512">
       <path
         fill="#00A04A"
@@ -670,7 +670,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.MEH" owl="1">
+  <t t-name="o-spreadsheet-Icon.MEH">
     <svg class="o-cf-icon meh" width="10" height="10" focusable="false" viewBox="0 0 496 512">
       <path
         fill="#F0AD4E"
@@ -678,7 +678,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.FROWN" owl="1">
+  <t t-name="o-spreadsheet-Icon.FROWN">
     <svg class="o-cf-icon frown" width="10" height="10" focusable="false" viewBox="0 0 496 512">
       <path
         fill="#DC6965"
@@ -687,7 +687,7 @@
     </svg>
   </t>
 
-  <t t-name="o-spreadsheet-Icon.GREEN_DOT" owl="1">
+  <t t-name="o-spreadsheet-Icon.GREEN_DOT">
     <svg class="o-cf-icon green-dot" width="10" height="10" focusable="false" viewBox="0 0 512 512">
       <path
         fill="#00A04A"
@@ -695,7 +695,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.YELLOW_DOT" owl="1">
+  <t t-name="o-spreadsheet-Icon.YELLOW_DOT">
     <svg
       class="o-cf-icon yellow-dot"
       width="10"
@@ -708,7 +708,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.RED_DOT" owl="1">
+  <t t-name="o-spreadsheet-Icon.RED_DOT">
     <svg class="o-cf-icon red-dot" width="10" height="10" focusable="false" viewBox="0 0 512 512">
       <path
         fill="#DC6965"
@@ -716,7 +716,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.SORT_RANGE" owl="1">
+  <t t-name="o-spreadsheet-Icon.SORT_RANGE">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -724,21 +724,21 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.SORT_ASCENDING" owl="1">
+  <t t-name="o-spreadsheet-Icon.SORT_ASCENDING">
     <svg class="o-icon" fill="currentColor">
       <path d="m3 13-1-1-1 1 3 3 3-3-1-1-1 1V0H3"/>
       <text x="9" y="7" class="small-text">A</text>
       <text x="9.3" y="15" class="small-text">Z</text>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.SORT_DESCENDING" owl="1">
+  <t t-name="o-spreadsheet-Icon.SORT_DESCENDING">
     <svg class="o-icon" fill="currentColor">
       <path d="m3 13.9-1-1-1 1 3 3 3-3-1-1-1 1V.9H3"/>
       <text x="9.3" y="7.9" class="small-text">Z</text>
       <text x="9" y="15.9" class="small-text">A</text>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.FILTER_ICON" owl="1">
+  <t t-name="o-spreadsheet-Icon.FILTER_ICON">
     <svg
       class="o-cf-icon filter-icon"
       width="10"
@@ -751,7 +751,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.FILTER_ICON_ACTIVE" owl="1">
+  <t t-name="o-spreadsheet-Icon.FILTER_ICON_ACTIVE">
     <svg
       class="o-cf-icon filter-icon-active"
       width="10"
@@ -764,7 +764,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.FILTER_ICON_INACTIVE" owl="1">
+  <t t-name="o-spreadsheet-Icon.FILTER_ICON_INACTIVE">
     <svg
       class="o-cf-icon filter-icon-inactive"
       width="10"
@@ -777,7 +777,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.MENU_FILTER_ICON" owl="1">
+  <t t-name="o-spreadsheet-Icon.MENU_FILTER_ICON">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -785,7 +785,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.SEARCH" owl="1">
+  <t t-name="o-spreadsheet-Icon.SEARCH">
     <svg class="search-icon" width="10" height="10" focusable="false" viewBox="0 0 512 512">
       <path
         fill="currentColor"
@@ -793,7 +793,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.CHECK" owl="1">
+  <t t-name="o-spreadsheet-Icon.CHECK">
     <svg width="24" height="24" viewBox="3 0 24 24">
       <path
         d="M18.707 7.293a1 1 0 0 1 0 1.414L11.414 16a2 2 0 0 1-2.828 0l-3.293-3.293a1 1 0 1 1 1.414-1.414L10 14.586l7.293-7.293a1 1 0 0 1 1.414 0z"
@@ -801,29 +801,29 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.PERCENT" owl="1">
+  <t t-name="o-spreadsheet-Icon.PERCENT">
     <span class="o-text-icon">%</span>
   </t>
-  <t t-name="o-spreadsheet-Icon.DECRASE_DECIMAL" owl="1">
+  <t t-name="o-spreadsheet-Icon.DECRASE_DECIMAL">
     <span class="o-text-icon">.0</span>
   </t>
-  <t t-name="o-spreadsheet-Icon.INCREASE_DECIMAL" owl="1">
+  <t t-name="o-spreadsheet-Icon.INCREASE_DECIMAL">
     <span class="o-text-icon">.00</span>
   </t>
-  <t t-name="o-spreadsheet-Icon.NUMBER_FORMATS" owl="1">
+  <t t-name="o-spreadsheet-Icon.NUMBER_FORMATS">
     <svg class="o-icon" fill="currentColor">
       <path
         d="M0 6h2v8h2V4H0m9 0H5v2h4v2H6.5A1.5 1.5 0 0 0 5 9.5V14h6v-2H7v-2h2.5A1.5 1.5 0 0 0 11 8.5v-3A1.5 1.5 0 0 0 9.5 4M12 4v2h4v2h-2v2h2v2h-4v2h4.5a1.5 1.5 0 0 0 1.5-1.5v-2A1.5 1.5 0 0 0 16.5 9 1.5 1.5 0 0 0 18 7.5v-2A1.5 1.5 0 0 0 16.5 4"
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.FONT_SIZE" owl="1">
+  <t t-name="o-spreadsheet-Icon.FONT_SIZE">
     <svg class="o-icon" fill="currentColor">
       <text x="2" y="15" class="small-text">A</text>
       <text x="6" y="15" class="heavy-text">A</text>
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION" owl="1">
+  <t t-name="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION">
     <svg class="o-icon" viewBox="0 0 512 512">
       <path
         fill="currentColor"
@@ -831,7 +831,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.SPLIT_TEXT" owl="1">
+  <t t-name="o-spreadsheet-Icon.SPLIT_TEXT">
     <svg class="o-icon">
       <path
         fill="currentColor"
@@ -839,7 +839,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.ERROR" owl="1">
+  <t t-name="o-spreadsheet-Icon.ERROR">
     <svg class="error-icon" width="14" height="14" viewBox="0 0 512 512">
       <path
         fill="currentColor"
@@ -847,7 +847,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.DISPLAY_HEADER" owl="1">
+  <t t-name="o-spreadsheet-Icon.DISPLAY_HEADER">
     <svg class="o-icon" width="18" height="18">
       <path
         fill="currentColor"
@@ -855,7 +855,7 @@
       />
     </svg>
   </t>
-  <t t-name="o-spreadsheet-Icon.COG" owl="1">
+  <t t-name="o-spreadsheet-Icon.COG">
     <svg fill="currentColor" viewBox="0 0 16 16">
       <path
         d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"

--- a/src/components/link/link_display/link_display.xml
+++ b/src/components/link/link_display/link_display.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-LinkDisplay" owl="1">
+  <t t-name="o-spreadsheet-LinkDisplay">
     <div class="o-link-tool d-flex align-items-center">
       <!-- t-key to prevent owl from re-using the previous img element when the link changes.
     The wrong/previous image would be displayed while the new one loads -->

--- a/src/components/link/link_editor/link_editor.xml
+++ b/src/components/link/link_editor/link_editor.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-LinkEditor" owl="1">
+  <t t-name="o-spreadsheet-LinkEditor">
     <div
       class="o-link-editor"
       t-on-click.stop="() => this.menu.isOpen=false"

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Menu" owl="1">
+  <t t-name="o-spreadsheet-Menu">
     <Popover t-if="menuItemsAndSeparators.length" t-props="popoverProps">
       <div
         t-ref="menu"

--- a/src/components/paint_format_button/paint_format_button.xml
+++ b/src/components/paint_format_button/paint_format_button.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-PaintFormatButton" owl="1">
+  <t t-name="o-spreadsheet-PaintFormatButton">
     <span
       class="o-menu-item-button"
       title="Paint Format"

--- a/src/components/popover/popover.xml
+++ b/src/components/popover/popover.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Popover" owl="1">
+  <t t-name="o-spreadsheet-Popover">
     <t t-portal="'.o-spreadsheet'">
       <div
         class="o-popover"

--- a/src/components/scrollbar/scrollbar.xml
+++ b/src/components/scrollbar/scrollbar.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ScrollBar" owl="1">
+  <t t-name="o-spreadsheet-ScrollBar">
     <div class="o-scrollbar" t-on-scroll="onScroll" t-ref="scrollbar" t-att-style="positionCss">
       <div t-att-style="sizeCss"/>
     </div>

--- a/src/components/selection_input/selection_input.xml
+++ b/src/components/selection_input/selection_input.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-SelectionInput" owl="1">
+  <t t-name="o-spreadsheet-SelectionInput">
     <div class="o-selection">
       <div
         t-foreach="ranges"

--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-BarConfigPanel" owl="1">
+  <t t-name="o-spreadsheet-BarConfigPanel">
     <div>
       <div class="o-section pt-0">
         <label class="o-checkbox">

--- a/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_design_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-BarChartDesignPanel" owl="1">
+  <t t-name="o-spreadsheet-BarChartDesignPanel">
     <t t-set="background_color">Background Color</t>
     <div>
       <div class="o-section o-chart-background-color">

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-GaugeChartConfigPanel" owl="1">
+  <t t-name="o-spreadsheet-GaugeChartConfigPanel">
     <div>
       <div class="o-section o-data-series">
         <div class="o-section-title">Data range</div>

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-GaugeChartDesignPanel" owl="1">
+  <t t-name="o-spreadsheet-GaugeChartDesignPanel">
     <t t-set="background_color">Background Color</t>
     <div>
       <div class="o-section o-chart-background-color">
@@ -65,7 +65,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet-GaugeChartColorSectionTemplate" owl="1">
+  <t t-name="o-spreadsheet-GaugeChartColorSectionTemplate">
     <div class="o-gauge-color-set">
       <table>
         <tr>
@@ -110,7 +110,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet-GaugeChartColorSectionTemplateRow" owl="1">
+  <t t-name="o-spreadsheet-GaugeChartColorSectionTemplateRow">
     <tr>
       <td>
         <ColorPickerWidget

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-LineBarPieConfigPanel" owl="1">
+  <t t-name="o-spreadsheet-LineBarPieConfigPanel">
     <div>
       <div class="o-section o-data-series">
         <div class="o-section-title">Data Series</div>

--- a/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
+++ b/src/components/side_panel/chart/line_bar_pie_panel/design_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-LineBarPieDesignPanel" owl="1">
+  <t t-name="o-spreadsheet-LineBarPieDesignPanel">
     <t t-set="background_color">Background Color</t>
     <div>
       <div class="o-section o-chart-background-color">

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-LineConfigPanel" owl="1">
+  <t t-name="o-spreadsheet-LineConfigPanel">
     <div>
       <div class="o-section pt-0">
         <label class="o-checkbox">

--- a/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_design_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-LineChartDesignPanel" owl="1">
+  <t t-name="o-spreadsheet-LineChartDesignPanel">
     <t t-set="background_color">Background Color</t>
     <div>
       <div class="o-section o-chart-background-color">

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ChartPanel" owl="1">
+  <t t-name="o-spreadsheet-ChartPanel">
     <div class="o-chart">
       <div class="o-panel">
         <div

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ScorecardChartConfigPanel" owl="1">
+  <t t-name="o-spreadsheet-ScorecardChartConfigPanel">
     <div>
       <div class="o-section o-data-series">
         <div class="o-section-title">Key value</div>

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ScorecardChartDesignPanel" owl="1">
+  <t t-name="o-spreadsheet-ScorecardChartDesignPanel">
     <t t-set="background_color">Background Color</t>
     <t t-set="color_up">Color Up</t>
     <t t-set="color_down">Color Down</t>

--- a/src/components/side_panel/conditional_formatting/cell_is_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/cell_is_rule_editor.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-CellIsRuleEditorPreview" owl="1">
+  <t t-name="o-spreadsheet-CellIsRuleEditorPreview">
     <div
       class="o-cf-preview-line"
       t-attf-style="font-weight:{{currentStyle.bold ?'bold':'normal'}};
@@ -13,7 +13,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet-CellIsRuleEditor" owl="1">
+  <t t-name="o-spreadsheet-CellIsRuleEditor">
     <t t-set="fill_color">Fill Color</t>
     <t t-set="text_color">Text Color</t>
     <div class="o-cf-cell-is-rule">

--- a/src/components/side_panel/conditional_formatting/color_scale_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/color_scale_rule_editor.xml
@@ -1,9 +1,9 @@
 <templates>
-  <t t-name="o-spreadsheet-ColorScaleRuleEditorPreview" owl="1">
+  <t t-name="o-spreadsheet-ColorScaleRuleEditorPreview">
     <div class="o-cf-preview-gradient" t-attf-style="{{getPreviewGradient()}}">Preview text</div>
   </t>
 
-  <t t-name="o-spreadsheet-ColorScaleRuleEditorThreshold" owl="1">
+  <t t-name="o-spreadsheet-ColorScaleRuleEditorThreshold">
     <t t-set="fill_color">Fill Color</t>
     <div t-attf-class="o-threshold o-threshold-{{thresholdType}}">
       <t t-if="thresholdType === 'midpoint'">
@@ -49,7 +49,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet-ColorScaleRuleEditor" owl="1">
+  <t t-name="o-spreadsheet-ColorScaleRuleEditor">
     <div class="o-cf-color-scale-editor">
       <div class="o-section-subtitle">Preview</div>
       <t t-call="o-spreadsheet-ColorScaleRuleEditorPreview"/>

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.xml
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-ConditionalFormattingPanel" owl="1">
+  <t t-name="o-spreadsheet-ConditionalFormattingPanel">
     <div class="o-cf">
       <t t-if="state.mode === 'list' || state.mode === 'reorder'">
         <div class="o-cf-preview-list">
@@ -119,7 +119,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet-ConditionalFormattingPanelPreview" owl="1">
+  <t t-name="o-spreadsheet-ConditionalFormattingPanelPreview">
     <div class="o-cf-preview" t-att-class="{ 'o-cf-cursor-ptr': state.mode !== 'reorder' }">
       <t t-if="cf.rule.type==='IconSetRule'">
         <div class="o-cf-preview-icon">

--- a/src/components/side_panel/conditional_formatting/icon_set_rule_editor.xml
+++ b/src/components/side_panel/conditional_formatting/icon_set_rule_editor.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-IconSets" owl="1">
+  <t t-name="o-spreadsheet-IconSets">
     <div>
       <div class="o-section-subtitle">Icons</div>
       <div class="o-cf-iconsets">
@@ -23,7 +23,7 @@
     </div>
   </t>
 
-  <t t-name="o-spreadsheet-IconSetInflexionPointRow" owl="1">
+  <t t-name="o-spreadsheet-IconSetInflexionPointRow">
     <tr>
       <td>
         <div t-on-click.stop="(ev) => this.toggleMenu('iconSet-'+icon+'Icon', ev)">
@@ -66,7 +66,7 @@
     </tr>
   </t>
 
-  <t t-name="o-spreadsheet-IconSetInflexionPoints" owl="1">
+  <t t-name="o-spreadsheet-IconSetInflexionPoints">
     <div class="o-inflection">
       <table>
         <tr>
@@ -108,7 +108,7 @@
       </table>
     </div>
   </t>
-  <t t-name="o-spreadsheet-IconSetEditor" owl="1">
+  <t t-name="o-spreadsheet-IconSetEditor">
     <div class="o-cf-iconset-rule">
       <t t-call="o-spreadsheet-IconSets"/>
       <t t-call="o-spreadsheet-IconSetInflexionPoints"/>

--- a/src/components/side_panel/custom_currency/custom_currency.xml
+++ b/src/components/side_panel/custom_currency/custom_currency.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-CustomCurrencyPanel" owl="1">
+  <t t-name="o-spreadsheet-CustomCurrencyPanel">
     <div class="o-custom-currency">
       <div class="o-section" t-if="availableCurrencies.length > 1">
         <div class="o-section-title">Currency</div>

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-FindAndReplacePanel" owl="1">
+  <t t-name="o-spreadsheet-FindAndReplacePanel">
     <div class="o-find-and-replace" tabindex="0" t-ref="findAndReplace">
       <div class="o-section">
         <div class="o-section-title">Search</div>

--- a/src/components/side_panel/settings/settings_panel.xml
+++ b/src/components/side_panel/settings/settings_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-SettingsPanel" owl="1">
+  <t t-name="o-spreadsheet-SettingsPanel">
     <div class="o-settings-panel">
       <div class="o-section">
         <div class="o-section-title">Locale</div>

--- a/src/components/side_panel/side_panel/side_panel.xml
+++ b/src/components/side_panel/side_panel/side_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-SidePanel" owl="1">
+  <t t-name="o-spreadsheet-SidePanel">
     <div class="o-sidePanel">
       <div class="o-sidePanelHeader">
         <div class="o-sidePanelTitle" t-esc="getTitle()"/>

--- a/src/components/side_panel/side_panel_errors/side_panel_errors.xml
+++ b/src/components/side_panel/side_panel_errors/side_panel_errors.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-SidePanelErrors" owl="1">
+  <t t-name="o-spreadsheet-SidePanelErrors">
     <t t-foreach="props.messages" t-as="msg" t-key="msg">
       <div class="d-flex align-items-center" t-att-class="divClasses">
         <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.xml
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-SplitIntoColumnsPanel" owl="1">
+  <t t-name="o-spreadsheet-SplitIntoColumnsPanel">
     <div class="o-split-to-cols-panel">
       <div class="o-section">
         <div class="o-section-title">Separator</div>

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-Spreadsheet" owl="1">
+  <t t-name="o-spreadsheet-Spreadsheet">
     <div
       class="o-spreadsheet"
       t-on-keydown="(ev) => !env.isDashboard() and this.onKeydown(ev)"

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-TopBar" owl="1">
+  <t t-name="o-spreadsheet-TopBar">
     <t t-set="text_color">Text Color</t>
     <t t-set="fill_color">Fill Color</t>
     <div


### PR DESCRIPTION
## Description:

Since all templates are now imported within the owl app, specifying the `owl="1"` attribute in templates is no longer necessary.

Task: : [3470126](https://www.odoo.com/web#id=3470126&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo