### PR TITLE
[FIX] scorecard: fix baseline arrow

### DIFF
--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -52,6 +52,13 @@ function checkBaseline(definition: ScorecardChartDefinition): CommandResult {
     : CommandResult.Success;
 }
 
+const arrowDownPath = new window.Path2D(
+  "M8.6 4.8a.5.5 0 0 1 0 .75l-3.9 3.9a.5 .5 0 0 1 -.75 0l-3.8 -3.9a.5 .5 0 0 1 0 -.75l.4-.4a.5.5 0 0 1 .75 0l2.3 2.4v-5.7c0-.25.25-.5.5-.5h.6c.25 0 .5.25.5.5v5.8l2.3 -2.4a.5.5 0 0 1 .75 0z"
+);
+const arrowUpPath = new window.Path2D(
+  "M8.7 5.5a.5.5 0 0 0 0-.75l-3.8-4a.5.5 0 0 0-.75 0l-3.8 4a.5.5 0 0 0 0 .75l.4.4a.5.5 0 0 0 .75 0l2.3-2.4v5.8c0 .25.25.5.5.5h.6c.25 0 .5-.25.5-.5v-5.8l2.2 2.4a.5.5 0 0 0 .75 0z"
+);
+
 export class ScorecardChart extends AbstractChart {
   readonly keyValue?: Range;
   readonly baseline?: Range;
@@ -205,14 +212,24 @@ export function drawScoreChart(structure: ScorecardChartConfig, canvas: HTMLCanv
     );
   }
 
-  if (structure.baselineArrow) {
-    ctx.font = structure.baselineArrow.style.font;
+  if (structure.baselineArrow && structure.baselineArrow.style.size > 0) {
+    ctx.save();
     ctx.fillStyle = structure.baselineArrow.style.color;
-    ctx.fillText(
-      structure.baselineArrow.text,
-      structure.baselineArrow.position.x,
-      structure.baselineArrow.position.y
-    );
+    ctx.translate(structure.baselineArrow.position.x, structure.baselineArrow.position.y);
+    // This ratio is computed according to the original svg size and the final size we want
+    const ratio = structure.baselineArrow.style.size / 10;
+    ctx.scale(ratio, ratio);
+    switch (structure.baselineArrow.direction) {
+      case "down": {
+        ctx.fill(arrowDownPath);
+        break;
+      }
+      case "up": {
+        ctx.fill(arrowUpPath);
+        break;
+      }
+    }
+    ctx.restore();
   }
 
   if (structure.baselineDescr) {

--- a/tests/figures/chart/scorecard_chart_component.test.ts
+++ b/tests/figures/chart/scorecard_chart_component.test.ts
@@ -139,7 +139,7 @@ describe("Scorecard charts computation", () => {
     expect(chartDesign.key?.text).toEqual("0");
     expect(chartDesign.baseline?.text).toEqual("0");
     expect(chartDesign.baselineDescr).toBeUndefined();
-    expect(chartDesign.baselineArrow?.text).toEqual("");
+    expect(chartDesign.baselineArrow).toBeUndefined();
   });
 
   test("Percentage baseline display a percentage", () => {
@@ -165,7 +165,7 @@ describe("Scorecard charts computation", () => {
     createScorecardChart(model, { keyValue: "A1", baseline: "B3" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
-    expect(chartDesign.baselineArrow?.text).toBe("\u{1F873}");
+    expect(chartDesign.baselineArrow?.direction).toBe("down");
     expect(chartDesign.baselineArrow?.style.color).toBeSameColorAs("#DC6965");
     expect(chartDesign.baseline?.style.color).toBeSameColorAs("#DC6965");
     expect(chartDesign.baseline?.text).toEqual("1");
@@ -175,7 +175,7 @@ describe("Scorecard charts computation", () => {
     createScorecardChart(model, { keyValue: "A1", baseline: "B1" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
-    expect(chartDesign.baselineArrow?.text).toBe("\u{1F871}");
+    expect(chartDesign.baselineArrow?.direction).toBe("up");
     expect(chartDesign.baselineArrow?.style.color).toBeSameColorAs("#00A04A");
     expect(chartDesign.baseline?.style.color).toBeSameColorAs("#00A04A");
     expect(chartDesign.baseline?.text).toEqual("1");
@@ -185,7 +185,7 @@ describe("Scorecard charts computation", () => {
     createScorecardChart(model, { keyValue: "A1", baseline: "B2" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
 
-    expect(chartDesign.baselineArrow?.text).toBe("");
+    expect(chartDesign.baselineArrow).toBeUndefined();
     expect(chartDesign.baseline?.style.color).toBeSameColorAs("#525252");
     expect(chartDesign.baseline?.text).toEqual("0");
   });

--- a/tests/setup/canvas.mock.ts
+++ b/tests/setup/canvas.mock.ts
@@ -37,3 +37,19 @@ const patch = {
 
 /* js-ignore */
 Object.assign(HTMLCanvasElement.prototype, patch);
+
+if (!window.Path2D) {
+  window.Path2D = class Path2D {
+    addPath() {}
+    closePath() {}
+    moveTo() {}
+    lineTo() {}
+    bezierCurveTo() {}
+    quadraticCurveTo() {}
+    arc() {}
+    arcTo() {}
+    ellipse() {}
+    rect() {}
+    roundRect() {}
+  };
+}


### PR DESCRIPTION
## Task Description

Since a825627 the baseline arrow are drawn as an unicode character. However, this seems not to be supported by all browsers/OS, and we need to change this behavior to directly draw an arrow. This PR aims to draw the arrow using an SVG path and Path2D, fixing this issue.

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo