### PR TITLE
[IMP] scorecard: handling CF font style on chart

### DIFF
--- a/src/helpers/charts/gauge_chart.ts
+++ b/src/helpers/charts/gauge_chart.ts
@@ -395,6 +395,6 @@ function createGaugeChartRuntime(chart: GaugeChart, getters: Getters): GaugeChar
 
   return {
     chartJsConfig: config,
-    background: getters.getBackgroundOfSingleCellChart(chart.background, dataRange),
+    background: getters.getStyleOfSingleCellChart(chart.background, dataRange).background,
   };
 }

--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -27,7 +27,6 @@ import { toUnboundedZone, zoneToXc } from "../zones";
 import { AbstractChart } from "./abstract_chart";
 import {
   adaptChartRange,
-  chartFontColor,
   copyLabelRangeWithNewSheetId,
   getBaselineArrowDirection,
   getBaselineColor,
@@ -207,7 +206,10 @@ function createScorecardChartRuntime(
     const baselineZone = chart.baseline.zone;
     baselineCell = getters.getCell(chart.baseline.sheetId, baselineZone.left, baselineZone.top);
   }
-  const background = getters.getBackgroundOfSingleCellChart(chart.background, chart.keyValue);
+  const { background, fontColor } = getters.getStyleOfSingleCellChart(
+    chart.background,
+    chart.keyValue
+  );
   return {
     title: _t(chart.title),
     keyValue: formattedKeyValue || keyValue,
@@ -225,7 +227,7 @@ function createScorecardChartRuntime(
       chart.baselineColorDown
     ),
     baselineDescr: chart.baselineDescr ? _t(chart.baselineDescr) : "",
-    fontColor: chartFontColor(background),
+    fontColor,
     background,
     baselineStyle: chart.baselineMode !== "percentage" ? baselineCell?.style : undefined,
     keyValueStyle: keyValueCell?.style,

--- a/tests/components/scorecard_chart.test.ts
+++ b/tests/components/scorecard_chart.test.ts
@@ -4,11 +4,12 @@ import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart"
 import {
   createScorecardChart as createScorecardChartHelper,
   setCellContent,
+  setStyle,
   updateChart,
 } from "../test_helpers/commands_helpers";
 import { dragElement, getElComputedStyle, simulateClick } from "../test_helpers/dom_helper";
 import { getCellContent } from "../test_helpers/getters_helpers";
-import { mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
+import { mountSpreadsheet, nextTick, target, toRangesData } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 let model: Model;
@@ -383,5 +384,27 @@ describe("Scorecard charts", () => {
     updateChart(model, chartId, { baselineDescr: "" }, sheetId);
     await nextTick();
     expect(getElementFontSize(getChartBaselineElement())).toBeGreaterThan(baselineFontSize);
+  });
+
+  test("Scorecard chart adapts CF font color properly while prioritizing user set values", async () => {
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: {
+        rule: {
+          type: "CellIsRule",
+          values: [],
+          operator: "IsNotEmpty",
+          style: { textColor: "#FF0000", fillColor: "#00FF00" },
+        },
+        id: "cfId",
+      },
+      ranges: toRangesData(sheetId, "A1"),
+      sheetId,
+    });
+    setCellContent(model, "A1", "30");
+    await createScorecardChart(model, { keyValue: "A1" }, chartId);
+    expect(getChartKeyElement()!.style["color"]).toBeSameColorAs("#FF0000");
+    setStyle(model, "A1", { textColor: "#FFAAAA" });
+    await nextTick();
+    expect(getChartKeyElement()!.style["color"]).toBeSameColorAs("#FFAAAA");
   });
 });


### PR DESCRIPTION
## Description:

Before:
Any applied CF font color on key cell would not reflect on chart

After:
Text color of Key Value will reflect as follows:
- If no font color is set, then default text color will be applied.
- If CF font color is applied on cell, key value will reflect that text color.
- If user sets a font color on cell, then user applied color of key value 
will take precedence over CF font color

"getStyleOfSingleCellChart" method of evaluation chart is modified to
"getBackgroundOfSingleCellChart", which handles style of a single cell 
for chart at runtime .

Task: : [3543131](https://www.odoo.com/web#id=3543131&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo