### PR TITLE
[FIX] xlsx export: remove unsupported characters

### DIFF
--- a/src/xlsx/helpers/xml_helpers.ts
+++ b/src/xlsx/helpers/xml_helpers.ts
@@ -24,12 +24,17 @@ export function createXMLFile(
 }
 
 function xmlEscape(str: XMLAttributeValue): string {
-  return String(str)
-    .replace(/\&/g, "&amp;")
-    .replace(/\</g, "&lt;")
-    .replace(/\>/g, "&gt;")
-    .replace(/\"/g, "&quot;")
-    .replace(/\'/g, "&apos;");
+  return (
+    String(str)
+      .replace(/\&/g, "&amp;")
+      .replace(/\</g, "&lt;")
+      .replace(/\>/g, "&gt;")
+      .replace(/\"/g, "&quot;")
+      .replace(/\'/g, "&apos;")
+      // Delete all ASCII control characters except for TAB (\x09), LF (\x0A) and CR (\x0D)
+      // They are not valid at all in XML 1.0 (even escaped)
+      .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "")
+  );
 }
 
 export function formatAttributes(attrs: XMLAttributes): XMLString {

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -1,4 +1,4 @@
-import { buildSheetLink } from "../src/helpers";
+import { buildSheetLink, toXC } from "../src/helpers";
 import { Model } from "../src/model";
 import { ChartTypes } from "../src/types";
 import { adaptFormulaToExcel } from "../src/xlsx/functions/cells";
@@ -862,6 +862,14 @@ describe("Test XLSX export", () => {
       `[Sheet1](${buildSheetLink("invalid id because the sheet was deleted")})`
     );
     expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
+  });
+
+  test("Invalid ASCII characters are escaped in XML", async () => {
+    const model = new Model({ sheets: [{ rowNumber: 200 }] });
+    for (let i = 0; i < 127; i++) {
+      setCellContent(model, toXC(0, i), String.fromCharCode(i));
+    }
+    expect(() => exportPrettifiedXlsx(model)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Description

ASCII control characters are invalid in XML 1.0, but we didn't handle them when exporting to XLSX, leading to traceback.

Task: : [3552957](https://www.odoo.com/web#id=3552957&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo