### PR TITLE
[FIX] FilterEvaluationPlugin: insert/remove row on data filter header

### DIFF
--- a/src/plugins/core/filters.ts
+++ b/src/plugins/core/filters.ts
@@ -223,6 +223,14 @@ export class FiltersPlugin extends CorePlugin<FiltersState> implements FiltersSt
 
   private onDeleteColumnsRows(cmd: RemoveColumnsRowsCommand) {
     for (const table of this.getFilterTables(cmd.sheetId)) {
+      // Remove the filter tables whose data filter headers are in the removed rows.
+      if (cmd.dimension === "ROW" && cmd.elements.includes(table.zone.top)) {
+        const tables = { ...this.tables[cmd.sheetId] };
+        delete tables[table.id];
+        this.history.update("tables", cmd.sheetId, tables);
+        continue;
+      }
+
       const zone = reduceZoneOnDeletion(
         table.zone,
         cmd.dimension === "COL" ? "left" : "top",

--- a/src/plugins/ui/filter_evaluation.ts
+++ b/src/plugins/ui/filter_evaluation.ts
@@ -74,6 +74,8 @@ export class FilterEvaluationPlugin extends UIPlugin {
         break;
       case "HIDE_COLUMNS_ROWS":
       case "UNHIDE_COLUMNS_ROWS":
+      case "ADD_COLUMNS_ROWS":
+      case "REMOVE_COLUMNS_ROWS":
         this.updateHiddenRows();
         break;
       case "UPDATE_FILTER":

--- a/tests/plugins/filter_evaluation.test.ts
+++ b/tests/plugins/filter_evaluation.test.ts
@@ -2,8 +2,10 @@ import { Model } from "../../src";
 import { toZone } from "../../src/helpers";
 import { UID } from "../../src/types";
 import {
+  addRows,
   createFilter,
   deleteFilter,
+  deleteRows,
   hideColumns,
   hideRows,
   setBorder,
@@ -163,5 +165,40 @@ describe("Filter Evaluation Plugin", () => {
       sheetIdTo: "sh2",
     });
     expect(model.getters.getFilter("sh2", 0, 0)).toBeTruthy();
+  });
+
+  test("Inserting rows above or below the data filter header updates the filtered rows", () => {
+    const model = new Model();
+
+    createFilter(model, "A1:A2");
+    setCellContent(model, "A2", "Hi");
+
+    updateFilter(model, "A1", ["Hi"]);
+    expect(model.getters.isRowFiltered(sheetId, 1)).toEqual(true);
+
+    addRows(model, "before", 0, 1);
+    expect(model.getters.isRowFiltered(sheetId, 1)).toEqual(false);
+    expect(model.getters.isRowFiltered(sheetId, 2)).toEqual(true);
+
+    addRows(model, "after", 1, 1);
+    expect(model.getters.isRowFiltered(sheetId, 2)).toEqual(false);
+    expect(model.getters.isRowFiltered(sheetId, 3)).toEqual(true);
+  });
+
+  test("Removing rows above the data filter header updates the filtered rows", () => {
+    const model = new Model();
+
+    createFilter(model, "A4:A6");
+    setCellContent(model, "A5", "Hi");
+    setCellContent(model, "A6", "Hi");
+
+    updateFilter(model, "A4", ["Hi"]);
+    expect(model.getters.isRowFiltered(sheetId, 4)).toEqual(true);
+    expect(model.getters.isRowFiltered(sheetId, 5)).toEqual(true);
+
+    deleteRows(model, [0, 1, 2]);
+
+    expect(model.getters.isRowFiltered(sheetId, 1)).toEqual(true);
+    expect(model.getters.isRowFiltered(sheetId, 2)).toEqual(true);
   });
 });

--- a/tests/plugins/filters.test.ts
+++ b/tests/plugins/filters.test.ts
@@ -492,15 +492,9 @@ describe("Filters plugin", () => {
         ]);
       });
 
-      test("On the left part of the zone", () => {
+      test("Removing rows with filter table should remove the filter table", () => {
         deleteRows(model, [2]);
-        expect(model.getters.getFilterTables(sheetId)[0].zone).toEqual(toZone("C3:F5"));
-        expect(getFilterValues(model)).toEqual([
-          { zone: "C3:C5", value: ["C"] },
-          { zone: "D3:D5", value: ["D"] },
-          { zone: "E3:E5", value: ["E"] },
-          { zone: "F3:F5", value: ["F"] },
-        ]);
+        expect(model.getters.getFilterTables(sheetId)).toEqual([]);
       });
 
       test("Inside the zone", () => {


### PR DESCRIPTION
## Description:

This PR includes two distinct commits that address issues related to the handling of data filter headers in our SheetPlugin and FilterEvaluationPlugin.

Commit 1: [FIX] FilterEvaluationPlugin: insert/remove row on data filter header

- Previously, when inserting a row above or below a data filter header, hidden rows inside the data filter were not being updated. This caused a state inconsistency issue between the data filter header and the data filter values.
- This commit address the problem by ensuring that hidden rows inside the data filter header are correctly updated when rows are inserted above or below the data filter header.

- Another issue occurred when removing a row above the data filter header while certain rows were filtered. This led to a mismatch in the data filter state, revealing hidden rows. 
- This commit fixes this problem by updating the handling of hidden rows inside the data filter header during row removal.

Commit 2: [FIX] SheetPlugin: removing row with data filter header

- Previously, removing rows that included the filter header failed to remove the associated data filter tables.
- This commit addresses the issue by ensuring the data filter tables is also removed when rows with the filter header are deleted.

Task: : [3546012](https://www.odoo.com/web#id=3546012&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo