### PR TITLE
[FIX] popover: fix popover position when too much items

### DIFF
--- a/src/components/popover.ts
+++ b/src/components/popover.ts
@@ -44,12 +44,14 @@ export class Popover extends Component<Props, SpreadsheetEnv> {
   };
   private getters = this.env.getters;
 
+  get maxHeight(): number {
+    return Math.max(0, this.viewportDimension.height - BOTTOMBAR_HEIGHT - SCROLLBAR_WIDTH);
+  }
+
   get style() {
     const horizontalPosition = `left:${this.horizontalPosition()}`;
     const verticalPosition = `top:${this.verticalPosition()}`;
-    const height = `max-height:${
-      this.viewportDimension.height - BOTTOMBAR_HEIGHT - SCROLLBAR_WIDTH
-    }`;
+    const height = `max-height:${this.maxHeight}`;
     return `
       position: absolute;
       z-index: 5;
@@ -74,7 +76,10 @@ export class Popover extends Component<Props, SpreadsheetEnv> {
 
   private get shouldRenderBottom(): boolean {
     const { y } = this.props.position;
-    return y + this.props.childHeight < this.viewportDimension.height + TOPBAR_HEIGHT;
+    return (
+      y + Math.min(this.props.childHeight, this.maxHeight) <
+      this.viewportDimension.height + TOPBAR_HEIGHT
+    );
   }
 
   private horizontalPosition(): number {

--- a/tests/components/top_bar.test.ts
+++ b/tests/components/top_bar.test.ts
@@ -296,6 +296,22 @@ describe("TopBar component", () => {
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
   });
 
+  test("Opened menu with too much items is still correctly positioned", async () => {
+    for (let i = 0; i < 100; i++) {
+      topbarMenuRegistry.addChild(`testaction-${i}`, ["file"], {
+        name: `TestAction ${i}`,
+        sequence: 1,
+        action: () => {},
+      });
+    }
+    parent = new Parent(new Model());
+    await parent.mount(fixture);
+    triggerMouseEvent(".o-topbar-menu[data-id='file']", "click");
+    await nextTick();
+    const menuElement = fixture.querySelector(".o-popover")! as HTMLElement;
+    expect(menuElement.style.top).toBe("0px");
+  });
+
   test("Can click on a menuItem do execute action and close menus", async () => {
     const menuDefinitions = Object.assign({}, topbarMenuRegistry.content);
     let number = 0;


### PR DESCRIPTION
## Task Description

When opening a topbar menu with too many items in it (which can happen, mainly, in Odoo with too many data sources), the menu is not correctly placed. This comes from the fact that, in the computation of the position, we check if the popover should render from the bottom using the original children size instead of the real size of the popover (the min between the 'maxSize' that the popover can be and the children size).

## Related Task

- Task: [3418671](https://www.odoo.com/web#id=3418671&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo