### PR TITLE
[FIX] Charts: fix incoherent panel state

### DIFF
--- a/src/helpers/charts/chart_common.ts
+++ b/src/helpers/charts/chart_common.ts
@@ -182,13 +182,8 @@ export function createDataSets(
           )
         );
       }
-    } else if (zone.left === zone.right && zone.top === zone.bottom) {
-      // A single cell. If it's only the title, the dataset is not added.
-      if (!dataSetsHaveTitle) {
-        dataSets.push(createDataSet(getters, dataSetSheetId, zone, undefined));
-      }
     } else {
-      /* 1 row or 1 column */
+      /* 1 cell, 1 row or 1 column */
       dataSets.push(
         createDataSet(
           getters,

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -1259,6 +1259,53 @@ describe("figures", () => {
       await simulateClick(".o-menu div[data-name='edit']");
       expect(document.querySelector("input[name='labelsAsText']")).toBeFalsy();
     });
+
+    test("Side panel correctly reacts to has_header checkbox check/uncheck (with only one point)", async () => {
+      createTestChart("basicChart");
+      updateChart(model, chartId, { type: "line", labelRange: "C2", dataSets: ["A1"] });
+      await nextTick();
+      await simulateClick(".o-figure");
+      await simulateClick(".o-chart-menu-item");
+      await simulateClick(".o-menu div[data-name='edit']");
+
+      const checkbox = document.querySelector("input[name='labelsAsText']") as HTMLInputElement;
+      expect(checkbox.checked).toBe(false);
+
+      await simulateClick(checkbox);
+      expect(checkbox.checked).toBe(true);
+    });
+
+    test("Side panel correctly reacts to has_header checkbox check/uncheck (with two datasets)", async () => {
+      createTestChart("basicChart");
+      updateChart(model, chartId, { type: "line", labelRange: "C2", dataSets: ["A1:A2", "A1"] });
+      await nextTick();
+      await simulateClick(".o-figure");
+      await simulateClick(".o-chart-menu-item");
+      await simulateClick(".o-menu div[data-name='edit']");
+
+      const checkbox = document.querySelector("input[name='labelsAsText']") as HTMLInputElement;
+      expect(checkbox.checked).toBe(false);
+
+      expect(checkbox.checked).toBe(false);
+      expect((model.getters.getChartDefinition(chartId) as LineChartDefinition).dataSets).toEqual([
+        "A1:A2",
+        "A1",
+      ]);
+
+      await simulateClick(checkbox);
+      expect(checkbox.checked).toBe(true);
+      expect((model.getters.getChartDefinition(chartId) as LineChartDefinition).dataSets).toEqual([
+        "A1:A2",
+        "A1",
+      ]);
+
+      await simulateClick(checkbox);
+      expect(checkbox.checked).toBe(false);
+      expect((model.getters.getChartDefinition(chartId) as LineChartDefinition).dataSets).toEqual([
+        "A1:A2",
+        "A1",
+      ]);
+    });
   });
 });
 

--- a/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
+++ b/tests/plugins/chart/__snapshots__/basic_chart.test.ts.snap
@@ -741,7 +741,21 @@ Object {
   "background": "#FFFFFF",
   "chartJsConfig": Object {
     "data": Object {
-      "datasets": Array [],
+      "datasets": Array [
+        Object {
+          "backgroundColor": "#1F77B4",
+          "borderColor": "rgb(31,119,180)",
+          "data": Array [
+            undefined,
+            undefined,
+            undefined,
+          ],
+          "fill": false,
+          "label": "30",
+          "lineTension": 0,
+          "pointBackgroundColor": "rgb(31,119,180)",
+        },
+      ],
       "labels": Array [
         "P4",
         "P5",

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -197,7 +197,7 @@ describe("datasource tests", function () {
       "1"
     );
     expect(model.getters.getChartDefinition("1")).toMatchObject({
-      dataSets: [],
+      dataSets: ["B8"],
       labelRange: "Sheet1!B7:D7",
       title: "test",
       type: "line",
@@ -540,7 +540,8 @@ describe("datasource tests", function () {
     );
     deleteRows(model, [1, 2, 3, 4]);
     const chart = (model.getters.getChartRuntime("1") as LineChartRuntime).chartJsConfig;
-    expect(chart.data!.datasets).toHaveLength(0);
+    expect(chart.data!.datasets?.[0].data).toHaveLength(0);
+    expect(chart.data!.datasets?.[1].data).toHaveLength(0);
     expect(chart.data!.labels).toEqual([]);
   });
 


### PR DESCRIPTION
## Description:

This task aims to address some issues in the side panel of a chart:
1. When having only one point in a dataseries and selecting "First
row as header", the point disappear from the chart (legit), but
we don't have the possibility to uncheck this checkbox.
2. When having a normal dataset and another dataset containing one
point, checking the "... as header" checkbox works has expected, but
unchecking it don't make the 'one-point' dataset come back

Related Task:

Task: 3380568
## Related Task(s):
- Task: [3380568](https://www.odoo.com/web#id=3380568&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo