### PR TITLE
[IMP] headers: add header position UI plugin

### DIFF
--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -288,10 +288,7 @@ export class InternalViewport {
       if (this.getters.isHeaderHidden(sheetId, dimension, i) || isHiddenInViewport) {
         continue;
       }
-      size +=
-        dimension === "COL"
-          ? this.getters.getColSize(sheetId, i)
-          : this.getters.getRowSize(sheetId, i);
+      size += this.getters.getHeaderSize(sheetId, dimension, i);
       if (size > position) {
         return i;
       }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -50,6 +50,7 @@ import {
   GridSelectionPlugin,
   SheetViewPlugin,
 } from "./ui_stateful";
+import { HeaderPositionsUIPlugin } from "./ui_stateful/header_positions";
 
 export const corePluginRegistry = new Registry<CorePluginConstructor>()
   .add("settings", SettingsPlugin)
@@ -70,7 +71,6 @@ export const corePluginRegistry = new Registry<CorePluginConstructor>()
 // Plugins which handle a specific feature, without handling any core commands
 export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("ui_sheet", SheetUIPlugin)
-  .add("header_visibility_ui", HeaderVisibilityUIPlugin)
   .add("ui_options", UIOptionsPlugin)
   .add("selectionInputManager", SelectionInputsManagerPlugin)
   .add("highlight", HighlightPlugin)
@@ -90,6 +90,8 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
 export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()
   .add("selection", GridSelectionPlugin)
   .add("evaluation_filter", FilterEvaluationPlugin)
+  .add("header_visibility_ui", HeaderVisibilityUIPlugin)
+  .add("header_positions", HeaderPositionsUIPlugin)
   .add("viewport", SheetViewPlugin)
   .add("clipboard", ClipboardPlugin)
   .add("edition", EditionPlugin);

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -23,7 +23,7 @@ import {
   EvaluationDataValidationPlugin,
   EvaluationPlugin,
 } from "./ui_core_views";
-import { UIRowSizePlugin } from "./ui_core_views/row_size";
+import { HeaderSizeUIPlugin } from "./ui_core_views/header_sizes_ui";
 import {
   AutofillPlugin,
   AutomaticSumPlugin,
@@ -99,6 +99,6 @@ export const coreViewsPluginRegistry = new Registry<UIPluginConstructor>()
   .add("evaluation", EvaluationPlugin)
   .add("evaluation_chart", EvaluationChartPlugin)
   .add("evaluation_cf", EvaluationConditionalFormatPlugin)
-  .add("row_size", UIRowSizePlugin)
+  .add("row_size", HeaderSizeUIPlugin)
   .add("custom_colors", CustomColorsPlugin)
   .add("data_validation_ui", EvaluationDataValidationPlugin);

--- a/src/plugins/ui_core_views/header_sizes_ui.ts
+++ b/src/plugins/ui_core_views/header_sizes_ui.ts
@@ -9,7 +9,7 @@ import {
   removeIndexesFromArray,
 } from "../../helpers";
 import { Command } from "../../types";
-import { CellPosition, HeaderIndex, Immutable, Pixel, UID } from "../../types/misc";
+import { CellPosition, Dimension, HeaderIndex, Immutable, Pixel, UID } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
 interface HeaderSizeState {
@@ -21,8 +21,8 @@ interface CellWithSize {
   size: Pixel;
 }
 
-export class UIRowSizePlugin extends UIPlugin<HeaderSizeState> implements HeaderSizeState {
-  static getters = ["getRowSize"] as const;
+export class HeaderSizeUIPlugin extends UIPlugin<HeaderSizeState> implements HeaderSizeState {
+  static getters = ["getRowSize", "getHeaderSize"] as const;
 
   readonly tallestCellInRow: Immutable<Record<UID, Array<CellWithSize | undefined>>> = {};
 
@@ -112,6 +112,12 @@ export class UIRowSizePlugin extends UIPlugin<HeaderSizeState> implements Header
         this.tallestCellInRow[sheetId][row]?.size ??
         DEFAULT_CELL_HEIGHT
     );
+  }
+
+  getHeaderSize(sheetId: UID, dimension: Dimension, index: HeaderIndex): Pixel {
+    return dimension === "ROW"
+      ? this.getRowSize(sheetId, index)
+      : this.getters.getColSize(sheetId, index);
   }
 
   private updateRowSizeForCellChange(sheetId: UID, row: HeaderIndex, col: HeaderIndex) {

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -178,10 +178,7 @@ export class SheetUIPlugin extends UIPlugin {
       if (this.getters.isHeaderHidden(sheetId, dimension, i)) {
         continue;
       }
-      offset +=
-        dimension === "COL"
-          ? this.getters.getColSize(sheetId, i)
-          : this.getters.getRowSize(sheetId, i);
+      offset += this.getters.getHeaderSize(sheetId, dimension, i);
     }
     return offset;
   }

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -7,14 +7,7 @@ import {
 } from "../../helpers/index";
 import { localizeFormula } from "../../helpers/locale";
 import { Command, CommandResult, LocalCommand, UID } from "../../types";
-import {
-  CellPosition,
-  Dimension,
-  HeaderDimensions,
-  HeaderIndex,
-  Pixel,
-  Style,
-} from "../../types/misc";
+import { CellPosition, HeaderIndex, Pixel, Style } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
 export class SheetUIPlugin extends UIPlugin {
@@ -24,9 +17,6 @@ export class SheetUIPlugin extends UIPlugin {
     "getTextWidth",
     "getCellText",
     "getCellMultiLineText",
-    "getColDimensions",
-    "getRowDimensions",
-    "getColRowOffset",
   ] as const;
 
   private ctx = document.createElement("canvas").getContext("2d")!;
@@ -127,60 +117,6 @@ export class SheetUIPlugin extends UIPlugin {
     const style = this.getters.getCellStyle(position);
     const text = this.getters.getCellText(position, this.getters.shouldShowFormulas());
     return splitTextToWidth(this.ctx, text, style, width);
-  }
-
-  /**
-   * Returns the size, start and end coordinates of a column on an unfolded sheet
-   */
-  getColDimensions(sheetId: UID, col: HeaderIndex): HeaderDimensions {
-    const start = this.getColRowOffset("COL", 0, col, sheetId);
-    const size = this.getters.getColSize(sheetId, col);
-    const isColHidden = this.getters.isColHidden(sheetId, col);
-    return {
-      start,
-      size,
-      end: start + (isColHidden ? 0 : size),
-    };
-  }
-
-  /**
-   * Returns the size, start and end coordinates of a row an unfolded sheet
-   */
-  getRowDimensions(sheetId: UID, row: HeaderIndex): HeaderDimensions {
-    const start = this.getColRowOffset("ROW", 0, row, sheetId);
-    const size = this.getters.getRowSize(sheetId, row);
-    const isRowHidden = this.getters.isRowHidden(sheetId, row);
-    return {
-      start,
-      size: size,
-      end: start + (isRowHidden ? 0 : size),
-    };
-  }
-
-  /**
-   * Returns the offset of a header (determined by the dimension) at the given index
-   * based on the referenceIndex given. If start === 0, this method will return
-   * the start attribute of the header.
-   *
-   * i.e. The size from A to B is the distance between A.start and B.end
-   */
-  getColRowOffset(
-    dimension: Dimension,
-    referenceIndex: HeaderIndex,
-    index: HeaderIndex,
-    sheetId: UID = this.getters.getActiveSheetId()
-  ): Pixel {
-    if (index < referenceIndex) {
-      return -this.getColRowOffset(dimension, index, referenceIndex);
-    }
-    let offset = 0;
-    for (let i = referenceIndex; i < index; i++) {
-      if (this.getters.isHeaderHidden(sheetId, dimension, i)) {
-        continue;
-      }
-      offset += this.getters.getHeaderSize(sheetId, dimension, i);
-    }
-    return offset;
   }
 
   doesCellHaveGridIcon(position: CellPosition): boolean {

--- a/src/plugins/ui_stateful/header_positions.ts
+++ b/src/plugins/ui_stateful/header_positions.ts
@@ -1,0 +1,133 @@
+import { deepCopy } from "../../helpers/index";
+import { Command, UID } from "../../types";
+import { invalidateEvaluationCommands } from "../../types/commands";
+import { Dimension, HeaderDimensions, HeaderIndex, Pixel } from "../../types/misc";
+import { UIPlugin } from "../ui_plugin";
+
+export class HeaderPositionsUIPlugin extends UIPlugin {
+  static getters = ["getColDimensions", "getRowDimensions", "getColRowOffset"] as const;
+
+  private headerPositions: Record<UID, Record<Dimension, Record<HeaderIndex, Pixel>>> = {};
+  private isDirty = true;
+
+  handle(cmd: Command) {
+    if (invalidateEvaluationCommands.has(cmd.type)) {
+      this.headerPositions = {};
+      this.isDirty = true;
+    }
+
+    switch (cmd.type) {
+      case "START":
+        for (const sheetId of this.getters.getSheetIds()) {
+          this.headerPositions[sheetId] = this.computeHeaderPositionsOfSheet(sheetId);
+        }
+        break;
+      case "UPDATE_CELL":
+        if ("content" in cmd || "format" in cmd || cmd.style?.fontSize !== undefined) {
+          this.headerPositions = {};
+          this.isDirty = true;
+        }
+        break;
+      case "UPDATE_FILTER":
+      case "REMOVE_FILTER_TABLE":
+        this.headerPositions = {};
+        this.isDirty = true;
+        break;
+      case "REMOVE_COLUMNS_ROWS":
+      case "RESIZE_COLUMNS_ROWS":
+      case "HIDE_COLUMNS_ROWS":
+      case "ADD_COLUMNS_ROWS":
+      case "UNHIDE_COLUMNS_ROWS":
+      case "FOLD_HEADER_GROUP":
+      case "UNFOLD_HEADER_GROUP":
+      case "FOLD_HEADER_GROUPS_IN_ZONE":
+      case "UNFOLD_HEADER_GROUPS_IN_ZONE":
+      case "UNFOLD_ALL_HEADER_GROUPS":
+      case "FOLD_ALL_HEADER_GROUPS":
+      case "UNGROUP_HEADERS":
+      case "GROUP_HEADERS":
+      case "CREATE_SHEET":
+        this.headerPositions[cmd.sheetId] = this.computeHeaderPositionsOfSheet(cmd.sheetId);
+        break;
+      case "DUPLICATE_SHEET":
+        this.headerPositions[cmd.sheetIdTo] = deepCopy(this.headerPositions[cmd.sheetId]);
+        break;
+    }
+  }
+
+  finalize() {
+    if (this.isDirty) {
+      for (const sheetId of this.getters.getSheetIds()) {
+        this.headerPositions[sheetId] = this.computeHeaderPositionsOfSheet(sheetId);
+      }
+      this.isDirty = false;
+    }
+  }
+
+  /**
+   * Returns the size, start and end coordinates of a column on an unfolded sheet
+   */
+  getColDimensions(sheetId: UID, col: HeaderIndex): HeaderDimensions {
+    const start = this.headerPositions[sheetId]["COL"][col];
+    const size = this.getters.getColSize(sheetId, col);
+    const isColHidden = this.getters.isColHidden(sheetId, col);
+    return {
+      start,
+      size,
+      end: start + (isColHidden ? 0 : size),
+    };
+  }
+
+  /**
+   * Returns the size, start and end coordinates of a row an unfolded sheet
+   */
+  getRowDimensions(sheetId: UID, row: HeaderIndex): HeaderDimensions {
+    const start = this.headerPositions[sheetId]["ROW"][row];
+    const size = this.getters.getRowSize(sheetId, row);
+    const isRowHidden = this.getters.isRowHidden(sheetId, row);
+    return {
+      start,
+      size: size,
+      end: start + (isRowHidden ? 0 : size),
+    };
+  }
+
+  /**
+   * Returns the offset of a header (determined by the dimension) at the given index
+   * based on the referenceIndex given. If start === 0, this method will return
+   * the start attribute of the header.
+   *
+   * i.e. The size from A to B is the distance between A.start and B.end
+   */
+  getColRowOffset(
+    dimension: Dimension,
+    referenceIndex: HeaderIndex,
+    index: HeaderIndex,
+    sheetId: UID = this.getters.getActiveSheetId()
+  ): Pixel {
+    const referencePosition = this.headerPositions[sheetId][dimension][referenceIndex];
+    const position = this.headerPositions[sheetId][dimension][index];
+    return position - referencePosition;
+  }
+
+  private computeHeaderPositionsOfSheet(sheetId: UID) {
+    return {
+      COL: this.computePositions(sheetId, "COL"),
+      ROW: this.computePositions(sheetId, "ROW"),
+    };
+  }
+
+  private computePositions(sheetId: UID, dimension: Dimension): Record<HeaderIndex, Pixel> {
+    const positions: Record<HeaderIndex, Pixel> = {};
+    let offset = 0;
+    // loop on number of headers +1 so the position of (last header + 1) is the end of the sheet
+    for (let i = 0; i < this.getters.getNumberHeaders(sheetId, dimension) + 1; i++) {
+      positions[i] = offset;
+      if (this.getters.isHeaderHidden(sheetId, dimension, i)) {
+        continue;
+      }
+      offset += this.getters.getHeaderSize(sheetId, dimension, i);
+    }
+    return positions;
+  }
+}

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -204,10 +204,7 @@ export class GridSelectionPlugin extends UIPlugin {
     switch (cmd.type) {
       case "START":
         const firstSheetId = this.getters.getVisibleSheetIds()[0];
-        this.dispatch("ACTIVATE_SHEET", {
-          sheetIdTo: firstSheetId,
-          sheetIdFrom: firstSheetId,
-        });
+        this.activateSheet(firstSheetId, firstSheetId);
         const { col, row } = this.getters.getNextVisibleCellPosition({
           sheetId: firstSheetId,
           col: 0,
@@ -220,24 +217,7 @@ export class GridSelectionPlugin extends UIPlugin {
         this.moveClient({ sheetId: firstSheetId, col: 0, row: 0 });
         break;
       case "ACTIVATE_SHEET": {
-        if (!this.getters.isSheetVisible(cmd.sheetIdTo)) {
-          this.dispatch("SHOW_SHEET", { sheetId: cmd.sheetIdTo });
-        }
-        this.setActiveSheet(cmd.sheetIdTo);
-        this.sheetsData[cmd.sheetIdFrom] = {
-          gridSelection: deepCopy(this.gridSelection),
-        };
-        if (cmd.sheetIdTo in this.sheetsData) {
-          Object.assign(this, this.sheetsData[cmd.sheetIdTo]);
-          this.selection.resetDefaultAnchor(this, deepCopy(this.gridSelection.anchor));
-        } else {
-          const { col, row } = this.getters.getNextVisibleCellPosition({
-            sheetId: cmd.sheetIdTo,
-            col: 0,
-            row: 0,
-          });
-          this.selectCell(col, row);
-        }
+        this.activateSheet(cmd.sheetIdFrom, cmd.sheetIdTo);
         break;
       }
       case "REMOVE_COLUMNS_ROWS": {
@@ -535,6 +515,28 @@ export class GridSelectionPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
   // Other
   // ---------------------------------------------------------------------------
+
+  private activateSheet(sheetIdFrom: UID, sheetIdTo: UID) {
+    if (!this.getters.isSheetVisible(sheetIdTo)) {
+      this.dispatch("SHOW_SHEET", { sheetId: sheetIdTo });
+    }
+    this.setActiveSheet(sheetIdTo);
+    this.sheetsData[sheetIdFrom] = {
+      gridSelection: deepCopy(this.gridSelection),
+    };
+    if (sheetIdTo in this.sheetsData) {
+      Object.assign(this, this.sheetsData[sheetIdTo]);
+      this.selection.resetDefaultAnchor(this, deepCopy(this.gridSelection.anchor));
+    } else {
+      const { col, row } = this.getters.getNextVisibleCellPosition({
+        sheetId: sheetIdTo,
+        col: 0,
+        row: 0,
+      });
+      this.selectCell(col, row);
+    }
+  }
+
   /**
    * Ensure selections are not outside sheet boundaries.
    * They are clipped to fit inside the sheet if needed.

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -679,10 +679,7 @@ export class GridSelectionPlugin extends UIPlugin {
     const toRemove = isBasedBefore ? cmd.elements.map((el) => el + thickness) : cmd.elements;
     let currentIndex = cmd.base;
     for (const element of toRemove) {
-      const size =
-        cmd.dimension === "COL"
-          ? this.getters.getColSize(cmd.sheetId, element)
-          : this.getters.getRowSize(cmd.sheetId, element);
+      const size = this.getters.getHeaderSize(cmd.sheetId, cmd.dimension, element);
       this.dispatch("RESIZE_COLUMNS_ROWS", {
         dimension: cmd.dimension,
         sheetId: cmd.sheetId,

--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -378,10 +378,7 @@ export class SheetViewPlugin extends UIPlugin {
       if (!visibleIndexes.includes(i)) {
         continue;
       }
-      offset +=
-        dimension === "COL"
-          ? this.getters.getColSize(sheetId, i)
-          : this.getters.getRowSize(sheetId, i);
+      offset += this.getters.getHeaderSize(sheetId, dimension, i);
     }
     return offset;
   }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -106,7 +106,7 @@ export function isPositionDependent(cmd: CoreCommand): boolean {
   return "col" in cmd && "row" in cmd && "sheetId" in cmd;
 }
 
-export const invalidateEvaluationCommands = new Set<CoreViewCommandTypes>([
+export const invalidateEvaluationCommands = new Set<CommandTypes>([
   "RENAME_SHEET",
   "DELETE_SHEET",
   "CREATE_SHEET",
@@ -123,7 +123,7 @@ export const invalidateDependenciesCommands = new Set<CommandTypes>([
   "MOVE_RANGES",
 ]);
 
-export const invalidateCFEvaluationCommands = new Set<CoreViewCommandTypes>([
+export const invalidateCFEvaluationCommands = new Set<CommandTypes>([
   ...invalidateEvaluationCommands,
   "DUPLICATE_SHEET",
   "EVALUATE_CELLS",

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -36,6 +36,7 @@ import { SheetUIPlugin } from "../plugins/ui_feature/ui_sheet";
 import { ClipboardPlugin } from "../plugins/ui_stateful/clipboard";
 import { EditionPlugin } from "../plugins/ui_stateful/edition";
 import { FilterEvaluationPlugin } from "../plugins/ui_stateful/filter_evaluation";
+import { HeaderPositionsUIPlugin } from "../plugins/ui_stateful/header_positions";
 import { GridSelectionPlugin } from "../plugins/ui_stateful/selection";
 import { SheetViewPlugin } from "../plugins/ui_stateful/sheetview";
 // -----------------------------------------------------------------------------
@@ -140,4 +141,5 @@ export type Getters = {
   PluginGetters<typeof FilterEvaluationPlugin> &
   PluginGetters<typeof SplitToColumnsPlugin> &
   PluginGetters<typeof HeaderSizeUIPlugin> &
-  PluginGetters<typeof EvaluationDataValidationPlugin>;
+  PluginGetters<typeof EvaluationDataValidationPlugin> &
+  PluginGetters<typeof HeaderPositionsUIPlugin>;

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -18,7 +18,7 @@ import { EvaluationPlugin } from "../plugins/ui_core_views/cell_evaluation";
 import { CustomColorsPlugin } from "../plugins/ui_core_views/custom_colors";
 import { EvaluationChartPlugin } from "../plugins/ui_core_views/evaluation_chart";
 import { EvaluationConditionalFormatPlugin } from "../plugins/ui_core_views/evaluation_conditional_format";
-import { UIRowSizePlugin } from "../plugins/ui_core_views/row_size";
+import { HeaderSizeUIPlugin } from "../plugins/ui_core_views/header_sizes_ui";
 import { AutofillPlugin } from "../plugins/ui_feature/autofill";
 import { AutomaticSumPlugin } from "../plugins/ui_feature/automatic_sum";
 import { CellPopoverPlugin } from "../plugins/ui_feature/cell_popovers";
@@ -139,5 +139,5 @@ export type Getters = {
   PluginGetters<typeof CellPopoverPlugin> &
   PluginGetters<typeof FilterEvaluationPlugin> &
   PluginGetters<typeof SplitToColumnsPlugin> &
-  PluginGetters<typeof UIRowSizePlugin> &
+  PluginGetters<typeof HeaderSizeUIPlugin> &
   PluginGetters<typeof EvaluationDataValidationPlugin>;


### PR DESCRIPTION
## [IMP] headers: add header position UI plugin:

This commit add the `HeaderPositionsUIPlugin` which computes and stores
the positions of the headers.

Before this the headers positions weren't stored, and needed to be
computed by adding together the size of all the preceding headers in a
loop. This was a performance issue when scrolling on larger sheets.

## [IMP] selection: don't dispatch at `START`

The plugin selection dispatched a command `ACTIVATE_SHEET` when handling
the `START` command. This meant that plugins that were loaded after
selection would receive a command and needed to handle it even before
they initialized themselves at `START`.

## [IMP] headers: add `getHeaderSize` getter

Add a getter `getHeaderSize` to avoid having to write ternary
every time we need to get either the row of column size.


Task: : [3563624](https://www.odoo.com/web#id=3563624&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo