### PR TITLE
[IMP] *: export menu helpers & block change of props model to `Spreadsheet`

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -3,6 +3,7 @@ import {
   onMounted,
   onPatched,
   onWillUnmount,
+  onWillUpdateProps,
   useExternalListener,
   useState,
   useSubEnv,
@@ -225,6 +226,13 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     useExternalListener(window, "beforeunload", this.unbindModelEvents.bind(this));
 
     this.bindModelEvents();
+
+    onWillUpdateProps((nextProps) => {
+      if (nextProps.model !== this.props.model) {
+        throw new Error("Changing the props model is not supported at the moment.");
+      }
+    });
+
     onMounted(() => {
       this.checkViewportSize();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
+import { createAction, createActions } from "./actions/action";
 import { ChartJsComponent } from "./components/figures/chart/chartJs/chartjs";
 import { ScorecardChart } from "./components/figures/chart/scorecard/chart_scorecard";
 import { FigureComponent } from "./components/figures/figure/figure";
 import { ChartFigure } from "./components/figures/figure_chart/figure_chart";
 import { Grid } from "./components/grid/grid";
 import { GridOverlay } from "./components/grid_overlay/grid_overlay";
+import { Menu } from "./components/menu/menu";
 import {
   BarConfigPanel,
   chartSidePanelComponentRegistry,
@@ -204,6 +206,8 @@ export const helpers = {
   isDefined,
   lazy,
   genericRepeat,
+  createAction,
+  createActions,
 };
 
 export const links = {
@@ -229,6 +233,7 @@ export const components = {
   ScorecardChartConfigPanel,
   ScorecardChartDesignPanel,
   FigureComponent,
+  Menu,
 };
 
 export function addFunction(functionName: string, functionDescription: AddFunctionDescription) {


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo