### PR TITLE
[IMP] charts: add an 'extraData' key in definition

### DIFF
--- a/src/helpers/figures/charts/abstract_chart.ts
+++ b/src/helpers/figures/charts/abstract_chart.ts
@@ -23,11 +23,13 @@ export abstract class AbstractChart {
   readonly title: string;
   abstract readonly type: ChartType;
   protected readonly getters: CoreGetters;
+  readonly extraData?: any;
 
   constructor(definition: ChartDefinition, sheetId: UID, getters: CoreGetters) {
     this.title = definition.title;
     this.sheetId = sheetId;
     this.getters = getters;
+    this.extraData = definition.extraData;
   }
 
   /**

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -103,6 +103,7 @@ export class BarChart extends AbstractChart {
       type: "bar",
       verticalAxisPosition: "left",
       labelRange: context.auxiliaryRange || undefined,
+      extraData: context.extraData,
     };
   }
 
@@ -116,6 +117,7 @@ export class BarChart extends AbstractChart {
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
+      extraData: this.extraData,
     };
   }
 
@@ -159,6 +161,7 @@ export class BarChart extends AbstractChart {
       title: this.title,
       stacked: this.stacked,
       aggregated: this.aggregated,
+      extraData: this.extraData,
     };
   }
 

--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -198,6 +198,7 @@ export class GaugeChart extends AbstractChart {
           value: "40",
         },
       },
+      extraData: context.extraData,
     };
   }
 
@@ -228,6 +229,7 @@ export class GaugeChart extends AbstractChart {
       dataRange: dataRange
         ? this.getters.getRangeString(dataRange, targetSheetId || this.sheetId)
         : undefined,
+      extraData: this.extraData,
     };
   }
 
@@ -243,6 +245,7 @@ export class GaugeChart extends AbstractChart {
       range: this.dataRange
         ? [this.getters.getRangeString(this.dataRange, this.sheetId)]
         : undefined,
+      extraData: this.extraData,
     };
   }
 

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -113,6 +113,7 @@ export class LineChart extends AbstractChart {
       labelRange: context.auxiliaryRange || undefined,
       stacked: false,
       aggregated: false,
+      extraData: context.extraData,
     };
   }
 
@@ -141,6 +142,7 @@ export class LineChart extends AbstractChart {
       labelsAsText: this.labelsAsText,
       stacked: this.stacked,
       aggregated: this.aggregated,
+      extraData: this.extraData,
     };
   }
 
@@ -154,6 +156,7 @@ export class LineChart extends AbstractChart {
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
+      extraData: this.extraData,
     };
   }
 

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -97,6 +97,7 @@ export class PieChart extends AbstractChart {
       type: "pie",
       labelRange: context.auxiliaryRange || undefined,
       aggregated: false,
+      extraData: context.extraData,
     };
   }
 
@@ -114,6 +115,7 @@ export class PieChart extends AbstractChart {
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
+      extraData: this.extraData,
     };
   }
 
@@ -135,6 +137,7 @@ export class PieChart extends AbstractChart {
         : undefined,
       title: this.title,
       aggregated: this.aggregated,
+      extraData: this.extraData,
     };
   }
 

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -89,6 +89,7 @@ export class ScorecardChart extends AbstractChart {
       baselineColorUp: DEFAULT_SCORECARD_BASELINE_COLOR_UP,
       baselineColorDown: DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
       baseline: context.auxiliaryRange || "",
+      extraData: context.extraData,
     };
   }
 
@@ -136,6 +137,7 @@ export class ScorecardChart extends AbstractChart {
       auxiliaryRange: this.baseline
         ? this.getters.getRangeString(this.baseline, this.sheetId)
         : undefined,
+      extraData: this.extraData,
     };
   }
 
@@ -158,6 +160,7 @@ export class ScorecardChart extends AbstractChart {
       keyValue: keyValue
         ? this.getters.getRangeString(keyValue, targetSheetId || this.sheetId)
         : undefined,
+      extraData: this.extraData,
     };
   }
 

--- a/src/types/chart/bar_chart.ts
+++ b/src/types/chart/bar_chart.ts
@@ -13,6 +13,7 @@ export interface BarChartDefinition {
   readonly legendPosition: LegendPosition;
   readonly stacked: boolean;
   readonly aggregated?: boolean;
+  readonly extraData?: any;
 }
 
 export type BarChartRuntime = {

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -64,4 +64,5 @@ export interface ChartCreationContext {
   readonly title?: string;
   readonly background?: string;
   readonly auxiliaryRange?: string;
+  readonly extraData?: any;
 }

--- a/src/types/chart/gauge_chart.ts
+++ b/src/types/chart/gauge_chart.ts
@@ -7,6 +7,7 @@ export interface GaugeChartDefinition {
   readonly dataRange?: string;
   readonly sectionRule: SectionRule;
   readonly background?: Color;
+  readonly extraData?: any;
 }
 
 export interface SectionRule {

--- a/src/types/chart/line_chart.ts
+++ b/src/types/chart/line_chart.ts
@@ -14,6 +14,7 @@ export interface LineChartDefinition {
   readonly labelsAsText: boolean;
   readonly stacked: boolean;
   readonly aggregated?: boolean;
+  readonly extraData?: any;
 }
 
 export type LineChartRuntime = {

--- a/src/types/chart/pie_chart.ts
+++ b/src/types/chart/pie_chart.ts
@@ -11,6 +11,7 @@ export interface PieChartDefinition {
   readonly background?: Color;
   readonly legendPosition: LegendPosition;
   readonly aggregated?: boolean;
+  readonly extraData?: any;
 }
 
 export type PieChartRuntime = {

--- a/src/types/chart/scorecard_chart.ts
+++ b/src/types/chart/scorecard_chart.ts
@@ -10,6 +10,7 @@ export interface ScorecardChartDefinition {
   readonly background?: Color;
   readonly baselineColorUp: Color;
   readonly baselineColorDown: Color;
+  readonly extraData?: any;
 }
 
 export type BaselineMode = "text" | "difference" | "percentage";

--- a/tests/collaborative/collaborative_sheet_manipulations.test.ts
+++ b/tests/collaborative/collaborative_sheet_manipulations.test.ts
@@ -577,6 +577,9 @@ describe("Collaborative Sheet manipulation", () => {
       verticalAxisPosition: "left",
       legendPosition: "top",
       aggregated: false,
+      extraData: {
+        someNewKey: "someNewValue",
+      },
     };
 
     test(`Concurrently chart creation & update and add columns`, () => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -149,6 +149,9 @@ export function createChart(
       stacked: ("stacked" in data && data.stacked) || false,
       labelsAsText: ("labelsAsText" in data && data.labelsAsText) || false,
       aggregated: ("aggregated" in data && data.aggregated) || false,
+      extraData: data.extraData || {
+        someKey: "someValue",
+      },
     },
   });
 }

--- a/tests/xlsx_import_export.test.ts
+++ b/tests/xlsx_import_export.test.ts
@@ -276,7 +276,7 @@ describe("Export data to xlsx then import it", () => {
     const importedModel = exportToXlsxThenImport(model);
     const newChartId = importedModel.getters.getChartIds(sheetId)[0];
     const newChart = importedModel.getters.getChartDefinition(newChartId);
-    expect(newChart).toMatchObject(chartDef);
+    expect(newChart).toMatchObject({ ...chartDef, extraData: undefined });
   });
 
   test("hyperlinks", () => {


### PR DESCRIPTION
## Task Description:

This PR aims to add a new extraData key in the chart definition to be able to add extraData when trying to extend the lib. For example, this key is now used in odoo to keep the link to an Odoo Menu when copying chart.

## Related Task/PR:

- Task: : [3380568](https://www.odoo.com/web#id=3380568&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo