### PR TITLE
[FIX] Figure: Pass figure as child component props

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -1,11 +1,11 @@
 import { Component, onMounted, useEffect, useRef } from "@odoo/owl";
 import type { Chart, ChartConfiguration } from "chart.js";
-import { SpreadsheetChildEnv, UID } from "../../../../types";
+import { Figure, SpreadsheetChildEnv } from "../../../../types";
 import { ChartJSRuntime } from "../../../../types/chart/chart";
 import { GaugeChartConfiguration, GaugeChartOptions } from "../../../../types/chart/gauge_chart";
 
 interface Props {
-  figureId: UID;
+  figure: Figure;
 }
 
 export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
@@ -23,7 +23,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   }
 
   get chartRuntime(): ChartJSRuntime {
-    const runtime = this.env.model.getters.getChartRuntime(this.props.figureId);
+    const runtime = this.env.model.getters.getChartRuntime(this.props.figure.id);
     if (!("chartJsConfig" in runtime)) {
       throw new Error("Unsupported chart runtime");
     }
@@ -73,5 +73,5 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
 }
 
 ChartJsComponent.props = {
-  figureId: String,
+  figure: Object,
 };

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,11 +1,11 @@
 import { Component, useEffect, useRef } from "@odoo/owl";
 import { drawScoreChart } from "../../../../helpers/figures/charts/scorecard_chart";
 import { getScorecardConfiguration } from "../../../../helpers/figures/charts/scorecard_chart_config_builder";
-import { SpreadsheetChildEnv, UID } from "../../../../types";
+import { Figure, SpreadsheetChildEnv } from "../../../../types";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
 
 interface Props {
-  figureId: UID;
+  figure: Figure;
 }
 
 export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
@@ -13,7 +13,7 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   private canvas = useRef("chartContainer");
 
   get runtime(): ScorecardChartRuntime {
-    return this.env.model.getters.getChartRuntime(this.props.figureId) as ScorecardChartRuntime;
+    return this.env.model.getters.getChartRuntime(this.props.figure.id) as ScorecardChartRuntime;
   }
 
   setup() {
@@ -32,5 +32,5 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
 }
 
 ScorecardChart.props = {
-  figureId: String,
+  figure: Object,
 };

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -15,7 +15,7 @@
           t-component="figureRegistry.get(props.figure.tag).Component"
           t-key="props.figure.id"
           onFigureDeleted="props.onFigureDeleted"
-          figureId="props.figure.id"
+          figure="props.figure"
         />
         <div class="o-figure-menu position-absolute m-2" t-if="!env.isDashboard()">
           <div

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -1,6 +1,6 @@
 import { Component } from "@odoo/owl";
 import { chartComponentRegistry } from "../../../registries/chart_types";
-import { ChartType, SpreadsheetChildEnv, UID } from "../../../types";
+import { ChartType, Figure, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
 
 // -----------------------------------------------------------------------------
@@ -15,9 +15,9 @@ css/* scss */ `
 `;
 
 interface Props {
-  // props figure is necessary scorecards, we need the chart dimension at render to avoid having to force the
+  // props figure is currently necessary scorecards, we need the chart dimension at render to avoid having to force the
   // style by hand in the useEffect()
-  figureId: UID;
+  figure: Figure;
   onFigureDeleted: () => void;
 }
 
@@ -26,12 +26,12 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   static components = {};
 
   onDoubleClick() {
-    this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figureId });
+    this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
     this.env.openSidePanel("ChartPanel");
   }
 
   get chartType(): ChartType {
-    return this.env.model.getters.getChartType(this.props.figureId);
+    return this.env.model.getters.getChartType(this.props.figure.id);
   }
 
   get chartComponent(): new (...args: any) => Component {
@@ -45,6 +45,6 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
 }
 
 ChartFigure.props = {
-  figureId: String,
+  figure: Object,
   onFigureDeleted: Function,
 };

--- a/src/components/figures/figure_chart/figure_chart.xml
+++ b/src/components/figures/figure_chart/figure_chart.xml
@@ -3,8 +3,8 @@
     <div class="o-chart-container w-100 h-100" t-on-dblclick="onDoubleClick">
       <t
         t-component="chartComponent"
-        figureId="this.props.figureId"
-        t-key="this.props.figureId + '-' + chartType"
+        figure="this.props.figure"
+        t-key="this.props.figure.id + '-' + chartType"
       />
     </div>
   </t>

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -1,8 +1,8 @@
 import { Component } from "@odoo/owl";
-import { SpreadsheetChildEnv, UID } from "../../../types";
+import { Figure, SpreadsheetChildEnv, UID } from "../../../types";
 
 interface Props {
-  figureId: UID;
+  figure: Figure;
   onFigureDeleted: () => void;
 }
 
@@ -15,7 +15,7 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
   // ---------------------------------------------------------------------------
 
   get figureId(): UID {
-    return this.props.figureId;
+    return this.props.figure.id;
   }
 
   get getImagePath(): string {
@@ -24,6 +24,6 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
 }
 
 ImageFigure.props = {
-  figureId: String,
+  figure: Object,
   onFigureDeleted: Function,
 };


### PR DESCRIPTION
Partial revert of a825627d. In theory, the children of a figure (i.e. charts and images) should not need any information from the parent figure except its id to handle themselves but some charts require the figure dimension to properly draw themselves in the component.

There are solutions to this but they begin to be more complicated both to implement and to test!

Add to this that we also use the figure information in some integration in Odoo, it is better to keep providing the full figure as a component props.

Task: /

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo