### PR TITLE
[FIX] grid: hover cell wrongly used event.offset

### DIFF
--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -9,6 +9,7 @@ import {
   SpreadsheetChildEnv,
 } from "../../types";
 import { FiguresContainer } from "../figures/figure_container/figure_container";
+import { useAbsolutePosition } from "../helpers/position_hook";
 import { useInterval } from "../helpers/time_hooks";
 
 function useCellHovered(
@@ -20,7 +21,7 @@ function useCellHovered(
     col: undefined,
     row: undefined,
   };
-  const { Date } = window;
+  const gridPosition = useAbsolutePosition(gridRef);
   let x = 0;
   let y = 0;
   let lastMoved = 0;
@@ -47,8 +48,8 @@ function useCellHovered(
     }
   }
   function updateMousePosition(e: MouseEvent) {
-    x = e.offsetX;
-    y = e.offsetY;
+    x = e.clientX - gridPosition.x;
+    y = e.clientY - gridPosition.y;
     lastMoved = Date.now();
   }
 


### PR DESCRIPTION
## Description

The `useCellHovered` hook used the `event.offsetX` and `event.offsetY` to determine the hovered cell. This is wrong because the offset is relative to the target element, and thus was wrong when the user hovered something like a chart.

Fix this by using the `event.clientX` and `event.clientY` and the grid position instead.

Task:

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3495630](https://www.odoo.com/web#id=3495630&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo