### PR TITLE
[FIX] composer: ctrl+space shortcut not working

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -278,7 +278,9 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     if (ev.ctrlKey) {
       ev.preventDefault();
       ev.stopPropagation();
-      this.showAutocomplete("");
+      const token = this.env.model.getters.getTokenAtCursor();
+      const searchTerm = token && token.type === "SYMBOL" ? token.value : "";
+      this.showAutocomplete(searchTerm);
       this.env.model.dispatch("STOP_COMPOSER_RANGE_SELECTION");
     }
   }

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -279,6 +279,17 @@ describe("Functions autocomplete", () => {
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SUM");
     });
+
+    test("=S and CTRL+Space show autocomplete for S", async () => {
+      await typeInComposer("=S");
+      keyDown({ key: " ", ctrlKey: true });
+      await keyUp({ key: " ", ctrlKey: true });
+
+      const autocompleteValues = fixture.querySelectorAll(".o-autocomplete-value");
+      expect(autocompleteValues).toHaveLength(2);
+      expect(autocompleteValues[0].textContent).toBe("SUM");
+      expect(autocompleteValues[1].textContent).toBe("SZZ");
+    });
   });
 });
 

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -172,6 +172,17 @@ describe("Functions autocomplete", () => {
       ).toBe("SUM");
     });
 
+    test("Moving the cursor with the arrow keys opens and close the autocomplete ", async () => {
+      await typeInComposer("=S");
+      expect(fixture.querySelector(".o-autocomplete-value")).not.toBeNull();
+      keyDown({ key: "ArrowLeft" });
+      await keyUp({ key: "ArrowLeft" });
+      expect(fixture.querySelector(".o-autocomplete-value")).toBeNull();
+      keyDown({ key: "ArrowRight" });
+      await keyUp({ key: "ArrowRight" });
+      expect(fixture.querySelector(".o-autocomplete-value")).not.toBeNull();
+    });
+
     test("autocomplete restrict number of proposition to 10", async () => {
       for (let i = 0; i < 20; i++) {
         functionRegistry.add(`SUM${i + 1}`, {
@@ -251,9 +262,9 @@ describe("Functions autocomplete", () => {
     });
     test("= and CTRL+Space show autocomplete", async () => {
       await typeInComposer("=");
-      await keyDown({ key: " ", ctrlKey: true });
-      //TODO Need a second nextTick to wait the re-render of SelectionInput (onMounted => uuid assignation). But why not before ?
-      await nextTick();
+      keyDown({ key: " ", ctrlKey: true });
+      await keyUp({ key: " ", ctrlKey: true });
+
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(3);
       await keyDown({ key: "Tab" });
       expect(composerEl.textContent).toBe("=IF(");


### PR DESCRIPTION
## Description

The ctrl+space shortcut is supposed to open the autocomplete dropdown, but since a49477b the autocomplete was instantaneously closing itself at the keyUp event.

This didn't appear in the tests, because the tests were only dispatching a keyDown event, and no keyUp event.

Task: : [3504025](https://www.odoo.com/web#id=3504025&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo