### PR TITLE
[FIX] LineChart: Do not store window.Chart at top level

### DIFF
--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -56,9 +56,6 @@ import {
   getFillingMode,
 } from "./chart_ui_common";
 
-// @ts-ignore
-const Chart: typeof ChartType = window.Chart;
-
 export class LineChart extends AbstractChart {
   readonly dataSets: DataSet[];
   readonly labelRange?: Range | undefined;
@@ -295,7 +292,9 @@ function getLineConfiguration(
       generateLabels(chart) {
         // color the legend labels with the dataset color, without any transparency
         const { data } = chart;
-        const labels = Chart.defaults.plugins.legend.labels.generateLabels!(chart);
+        /** @ts-ignore */
+        const labels = (window.Chart as typeof ChartType).defaults.plugins.legend.labels
+          .generateLabels!(chart);
         for (const [index, label] of labels.entries()) {
           label.fillStyle = data.datasets![index].borderColor as string;
         }


### PR DESCRIPTION
If for some reason the spreadsheet dependencies were not loaded before the library itself, we would store an undefined reference in `Chart` which ultimately leads to a traceback when trying to generate a `LineChart`

Task: 3476486

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo