### PR TITLE
[FIX] clipboard: copy/paste of CF in another sheet

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -2,7 +2,7 @@
 // Miscellaneous
 //------------------------------------------------------------------------------
 import { NEWLINE } from "../constants";
-import { ConsecutiveIndexes, Lazy, UID } from "../types";
+import { ConditionalFormat, ConsecutiveIndexes, Lazy, UID } from "../types";
 import { Cloneable } from "./../types/misc";
 /**
  * Stringify an object, like JSON.stringify, except that the first level of keys
@@ -486,4 +486,8 @@ export function insertItemsAtIndex<T>(array: readonly T[], items: T[], index: nu
   const newArray = [...array];
   newArray.splice(index, 0, ...items);
   return newArray;
+}
+
+export function areConditionalFormatEquivalents(cf1: ConditionalFormat, cf2: ConditionalFormat) {
+  return cf1.stopIfTrue === cf2.stopIfTrue && deepEquals(cf1.rule, cf2.rule);
 }

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -1725,6 +1725,41 @@ describe("clipboard", () => {
     expect(getStyle(model, "A2", sheet1)).toEqual({});
   });
 
+  test("copy paste CF in another sheet => change CF => copy paste again doesn't overwrite the previously pasted CF", () => {
+    const model = new Model();
+    createSheet(model, {});
+    const sheet1Id = model.getters.getSheetIds()[0];
+    const sheet2Id = model.getters.getSheetIds()[1];
+
+    const cf = createEqualCF("2", { fillColor: "#00FF00" }, "cfId");
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf,
+      ranges: toRangesData(sheet1Id, "A1"),
+      sheetId: sheet1Id,
+    });
+
+    copy(model, "A1");
+    activateSheet(model, sheet2Id);
+    paste(model, "A1");
+    expect(model.getters.getConditionalFormats(sheet2Id)).toMatchObject([
+      { ranges: ["A1"], rule: { style: { fillColor: "#00FF00" } } },
+    ]);
+
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF("2", { fillColor: "#FF0000" }, "cfId"),
+      ranges: toRangesData(sheet1Id, "A1"),
+      sheetId: sheet1Id,
+    });
+    activateSheet(model, sheet1Id);
+    copy(model, "A1");
+    activateSheet(model, sheet2Id);
+    paste(model, "B2");
+    expect(model.getters.getConditionalFormats(sheet2Id)).toMatchObject([
+      { ranges: ["A1"], rule: { style: { fillColor: "#00FF00" } } },
+      { ranges: ["B2"], rule: { style: { fillColor: "#FF0000" } } },
+    ]);
+  });
+
   test("can copy and paste a cell which contains a cross-sheet reference", () => {
     const model = new Model();
     createSheet(model, { sheetId: "42" });


### PR DESCRIPTION
## Description

There was an issue when copying/pasting a cell with a CF in another sheet. In the other sheet, a new CF was created with the same id as the original CF. This works fine when copy/pasting a CF for the first time. But after that, if the user were to modify the CF in the original sheet, a second copy/paste would overwrite the CF in the other sheet with the new changes.

This commit changes a bit the strategy for copy/pasting CFs in another sheet. Instead of always creating a new CF with the same id, the plugin tries to find a CF with the same rule in another sheet to put the copied cells into. If no CF with the same rule is found, then a new one with a new Id is created.

Task:

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3479451](https://www.odoo.com/web#id=3479451&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo