### PR TITLE
[FIX] find_and_replace: take array formula result into account

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -147,6 +147,7 @@ export class EvaluationPlugin extends UIPlugin {
     "getEvaluatedCell",
     "getEvaluatedCells",
     "getEvaluatedCellsInZone",
+    "getSpreadPositionsOf",
   ] as const;
 
   private shouldRebuildDependenciesGraph = true;
@@ -269,6 +270,10 @@ export class EvaluationPlugin extends UIPlugin {
     return positions(zone).map(({ col, row }) =>
       this.getters.getEvaluatedCell({ sheetId, col, row })
     );
+  }
+
+  getSpreadPositionsOf(position: CellPosition): CellPosition[] {
+    return this.evaluator.getSpreadPositionsOf(position);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -54,6 +54,16 @@ export class Evaluator {
     );
   }
 
+  getSpreadPositionsOf(position: CellPosition): CellPosition[] {
+    const positionId = this.encodePosition(position);
+    if (!this.spreadingRelations.isArrayFormula(positionId)) {
+      return [];
+    }
+    return Array.from(this.spreadingRelations.getArrayResultPositionIds(positionId)).map(
+      this.decodePosition.bind(this)
+    );
+  }
+
   getArrayFormulaSpreadingOn(position: CellPosition): CellPosition | undefined {
     const positionId = this.encodePosition(position);
     const formulaPosition = this.getArrayFormulaSpreadingOnId(positionId);

--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -159,21 +159,28 @@ export class FindAndReplacePlugin extends UIPlugin {
     const sheetId = this.getters.getActiveSheetId();
     const cells = this.getters.getCells(sheetId);
     const matches: SearchMatch[] = [];
-    if (this.toSearch) {
+    if (this.toSearch && this.currentSearchRegex) {
       for (const cell of Object.values(cells)) {
         const { col, row } = this.getters.getCellPosition(cell.id);
+        const cellPosition = { sheetId, col, row };
         const isColHidden = this.getters.isColHidden(sheetId, col);
         const isRowHidden = this.getters.isRowHidden(sheetId, row);
         if (isColHidden || isRowHidden) {
           continue;
         }
-        if (
-          cell &&
-          this.currentSearchRegex &&
-          this.currentSearchRegex.test(this.getSearchableString({ sheetId, col, row }))
-        ) {
+        if (this.currentSearchRegex.test(this.getSearchableString(cellPosition))) {
           const match: SearchMatch = { col, row, selected: false };
           matches.push(match);
+        }
+        for (const spreadPosition of this.getters.getSpreadPositionsOf(cellPosition)) {
+          if (this.currentSearchRegex.test(this.getSearchableString(spreadPosition))) {
+            const match: SearchMatch = {
+              col: spreadPosition.col,
+              row: spreadPosition.row,
+              selected: false,
+            };
+            matches.push(match);
+          }
         }
       }
     }
@@ -239,9 +246,12 @@ export class FindAndReplacePlugin extends UIPlugin {
     }
 
     const sheetId = this.getters.getActiveSheetId();
-    const cell = this.getters.getCell({ sheetId, ...selectedMatch });
-    const { col, row } = selectedMatch;
+    const position = { sheetId, ...selectedMatch };
 
+    const cell = this.getters.getCell(position);
+    if (!cell?.content) {
+      return;
+    }
     if (cell?.isFormula && !this.searchOptions.searchFormulas) {
       return;
     }
@@ -249,10 +259,10 @@ export class FindAndReplacePlugin extends UIPlugin {
       this.currentSearchRegex.source,
       this.currentSearchRegex.flags + "g"
     );
-    const toReplace: string | null = this.getSearchableString({ sheetId, col, row });
+    const toReplace: string | null = this.getSearchableString(position);
     const content = toReplace.replace(replaceRegex, replaceWith);
     const canonicalContent = canonicalizeNumberContent(content, this.getters.getLocale());
-    this.dispatch("UPDATE_CELL", { sheetId, col, row, content: canonicalContent });
+    this.dispatch("UPDATE_CELL", { ...position, content: canonicalContent });
   }
 
   /**

--- a/tests/find_and_replace/find_and_replace_plugin.test.ts
+++ b/tests/find_and_replace/find_and_replace_plugin.test.ts
@@ -315,6 +315,27 @@ describe("basic search", () => {
     expect(matches[3]).toStrictEqual({ col: 0, row: 5, selected: false });
   });
 });
+
+test("simple search with array formula", () => {
+  model = new Model();
+  setCellContent(model, "A1", "hell0");
+  setCellContent(model, "A2", "hello");
+  setCellContent(model, "A3", "=1");
+  setCellContent(model, "B1", "=TRANSPOSE(A1:A3)");
+  searchOptions = {
+    matchCase: false,
+    exactMatch: false,
+    searchFormulas: false,
+  };
+  model.dispatch("UPDATE_SEARCH", { toSearch: "hello", searchOptions });
+  const matches = model.getters.getSearchMatches();
+  const matchIndex = model.getters.getCurrentSelectedMatchIndex();
+  expect(matches).toHaveLength(2);
+  expect(matchIndex).toStrictEqual(0);
+  expect(matches[0]).toStrictEqual({ col: 2, row: 0, selected: true });
+  expect(matches[1]).toStrictEqual({ col: 0, row: 1, selected: false });
+});
+
 describe("next/previous cycle", () => {
   beforeEach(() => {
     model = new Model({ sheets: [{ id: "s1" }] });
@@ -696,4 +717,26 @@ describe("replace", () => {
     expect(matchIndex).toStrictEqual(null);
     expect(getActivePosition(model)).toBe("A1");
   });
+});
+
+test("replace don't replace value resulting from array formula", () => {
+  model = new Model();
+  setCellContent(model, "A1", "hell0");
+  setCellContent(model, "A2", "hello");
+  setCellContent(model, "A3", "=1");
+  setCellContent(model, "B1", "=TRANSPOSE(A1:A3)");
+  searchOptions = {
+    matchCase: false,
+    exactMatch: false,
+    searchFormulas: false,
+  };
+  model.dispatch("UPDATE_SEARCH", { toSearch: "hello", searchOptions });
+  model.dispatch("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
+  const matches = model.getters.getSearchMatches();
+  const matchIndex = model.getters.getCurrentSelectedMatchIndex();
+  expect(matches).toHaveLength(0);
+  expect(matchIndex).toStrictEqual(null);
+  expect(getCellContent(model, "A2")).toBe("kikou");
+  expect(getCellContent(model, "C1")).toBe("kikou");
+  expect(getCellContent(model, "B1")).not.toBe("#ERROR");
 });


### PR DESCRIPTION
## Task Description

Currently, in the find and replace results, we only look for matches in the cell directly, ignoring the values spread by an array formula. This PR aims to fix it, taking these values into account in the search, but also avoiding to replace them in a "FIND_AND_REPLACE_ALL" cycle, as writing a new value in these cells would avoid the array formula to spread.

## Related Task
- Task: [3413999](https://www.odoo.com/web#id=3413999&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo