### PR TITLE
[FIX] Menu: Hide the icon slot of the menu items when absent

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -166,7 +166,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get childrenHaveIcon(): boolean {
-    return this.props.menuItems.some((menuItem) => !!menuItem.icon || !!menuItem.isActive);
+    return this.props.menuItems.some((menuItem) => !!this.getIconName(menuItem));
   }
 
   getIconName(menu: Action) {

--- a/tests/components/__snapshots__/bottom_bar.test.ts.snap
+++ b/tests/components/__snapshots__/bottom_bar.test.ts.snap
@@ -13,9 +13,6 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     <div
       class="d-flex w-100"
     >
-      <div
-        class="o-menu-item-icon align-middle"
-      />
       
       <div
         class="o-menu-item-name align-middle text-truncate"
@@ -35,9 +32,6 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     <div
       class="d-flex w-100"
     >
-      <div
-        class="o-menu-item-icon align-middle"
-      />
       
       <div
         class="o-menu-item-name align-middle text-truncate"
@@ -57,9 +51,6 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     <div
       class="d-flex w-100"
     >
-      <div
-        class="o-menu-item-icon align-middle"
-      />
       
       <div
         class="o-menu-item-name align-middle text-truncate"
@@ -79,9 +70,6 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     <div
       class="d-flex w-100"
     >
-      <div
-        class="o-menu-item-icon align-middle"
-      />
       
       <div
         class="o-menu-item-name align-middle text-truncate"
@@ -101,9 +89,6 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     <div
       class="d-flex w-100"
     >
-      <div
-        class="o-menu-item-icon align-middle"
-      />
       
       <div
         class="o-menu-item-name align-middle text-truncate"
@@ -123,9 +108,6 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
     <div
       class="d-flex w-100"
     >
-      <div
-        class="o-menu-item-icon align-middle"
-      />
       
       <div
         class="o-menu-item-name align-middle text-truncate"

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -681,6 +681,25 @@ describe("Context Menu internal tests", () => {
     await nextTick();
     expect(fixture.querySelector("div[data-name='menuItem']")).toBeFalsy();
   });
+
+  test("Menu icon slot is visibile if one of the children has an icon", async () => {
+    let visible = false;
+    const menuItems = createActions([
+      {
+        name: "child1",
+        icon: () => (visible ? "o-spreadsheet-Icon.BOLD" : ""),
+      },
+      {
+        name: "child2",
+      },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+    expect(fixture.querySelectorAll(".o-menu-item-icon").length).toBe(0);
+    visible = true;
+    parent.render(true);
+    await nextTick();
+    expect(fixture.querySelectorAll(".o-menu-item-icon").length).toBe(2);
+  });
 });
 
 describe("Context Menu position on large screen 1000px/1000px", () => {


### PR DESCRIPTION
The refactoring of the menus, which introduced the possibility to attach an icon, was designed so that the icon slot would not be rendered if no menuitem had an icon. Unfortunately, this was broken when we introduced the dynamic icons in 8a9914a2.

Task: 3476424

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo