### PR TITLE
[REV] find & replace: shorten the debounce on find search

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -1,5 +1,4 @@
 import { Component, onMounted, onWillUnmount, useEffect, useRef, useState } from "@odoo/owl";
-import { debounce } from "../../../helpers";
 import { SpreadsheetChildEnv } from "../../../types/index";
 import { css } from "../../helpers/css";
 
@@ -57,7 +56,6 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
   private state: FindAndReplaceState = useState(this.initialState());
   private debounceTimeoutId;
   private showFormulaState: boolean = false;
-  private debouncedUpdateSearch!: Function;
 
   private findAndReplaceRef = useRef("findAndReplace");
 
@@ -71,7 +69,6 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
 
   setup() {
     this.showFormulaState = this.env.model.getters.shouldShowFormulas();
-    this.debouncedUpdateSearch = debounce(this.updateSearch.bind(this), 200);
 
     onMounted(() => this.focusInput());
 
@@ -128,6 +125,14 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
       toSearch: this.state.toSearch,
       searchOptions: this.state.searchOptions,
     });
+  }
+
+  debouncedUpdateSearch() {
+    clearTimeout(this.debounceTimeoutId);
+    this.debounceTimeoutId = setTimeout(() => {
+      this.updateSearch();
+      this.debounceTimeoutId = undefined;
+    }, 200);
   }
 
   replace() {

--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -152,6 +152,7 @@ describe("find and replace sidePanel component", () => {
     test("search match count is removed when input is cleared", async () => {
       setCellContent(model, "A1", "Hello");
       setInputValueAndTrigger(selectors.inputSearch, "Hel", "input");
+      await nextTick(); // wait the next render to check if the count is displayed
       expect(fixture.querySelector(".o-input-count")).toBeNull();
       jest.runOnlyPendingTimers();
       await nextTick();


### PR DESCRIPTION
## Description:

Partially revert forward-port https://github.com/odoo/o-spreadsheet/commit/b7219cedc5ceabe325c572f20298213806090d8f which broke the
behavior of https://github.com/odoo/o-spreadsheet/commit/a5a67d880cd25fa60291f64e71951ea79ec2d033

Open the side panel and start typing something that matches
some cells. A quick "0 / 0" is displayed a few frames (200ms,
the debounce time) before displaying the correct match result
(e.g. "1 / 3").

With this commit, nothing is displayed until the search
result is actually done.

`debounceTimeoutId` was left unused and never correctly
assigned with the debounce timeout id.

The behavior was tested... but notice how `await nextTick()`
in `find_replace_side_panel.test.ts` was removed....

Note: the original commit https://github.com/odoo/o-spreadsheet/commit/4123fd1b6ac9930eccc368259ed8f58c84a5ee64 (merged in 16.0) was correct
because https://github.com/odoo/o-spreadsheet/commit/a5a67d880cd25fa60291f64e71951ea79ec2d033 only came with saas-16.1

Task: /
Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo