### PR TITLE
[FIX] headers_overlay: reselect full column or row as dataseries range 

### DIFF
--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -197,7 +197,13 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
       return;
     }
     if (this.state.waitingForMove === true) {
-      this.startMovement(ev);
+      if (!this.env.model.getters.isGridSelectionActive()) {
+        this._selectElement(index, false);
+      } else {
+        // FIXME: Consider reintroducing this feature for all type of selection if we find
+        // a way to have the grid selection follow the other selections evolution
+        this.startMovement(ev);
+      }
       return;
     }
     if (this.env.model.getters.getEditionMode() === "editing") {

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -107,6 +107,7 @@ export class GridSelectionPlugin extends UIPlugin {
     "getSheetPosition",
     "isSelected",
     "getElementsFromSelection",
+    "isGridSelectionActive",
   ] as const;
 
   private gridSelection: {
@@ -332,6 +333,10 @@ export class GridSelectionPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
   // Getters
   // ---------------------------------------------------------------------------
+
+  isGridSelectionActive(): boolean {
+    return this.selection.isListening(this);
+  }
 
   getActiveSheet(): Readonly<Sheet> {
     return this.activeSheet;

--- a/src/selection_stream/selection_stream_processor.ts
+++ b/src/selection_stream/selection_stream_processor.ts
@@ -50,6 +50,7 @@ interface SelectionProcessor {
   ): DispatchResult;
   selectAll(): DispatchResult;
   loopSelection(): DispatchResult;
+  isListening(owner: unknown): boolean;
 }
 
 /**
@@ -392,6 +393,10 @@ export class SelectionStreamProcessor
       mode: "overrideSelection",
       anchor: { zone, cell: this.anchor.cell },
     });
+  }
+
+  isListening(owner: unknown): boolean {
+    return this.stream.isListening(owner);
   }
 
   /**

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -3,7 +3,13 @@ import { Model } from "../../src";
 import { SelectionInput } from "../../src/components/selection_input/selection_input";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/registries";
 import { activateSheet, createSheet, selectCell, undo } from "../test_helpers/commands_helpers";
-import { clickCell, keyDown, keyUp, simulateClick } from "../test_helpers/dom_helper";
+import {
+  clickCell,
+  keyDown,
+  keyUp,
+  selectColumnByClicking,
+  simulateClick,
+} from "../test_helpers/dom_helper";
 import {
   getChildFromComponent,
   makeTestFixture,
@@ -260,6 +266,26 @@ describe("Selection Input", () => {
     await nextTick();
     expect(onChanged).toHaveBeenCalled();
     expect(newRanges).toStrictEqual(["B4"]);
+  });
+
+  test("can select full col/row grid selection as selection input data series range", async () => {
+    const { env, model, fixture } = await mountSpreadsheet();
+    await selectColumnByClicking(model, "B");
+    OPEN_CF_SIDEPANEL_ACTION(env);
+    await nextTick();
+    await simulateClick(".o-cf-add");
+    await nextTick();
+    let input = fixture.querySelector(".o-selection-input input") as HTMLInputElement;
+    expect(input.value).toBe("B1:B100");
+
+    await simulateClick(input);
+    await selectColumnByClicking(model, "C");
+    input = fixture.querySelector(".o-selection-input input") as HTMLInputElement;
+    expect(input.value).toBe("C1:C100");
+
+    await selectColumnByClicking(model, "B");
+    input = fixture.querySelector(".o-selection-input input") as HTMLInputElement;
+    expect(input.value).toBe("B1:B100");
   });
 
   test("focus is transferred from one input to another", async () => {


### PR DESCRIPTION
## Description:

Steps to reproduce:
- Click on header "B" and insert a chart.
- Click on selection input to edit the chart data series and then click on
  header "A". The data is now "A:A".
- Click on header "B" again. The data series should be updated with "B:B",
  but nothing happens instead.

This issue is created since the boolean `waitingForMove` is true when a
column is currently selected, and a user tries to reselect that column
while editing chart dataseries. In this case, `startMovement` method is called
followed by an early return and hence `startSelection` is not called.

The root cause of this bug is that the `startMovement` feature should
only be activated by the active grid selection and not while using
`SelectionInput` or selecting a range while editing a cell. This commit
introduces a new getter `isGridSelectionActive` in order to identify if
some features should be accessible or not to the end user.

An ulterior pull request will address the other features that should be
deactivated while not using the grid selection, (like autofill, merge,
...)


Task: : [3481617](https://www.odoo.com/web#id=3481617&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo