### PR TITLE
[FIX] Find & Replace: Clear search debounce at unmount

### DIFF
--- a/tests/components/find_replace_side_panel.test.ts
+++ b/tests/components/find_replace_side_panel.test.ts
@@ -1,6 +1,10 @@
 import { Model, Spreadsheet } from "../../src";
 import { setCellContent } from "../test_helpers/commands_helpers";
-import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_helper";
+import {
+  setInputValueAndTrigger,
+  simulateClick,
+  triggerMouseEvent,
+} from "../test_helpers/dom_helper";
 import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
 jest.mock("../../src/helpers/uuid", () => require("../__mocks__/uuid"));
 
@@ -126,6 +130,14 @@ describe("find and replace sidePanel component", () => {
         searchOptions: { exactMatch: false, matchCase: false, searchFormulas: false },
         toSearch: "",
       });
+    });
+
+    test("Closing the sidepanel cancels the search", async () => {
+      setInputValueAndTrigger(selectors.inputSearch, "g", "input");
+      await simulateClick(".o-sidePanelClose");
+      jest.runOnlyPendingTimers();
+      await nextTick();
+      expect(dispatch).not.toHaveBeenCalledWith("UPDATE_SEARCH", expect.any(Object));
     });
   });
 


### PR DESCRIPTION
If a user were to quickly chain an input in the search input and then close the sidepanel, the search would be triggered after the closing of the side panel (200 ms of lag) and the user would see the search results highlighted without understanding what is going on. The proper fix will be applied in previous versions.

This commit reintroduces a manual timeout (rev of 4123fd1b) to clear it up at unmount.

Task: /

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo