### PR TITLE
[FIX] collaborative: display other users name

### DIFF
--- a/src/components/collaborative_client_tag/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.ts
@@ -39,7 +39,7 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
       left: `${x - 1}px`,
       border: `1px solid ${color}`,
       "background-color": color,
-      opacity: this.props.active ? "opacity:1 !important" : undefined,
+      opacity: this.props.active ? "1 !important" : undefined,
     });
   }
 }

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -787,6 +787,20 @@ describe("Multi User selection", () => {
     ({ parent, fixture } = await mountSpreadsheet({ model }));
   });
 
+  test("Render collaborative user when hovering the position", async () => {
+    const sheetId = model.getters.getActiveSheetId();
+    transportService.sendMessage({
+      type: "CLIENT_JOINED",
+      version: MESSAGE_VERSION,
+      client: { id: "david", name: "David", position: { sheetId, col: 1, row: 1 } },
+    });
+    await nextTick();
+    expect(getElComputedStyle(".o-client-tag", "opacity")).toBe("0");
+    await hoverCell(model, "B2", 400);
+    expect(getElComputedStyle(".o-client-tag", "opacity")).toBe("1");
+    expect(document.querySelector(".o-client-tag")?.textContent).toBe("David");
+  });
+
   test("Do not render multi user selection with invalid sheet", async () => {
     transportService.sendMessage({
       type: "CLIENT_JOINED",


### PR DESCRIPTION

## Description:

When there are multiple users connected on the same spreadsheet, hovering the other user's position should display its name. It's currently broken.

The css property applied is wrong:
it end up being `opacity: opacity: 1 !important;` instead of `opacity: 1 !important;`

Broken since 3710b7d

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo