### PR TITLE
[FIX] header_size: decouple added row from base row

### DIFF
--- a/src/plugins/core/header_size.ts
+++ b/src/plugins/core/header_size.ts
@@ -73,7 +73,11 @@ export class HeaderSizePlugin extends CorePlugin<HeaderSizeState> implements Hea
         let sizes = [...this.sizes[cmd.sheetId][cmd.dimension]];
         const addIndex = getAddHeaderStartIndex(cmd.position, cmd.base);
         const baseSize = sizes[cmd.base];
-        sizes.splice(addIndex, 0, ...Array(cmd.quantity).fill(baseSize));
+        const sizesToInsert = range(0, cmd.quantity).map(() => ({
+          manualSize: baseSize.manualSize,
+          computedSize: lazy(baseSize.computedSize()),
+        }));
+        sizes.splice(addIndex, 0, ...sizesToInsert);
         sizes = sizes.map((size, row) => {
           if (cmd.dimension === "ROW" && row > cmd.base + cmd.quantity) {
             // invalidate sizes

--- a/tests/plugins/resizing.test.ts
+++ b/tests/plugins/resizing.test.ts
@@ -257,6 +257,15 @@ describe("Model resizer", () => {
       expect(model.getters.getRowSize(sheetId, 3)).toEqual(20);
     });
 
+    test("Remove added row at the end with some content", () => {
+      let lastRow = model.getters.getNumberRows(sheetId) - 1;
+      addRows(model, "after", lastRow, 1);
+      lastRow += 1;
+      setCellContent(model, toXC(0, lastRow), "Hello");
+      deleteRows(model, [lastRow]);
+      expect(model.getters.getRowSize(sheetId, lastRow)).toEqual(DEFAULT_CELL_HEIGHT);
+    });
+
     test("Add row before", () => {
       addRows(model, "after", 0, 2, sheetId);
       expect(model.getters.getRowSize(sheetId, 2)).toEqual(DEFAULT_CELL_HEIGHT);
@@ -271,6 +280,13 @@ describe("Model resizer", () => {
       expect(model.getters.getRowSize(sheetId, 3)).toEqual(20);
       expect(model.getters.getRowSize(sheetId, 4)).toEqual(DEFAULT_CELL_HEIGHT);
       expect(model.getters.getRowSize(sheetId, 5)).toEqual(DEFAULT_CELL_HEIGHT);
+    });
+
+    test("added row is independent from base row", () => {
+      addRows(model, "after", 0, 1, sheetId);
+      setStyle(model, "A1", { fontSize: 36 });
+      expect(model.getters.getRowSize(sheetId, 0)).toEqual(getDefaultCellHeight({ fontSize: 36 }));
+      expect(model.getters.getRowSize(sheetId, 1)).toEqual(DEFAULT_CELL_HEIGHT);
     });
   });
 


### PR DESCRIPTION
Steps to reproduce:
- Insert a row below row 1
- change the font size of row 1 => rows 1 AND 2 are now bigger. The size of row 2 should not have changed

That's because we fill the size array for the new row with the same object (by reference) as the base one. Chaning any of the two rows impacts the other one.

We can also end up with a crash if you add a row below the last row. Let's say there are 10 rows, you insert a new one at the very bottom. Set some content in a cell of row 11 (now the size of row 10 is linked to the size of row 11). Now delete row 11
=> getting the size of row 10 will crash because it's linked to row 11 which no longer exists.


Task: : [3510863](https://www.odoo.com/web#id=3510863&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo