### PR TITLE
[FIX] evaluation: fix evaluateFormula getter typing

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -10,6 +10,7 @@ import {
   Format,
   FormattedValue,
   FormulaCell,
+  Matrix,
   Range,
   UID,
   Zone,
@@ -206,7 +207,7 @@ export class EvaluationPlugin extends UIPlugin {
   // Getters
   // ---------------------------------------------------------------------------
 
-  evaluateFormula(sheetId: UID, formulaString: string): any {
+  evaluateFormula(sheetId: UID, formulaString: string): CellValue | Matrix<CellValue> {
     const compiledFormula = compile(formulaString);
 
     const ranges: Range[] = [];

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -22,6 +22,7 @@ import {
   UID,
   Zone,
   invalidateCFEvaluationCommands,
+  isMatrix,
 } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 import { CoreViewCommand } from "./../../types/commands";
@@ -194,7 +195,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
         return percentile(rangeValues, Number(threshold.value) / 100, true);
       case "formula":
         const value = threshold.value && this.getters.evaluateFormula(sheetId, threshold.value);
-        return !(value instanceof Promise) ? value : null;
+        return typeof value === "number" ? value : null;
       default:
         return null;
     }
@@ -410,10 +411,13 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
       }
       const [value0, value1] = rule.values.map((val) => {
         if (val.startsWith("=")) {
-          return this.getters.evaluateFormula(target.sheetId, val);
+          return this.getters.evaluateFormula(target.sheetId, val) ?? "";
         }
         return parseLiteral(val, DEFAULT_LOCALE);
       });
+      if (isMatrix(value0) || isMatrix(value1)) {
+        return false;
+      }
 
       switch (rule.operator) {
         case "IsEmpty":

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -12,6 +12,7 @@ import {
   Lazy,
   Offset,
   UID,
+  isMatrix,
 } from "../../types";
 import { CoreViewCommand, invalidateEvaluationCommands } from "../../types/commands";
 import { CellErrorType, EvaluationError } from "../../types/errors";
@@ -223,7 +224,7 @@ export class EvaluationDataValidationPlugin extends UIPlugin {
         );
 
         const evaluated = this.getters.evaluateFormula(sheetId, translatedFormula);
-        return evaluated ? evaluated.toString() : "";
+        return evaluated && !isMatrix(evaluated) ? evaluated.toString() : "";
       } catch (e) {
         return e instanceof EvaluationError ? e.errorType : CellErrorType.GenericError;
       }

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -28,6 +28,7 @@ import {
   Format,
   HeaderIndex,
   Highlight,
+  isMatrix,
   LocalCommand,
   Locale,
   Range,
@@ -812,6 +813,10 @@ export class EditionPlugin extends UIPlugin {
       const cellValue = content.startsWith("=")
         ? this.getters.evaluateFormula(this.sheetId, content)
         : parseLiteral(content, this.getters.getLocale());
+
+      if (isMatrix(cellValue)) {
+        return CommandResult.Success;
+      }
 
       const validationResult = this.getters.getValidationResultForCellValue(
         cellValue,

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -1098,6 +1098,24 @@ describe("conditional formats types", () => {
       });
     });
 
+    test("CF with spreading formula is disabled", () => {
+      model.dispatch("ADD_CONDITIONAL_FORMAT", {
+        cf: {
+          rule: {
+            type: "CellIsRule",
+            operator: "NotContains",
+            values: ["=MUNIT(3)"],
+            style: { fillColor: "#ff0f0f" },
+          },
+          id: "11",
+        },
+        ranges: toRangesData(sheetId, "A1"),
+        sheetId,
+      });
+
+      expect(getStyle(model, "A1")).toEqual({});
+    });
+
     test("Operator GreaterThanOrEqual", () => {
       model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: {

--- a/tests/data_validation/data_validation_blocking_component.test.ts
+++ b/tests/data_validation/data_validation_blocking_component.test.ts
@@ -113,4 +113,13 @@ describe("Data validation with blocking rule", () => {
     expect(result).toBeCancelledBecause(CommandResult.BlockingValidationRule);
     expect(getCellContent(model, "A1")).toBe("");
   });
+
+  test("User can input spreading formula in blocking DV rule", async () => {
+    addDataValidation(model, "A1", "id", { type: "textContains", values: ["hi"] }, "blocking");
+    model.dispatch("START_EDITION", { text: "=MUNIT(6)" });
+    const result = model.dispatch("STOP_EDITION");
+
+    expect(result).toBeSuccessfullyDispatched();
+    expect(getCellContent(model, "A1")).toBe("1");
+  });
 });

--- a/tests/data_validation/evaluation_data_validation_plugin.test.ts
+++ b/tests/data_validation/evaluation_data_validation_plugin.test.ts
@@ -66,6 +66,16 @@ describe("Data validation evaluation", () => {
       expect(model.getters.isDataValidationInvalid(A1)).toEqual(false);
     });
 
+    test("Criterion with spreading formula values is ignored ", () => {
+      addDataValidation(model, "A1", "id", {
+        type: "isGreaterThan",
+        values: ["=MUNIT(3)"],
+      });
+
+      setCellContent(model, "A1", "8");
+      expect(model.getters.isDataValidationInvalid(A1)).toEqual(false);
+    });
+
     test("Can use references in formula values", () => {
       addDataValidation(model, "A1", "id", {
         type: "isBetween",


### PR DESCRIPTION
## Description

The getter evaluateFormula was typed as returning `any`, which led to wrong code that didn't handle array formula at all.

This commit fixes the typing, and fixes the code. The changes are:
 - both CFs and Data Validations are now disabled if they contain an array formula in their criterion values
 - the user can input an array formula in a range that has a blocking DV rule.

Task: : [3551249](https://www.odoo.com/web#id=3551249&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo