### PR TITLE
[IMP] formats: add more date and number formats

### DIFF
--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -88,6 +88,8 @@ export const formatNumberCurrencyRounded: ActionSpec = {
   },
 };
 
+const EXAMPLE_DATE = parseLiteral("2023/09/26 10:43:00 PM", DEFAULT_LOCALE);
+
 export const formatCustomCurrency: ActionSpec = {
   name: _t("Custom currency"),
   isVisible: (env) => env.loadCurrencies !== undefined,
@@ -96,19 +98,19 @@ export const formatCustomCurrency: ActionSpec = {
 
 export const formatNumberDate = createFormatActionSpec({
   name: _t("Date"),
-  descriptionValue: parseLiteral("9/26/2023", DEFAULT_LOCALE),
+  descriptionValue: EXAMPLE_DATE,
   format: (env) => env.model.getters.getLocale().dateFormat,
 });
 
 export const formatNumberTime = createFormatActionSpec({
   name: _t("Time"),
-  descriptionValue: parseLiteral("9/26/2023 10:43:00 PM", DEFAULT_LOCALE),
+  descriptionValue: EXAMPLE_DATE,
   format: (env) => env.model.getters.getLocale().timeFormat,
 });
 
 export const formatNumberDateTime = createFormatActionSpec({
   name: _t("Date time"),
-  descriptionValue: parseLiteral("9/26/2023 10:43:00 PM", DEFAULT_LOCALE),
+  descriptionValue: EXAMPLE_DATE,
   format: (env) => {
     const locale = env.model.getters.getLocale();
     return locale.dateFormat + " " + locale.timeFormat;
@@ -119,6 +121,53 @@ export const formatNumberDuration = createFormatActionSpec({
   name: _t("Duration"),
   descriptionValue: "27:51:38",
   format: "hhhh:mm:ss",
+});
+
+export const moreFormats: ActionSpec = {
+  name: _t("More date formats"),
+  execute: (env) => env.openSidePanel("MoreFormats", {}),
+};
+
+export const formatNumberFullDateTime = createFormatActionSpec({
+  name: _t("Full date time"),
+  format: "dddd d mmmm yyyy hh:mm:ss a",
+  descriptionValue: EXAMPLE_DATE,
+});
+
+export const formatNumberFullWeekDayAndMonth = createFormatActionSpec({
+  name: _t("Full week day and month"),
+  format: "dddd d mmmm yyyy",
+  descriptionValue: EXAMPLE_DATE,
+});
+
+export const formatNumberDayAndFullMonth = createFormatActionSpec({
+  name: _t("Day and full month"),
+  format: "d mmmm yyyy",
+  descriptionValue: EXAMPLE_DATE,
+});
+
+export const formatNumberShortWeekDay = createFormatActionSpec({
+  name: _t("Short week day"),
+  format: "ddd d mmm yyyy",
+  descriptionValue: EXAMPLE_DATE,
+});
+
+export const formatNumberDayAndShortMonth = createFormatActionSpec({
+  name: _t("Day and short month"),
+  format: "d mmm yyyy",
+  descriptionValue: EXAMPLE_DATE,
+});
+
+export const formatNumberFullMonth = createFormatActionSpec({
+  name: _t("Full month"),
+  format: "mmmm yyyy",
+  descriptionValue: EXAMPLE_DATE,
+});
+
+export const formatNumberShortMonth = createFormatActionSpec({
+  name: _t("Short month"),
+  format: "mmm yyyy",
+  descriptionValue: EXAMPLE_DATE,
 });
 
 export const incraseDecimalPlaces: ActionSpec = {

--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -16,6 +16,7 @@ import { Dimension, Format, SpreadsheetChildEnv, Style } from "../types/index";
 //------------------------------------------------------------------------------
 
 export function setFormatter(env: SpreadsheetChildEnv, format: Format) {
+  env.model.dispatch("CANCEL_EDITION");
   env.model.dispatch("SET_FORMATTING", {
     sheetId: env.model.getters.getActiveSheetId(),
     target: env.model.getters.getSelectedZones(),

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -37,6 +37,10 @@ css/* scss */ `
       cursor: pointer;
       user-select: none;
 
+      .o-menu-item-name {
+        min-width: 40%;
+      }
+
       &.o-menu-root {
         display: flex;
         justify-content: space-between;

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -29,7 +29,7 @@
                 <t t-set="description" t-value="menuItem.description(env)"/>
                 <div
                   t-if="description"
-                  class="o-menu-item-description ms-auto"
+                  class="o-menu-item-description ms-auto text-truncate"
                   t-esc="description"
                 />
                 <div

--- a/src/components/side_panel/more_formats/more_formats.ts
+++ b/src/components/side_panel/more_formats/more_formats.ts
@@ -1,0 +1,63 @@
+import { Component } from "@odoo/owl";
+import { createActions } from "../../../actions/action";
+import {
+  formatNumberDate,
+  formatNumberDateTime,
+  formatNumberDayAndFullMonth,
+  formatNumberDayAndShortMonth,
+  formatNumberDuration,
+  formatNumberFullDateTime,
+  formatNumberFullMonth,
+  formatNumberFullWeekDayAndMonth,
+  formatNumberShortMonth,
+  formatNumberShortWeekDay,
+  formatNumberTime,
+} from "../../../actions/format_actions";
+import { SpreadsheetChildEnv } from "../../../types";
+import { css } from "../../helpers";
+
+interface Props {
+  onCloseSidePanel: () => void;
+}
+
+css/* scss */ `
+  .o-more-formats-panel {
+    .format-preview {
+      height: 48px;
+      background-color: white;
+
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.08);
+      }
+    }
+    .check-icon {
+      width: 24px;
+    }
+  }
+`;
+
+const DATE_FORMAT_ACTIONS = createActions([
+  formatNumberFullDateTime,
+  formatNumberFullWeekDayAndMonth,
+  formatNumberDayAndFullMonth,
+  formatNumberShortWeekDay,
+  formatNumberDayAndShortMonth,
+  formatNumberFullMonth,
+  formatNumberShortMonth,
+  formatNumberDate,
+  formatNumberTime,
+  formatNumberDateTime,
+  formatNumberDuration,
+]);
+
+export class MoreFormatsPanel extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-MoreFormatsPanel";
+
+  get dateFormatsActions() {
+    return DATE_FORMAT_ACTIONS;
+  }
+}
+
+MoreFormatsPanel.props = {
+  onCloseSidePanel: Function,
+};

--- a/src/components/side_panel/more_formats/more_formats.xml
+++ b/src/components/side_panel/more_formats/more_formats.xml
@@ -1,0 +1,18 @@
+<templates>
+  <t t-name="o-spreadsheet-MoreFormatsPanel">
+    <div class="o-more-formats-panel">
+      <div
+        t-foreach="dateFormatsActions"
+        t-as="action"
+        t-key="action.name(env)"
+        t-att-data-name="action.name(env)"
+        t-on-click="() => action.execute(env)"
+        class="w-100 d-flex align-items-center border-bottom format-preview">
+        <span class="ms-3 check-icon">
+          <t t-if="action.isActive(env)" t-call="o-spreadsheet-Icon.CHECK"/>
+        </span>
+        <span t-out="action.description(env)"/>
+      </div>
+    </div>
+  </t>
+</templates>

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -4,6 +4,7 @@ import { parseLiteral } from "../../helpers/cells";
 import {
   colors,
   concat,
+  formatValue,
   fuzzyLookup,
   isDateTimeFormat,
   isEqual,
@@ -11,6 +12,7 @@ import {
   isNumber,
   markdownLink,
   numberToString,
+  parseDateTime,
   positionToZone,
   splitReference,
   updateSelectionOnDeletion,
@@ -505,7 +507,15 @@ export class EditionPlugin extends UIPlugin {
         return cell?.content || "";
       case CellValueType.number:
         if (format && isDateTimeFormat(format)) {
-          return formattedValue;
+          if (parseDateTime(formattedValue, locale) !== null) {
+            // formatted string can be parsed again
+            return formattedValue;
+          }
+          // display a simplified and parsable string otherwise
+          const timeFormat = Number.isInteger(value)
+            ? locale.dateFormat
+            : locale.dateFormat + " " + locale.timeFormat;
+          return formatValue(value, { locale, format: timeFormat });
         }
         return this.numberComposerContent(value, format, locale);
     }

--- a/src/registries/menus/number_format_menu_registry.ts
+++ b/src/registries/menus/number_format_menu_registry.ts
@@ -49,6 +49,10 @@ numberFormatMenuRegistry
     ...ACTION_FORMAT.formatNumberDuration,
     sequence: 100,
     separator: true,
+  })
+  .add("more_formats", {
+    ...ACTION_FORMAT.moreFormats,
+    sequence: 110,
   });
 
 export const formatNumberMenuItemSpec: ActionSpec = {

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -2,6 +2,7 @@ import { ChartPanel } from "../components/side_panel/chart/main_chart_panel/main
 import { ConditionalFormattingPanel } from "../components/side_panel/conditional_formatting/conditional_formatting";
 import { CustomCurrencyPanel } from "../components/side_panel/custom_currency/custom_currency";
 import { FindAndReplacePanel } from "../components/side_panel/find_and_replace/find_and_replace";
+import { MoreFormatsPanel } from "../components/side_panel/more_formats/more_formats";
 import { RemoveDuplicatesPanel } from "../components/side_panel/remove_duplicates/remove_duplicates";
 import { SettingsPanel } from "../components/side_panel/settings/settings_panel";
 import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns_panel/split_to_columns_panel";
@@ -59,4 +60,9 @@ sidePanelRegistry.add("RemoveDuplicates", {
 sidePanelRegistry.add("DataValidation", {
   title: _t("Data validation"),
   Body: DataValidationPanel,
+});
+
+sidePanelRegistry.add("MoreFormats", {
+  title: _t("More date formats"),
+  Body: MoreFormatsPanel,
 });

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -637,7 +637,7 @@ exports[`TopBar component can set cell format 1`] = `
               Number
             </div>
             <div
-              class="o-menu-item-description ms-auto"
+              class="o-menu-item-description ms-auto text-truncate"
             >
               1,000.12
             </div>
@@ -664,7 +664,7 @@ exports[`TopBar component can set cell format 1`] = `
               Percent
             </div>
             <div
-              class="o-menu-item-description ms-auto"
+              class="o-menu-item-description ms-auto text-truncate"
             >
               10.12%
             </div>
@@ -695,7 +695,7 @@ exports[`TopBar component can set cell format 1`] = `
               Currency
             </div>
             <div
-              class="o-menu-item-description ms-auto"
+              class="o-menu-item-description ms-auto text-truncate"
             >
               $1,000.12
             </div>
@@ -722,7 +722,7 @@ exports[`TopBar component can set cell format 1`] = `
               Currency rounded
             </div>
             <div
-              class="o-menu-item-description ms-auto"
+              class="o-menu-item-description ms-auto text-truncate"
             >
               $1,000
             </div>
@@ -775,7 +775,7 @@ exports[`TopBar component can set cell format 1`] = `
               Date
             </div>
             <div
-              class="o-menu-item-description ms-auto"
+              class="o-menu-item-description ms-auto text-truncate"
             >
               9/26/2023
             </div>
@@ -802,7 +802,7 @@ exports[`TopBar component can set cell format 1`] = `
               Time
             </div>
             <div
-              class="o-menu-item-description ms-auto"
+              class="o-menu-item-description ms-auto text-truncate"
             >
               10:43:00 PM
             </div>
@@ -829,7 +829,7 @@ exports[`TopBar component can set cell format 1`] = `
               Date time
             </div>
             <div
-              class="o-menu-item-description ms-auto"
+              class="o-menu-item-description ms-auto text-truncate"
             >
               9/26/2023 10:43:00 PM
             </div>
@@ -856,7 +856,7 @@ exports[`TopBar component can set cell format 1`] = `
               Duration
             </div>
             <div
-              class="o-menu-item-description ms-auto"
+              class="o-menu-item-description ms-auto text-truncate"
             >
               27:51:38
             </div>

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -864,6 +864,32 @@ exports[`TopBar component can set cell format 1`] = `
             
           </div>
         </div>
+        <div
+          class="o-separator"
+        />
+        
+        
+        <div
+          class="o-menu-item"
+          data-name="more_formats"
+          title="More date formats"
+        >
+          <div
+            class="d-flex w-100"
+          >
+            <div
+              class="o-menu-item-icon align-middle"
+            />
+            
+            <div
+              class="o-menu-item-name align-middle text-truncate"
+            >
+              More date formats
+            </div>
+            
+            
+          </div>
+        </div>
         
       </div>
       

--- a/tests/composer/edition_plugin.test.ts
+++ b/tests/composer/edition_plugin.test.ts
@@ -822,6 +822,24 @@ describe("edition", () => {
     expect(model.getters.getCurrentContent()).toBe("12:00:00 AM");
   });
 
+  test("non-parsable date format displays a simplified and parsable value", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setFormat(model, "dddd d mmmm yyyy", target("A1"));
+    expect(getEvaluatedCell(model, "A1").formattedValue).toBe("Sunday 31 December 1899");
+    expect(model.getters.getCurrentContent()).toBe("12/31/1899");
+  });
+
+  test("non-parsable date time format displays a simplified and parsable value", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1.5");
+    setFormat(model, "dddd d mmmm yyyy hh:mm:ss a", target("A1"));
+    expect(getEvaluatedCell(model, "A1").formattedValue).toBe(
+      "Sunday 31 December 1899 12:00:00 PM"
+    );
+    expect(model.getters.getCurrentContent()).toBe("12/31/1899 12:00:00 PM");
+  });
+
   test("write too long formulas raises an error", async () => {
     const model = new Model({});
     const spyNotify = jest.spyOn(model["config"], "raiseBlockingErrorUI");

--- a/tests/formats/more_formats_side_panel.test.ts
+++ b/tests/formats/more_formats_side_panel.test.ts
@@ -1,0 +1,40 @@
+import { Model } from "../../src";
+import { MoreFormatsPanel } from "../../src/components/side_panel/more_formats/more_formats";
+import { SpreadsheetChildEnv } from "../../src/types";
+import { setFormat } from "../test_helpers/commands_helpers";
+import { simulateClick } from "../test_helpers/dom_helper";
+import { getCell } from "../test_helpers/getters_helpers";
+import { mountComponent } from "../test_helpers/helpers";
+
+describe("more formats side panel component", () => {
+  let model: Model;
+  let fixture: HTMLElement;
+
+  async function mountFormatPanel(modelArg?: Model, env?: SpreadsheetChildEnv) {
+    model = modelArg ?? new Model();
+    ({ fixture } = await mountComponent(MoreFormatsPanel, {
+      model,
+      props: { onCloseSidePanel: () => {} },
+      env,
+    }));
+  }
+
+  test("can set format", async () => {
+    await mountFormatPanel();
+    const button = fixture.querySelector('div[data-name="Full week day and month"]');
+    expect(fixture.querySelectorAll(".check-icon svg")).toHaveLength(0);
+    await simulateClick(button);
+    expect(getCell(model, "A1")?.format).toEqual("dddd d mmmm yyyy");
+    expect(fixture.querySelectorAll(".check-icon svg")).toHaveLength(1);
+    expect(button?.querySelector(".check-icon svg")).toBeTruthy();
+  });
+
+  test("format is active when mounting panel", async () => {
+    const model = new Model();
+    setFormat(model, "dddd d mmmm yyyy");
+    await mountFormatPanel(model);
+    const button = fixture.querySelector('div[data-name="Full week day and month"]');
+    expect(fixture.querySelectorAll(".check-icon svg")).toHaveLength(1);
+    expect(button?.querySelector(".check-icon svg")).toBeTruthy();
+  });
+});

--- a/tests/menus/__snapshots__/context_menu_comonent.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_comonent.test.ts.snap
@@ -32,7 +32,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
         Cut
       </div>
       <div
-        class="o-menu-item-description ms-auto"
+        class="o-menu-item-description ms-auto text-truncate"
       >
         Ctrl+X
       </div>
@@ -68,7 +68,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
         Copy
       </div>
       <div
-        class="o-menu-item-description ms-auto"
+        class="o-menu-item-description ms-auto text-truncate"
       >
         Ctrl+C
       </div>
@@ -104,7 +104,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
         Paste
       </div>
       <div
-        class="o-menu-item-description ms-auto"
+        class="o-menu-item-description ms-auto text-truncate"
       >
         Ctrl+V
       </div>

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -1063,6 +1063,14 @@ describe("Menu Item actions", () => {
       expect(setAutoFormatAction.isActive?.(env)).toBe(true);
       expect(setNumberFormatAction.isActive?.(env)).toBe(false);
     });
+
+    test("cancel edition when setting a format", () => {
+      model.dispatch("START_EDITION", { text: "hello" });
+      expect(model.getters.getEditionMode()).toBe("editing");
+      doAction(["format", "format_number", "format_number_percent"], env);
+      expect(model.getters.getEditionMode()).toBe("inactive");
+      expect(getCellContent(model, "A1")).toBe("");
+    });
   });
 
   test("Format -> bold", () => {


### PR DESCRIPTION
## Description:

We support many formats but some are actually not available from the UI.

As an example, the format `d mmmm yyyy` to display '21 September 2023' is
already supported, but cannot be used because there's no button or menu
to set this format.

This commits add a side panel allowing to use some of those formats.

Task: : [3515610](https://www.odoo.com/web#id=3515610&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo