### PR TITLE
[IMP] bundle: raise if owl="1" found

### DIFF
--- a/tools/bundle_xml/bundle_xml_templates.cjs
+++ b/tools/bundle_xml/bundle_xml_templates.cjs
@@ -44,7 +44,14 @@ function getXmlTemplatesFiles(dir) {
 }
 
 function createOwlTemplateBundle(files, removeRootTags) {
-  const xmls = files.map((file) => fs.readFileSync(file, "utf8"));
+  const xmls = files.map((file) => {
+    const xml = fs.readFileSync(file, "utf8");
+    if (xml.includes('owl="1"')) {
+      const message = `owl="1" is no longer required in xml templates. Please remove it from ${file}`;
+      throw new Error(message);
+    }
+    return xml;
+  });
   let xml = xmls.join("\n");
   // individual xml files need a root tag but we can remove them in the bundle
   if (removeRootTags) {


### PR DESCRIPTION
Since 88815a2, owl="1" is no longer required. This commit adds a check to make sure it's not in any template. Just in case a sleepy dev and a sleepy reviewer manage to let one slip in the code.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo