### PR TITLE
[IMP] translation: accept number placeholder value

### DIFF
--- a/src/translation.ts
+++ b/src/translation.ts
@@ -1,4 +1,4 @@
-type SprintfValues = (string | String)[] | [{ [key: string]: string }];
+type SprintfValues = (string | String | number)[] | [{ [key: string]: string | number }];
 
 export type TranslationFunction = (string: string, ...values: SprintfValues) => string;
 

--- a/tests/helpers/translation.test.ts
+++ b/tests/helpers/translation.test.ts
@@ -5,6 +5,14 @@ describe("Translations", () => {
     expect(_t("Hello %s", "World")).toBe("Hello World");
   });
 
+  test("placeholder can be a number", () => {
+    expect(_t("The answer is %s", 42)).toBe("The answer is 42");
+  });
+
+  test("named placeholder can be a number", () => {
+    expect(_t("The answer is %(answer)s", { answer: 42 })).toBe("The answer is 42");
+  });
+
   test("placeholder can be string Object instead of primitive", () => {
     expect(_t("Hello %s", new String("World"))).toBe("Hello World");
     expect(_t("Hello %s", _t("World"))).toBe("Hello World");


### PR DESCRIPTION
## Description:

Currently, when you want to translate a string with a number placeholder, you explicitely need to call `toString()` on the number.

```ts
const n = 1;
_t("a number: %s", n.toString());
```

With this commit, we don't need the explicit casting anymore:

```ts
const n = 1;
_t("a number: %s", n); // now this works
```

Task: : [/](https://www.odoo.com/web#id=/&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo