### PR TITLE
[FIX] clipboard: cut/paste whole CF across sheets

### DIFF
--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -459,6 +459,10 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
 
     currentRanges = currentRanges.concat(toAdd);
     const newRange: string[] = recomputeZones(currentRanges, toRemove);
+    if (newRange.length === 0) {
+      this.dispatch("REMOVE_CONDITIONAL_FORMAT", { id: cf.id, sheetId });
+      return;
+    }
     this.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: {
         id: cf.id,

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -1252,44 +1252,19 @@ describe("clipboard", () => {
     });
   });
 
-  test("can cut and paste a conditional formatted cell to another page", () => {
-    const model = new Model({
-      sheets: [
-        {
-          colNumber: 5,
-          rowNumber: 5,
-        },
-        {
-          colNumber: 5,
-          rowNumber: 5,
-        },
-      ],
-    });
-    const sheet1 = model.getters.getVisibleSheets()[0];
-    const sheet2 = model.getters.getVisibleSheets()[1];
-    setCellContent(model, "A1", "1");
-    setCellContent(model, "A2", "2");
-    model.dispatch("ADD_CONDITIONAL_FORMAT", {
-      cf: createEqualCF("1", { fillColor: "#FF0000" }, "1"),
-      target: [toZone("A1"), toZone("A2")],
-      sheetId: model.getters.getActiveSheetId(),
-    });
-    model.dispatch("CUT", { target: [toZone("A1:A2")] });
-    activateSheet(model, sheet2);
+  test("can cut and paste a conditional formatted zone to another page", () => {
+    const model = new Model({ sheets: [{ id: "sheet1" }, { id: "sheet2" }] });
+    const cf = createEqualCF("1", { fillColor: "#FF0000" }, "id");
+    model.dispatch("ADD_CONDITIONAL_FORMAT", { cf, target: target("A1:A2"), sheetId: "sheet1" });
+
+    model.dispatch("CUT", { target: target("A1:A2") });
+    activateSheet(model, "sheet2");
     model.dispatch("PASTE", { target: target("A1") });
-    expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toEqual({
-      fillColor: "#FF0000",
-    });
-    expect(model.getters.getConditionalStyle(...toCartesian("A2"))).toBeUndefined();
-    setCellContent(model, "A1", "2");
-    setCellContent(model, "A2", "1");
-    expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesian("A2"))).toEqual({
-      fillColor: "#FF0000",
-    });
-    activateSheet(model, sheet1);
-    expect(model.getters.getConditionalStyle(...toCartesian("A1"))).toBeUndefined();
-    expect(model.getters.getConditionalStyle(...toCartesian("A2"))).toBeUndefined();
+
+    expect(model.getters.getConditionalFormats("sheet2")).toMatchObject([
+      { ranges: ["A1:A2"], rule: cf.rule },
+    ]);
+    expect(model.getters.getConditionalFormats("sheet1")).toEqual([]);
   });
 
   test("can copy and paste a cell which contains a cross-sheet reference", () => {


### PR DESCRIPTION
## Description

When cutting a whole conditional format and pasting it in another sheet, the CF wasn't removed from the first sheet.

Task: : [3502777](https://www.odoo.com/web#id=3502777&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo