### PR TITLE
[FIX] GridOverlay: Hovering over a figure should not open popovers

### DIFF
--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -47,9 +47,11 @@ function useCellHovered(
     }
   }
   function updateMousePosition(e: MouseEvent) {
-    x = e.offsetX;
-    y = e.offsetY;
-    lastMoved = Date.now();
+    if (gridRef.el === e.target) {
+      x = e.offsetX;
+      y = e.offsetY;
+      lastMoved = Date.now();
+    }
   }
 
   function recompute() {

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -31,7 +31,7 @@ let fixture: HTMLElement;
 let model: Model;
 let sheetId: UID;
 
-function createFigure(
+export function createFigure(
   model: Model,
   figureParameters: Partial<CreateFigureCommand["figure"]> = {},
   sheetId: UID = model.getters.getActiveSheetId()

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -47,6 +47,7 @@ import {
 } from "../test_helpers/getters_helpers";
 import { MockClipboard, mountSpreadsheet, nextTick, Touch } from "../test_helpers/helpers";
 import { MockTransportService } from "../__mocks__/transport_service";
+import { createFigure } from "./figure.test";
 import { mockChart } from "./__mocks__/chart";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("./__mocks__/content_editable_helper")
@@ -866,6 +867,18 @@ describe("error tooltip", () => {
     setCellContent(model, "C1", "=1/0");
     await hoverCell(model, "C8", 400);
     expect(document.querySelector(".o-error-tooltip")).not.toBeNull();
+  });
+
+  test("Hovering over a figure should not open popovers", async () => {
+    createFigure(model, { id: "figureId", y: 200, x: 200, width: 200, height: 200 });
+    await nextTick();
+    setCellContent(model, "C3", "[label](url.com)");
+
+    triggerMouseEvent(".o-figure", "mousemove", DEFAULT_CELL_WIDTH * 2, DEFAULT_CELL_HEIGHT * 2);
+    jest.advanceTimersByTime(400);
+    await nextTick();
+
+    expect(fixture.querySelector(".o-popover")).toBeNull();
   });
 
   test("composer content is set when clicking on merged cell (not top left)", async () => {


### PR DESCRIPTION
## Description:

Previously, when hovering over the chart, the cell popover would erroneously open. This issue occurred because `updateMousePosition` assigned the `clientX` and `clientY` values, and `getPosition` found the cell's position, creating a bug when hovering over the chart.

To address this problem, a conditional check has been added to ensure that `gridRef` is equal to the event target.

Task: : [3475001](https://www.odoo.com/web#id=3475001&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo