### PR TITLE
[REF] ot: extract and expose range transformation helper

### DIFF
--- a/src/collaborative/ot/ot_helpers.ts
+++ b/src/collaborative/ot/ot_helpers.ts
@@ -1,5 +1,5 @@
 import { expandZoneOnInsertion, reduceZoneOnDeletion } from "../../helpers";
-import { CoreCommand, UnboundedZone, Zone } from "../../types";
+import { CoreCommand, RangeData, UnboundedZone, Zone } from "../../types";
 
 export function transformZone<Z extends Zone | UnboundedZone>(
   zone: Z,
@@ -22,4 +22,18 @@ export function transformZone<Z extends Zone | UnboundedZone>(
     );
   }
   return { ...zone };
+}
+
+export function transformRangeData(range: RangeData, executed: CoreCommand): RangeData | undefined {
+  const deletedSheet = executed.type === "DELETE_SHEET" && executed.sheetId;
+
+  if ("sheetId" in executed && range._sheetId !== executed.sheetId) {
+    return range;
+  } else {
+    const newZone = transformZone(range._zone, executed);
+    if (newZone && deletedSheet !== range._sheetId) {
+      return { ...range, _zone: newZone };
+    }
+  }
+  return undefined;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { createAction, createActions } from "./actions/action";
+import { transformRangeData } from "./collaborative/ot/ot_helpers";
 import { ChartJsComponent } from "./components/figures/chart/chartJs/chartjs";
 import { ScorecardChart } from "./components/figures/chart/scorecard/chart_scorecard";
 import { FigureComponent } from "./components/figures/figure/figure";
@@ -209,6 +210,7 @@ export const helpers = {
   genericRepeat,
   createAction,
   createActions,
+  transformRangeData,
 };
 
 export const links = {


### PR DESCRIPTION

## Description:

Task 3554062 (text global filter with a range) introduces a range in an odoo command. The range needs to be transformed.

This commit extract the range data transformation logic and exposes the helper function in the root index.ts


Task: : [3554062](https://www.odoo.com/web#id=3554062&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo