### PR TITLE
[FIX] icons: Fix icon svg's

### DIFF
--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -107,6 +107,7 @@
   <t t-name="o-spreadsheet-Icon.CLEAR" owl="1">
     <svg class="o-icon">
       <path
+        fill="currentColor"
         d="M1.5 15a.75.75 0 0 0 0 1.5h15a.75.75 0 0 0 0-1.5M5.3 12.75c.1.1.3.2.5.2h4c.2 0 .4-.1.5-.2l5.5-5.5c.2-.3.2-.6 0-.8l-4.4-4.4c-.3-.2-.6-.2-.8 0l-4.8 4.8c-2.7 2.9-3.1 2.8-2.4 4M7 7.25l3.6 3.6-1 1-3.6.1-1.8-1.9"
       />
     </svg>
@@ -513,7 +514,7 @@
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_TYPE" owl="1">
     <svg class="o-icon">
-      <g fill="#000000" transform="translate(2 2)">
+      <g fill="currentColor" transform="translate(2 2)">
         <polygon points="0 0 0 2 14 2 14 0"/>
         <polygon points="0 6 0 8 5 8 5 6"/>
         <polygon points="9 6 9 8 14 8 14 6"/>
@@ -526,7 +527,7 @@
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_COLOR" owl="1">
     <svg class="o-icon">
-      <g fill="#000000" transform="translate(4 2)">
+      <g fill="currentColor" transform="translate(4 2)">
         <polygon points="0 12 0 9 7 2 10 5 3 12"/>
         <polygon points="8 1 9 0 12 3 11 4"/>
       </g>
@@ -534,7 +535,7 @@
   </t>
   <t t-name="o-spreadsheet-Icon.BORDER_NO_COLOR" owl="1">
     <svg class="o-icon">
-      <g fill="#000000">
+      <g fill="currentColor">
         <polygon points="4 12 4 9 11 2 14 5 7 12"/>
         <polygon points="12 1 13 0 16 3 15 4"/>
       </g>
@@ -794,10 +795,10 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.CHECK" owl="1">
-    <svg width="24" height="24" viewBox="3 0 24 24">
+    <svg class="o-icon" viewBox="0 0 24 24">
       <path
+        fill="currentColor"
         d="M18.707 7.293a1 1 0 0 1 0 1.414L11.414 16a2 2 0 0 1-2.828 0l-3.293-3.293a1 1 0 1 1 1.414-1.414L10 14.586l7.293-7.293a1 1 0 0 1 1.414 0z"
-        fill="#000"
       />
     </svg>
   </t>

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -614,14 +614,13 @@ exports[`TopBar component can set cell format 1`] = `
               class="o-menu-item-icon align-middle"
             >
               <svg
-                height="24"
-                viewBox="3 0 24 24"
-                width="24"
+                class="o-icon"
+                viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
                   d="M18.707 7.293a1 1 0 0 1 0 1.414L11.414 16a2 2 0 0 1-2.828 0l-3.293-3.293a1 1 0 1 1 1.414-1.414L10 14.586l7.293-7.293a1 1 0 0 1 1.414 0z"
-                  fill="#000"
+                  fill="currentColor"
                 />
               </svg>
             </div>


### PR DESCRIPTION
The checkmark icon viewbox was decentered and it could not inherit from the `currentColor`for its fill, other icons had the same issue.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo