### PR TITLE
[FIX] spreadsheet_edition: fixes image export in .xlsx

### DIFF
--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,82 +1,8 @@
-import { Component } from "@odoo/owl";
-import { DEFAULT_FONT } from "../../../../constants";
-import { getFontSizeMatchingWidth, relativeLuminance } from "../../../../helpers";
-import { Color, Figure, Pixel, SpreadsheetChildEnv, Style } from "../../../../types";
+import { Component, onMounted, onPatched, useRef } from "@odoo/owl";
+import { deepEquals } from "../../../../helpers";
+import { ScorecardChartDrawer } from "../../../../helpers/figures/charts/scorecard_chart";
+import { Figure, SpreadsheetChildEnv } from "../../../../types";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
-import { cellTextStyleToCss, cssPropertiesToCss } from "../../../helpers";
-import { css } from "../../../helpers/css";
-
-/* Sizes of boxes containing the texts, in percentage of the Chart size */
-const TITLE_FONT_SIZE = 18;
-
-const BASELINE_BOX_HEIGHT_RATIO = 0.35;
-const KEY_BOX_HEIGHT_RATIO = 0.65;
-
-/** Baseline description should have a smaller font than the baseline */
-const BASELINE_DESCR_FONT_RATIO = 0.9;
-
-/* Padding at the border of the chart, in percentage of the chart width */
-const CHART_PADDING_RATIO = 0.02;
-
-/**
- * Line height (in em)
- * Having a line heigh =1em (=font size) don't work, the font will overflow.
- */
-const LINE_HEIGHT = 1.2;
-
-css/* scss */ `
-  div.o-scorecard {
-    font-family: ${DEFAULT_FONT};
-    user-select: none;
-    background-color: white;
-    display: flex;
-    flex-direction: column;
-    box-sizing: border-box;
-
-    .o-scorecard-content {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-      justify-content: center;
-      text-align: center;
-    }
-
-    .o-title-text {
-      text-align: left;
-      height: ${LINE_HEIGHT + "em"};
-      line-height: ${LINE_HEIGHT + "em"};
-      overflow: hidden;
-      white-space: nowrap;
-    }
-
-    .o-key-text {
-      line-height: ${LINE_HEIGHT + "em"};
-      height: ${LINE_HEIGHT + "em"};
-      overflow: hidden;
-      white-space: nowrap;
-    }
-
-    .o-cf-icon {
-      display: inline-block;
-      width: 0.65em;
-      height: 1em;
-      line-height: 1em;
-      padding-bottom: 0.07em;
-      padding-right: 3px;
-    }
-
-    .o-baseline-text {
-      line-height: ${LINE_HEIGHT + "em"};
-      height: ${LINE_HEIGHT + "em"};
-      overflow: hidden;
-      white-space: nowrap;
-
-      .o-baseline-text-description {
-        white-space: pre;
-      }
-    }
-  }
-`;
 
 interface Props {
   figure: Figure;
@@ -84,190 +10,44 @@ interface Props {
 
 export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChart";
-  private ctx = document.createElement("canvas").getContext("2d")!;
+  private canvas = useRef("graphContainer");
 
   get runtime(): ScorecardChartRuntime {
     return this.env.model.getters.getChartRuntime(this.props.figure.id) as ScorecardChartRuntime;
   }
 
-  get title() {
-    return this.runtime.title;
-  }
+  setup() {
+    onMounted(() => {
+      this.createChart();
+    });
 
-  get keyValue() {
-    return this.runtime.keyValue;
-  }
-
-  get baseline() {
-    return this.runtime.baselineDisplay;
-  }
-
-  get baselineDescr() {
-    const baselineDescr = this.runtime.baselineDescr || "";
-    return this.baseline && baselineDescr ? " " + baselineDescr : baselineDescr;
-  }
-
-  get baselineArrowDirection() {
-    return this.runtime.baselineArrow;
-  }
-
-  get backgroundColor() {
-    return this.runtime.background;
-  }
-
-  get primaryFontColor() {
-    return this.runtime.fontColor;
-  }
-
-  get secondaryFontColor() {
-    return relativeLuminance(this.backgroundColor) > 0.3 ? "#525252" : "#C8C8C8";
-  }
-
-  get figure() {
-    return this.props.figure;
-  }
-
-  get chartStyle() {
-    return cssPropertiesToCss({
-      padding: `${this.chartPadding}px`,
-      background: this.backgroundColor,
+    let previousRuntime = this.runtime;
+    let previousWidth = this.props.figure.width;
+    let previousHeight = this.props.figure.height;
+    onPatched(() => {
+      const runtime = this.runtime;
+      const figure = this.props.figure;
+      if (
+        deepEquals(runtime, previousRuntime) &&
+        previousHeight === figure.height &&
+        previousWidth === figure.width
+      ) {
+        return;
+      }
+      this.createChart();
+      previousRuntime = runtime;
+      previousHeight = figure.height;
+      previousWidth = figure.width;
     });
   }
 
-  get chartContentStyle() {
-    return cssPropertiesToCss({ height: `${this.getDrawableHeight()}px` });
-  }
-
-  get chartPadding() {
-    return this.props.figure.width * CHART_PADDING_RATIO;
-  }
-
-  getTextStyles() {
-    // If the widest text overflows horizontally, scale it down, and apply the same scaling factors to all the other fonts.
-    const maxLineWidth = this.props.figure.width * (1 - 2 * CHART_PADDING_RATIO);
-    const widestElement = this.getWidestElement();
-    const baseFontSize = widestElement.getElementMaxFontSize(this.getDrawableHeight(), this);
-    const fontSizeMatchingWidth = getFontSizeMatchingWidth(
-      maxLineWidth,
-      baseFontSize,
-      (fontSize: number) => widestElement.getElementWidth(fontSize, this.ctx, this)
+  private createChart() {
+    const drawer = new ScorecardChartDrawer(
+      this.props,
+      this.canvas.el as HTMLCanvasElement,
+      this.runtime
     );
-    let scalingFactor = fontSizeMatchingWidth / baseFontSize;
-
-    // Fonts sizes in px
-    const keyFontSize =
-      new KeyValueElement().getElementMaxFontSize(this.getDrawableHeight(), this) * scalingFactor;
-    const baselineFontSize =
-      new BaselineElement().getElementMaxFontSize(this.getDrawableHeight(), this) * scalingFactor;
-
-    return {
-      titleStyle: this.getTextStyle({
-        fontSize: TITLE_FONT_SIZE,
-        color: this.secondaryFontColor,
-      }),
-      keyStyle: this.getTextStyle({
-        fontSize: keyFontSize,
-        cellStyle: this.runtime.keyValueStyle,
-        color: this.primaryFontColor,
-      }),
-      baselineStyle: this.getTextStyle({
-        fontSize: baselineFontSize,
-      }),
-      baselineValueStyle: this.getTextStyle({
-        fontSize: baselineFontSize,
-        cellStyle: this.runtime.baselineStyle,
-        color: this.runtime.baselineColor || this.secondaryFontColor,
-      }),
-      baselineDescrStyle: this.getTextStyle({
-        fontSize: baselineFontSize * BASELINE_DESCR_FONT_RATIO,
-        color: this.secondaryFontColor,
-      }),
-    };
-  }
-
-  /** Return an CSS style string corresponding to the given arguments */
-  private getTextStyle(args: { fontSize: number; color?: Color; cellStyle?: Style }) {
-    const cssAttributes = cellTextStyleToCss(args.cellStyle);
-    cssAttributes["font-size"] = `${args.fontSize}px`;
-    cssAttributes["display"] = "inline-block";
-    if (!cssAttributes["color"] && args.color) {
-      cssAttributes["color"] = args.color;
-    }
-
-    return cssPropertiesToCss(cssAttributes);
-  }
-
-  /** Get the height of the chart minus all the vertical paddings */
-  private getDrawableHeight(): number {
-    const verticalPadding = 2 * this.chartPadding;
-    let availableHeight = this.props.figure.height - verticalPadding;
-    availableHeight -= this.title ? TITLE_FONT_SIZE * LINE_HEIGHT : 0;
-    return availableHeight;
-  }
-
-  /** Return the element with he widest text in the chart */
-  private getWidestElement(): ScorecardScalableElement {
-    const baseline = new BaselineElement();
-    const keyValue = new KeyValueElement();
-
-    return baseline.getElementWidth(BASELINE_BOX_HEIGHT_RATIO, this.ctx, this) >
-      keyValue.getElementWidth(KEY_BOX_HEIGHT_RATIO, this.ctx, this)
-      ? baseline
-      : keyValue;
-  }
-}
-
-interface ScorecardScalableElement {
-  /** Return the width of an scorecard element in pixels */
-  getElementWidth: (
-    fontSize: number,
-    ctx: CanvasRenderingContext2D,
-    chart: ScorecardChart
-  ) => Pixel;
-
-  /**
-   * Get the maximal height of an element of the scorecard.
-   *
-   * This is computed such as all the height is taken by the elements, even if there is no title or baseline.
-   */
-  getElementMaxFontSize: (availableHeight: Pixel, chart: ScorecardChart) => number;
-}
-
-class BaselineElement implements ScorecardScalableElement {
-  getElementWidth(fontSize: number, ctx: CanvasRenderingContext2D, chart: ScorecardChart): Pixel {
-    if (!chart.runtime) return 0;
-    const baselineStr = chart.baseline;
-    // Put mock text to simulate the width of the up/down arrow
-    const largeText = chart.baselineArrowDirection !== "neutral" ? "A " + baselineStr : baselineStr;
-    ctx.font = `${fontSize}px ${DEFAULT_FONT}`;
-    let textWidth = ctx.measureText(largeText).width;
-    // Baseline descr font size should be smaller than baseline font size
-    ctx.font = `${fontSize * BASELINE_DESCR_FONT_RATIO}px ${DEFAULT_FONT}`;
-    textWidth += ctx.measureText(chart.baselineDescr).width;
-    return textWidth;
-  }
-
-  getElementMaxFontSize(availableHeight: Pixel, chart: ScorecardChart): number {
-    if (!chart.runtime) return 0;
-    const haveBaseline = chart.baseline !== "" || chart.baselineDescr;
-    const maxHeight = haveBaseline ? BASELINE_BOX_HEIGHT_RATIO * availableHeight : 0;
-    return maxHeight / LINE_HEIGHT;
-  }
-}
-
-class KeyValueElement implements ScorecardScalableElement {
-  getElementWidth(fontSize: number, ctx: CanvasRenderingContext2D, chart: ScorecardChart): Pixel {
-    if (!chart.runtime) return 0;
-    const str = chart.keyValue || "";
-    ctx.font = `${fontSize}px ${DEFAULT_FONT}`;
-    return ctx.measureText(str).width;
-  }
-
-  getElementMaxFontSize(availableHeight: Pixel, chart: ScorecardChart): number {
-    if (!chart.runtime) return 0;
-    const haveBaseline = chart.baseline !== "" || chart.baselineDescr;
-    const maxHeight = haveBaseline ? KEY_BOX_HEIGHT_RATIO * availableHeight : availableHeight;
-    return maxHeight / LINE_HEIGHT;
+    drawer.drawChart();
   }
 }
 

--- a/src/components/figures/chart/scorecard/chart_scorecard.xml
+++ b/src/components/figures/chart/scorecard/chart_scorecard.xml
@@ -1,33 +1,5 @@
 <templates>
   <t t-name="o-spreadsheet-ScorecardChart" owl="1">
-    <div class="o-scorecard w-100 h-100" t-att-style="chartStyle" t-ref="chart">
-      <t t-set="textStyles" t-value="getTextStyles()"/>
-      <div t-if="title" class="o-title-text" t-esc="title" t-att-style="textStyles.titleStyle"/>
-      <div class="o-scorecard-content" t-att-style="chartContentStyle">
-        <div class="o-key-text" t-if="keyValue" t-esc="keyValue" t-att-style="textStyles.keyStyle"/>
-        <t t-if="baseline || baselineDescr">
-          <div class="o-baseline-text" t-att-style="textStyles.baselineStyle">
-            <t t-if="baseline">
-              <t t-if="baselineArrowDirection === 'up'">
-                <t t-call="o-spreadsheet-Icon.ARROW_UP">
-                  <t t-set="color" t-value="'fill : ' + runtime.baselineColor"/>
-                </t>
-              </t>
-              <t t-if="baselineArrowDirection === 'down'">
-                <t t-call="o-spreadsheet-Icon.ARROW_DOWN">
-                  <t t-set="color" t-value="'fill : ' + runtime.baselineColor"/>
-                </t>
-              </t>
-              <span t-att-style="textStyles.baselineValueStyle" class="o-baseline-text-value">
-                <t t-esc="baseline"/>
-              </span>
-            </t>
-            <span t-att-style="textStyles.baselineDescrStyle" class="o-baseline-text-description">
-              <t t-esc="env._t(baselineDescr)"/>
-            </span>
-          </div>
-        </t>
-      </div>
-    </div>
+    <canvas class="o-figure-canvas w-100 h-100" t-att-style="canvasStyle" t-ref="graphContainer"/>
   </t>
 </templates>

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -2,8 +2,8 @@ import { ChartConfiguration } from "chart.js";
 import { ChartTerms } from "../../../components/translations_terms";
 import { MAX_CHAR_LABEL } from "../../../constants";
 import { _t } from "../../../translation";
-import { Color, Format, Getters, Range } from "../../../types";
-import { DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
+import { Color, Figure, Format, Getters, Range } from "../../../types";
+import { ChartRuntime, DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
 import { formatValue, isDateTimeFormat } from "../../format";
 import { range } from "../../misc";
 import { recomputeZones, zoneToXc } from "../../zones";
@@ -251,3 +251,35 @@ export function getFillingMode(index: number): "origin" | number {
     return index - 1;
   }
 }
+
+export function chartToImage(runtime: ChartRuntime, figure: Figure) {
+  // wrap the canvas in a div with a fixed size because chart.js would
+  // fill the whole page otherwise
+  const div = document.createElement("div");
+  div.style.width = `${figure.width}px`;
+  div.style.height = `${figure.height}px`;
+  const canvas = document.createElement("canvas");
+  div.append(canvas);
+  canvas.setAttribute("width", figure.width.toString());
+  canvas.setAttribute("height", figure.height.toString());
+  // we have to add the canvas to the DOM otherwise it won't be rendered
+  document.body.append(div);
+  runtime.chartJsConfig.plugins = [backgroundColorPlugin];
+  const chart = new window.Chart(canvas, runtime.chartJsConfig);
+  const img = chart.toBase64Image();
+  chart.destroy();
+  div.remove();
+  return img;
+}
+
+const backgroundColorPlugin = {
+  id: "customCanvasBackgroundColor",
+  beforeDraw: (chart, args, options) => {
+    const { ctx } = chart;
+    ctx.save();
+    ctx.globalCompositeOperation = "destination-over";
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, chart.width, chart.height);
+    ctx.restore();
+  },
+};

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -8,6 +8,7 @@ import { formatValue, isDateTimeFormat } from "../../format";
 import { range } from "../../misc";
 import { recomputeZones, zoneToXc } from "../../zones";
 import { AbstractChart } from "./abstract_chart";
+import { ScorecardChartDrawer } from "./scorecard_chart";
 /**
  * This file contains helpers that are common to different runtime charts (mainly
  * line, bar and pie charts)
@@ -252,7 +253,7 @@ export function getFillingMode(index: number): "origin" | number {
   }
 }
 
-export function chartToImage(runtime: ChartRuntime, figure: Figure) {
+export function chartToImage(runtime: ChartRuntime, figure: Figure, type: string) {
   // wrap the canvas in a div with a fixed size because chart.js would
   // fill the whole page otherwise
   const div = document.createElement("div");
@@ -264,12 +265,21 @@ export function chartToImage(runtime: ChartRuntime, figure: Figure) {
   canvas.setAttribute("height", figure.height.toString());
   // we have to add the canvas to the DOM otherwise it won't be rendered
   document.body.append(div);
-  runtime.chartJsConfig.plugins = [backgroundColorPlugin];
-  const chart = new window.Chart(canvas, runtime.chartJsConfig);
-  const img = chart.toBase64Image();
-  chart.destroy();
-  div.remove();
-  return img;
+  if ("chartJsConfig" in runtime) {
+    runtime.chartJsConfig.plugins = [backgroundColorPlugin];
+    const chart = new window.Chart(canvas, runtime.chartJsConfig);
+    const img = chart.toBase64Image();
+    chart.destroy();
+    div.remove();
+    return img;
+  } else if (type === "scorecard") {
+    const drawer = new ScorecardChartDrawer({ figure }, canvas, runtime);
+    drawer.drawChart();
+    const img = canvas.toDataURL();
+    div.remove();
+    return img;
+  }
+  return "";
 }
 
 const backgroundColorPlugin = {

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -37,6 +37,7 @@ import {
   getBaselineColor,
   getBaselineText,
 } from "./chart_common";
+import { getDefaultChartJsRuntime } from "./chart_ui_common";
 
 function checkKeyValue(definition: ScorecardChartDefinition): CommandResult {
   return definition.keyValue && !rangeReference.test(definition.keyValue)
@@ -205,6 +206,7 @@ export function createScorecardChartRuntime(
     baselineCell = getters.getEvaluatedCell(baselinePosition);
   }
   const background = getters.getBackgroundOfSingleCellChart(chart.background, chart.keyValue);
+  const fontColor = chartFontColor(background);
   return {
     title: _t(chart.title),
     keyValue: formattedKeyValue || keyValue,
@@ -218,7 +220,7 @@ export function createScorecardChartRuntime(
       chart.baselineColorDown
     ),
     baselineDescr: chart.baselineDescr ? _t(chart.baselineDescr) : "",
-    fontColor: chartFontColor(background),
+    fontColor,
     background,
     baselineStyle:
       chart.baselineMode !== "percentage" && baseline
@@ -235,5 +237,6 @@ export function createScorecardChartRuntime(
           row: chart.keyValue.zone.top,
         })
       : undefined,
+    chartJsConfig: getDefaultChartJsRuntime(chart, [], fontColor, ""),
   };
 }

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -1,5 +1,7 @@
 import { transformZone } from "../../../collaborative/ot/ot_helpers";
+import { cssPropertiesToCss } from "../../../components/helpers";
 import {
+  DEFAULT_FONT,
   DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
   DEFAULT_SCORECARD_BASELINE_COLOR_UP,
   DEFAULT_SCORECARD_BASELINE_MODE,
@@ -12,7 +14,10 @@ import {
   CommandResult,
   CoreGetters,
   EvaluatedCell,
+  Figure,
   Getters,
+  Pixel,
+  PixelPosition,
   Range,
   RemoveColumnsRowsCommand,
   UID,
@@ -25,6 +30,8 @@ import {
   ScorecardChartRuntime,
 } from "../../../types/chart/scorecard_chart";
 import { Validator } from "../../../types/validator";
+import { relativeLuminance } from "../../color";
+import { getFontSizeMatchingWidth } from "../../misc";
 import { createRange } from "../../range";
 import { rangeReference } from "../../references";
 import { toUnboundedZone, zoneToXc } from "../../zones";
@@ -37,7 +44,6 @@ import {
   getBaselineColor,
   getBaselineText,
 } from "./chart_common";
-import { getDefaultChartJsRuntime } from "./chart_ui_common";
 
 function checkKeyValue(definition: ScorecardChartDefinition): CommandResult {
   return definition.keyValue && !rangeReference.test(definition.keyValue)
@@ -50,6 +56,55 @@ function checkBaseline(definition: ScorecardChartDefinition): CommandResult {
     ? CommandResult.InvalidScorecardBaseline
     : CommandResult.Success;
 }
+
+/* Sizes of boxes containing the texts, in percentage of the Chart size */
+const TITLE_FONT_SIZE = 18;
+
+const BASELINE_BOX_HEIGHT_RATIO = 0.35;
+const KEY_BOX_HEIGHT_RATIO = 0.65;
+
+/** Baseline description should have a smaller font than the baseline */
+const BASELINE_DESCR_FONT_RATIO = 0.9;
+
+/* Padding at the border of the chart, in percentage of the chart width */
+const CHART_PADDING_RATIO = 0.02;
+
+/**
+ * Line height (in em)
+ * Having a line heigh =1em (=font size) don't work, the font will overflow.
+ */
+const LINE_HEIGHT = 1.2;
+
+type ScorecardChartDesignElement = {
+  text: string;
+  style: {
+    font: string;
+    color: Color;
+    strikethrough?: {
+      from: PixelPosition;
+      to: PixelPosition;
+    };
+    underline?: {
+      from: PixelPosition;
+      to: PixelPosition;
+    };
+    lineWidth?: number;
+  };
+  position: PixelPosition;
+};
+
+export type ScorecardChartDesign = {
+  canvas: {
+    width: number;
+    height: number;
+    backgroundColor: Color;
+  };
+  title: ScorecardChartDesignElement;
+  baselineArrow: ScorecardChartDesignElement;
+  baseline: ScorecardChartDesignElement;
+  baselineDescr: ScorecardChartDesignElement;
+  key: ScorecardChartDesignElement;
+};
 
 export class ScorecardChart extends AbstractChart {
   readonly keyValue?: Range;
@@ -178,6 +233,470 @@ export class ScorecardChart extends AbstractChart {
   }
 }
 
+export function formatBaselineDescr(
+  baselineDescr: string | undefined,
+  baseline: string | undefined
+): string {
+  const _baselineDescr = baselineDescr || "";
+  return baseline && _baselineDescr ? " " + _baselineDescr : _baselineDescr;
+}
+
+export class ScorecardChartDrawer {
+  ctx = document.createElement("canvas").getContext("2d")!;
+  constructor(
+    private props: { figure: Figure },
+    private canvas: HTMLCanvasElement,
+    readonly runtime: ScorecardChartRuntime
+  ) {}
+
+  drawChart() {
+    const structure = this.computeChart();
+    const canvas = this.canvas;
+    const ctx = canvas.getContext("2d")!;
+    // Background
+    ctx.fillStyle = structure.canvas.backgroundColor;
+    ctx.fillRect(0, 0, structure.canvas.width, structure.canvas.height);
+
+    // Title
+    if (structure.title) {
+      ctx.font = structure.title.style.font;
+      ctx.fillStyle = structure.title.style.color;
+      ctx.fillText(structure.title.text, structure.title.position.x, structure.title.position.y);
+    }
+
+    // Baseline
+    if (structure.baseline) {
+      ctx.font = structure.baseline.style.font;
+      ctx.fillStyle = structure.baseline.style.color;
+      ctx.fillText(
+        structure.baseline.text,
+        structure.baseline.position.x,
+        structure.baseline.position.y
+      );
+      if (structure.baseline.style?.strikethrough) {
+        ctx.lineWidth = structure.baseline.style.lineWidth ?? 1;
+        ctx.strokeStyle = structure.baseline.style.color;
+        ctx.beginPath();
+        ctx.moveTo(
+          structure.baseline.style.strikethrough.from.x,
+          structure.baseline.style.strikethrough.from.y
+        );
+        ctx.lineTo(
+          structure.baseline.style.strikethrough.to.x,
+          structure.baseline.style.strikethrough.to.y
+        );
+        ctx.stroke();
+      }
+      if (structure.baseline.style?.underline) {
+        ctx.lineWidth = structure.baseline.style.lineWidth ?? 1;
+        ctx.strokeStyle = structure.baseline.style.color;
+        ctx.beginPath();
+        ctx.moveTo(
+          structure.baseline.style.underline.from.x,
+          structure.baseline.style.underline.from.y
+        );
+        ctx.lineTo(
+          structure.baseline.style.underline.to.x,
+          structure.baseline.style.underline.to.y
+        );
+        ctx.stroke();
+      }
+    }
+
+    // Baseline arrow
+    if (structure.baselineArrow) {
+      ctx.font = structure.baselineArrow.style.font;
+      ctx.fillStyle = structure.baselineArrow.style.color;
+      ctx.fillText(
+        structure.baselineArrow.text,
+        structure.baselineArrow.position.x,
+        structure.baselineArrow.position.y
+      );
+    }
+
+    // Baseline description
+    if (structure.baselineDescr) {
+      ctx.font = structure.baselineDescr.style.font;
+      ctx.fillStyle = structure.baselineDescr.style.color;
+      ctx.fillText(
+        structure.baselineDescr.text,
+        structure.baselineDescr.position.x,
+        structure.baselineDescr.position.y
+      );
+    }
+
+    // Key value
+    if (structure.key) {
+      ctx.font = structure.key.style.font;
+      ctx.fillStyle = structure.key.style.color;
+      ctx.fillText(structure.key.text, structure.key.position.x, structure.key.position.y);
+      if (structure.key.style?.strikethrough) {
+        ctx.lineWidth = structure.key.style.lineWidth ?? 1;
+        ctx.strokeStyle = structure.key.style.color;
+        ctx.beginPath();
+        ctx.moveTo(
+          structure.key.style.strikethrough.from.x,
+          structure.key.style.strikethrough.from.y
+        );
+        ctx.lineTo(structure.key.style.strikethrough.to.x, structure.key.style.strikethrough.to.y);
+        ctx.stroke();
+      }
+      if (structure.key.style?.underline) {
+        ctx.lineWidth = structure.key.style.lineWidth ?? 1;
+        ctx.strokeStyle = structure.key.style.color;
+        ctx.beginPath();
+        ctx.moveTo(structure.key.style.underline.from.x, structure.key.style.underline.from.y);
+        ctx.lineTo(structure.key.style.underline.to.x, structure.key.style.underline.to.y);
+        ctx.stroke();
+      }
+    }
+  }
+
+  computeChart(): ScorecardChartDesign {
+    const structure: any = {
+      canvas: {
+        width: this.props.figure.width,
+        height: this.props.figure.height,
+        backgroundColor: this.backgroundColor,
+      },
+      title: undefined,
+    };
+    const canvas = this.canvas;
+    canvas.width = this.props.figure.width;
+    canvas.height = this.props.figure.height;
+    const ctx = canvas.getContext("2d")!;
+    const style = this.getTextStyles();
+    ctx.font = `${style.titleStyle.fontSize}px ${DEFAULT_FONT}`;
+    const titleMeasure = ctx.measureText(this.title);
+    const titleHeight =
+      titleMeasure.actualBoundingBoxAscent + titleMeasure.actualBoundingBoxDescent;
+    if (this.title) {
+      structure.title = {
+        text: this.title,
+        style: {
+          font: `${style.titleStyle.fontSize}px ${DEFAULT_FONT}`,
+          color: style.titleStyle.color,
+        },
+        position: {
+          x: this.chartPadding,
+          y: this.chartPadding + titleHeight,
+        },
+      };
+    }
+    ctx.font = `${style.baselineValueStyle.fontSize}px ${DEFAULT_FONT}`;
+    let baselineArrow = "";
+    if (this.baselineArrowDirection === "up") {
+      baselineArrow = "\u{1F871}";
+    } else if (this.baselineArrowDirection === "down") {
+      baselineArrow = "\u{1F873}";
+    }
+    const baselineArrowMeasure = ctx.measureText(baselineArrow);
+    const baselineMeasure = ctx.measureText(this.baseline);
+    const baselineHeight =
+      baselineMeasure.actualBoundingBoxAscent + baselineMeasure.actualBoundingBoxDescent;
+    ctx.font = `${style.baselineDescrStyle.fontSize}px ${DEFAULT_FONT}`;
+    const descrMeasure = ctx.measureText(this.baselineDescr);
+    ctx.font = `${style.baselineValueStyle.fontSize}px ${DEFAULT_FONT}`;
+    structure.baselineArrow = {
+      text: baselineArrow,
+      style: {
+        font: ctx.font,
+        color: style.baselineValueStyle.color,
+      },
+      position: {
+        x:
+          canvas.width / 2 -
+          (baselineMeasure.width + descrMeasure.width + baselineArrowMeasure.width) / 2,
+        y: canvas.height - 2 * this.chartPadding,
+      },
+    };
+    if (style.baselineValueStyle.cellStyle?.bold) {
+      ctx.font = "bold " + ctx.font;
+    }
+    if (style.baselineValueStyle.cellStyle?.italic) {
+      ctx.font = "italic " + ctx.font;
+    }
+    structure.baseline = {
+      text: this.baseline,
+      style: {
+        color: style.baselineValueStyle.cellStyle?.textColor || style.baselineValueStyle.color,
+        font: ctx.font,
+      },
+      position: {
+        x: structure.baselineArrow.position.x + baselineArrowMeasure.width,
+        y: structure.baselineArrow.position.y,
+      },
+    };
+    if (style.baselineValueStyle.cellStyle?.strikethrough) {
+      structure.baseline.style.lineWidth = style.baselineValueStyle.fontSize / 10;
+      structure.baseline.style.strikethrough = {
+        from: {
+          x: structure.baseline.position.x,
+          y: canvas.height - this.chartPadding - baselineHeight / 2,
+        },
+        to: {
+          x: structure.baseline.position.x + baselineMeasure.width,
+          y: canvas.height - this.chartPadding - baselineHeight / 2,
+        },
+      };
+    }
+    if (style.baselineValueStyle.cellStyle?.underline) {
+      structure.baseline.style.lineWidth = style.baselineValueStyle.fontSize / 10;
+      structure.baseline.style.underline = {
+        from: {
+          x: structure.baseline.position.x,
+          y: canvas.height - this.chartPadding,
+        },
+        to: {
+          x: structure.baseline.position.x + baselineMeasure.width,
+          y: canvas.height - this.chartPadding,
+        },
+      };
+    }
+    if (this.baselineDescr) {
+      structure.baselineDescr = {
+        text: this.baselineDescr,
+        style: {
+          color: style.baselineDescrStyle.color,
+          font: `${style.baselineDescrStyle.fontSize}px ${DEFAULT_FONT}`,
+        },
+        position: {
+          x: structure.baseline.position.x + baselineMeasure.width,
+          y: structure.baseline.position.y,
+        },
+      };
+    }
+    ctx.font = `${style.keyStyle.fontSize}px ${DEFAULT_FONT}`;
+    const keyMeasure = ctx.measureText(this.keyValue);
+    const keyHeigth = keyMeasure.actualBoundingBoxAscent + keyMeasure.actualBoundingBoxDescent;
+    if (this.keyValue) {
+      if (style.keyStyle.cellStyle?.bold) {
+        ctx.font = "bold " + ctx.font;
+      }
+      if (style.keyStyle.cellStyle?.italic) {
+        ctx.font = "italic " + ctx.font;
+      }
+      structure.key = {
+        text: this.keyValue,
+        style: {
+          color: style.keyStyle.cellStyle?.textColor || style.keyStyle.color,
+          font: ctx.font,
+        },
+        position: {
+          x: (canvas.width - keyMeasure.width) / 2,
+          y: (canvas.height - baselineHeight + titleHeight + keyHeigth - this.chartPadding) / 2,
+        },
+      };
+      if (style.keyStyle.cellStyle?.strikethrough) {
+        structure.key.style.lineWidth = style.keyStyle.fontSize / 10;
+        structure.key.style.strikethrough = {
+          from: {
+            x: (canvas.width - keyMeasure.width) / 2,
+            y: (canvas.height - baselineHeight + titleHeight - this.chartPadding) / 2,
+          },
+          to: {
+            x: (canvas.width - keyMeasure.width) / 2 + keyMeasure.width,
+            y: (canvas.height - baselineHeight + titleHeight - this.chartPadding) / 2,
+          },
+        };
+      }
+      if (style.keyStyle.cellStyle?.underline) {
+        structure.key.style.lineWidth = style.keyStyle.fontSize / 10;
+        structure.key.style.underline = {
+          from: {
+            x: (canvas.width - keyMeasure.width) / 2,
+            y:
+              (canvas.height - baselineHeight + titleHeight + keyHeigth - this.chartPadding) / 2 +
+              style.keyStyle.fontSize / 10,
+          },
+          to: {
+            x: (canvas.width - keyMeasure.width) / 2 + keyMeasure.width,
+            y:
+              (canvas.height - baselineHeight + titleHeight + keyHeigth - this.chartPadding) / 2 +
+              style.keyStyle.fontSize / 10,
+          },
+        };
+      }
+    }
+    return structure;
+  }
+
+  get title() {
+    return this.runtime.title;
+  }
+
+  get keyValue() {
+    return this.runtime.keyValue;
+  }
+
+  get baseline() {
+    return this.runtime.baselineDisplay;
+  }
+
+  get baselineDescr() {
+    return formatBaselineDescr(this.runtime.baselineDescr, this.baseline);
+  }
+
+  get baselineArrowDirection() {
+    return this.runtime.baselineArrow;
+  }
+
+  get backgroundColor() {
+    return this.runtime.background;
+  }
+
+  get primaryFontColor() {
+    return this.runtime.fontColor;
+  }
+
+  get secondaryFontColor() {
+    return relativeLuminance(this.backgroundColor) > 0.3 ? "#525252" : "#C8C8C8";
+  }
+
+  get figure() {
+    return this.props.figure;
+  }
+
+  get chartStyle() {
+    return cssPropertiesToCss({
+      padding: `${this.chartPadding}px`,
+      background: this.backgroundColor,
+    });
+  }
+
+  get chartContentStyle() {
+    return cssPropertiesToCss({ height: `${this.getDrawableHeight()}px` });
+  }
+
+  get chartPadding() {
+    return this.props.figure.width * CHART_PADDING_RATIO;
+  }
+
+  getTextStyles() {
+    // If the widest text overflows horizontally, scale it down, and apply the same scaling factors to all the other fonts.
+    const maxLineWidth = this.props.figure.width * (1 - 2 * CHART_PADDING_RATIO);
+    const widestElement = this.getWidestElement();
+    const baseFontSize = widestElement.getElementMaxFontSize(this.getDrawableHeight(), this);
+    const fontSizeMatchingWidth = getFontSizeMatchingWidth(
+      maxLineWidth,
+      baseFontSize,
+      (fontSize: number) => widestElement.getElementWidth(fontSize, this.ctx, this)
+    );
+    let scalingFactor = fontSizeMatchingWidth / baseFontSize;
+
+    // Fonts sizes in px
+    const keyFontSize =
+      new KeyValueElement().getElementMaxFontSize(this.getDrawableHeight(), this) * scalingFactor;
+    const baselineFontSize =
+      new BaselineElement().getElementMaxFontSize(this.getDrawableHeight(), this) * scalingFactor;
+
+    return {
+      titleStyle: {
+        fontSize: TITLE_FONT_SIZE,
+        color: this.secondaryFontColor,
+      },
+      keyStyle: {
+        fontSize: keyFontSize,
+        cellStyle: this.runtime.keyValueStyle,
+        color: this.primaryFontColor,
+      },
+      baselineStyle: {
+        fontSize: baselineFontSize,
+      },
+      baselineValueStyle: {
+        fontSize: baselineFontSize,
+        cellStyle: this.runtime.baselineStyle,
+        color: this.runtime.baselineColor || this.secondaryFontColor,
+      },
+      baselineDescrStyle: {
+        fontSize: baselineFontSize * BASELINE_DESCR_FONT_RATIO,
+        color: this.secondaryFontColor,
+      },
+    };
+  }
+
+  /** Get the height of the chart minus all the vertical paddings */
+  private getDrawableHeight(): number {
+    const verticalPadding = 2 * this.chartPadding;
+    let availableHeight = this.props.figure.height - verticalPadding;
+    availableHeight -= this.title ? TITLE_FONT_SIZE * LINE_HEIGHT : 0;
+    return availableHeight;
+  }
+
+  /** Return the element with he widest text in the chart */
+  private getWidestElement(): ScorecardScalableElement {
+    const baseline = new BaselineElement();
+    const keyValue = new KeyValueElement();
+
+    return baseline.getElementWidth(BASELINE_BOX_HEIGHT_RATIO, this.ctx, this) >
+      keyValue.getElementWidth(KEY_BOX_HEIGHT_RATIO, this.ctx, this)
+      ? baseline
+      : keyValue;
+  }
+}
+
+interface ScorecardScalableElement {
+  /** Return the width of an scorecard element in pixels */
+  getElementWidth: (
+    fontSize: number,
+    ctx: CanvasRenderingContext2D,
+    chart: ScorecardChartDrawer
+  ) => Pixel;
+
+  /**
+   * Get the maximal height of an element of the scorecard.
+   *
+   * This is computed such as all the height is taken by the elements, even if there is no title or baseline.
+   */
+  getElementMaxFontSize: (availableHeight: Pixel, chart: ScorecardChartDrawer) => number;
+}
+
+class BaselineElement implements ScorecardScalableElement {
+  getElementWidth(
+    fontSize: number,
+    ctx: CanvasRenderingContext2D,
+    chart: ScorecardChartDrawer
+  ): Pixel {
+    if (!chart.runtime) return 0;
+    const baselineStr = chart.baseline;
+    // Put mock text to simulate the width of the up/down arrow
+    const largeText = chart.baselineArrowDirection !== "neutral" ? "A " + baselineStr : baselineStr;
+    ctx.font = `${fontSize}px ${DEFAULT_FONT}`;
+    let textWidth = ctx.measureText(largeText).width;
+    // Baseline descr font size should be smaller than baseline font size
+    ctx.font = `${fontSize * BASELINE_DESCR_FONT_RATIO}px ${DEFAULT_FONT}`;
+    textWidth += ctx.measureText(chart.baselineDescr).width;
+    return textWidth;
+  }
+
+  getElementMaxFontSize(availableHeight: Pixel, chart: ScorecardChartDrawer): number {
+    if (!chart.runtime) return 0;
+    const haveBaseline = chart.baseline !== "" || chart.baselineDescr;
+    const maxHeight = haveBaseline ? BASELINE_BOX_HEIGHT_RATIO * availableHeight : 0;
+    return maxHeight / LINE_HEIGHT;
+  }
+}
+
+class KeyValueElement implements ScorecardScalableElement {
+  getElementWidth(
+    fontSize: number,
+    ctx: CanvasRenderingContext2D,
+    chart: ScorecardChartDrawer
+  ): Pixel {
+    if (!chart.runtime) return 0;
+    const str = chart.keyValue || "";
+    ctx.font = `${fontSize}px ${DEFAULT_FONT}`;
+    return ctx.measureText(str).width;
+  }
+
+  getElementMaxFontSize(availableHeight: Pixel, chart: ScorecardChartDrawer): number {
+    if (!chart.runtime) return 0;
+    const haveBaseline = chart.baseline !== "" || chart.baselineDescr;
+    const maxHeight = haveBaseline ? KEY_BOX_HEIGHT_RATIO * availableHeight : availableHeight;
+    return maxHeight / LINE_HEIGHT;
+  }
+}
+
 export function createScorecardChartRuntime(
   chart: ScorecardChart,
   getters: Getters
@@ -206,7 +725,6 @@ export function createScorecardChartRuntime(
     baselineCell = getters.getEvaluatedCell(baselinePosition);
   }
   const background = getters.getBackgroundOfSingleCellChart(chart.background, chart.keyValue);
-  const fontColor = chartFontColor(background);
   return {
     title: _t(chart.title),
     keyValue: formattedKeyValue || keyValue,
@@ -220,7 +738,7 @@ export function createScorecardChartRuntime(
       chart.baselineColorDown
     ),
     baselineDescr: chart.baselineDescr ? _t(chart.baselineDescr) : "",
-    fontColor,
+    fontColor: chartFontColor(background),
     background,
     baselineStyle:
       chart.baselineMode !== "percentage" && baseline
@@ -237,6 +755,5 @@ export function createScorecardChartRuntime(
           row: chart.keyValue.zone.top,
         })
       : undefined,
-    chartJsConfig: getDefaultChartJsRuntime(chart, [], fontColor, ""),
   };
 }

--- a/src/plugins/core/chart.ts
+++ b/src/plugins/core/chart.ts
@@ -1,19 +1,13 @@
 import { DEFAULT_FIGURE_HEIGHT, DEFAULT_FIGURE_WIDTH, FIGURE_ID_SPLITTER } from "../../constants";
 import { AbstractChart } from "../../helpers/figures/charts/abstract_chart";
 import { chartFactory, validateChartDefinition } from "../../helpers/figures/charts/chart_factory";
-import {
-  ChartCreationContext,
-  ChartDefinition,
-  ChartType,
-  ExcelChartDefinition,
-} from "../../types/chart/chart";
+import { ChartCreationContext, ChartDefinition, ChartType } from "../../types/chart/chart";
 import {
   ApplyRangeChange,
   Command,
   CommandResult,
   CoreCommand,
   CreateChartCommand,
-  ExcelWorkbookData,
   Figure,
   FigureData,
   Pixel,
@@ -194,25 +188,6 @@ export class ChartPlugin extends CorePlugin<ChartState> implements ChartState {
         }
         sheet.figures = figures;
       }
-    }
-  }
-
-  exportForExcel(data: ExcelWorkbookData) {
-    for (let sheet of data.sheets) {
-      const sheetFigures = this.getters.getFigures(sheet.id);
-      const figures: FigureData<ExcelChartDefinition>[] = [];
-      for (let figure of sheetFigures) {
-        if (figure && figure.tag === "chart") {
-          const figureData = this.charts[figure.id]?.getDefinitionForExcel();
-          if (figureData) {
-            figures.push({
-              ...figure,
-              data: figureData,
-            });
-          }
-        }
-      }
-      sheet.charts = figures;
     }
   }
 

--- a/src/plugins/core/image.ts
+++ b/src/plugins/core/image.ts
@@ -156,6 +156,9 @@ export class ImagePlugin extends CorePlugin<ImageState> implements ImageState {
 
   exportForExcel(data: ExcelWorkbookData) {
     for (const sheet of data.sheets) {
+      if (!sheet.images) {
+        sheet.images = [];
+      }
       const figures = this.getters.getFigures(sheet.id);
       const images: FigureData<Image>[] = [];
       for (const figure of figures) {
@@ -169,7 +172,7 @@ export class ImagePlugin extends CorePlugin<ImageState> implements ImageState {
           }
         }
       }
-      sheet.images = images;
+      sheet.images = [...sheet.images, ...images];
     }
   }
 

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -105,7 +105,7 @@ export class EvaluationChartPlugin extends UIPlugin {
             }
             const type = this.getters.getChartType(figureId);
             const runtime = chartRegistry.get(type)?.getChartRuntime(chart, this.getters);
-            const img = chartToImage(runtime, figure);
+            const img = chartToImage(runtime, figure, type);
             images.push({
               ...figure,
               tag: "image",

--- a/src/plugins/ui_core_views/evaluation_chart.ts
+++ b/src/plugins/ui_core_views/evaluation_chart.ts
@@ -1,12 +1,14 @@
 import { BACKGROUND_CHART_COLOR } from "../../constants";
-import { chartRuntimeFactory } from "../../helpers/figures/charts";
-import { Color, Range, UID } from "../../types";
-import { ChartRuntime } from "../../types/chart/chart";
+import { chartRuntimeFactory, chartToImage } from "../../helpers/figures/charts";
+import { chartRegistry } from "../../registries";
+import { Color, ExcelWorkbookData, FigureData, Range, UID } from "../../types";
+import { ChartRuntime, ExcelChartDefinition } from "../../types/chart/chart";
 import {
   Command,
   invalidateCFEvaluationCommands,
   invalidateEvaluationCommands,
 } from "../../types/commands";
+import { Image } from "../../types/image";
 import { UIPlugin } from "../ui_plugin";
 
 export class EvaluationChartPlugin extends UIPlugin {
@@ -77,5 +79,47 @@ export class EvaluationChartPlugin extends UIPlugin {
     const sheetId = mainRange.sheetId;
     const style = this.getters.getCellComputedStyle({ sheetId, col, row });
     return style.fillColor || BACKGROUND_CHART_COLOR;
+  }
+
+  exportForExcel(data: ExcelWorkbookData) {
+    for (let sheet of data.sheets) {
+      if (!sheet.images) {
+        sheet.images = [];
+      }
+      const sheetFigures = this.getters.getFigures(sheet.id);
+      const figures: FigureData<ExcelChartDefinition>[] = [];
+      const images: FigureData<Image>[] = [];
+      for (let figure of sheetFigures) {
+        if (figure && figure.tag === "chart") {
+          const figureId = figure.id;
+          const figureData = this.getters.getChart(figureId)?.getDefinitionForExcel();
+          if (figureData) {
+            figures.push({
+              ...figure,
+              data: figureData,
+            });
+          } else {
+            const chart = this.getters.getChart(figureId);
+            if (!chart) {
+              continue;
+            }
+            const type = this.getters.getChartType(figureId);
+            const runtime = chartRegistry.get(type)?.getChartRuntime(chart, this.getters);
+            const img = chartToImage(runtime, figure);
+            images.push({
+              ...figure,
+              tag: "image",
+              data: {
+                mimetype: "image/png",
+                path: img,
+                size: { width: figure.width, height: figure.height },
+              },
+            });
+          }
+        }
+      }
+      sheet.images = [...sheet.images, ...images];
+      sheet.charts = figures;
+    }
   }
 }

--- a/src/types/chart/scorecard_chart.ts
+++ b/src/types/chart/scorecard_chart.ts
@@ -1,3 +1,4 @@
+import { ChartConfiguration } from "chart.js";
 import { Color, Style } from "../misc";
 
 export interface ScorecardChartDefinition {
@@ -15,6 +16,7 @@ export interface ScorecardChartDefinition {
 export type BaselineMode = "text" | "difference" | "percentage";
 export type BaselineArrowDirection = "neutral" | "up" | "down";
 export interface ScorecardChartRuntime {
+  readonly chartJsConfig: ChartConfiguration;
   readonly title: string;
   readonly keyValue: string;
   readonly baselineDisplay: string;

--- a/src/types/chart/scorecard_chart.ts
+++ b/src/types/chart/scorecard_chart.ts
@@ -1,4 +1,3 @@
-import { ChartConfiguration } from "chart.js";
 import { Color, Style } from "../misc";
 
 export interface ScorecardChartDefinition {
@@ -16,7 +15,6 @@ export interface ScorecardChartDefinition {
 export type BaselineMode = "text" | "difference" | "percentage";
 export type BaselineArrowDirection = "neutral" | "up" | "down";
 export interface ScorecardChartRuntime {
-  readonly chartJsConfig: ChartConfiguration;
   readonly title: string;
   readonly keyValue: string;
   readonly baselineDisplay: string;

--- a/tests/components/__mocks__/chart.ts
+++ b/tests/components/__mocks__/chart.ts
@@ -18,6 +18,7 @@ export const mockChart = () => {
     get data() {
       return mockChartData.data;
     }
+    toBase64Image = () => "";
     destroy = () => {};
     update = () => {};
     options = mockChartData.options;

--- a/tests/components/__snapshots__/scorecard_chart.test.ts.snap
+++ b/tests/components/__snapshots__/scorecard_chart.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Scorecard charts Scorecard snapshot 1`] = `
+exports[`Scorecard charts snapshots Scorecard snapshot 1`] = `
 <div
   class="o-figure w-100 h-100"
   data-id="someuuid"
@@ -10,63 +10,11 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
   <div
     class="o-chart-container w-100 h-100"
   >
-    <div
-      class="o-scorecard w-100 h-100"
-      style="padding:10.72px; background:#FFFFFF;"
-    >
-      <div
-        class="o-title-text"
-        style="font-size:18px; display:inline-block; color:#525252;"
-      >
-        hello
-      </div>
-      
-      <div
-        class="o-scorecard-content"
-        style="height:291.96px;"
-      >
-        <div
-          class="o-key-text"
-          style="font-size:69.24101876395092px; display:inline-block; color:#000000;"
-        >
-          2
-        </div>
-        
-        <div
-          class="o-baseline-text"
-          style="font-size:37.28362548828126px; display:inline-block;"
-        >
-          <svg
-            class="o-cf-icon arrow-up"
-            focusable="false"
-            height="10"
-            viewBox="0 0 448 512"
-            width="10"
-          >
-            <path
-              d="M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z"
-              fill="#00A04A"
-              style="fill : #00A04A"
-            />
-          </svg>
-          
-          <span
-            class="o-baseline-text-value"
-            style="font-size:37.28362548828126px; display:inline-block; color:#00A04A;"
-          >
-            1
-          </span>
-          
-          <span
-            class="o-baseline-text-description"
-            style="font-size:33.55526293945314px; display:inline-block; color:#525252;"
-          >
-             description
-          </span>
-        </div>
-        
-      </div>
-    </div>
+    <canvas
+      class="o-figure-canvas w-100 h-100"
+      height="335"
+      width="536"
+    />
   </div>
   
   <div
@@ -109,7 +57,7 @@ exports[`Scorecard charts Scorecard snapshot 1`] = `
 </div>
 `;
 
-exports[`Scorecard charts scorecard text is resized while figure is resized 1`] = `
+exports[`Scorecard charts snapshots scorecard text is resized while figure is resized 1`] = `
 <div
   class="o-figure w-100 h-100"
   data-id="someuuid"
@@ -119,63 +67,11 @@ exports[`Scorecard charts scorecard text is resized while figure is resized 1`] 
   <div
     class="o-chart-container w-100 h-100"
   >
-    <div
-      class="o-scorecard w-100 h-100"
-      style="padding:4.72px; background:#FFFFFF;"
-    >
-      <div
-        class="o-title-text"
-        style="font-size:18px; display:inline-block; color:#525252;"
-      >
-        hello
-      </div>
-      
-      <div
-        class="o-scorecard-content"
-        style="height:103.96000000000001px;"
-      >
-        <div
-          class="o-key-text"
-          style="font-size:30.46703915550596px; display:inline-block; color:#000000;"
-        >
-          2
-        </div>
-        
-        <div
-          class="o-baseline-text"
-          style="font-size:16.405328776041667px; display:inline-block;"
-        >
-          <svg
-            class="o-cf-icon arrow-up"
-            focusable="false"
-            height="10"
-            viewBox="0 0 448 512"
-            width="10"
-          >
-            <path
-              d="M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z"
-              fill="#00A04A"
-              style="fill : #00A04A"
-            />
-          </svg>
-          
-          <span
-            class="o-baseline-text-value"
-            style="font-size:16.405328776041667px; display:inline-block; color:#00A04A;"
-          >
-            1
-          </span>
-          
-          <span
-            class="o-baseline-text-description"
-            style="font-size:14.764795898437502px; display:inline-block; color:#525252;"
-          >
-             description
-          </span>
-        </div>
-        
-      </div>
-    </div>
+    <canvas
+      class="o-figure-canvas w-100 h-100"
+      height="135"
+      width="236"
+    />
   </div>
   
   <div

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -1,6 +1,15 @@
 import { Model } from "../../src";
+import {
+  formatBaselineDescr,
+  ScorecardChartDesign,
+  ScorecardChartDrawer,
+} from "../../src/helpers/figures/charts";
 import { UID } from "../../src/types";
-import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart";
+import {
+  ScorecardChartDefinition,
+  ScorecardChartRuntime,
+} from "../../src/types/chart/scorecard_chart";
+import { MockCanvasRenderingContext2D } from "../setup/canvas.mock";
 import {
   createScorecardChart as createScorecardChartHelper,
   setCellContent,
@@ -17,31 +26,6 @@ let sheetId: string;
 
 function getChartElement(): HTMLElement {
   return fixture.querySelector(".o-figure")!;
-}
-
-function getChartTitleElement(): HTMLElement {
-  return fixture.querySelector(".o-figure div.o-title-text")!;
-}
-
-function getChartKeyElement(): HTMLElement {
-  return fixture.querySelector(".o-figure div.o-key-text")!;
-}
-
-function getChartBaselineElement(): HTMLElement {
-  return fixture.querySelector(".o-figure div.o-baseline-text")!;
-}
-
-function getChartBaselineTextElement(): HTMLElement {
-  return fixture.querySelector(".o-figure .o-baseline-text-value")!;
-}
-
-function getChartBaselineDescrElement(): HTMLElement {
-  return fixture.querySelector(".o-figure .o-baseline-text-description")!;
-}
-
-function getElementFontSize(element: HTMLElement): number {
-  const fontSizeAttr = element.style.fontSize;
-  return Number(fontSizeAttr.slice(0, fontSizeAttr.length - 2));
 }
 
 async function createScorecardChart(
@@ -66,17 +50,21 @@ async function updateScorecardChartSize(width: number, height: number) {
   await nextTick();
 }
 
-function getChartBaselineTextContent() {
-  const baseline = getChartBaselineElement()!;
-  const spans = baseline.querySelectorAll("span");
-  let text = "";
-  for (let span of spans) {
-    text += span.textContent;
-  }
-  return text;
+function getFontSize(font: string) {
+  return Number(font.match(/([0-9\.]*)px/)?.[1]);
 }
 
-describe("Scorecard charts", () => {
+function getScorecardData(chartId: UID): ScorecardChartDesign {
+  const canvas = document.createElement("canvas");
+  const figure = model.getters.getFigure(sheetId, chartId)!;
+  const runtime = model.getters.getChartRuntime(chartId) as ScorecardChartRuntime;
+  const drawer = new ScorecardChartDrawer({ figure }, canvas, runtime);
+  return drawer.computeChart();
+}
+
+let scorecardChartStyle;
+
+describe("Scorecard charts snapshots", () => {
   beforeEach(async () => {
     chartId = "someuuid";
     sheetId = "Sheet1";
@@ -128,39 +116,84 @@ describe("Scorecard charts", () => {
     await nextTick();
     expect(getChartElement()).toMatchSnapshot();
   });
+});
 
-  test("Chart display correct info", async () => {
-    await createScorecardChart(
-      model,
-      { keyValue: "A1", baseline: "B1", title: "hello", baselineDescr: "description" },
-      chartId
-    );
-
-    expect(getChartElement()).toBeTruthy();
-    expect(getChartTitleElement()?.textContent).toEqual("hello");
-    expect(getChartKeyElement()?.textContent).toEqual("2");
-    expect(getChartBaselineTextContent()).toEqual("1 description");
+describe("Scorecard charts rendering", () => {
+  beforeEach(async () => {
+    chartId = "someuuid";
+    sheetId = "Sheet1";
+    const data = {
+      sheets: [
+        {
+          name: sheetId,
+          colNumber: 10,
+          rowNumber: 10,
+          rows: {},
+          cells: {
+            A1: { content: "2" },
+            A2: { content: "3" },
+            A3: { content: "2.1234" },
+            B1: { content: "1" },
+            B2: { content: "2" },
+            B3: { content: "3" },
+          },
+        },
+      ],
+    };
+    ({ model, fixture } = await mountSpreadsheet({ model: new Model(data) }));
+    scorecardChartStyle = {
+      title: {
+        fontSize: 0,
+        color: "",
+      },
+      key: {
+        fontSize: 0,
+        color: "",
+      },
+      baseline: {
+        fontSize: 0,
+        color: "",
+      },
+      baselineDescr: {
+        fontSize: 0,
+        color: "",
+      },
+    };
+    jest
+      .spyOn(MockCanvasRenderingContext2D.prototype, "fillText")
+      .mockImplementation(function (
+        this: MockCanvasRenderingContext2D,
+        text: string,
+        x: number,
+        y: number
+      ) {
+        const runtime = model.getters.getChartRuntime(chartId) as ScorecardChartRuntime;
+        if (runtime.baselineDisplay === text) {
+          scorecardChartStyle.baseline.fontSize = getFontSize(this.font);
+          scorecardChartStyle.baseline.color = this.fillStyle;
+          scorecardChartStyle.baseline.bold = this.font.includes("bold");
+          scorecardChartStyle.baseline.italic = this.font.includes("italic");
+        } else if (text === runtime.keyValue) {
+          scorecardChartStyle.key.fontSize = getFontSize(this.font);
+          scorecardChartStyle.key.color = this.fillStyle;
+          scorecardChartStyle.key.bold = this.font.includes("bold");
+          scorecardChartStyle.key.italic = this.font.includes("italic");
+        } else if (text === runtime.title) {
+          scorecardChartStyle.title.fontSize = getFontSize(this.font);
+          scorecardChartStyle.title.color = this.fillStyle;
+          scorecardChartStyle.title.bold = this.font.includes("bold");
+          scorecardChartStyle.title.italic = this.font.includes("italic");
+        } else if (text === formatBaselineDescr(runtime.baselineDescr, runtime.baselineDisplay)) {
+          scorecardChartStyle.baselineDescr.fontSize = getFontSize(this.font);
+          scorecardChartStyle.baselineDescr.color = this.fillStyle;
+          scorecardChartStyle.baselineDescr.bold = this.font.includes("bold");
+          scorecardChartStyle.baselineDescr.italic = this.font.includes("italic");
+        }
+      });
   });
 
-  test("Baseline = 0 correctly displayed", async () => {
-    setCellContent(model, "B1", "0");
-    setCellContent(model, "A1", "0");
-    await createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
-
-    expect(getChartElement()).toBeTruthy();
-    expect(getChartKeyElement()?.textContent).toEqual("0");
-    expect(getChartBaselineTextContent()).toEqual("0");
-  });
-
-  test("Percentage baseline display a percentage", async () => {
-    await createScorecardChart(
-      model,
-      { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
-      chartId
-    );
-
-    expect(getChartElement()).toBeTruthy();
-    expect(getChartBaselineTextContent()).toEqual("100%");
+  afterEach(() => {
+    jest.spyOn(MockCanvasRenderingContext2D.prototype, "fillText").mockRestore();
   });
 
   test("Baseline with mode 'text' is plainly displayed", async () => {
@@ -169,94 +202,22 @@ describe("Scorecard charts", () => {
       { keyValue: "A1", baseline: "B1", baselineMode: "text" },
       chartId
     );
-    expect(getChartElement()).toBeTruthy();
-    expect(getChartBaselineTextContent()).toEqual("1");
-    expect(getChartBaselineTextElement()!.style["color"]).toBeSameColorAs("#525252");
+    expect(scorecardChartStyle.baseline.color).toBeSameColorAs("#525252");
   });
 
   test("Key < baseline display in red with down arrow", async () => {
     await createScorecardChart(model, { keyValue: "A1", baseline: "B3" }, chartId);
-
-    const baselineElement = getChartBaselineElement();
-    expect(baselineElement.querySelector("svg.arrow-down")).toBeTruthy();
-    expect(baselineElement.querySelector("span")!.style["color"]).toBeSameColorAs("#DC6965");
-    expect(getChartBaselineTextContent()).toEqual("1");
+    expect(scorecardChartStyle.baseline.color).toBeSameColorAs("#DC6965");
   });
 
   test("Key > baseline display in green with up arrow", async () => {
     await createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
-
-    const baselineElement = getChartBaselineElement();
-    expect(baselineElement.querySelector("svg.arrow-up")).toBeTruthy();
-    expect(baselineElement.querySelector("span")!.style["color"]).toBeSameColorAs("#00A04A");
-    expect(getChartBaselineTextContent()).toEqual("1");
+    expect(scorecardChartStyle.baseline.color).toBeSameColorAs("#00A04A");
   });
 
   test("Key = baseline display default font color with no arrow", async () => {
     await createScorecardChart(model, { keyValue: "A1", baseline: "B2" }, chartId);
-
-    const baselineElement = getChartBaselineElement();
-    expect(baselineElement.querySelector("svg")).toBeFalsy();
-    expect(baselineElement.querySelector("span")!.style["color"]).toBeSameColorAs("#525252");
-    expect(getChartBaselineTextContent()).toEqual("0");
-  });
-
-  test("Key value is displayed with the cell evaluated format", async () => {
-    setCellContent(model, "C1", "=A1");
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1"),
-      format: "0%",
-    });
-    await createScorecardChart(model, { keyValue: "C1" }, chartId);
-    expect(getChartKeyElement()?.textContent).toEqual("200%");
-  });
-
-  test("Baseline is displayed with the cell evaluated format", async () => {
-    setCellContent(model, "C1", "=B2");
-    await createScorecardChart(model, { keyValue: "A3", baseline: "C1" }, chartId);
-    expect(getChartBaselineElement()?.textContent).toEqual((0.12).toLocaleString());
-
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("B2"),
-      format: "[$$]#,##0.00",
-    });
-    await nextTick();
-    expect(getChartBaselineElement()?.textContent).toEqual("$0.12");
-  });
-
-  test("Baseline with lot of decimal is truncated", async () => {
-    setCellContent(model, "C1", "=B2");
-    await createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
-    expect(getCellContent(model, "A3")).toEqual("2.1234");
-    expect(getChartBaselineElement()?.textContent).toEqual((0.12).toLocaleString());
-  });
-
-  test("Baseline with lot of decimal isn't truncated if the cell has a format", async () => {
-    await createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("B2"),
-      format: "[$$]#,####0.0000",
-    });
-    await nextTick();
-    expect(getChartBaselineElement()?.textContent).toEqual("$0.1234");
-  });
-
-  test("Baseline percentage mode format has priority over cell format", async () => {
-    await createScorecardChart(
-      model,
-      { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
-      chartId
-    );
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("B1"),
-      format: "[$$]#,####0.0000",
-    });
-    await nextTick();
-    expect(getChartBaselineElement()?.textContent).toEqual("100%");
+    expect(scorecardChartStyle.baseline.color).toBeSameColorAs("#525252");
   });
 
   test("Key value and baseline are displayed with the cell style", async () => {
@@ -267,21 +228,17 @@ describe("Scorecard charts", () => {
         textColor: "#FF0000",
         bold: true,
         italic: true,
-        strikethrough: true,
-        underline: true,
       },
     });
     await createScorecardChart(model, { keyValue: "A1", baseline: "A1" }, chartId);
-    for (const el of [getChartKeyElement()!, getChartBaselineTextElement()!]) {
-      const style = el!.style;
-      expect(style["font-style"]).toEqual("italic");
-      expect(style["font-weight"]).toEqual("bold");
-      expect(style["color"]).toBeSameColorAs("#FF0000");
-      expect(style["text-decoration"]).toEqual("line-through underline");
+    for (const style of [scorecardChartStyle.key, scorecardChartStyle.baseline]) {
+      expect(style.italic).toEqual(true);
+      expect(style.bold).toEqual(true);
+      expect(style.color).toBeSameColorAs("#FF0000");
     }
   });
 
-  test("Baseline mode percentage don't inherit of the style/format of the cell", async () => {
+  test("Baseline mode percentage don't inherit of the style of the cell", async () => {
     model.dispatch("SET_FORMATTING", {
       sheetId,
       target: target("A1"),
@@ -293,8 +250,7 @@ describe("Scorecard charts", () => {
       { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
       chartId
     );
-    expect(getChartBaselineTextElement()!.style["font-weight"]).not.toEqual("bold");
-    expect(getChartBaselineTextContent()).toEqual("100%");
+    expect(scorecardChartStyle.baseline.bold).not.toEqual(true);
   });
 
   test("High contrast font colors with dark background", async () => {
@@ -310,10 +266,10 @@ describe("Scorecard charts", () => {
       chartId
     );
 
-    expect(getChartTitleElement()!.style["color"]).toBeSameColorAs("#C8C8C8");
-    expect(getChartBaselineTextElement()!.style["color"]).toBeSameColorAs("#C8C8C8");
-    expect(getChartBaselineDescrElement()!.style["color"]).toBeSameColorAs("#C8C8C8");
-    expect(getChartKeyElement()!.style["color"]).toBeSameColorAs("#FFFFFF");
+    expect(scorecardChartStyle.title.color).toBeSameColorAs("#C8C8C8");
+    expect(scorecardChartStyle.baseline.color).toBeSameColorAs("#C8C8C8");
+    expect(scorecardChartStyle.baselineDescr.color).toBeSameColorAs("#C8C8C8");
+    expect(scorecardChartStyle.key.color).toBeSameColorAs("#FFFFFF");
   });
 
   test("Increasing size of the chart scale up the font sizes", async () => {
@@ -325,15 +281,15 @@ describe("Scorecard charts", () => {
 
     await updateScorecardChartSize(100, 100);
 
-    const baselineFontSize = getElementFontSize(getChartBaselineElement());
-    const titleFontSize = getElementFontSize(getChartTitleElement());
-    const keyFontSize = getElementFontSize(getChartKeyElement());
+    const baselineFontSize = scorecardChartStyle.baseline.fontSize;
+    const titleFontSize = scorecardChartStyle.title.fontSize;
+    const keyFontSize = scorecardChartStyle.key.fontSize;
 
     await updateScorecardChartSize(200, 200);
 
-    expect(getElementFontSize(getChartBaselineElement())).toBeGreaterThan(baselineFontSize);
-    expect(getElementFontSize(getChartTitleElement())).toEqual(titleFontSize);
-    expect(getElementFontSize(getChartKeyElement())).toBeGreaterThan(keyFontSize);
+    expect(scorecardChartStyle.baseline.fontSize).toBeGreaterThan(baselineFontSize);
+    expect(scorecardChartStyle.title.fontSize).toEqual(titleFontSize);
+    expect(scorecardChartStyle.key.fontSize).toBeGreaterThan(keyFontSize);
   });
 
   test("Decreasing size of the chart scale down the font sizes", async () => {
@@ -345,15 +301,15 @@ describe("Scorecard charts", () => {
 
     await updateScorecardChartSize(200, 200);
 
-    const baselineFontSize = getElementFontSize(getChartBaselineElement());
-    const titleFontSize = getElementFontSize(getChartTitleElement());
-    const keyFontSize = getElementFontSize(getChartKeyElement());
+    const baselineFontSize = scorecardChartStyle.baseline.fontSize;
+    const titleFontSize = scorecardChartStyle.title.fontSize;
+    const keyFontSize = scorecardChartStyle.key.fontSize;
 
     await updateScorecardChartSize(100, 100);
 
-    expect(getElementFontSize(getChartBaselineElement())).toBeLessThan(baselineFontSize);
-    expect(getElementFontSize(getChartTitleElement())).toEqual(titleFontSize);
-    expect(getElementFontSize(getChartKeyElement())).toBeLessThan(keyFontSize);
+    expect(scorecardChartStyle.baseline.fontSize).toBeLessThan(baselineFontSize);
+    expect(scorecardChartStyle.title.fontSize).toEqual(titleFontSize);
+    expect(scorecardChartStyle.key.fontSize).toBeLessThan(keyFontSize);
   });
 
   test("Font size scale down if we put a long key value", async () => {
@@ -362,14 +318,14 @@ describe("Scorecard charts", () => {
       { keyValue: "A1", baseline: "B2", title: "This is a title" },
       chartId
     );
-    const baselineFontSize = getElementFontSize(getChartBaselineElement());
-    const titleFontSize = getElementFontSize(getChartTitleElement());
-    const keyFontSize = getElementFontSize(getChartKeyElement());
-    setCellContent(model, "A1", "123456789123456789123456879");
+    const baselineFontSize = scorecardChartStyle.baseline.fontSize;
+    const titleFontSize = scorecardChartStyle.title.fontSize;
+    const keyFontSize = scorecardChartStyle.key.fontSize;
+    setCellContent(model, "A1", "123456789123456789123456789");
     await nextTick();
-    expect(getElementFontSize(getChartBaselineElement())).toBeLessThan(baselineFontSize);
-    expect(getElementFontSize(getChartTitleElement())).toEqual(titleFontSize);
-    expect(getElementFontSize(getChartKeyElement())).toBeLessThan(keyFontSize);
+    expect(scorecardChartStyle.baseline.fontSize).toBeLessThan(baselineFontSize);
+    expect(scorecardChartStyle.title.fontSize).toEqual(titleFontSize);
+    expect(scorecardChartStyle.key.fontSize).toBeLessThan(keyFontSize);
   });
 
   test("Font size scale up if we remove a long description", async () => {
@@ -382,10 +338,277 @@ describe("Scorecard charts", () => {
       },
       chartId
     );
-    const baselineFontSize = getElementFontSize(getChartBaselineElement());
-
+    const baselineFontSize = scorecardChartStyle.baseline.fontSize;
     updateChart(model, chartId, { baselineDescr: "" }, sheetId);
     await nextTick();
-    expect(getElementFontSize(getChartBaselineElement())).toBeGreaterThan(baselineFontSize);
+    expect(scorecardChartStyle.baseline.fontSize).toBeGreaterThan(baselineFontSize);
+  });
+});
+
+describe("Scorecard charts computation", () => {
+  beforeEach(async () => {
+    chartId = "someuuid";
+    sheetId = "Sheet1";
+    const data = {
+      sheets: [
+        {
+          name: sheetId,
+          colNumber: 10,
+          rowNumber: 10,
+          rows: {},
+          cells: {
+            A1: { content: "2" },
+            A2: { content: "3" },
+            A3: { content: "2.1234" },
+            B1: { content: "1" },
+            B2: { content: "2" },
+            B3: { content: "3" },
+          },
+        },
+      ],
+    };
+    ({ model, fixture } = await mountSpreadsheet({ model: new Model(data) }));
+  });
+
+  test("Chart display correct info", async () => {
+    await createScorecardChart(
+      model,
+      { keyValue: "A1", baseline: "B1", title: "hello", baselineDescr: "description" },
+      chartId
+    );
+    const chartData = getScorecardData(chartId);
+
+    expect(chartData.title.text).toEqual("hello");
+    expect(chartData.baseline.text).toEqual("1");
+    expect(chartData.baselineDescr.text).toEqual(" description");
+    expect(chartData.key.text).toEqual("2");
+  });
+
+  test("Baseline = 0 correctly displayed", async () => {
+    setCellContent(model, "B1", "0");
+    setCellContent(model, "A1", "0");
+    await createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
+    const chartData = getScorecardData(chartId);
+
+    expect(chartData.key.text).toEqual("0");
+    expect(chartData.baseline.text).toEqual("0");
+    expect(chartData.baselineDescr).toBeUndefined();
+    expect(chartData.baselineArrow.text).toEqual("");
+  });
+
+  test("Percentage baseline display a percentage", async () => {
+    await createScorecardChart(
+      model,
+      { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
+      chartId
+    );
+    const chartData = getScorecardData(chartId);
+
+    expect(chartData.baseline.text).toEqual("100%");
+  });
+
+  test("Baseline with mode 'text' is plainly displayed", async () => {
+    await createScorecardChart(
+      model,
+      { keyValue: "A1", baseline: "B1", baselineMode: "text" },
+      chartId
+    );
+    const chartData = getScorecardData(chartId);
+
+    expect(chartData.baseline.text).toEqual("1");
+    expect(chartData.baseline.style.color).toBeSameColorAs("#525252");
+  });
+
+  test("Key < baseline display in red with down arrow", async () => {
+    await createScorecardChart(model, { keyValue: "A1", baseline: "B3" }, chartId);
+    const chartData = getScorecardData(chartId);
+
+    expect(chartData.baselineArrow.text).toBe("\u{1F873}");
+    expect(chartData.baselineArrow.style.color).toBeSameColorAs("#DC6965");
+    expect(chartData.baseline.style.color).toBeSameColorAs("#DC6965");
+    expect(chartData.baseline.text).toEqual("1");
+  });
+
+  test("Key > baseline display in green with up arrow", async () => {
+    await createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
+    const chartData = getScorecardData(chartId);
+
+    expect(chartData.baselineArrow.text).toBe("\u{1F871}");
+    expect(chartData.baselineArrow.style.color).toBeSameColorAs("#00A04A");
+    expect(chartData.baseline.style.color).toBeSameColorAs("#00A04A");
+    expect(chartData.baseline.text).toEqual("1");
+  });
+
+  test("Key = baseline display default font color with no arrow", async () => {
+    await createScorecardChart(model, { keyValue: "A1", baseline: "B2" }, chartId);
+    const chartData = getScorecardData(chartId);
+
+    expect(chartData.baselineArrow.text).toBe("");
+    expect(chartData.baseline.style.color).toBeSameColorAs("#525252");
+    expect(chartData.baseline.text).toEqual("0");
+  });
+
+  test("Key value is displayed with the cell evaluated format", async () => {
+    await createScorecardChart(model, { keyValue: "C1" }, chartId);
+    setCellContent(model, "C1", "=A1");
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: target("A1"),
+      format: "0%",
+    });
+    const chartData = getScorecardData(chartId);
+    expect(chartData.key.text).toEqual("200%");
+  });
+
+  test("Baseline is displayed with the cell evaluated format", async () => {
+    setCellContent(model, "C1", "=B2");
+    await createScorecardChart(model, { keyValue: "A3", baseline: "C1" }, chartId);
+    let chartData = getScorecardData(chartId);
+    expect(chartData.baseline.text).toEqual((0.12).toLocaleString());
+
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: target("B2"),
+      format: "[$$]#,##0.00",
+    });
+    await nextTick();
+    chartData = getScorecardData(chartId);
+    expect(chartData.baseline.text).toEqual("$0.12");
+  });
+
+  test("Baseline with lot of decimal is truncated", async () => {
+    setCellContent(model, "C1", "=B2");
+    await createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
+    const chartData = getScorecardData(chartId);
+    expect(chartData.baseline.text).toEqual((0.12).toLocaleString());
+    expect(getCellContent(model, "A3")).toEqual("2.1234");
+  });
+
+  test("Baseline with lot of decimal isn't truncated if the cell has a format", async () => {
+    await createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: target("B2"),
+      format: "[$$]#,####0.0000",
+    });
+    await nextTick();
+    const chartData = getScorecardData(chartId);
+    expect(chartData.baseline.text).toEqual("$0.1234");
+  });
+
+  test("Baseline percentage mode format has priority over cell format", async () => {
+    await createScorecardChart(
+      model,
+      { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
+      chartId
+    );
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: target("B1"),
+      format: "[$$]#,####0.0000",
+    });
+    await nextTick();
+    const chartData = getScorecardData(chartId);
+    expect(chartData.baseline.text).toEqual("100%");
+  });
+
+  test("Key value and baseline are displayed with the cell style", async () => {
+    await createScorecardChart(model, { keyValue: "A1", baseline: "A1" }, chartId);
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: target("A1"),
+      style: {
+        textColor: "#FF0000",
+        bold: true,
+        italic: true,
+        strikethrough: true,
+        underline: true,
+      },
+    });
+    const chartData = getScorecardData(chartId);
+    for (const style of [chartData.key.style, chartData.baseline.style]) {
+      expect(style.font.includes("bold")).toBeTruthy();
+      expect(style.font.includes("italic")).toBeTruthy();
+      expect(style.color).toBeSameColorAs("#FF0000");
+      expect(style.strikethrough).not.toBeUndefined();
+      expect(style.underline).not.toBeUndefined();
+    }
+  });
+
+  test("Baseline mode percentage don't inherit of the style/format of the cell", async () => {
+    await createScorecardChart(
+      model,
+      { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
+      chartId
+    );
+    model.dispatch("SET_FORMATTING", {
+      sheetId,
+      target: target("A1"),
+      style: { bold: true },
+      format: "0.0",
+    });
+    const chartData = getScorecardData(chartId);
+    expect(chartData.baseline.style.font.includes("bold")).toBeFalsy();
+    expect(chartData.baseline.text).toEqual("100%");
+  });
+
+  test("High contrast font colors with dark background", async () => {
+    await createScorecardChart(
+      model,
+      {
+        keyValue: "A1",
+        baseline: "A1",
+        baselineDescr: "descr",
+        title: "title",
+        background: "#000000",
+      },
+      chartId
+    );
+    const chartData = getScorecardData(chartId);
+
+    expect(chartData.title.style.color).toBeSameColorAs("#C8C8C8");
+    expect(chartData.baseline.style.color).toBeSameColorAs("#C8C8C8");
+    expect(chartData.baselineDescr.style.color).toBeSameColorAs("#C8C8C8");
+    expect(chartData.key.style.color).toBeSameColorAs("#FFFFFF");
+  });
+
+  test("Font size scale down if we put a long key value", async () => {
+    await createScorecardChart(
+      model,
+      { keyValue: "A1", baseline: "B2", title: "This is a title" },
+      chartId
+    );
+    const chartData1 = getScorecardData(chartId);
+    setCellContent(model, "A1", "123456789123456789123456789");
+    await nextTick();
+    const chartData2 = getScorecardData(chartId);
+    expect(getFontSize(chartData2.baseline.style.font)).toBeLessThan(
+      getFontSize(chartData1.baseline.style.font)
+    );
+    expect(getFontSize(chartData2.title.style.font)).toEqual(
+      getFontSize(chartData1.title.style.font)
+    );
+    expect(getFontSize(chartData2.key.style.font)).toBeLessThan(
+      getFontSize(chartData1.key.style.font)
+    );
+  });
+
+  test("Font size scale up if we remove a long description", async () => {
+    await createScorecardChart(
+      model,
+      {
+        keyValue: "A1",
+        baseline: "B2",
+        baselineDescr: "This is a very very very very long description",
+      },
+      chartId
+    );
+    const chartData1 = getScorecardData(chartId);
+    updateChart(model, chartId, { baselineDescr: "" }, sheetId);
+    await nextTick();
+    const chartData2 = getScorecardData(chartId);
+    expect(getFontSize(chartData2.baseline.style.font)).toBeGreaterThan(
+      getFontSize(chartData1.baseline.style.font)
+    );
   });
 });

--- a/tests/setup/canvas.mock.ts
+++ b/tests/setup/canvas.mock.ts
@@ -1,5 +1,6 @@
 export class MockCanvasRenderingContext2D {
   font: string = "";
+  fillStyle: string = "";
   translate() {}
   scale() {}
   clearRect() {}
@@ -9,7 +10,7 @@ export class MockCanvasRenderingContext2D {
   stroke() {}
   fillRect() {}
   strokeRect() {}
-  fillText() {}
+  fillText(text: string, x: number, y: number) {}
   fill() {}
   save() {}
   rect() {}

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -524,6 +524,7 @@ export const mockChart = () => {
     get data() {
       return mockChartData.data;
     }
+    toBase64Image = () => "";
     destroy = () => {};
     update = () => {};
     options = mockChartData.options;

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -17,7 +17,7 @@ import {
   updateFilter,
 } from "./test_helpers/commands_helpers";
 import { TEST_CHART_DATA } from "./test_helpers/constants";
-import { exportPrettifiedXlsx, mockChart, toRangesData } from "./test_helpers/helpers";
+import { exportPrettifiedXlsx, mockChart, nextTick, toRangesData } from "./test_helpers/helpers";
 
 function getExportedExcelData(model: Model): ExcelWorkbookData {
   model.dispatch("EVALUATE_CELLS");
@@ -854,6 +854,7 @@ describe("Test XLSX export", () => {
     });
 
     test("Scorecard is exported as an image", () => {
+      window.HTMLCanvasElement.prototype.toDataURL = () => "crap_image_data";
       const model = new Model({
         sheets: chartData.sheets,
       });
@@ -862,11 +863,12 @@ describe("Test XLSX export", () => {
       expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
     });
 
-    test("Gauche Chart is exported as an image", () => {
+    test("Gauche Chart is exported as an image", async () => {
       const model = new Model({
         sheets: chartData.sheets,
       });
       createGaugeChart(model, TEST_CHART_DATA.gauge);
+      await nextTick();
       expect(getExportedExcelData(model).sheets[0].charts.length).toBe(0);
       expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
     });

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -8,13 +8,16 @@ import { escapeXml, parseXML } from "../src/xlsx/helpers/xml_helpers";
 import {
   createChart,
   createFilter,
+  createGaugeChart,
   createImage,
+  createScorecardChart,
   createSheet,
   merge,
   setCellContent,
   updateFilter,
 } from "./test_helpers/commands_helpers";
-import { exportPrettifiedXlsx, toRangesData } from "./test_helpers/helpers";
+import { TEST_CHART_DATA } from "./test_helpers/constants";
+import { exportPrettifiedXlsx, mockChart, toRangesData } from "./test_helpers/helpers";
 
 function getExportedExcelData(model: Model): ExcelWorkbookData {
   model.dispatch("EVALUATE_CELLS");
@@ -26,6 +29,8 @@ function getExportedExcelData(model: Model): ExcelWorkbookData {
   }
   return data;
 }
+
+mockChart();
 
 const simpleData = {
   sheets: [
@@ -809,7 +814,7 @@ describe("Test XLSX export", () => {
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
 
-    test("charts that aggregate labels", async () => {
+    test("charts that aggregate labels are exported as image", async () => {
       const model = new Model({
         sheets: [
           {
@@ -832,37 +837,38 @@ describe("Test XLSX export", () => {
           },
         ],
       });
-      createChart(
-        model,
-        {
-          dataSets: ["Sheet1!B1:B9"],
-          labelRange: "Sheet1!A2:A9",
-          aggregated: true,
-          type: "bar",
-        },
-        "1"
-      );
-      createChart(
-        model,
-        {
-          dataSets: ["Sheet1!B1:B9"],
-          labelRange: "Sheet1!A2:A9",
-          aggregated: true,
-          type: "line",
-        },
-        "1"
-      );
-      createChart(
-        model,
-        {
-          dataSets: ["Sheet1!B1:B9"],
-          labelRange: "Sheet1!A2:A9",
-          aggregated: true,
-          type: "pie",
-        },
-        "1"
-      );
+      for (const type of ["bar", "line", "pie"]) {
+        createChart(
+          model,
+          {
+            dataSets: ["Sheet1!B1:B9"],
+            labelRange: "Sheet1!A2:A9",
+            aggregated: true,
+            type: type as "bar" | "line" | "pie",
+          },
+          "1"
+        );
+        expect(getExportedExcelData(model).sheets[0].charts.length).toBe(0);
+        expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
+      }
+    });
+
+    test("Scorecard is exported as an image", () => {
+      const model = new Model({
+        sheets: chartData.sheets,
+      });
+      createScorecardChart(model, TEST_CHART_DATA.scorecard);
       expect(getExportedExcelData(model).sheets[0].charts.length).toBe(0);
+      expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
+    });
+
+    test("Gauche Chart is exported as an image", () => {
+      const model = new Model({
+        sheets: chartData.sheets,
+      });
+      createGaugeChart(model, TEST_CHART_DATA.gauge);
+      expect(getExportedExcelData(model).sheets[0].charts.length).toBe(0);
+      expect(getExportedExcelData(model).sheets[0].images.length).toBe(1);
     });
 
     test("stacked bar chart", async () => {


### PR DESCRIPTION
## Task Description

o-spreadsheet now allows to insert images in a spreadsheet, and we also allow to export them inside .xlsx file. However, while this works as intended in a standalone o-spreadsheet server, it doens't work correctly in Odoo as the data of the image are not found while we try ton convert the spreadsheet to an xlsx file. This PR aims to simplify the request made to get the binary data of the image file.

Moreover, this PR also add the export of Odoo chart as an image. The way these image are exported is slightly different than classical image, as the chart is converted to base64 data_url, and then directly converted from base64 to binary string, while classical image are loaded from a file to a binary string.

## Related tas/PR
- Task: : [3524473](https://www.odoo.com/web#id=3524473&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
- https://github.com/odoo/enterprise/pull/47928

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo