### PR TITLE
[FIX] Selection: exclude hidden rows/cols in selection statistics

### DIFF
--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -415,12 +415,19 @@ export class GridSelectionPlugin extends UIPlugin {
   }
 
   getStatisticFnResults(): { [name: string]: number | undefined } {
+    const sheetId = this.getters.getActiveSheetId();
     // get deduplicated cells in zones
     const cells = new Set(
       this.gridSelection.zones
-        .map((zone) => this.getters.getCellsInZone(this.getters.getActiveSheetId(), zone))
+        .map((zone) => this.getters.getCellsInZone(sheetId, zone))
         .flat()
-        .filter((cell) => cell !== undefined)
+        .filter((cell) => {
+          if (!cell) {
+            return false;
+          }
+          const { col, row } = this.getters.getCellPosition(cell?.id!);
+          return !this.getters.isRowHidden(sheetId, row) && !this.getters.isColHidden(sheetId, col);
+        })
     );
 
     let cellsTypes = new Set<CellValueType>();

--- a/tests/plugins/core.test.ts
+++ b/tests/plugins/core.test.ts
@@ -7,6 +7,7 @@ import {
   addColumns,
   addRows,
   createSheet,
+  hideRows,
   redo,
   resizeColumns,
   resizeRows,
@@ -44,6 +45,21 @@ describe("core", () => {
       // A2 is now present in two selection
       statisticFnResults = model.getters.getStatisticFnResults();
       expect(statisticFnResults["Count"]).toBe(3);
+    });
+
+    test("statistic function should not include hidden rows/columns in calculations", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "1");
+      setCellContent(model, "A2", "2");
+      setCellContent(model, "A3", "3");
+
+      setSelection(model, ["A1:A4"]);
+      let statisticFnResults = model.getters.getStatisticFnResults();
+      expect(statisticFnResults["Sum"]).toBe(6);
+
+      hideRows(model, [1, 2]);
+      statisticFnResults = model.getters.getStatisticFnResults();
+      expect(statisticFnResults["Sum"]).toBe(1);
     });
 
     describe("return undefined if the types handled by the function are not present among the types of the selected cells", () => {


### PR DESCRIPTION
## Description:

Previously, the Selection Statistics displayed calculations for all rows and columns, even when some were hidden.

This commit addresses the issue by considering only the cells that are not hidden in the statistics calculation.

Task: : [3508872](https://www.odoo.com/web#id=3508872&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo