### PR TITLE
[FIX] sheetview: performance issue for too many rows/cols

### DIFF
--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -147,37 +147,31 @@ export class InternalViewport {
     const sheetId = this.sheetId;
     const { end } = this.getters.getColDimensions(sheetId, targetCol);
     const maxCol = this.getters.getNumberCols(sheetId);
-
     if (this.offsetX + this.offsetCorrectionX + this.viewportWidth < end) {
-      for (
-        let col = this.left;
-        this.offsetX + this.offsetCorrectionX + this.viewportWidth < end;
-        col++
-      ) {
-        if (col > maxCol) {
-          break;
-        }
-        if (this.getters.isColHidden(sheetId, col)) {
-          continue;
-        }
-
-        this.offsetX = this.getters.getColDimensions(sheetId, col).end - this.offsetCorrectionX;
-        this.offsetScrollbarX = this.offsetX;
-        this.adjustViewportZoneX();
+      let finalTarget = targetCol;
+      while (this.getters.isColHidden(sheetId, finalTarget) && targetCol < maxCol) {
+        finalTarget++;
       }
+      const finalTargetEnd = this.getters.getColDimensions(sheetId, finalTarget).end;
+      const startIndex = this.searchHeaderIndex(
+        "COL",
+        finalTargetEnd - this.viewportWidth - this.offsetCorrectionX,
+        this.boundaries.left,
+        true
+      );
+      this.offsetX =
+        this.getters.getColDimensions(sheetId, startIndex).end - this.offsetCorrectionX;
+      this.offsetScrollbarX = this.offsetX;
+      this.adjustViewportZoneX();
     } else if (this.left > targetCol) {
-      for (let col = this.left; col >= targetCol; col--) {
-        if (col < 0) {
-          break;
-        }
-        if (this.getters.isColHidden(sheetId, col)) {
-          continue;
-        }
-
-        this.offsetX = this.getters.getColDimensions(sheetId, col).start - this.offsetCorrectionX;
-        this.offsetScrollbarX = this.offsetX;
-        this.adjustViewportZoneX();
+      let finalTarget = targetCol;
+      while (this.getters.isColHidden(sheetId, finalTarget) && targetCol > 0) {
+        finalTarget--;
       }
+      this.offsetX =
+        this.getters.getColDimensions(sheetId, finalTarget).start - this.offsetCorrectionX;
+      this.offsetScrollbarX = this.offsetX;
+      this.adjustViewportZoneX();
     }
   }
 
@@ -185,37 +179,31 @@ export class InternalViewport {
     const sheetId = this.sheetId;
     const { end } = this.getters.getRowDimensions(sheetId, targetRow);
     const maxRow = this.getters.getNumberRows(sheetId);
-
     if (this.offsetY + this.viewportHeight + this.offsetCorrectionY < end) {
-      for (
-        let row = this.top;
-        this.offsetY + this.viewportHeight + this.offsetCorrectionY < end;
-        row++
-      ) {
-        if (row > maxRow) {
-          break;
-        }
-        if (this.getters.isRowHidden(sheetId, row)) {
-          continue;
-        }
-
-        this.offsetY = this.getters.getRowDimensions(sheetId, row).end - this.offsetCorrectionY;
-        this.offsetScrollbarY = this.offsetY;
-        this.adjustViewportZoneY();
+      let finalTarget = targetRow;
+      while (this.getters.isRowHidden(sheetId, finalTarget) && targetRow < maxRow) {
+        finalTarget++;
       }
+      const finalTargetEnd = this.getters.getRowDimensions(sheetId, finalTarget).end;
+      const startIndex = this.searchHeaderIndex(
+        "ROW",
+        finalTargetEnd - this.viewportHeight - this.offsetCorrectionY,
+        this.boundaries.top,
+        true
+      );
+      this.offsetY =
+        this.getters.getRowDimensions(sheetId, startIndex).end - this.offsetCorrectionY;
+      this.offsetScrollbarY = this.offsetY;
+      this.adjustViewportZoneY();
     } else if (this.top > targetRow) {
-      for (let row = this.top; row >= targetRow; row--) {
-        if (row < 0) {
-          break;
-        }
-        if (this.getters.isRowHidden(sheetId, row)) {
-          continue;
-        }
-
-        this.offsetY = this.getters.getRowDimensions(sheetId, row).start - this.offsetCorrectionY;
-        this.offsetScrollbarY = this.offsetY;
-        this.adjustViewportZoneY();
+      let finalTarget = targetRow;
+      while (this.getters.isRowHidden(sheetId, finalTarget) && targetRow > 0) {
+        finalTarget--;
       }
+      this.offsetY =
+        this.getters.getRowDimensions(sheetId, finalTarget).start - this.offsetCorrectionY;
+      this.offsetScrollbarY = this.offsetY;
+      this.adjustViewportZoneY();
     }
   }
 


### PR DESCRIPTION
This commit fixes a performance issue when there are too many
rows/cols. Trying to jump between (sustantially) distant cells would
take a huge amount of time. The issue lies in the implementation
where we would iterate on each row (resp. col) between the current top (resp.
left) cell and the one targeted. The greater the distance, the more
operations we had (O(n)).

This revision proposes an implementation in O(1).

Performances:
-------------
On a sheet with 10_000 rows. Jumping from A1 to A10000 with the shortcut
`Shift+ArrowDown`.

Before: `InternalViewport > adjustPosition`  ~23150 ms
After: `InternalViewport > adjustPosition` ~4 ms

Co-authored-by: Rémi Rahir (rar) <rar@odoo.com>

Task: /

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo