### PR TITLE
[FIX] locale: string dates in CF aren't (un)localized

### DIFF
--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -1,7 +1,7 @@
 import { Component, onMounted, useRef, useState } from "@odoo/owl";
 import { markdownLink } from "../../../helpers";
 import { detectLink, urlRepresentation } from "../../../helpers/links";
-import { canonicalizeContent } from "../../../helpers/locale";
+import { canonicalizeNumberContent } from "../../../helpers/locale";
 import { linkMenuRegistry } from "../../../registries/menus/link_menu_registry";
 import { DOMCoordinates, Link, Position, SpreadsheetChildEnv } from "../../../types";
 import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popovers";
@@ -169,7 +169,9 @@ export class LinkEditor extends Component<LinkEditorProps, SpreadsheetChildEnv> 
   save() {
     const { col, row } = this.props.cellPosition;
     const locale = this.env.model.getters.getLocale();
-    const label = this.link.label ? canonicalizeContent(this.link.label, locale) : this.link.url;
+    const label = this.link.label
+      ? canonicalizeNumberContent(this.link.label, locale)
+      : this.link.url;
     this.env.model.dispatch("UPDATE_CELL", {
       col: col,
       row: row,

--- a/src/formulas/formula_locale.ts
+++ b/src/formulas/formula_locale.ts
@@ -1,4 +1,4 @@
-import { toCanonicalNumberString } from "../helpers/locale";
+import { canonicalizeNumberLiteral } from "../helpers/locale";
 import { DEFAULT_LOCALE, Locale } from "../types";
 import { tokenize } from "./tokenizer";
 
@@ -6,7 +6,7 @@ import { tokenize } from "./tokenizer";
 export function canonicalizeNumberValue(content: string, locale: Locale) {
   return content.startsWith("=")
     ? canonicalizeFormula(content, locale)
-    : toCanonicalNumberString(content, locale);
+    : canonicalizeNumberLiteral(content, locale);
 }
 
 /** Change a formula to its canonical form (en_US locale) */

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -10,6 +10,7 @@ import {
   ColorScaleMidPointThreshold,
   ColorScaleRule,
   ColorScaleThreshold,
+  DEFAULT_LOCALE,
   EvaluatedCell,
   HeaderIndex,
   IconSetRule,
@@ -388,8 +389,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       if (cell.type === CellValueType.error) {
         return false;
       }
-      const locale = this.getters.getLocale();
-      const values = rule.values.map((val) => parseLiteral(val, locale));
+      const values = rule.values.map((val) => parseLiteral(val, DEFAULT_LOCALE));
       switch (rule.operator) {
         case "IsEmpty":
           return cell.value.toString().trim() === "";

--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -1,5 +1,5 @@
 import { escapeRegExp } from "../../helpers";
-import { canonicalizeContent } from "../../helpers/locale";
+import { canonicalizeNumberContent } from "../../helpers/locale";
 import {
   CellPosition,
   Color,
@@ -253,7 +253,7 @@ export class FindAndReplacePlugin extends UIPlugin {
     );
     const toReplace: string | null = this.getSearchableString({ sheetId, col, row });
     const content = toReplace.replace(replaceRegex, replaceWith);
-    const canonicalContent = canonicalizeContent(content, this.getters.getLocale());
+    const canonicalContent = canonicalizeNumberContent(content, this.getters.getLocale());
     this.dispatch("UPDATE_CELL", { sheetId, col, row, content: canonicalContent });
   }
 

--- a/src/plugins/ui_feature/split_to_columns.ts
+++ b/src/plugins/ui_feature/split_to_columns.ts
@@ -1,6 +1,6 @@
 import { NEWLINE } from "../../constants";
 import { range } from "../../helpers";
-import { canonicalizeContent } from "../../helpers/locale";
+import { canonicalizeNumberContent } from "../../helpers/locale";
 import {
   CellPosition,
   CellValueType,
@@ -82,7 +82,7 @@ export class SplitToColumnsPlugin extends UIPlugin {
           sheetId,
           col: col + index,
           row,
-          content: canonicalizeContent(content, this.getters.getLocale()),
+          content: canonicalizeNumberContent(content, this.getters.getLocale()),
           format: "",
           style: mainCell?.style || null,
         });

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -14,7 +14,7 @@ import {
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
 } from "../../helpers/index";
-import { canonicalizeContent, localizeFormula } from "../../helpers/locale";
+import { canonicalizeNumberContent, localizeFormula } from "../../helpers/locale";
 import { loopThroughReferenceType } from "../../helpers/reference_type";
 import { _lt } from "../../translation";
 import {
@@ -448,7 +448,7 @@ export class EditionPlugin extends UIPlugin {
       if (content) {
         const sheetId = this.getters.getActiveSheetId();
         const cell = this.getters.getEvaluatedCell({ sheetId, col: this.col, row: this.row });
-        content = canonicalizeContent(content, this.getters.getLocale());
+        content = canonicalizeNumberContent(content, this.getters.getLocale());
         if (content.startsWith("=")) {
           const left = this.currentTokens.filter((t) => t.type === "LEFT_PAREN").length;
           const right = this.currentTokens.filter((t) => t.type === "RIGHT_PAREN").length;

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -77,7 +77,6 @@ const selectors = {
   description: {
     ruletype: {
       rule: ".o-cf-preview-description-rule",
-      values: ".o-cf-preview-description-values",
     },
     range: ".o-cf-preview-range",
   },
@@ -1371,6 +1370,27 @@ describe("UI of conditional formats", () => {
     expect(
       (model.getters.getConditionalFormats(sheetId)[lastCfIndex].rule as CellIsRule).values
     ).toEqual(["3.59"]);
+  });
+
+  test("CF date rule values are canonicalized when sending them to the model", async () => {
+    updateLocale(model, FR_LOCALE);
+    await click(fixture, selectors.buttonAdd);
+    await nextTick();
+
+    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "Equal", "change");
+    await nextTick();
+    setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "01/05/2012", "input");
+
+    await click(fixture, selectors.buttonSave);
+    const sheetId = model.getters.getActiveSheetId();
+
+    const lastCfIndex = model.getters.getConditionalFormats(sheetId).length - 1;
+    expect(
+      (model.getters.getConditionalFormats(sheetId)[lastCfIndex].rule as CellIsRule).values
+    ).toEqual(["5/1/2012"]);
+
+    const description = fixture.querySelector(selectors.description.ruletype.rule);
+    expect(description?.textContent).toContain("01/05/2012");
   });
 });
 

--- a/tests/helpers/locale.test.ts
+++ b/tests/helpers/locale.test.ts
@@ -21,6 +21,9 @@ describe("Locale helpers", () => {
       expect(canonicalizeContent("1,", FR_LOCALE)).toBe("1.");
       expect(canonicalizeContent("1,1%", FR_LOCALE)).toBe("1.1%");
       expect(canonicalizeContent("$1,1", FR_LOCALE)).toBe("$1.1");
+      expect(canonicalizeContent("01/10/2022", FR_LOCALE)).toBe("10/1/2022");
+      expect(canonicalizeContent("01/10/2022 10:00:00", FR_LOCALE)).toBe("10/1/2022 10:00:00 AM");
+      expect(canonicalizeContent("01-10-2022", FR_LOCALE)).toBe("10/1/2022");
     });
 
     test("Non-number literals aren't canonicalize", () => {
@@ -50,6 +53,9 @@ describe("Locale helpers", () => {
       expect(localizeContent("1.1", FR_LOCALE)).toBe("1,1");
       expect(localizeContent("1.1%", FR_LOCALE)).toBe("1,1%");
       expect(localizeContent("$1.1", FR_LOCALE)).toBe("$1,1");
+      expect(localizeContent("10/1/2022", FR_LOCALE)).toBe("01/10/2022");
+      expect(localizeContent("10/1/2022 10:00:00", FR_LOCALE)).toBe("01/10/2022 10:00:00");
+      expect(localizeContent("10-1-2022", FR_LOCALE)).toBe("01/10/2022");
     });
 
     test("Non-number literals aren't localized", () => {

--- a/tests/plugins/conditional_formatting.test.ts
+++ b/tests/plugins/conditional_formatting.test.ts
@@ -13,7 +13,9 @@ import {
   setCellContent,
   setStyle,
   undo,
+  updateLocale,
 } from "../test_helpers/commands_helpers";
+import { FR_LOCALE } from "../test_helpers/constants";
 import { getStyle } from "../test_helpers/getters_helpers";
 import {
   createColorScale,
@@ -2073,5 +2075,17 @@ describe("conditional formats types", () => {
       expect(getStyle(model, "A2")).toEqual({});
       expect(getStyle(model, "A3")).toEqual({ fillColor: "#FF00FF" });
     });
+  });
+
+  test("CF evaluation uses default locale, and not current locale", () => {
+    updateLocale(model, FR_LOCALE);
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF("01/12/2012", { fillColor: "#0000FF" }, "id"),
+      ranges: toRangesData(sheetId, "A1"),
+      sheetId,
+    });
+    setCellContent(model, "A1", "01/12/2012");
+    // Cf is 12 of January (commands should use canonical formatting), but cell is 1 of December (input in french locale)
+    expect(getStyle(model, "A1")).toEqual({});
   });
 });

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -1,4 +1,4 @@
-import { getCanonicalSheetName, toZone } from "../../src/helpers";
+import { getCanonicalSheetName, jsDateToRoundNumber, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { CellValueType, CommandResult, DEFAULT_LOCALE } from "../../src/types";
 import {
@@ -1153,6 +1153,15 @@ describe("edition", () => {
         updateLocale(model, FR_LOCALE);
         editCell(model, "A1", '="3,14"');
         expect(getCell(model, "A1")?.content).toBe('="3,14"');
+      });
+
+      test("Can input localized date", () => {
+        updateLocale(model, FR_LOCALE);
+        editCell(model, "A1", "30/01/2020");
+        expect(getCell(model, "A1")?.format).toBe("dd/mm/yyyy");
+        expect(getCell(model, "A1")?.content).toBe(
+          jsDateToRoundNumber(new Date(2020, 0, 30)).toString()
+        );
       });
     });
   });


### PR DESCRIPTION
## Description

Using CF with date string works (eg. value is greater than "10/20/2012"), but the date string is not canonicalized when sending the CF rule in the model. This cause the CF to stop working when the locale is changed, because "10/20/2012" is not a valid date in french for example.

This commit fixes the issue by canonicalizing the date string before sending it to the model, and localizing it back to display it to the user.

The CF evaluation also used the current locale to evaluate the CF values. This was wrong and it should use the default locale, because CF values are canonicalized before sending them to the model.

Task:

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3481670](https://www.odoo.com/web#id=3481670&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo