### PR TITLE
[FIX] clipboard: fix array formula copy

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -644,13 +644,14 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       const content = clipboardData.getData(ClipboardMIMEType.PlainText);
       const target = this.env.model.getters.getSelectedZones();
       const clipboardString = this.env.model.getters.getClipboardTextContent();
+      const isCutOperation = this.env.model.getters.isCutOperation();
       if (clipboardString === content) {
         // the paste actually comes from o-spreadsheet itself
         interactivePaste(this.env, target);
       } else {
         interactivePasteFromOS(this.env, target, content);
       }
-      if (this.env.model.getters.isCutOperation()) {
+      if (isCutOperation) {
         await this.env.clipboard.write({ [ClipboardMIMEType.PlainText]: "" });
       }
     }

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -149,6 +149,7 @@ export class EvaluationPlugin extends UIPlugin {
     "getEvaluatedCells",
     "getEvaluatedCellsInZone",
     "getSpreadPositionsOf",
+    "getArrayFormulaSpreadingOn",
   ] as const;
 
   private shouldRebuildDependenciesGraph = true;
@@ -277,6 +278,10 @@ export class EvaluationPlugin extends UIPlugin {
     return this.evaluator.getSpreadPositionsOf(position);
   }
 
+  getArrayFormulaSpreadingOn(position: CellPosition): CellPosition | undefined {
+    return this.evaluator.getArrayFormulaSpreadingOn(position);
+  }
+
   // ---------------------------------------------------------------------------
   // Export
   // ---------------------------------------------------------------------------
@@ -329,7 +334,7 @@ export class EvaluationPlugin extends UIPlugin {
       return undefined;
     }
 
-    const spreadingFormulaPosition = this.evaluator.getArrayFormulaSpreadingOn(position);
+    const spreadingFormulaPosition = this.getArrayFormulaSpreadingOn(position);
 
     if (spreadingFormulaPosition === undefined) {
       return undefined;

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -117,6 +117,9 @@ export class ClipboardPlugin extends UIPlugin {
         const pasteOption =
           cmd.pasteOption || (this.paintFormatStatus !== "inactive" ? "onlyFormat" : undefined);
         this.state.paste(cmd.target, { pasteOption, shouldPasteCF: true, selectTarget: true });
+        if (this.state.operation === "CUT") {
+          this.state = undefined;
+        }
         this.lastPasteState = this.state;
         if (this.paintFormatStatus === "oneOff") {
           this.paintFormatStatus = "inactive";

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -195,7 +195,6 @@ export function isMatrix(x: any): x is Matrix<any> {
 
 export interface ClipboardCell {
   cell?: Cell;
-  style?: Style;
   evaluatedCell: EvaluatedCell;
   border?: Border;
   position: CellPosition;

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -2052,6 +2052,79 @@ describe("clipboard: pasting outside of sheet", () => {
     expect(getEvaluatedCell(model, "A1").value).toBe(8.14);
   });
 
+  test("Can copy parts of the spread values", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+    setCellContent(model, "A3", "3");
+    setCellContent(model, "B1", "=TRANSPOSE(A1:A3)");
+    copy(model, "C1:D1");
+    paste(model, "C2");
+    expect(getEvaluatedCell(model, "C2").value).toBe(2);
+    expect(getEvaluatedCell(model, "D2").value).toBe(3);
+  });
+
+  test("Cutting parts of the spread values will make a copy of the values", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+    setCellContent(model, "A3", "3");
+    setCellContent(model, "B1", "=TRANSPOSE(A1:A3)");
+    cut(model, "C1:D1");
+    paste(model, "C2");
+    expect(getEvaluatedCell(model, "B1").value).toBe(1);
+    expect(getEvaluatedCell(model, "C1").value).toBe(2);
+    expect(getEvaluatedCell(model, "C2").value).toBe(2);
+    expect(getEvaluatedCell(model, "D1").value).toBe(3);
+    expect(getEvaluatedCell(model, "D2").value).toBe(3);
+  });
+
+  test("can copy and paste format only from spread value", () => {
+    const model = new Model();
+
+    // formula without format
+    setCellContent(model, "A1", "=SUM(1+2)");
+
+    // formula with format set on it
+    setCellContent(model, "A2", "=SUM(1+2)");
+    setCellFormat(model, "A2", "0%");
+
+    // formula that return value with format
+    setCellContent(model, "A3", "=DATE(2042,1,1)");
+
+    // formula that return value with format and other format seted on it
+    setCellContent(model, "A4", "=DATE(2042,1,1)");
+    setCellFormat(model, "A4", "0%");
+
+    // formula that return value with format inferred from reference
+    setCellContent(model, "A5", "3");
+    setCellFormat(model, "A5", "0%");
+    setCellContent(model, "A6", "=SUM(1+A5)");
+
+    // formula that return value with format inferred from reference and other format seted on it
+    setCellContent(model, "A7", "3");
+    setCellFormat(model, "A7", "0%");
+    setCellContent(model, "A8", "=SUM(1+A7)");
+    setCellFormat(model, "A8", "#,##0[$$]");
+
+    setCellContent(model, "B1", "=TRANSPOSE(A1:A8)");
+
+    for (const cell of ["C2", "D2", "E2", "F2", "G2", "H2", "I2"]) {
+      setCellContent(model, cell, "42");
+    }
+
+    copy(model, "C1:I1");
+    paste(model, "C2", "onlyFormat");
+
+    expect(getCellContent(model, "C2")).toBe("4200%");
+    expect(getCellContent(model, "D2")).toBe("2/10/1900");
+    expect(getCellContent(model, "E2")).toBe("4200%");
+    expect(getCellContent(model, "F2")).toBe("4200%");
+    expect(getCellContent(model, "G2")).toBe("4200%");
+    expect(getCellContent(model, "H2")).toBe("4200%");
+    expect(getCellContent(model, "I2")).toBe("42$");
+  });
+
   describe("add col/row can invalidate the clipboard of cut", () => {
     test("adding a column before a cut zone is invalidating the clipboard", () => {
       const model = new Model();


### PR DESCRIPTION
## Task Description

When copying/cutting parts of the spread of an array formula, we currently copy an object with an evaluatedCell but without any cell, as there is no real cell to copy. Then, when pasting the copied values, we skip these parts as we look only for valid cell.

This commit aims to change this behaviour by pasting the evaluated cell when the cell is undefined.

## Related Task
- Task: [3541325](https://www.odoo.com/web#id=3541325&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo