### PR TITLE
[REF] drag&drop: stop using CUT/PASTE commands

### DIFF
--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -40,7 +40,7 @@ export class ClipboardPlugin extends UIPlugin {
   allowDispatch(cmd: Command): CommandResult {
     switch (cmd.type) {
       case "CUT":
-        const zones = cmd.target || this.getters.getSelectedZones();
+        const zones = this.getters.getSelectedZones();
         const state = this.getClipboardState(zones, cmd.type);
         return state.isCutAllowed(zones);
       case "PASTE":
@@ -71,7 +71,7 @@ export class ClipboardPlugin extends UIPlugin {
     switch (cmd.type) {
       case "COPY":
       case "CUT":
-        const zones = ("target" in cmd && cmd.target) || this.getters.getSelectedZones();
+        const zones = this.getters.getSelectedZones();
         this.state = this.getClipboardState(zones, cmd.type);
         this.status = "visible";
         break;

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -1,6 +1,7 @@
 import { SELECTION_BORDER_COLOR } from "../../constants";
 import { SUM } from "../../functions/module_math";
 import { AVERAGE, COUNT, COUNTA, MAX, MIN } from "../../functions/module_statistical";
+import { ClipboardCellsState } from "../../helpers/clipboard/clipboard_cells_state";
 import {
   clip,
   deepCopy,
@@ -601,27 +602,30 @@ export class GridSelectionPlugin extends UIPlugin {
     const deltaCol = isBasedBefore && isCol ? thickness : 0;
     const deltaRow = isBasedBefore && !isCol ? thickness : 0;
 
-    this.dispatch("CUT", {
-      target: [
-        {
-          left: isCol ? start + deltaCol : 0,
-          right: isCol ? end + deltaCol : this.getters.getNumberCols(cmd.sheetId) - 1,
-          top: !isCol ? start + deltaRow : 0,
-          bottom: !isCol ? end + deltaRow : this.getters.getNumberRows(cmd.sheetId) - 1,
-        },
-      ],
-    });
-
-    this.dispatch("PASTE", {
-      target: [
-        {
-          left: isCol ? cmd.base : 0,
-          right: isCol ? cmd.base + thickness - 1 : this.getters.getNumberCols(cmd.sheetId) - 1,
-          top: !isCol ? cmd.base : 0,
-          bottom: !isCol ? cmd.base + thickness - 1 : this.getters.getNumberRows(cmd.sheetId) - 1,
-        },
-      ],
-    });
+    const target = [
+      {
+        left: isCol ? start + deltaCol : 0,
+        right: isCol ? end + deltaCol : this.getters.getNumberCols(cmd.sheetId) - 1,
+        top: !isCol ? start + deltaRow : 0,
+        bottom: !isCol ? end + deltaRow : this.getters.getNumberRows(cmd.sheetId) - 1,
+      },
+    ];
+    const state = new ClipboardCellsState(
+      target,
+      "CUT",
+      this.getters,
+      this.dispatch,
+      this.selection
+    );
+    const pasteTarget = [
+      {
+        left: isCol ? cmd.base : 0,
+        right: isCol ? cmd.base + thickness - 1 : this.getters.getNumberCols(cmd.sheetId) - 1,
+        top: !isCol ? cmd.base : 0,
+        bottom: !isCol ? cmd.base + thickness - 1 : this.getters.getNumberRows(cmd.sheetId) - 1,
+      },
+    ];
+    state.paste(pasteTarget, { selectTarget: true });
 
     const toRemove = isBasedBefore ? cmd.elements.map((el) => el + thickness) : cmd.elements;
     let currentIndex = cmd.base;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -474,8 +474,6 @@ export interface CopyCommand {
 
 export interface CutCommand {
   type: "CUT";
-  /** Zones to cut. If none were given, will copy the zones in the selection*/
-  target?: Zone[];
 }
 
 export interface PasteCommand {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -1894,9 +1894,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "B1", "2");
 
-      model.dispatch("CUT", { target: target("A1:B1") });
+      cut(model, "A1:B1");
       addColumns(model, "before", "A", 1);
-      model.dispatch("PASTE", { target: [toZone("A2")] });
+      paste(model, "A2");
       expect(getCellContent(model, "B1")).toBe("1");
       expect(getCellContent(model, "C1")).toBe("2");
       expect(getCellContent(model, "A2")).toBe("");
@@ -1909,9 +1909,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "B1", "2");
 
-      model.dispatch("CUT", { target: target("A1:B1") });
+      cut(model, "A1:B1");
       addColumns(model, "after", "B", 1);
-      model.dispatch("PASTE", { target: [toZone("A2")] });
+      paste(model, "A2");
       expect(getCellContent(model, "A1")).toBe("");
       expect(getCellContent(model, "B1")).toBe("");
       expect(getCellContent(model, "A2")).toBe("1");
@@ -1923,9 +1923,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "B1", "2");
 
-      model.dispatch("CUT", { target: target("A1:B1") });
+      cut(model, "A1:B1");
       addColumns(model, "after", "A", 1);
-      model.dispatch("PASTE", { target: [toZone("A2")] });
+      paste(model, "A2");
       expect(getCellContent(model, "A1")).toBe("1");
       expect(getCellContent(model, "C1")).toBe("2");
       expect(getCellContent(model, "A2")).toBe("");
@@ -1937,9 +1937,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "B1", "2");
 
-      model.dispatch("CUT", { target: target("A1:B1") });
+      cut(model, "A1:B1");
       addColumns(model, "after", "A", 5);
-      model.dispatch("PASTE", { target: [toZone("A2")] });
+      paste(model, "A2");
       expect(getCellContent(model, "A1")).toBe("1");
       expect(getCellContent(model, "G1")).toBe("2");
       expect(getCellContent(model, "A2")).toBe("");
@@ -1951,9 +1951,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "2");
 
-      model.dispatch("CUT", { target: target("A1:A2") });
+      cut(model, "A1:A2");
       addRows(model, "before", 0, 1);
-      model.dispatch("PASTE", { target: [toZone("C1")] });
+      paste(model, "C1");
       expect(getCellContent(model, "A2")).toBe("1");
       expect(getCellContent(model, "A3")).toBe("2");
       expect(getCellContent(model, "C1")).toBe("");
@@ -1966,9 +1966,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "2");
 
-      model.dispatch("CUT", { target: target("A1:A2") });
+      cut(model, "A1:A2");
       addRows(model, "after", 2, 1);
-      model.dispatch("PASTE", { target: [toZone("C1")] });
+      paste(model, "C1");
       expect(getCellContent(model, "A1")).toBe("");
       expect(getCellContent(model, "A2")).toBe("");
       expect(getCellContent(model, "C1")).toBe("1");
@@ -1980,9 +1980,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "2");
 
-      model.dispatch("CUT", { target: target("A1:A2") });
+      cut(model, "A1:A2");
       addRows(model, "after", 0, 1);
-      model.dispatch("PASTE", { target: [toZone("C1")] });
+      paste(model, "C1");
       expect(getCellContent(model, "A1")).toBe("1");
       expect(getCellContent(model, "A3")).toBe("2");
       expect(getCellContent(model, "C1")).toBe("");
@@ -1994,9 +1994,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "2");
 
-      model.dispatch("CUT", { target: target("A1:A2") });
+      cut(model, "A1:A2");
       addRows(model, "after", 0, 5);
-      model.dispatch("PASTE", { target: [toZone("C1")] });
+      paste(model, "C1");
       expect(getCellContent(model, "A1")).toBe("1");
       expect(getCellContent(model, "A7")).toBe("2");
       expect(getCellContent(model, "C1")).toBe("");
@@ -2010,9 +2010,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteColumns(model, ["A"]);
-      model.dispatch("PASTE", { target: [toZone("D1")] });
+      paste(model, "D1");
       expect(getCellContent(model, "A2")).toBe("1");
       expect(getCellContent(model, "B2")).toBe("2");
       expect(getCellContent(model, "D1")).toBe("");
@@ -2024,9 +2024,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteColumns(model, ["D"]);
-      model.dispatch("PASTE", { target: [toZone("D1")] });
+      paste(model, "D1");
       expect(getCellContent(model, "B2")).toBe("");
       expect(getCellContent(model, "C2")).toBe("");
       expect(getCellContent(model, "D1")).toBe("1");
@@ -2038,9 +2038,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteColumns(model, ["C"]);
-      model.dispatch("PASTE", { target: [toZone("D1")] });
+      paste(model, "D1");
       expect(getCellContent(model, "B2")).toBe("1");
       expect(getCellContent(model, "D1")).toBe("");
     });
@@ -2050,9 +2050,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteRows(model, [0]);
-      model.dispatch("PASTE", { target: [toZone("D1")] });
+      paste(model, "D1");
       expect(getCellContent(model, "B1")).toBe("1");
       expect(getCellContent(model, "C1")).toBe("2");
       expect(getCellContent(model, "D1")).toBe("");
@@ -2064,9 +2064,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "C2", "2");
 
-      model.dispatch("CUT", { target: target("B2:C2") });
+      cut(model, "B2:C2");
       deleteRows(model, [3]);
-      model.dispatch("PASTE", { target: [toZone("D1")] });
+      paste(model, "D1");
       expect(getCellContent(model, "B2")).toBe("");
       expect(getCellContent(model, "C2")).toBe("");
       expect(getCellContent(model, "D1")).toBe("1");
@@ -2078,9 +2078,9 @@ describe("clipboard: pasting outside of sheet", () => {
       setCellContent(model, "B2", "1");
       setCellContent(model, "B3", "2");
 
-      model.dispatch("CUT", { target: target("B2:B3") });
+      cut(model, "B2:B3");
       deleteRows(model, [2]);
-      model.dispatch("PASTE", { target: [toZone("D1")] });
+      paste(model, "D1");
       expect(getCellContent(model, "B2")).toBe("1");
       expect(getCellContent(model, "D1")).toBe("");
     });


### PR DESCRIPTION
## Description

The drag & drop of columns/rows was using CUT/PASTE commands. This had 2 issues:

- it changes the state of the clipboard, which is not the expected behavior of a drag & drop
- if the user tried to drag & drop a column/row when a figure is selected, the clipboard will cut/paste the figure and not the column/row

Now the drag & drop of columns/rows is using the ClipboardCellState object directly. The target of the CUT commands can now be removed.

Task: : [3502194](https://www.odoo.com/web#id=3502194&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo