### PR TITLE
[REV] components: prevent mouse event defaults on drag-and-drop

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -392,7 +392,8 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     let prevCol = col;
     let prevRow = row;
 
-    const onMouseMove = (col: HeaderIndex, row: HeaderIndex) => {
+    const onMouseMove = (col: HeaderIndex, row: HeaderIndex, ev: MouseEvent) => {
+      ev.preventDefault();
       if ((col !== prevCol && col != -1) || (row !== prevRow && row != -1)) {
         prevCol = col === -1 ? prevCol : col;
         prevRow = row === -1 ? prevRow : row;

--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -9,35 +9,26 @@ export function startDnd(
   onMouseUp: EventFn,
   onMouseDown: EventFn = () => {}
 ) {
-  const _onMouseDown = (ev: MouseEvent) => {
-    ev.preventDefault();
-    onMouseDown(ev);
-  };
-  const _onMouseMove = (ev: MouseEvent) => {
-    ev.preventDefault();
-    onMouseMove(ev);
-  };
   const _onMouseUp = (ev: MouseEvent) => {
-    ev.preventDefault();
     onMouseUp(ev);
 
-    window.removeEventListener("mousedown", _onMouseDown);
+    window.removeEventListener("mousedown", onMouseDown);
     window.removeEventListener("mouseup", _onMouseUp);
     window.removeEventListener("dragstart", _onDragStart);
-    window.removeEventListener("mousemove", _onMouseMove);
-    window.removeEventListener("wheel", _onMouseMove);
+    window.removeEventListener("mousemove", onMouseMove);
+    window.removeEventListener("wheel", onMouseMove);
   };
   function _onDragStart(ev: DragEvent) {
     ev.preventDefault();
   }
-  window.addEventListener("mousedown", _onMouseDown);
+  window.addEventListener("mousedown", onMouseDown);
   window.addEventListener("mouseup", _onMouseUp);
   window.addEventListener("dragstart", _onDragStart);
-  window.addEventListener("mousemove", _onMouseMove);
+  window.addEventListener("mousemove", onMouseMove);
   // mouse wheel on window is by default a passive event.
   // preventDefault() is not allowed in passive event handler.
   // https://chromestatus.com/feature/6662647093133312
-  window.addEventListener("wheel", _onMouseMove, { passive: false });
+  window.addEventListener("wheel", onMouseMove, { passive: false });
 }
 
 /**


### PR DESCRIPTION
Preventing the default events in DnD unfortunately introduced a 'too generic' behaviour. Due to the current state of the model and component synergy, we have some limitations when drag-and-dropping.

Specifically, an issue can arise when a user would input a character just after starting drag-n-drop (i.e. hit a key just after a mousedown on the grid). In this situation, inputting the character will make a switch to a state of cell edition, which is not compatible with the callbacks provided to the drag-n-drop. So any further mouve of the mouse will then invoke the SelectionStreamProcessor, that will contact the `EditionPlugin` but since we are not selecting a cell, it does not make sense and is simply ignored but the plugin[1]. The user will end up in a situation were they think they are selecting a zone but nothing happens.

Commit 1178bbec was introduced to fix a very specific issue but doing so, removed the ability to target another DOM node on `mousedown` event, which happens to be very helpful to lose the focus of the `hiddenInput` focused by in grid when we click somewhere on `GridOverlay`. It turns out the original addressed issue can be handled case-by-case by preventing the default behaviour of the mousemove callback. This revision suggests to take a more surgical approach and prenvent the default behaviour where it is required (uncalled-for pre-optimisation is bad, m'kay?). If we were to require more generic limitations in the future, then we will need to introduce a way to invalidate drag-and-drop under given conditions.

[1] in later versions (16.5-alpha and onwards) it's no longer ignored but will rather trigger an error...

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo