### PR TITLE
[FIX] border_editor, top_bar: dark-mode adaptations

### DIFF
--- a/src/components/border_editor/border_editor.ts
+++ b/src/components/border_editor/border_editor.ts
@@ -59,6 +59,7 @@ export interface BorderEditorProps {
 css/* scss */ `
   .o-border-selector {
     padding: 4px;
+    background-color: white;
   }
   .o-divider {
     border-right: 1px solid #e0e2e4;

--- a/src/components/border_editor/border_editor.xml
+++ b/src/components/border_editor/border_editor.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-BorderEditor" owl="1">
     <Popover t-props="popoverProps">
       <div
-        class="d-flex bg-white o-border-selector"
+        class="d-flex o-border-selector"
         t-on-click.stop=""
         t-att-class="props.class ? props.class : ''">
         <div class="o-border-selector-section">

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-TopBar" owl="1">
     <div
-      class="o-spreadsheet-topbar o-two-columns bg-white d-flex flex-column user-select-none"
+      class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none"
       t-on-click="props.onClick">
       <div class="o-topbar-top d-flex justify-content-between">
         <!-- Menus -->

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
 >
   
   <div
-    class="o-spreadsheet-topbar o-two-columns bg-white d-flex flex-column user-select-none"
+    class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none"
   >
     <div
       class="o-topbar-top d-flex justify-content-between"

--- a/tests/components/__snapshots__/top_bar.test.ts.snap
+++ b/tests/components/__snapshots__/top_bar.test.ts.snap
@@ -6,7 +6,7 @@ exports[`TopBar component can set cell format 1`] = `
     class="o-spreadsheet"
   >
     <div
-      class="o-spreadsheet-topbar o-two-columns bg-white d-flex flex-column user-select-none"
+      class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none"
     >
       <div
         class="o-topbar-top d-flex justify-content-between"
@@ -894,7 +894,7 @@ exports[`TopBar component can set cell format 1`] = `
 
 exports[`TopBar component simple rendering 1`] = `
 <div
-  class="o-spreadsheet-topbar o-two-columns bg-white d-flex flex-column user-select-none"
+  class="o-spreadsheet-topbar o-two-columns d-flex flex-column user-select-none"
 >
   <div
     class="o-topbar-top d-flex justify-content-between"


### PR DESCRIPTION
Prior to this PR, spreadsheet top bar was using a `bg-white` class, making it pure black in dark mode.
Since spreadsheet is designed with light colors and we don't provide a dark-mode for it yet, this commit replaces the class with raw CSS.

task-3201038

required by:
- https://github.com/odoo/odoo/pull/130991
- https://github.com/odoo/enterprise/pull/44458

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo