### PR TITLE
[IMP] PieChart: exclude negative values

### DIFF
--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -2052,6 +2052,56 @@ describe("Cumulative Data line chart", () => {
   });
 });
 
+describe("Pie chart negative values", () => {
+  test("Pie chart to exclude negative values and labels in single dataset", () => {
+    setCellContent(model, "D6", "-23");
+    createChart(
+      model,
+      {
+        dataSets: ["D5:D10"],
+        labelRange: "A2:A6",
+        type: "pie",
+      },
+      "1"
+    );
+    const expectedData = ["P6", 32, 42]; // -23 is filtered out from dataset
+    const expectedLabels = ["P2", "P3", "P4"];
+
+    expect(
+      (model.getters.getChartRuntime("1") as PieChartRuntime).chartJsConfig.data.datasets[0].data
+    ).toEqual(expectedData);
+    expect(
+      (model.getters.getChartRuntime("1") as PieChartRuntime).chartJsConfig.data.labels
+    ).toEqual(expectedLabels);
+  });
+
+  test("Pie chart to replace negative values with 0 in multiple dataset", () => {
+    setCellContent(model, "D6", "-23");
+    setCellContent(model, "D8", "-3");
+    createChart(
+      model,
+      {
+        dataSets: ["D5:D9", "B1:B5"],
+        labelRange: "A2:A6",
+        type: "pie",
+      },
+      "1"
+    );
+    const expectedData = [0, "P6", 0, 42]; // -23 and -3 are replaced by 0
+    const expectedLabels = ["P2", "P3", "P4", ""];
+
+    expect(
+      (model.getters.getChartRuntime("1") as PieChartRuntime).chartJsConfig.data.datasets[0].data
+    ).toEqual(expectedData);
+    expect(
+      (model.getters.getChartRuntime("1") as PieChartRuntime).chartJsConfig.data.datasets[1].data
+    ).toEqual([10, 11, 12, 13]);
+    expect(
+      (model.getters.getChartRuntime("1") as PieChartRuntime).chartJsConfig.data.labels
+    ).toEqual(expectedLabels);
+  });
+});
+
 test("creating chart with single dataset should have legend position set as none, followed by changing it to top", async () => {
   createChart(
     model,


### PR DESCRIPTION
## Description:

Added a function in PieChart component to exclude negative values when rendering. This enhancement ensures that negative values and corresponding labels are not included in the pie chart  in case of single dataset , And in case of multiple dataset negative values are replaced with 0 to ensure accurate representation of the data.

Task: [3510971](https://www.odoo.com/web#id=3510971&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo