### PR TITLE
[IMP] edition: add extra rows for spreading formulas

### DIFF
--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -4,6 +4,7 @@ import {
   colors,
   getCanonicalSheetName,
   jsDateToRoundNumber,
+  toXC,
   toZone,
 } from "../../src/helpers";
 import { Model } from "../../src/model";
@@ -20,6 +21,7 @@ import {
   merge,
   moveAnchorCell,
   paste,
+  redo,
   renameSheet,
   resizeAnchorZone,
   selectCell,
@@ -28,6 +30,7 @@ import {
   setFormat,
   setSelection,
   setStyle,
+  undo,
   updateLocale,
 } from "../test_helpers/commands_helpers";
 import { FR_LOCALE } from "../test_helpers/constants";
@@ -48,6 +51,12 @@ let container: DependencyContainer;
 beforeEach(() => {
   ({ model, container, store: composerStore } = makeStore(ComposerStore));
 });
+
+function editCell(model: Model, xc: string, content: string) {
+  selectCell(model, xc);
+  composerStore.startEdition(content);
+  composerStore.stopEdition();
+}
 
 describe("edition", () => {
   test("adding and removing a cell (by setting its content to empty string", () => {
@@ -895,12 +904,6 @@ describe("edition", () => {
   });
 
   describe("Localized numbers and formulas", () => {
-    function editCell(model: Model, xc: string, content: string) {
-      selectCell(model, xc);
-      composerStore.startEdition(content);
-      composerStore.stopEdition();
-    }
-
     describe("Number litterals", () => {
       test("Decimal number detected with decimal separator of locale", () => {
         editCell(model, "A1", "3,14");
@@ -1038,6 +1041,56 @@ describe("edition", () => {
         );
       });
     });
+  });
+
+  test("Adding a spreading formula at the bottom of the sheet add enough rows for the formula to spread", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    const numberOfRows = model.getters.getNumberRows(sheetId);
+
+    const cellOnLastRow = toXC(0, numberOfRows - 1);
+    editCell(model, cellOnLastRow, "=TRANSPOSE(A1:E1)");
+
+    expect(model.getters.getNumberRows(sheetId)).toBe(numberOfRows + 4 + 50);
+    expect(getCellContent(model, cellOnLastRow)).toBe("0");
+  });
+
+  test("Adding a spreading formula at the right of the sheet add enough cols for the formula to spread", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    const numberOfCols = model.getters.getNumberCols(sheetId);
+
+    const cellOnLastCol = toXC(numberOfCols - 1, 0);
+    editCell(model, cellOnLastCol, "=TRANSPOSE(A1:A5)");
+
+    expect(model.getters.getNumberCols(sheetId)).toBe(numberOfCols + 4 + 20);
+    expect(getCellContent(model, cellOnLastCol)).toBe("0");
+  });
+
+  test("Can undo/redo after adding a spreading formula at the end of the sheet", () => {
+    const sheetId = model.getters.getActiveSheetId();
+    const numberOfCols = model.getters.getNumberCols(sheetId);
+
+    const cellOnLastCol = toXC(numberOfCols - 1, 0);
+    editCell(model, cellOnLastCol, "=TRANSPOSE(A1:A5)");
+
+    expect(model.getters.getNumberCols(sheetId)).toBe(numberOfCols + 4 + 20);
+    expect(getCell(model, cellOnLastCol)?.content).toBe("=TRANSPOSE(A1:A5)");
+
+    // A current unavoidable limitation is that we have multiple history steps (add cols + update cell)
+    undo(model);
+    expect(model.getters.getNumberCols(sheetId)).toBe(numberOfCols + 4 + 20);
+    expect(getCellContent(model, cellOnLastCol)).toBe("");
+
+    undo(model);
+    expect(model.getters.getNumberCols(sheetId)).toBe(numberOfCols);
+    expect(getCellContent(model, cellOnLastCol)).toBe("");
+
+    redo(model);
+    expect(model.getters.getNumberCols(sheetId)).toBe(numberOfCols + 4 + 20);
+    expect(getCellContent(model, cellOnLastCol)).toBe("");
+
+    redo(model);
+    expect(model.getters.getNumberCols(sheetId)).toBe(numberOfCols + 4 + 20);
+    expect(getCell(model, cellOnLastCol)?.content).toBe("=TRANSPOSE(A1:A5)");
   });
 
   test("Invalid references are filtered out from the highlights", () => {


### PR DESCRIPTION
## Description

The goal of this commit is to add extra rows to the spreadsheet when the user create a new spreading formula, but there is not enough rows for the formula to spread.

Task: : [3458203](https://www.odoo.com/web#id=3458203&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo