### PR TITLE
[IMP] demo: disable HTML quirks mode

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />

--- a/demo/main.js
+++ b/demo/main.js
@@ -343,7 +343,7 @@ Demo.template = xml/* xml */ `
       <Spreadsheet model="model" t-key="state.key"/>
     </div>
   </div>
-  <div t-else="">
+  <div t-else="" class="vh-100">
     <Spreadsheet model="model" t-key="state.key"/>
   </div>
 `;


### PR DESCRIPTION
## Description

If the HTML of a page isn't prefixed by `<!DOCTYPE html>`, the browser interpret the page in "quirk mode"[1], which is a mode for backward compatibility  with very old browsers. The Demo page of o-spreadsheet was in this backward compatibility mode, this commit changes it to modern mode.

I couldn't find a good documentation of the effects of quirks mode, some differences that I observed are:

- css selectors are case-sensitive in modern mode, but not in quirks mode
- the relationship between the line-height/padding and the actual height of a div seems different

This should reduce the differences between the demo page and the rendered spreadsheet in odoo.

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_

Task: : [3506565](https://www.odoo.com/web#id=3506565&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo