### PR TITLE
[IMP] Functions: add SORT, SORTN and RANK

### DIFF
--- a/src/functions/helper_matrices.ts
+++ b/src/functions/helper_matrices.ts
@@ -1,5 +1,5 @@
 import { _t } from "../translation";
-import { Matrix } from "../types";
+import { Matrix, isMatrix } from "../types";
 
 export function getUnitMatrix(n: number): Matrix<number> {
   const matrix: Matrix<number> = Array(n);
@@ -133,4 +133,17 @@ export function multiplyMatrices(matrix1: Matrix<number>, matrix2: Matrix<number
     }
   }
   return result;
+}
+
+/**
+ * Return the input if it's a scalar or the first element of the input if it's a matrix.
+ */
+export function toScalar<T>(matrix: Matrix<T> | T): T {
+  if (!isMatrix(matrix)) {
+    return matrix;
+  }
+  if (matrix.length !== 1 || matrix[0].length !== 1) {
+    throw new Error("toScalar: matrix should be a scalar or a 1x1 matrix");
+  }
+  return matrix[0][0];
 }

--- a/src/functions/module_filter.ts
+++ b/src/functions/module_filter.ts
@@ -1,9 +1,105 @@
+import { range } from "../helpers";
+import { cellsSortingCriterion } from "../helpers/sort";
 import { _t } from "../translation";
-import { AddFunctionDescription, Arg, isMatrix, Matrix, Maybe, ValueAndFormat } from "../types";
+import {
+  AddFunctionDescription,
+  Arg,
+  CellValue,
+  CellValueType,
+  isMatrix,
+  Locale,
+  Matrix,
+  Maybe,
+  ValueAndFormat,
+} from "../types";
 import { NotAvailableError } from "../types/errors";
 import { arg } from "./arguments";
 import { assertSameDimensions, assertSingleColOrRow } from "./helper_assert";
-import { assert, matrixMap, toBoolean, toMatrix, transposeMatrix } from "./helpers";
+import { toScalar } from "./helper_matrices";
+import { assert, matrixMap, toBoolean, toMatrix, toNumber, transposeMatrix } from "./helpers";
+
+function sortMatrix(
+  matrix: Matrix<ValueAndFormat>,
+  locale: Locale,
+  ...criteria: Arg[]
+): Matrix<ValueAndFormat> {
+  for (const [i, value] of criteria.entries()) {
+    assert(
+      () => value !== undefined,
+      _t(
+        `Value for parameter %d is missing, while the function [[FUNCTION_NAME]] expect a number or a range.`,
+        i + 1
+      )
+    );
+  }
+  const sortingOrders: ("ascending" | "descending")[] = [];
+  const sortColumns: Matrix<CellValue> = [];
+  const nRows = matrix.length;
+  for (let i = 0; i < criteria.length; i += 2) {
+    sortingOrders.push(toBoolean(toScalar(criteria[i + 1])?.value) ? "ascending" : "descending");
+    const sortColumn = criteria[i];
+    if (isMatrix(sortColumn) && (sortColumn.length > 1 || sortColumn[0].length > 1)) {
+      assert(
+        () => sortColumn.length === 1 && sortColumn[0].length === nRows,
+        _t(
+          `Wrong size for %s. Expected a range of size 1x%s. Got %sx%s.`,
+          `sort_column{i + 1}`,
+          nRows,
+          sortColumn.length,
+          sortColumn[0].length
+        )
+      );
+      sortColumns.push(sortColumn.flat().map((c) => c.value));
+    } else {
+      const colIndex = toNumber(toScalar(sortColumn)?.value, locale);
+      if (colIndex < 1 || colIndex > matrix[0].length) {
+        return matrix;
+      }
+      sortColumns.push(matrix.map((row) => row[colIndex - 1].value));
+    }
+  }
+  if (sortColumns.length === 0) {
+    for (let i = 0; i < matrix[0].length; i++) {
+      sortColumns.push(matrix.map((row) => row[i].value));
+      sortingOrders.push("ascending");
+    }
+  }
+  const sortingCriteria = {
+    descending: cellsSortingCriterion("descending"),
+    ascending: cellsSortingCriterion("ascending"),
+  };
+  const indexes = range(0, matrix.length);
+  indexes.sort((a, b) => {
+    for (const [i, sortColumn] of sortColumns.entries()) {
+      const left = sortColumn[a];
+      const right = sortColumn[b];
+      const leftCell = {
+        value: left,
+        type:
+          left === null
+            ? CellValueType.empty
+            : typeof left === "string"
+            ? CellValueType.text
+            : (typeof left as CellValueType),
+      };
+      const rightCell = {
+        value: right,
+        type:
+          right === null
+            ? CellValueType.empty
+            : typeof right === "string"
+            ? CellValueType.text
+            : (typeof right as CellValueType),
+      };
+      const result = sortingCriteria[sortingOrders[i]](leftCell, rightCell);
+      if (result !== 0) {
+        return result;
+      }
+    }
+    return 0;
+  });
+  return indexes.map((i) => matrix[i]);
+}
 
 // -----------------------------------------------------------------------------
 // FILTER
@@ -65,6 +161,133 @@ export const FILTER = {
   },
   isExported: true,
 } satisfies AddFunctionDescription;
+
+// -----------------------------------------------------------------------------
+// SORT
+// -----------------------------------------------------------------------------
+export const SORT: AddFunctionDescription = {
+  description: _t("Sorts the rows of a given array or range by the values in one or more columns."),
+  args: [
+    arg("range (range)", _t("The data to be sorted.")),
+    arg(
+      "sort_column (any, range<number>, repeating)",
+      _t(
+        "The index of the column in range or a range outside of range containing the values by which to sort."
+      )
+    ),
+    arg(
+      "is_ascending (boolean, repeating)",
+      _t(
+        "TRUE or FALSE indicating whether to sort sort_column in ascending order. FALSE sorts in descending order."
+      )
+    ),
+  ],
+  returns: ["RANGE"],
+  computeValueAndFormat: function (
+    range: Matrix<ValueAndFormat>,
+    ...sortingCriteria: Arg[]
+  ): Matrix<ValueAndFormat> {
+    const _range = transposeMatrix(range);
+    return transposeMatrix(sortMatrix(_range, this.locale, ...sortingCriteria));
+  },
+  isExported: true,
+};
+
+// -----------------------------------------------------------------------------
+// SORTN
+// -----------------------------------------------------------------------------
+export const SORTN: AddFunctionDescription = {
+  description: _t("Returns the first n items in a data set after performing a sort."),
+  args: [
+    arg("range (range)", _t("The data to be sorted.")),
+    arg("n (number, default=1)", _t("The number of items to return.")),
+    arg(
+      "display_ties_mode (number, default=0)",
+      _t("A number representing the way to display ties.")
+    ),
+    arg(
+      "sort_column (number, range<number>, repeating)",
+      _t(
+        "The index of the column in range or a range outside of range containing the values by which to sort."
+      )
+    ),
+    arg(
+      "is_ascending (boolean, repeating)",
+      _t(
+        "TRUE or FALSE indicating whether to sort sort_column in ascending order. FALSE sorts in descending order."
+      )
+    ),
+  ],
+  returns: ["RANGE"],
+  computeValueAndFormat: function (
+    range: Matrix<ValueAndFormat>,
+    n: Maybe<ValueAndFormat>,
+    displayTiesMode: Maybe<ValueAndFormat>,
+    ...sortingCriteria: (ValueAndFormat | Matrix<ValueAndFormat>)[]
+  ): any {
+    const _n = toNumber(n?.value ?? 1, this.locale);
+    assert(() => _n >= 0, _t(`Wrong value of 'n'. Expected a positive number. Got %s.`, _n));
+    const _displayTiesMode = toNumber(displayTiesMode?.value ?? 0, this.locale);
+    assert(
+      () => _displayTiesMode >= 0 && _displayTiesMode <= 3,
+      _t(
+        `Wrong value of 'display_ties_mode'. Expected a positive number between 0 and 3. Got %s.`,
+        _displayTiesMode
+      )
+    );
+    const sortedData = sortMatrix(transposeMatrix(range), this.locale, ...sortingCriteria);
+    const sameRows = (i: number, j: number) =>
+      JSON.stringify(sortedData[i].map((c) => c.value)) ===
+      JSON.stringify(sortedData[j].map((c) => c.value));
+    /*
+     * displayTiesMode determine how ties (equal values) are dealt with:
+     * 0 - ignore ties and show first n rows only
+     * 1 - show first n rows plus any additional ties with nth row
+     * 2 - show n rows but remove duplicates
+     * 3 - show first n unique rows and all duplicates of these rows
+     */
+    switch (_displayTiesMode) {
+      case 0:
+        return transposeMatrix(sortedData.slice(0, _n));
+      case 1:
+        for (let i = _n; i < sortedData.length; i++) {
+          if (!sameRows(i, _n - 1)) {
+            return transposeMatrix(sortedData.slice(0, i));
+          }
+        }
+        return transposeMatrix(sortedData);
+      case 2: {
+        const uniques = [sortedData[0]];
+        for (let i = 1; i < sortedData.length; i++) {
+          for (let j = 0; j < i; j++) {
+            if (sameRows(i, j)) {
+              break;
+            }
+            if (j === i - 1) {
+              uniques.push(sortedData[i]);
+            }
+          }
+        }
+        return transposeMatrix(uniques.slice(0, _n));
+      }
+      case 3: {
+        const uniques = [sortedData[0]];
+        let counter = 1;
+        for (let i = 1; i < sortedData.length; i++) {
+          if (!sameRows(i, i - 1)) {
+            counter++;
+          }
+          if (counter > _n) {
+            break;
+          }
+          uniques.push(sortedData[i]);
+        }
+        return transposeMatrix(uniques);
+      }
+    }
+  },
+  isExported: true,
+};
 
 // -----------------------------------------------------------------------------
 // UNIQUE

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -13,6 +13,7 @@ import {
   ValueAndFormat,
   isMatrix,
 } from "../types";
+import { NotAvailableError } from "../types/errors";
 import { arg } from "./arguments";
 import { invertMatrix, multiplyMatrices } from "./helper_matrices";
 import { assertSameNumberOfElements } from "./helper_statistical";
@@ -1524,6 +1525,49 @@ export const QUARTILE_INC = {
   },
   isExported: true,
 } satisfies AddFunctionDescription;
+
+// RANK
+// -----------------------------------------------------------------------------
+export const RANK: AddFunctionDescription = {
+  description: _t("Returns the rank of a specified value in a dataset."),
+  args: [
+    arg("value (number)", _t("The value whose rank will be determined.")),
+    arg("data (range)", _t("The range containing the dataset to consider.")),
+    arg(
+      "is_ascending (boolean, default=FALSE)",
+      _t("Whether to consider the values in data in descending or ascending order.")
+    ),
+  ],
+  returns: ["ANY"],
+  compute: function (
+    value: Maybe<CellValue>,
+    data: Matrix<CellValue>,
+    isAscending: Maybe<CellValue> = false
+  ): number {
+    const _isAscending = toBoolean(isAscending);
+    const _value = toNumber(value, this.locale);
+    let rank = 1;
+    let found = false;
+    for (const row of data) {
+      for (const cell of row) {
+        if (typeof cell !== "number") {
+          continue;
+        }
+        const _cell = toNumber(cell, this.locale);
+        if (_cell === _value) {
+          found = true;
+        } else if (_cell > _value !== _isAscending) {
+          rank++;
+        }
+      }
+    }
+    if (!found) {
+      throw new NotAvailableError(_t("Value not found in the given data."));
+    }
+    return rank;
+  },
+  isExported: true,
+};
 
 // -----------------------------------------------------------------------------
 // RSQ

--- a/src/helpers/sort.ts
+++ b/src/helpers/sort.ts
@@ -1,5 +1,6 @@
 import { _t } from "../translation";
 import {
+  CellValue,
   CellValueType,
   CommandResult,
   DispatchResult,
@@ -21,6 +22,29 @@ const SORT_TYPES: CellValueType[] = [
   CellValueType.boolean,
 ];
 
+export function cellsSortingCriterion(sortingOrder: string) {
+  const inverse = sortingOrder === "ascending" ? 1 : -1;
+  return (
+    left: { type: CellValueType; value: CellValue },
+    right: { type: CellValueType; value: CellValue }
+  ) => {
+    if (left.type === CellValueType.empty) {
+      return right.type === CellValueType.empty ? 0 : 1;
+    } else if (right.type === CellValueType.empty) {
+      return -1;
+    }
+    let typeOrder = SORT_TYPES.indexOf(left.type) - SORT_TYPES.indexOf(right.type);
+    if (typeOrder === 0) {
+      if (left.type === CellValueType.text || left.type === CellValueType.error) {
+        typeOrder = (left.value as string).localeCompare(right.value as string);
+      } else {
+        typeOrder = (left.value as number) - (right.value as number);
+      }
+    }
+    return inverse * typeOrder;
+  };
+}
+
 export function sortCells(
   cells: EvaluatedCell[],
   sortDirection: SortDirection,
@@ -31,28 +55,14 @@ export function sortCells(
     type: cell.type,
     value: cell.value,
   }));
-  let emptyCells: CellWithIndex[] = cellsWithIndex.filter((x) => x.type === CellValueType.empty);
-  let nonEmptyCells: CellWithIndex[] = cellsWithIndex.filter((x) => x.type !== CellValueType.empty);
-  if (emptyCellAsZero) {
-    nonEmptyCells.push(
-      ...emptyCells.map((emptyCell) => ({ ...emptyCell, type: CellValueType.number, value: 0 }))
-    );
-    emptyCells = [];
-  }
 
-  const inverse = sortDirection === "descending" ? -1 : 1;
+  const cellsToSort = emptyCellAsZero
+    ? cellsWithIndex.map((cell) =>
+        cell.type === CellValueType.empty ? { ...cell, type: CellValueType.number, value: 0 } : cell
+      )
+    : cellsWithIndex;
 
-  return nonEmptyCells
-    .sort((left, right) => {
-      let typeOrder = SORT_TYPES.indexOf(left.type) - SORT_TYPES.indexOf(right.type);
-      if (typeOrder === 0) {
-        if (left.type === CellValueType.text || left.type === CellValueType.error) {
-          typeOrder = left.value.localeCompare(right.value);
-        } else typeOrder = left.value - right.value;
-      }
-      return inverse * typeOrder;
-    })
-    .concat(emptyCells);
+  return cellsToSort.sort(cellsSortingCriterion(sortDirection));
 }
 
 export function interactiveSortSelection(

--- a/tests/functions/module_filter.test.ts
+++ b/tests/functions/module_filter.test.ts
@@ -217,3 +217,807 @@ describe("UNIQUE function", () => {
     expect(getCellError(model, "D1")).toBe("No unique values found");
   });
 });
+
+describe("SORT function", () => {
+  test("Sorting a single column of numbers", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",
+       A2: "2",
+       A3: "3",
+       A4: "1",
+       A5: "4",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:A5)");
+    expect(getRangeValuesAsMatrix(model, "A11:A15")).toEqual([[1], [1], [2], [3], [4]]);
+  });
+
+  test("Full sorting with multiple columns", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "1", C1: "1",
+      A2: "2", B2: "1", C2: "2",
+      A3: "3", B3: "2", C3: "1",
+      A4: "1", B4: "3", C4: "3",
+      A5: "2", B5: "3", C5: "1",
+      A6: "4", B6: "2", C6: "1",
+      A7: "3", B7: "4", C7: "4",
+      A8: "4", B8: "1", C8: "2",
+      A9: "2", B9: "1", C9: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:C9)");
+    expect(getRangeValuesAsMatrix(model, "A11:C19")).toEqual([
+      [1, 1, 1],
+      [1, 3, 3],
+      [2, 1, 1],
+      [2, 1, 2],
+      [2, 3, 1],
+      [3, 2, 1],
+      [3, 4, 4],
+      [4, 1, 2],
+      [4, 2, 1],
+    ]);
+  });
+
+  test("Empty cell going last no matter the ascending/descending order", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",
+       A2: "2",
+
+       A4: "4",
+
+       A6: "3",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "B1", "=SORT(A1:A6, 1, TRUE)");
+    expect(getRangeValuesAsMatrix(model, "B5:B6")).toEqual([[0], [0]]);
+    setCellContent(model, "B1", "=SORT(A1:A6, 1, FALSE)");
+    expect(getRangeValuesAsMatrix(model, "B5:B6")).toEqual([[0], [0]]);
+  });
+
+  test("Full sorting with multiple columns of string", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "a",    B1: "yihaa",
+      A2: "f",    B2: "aaaah",
+      A3: "a",    B3: "hey",
+      A4: "g",    B4: "coucou",
+      A5: "g",    B5: "salut",
+      A6: "ok",   B6: "a",
+      A7: "ko",   B7: "z",
+      A8: "null", B8: "yep"
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:B8)");
+    expect(getRangeValuesAsMatrix(model, "A11:B18")).toEqual([
+      ["a", "hey"],
+      ["a", "yihaa"],
+      ["f", "aaaah"],
+      ["g", "coucou"],
+      ["g", "salut"],
+      ["ko", "z"],
+      ["null", "yep"],
+      ["ok", "a"],
+    ]);
+  });
+
+  test("Full sorting with multiple columns of different data types", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "a",    B1: "1",
+      A2: "f",    B2: "1",
+      A3: "a",    B3: "2",
+      A4: "g",    B4: "24",
+      A5: "g",    B5: "5",
+      A6: "ok",   B6: "0",
+      A7: "ko",   B7: "1",
+      A8: "null", B8: "2"
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:B8)");
+    expect(getRangeValuesAsMatrix(model, "A11:B18")).toEqual([
+      ["a", 1],
+      ["a", 2],
+      ["f", 1],
+      ["g", 5],
+      ["g", 24],
+      ["ko", 1],
+      ["null", 2],
+      ["ok", 0],
+    ]);
+  });
+
+  test("Sorting a column of mixed data types", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",
+       A2: "f",
+       A3: "10",
+       A4: "=FALSE()",
+       A5: "",
+       A6: "22",
+       A7: "=TRUE()",
+       A8: "test",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:A9)");
+    expect(getRangeValuesAsMatrix(model, "A11:A19")).toEqual([
+      [1],
+      [10],
+      [22],
+      ["f"],
+      ["test"],
+      [false],
+      [true],
+      [0],
+      [0],
+    ]);
+  });
+
+  test("Sorting a single column of string", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "a",
+       A2: "f",
+       A3: "aa",
+       A4: "test",
+       A5: "e",
+       A6: "g",
+       A7: "rrrr",
+       A8: "ok",
+       A9: "ko",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:A9)");
+    expect(getRangeValuesAsMatrix(model, "A11:A19")).toEqual([
+      ["a"],
+      ["aa"],
+      ["e"],
+      ["f"],
+      ["g"],
+      ["ko"],
+      ["ok"],
+      ["rrrr"],
+      ["test"],
+    ]);
+  });
+
+  test("Ascending Sorting multiple columns specifying column number", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "1", C1: "1",
+      A2: "2", B2: "1", C2: "2",
+      A3: "3", B3: "2", C3: "1",
+      A4: "1", B4: "3", C4: "3",
+      A5: "2", B5: "3", C5: "1",
+      A6: "4", B6: "2", C6: "1",
+      A7: "3", B7: "4", C7: "4",
+      A8: "4", B8: "1", C8: "2",
+      A9: "2", B9: "1", C9: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:C9,1,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C19")).toEqual([
+      [1, 1, 1],
+      [1, 3, 3],
+      [2, 1, 2],
+      [2, 3, 1],
+      [2, 1, 1],
+      [3, 2, 1],
+      [3, 4, 4],
+      [4, 2, 1],
+      [4, 1, 2],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C9,2,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C19")).toEqual([
+      [1, 1, 1],
+      [2, 1, 2],
+      [4, 1, 2],
+      [2, 1, 1],
+      [3, 2, 1],
+      [4, 2, 1],
+      [1, 3, 3],
+      [2, 3, 1],
+      [3, 4, 4],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C9,3,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C19")).toEqual([
+      [1, 1, 1],
+      [3, 2, 1],
+      [2, 3, 1],
+      [4, 2, 1],
+      [2, 1, 1],
+      [2, 1, 2],
+      [4, 1, 2],
+      [1, 3, 3],
+      [3, 4, 4],
+    ]);
+  });
+
+  test("Descending Sorting multiple columns specifying column number", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "1", C1: "1",
+      A2: "2", B2: "1", C2: "2",
+      A3: "3", B3: "2", C3: "1",
+      A4: "1", B4: "3", C4: "3",
+      A5: "2", B5: "3", C5: "1",
+      A6: "4", B6: "2", C6: "1",
+      A7: "3", B7: "4", C7: "4",
+      A8: "4", B8: "1", C8: "2",
+      A9: "2", B9: "1", C9: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:C9,1,FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C19")).toEqual([
+      [4, 2, 1],
+      [4, 1, 2],
+      [3, 2, 1],
+      [3, 4, 4],
+      [2, 1, 2],
+      [2, 3, 1],
+      [2, 1, 1],
+      [1, 1, 1],
+      [1, 3, 3],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10,2,FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C19")).toEqual([
+      [3, 4, 4],
+      [1, 3, 3],
+      [2, 3, 1],
+      [3, 2, 1],
+      [4, 2, 1],
+      [1, 1, 1],
+      [2, 1, 2],
+      [4, 1, 2],
+      [2, 1, 1],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10,3,FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C19")).toEqual([
+      [3, 4, 4],
+      [1, 3, 3],
+      [2, 1, 2],
+      [4, 1, 2],
+      [1, 1, 1],
+      [3, 2, 1],
+      [2, 3, 1],
+      [4, 2, 1],
+      [2, 1, 1],
+    ]);
+  });
+
+  test("Sorting multiple columns specifying multiple column numbers", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",  B1: "1",  C1: "1",
+       A2: "2",  B2: "1",  C2: "2",
+       A3: "3",  B3: "2",  C3: "1",
+       A4: "1",  B4: "3",  C4: "3",
+       A5: "2",  B5: "3",  C5: "1",
+       A6: "4",  B6: "2",  C6: "1",
+       A7: "3",  B7: "4",  C7: "4",
+       A8: "2",  B8: "1",  C8: "1",
+       A9: "4",  B9: "1",  C9: "2",
+      A10: "2", B10: "1", C10: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:C10, 1, TRUE, 2, FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [1, 3, 3],
+      [1, 1, 1],
+      [2, 3, 1],
+      [2, 1, 2],
+      [2, 1, 1],
+      [2, 1, 1],
+      [3, 4, 4],
+      [3, 2, 1],
+      [4, 2, 1],
+      [4, 1, 2],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10, 1, FALSE, 2, TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [4, 1, 2],
+      [4, 2, 1],
+      [3, 2, 1],
+      [3, 4, 4],
+      [2, 1, 2],
+      [2, 1, 1],
+      [2, 1, 1],
+      [2, 3, 1],
+      [1, 1, 1],
+      [1, 3, 3],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10, 1, FALSE, 2, TRUE, 3, TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [4, 1, 2],
+      [4, 2, 1],
+      [3, 2, 1],
+      [3, 4, 4],
+      [2, 1, 1],
+      [2, 1, 1],
+      [2, 1, 2],
+      [2, 3, 1],
+      [1, 1, 1],
+      [1, 3, 3],
+    ]);
+  });
+
+  test("Ascending Sorting multiple columns specifying range", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",  B1: "1",  C1: "1",
+       A2: "2",  B2: "1",  C2: "2",
+       A3: "3",  B3: "2",  C3: "1",
+       A4: "1",  B4: "3",  C4: "3",
+       A5: "2",  B5: "3",  C5: "1",
+       A6: "4",  B6: "2",  C6: "1",
+       A7: "3",  B7: "4",  C7: "4",
+       A8: "2",  B8: "1",  C8: "1",
+       A9: "4",  B9: "1",  C9: "2",
+      A10: "2", B10: "1", C10: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:C10,A1:A10,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [1, 1, 1],
+      [1, 3, 3],
+      [2, 1, 2],
+      [2, 3, 1],
+      [2, 1, 1],
+      [2, 1, 1],
+      [3, 2, 1],
+      [3, 4, 4],
+      [4, 2, 1],
+      [4, 1, 2],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10,B1:B10,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [1, 1, 1],
+      [2, 1, 2],
+      [2, 1, 1],
+      [4, 1, 2],
+      [2, 1, 1],
+      [3, 2, 1],
+      [4, 2, 1],
+      [1, 3, 3],
+      [2, 3, 1],
+      [3, 4, 4],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10,C1:C10,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [1, 1, 1],
+      [3, 2, 1],
+      [2, 3, 1],
+      [4, 2, 1],
+      [2, 1, 1],
+      [2, 1, 1],
+      [2, 1, 2],
+      [4, 1, 2],
+      [1, 3, 3],
+      [3, 4, 4],
+    ]);
+  });
+
+  test("Descending Sorting multiple columns specifying range", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",  B1: "1",  C1: "1",
+       A2: "2",  B2: "1",  C2: "2",
+       A3: "3",  B3: "2",  C3: "1",
+       A4: "1",  B4: "3",  C4: "3",
+       A5: "2",  B5: "3",  C5: "1",
+       A6: "4",  B6: "2",  C6: "1",
+       A7: "3",  B7: "4",  C7: "4",
+       A8: "2",  B8: "1",  C8: "1",
+       A9: "4",  B9: "1",  C9: "2",
+      A10: "2", B10: "1", C10: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:C10,A1:A10,FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [4, 2, 1],
+      [4, 1, 2],
+      [3, 2, 1],
+      [3, 4, 4],
+      [2, 1, 2],
+      [2, 3, 1],
+      [2, 1, 1],
+      [2, 1, 1],
+      [1, 1, 1],
+      [1, 3, 3],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10,B1:B10,FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [3, 4, 4],
+      [1, 3, 3],
+      [2, 3, 1],
+      [3, 2, 1],
+      [4, 2, 1],
+      [1, 1, 1],
+      [2, 1, 2],
+      [2, 1, 1],
+      [4, 1, 2],
+      [2, 1, 1],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10,C1:C10,FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [3, 4, 4],
+      [1, 3, 3],
+      [2, 1, 2],
+      [4, 1, 2],
+      [1, 1, 1],
+      [3, 2, 1],
+      [2, 3, 1],
+      [4, 2, 1],
+      [2, 1, 1],
+      [2, 1, 1],
+    ]);
+  });
+
+  test("Sorting multiple columns specifying multiple ranges to base to sorting on", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",  B1: "1",  C1: "1",
+       A2: "2",  B2: "1",  C2: "2",
+       A3: "3",  B3: "2",  C3: "1",
+       A4: "1",  B4: "3",  C4: "3",
+       A5: "2",  B5: "3",  C5: "1",
+       A6: "4",  B6: "2",  C6: "1",
+       A7: "3",  B7: "4",  C7: "4",
+       A8: "2",  B8: "1",  C8: "1",
+       A9: "4",  B9: "1",  C9: "2",
+      A10: "2", B10: "1", C10: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORT(A1:C10, A1:A10, TRUE, B1:B10, FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [1, 3, 3],
+      [1, 1, 1],
+      [2, 3, 1],
+      [2, 1, 2],
+      [2, 1, 1],
+      [2, 1, 1],
+      [3, 4, 4],
+      [3, 2, 1],
+      [4, 2, 1],
+      [4, 1, 2],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10, A1:A10, FALSE, B1:B10, TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [4, 1, 2],
+      [4, 2, 1],
+      [3, 2, 1],
+      [3, 4, 4],
+      [2, 1, 2],
+      [2, 1, 1],
+      [2, 1, 1],
+      [2, 3, 1],
+      [1, 1, 1],
+      [1, 3, 3],
+    ]);
+    setCellContent(model, "A11", "=SORT(A1:C10, A1:A10, FALSE, B1:B10, TRUE, C1:C10, TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [4, 1, 2],
+      [4, 2, 1],
+      [3, 2, 1],
+      [3, 4, 4],
+      [2, 1, 1],
+      [2, 1, 1],
+      [2, 1, 2],
+      [2, 3, 1],
+      [1, 1, 1],
+      [1, 3, 3],
+    ]);
+  });
+
+  test.each(["-1", "0", "4"])("Sorting with invalid column index (%s)", (index) => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",  B1: "1",  C1: "1",
+       A2: "2",  B2: "1",  C2: "2",
+       A3: "3",  B3: "2",  C3: "1",
+       A4: "1",  B4: "3",  C4: "3",
+       A5: "2",  B5: "3",  C5: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", `=SORT(A1:C5, 5, ${index})`);
+    expect(getRangeValuesAsMatrix(model, "A11:C15")).toEqual([
+      [1, 1, 1],
+      [2, 1, 2],
+      [3, 2, 1],
+      [1, 3, 3],
+      [2, 3, 1],
+    ]);
+  });
+
+  test("Sorting with missing 'order' argument", () => {
+    const model = new Model();
+    setCellContent(model, "B1", "=SORT(A1:A2, 1)");
+    expect(getRangeValuesAsMatrix(model, "B1")).toEqual([["#BAD_EXPR"]]);
+    expect(checkFunctionDoesntSpreadBeyondRange(model, "B1")).toBeTruthy();
+  });
+});
+
+describe("SORTN function", () => {
+  test("Sorting a single column of numbers", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",
+       A2: "2",
+       A3: "3",
+       A4: "1",
+       A5: "2",
+       A6: "2",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:A6, 5, 0)");
+    expect(getRangeValuesAsMatrix(model, "A11:A16")).toEqual([[1], [1], [2], [2], [2], [""]]);
+  });
+
+  test("Full sorting with multiple columns", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "1", C1: "1",
+      A2: "2", B2: "1", C2: "2",
+      A3: "1", B3: "3", C3: "3",
+      A4: "2", B4: "3", C4: "1",
+      A5: "2", B5: "1", C5: "1",
+      A6: "2", B6: "1", C6: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:C6, 5, 0)");
+    expect(getRangeValuesAsMatrix(model, "A11:C16")).toEqual([
+      [1, 1, 1],
+      [1, 3, 3],
+      [2, 1, 1],
+      [2, 1, 1],
+      [2, 1, 2],
+      ["", "", ""],
+    ]);
+  });
+
+  test("Full sorting with multiple columns using default parameters", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",  B1: "1",  C1: "1",
+       A2: "2",  B2: "1",  C2: "2",
+       A3: "3",  B3: "2",  C3: "1",
+       A4: "1",  B4: "3",  C4: "3",
+       A5: "2",  B5: "3",  C5: "1",
+       A6: "4",  B6: "2",  C6: "1",
+       A7: "3",  B7: "4",  C7: "4",
+       A8: "2",  B8: "1",  C8: "1",
+       A9: "4",  B9: "1",  C9: "2",
+      A10: "2", B10: "1", C10: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:C10)");
+    expect(getRangeValuesAsMatrix(model, "A11:C12")).toEqual([
+      [1, 1, 1],
+      ["", "", ""],
+    ]);
+  });
+
+  test("Full sorting with different display ties modes", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",  B1: "1",  C1: "1",
+       A2: "2",  B2: "1",  C2: "2",
+       A3: "3",  B3: "2",  C3: "1",
+       A4: "1",  B4: "3",  C4: "3",
+       A5: "2",  B5: "3",  C5: "1",
+       A6: "2",  B6: "3",  C6: "1",
+       A7: "3",  B7: "4",  C7: "4",
+       A8: "2",  B8: "1",  C8: "1",
+       A9: "4",  B9: "1",  C9: "2",
+      A10: "2", B10: "1", C10: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:C10, 3, 1)");
+    expect(getRangeValuesAsMatrix(model, "A11:C15")).toEqual([
+      [1, 1, 1],
+      [1, 3, 3],
+      [2, 1, 1],
+      [2, 1, 1],
+      ["", "", ""],
+    ]);
+    setCellContent(model, "A11", "=SORTN(A1:C10, 5, 2)");
+    expect(getRangeValuesAsMatrix(model, "A11:C16")).toEqual([
+      [1, 1, 1],
+      [1, 3, 3],
+      [2, 1, 1],
+      [2, 1, 2],
+      [2, 3, 1],
+      ["", "", ""],
+    ]);
+    setCellContent(model, "A11", "=SORTN(A1:C10, 5, 3)");
+    expect(getRangeValuesAsMatrix(model, "A11:C18")).toEqual([
+      [1, 1, 1],
+      [1, 3, 3],
+      [2, 1, 1],
+      [2, 1, 1],
+      [2, 1, 2],
+      [2, 3, 1],
+      [2, 3, 1],
+      ["", "", ""],
+    ]);
+  });
+
+  test("Sorting with bad n argument", () => {
+    const model = new Model();
+    setCellContent(model, "A11", "=SORTN(A1:C10, -1, 0)");
+    expect(getCellContent(model, "A11")).toEqual("#ERROR");
+    expect(getCellError(model, "A11")).toBe(
+      "Wrong value of 'n'. Expected a positive number. Got -1."
+    );
+    expect(checkFunctionDoesntSpreadBeyondRange(model, "A11")).toBeTruthy();
+  });
+
+  test("Sorting with a too big n value returns full sorted range", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "2",
+       A2: "3",
+       A3: "1",
+       A4: "2",
+       A5: "4",
+       A6: "3",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:A6, 30, 0)");
+    expect(getRangeValuesAsMatrix(model, "A11:A16")).toEqual([[1], [2], [2], [3], [3], [4]]);
+  });
+
+  test.each(["-1", "4"])("Sorting with bad display ties mode argument", (mode) => {
+    const model = new Model();
+    setCellContent(model, "A11", `=SORTN(A1:C10, 1, ${mode})`);
+    expect(getCellContent(model, "A11")).toEqual("#ERROR");
+    expect(getCellError(model, "A11")).toBe(
+      `Wrong value of 'display_ties_mode'. Expected a positive number between 0 and 3. Got ${mode}.`
+    );
+    expect(checkFunctionDoesntSpreadBeyondRange(model, "A11")).toBeTruthy();
+  });
+
+  test("Ascending Sorting multiple columns specifying column number", () => {
+    //prettier-ignore
+    const grid = {
+       A1: "1",  B1: "1",  C1: "1",
+       A2: "2",  B2: "1",  C2: "2",
+       A3: "3",  B3: "2",  C3: "1",
+       A4: "1",  B4: "3",  C4: "3",
+       A5: "2",  B5: "3",  C5: "1",
+       A6: "4",  B6: "2",  C6: "1",
+       A7: "3",  B7: "4",  C7: "4",
+       A8: "2",  B8: "1",  C8: "1",
+       A9: "4",  B9: "1",  C9: "2",
+      A10: "2", B10: "1", C10: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:C10,10,0,2,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C20")).toEqual([
+      [1, 1, 1],
+      [2, 1, 2],
+      [2, 1, 1],
+      [4, 1, 2],
+      [2, 1, 1],
+      [3, 2, 1],
+      [4, 2, 1],
+      [1, 3, 3],
+      [2, 3, 1],
+      [3, 4, 4],
+    ]);
+  });
+
+  test("Descending Sorting multiple columns specifying column number", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1",  B1: "1",  C1: "1",
+      A2: "2",  B2: "1",  C2: "2",
+      A3: "3",  B3: "2",  C3: "1",
+      A4: "1",  B4: "3",  C4: "3",
+      A5: "3",  B5: "4",  C5: "4",
+      A6: "4",  B6: "1",  C6: "2",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:C6,5,0,3,FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C16")).toEqual([
+      [3, 4, 4],
+      [1, 3, 3],
+      [2, 1, 2],
+      [4, 1, 2],
+      [1, 1, 1],
+      ["", "", ""],
+    ]);
+  });
+
+  test("Sorting multiple columns specifying multiple column numbers", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "2",  B1: "1",  C1: "2",
+      A2: "3",  B2: "2",  C2: "1",
+      A3: "4",  B3: "2",  C3: "1",
+      A4: "3",  B4: "4",  C4: "4",
+      A5: "2",  B5: "1",  C5: "1",
+      A6: "4",  B6: "1",  C6: "2",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:C6, 5, 0, 1, FALSE, 2, TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C16")).toEqual([
+      [4, 1, 2],
+      [4, 2, 1],
+      [3, 2, 1],
+      [3, 4, 4],
+      [2, 1, 2],
+      ["", "", ""],
+    ]);
+  });
+
+  test("Ascending Sorting multiple columns specifying range", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "1", C1: "1",
+      A2: "2", B2: "1", C2: "2",
+      A3: "3", B3: "2", C3: "1",
+      A4: "2", B4: "1", C4: "1",
+      A5: "4", B5: "1", C5: "2",
+      A6: "2", B6: "1", C6: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:C6,5,0,B1:B6,TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C16")).toEqual([
+      [1, 1, 1],
+      [2, 1, 2],
+      [2, 1, 1],
+      [4, 1, 2],
+      [2, 1, 1],
+      ["", "", ""],
+    ]);
+  });
+
+  test("Descending Sorting multiple columns specifying range", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "2", B1: "1", C1: "2",
+      A2: "3", B2: "2", C2: "1",
+      A3: "2", B3: "3", C3: "1",
+      A4: "4", B4: "2", C4: "1",
+      A5: "3", B5: "4", C5: "4",
+      A6: "4", B6: "1", C6: "2",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:C6,5,0,A1:A6,FALSE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C16")).toEqual([
+      [4, 2, 1],
+      [4, 1, 2],
+      [3, 2, 1],
+      [3, 4, 4],
+      [2, 1, 2],
+      ["", "", ""],
+    ]);
+  });
+
+  test("Sorting multiple columns specifying multiple ranges to base to sorting on", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "2", B1: "1", C1: "2",
+      A2: "3", B2: "2", C2: "1",
+      A3: "4", B3: "2", C3: "1",
+      A4: "3", B4: "4", C4: "4",
+      A5: "4", B5: "1", C5: "2",
+      A6: "2", B6: "1", C6: "1",
+    };
+    const model = createModelFromGrid(grid);
+    setCellContent(model, "A11", "=SORTN(A1:C6, 5, 0, A1:A6, FALSE, B1:B6, TRUE)");
+    expect(getRangeValuesAsMatrix(model, "A11:C16")).toEqual([
+      [4, 1, 2],
+      [4, 2, 1],
+      [3, 2, 1],
+      [3, 4, 4],
+      [2, 1, 2],
+      ["", "", ""],
+    ]);
+  });
+});

--- a/tests/functions/module_statistical.test.ts
+++ b/tests/functions/module_statistical.test.ts
@@ -1847,6 +1847,117 @@ describe.each([["QUARTILE"], ["QUARTILE.INC"], ["QUARTILE.EXC"]])("%s formula", 
   });
 });
 
+describe("RANK formula", () => {
+  test("functional tests on simple arguments with column data", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "=RANK(1, A1:A6, TRUE)",
+      A2: "3", B2: "=RANK(1, A1:A6, FALSE)",
+      A3: "1", B3: "=RANK(2, A1:A6, TRUE)",
+      A4: "2", B4: "=RANK(3, A1:A6, TRUE)",
+      A5: "4", B5: "=RANK(4, A1:A6, TRUE)",
+      A6: "3", B6: "=RANK(4, A1:A6, FALSE)",
+    };
+    expect(evaluateCell("B1", grid)).toBe(1);
+    expect(evaluateCell("B2", grid)).toBe(5);
+    expect(evaluateCell("B3", grid)).toBe(3);
+    expect(evaluateCell("B4", grid)).toBe(4);
+    expect(evaluateCell("B5", grid)).toBe(6);
+    expect(evaluateCell("B6", grid)).toBe(1);
+  });
+
+  test("functional tests on simple arguments with row data", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "3", C1: "1", D1: "2", E1: "4", F1: "3",
+      A2: "=RANK(1, A1:F1, TRUE)",
+      A3: "=RANK(1, A1:F1, FALSE)",
+      A4: "=RANK(2, A1:F1, TRUE)",
+      A5: "=RANK(3, A1:F1, TRUE)",
+      A6: "=RANK(4, A1:F1, TRUE)",
+      A7: "=RANK(4, A1:F1, FALSE)",
+    };
+    expect(evaluateCell("A2", grid)).toBe(1);
+    expect(evaluateCell("A3", grid)).toBe(5);
+    expect(evaluateCell("A4", grid)).toBe(3);
+    expect(evaluateCell("A5", grid)).toBe(4);
+    expect(evaluateCell("A6", grid)).toBe(6);
+    expect(evaluateCell("A7", grid)).toBe(1);
+  });
+
+  test("functional tests on simple arguments with matrix data", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "3", C1: "1",
+      A2: "2", B2: "4", C2: "3",
+      A3: "=RANK(1, A1:C2, TRUE)",
+      A4: "=RANK(1, A1:C2, FALSE)",
+      A5: "=RANK(2, A1:C2, TRUE)",
+      A6: "=RANK(3, A1:C2, TRUE)",
+      A7: "=RANK(4, A1:C2, TRUE)",
+      A8: "=RANK(4, A1:C2, FALSE)",
+    };
+    expect(evaluateCell("A3", grid)).toBe(1);
+    expect(evaluateCell("A4", grid)).toBe(5);
+    expect(evaluateCell("A5", grid)).toBe(3);
+    expect(evaluateCell("A6", grid)).toBe(4);
+    expect(evaluateCell("A7", grid)).toBe(6);
+    expect(evaluateCell("A8", grid)).toBe(1);
+  });
+
+  test("functional tests on simple arguments with already asc-sorted data", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "1", B1: "=RANK(1, A1:A6, TRUE)",
+      A2: "1", B2: "=RANK(1, A1:A6, FALSE)",
+      A3: "2", B3: "=RANK(2, A1:A6, TRUE)",
+      A4: "3", B4: "=RANK(3, A1:A6, TRUE)",
+      A5: "3", B5: "=RANK(4, A1:A6, TRUE)",
+      A6: "4", B6: "=RANK(4, A1:A6, FALSE)",
+    };
+    expect(evaluateCell("B1", grid)).toBe(1);
+    expect(evaluateCell("B2", grid)).toBe(5);
+    expect(evaluateCell("B3", grid)).toBe(3);
+    expect(evaluateCell("B4", grid)).toBe(4);
+    expect(evaluateCell("B5", grid)).toBe(6);
+    expect(evaluateCell("B6", grid)).toBe(1);
+  });
+
+  test("functional tests on simple arguments with already desc-sorted data", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "4", B1: "=RANK(1, A1:A6, TRUE)",
+      A2: "3", B2: "=RANK(1, A1:A6, FALSE)",
+      A3: "3", B3: "=RANK(2, A1:A6, TRUE)",
+      A4: "2", B4: "=RANK(3, A1:A6, TRUE)",
+      A5: "1", B5: "=RANK(4, A1:A6, TRUE)",
+      A6: "1", B6: "=RANK(4, A1:A6, FALSE)",
+    };
+    expect(evaluateCell("B1", grid)).toBe(1);
+    expect(evaluateCell("B2", grid)).toBe(5);
+    expect(evaluateCell("B3", grid)).toBe(3);
+    expect(evaluateCell("B4", grid)).toBe(4);
+    expect(evaluateCell("B5", grid)).toBe(6);
+    expect(evaluateCell("B6", grid)).toBe(1);
+  });
+
+  test("functional tests with value not in data", () => {
+    //prettier-ignore
+    const grid = {
+      A1: "4", B1: "=RANK(0, A1:A6, TRUE)",
+      A2: "3", B2: "=RANK(0, A1:A6, FALSE)",
+      A3: "3", B3: "=RANK(5, A1:A6, TRUE)",
+      A4: "2", B4: "=RANK(5, A1:A6, FALSE)",
+      A5: "1",
+      A6: "1",
+    };
+    expect(evaluateCell("B1", grid)).toBe("#N/A");
+    expect(evaluateCell("B2", grid)).toBe("#N/A");
+    expect(evaluateCell("B3", grid)).toBe("#N/A");
+    expect(evaluateCell("B4", grid)).toBe("#N/A");
+  });
+});
+
 describe("SMALL formula", () => {
   test("functional tests on simple arguments", () => {
     expect(evaluateCell("A1", { A1: "=SMALL()" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A


### PR DESCRIPTION
## Task Description

This PR aims to add three new functions in o-spreadsheet : RANK, SORT and SORTN. To be able to use the same comparator in SORT than in our alread-y done sorting mechanism (from the DATA > SORT menu), the already present sort algorithm has been a little bit refactored to extract the type avec value comparison part.

- [RANK](https://support.google.com/docs/answer/3094098?hl=en&sjid=3606175902086747939-EU)
- [SORT](https://support.google.com/docs/answer/3093150?hl=en&ref_topic=3105422&sjid=3606175902086747939-EU)
- [SORTN](https://support.google.com/docs/answer/7354624?hl=en&ref_topic=3105422&sjid=3606175902086747939-EU)

## Related Task
Task: : [3472980](https://www.odoo.com/web#id=3472980&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo