### PR TITLE
[FIX] ChartPanel: deleting chart while editing data series gives traceback

### DIFF
--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -90,7 +90,7 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   canUpdateChart<T extends ChartDefinition>(figureId: UID, updateDefinition: Partial<T>) {
-    if (figureId !== this.figureId) {
+    if (figureId !== this.figureId || !this.env.model.getters.isChartDefined(figureId)) {
       return;
     }
     const definition: T = {

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -18,6 +18,7 @@ import {
   click,
   doubleClick,
   focusAndKeyDown,
+  keyDown,
   setInputValueAndTrigger,
   simulateClick,
   triggerMouseEvent,
@@ -525,6 +526,23 @@ describe("charts", () => {
       expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
     }
   );
+
+  test("Deleting a chart with active selection input does not produce a traceback", async () => {
+    createTestChart("basicChart");
+    await nextTick();
+
+    await simulateClick(".o-figure");
+    await simulateClick(".o-figure-menu-item");
+    await simulateClick(".o-menu div[data-name='edit']");
+    await simulateClick(".o-data-series .o-add-selection");
+    const element = document.querySelectorAll(".o-data-series input")[0];
+    setInputValueAndTrigger(element, "C1:C4", "input");
+    await nextTick();
+
+    await simulateClick(".o-figure");
+    await keyDown({ key: "Delete" });
+    expect(fixture.querySelector(".o-figure")).toBeFalsy();
+  });
 
   test("double click a chart in readonly mode does not open the side panel", async () => {
     createTestChart("basicChart");


### PR DESCRIPTION
## Description:

Previously, if a user deleted a chart while editing the data series, it would result in a traceback with the message `There is no chart with the given figureId.`

This commit addresses and resolves this issue by verifying the existence of the chart before performing any updates.

Task: : [3523882](https://www.odoo.com/web#id=3523882&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo