### PR TITLE
[IMP] export: do not export defaulf style values

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 import { _t } from "./translation";
-import { BorderDescr, Color } from "./types";
+import { BorderDescr, Color, Style } from "./types";
 import { CellErrorType } from "./types/errors";
 
 export const CANVAS_SHIFT = 0.5;
@@ -147,14 +147,28 @@ export const MENU_SEPARATOR_BORDER_WIDTH = 1;
 export const MENU_SEPARATOR_PADDING = 5;
 export const MENU_SEPARATOR_HEIGHT = MENU_SEPARATOR_BORDER_WIDTH + 2 * MENU_SEPARATOR_PADDING;
 
+// Style
+export const DEFAULT_STYLE = {
+  align: "left",
+  verticalAlign: "bottom",
+  wrapping: "overflow",
+  bold: false,
+  italic: false,
+  strikethrough: false,
+  underline: false,
+  fontSize: 10,
+  fillColor: "",
+  textColor: "#000000",
+} satisfies Required<Style>;
+
+export const DEFAULT_VERTICAL_ALIGN = DEFAULT_STYLE.verticalAlign;
+export const DEFAULT_WRAPPING_MODE = DEFAULT_STYLE.wrapping;
+
 // Fonts
 export const DEFAULT_FONT_WEIGHT = "400";
-export const DEFAULT_FONT_SIZE = 10;
+export const DEFAULT_FONT_SIZE = DEFAULT_STYLE.fontSize;
 export const HEADER_FONT_SIZE = 11;
 export const DEFAULT_FONT = "'Roboto', arial";
-export const DEFAULT_VERTICAL_ALIGN = "bottom";
-export const DEFAULT_HORIZONTAL_ALIGN = "left";
-export const DEFAULT_WRAPPING_MODE = "overflow";
 
 // Borders
 export const DEFAULT_BORDER_DESC: BorderDescr = { style: "thin", color: "#000000" };

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_STYLE } from "../../constants";
 import { compile, tokenize } from "../../formulas";
 import { parseLiteral } from "../../helpers/cells";
 import {
@@ -228,9 +229,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       for (const position of positions) {
         const cell = this.getters.getCell(position)!;
         const xc = toXC(position.col, position.row);
-
+        const style = this.removeDefaultStyleValues(cell.style);
         cells[xc] = {
-          style: cell.style ? getItemId<Style>(cell.style, styles) : undefined,
+          style: Object.keys(style).length ? getItemId<Style>(style, styles) : undefined,
           format: cell.format ? getItemId<Format>(cell.format, formats) : undefined,
           content: cell.content || undefined,
         };
@@ -255,6 +256,16 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
 
   exportForExcel(data: ExcelWorkbookData) {
     this.export(data);
+  }
+
+  private removeDefaultStyleValues(style: Style | undefined): Style {
+    const cleanedStyle = { ...style };
+    for (const [property, defaultValue] of Object.entries(DEFAULT_STYLE)) {
+      if (cleanedStyle[property] === defaultValue) {
+        delete cleanedStyle[property];
+      }
+    }
+    return cleanedStyle;
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -11041,9 +11041,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
         <xf numFmtId="0" fillId="0" fontId="2" borderId="0"/>
         <xf numFmtId="0" fillId="0" fontId="3" borderId="0"/>
         <xf numFmtId="0" fillId="0" fontId="3" borderId="1"/>
-        <xf numFmtId="0" fillId="0" fontId="4" borderId="0" applyAlignment="1">
-            <alignment horizontal="left"/>
-        </xf>
+        <xf numFmtId="0" fillId="0" fontId="4" borderId="0"/>
         <xf numFmtId="0" fillId="0" fontId="3" borderId="2"/>
         <xf numFmtId="0" fillId="0" fontId="3" borderId="3"/>
         <xf numFmtId="0" fillId="0" fontId="3" borderId="4"/>

--- a/tests/plugins/style.test.ts
+++ b/tests/plugins/style.test.ts
@@ -1,7 +1,17 @@
-import { DEFAULT_FONT_SIZE, PADDING_AUTORESIZE_HORIZONTAL } from "../../src/constants";
+import {
+  DEFAULT_FONT_SIZE,
+  DEFAULT_STYLE,
+  PADDING_AUTORESIZE_HORIZONTAL,
+} from "../../src/constants";
 import { fontSizeInPixels, toCartesian, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
-import { createSheet, selectCell, setCellContent, undo } from "../test_helpers/commands_helpers";
+import {
+  createSheet,
+  selectCell,
+  setCellContent,
+  setStyle,
+  undo,
+} from "../test_helpers/commands_helpers";
 import { getCell, getCellContent } from "../test_helpers/getters_helpers";
 import { createEqualCF, target, toRangesData } from "../test_helpers/helpers";
 
@@ -54,6 +64,27 @@ describe("styles", () => {
     });
     expect(getCellContent(model, "B1")).toBe("b1");
     expect(getCell(model, "B1")!.style).not.toBeDefined();
+  });
+
+  test("default style values are not exported", () => {
+    const model = new Model();
+    setStyle(model, "A1", DEFAULT_STYLE);
+    const data = model.exportData();
+    expect(data.sheets[0].cells.A1?.style).toBeUndefined();
+    expect(data.styles).toEqual({});
+  });
+
+  test("only non default style values are exported", () => {
+    const model = new Model();
+    setStyle(model, "A1", {
+      bold: true,
+      italic: false,
+    });
+    const data = model.exportData();
+    expect(data.sheets[0].cells.A1?.style).toBe(1);
+    expect(data.styles).toEqual({
+      1: { bold: true },
+    });
   });
 
   test("clearing format on a cell with no content actually remove it", () => {


### PR DESCRIPTION
Open the background color picker and click on
"No Color".
Double click on the Bold icon (to set the bold and remove it)

Now export the spreadsheet.

You'll see something like
```
{
  ...
     "cells": {
       "A1": { "style": 1 },
     },
  ...
  "styles": {
    "1": {
      "fillColor": "",
      "bold": false,
    }
  }
}
```

The style is actually useless.
If many cells have this useless style, it can quickly bloat the export with lots and lots of useless lines (which can end up being committed in odoo's source code of dashboards).

With this commit, default values are no longer exported.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo