### PR TITLE
[FIX] clipboard: copy/paste of CF in another sheet

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -248,3 +248,27 @@ export function isDefined<T>(argument: T | undefined): argument is T {
 }
 
 export const DEBUG: { [key: string]: any } = {};
+
+/**
+ * Compares two objects.
+ */
+export function deepEquals<T extends Object>(o1: T, o2: T): boolean {
+  if (o1 === o2) return true;
+  if ((o1 && !o2) || (o2 && !o1)) return false;
+
+  // Objects can have different keys if the values are undefined
+  const keys = new Set<string>();
+  Object.keys(o1).forEach((key) => keys.add(key));
+  Object.keys(o2).forEach((key) => keys.add(key));
+
+  for (let key of keys) {
+    if (typeof o1[key] !== typeof o1[key]) return false;
+    if (typeof o1[key] === "object") {
+      if (!deepEquals(o1[key], o2[key])) return false;
+    } else {
+      if (o1[key] !== o2[key]) return false;
+    }
+  }
+
+  return true;
+}

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -252,9 +252,11 @@ export const DEBUG: { [key: string]: any } = {};
 /**
  * Compares two objects.
  */
-export function deepEquals<T extends Object>(o1: T, o2: T): boolean {
+export function deepEquals(o1: any, o2: any): boolean {
   if (o1 === o2) return true;
   if ((o1 && !o2) || (o2 && !o1)) return false;
+  if (typeof o1 !== typeof o2) return false;
+  if (typeof o1 !== "object") return o1 === o2;
 
   // Objects can have different keys if the values are undefined
   const keys = new Set<string>();

--- a/tests/helpers/misc.test.ts
+++ b/tests/helpers/misc.test.ts
@@ -1,4 +1,4 @@
-import { deepCopy } from "../../src/helpers";
+import { deepCopy, deepEquals } from "../../src/helpers";
 import { groupConsecutive, range } from "../../src/helpers/misc";
 
 describe("Misc", () => {
@@ -122,4 +122,25 @@ describe("deepCopy", () => {
     expect("1" in copy).toBe(false);
     expect("2" in copy).toBe(true);
   });
+});
+
+test.each([
+  [1, 1, true],
+  [1, 5, false],
+  [1, Number(1), true],
+  ["ok", "ok", true],
+  ["ok", "ko", false],
+  [5, "5", false],
+  [true, true, true],
+  [true, false, false],
+  [{}, {}, true],
+  [{ a: 1 }, { a: 1 }, true],
+  [{ a: 1 }, { a: 2 }, false],
+  [{ a: undefined }, {}, true],
+  [{ a: undefined }, { a: null }, false],
+  [{ a: null }, {}, false],
+  [{ a: 1, b: undefined }, { a: 1 }, true],
+  [undefined, undefined, true],
+])("deepEquals %s %s", (o1: any, o2: any, expectedResult) => {
+  expect(deepEquals(o1, o2)).toEqual(expectedResult);
 });


### PR DESCRIPTION
## Description

There was an issue when copying/pasting a cell with a CF in another sheet. In the other sheet, a new CF was created with the same id as the original CF. This works fine when copy/pasting a CF for the first time. But after that, if the user were to modify the CF in the original sheet, a second copy/paste would overwrite the CF in the other sheet with the new changes.

This commit changes a bit the strategy for copy/pasting CFs in another sheet. Instead of always creating a new CF with the same id, the plugin tries to find a CF with the same rule in another sheet to put the copied cells into. If no CF with the same rule is found, then a new one with a new Id is created.

Task:

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3479451](https://www.odoo.com/web#id=3479451&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo