### PR TITLE
[FIX] find_and_replace: remove useless tab index

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -45,7 +45,7 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
   private showFormulaState: boolean = false;
   private debouncedUpdateSearch!: Function;
 
-  private findAndReplaceRef = useRef("findAndReplace");
+  private searchInput = useRef("searchInput");
 
   get hasSearchResult() {
     return this.env.model.getters.getCurrentSelectedMatchIndex() !== null;
@@ -59,7 +59,7 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     this.showFormulaState = this.env.model.getters.shouldShowFormulas();
     this.debouncedUpdateSearch = debounce(this.updateSearch.bind(this), 200);
 
-    onMounted(() => this.focusInput());
+    onMounted(() => this.searchInput.el?.focus());
 
     onWillUnmount(() => {
       this.env.model.dispatch("CLEAR_SEARCH");
@@ -131,13 +131,6 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
   // ---------------------------------------------------------------------------
   // Private
   // ---------------------------------------------------------------------------
-  private focusInput() {
-    const el = this.findAndReplaceRef.el!;
-    const input = el.querySelector(`input`);
-    if (input) {
-      input.focus();
-    }
-  }
 
   private initialState(): FindAndReplaceState {
     return {

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -1,11 +1,12 @@
 <templates>
   <t t-name="o-spreadsheet-FindAndReplacePanel">
-    <div class="o-find-and-replace" tabindex="0" t-ref="findAndReplace">
+    <div class="o-find-and-replace">
       <div class="o-section">
         <div class="o-section-title">Search</div>
         <div class="o-input-search-container">
           <input
             type="text"
+            t-ref="searchInput"
             class="o-input o-input-with-count"
             t-on-input="onInput"
             t-on-keydown="onKeydownSearch"


### PR DESCRIPTION
Since eebf105, the side panel no longer needs to be focusable Task: /

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo