### PR TITLE
[FIX] ErrorToolTip: fix error tooltip long text

### DIFF
--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -13,6 +13,7 @@ css/* scss */ `
     background-color: white;
     border-left: 3px solid red;
     padding: 10px;
+    overflow-wrap: break-word;
   }
 `;
 


### PR DESCRIPTION
## Description:

Previously, the error tooltip was not showing the full error message when the text was too long.

This commit fixes this issue by adding a `overflow-wrap: break-word` to the error tooltip. This way, the text will be wrapped when it is too long.

Task: : [3328557](https://www.odoo.com/web#id=3328557&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo