### PR TITLE
[IMP] Spreadsheet: Introduce single-value INDEX function

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -2,8 +2,12 @@ import { toZone } from "../helpers/index";
 import { _lt } from "../translation";
 import {
   AddFunctionDescription,
+  Arg,
+  ArgValue,
   FunctionReturnValue,
+  isMatrix,
   MatrixArgValue,
+  PrimitiveArg,
   PrimitiveArgValue,
 } from "../types";
 import { args } from "./arguments";
@@ -123,6 +127,53 @@ export const HLOOKUP: AddFunctionDescription = {
     );
 
     return range[colIndex][_index - 1] as FunctionReturnValue;
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// INDEX
+// -----------------------------------------------------------------------------
+
+export const INDEX: AddFunctionDescription = {
+  description: _lt(`Returns the content of a cell, specified by row and column offset.`),
+  args: args(`
+      reference (any, range) ${_lt("The range of cells from which the value is returned.")}
+      row (number) ${_lt(
+        "The index of the row to be returned from within the reference range of cells."
+      )}
+      column (number) ${_lt(
+        "The index of the column to be returned from within the reference range of cells."
+      )}
+`),
+  returns: ["ANY"],
+  computeFormat: (reference: Arg, row: PrimitiveArg, column: PrimitiveArg) => {
+    const _row = toNumber(row.value);
+    const _column = toNumber(column.value);
+    return reference[_column - 1][_row - 1]?.format;
+  },
+  compute: function (reference: ArgValue, row: PrimitiveArgValue, column: PrimitiveArgValue): any {
+    const _reference = isMatrix(reference) ? reference : [[reference]];
+    const _row = toNumber(row);
+    const _column = toNumber(column);
+
+    assert(
+      () =>
+        _column >= 0 &&
+        _column - 1 < _reference.length &&
+        _row >= 0 &&
+        _row - 1 < _reference[0].length,
+      _lt("Index out of range.")
+    );
+
+    assert(
+      () => row !== 0 && column !== 0,
+      _lt(
+        "This function can only return a single cell value, not an array. Provide valid row and column indices."
+      )
+    );
+
+    return _reference[_column - 1][_row - 1];
   },
   isExported: true,
 };

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -177,6 +177,10 @@ interface FormulaReturn extends Omit<FunctionReturn, "value"> {
 }
 export type FunctionReturnValue = string | number | boolean;
 
+export function isMatrix(x: any): x is any[][] {
+  return Array.isArray(x) && Array.isArray(x[0]);
+}
+
 export interface ClipboardCell {
   cell?: Cell;
   border?: Border;


### PR DESCRIPTION
## Description:

This PR introduces a version of the INDEX function. The new INDEX function is designed to return single values, addressing a specific use case where array output is not required.

Task: : [3483842](https://www.odoo.com/web#id=3483842&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo