### PR TITLE
[FIX] filters: hide sort buttons in readonly mode

### DIFF
--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -154,6 +154,10 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
     this.state.values = this.getFilterValues(this.props.filterPosition);
   }
 
+  get isReadonly() {
+    return this.env.model.getters.isReadonly();
+  }
+
   private getFilterValues(position: Position): Value[] {
     const sheetId = this.env.model.getters.getActiveSheetId();
     const filter = this.env.model.getters.getFilter(sheetId, position.col, position.row);

--- a/src/components/filters/filter_menu/filter_menu.xml
+++ b/src/components/filters/filter_menu/filter_menu.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-FilterMenu" owl="1">
     <div class="o-filter-menu d-flex flex-column bg-white" t-on-wheel.stop="">
-      <div>
+      <div t-if="!isReadonly">
         <div class="o-filter-menu-item" t-on-click="() => this.sortFilterZone('ascending')">
           Sort ascending (A ⟶ Z)
         </div>
@@ -9,7 +9,7 @@
           Sort descending (Z ⟶ A)
         </div>
       </div>
-      <div class="o-separator"/>
+      <div class="o-separator" t-if="!isReadonly"/>
       <div class="o-filter-menu-actions">
         <div class="o-filter-menu-action-text" t-on-click="selectAll">Select all</div>
         <div class="o-filter-menu-action-text" t-on-click="clearAll">Clear</div>

--- a/tests/components/__snapshots__/filter_menu.test.ts.snap
+++ b/tests/components/__snapshots__/filter_menu.test.ts.snap
@@ -16,9 +16,11 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
        Sort descending (Z ⟶ A) 
     </div>
   </div>
+  
   <div
     class="o-separator"
   />
+  
   <div
     class="o-filter-menu-actions"
   >

--- a/tests/components/filter_menu.test.ts
+++ b/tests/components/filter_menu.test.ts
@@ -299,4 +299,18 @@ describe("Filter menu component", () => {
       B15: { content: "ba" },
     });
   });
+
+  test("cannot sort filter table in readonly mode", async () => {
+    createFilter(model, "A10:B15");
+    await nextTick();
+    await openFilterMenu();
+    expect(
+      [...fixture.querySelectorAll(".o-filter-menu-item")].map((el) => el.textContent)
+    ).toEqual([" Sort ascending (A ⟶ Z) ", " Sort descending (Z ⟶ A) ", "✓(Blanks)"]);
+    model.updateMode("readonly");
+    await nextTick();
+    expect(
+      [...fixture.querySelectorAll(".o-filter-menu-item")].map((el) => el.textContent)
+    ).toEqual(["✓(Blanks)"]);
+  });
 });

--- a/tests/plugins/filter_evaluation.test.ts
+++ b/tests/plugins/filter_evaluation.test.ts
@@ -36,7 +36,8 @@ describe("Filter Evaluation Plugin", () => {
     createFilter(model, "B1:B5");
   });
 
-  test("Can filter a row", () => {
+  test.each(["normal", "readonly", "dashboard"] as const)("Can filter a row", (mode) => {
+    model.updateMode(mode);
     updateFilter(model, "A1", ["A2", "A3"]);
     expect(model.getters.isRowHidden(sheetId, 0)).toEqual(false);
     expect(model.getters.isRowHidden(sheetId, 1)).toEqual(true);


### PR DESCRIPTION
## Description:

Given a spreadsheet with a filter table, in readonly mode, you can click on the "Sort ascending (A ⟶ Z)" but nothing happens. It's normal that nothing is happening since the spreadsheet is cannot be edited.

This commit hides the sorting buttons in readonly mode.


opw: : [3475613](https://www.odoo.com/web#id=3475613&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo