### PR TITLE
[FIX] evaluation: compute cell only once

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
@@ -115,7 +115,7 @@ class CompilationParametersBuilder {
     const evaluatedCell = this.getEvaluatedCell(position);
     if (evaluatedCell.type === CellValueType.empty) {
       const cell = this.getters.getCell(position);
-      if (!cell || cell.content === "") {
+      if (!cell || (!cell.isFormula && cell.content === "")) {
         return undefined;
       }
     }

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -50,8 +50,10 @@ export class Evaluator {
 
   constructor(private readonly context: ModelConfig["custom"], getters: Getters) {
     this.getters = getters;
-    this.compilationParams = buildCompilationParameters(context, getters, (position) =>
-      this.computeCell(this.encodePosition(position))
+    this.compilationParams = buildCompilationParameters(
+      this.context,
+      this.getters,
+      this.computeAndSave.bind(this)
     );
   }
 
@@ -90,8 +92,10 @@ export class Evaluator {
   }
 
   updateCompilationParameters() {
-    this.compilationParams = buildCompilationParameters(this.context, this.getters, (position) =>
-      this.computeCell(this.encodePosition(position))
+    this.compilationParams = buildCompilationParameters(
+      this.context,
+      this.getters,
+      this.computeAndSave.bind(this)
     );
   }
 
@@ -223,6 +227,15 @@ export class Evaluator {
     } finally {
       this.cellsBeingComputed.delete(cellId);
     }
+  }
+
+  private computeAndSave(position: CellPosition) {
+    const positionId = this.encodePosition(position);
+    const evaluatedCell = this.computeCell(positionId);
+    if (!this.evaluatedCells.has(positionId)) {
+      this.setEvaluatedCell(positionId, evaluatedCell);
+    }
+    return evaluatedCell;
   }
 
   private handleError(e: Error | any, cell: Cell): EvaluatedCell {

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -123,6 +123,30 @@ describe("evaluateCells", () => {
     expect(evaluateCell("C1", grid)).toBe(0);
   });
 
+  test("compute cell only once when references multiple times", () => {
+    const mock = jest.fn().mockReturnValue(42);
+    functionRegistry.add("MY.FUNC", {
+      description: "any function",
+      compute: mock,
+      args: [],
+      returns: ["NUMBER"],
+    });
+    new Model({
+      sheets: [
+        {
+          cells: {
+            A1: { content: "=D1" },
+            A2: { content: "=D1" },
+            A3: { content: "=D1" },
+            D1: { content: "=MY.FUNC()" },
+          },
+        },
+      ],
+    });
+    expect(mock).toHaveBeenCalledTimes(1);
+    functionRegistry.remove("MY.FUNC");
+  });
+
   test("Percent operator", () => {
     const grid = { A1: "1", B1: "=(5+A1)%" };
     expect(evaluateCell("B1", grid)).toBe(0.06);


### PR DESCRIPTION

## Description:

At the first evaluation, cells are computed in the order they are defined. When a formula references another cell, the cell is computed (if it's not already computed). However, the result is currently not stored. Therefore, if another formula references the same cell, it will be recomputed!

It can drastically slow down the evaluation as the same cells can be recomputed an enormous amount of time.

In a (quite big) spreadsheet prepared for a demo at OXP, evaluation goes from more than 30 seconds to less than 500ms

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo