### PR TITLE
[FIX] popover: fix popover position when too much items

### DIFF
--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -43,16 +43,17 @@ export class Popover extends Component<Props, SpreadsheetChildEnv> {
 
   private spreadsheetPosition = useSpreadsheetPosition();
 
+  get maxHeight(): Pixel {
+    return Math.max(0, this.viewportDimension.height - BOTTOMBAR_HEIGHT - SCROLLBAR_WIDTH);
+  }
+
   get style() {
     // the props's position is expressed relative to the "body" element
     // but we teleport the element in ".o-spreadsheet" to keep everything
     // within our control and to avoid leaking into external DOM
     const horizontalPosition = `left:${this.horizontalPosition() - this.spreadsheetPosition.x}`;
     const verticalPosition = `top:${this.verticalPosition() - this.spreadsheetPosition.y}`;
-    const maxHeight = Math.max(
-      0,
-      this.viewportDimension.height - BOTTOMBAR_HEIGHT - SCROLLBAR_WIDTH
-    );
+    const maxHeight = this.maxHeight;
     const height = `max-height:${maxHeight}`;
     const shadow = maxHeight !== 0 ? "box-shadow: 1px 2px 5px 2px rgb(51 51 51 / 15%);" : "";
     return `
@@ -80,7 +81,7 @@ export class Popover extends Component<Props, SpreadsheetChildEnv> {
   private get shouldRenderBottom(): boolean {
     const { y } = this.props.position;
     return (
-      y + this.props.childHeight <
+      y + Math.min(this.props.childHeight, this.maxHeight) <
       this.viewportDimension.height + (this.env.isDashboard() ? 0 : TOPBAR_HEIGHT)
     );
   }

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -434,6 +434,21 @@ describe("TopBar component", () => {
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
   });
 
+  test("Opened menu with too much items is still correctly positioned", async () => {
+    for (let i = 0; i < 100; i++) {
+      topbarMenuRegistry.addChild(`testaction-${i}`, ["file"], {
+        name: `TestAction ${i}`,
+        sequence: 1,
+        action: () => {},
+      });
+    }
+    await mountParent();
+    triggerMouseEvent(".o-topbar-menu[data-id='file']", "click");
+    await nextTick();
+    const menuElement = fixture.querySelector(".o-popover")! as HTMLElement;
+    expect(menuElement.style.top).toBe("0px");
+  });
+
   test("Can add a custom component to topbar", async () => {
     const compDefinitions = Object.assign({}, topbarComponentRegistry.content);
     class Comp extends Component {


### PR DESCRIPTION
## Task Description

When opening a topbar menu with too many items in it (which can happen, mainly, in Odoo with too many data sources), the menu is not correctly placed. This comes from the fact that, in the computation of the position, we check if the popover should render from the bottom using the original children size instead of the real size of the popover (the min between the 'maxSize' that the popover can be and the children size).

## Related Task

- Task: [3418671](https://www.odoo.com/web#id=3418671&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo