### PR TITLE
[REF] chart_test: improve test speed/readability

### DIFF
--- a/tests/colors/color_picker_component.test.ts
+++ b/tests/colors/color_picker_component.test.ts
@@ -9,7 +9,7 @@ import {
   setInputValueAndTrigger,
   simulateClick,
 } from "../test_helpers/dom_helper";
-import { mountComponent, nextTick } from "../test_helpers/helpers";
+import { mountComponent } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
 mockGetBoundingClientRect({
@@ -94,8 +94,7 @@ describe("Color Picker buttons", () => {
     await simulateClick(".o-color-picker-toggler");
     await simulateClick(".o-gradient");
     const color = "#12EF78";
-    setInputValueAndTrigger(".o-custom-input-preview input", color, "input");
-    await nextTick();
+    await setInputValueAndTrigger(".o-custom-input-preview input", color);
     const previewColor = toHex(getElComputedStyle(".o-color-preview", "backgroundColor"));
     // hex <-> hsla is not a bijection, this specific color
     // is not exactly the same when processed
@@ -110,8 +109,7 @@ describe("Color Picker buttons", () => {
     await simulateClick(".o-color-picker-toggler");
     await simulateClick(".o-gradient");
     const color = "12ef78";
-    setInputValueAndTrigger(".o-custom-input-preview input", color, "input");
-    await nextTick();
+    await setInputValueAndTrigger(".o-custom-input-preview input", color);
     await simulateClick(".o-add-button");
     expect(onColorPicked).toHaveBeenCalledWith(toHex(color));
   });
@@ -121,8 +119,7 @@ describe("Color Picker buttons", () => {
     await mountColorPicker({ onColorPicked });
     await simulateClick(".o-color-picker-toggler");
     const target = document.querySelector(".o-custom-input-preview input");
-    setInputValueAndTrigger(target, "this is not a color", "input");
-    await nextTick();
+    await setInputValueAndTrigger(target, "this is not a color");
 
     expect(fixture.querySelector(".o-wrong-color")).not.toBeNull();
     const addButton = fixture.querySelector(".o-add-button")!;
@@ -135,8 +132,7 @@ describe("Color Picker buttons", () => {
     const onColorPicked = jest.fn();
     await mountColorPicker({ onColorPicked });
     await simulateClick(".o-color-picker-toggler");
-    setInputValueAndTrigger(".o-custom-input-preview input", "this is not a color", "input");
-    await nextTick();
+    await setInputValueAndTrigger(".o-custom-input-preview input", "this is not a color");
     await simulateClick(".o-add-button");
     expect(fixture.querySelector(".o-wrong-color")).not.toBeNull();
     await simulateClick(".o-gradient");
@@ -181,8 +177,7 @@ describe("Color Picker buttons", () => {
     await simulateClick(".o-color-picker-toggler");
 
     const inputTarget = fixture.querySelector(".o-custom-input-preview input")!;
-    setInputValueAndTrigger(inputTarget, hexCode as Color, "input");
-    await nextTick();
+    await setInputValueAndTrigger(inputTarget, hexCode as Color);
     expect((inputTarget as HTMLInputElement).value).toBeSameColorAs(hexCode.slice(0, 7));
     const addButton = fixture.querySelector(".o-add-button")!;
     expect(addButton.classList).not.toContain("o-disabled");
@@ -196,8 +191,7 @@ describe("Color Picker buttons", () => {
     await simulateClick(".o-color-picker-toggler");
 
     const inputTarget = fixture.querySelector(".o-custom-input-preview input")!;
-    setInputValueAndTrigger(inputTarget, hexCode as Color, "input");
-    await nextTick();
+    await setInputValueAndTrigger(inputTarget, hexCode as Color);
     expect((inputTarget as HTMLInputElement).value).toBe(hexCode.slice(0, 7));
     const addButton = fixture.querySelector(".o-add-button")!;
     expect(addButton.classList).toContain("o-disabled");

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -199,10 +199,9 @@ describe("UI of conditional formats", () => {
       await nextTick();
 
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "A1:A3", "change");
-      setInputValueAndTrigger(selectors.ruleEditor.range, "A1:A3", "input");
-      setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
-      setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3", "input");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "A1:A3");
+      setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith");
+      setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3");
 
       await click(fixture, selectors.ruleEditor.editor.bold);
       await click(fixture, selectors.ruleEditor.editor.italic);
@@ -237,12 +236,12 @@ describe("UI of conditional formats", () => {
 
     test("Can cycle on reference (with F4) in a CellIsRule editor input", async () => {
       await click(fixture.querySelectorAll(selectors.listPreview)[0]);
-      setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
+      setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith");
 
       const input = fixture.querySelector(
         selectors.ruleEditor.editor.valueInput
       )! as HTMLInputElement;
-      setInputValueAndTrigger(input, "=A2", "input");
+      setInputValueAndTrigger(input, "=A2");
       input.focus();
       await nextTick();
       await keyDown({ key: "F4" });
@@ -304,7 +303,7 @@ describe("UI of conditional formats", () => {
       await click(fixture.querySelectorAll(selectors.listPreview)[1]);
       await nextTick();
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
       await click(fixture, selectors.colorScaleEditor.minColor);
       await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
@@ -359,10 +358,9 @@ describe("UI of conditional formats", () => {
       await nextTick();
 
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "A1:A3", "input");
-      setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
-      await nextTick();
-      setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3", "input");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "A1:A3");
+      await setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith");
+      setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3");
 
       await click(fixture, selectors.ruleEditor.editor.bold);
       await click(fixture, selectors.ruleEditor.editor.italic);
@@ -398,7 +396,7 @@ describe("UI of conditional formats", () => {
       await click(fixture, selectors.buttonAdd);
       await nextTick();
 
-      setInputValueAndTrigger(selectors.ruleEditor.range, "hello", "input");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "hello");
 
       const dispatch = spyModelDispatch(model);
       //  click save
@@ -457,7 +455,7 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
     await click(fixture, selectors.colorScaleEditor.maxColor);
@@ -493,18 +491,16 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10");
     await click(fixture, selectors.colorScaleEditor.maxColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "20", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "20");
 
     const dispatch = spyModelDispatch(model);
     //  click save
@@ -539,18 +535,16 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "percentage", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.minType, "percentage");
+    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10");
     await click(fixture, selectors.colorScaleEditor.maxColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "percentage", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "90", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "percentage");
+    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "90");
 
     const dispatch = spyModelDispatch(model);
     //  click save
@@ -585,18 +579,16 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "percentile", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.minType, "percentile");
+    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10");
     await click(fixture, selectors.colorScaleEditor.maxColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "percentile", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "90", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "percentile");
+    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "90");
 
     const dispatch = spyModelDispatch(model);
     //  click save
@@ -631,25 +623,22 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
     await click(fixture, selectors.colorScaleEditor.minColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerBlue);
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "0", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "0");
 
-    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number", "change");
-    await nextTick();
+    await setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number");
     await click(fixture, selectors.colorScaleEditor.midColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerOrange);
-    setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "50", "input");
+    setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "50");
 
     await click(fixture, selectors.colorScaleEditor.maxColor);
     await click(fixture, selectors.colorScaleEditor.colorPickerYellow);
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "100", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "100");
 
     const dispatch = spyModelDispatch(model);
     //  click save
@@ -695,8 +684,7 @@ describe("UI of conditional formats", () => {
   test("error if range is empty", async () => {
     await click(fixture, selectors.buttonAdd);
     await nextTick();
-    setInputValueAndTrigger(selectors.ruleEditor.range, "", "input");
-    await nextTick();
+    await setInputValueAndTrigger(selectors.ruleEditor.range, "");
     await click(fixture, selectors.buttonSave);
     expect(errorMessages()).toEqual(["A range needs to be defined"]);
     expect(fixture.querySelector(selectors.ruleEditor.range)?.className).toContain("o-invalid");
@@ -708,14 +696,12 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "20", "input");
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "10", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "20");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "10");
 
     expect(errorMessages()).toHaveLength(0);
 
@@ -740,19 +726,16 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "60", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "60");
 
-    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "50", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "50");
 
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "10", "input");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "10");
 
     expect(errorMessages()).toHaveLength(0);
 
@@ -782,16 +765,14 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
-    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number", "change");
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "0", "input");
-    setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "50", "input");
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "25", "input");
-    await nextTick();
+    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "0");
+    setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "50");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "25");
 
     expect(errorMessages()).toHaveLength(0);
 
@@ -819,15 +800,13 @@ describe("UI of conditional formats", () => {
       await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
-      setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
-      setInputValueAndTrigger(selectors.colorScaleEditor.midType, "none", "change");
-      setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
-      await nextTick();
-      setInputValueAndTrigger(selectors.colorScaleEditor.minValue, invalidValue, "input");
-      setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "25", "input");
-      await nextTick();
+      setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number");
+      setInputValueAndTrigger(selectors.colorScaleEditor.midType, "none");
+      await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
+      setInputValueAndTrigger(selectors.colorScaleEditor.minValue, invalidValue);
+      await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "25");
 
       expect(errorMessages()).toHaveLength(0);
 
@@ -854,16 +833,14 @@ describe("UI of conditional formats", () => {
       await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
-      setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
-      setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number", "change");
-      setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
-      await nextTick();
-      setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10", "input");
-      setInputValueAndTrigger(selectors.colorScaleEditor.midValue, invalidValue, "input");
-      setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "25", "input");
-      await nextTick();
+      setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number");
+      setInputValueAndTrigger(selectors.colorScaleEditor.midType, "number");
+      await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
+      setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "10");
+      setInputValueAndTrigger(selectors.colorScaleEditor.midValue, invalidValue);
+      await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "25");
 
       expect(errorMessages()).toHaveLength(0);
 
@@ -890,15 +867,13 @@ describe("UI of conditional formats", () => {
       await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
-      setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
-      setInputValueAndTrigger(selectors.colorScaleEditor.midType, "none", "change");
-      setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
-      await nextTick();
-      setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "1", "input");
-      setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, invalidValue, "input");
-      await nextTick();
+      setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number");
+      setInputValueAndTrigger(selectors.colorScaleEditor.midType, "none");
+      await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
+      setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "1");
+      await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, invalidValue);
 
       expect(errorMessages()).toHaveLength(0);
 
@@ -923,15 +898,13 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "formula", "change");
-    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "none", "change");
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "formula", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "=SUM(1", "input");
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "=SUM(1,2)", "input");
-    await nextTick();
+    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "formula");
+    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "none");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "formula");
+    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "=SUM(1");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "=SUM(1,2)");
 
     expect(errorMessages()).toHaveLength(0);
 
@@ -955,16 +928,14 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number", "change");
-    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "formula", "change");
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "1", "input");
-    setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "=SUM(1", "input");
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "3", "input");
-    await nextTick();
+    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "formula");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "number");
+    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "1");
+    setInputValueAndTrigger(selectors.colorScaleEditor.midValue, "=SUM(1");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "3");
 
     expect(errorMessages()).toHaveLength(0);
 
@@ -984,7 +955,7 @@ describe("UI of conditional formats", () => {
 
   test("single color missing a single value", async () => {
     await click(fixture, selectors.buttonAdd);
-    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "GreaterThan", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "GreaterThan");
     expect(fixture.querySelector(".o-invalid")).toBeNull();
     await click(fixture, selectors.buttonSave);
     expect(fixture.querySelector(".o-invalid")).not.toBeNull();
@@ -993,7 +964,7 @@ describe("UI of conditional formats", () => {
 
   test("single color missing two values", async () => {
     await click(fixture, selectors.buttonAdd);
-    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "Between", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "Between");
     expect(fixture.querySelector(".o-invalid")).toBeNull();
     await click(fixture, selectors.buttonSave);
     expect([...fixture.querySelectorAll(".o-invalid")]).toHaveLength(2);
@@ -1001,7 +972,7 @@ describe("UI of conditional formats", () => {
       "The argument is missing. Please provide a value",
       "The second argument is missing. Please provide a value",
     ]);
-    setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "25", "input");
+    setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "25");
     await click(fixture, selectors.buttonSave);
     expect([...fixture.querySelectorAll(".o-invalid")]).toHaveLength(1);
     expect(errorMessages()).toEqual(["The second argument is missing. Please provide a value"]);
@@ -1009,7 +980,7 @@ describe("UI of conditional formats", () => {
 
   test("changing rule type resets errors", async () => {
     await click(fixture, selectors.buttonAdd);
-    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "GreaterThan", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "GreaterThan");
     await click(fixture, selectors.buttonSave);
     expect(errorMessages()).not.toHaveLength(0);
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
@@ -1023,15 +994,13 @@ describe("UI of conditional formats", () => {
     await click(fixture.querySelectorAll(selectors.cfTabSelector)[1]);
 
     // change every value
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "change");
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
-    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "formula", "change");
-    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "none", "change");
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "formula", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "=SUM(1", "input");
-    setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "=SUM(1,2)", "input");
-    await nextTick();
+    setInputValueAndTrigger(selectors.colorScaleEditor.minType, "formula");
+    setInputValueAndTrigger(selectors.colorScaleEditor.midType, "none");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.maxType, "formula");
+    setInputValueAndTrigger(selectors.colorScaleEditor.maxValue, "=SUM(1");
+    await setInputValueAndTrigger(selectors.colorScaleEditor.minValue, "=SUM(1,2)");
 
     expect(errorMessages()).toHaveLength(0);
 
@@ -1095,7 +1064,7 @@ describe("UI of conditional formats", () => {
       await click(fixture.querySelectorAll(selectors.cfTabSelector)[2]);
 
       // change every value
-      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5", "input");
+      setInputValueAndTrigger(selectors.ruleEditor.range, "B2:B5");
 
       const dispatch = spyModelDispatch(model);
       //  click save
@@ -1141,19 +1110,13 @@ describe("UI of conditional formats", () => {
       const operatorinflectionUpper = rows[2].querySelectorAll("select")[0];
       const inputinflectionUpper = rows[2].querySelectorAll("input")[0];
 
-      setInputValueAndTrigger(typeinflectionLower, "number", "change");
-      await nextTick();
-      setInputValueAndTrigger(operatorinflectionLower, "ge", "change");
-      await nextTick();
-      setInputValueAndTrigger(inputinflectionLower, "10", "input");
-      await nextTick();
+      await setInputValueAndTrigger(typeinflectionLower, "number");
+      await setInputValueAndTrigger(operatorinflectionLower, "ge");
+      await setInputValueAndTrigger(inputinflectionLower, "10");
 
-      setInputValueAndTrigger(typeinflectionUpper, "number", "change");
-      await nextTick();
-      setInputValueAndTrigger(operatorinflectionUpper, "ge", "change");
-      await nextTick();
-      setInputValueAndTrigger(inputinflectionUpper, "0", "input");
-      await nextTick();
+      await setInputValueAndTrigger(typeinflectionUpper, "number");
+      await setInputValueAndTrigger(operatorinflectionUpper, "ge");
+      await setInputValueAndTrigger(inputinflectionUpper, "0");
 
       const dispatch = spyModelDispatch(model);
       //  click save
@@ -1283,13 +1246,13 @@ describe("UI of conditional formats", () => {
     const rows = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.rows);
     const inputInflectionLower = rows[1].querySelectorAll("input")[0];
     const inputInflectionUpper = rows[2].querySelectorAll("input")[0];
-    setInputValueAndTrigger(inputInflectionLower, "hello", "input");
+    setInputValueAndTrigger(inputInflectionLower, "hello");
     await click(fixture, selectors.buttonSave);
     expect(inputInflectionLower.classList).toContain("o-invalid");
     expect(inputInflectionUpper.classList).not.toContain("o-invalid");
     expect(errorMessages()).toEqual(["The first value must be a number"]);
 
-    setInputValueAndTrigger(inputInflectionUpper, "hello", "input");
+    setInputValueAndTrigger(inputInflectionUpper, "hello");
     await click(fixture, selectors.buttonSave);
     expect(inputInflectionLower.classList).toContain("o-invalid");
     expect(inputInflectionUpper.classList).toContain("o-invalid");
@@ -1305,10 +1268,8 @@ describe("UI of conditional formats", () => {
     const rows = document.querySelectorAll(selectors.ruleEditor.editor.iconSetRule.rows);
     const inputInflectionLower = rows[1].querySelectorAll("input")[0];
     const inputInflectionUpper = rows[2].querySelectorAll("input")[0];
-    setInputValueAndTrigger(inputInflectionUpper, "10", "input");
-    await nextTick();
-    setInputValueAndTrigger(inputInflectionLower, "1", "input");
-    await nextTick();
+    await setInputValueAndTrigger(inputInflectionUpper, "10");
+    await setInputValueAndTrigger(inputInflectionLower, "1");
     await click(fixture, selectors.buttonSave);
     expect(inputInflectionLower.classList).toContain("o-invalid");
     expect(inputInflectionUpper.classList).toContain("o-invalid");
@@ -1320,8 +1281,7 @@ describe("UI of conditional formats", () => {
   test("Configuration is locally saved when switching cf type", async () => {
     await click(fixture, selectors.buttonAdd);
 
-    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
-    await nextTick();
+    await setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith");
     expect(
       (
         document.querySelector(
@@ -1344,10 +1304,8 @@ describe("UI of conditional formats", () => {
 
   test("switching to list resets the rules to their default value", async () => {
     await click(fixture, selectors.buttonAdd);
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B5:C7", "change");
-    setInputValueAndTrigger(selectors.ruleEditor.range, "B5:C7", "input");
-    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith", "change");
-    await nextTick();
+    setInputValueAndTrigger(selectors.ruleEditor.range, "B5:C7");
+    await setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "BeginsWith");
     await click(fixture, selectors.buttonCancel);
     await click(fixture, selectors.buttonAdd);
     expect((document.querySelector(selectors.ruleEditor.range) as HTMLInputElement).value).toBe(
@@ -1363,9 +1321,8 @@ describe("UI of conditional formats", () => {
     await click(fixture, selectors.buttonAdd);
     await nextTick();
 
-    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "Equal", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3,59", "input");
+    await setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "Equal");
+    setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "3,59");
 
     await click(fixture, selectors.buttonSave);
     const sheetId = model.getters.getActiveSheetId();
@@ -1381,9 +1338,8 @@ describe("UI of conditional formats", () => {
     await click(fixture, selectors.buttonAdd);
     await nextTick();
 
-    setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "Equal", "change");
-    await nextTick();
-    setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "01/05/2012", "input");
+    await setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "Equal");
+    setInputValueAndTrigger(selectors.ruleEditor.editor.valueInput, "01/05/2012");
 
     await click(fixture, selectors.buttonSave);
     const sheetId = model.getters.getActiveSheetId();

--- a/tests/data_filter/filter_menu_component.test.ts
+++ b/tests/data_filter/filter_menu_component.test.ts
@@ -194,11 +194,9 @@ describe("Filter menu component", () => {
 
     test("Clear all work on the displayed values", async () => {
       await openFilterMenu();
-      setInputValueAndTrigger(".o-filter-menu input", "1", "input");
-      await nextTick();
+      await setInputValueAndTrigger(".o-filter-menu input", "1");
       await simulateClick(".o-filter-menu-action-text:nth-of-type(2)");
-      setInputValueAndTrigger(".o-filter-menu input", "", "input");
-      await nextTick();
+      await setInputValueAndTrigger(".o-filter-menu input", "");
       expect(getFilterMenuValues()).toEqual([
         { value: "(Blanks)", isChecked: true },
         { value: "1", isChecked: false },
@@ -209,11 +207,9 @@ describe("Filter menu component", () => {
     test("Select all work on the displayed values", async () => {
       await openFilterMenu();
       await simulateClick(".o-filter-menu-action-text:nth-of-type(2)");
-      setInputValueAndTrigger(".o-filter-menu input", "1", "input");
-      await nextTick();
+      await setInputValueAndTrigger(".o-filter-menu input", "1");
       await simulateClick(".o-filter-menu-action-text:nth-of-type(1)");
-      setInputValueAndTrigger(".o-filter-menu input", "", "input");
-      await nextTick();
+      await setInputValueAndTrigger(".o-filter-menu input", "");
       expect(getFilterMenuValues()).toEqual([
         { value: "(Blanks)", isChecked: false },
         { value: "1", isChecked: true },
@@ -231,8 +227,7 @@ describe("Filter menu component", () => {
     describe("Search bar", () => {
       test("Can filter values with the search bar", async () => {
         await openFilterMenu();
-        setInputValueAndTrigger(".o-filter-menu input", "1", "input");
-        await nextTick();
+        await setInputValueAndTrigger(".o-filter-menu input", "1");
         expect(getFilterMenuValues().map((v) => v.value)).toEqual(["1"]);
       });
 
@@ -251,8 +246,7 @@ describe("Filter menu component", () => {
         setCellContent(model, "A5", "Illinois");
 
         await openFilterMenu();
-        setInputValueAndTrigger(".o-filter-menu input", "lo", "input");
-        await nextTick();
+        await setInputValueAndTrigger(".o-filter-menu input", "lo");
         expect(getFilterMenuValues().map((v) => v.value)).toEqual(["Florida", "Illinois"]);
       });
 

--- a/tests/data_validation/data_validation_generics_side_panel_component.test.ts
+++ b/tests/data_validation/data_validation_generics_side_panel_component.test.ts
@@ -84,12 +84,11 @@ describe("data validation sidePanel component", () => {
     await nextTick();
     await changeCriterionType(type);
 
-    setInputValueAndTrigger(".o-selection-input input", "A1:A5", "input");
+    setInputValueAndTrigger(".o-selection-input input", "A1:A5");
 
     const valuesInputs = fixture.querySelectorAll(".o-dv-settings input");
     for (let i = 0; i < criterion.values.length; i++) {
-      setInputValueAndTrigger(valuesInputs[i], criterion.values[i], "input");
-      await nextTick();
+      await setInputValueAndTrigger(valuesInputs[i], criterion.values[i]);
     }
 
     await simulateClick(".o-dv-save");
@@ -109,11 +108,11 @@ describe("data validation sidePanel component", () => {
   test("Date criteria have a dateValue select input", async () => {
     await simulateClick(".o-dv-add");
     await nextTick();
-    setInputValueAndTrigger(".o-selection-input input", "A1:A5", "input");
+    setInputValueAndTrigger(".o-selection-input input", "A1:A5");
     await changeCriterionType("dateIs");
 
     expect(fixture.querySelector(".o-dv-date-value")).toBeTruthy();
-    setInputValueAndTrigger(".o-dv-date-value", "tomorrow", "change");
+    setInputValueAndTrigger(".o-dv-date-value", "tomorrow");
 
     await simulateClick(".o-dv-save");
     expect(getDataValidationRules(model, sheetId)).toEqual([
@@ -130,11 +129,10 @@ describe("data validation sidePanel component", () => {
     await nextTick();
     await changeCriterionType("dateIs");
 
-    setInputValueAndTrigger(".o-selection-input input", "A1:A5", "input");
+    setInputValueAndTrigger(".o-selection-input input", "A1:A5");
 
     const valuesInput = fixture.querySelector(".o-dv-settings input");
-    setInputValueAndTrigger(valuesInput, "thisIsNotADate", "input");
-    await nextTick();
+    await setInputValueAndTrigger(valuesInput, "thisIsNotADate");
 
     expect(fixture.querySelector(".o-input.o-invalid")).toBeTruthy();
     expect(fixture.querySelector(".o-dv-save")!.classList).toContain("o-disabled");
@@ -145,13 +143,11 @@ describe("data validation sidePanel component", () => {
     await nextTick();
     await changeCriterionType("isBetween");
 
-    setInputValueAndTrigger(".o-selection-input input", "A1:A5", "input");
+    setInputValueAndTrigger(".o-selection-input input", "A1:A5");
 
     const valuesInputs = fixture.querySelectorAll(".o-dv-settings input");
-    setInputValueAndTrigger(valuesInputs[0], "Not a number", "input");
-    await nextTick();
-    setInputValueAndTrigger(valuesInputs[1], "Neither is this", "input");
-    await nextTick();
+    await setInputValueAndTrigger(valuesInputs[0], "Not a number");
+    await setInputValueAndTrigger(valuesInputs[1], "Neither is this");
 
     expect(fixture.querySelectorAll(".o-input.o-invalid")).toHaveLength(2);
     expect(fixture.querySelector(".o-dv-save")!.classList).toContain("o-disabled");
@@ -161,8 +157,8 @@ describe("data validation sidePanel component", () => {
     await simulateClick(".o-dv-add");
     await nextTick();
 
-    setInputValueAndTrigger(".o-dv-settings input", "Random text", "input");
-    setInputValueAndTrigger(".o-dv-reject-input", "true", "change");
+    setInputValueAndTrigger(".o-dv-settings input", "Random text");
+    setInputValueAndTrigger(".o-dv-reject-input", "true");
     simulateClick(".o-dv-save");
 
     expect(model.getters.getDataValidationRules(sheetId)).toMatchObject([{ isBlocking: true }]);
@@ -205,8 +201,7 @@ describe("data validation sidePanel component", () => {
       await changeCriterionType("isEqual");
 
       const valuesInput = fixture.querySelector(".o-dv-settings input");
-      setInputValueAndTrigger(valuesInput, "5,5", "input");
-      await nextTick();
+      await setInputValueAndTrigger(valuesInput, "5,5");
 
       expect(fixture.querySelector(".o-input.o-invalid")).toBeFalsy();
       expect(fixture.querySelector(".o-dv-save")!.classList).not.toContain("o-disabled");
@@ -228,8 +223,7 @@ describe("data validation sidePanel component", () => {
       await changeCriterionType("dateIs");
 
       const valuesInput = fixture.querySelector(".o-dv-settings input");
-      setInputValueAndTrigger(valuesInput, "30/03/2022", "input");
-      await nextTick();
+      await setInputValueAndTrigger(valuesInput, "30/03/2022");
 
       expect(fixture.querySelector(".o-input.o-invalid")).toBeFalsy();
       expect(fixture.querySelector(".o-dv-save")!.classList).not.toContain("o-disabled");
@@ -251,8 +245,7 @@ describe("data validation sidePanel component", () => {
       await changeCriterionType("textIs");
 
       const valuesInput = fixture.querySelector(".o-dv-settings input");
-      setInputValueAndTrigger(valuesInput, "=SUM(5,5; 3)", "input");
-      await nextTick();
+      await setInputValueAndTrigger(valuesInput, "=SUM(5,5; 3)");
 
       expect(fixture.querySelector(".o-input.o-invalid")).toBeFalsy();
       expect(fixture.querySelector(".o-dv-save")!.classList).not.toContain("o-disabled");

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -60,7 +60,7 @@ describe("Edit criterion in side panel", () => {
       const inputs = fixture.querySelectorAll<HTMLInputElement>(".o-dv-list-values .o-input");
       expect(inputs).toHaveLength(4);
 
-      setInputValueAndTrigger(inputs[3], "new value", "input");
+      setInputValueAndTrigger(inputs[3], "new value");
       await click(fixture, ".o-dv-save");
 
       expect(getDataValidationRules(model)[0].criterion.values).toEqual([
@@ -105,7 +105,7 @@ describe("Edit criterion in side panel", () => {
 
     test("Can change display style", () => {
       const displayStyleInput = fixture.querySelector<HTMLInputElement>(".o-dv-display-style");
-      setInputValueAndTrigger(displayStyleInput, "plainText", "change");
+      setInputValueAndTrigger(displayStyleInput, "plainText");
       click(fixture, ".o-dv-save");
       expect(
         (getDataValidationRules(model)[0].criterion as IsValueInListCriterion).displayStyle
@@ -142,14 +142,14 @@ describe("Edit criterion in side panel", () => {
       const rangeInput = fixture.querySelector<HTMLInputElement>(
         ".o-dv-settings .o-selection-input input"
       )!;
-      setInputValueAndTrigger(rangeInput, "B1:B9", "input");
+      setInputValueAndTrigger(rangeInput, "B1:B9");
       await click(fixture, ".o-dv-save");
       expect(getDataValidationRules(model)[0].criterion.values).toEqual(["B1:B9"]);
     });
 
     test("Can change display style", () => {
       const displayStyleInput = fixture.querySelector<HTMLInputElement>(".o-dv-display-style");
-      setInputValueAndTrigger(displayStyleInput, "plainText", "change");
+      setInputValueAndTrigger(displayStyleInput, "plainText");
       click(fixture, ".o-dv-save");
       expect(
         (getDataValidationRules(model)[0].criterion as IsValueInListCriterion).displayStyle

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -241,7 +241,7 @@ describe("charts", () => {
           });
           break;
         case "scorecard":
-          setInputValueAndTrigger(dataSeriesValues, "B2:B4", "input");
+          setInputValueAndTrigger(dataSeriesValues, "B2:B4");
           expect(dispatch).toHaveBeenLastCalledWith("CHANGE_RANGE", {
             value: "B2:B4",
             id: expect.anything(),
@@ -250,7 +250,7 @@ describe("charts", () => {
           break;
       }
       await simulateClick(".o-panel .inactive");
-      setInputValueAndTrigger(".o-chart-title input", "hello", "change");
+      setInputValueAndTrigger(".o-chart-title input", "hello");
       expect(dispatch).toHaveBeenLastCalledWith("UPDATE_CHART", {
         id: chartId,
         sheetId,
@@ -286,7 +286,7 @@ describe("charts", () => {
     await openChartDesignSidePanel("1");
 
     await simulateClick(".o-chart-title input");
-    setInputValueAndTrigger(".o-chart-title input", "first_title", "input");
+    setInputValueAndTrigger(".o-chart-title input", "first_title", "onlyInput");
 
     const figures = fixture.querySelectorAll(".o-figure");
     await simulateClick(figures[1] as HTMLElement);
@@ -320,8 +320,7 @@ describe("charts", () => {
     const figures = fixture.querySelectorAll(".o-figure");
     await simulateClick(figures[1] as HTMLElement);
     await simulateClick(".o-chart-title input");
-    setInputValueAndTrigger(".o-chart-title input", "new_title", "input");
-    setInputValueAndTrigger(".o-chart-title input", "new_title", "change");
+    setInputValueAndTrigger(".o-chart-title input", "new_title");
 
     expect(model.getters.getChartDefinition("1").title).toBe("old_title_1");
     expect(model.getters.getChartDefinition("2").title).toBe("new_title");
@@ -336,7 +335,7 @@ describe("charts", () => {
       await simulateClick(".o-chart-title input");
       const chartTitle = document.querySelector(".o-chart-title input") as HTMLInputElement;
       expect(chartTitle.value).toBe("hello");
-      setInputValueAndTrigger(".o-chart-title input", "hello_new_title", "input");
+      setInputValueAndTrigger(".o-chart-title input", "hello_new_title");
       await simulateClick(".o-grid-overlay");
       expect(chartTitle.value).toBe("hello_new_title");
     }
@@ -405,8 +404,7 @@ describe("charts", () => {
       expect(model.getters.getChartDefinition(chartId)?.[attrName]).not.toBeUndefined();
 
       await simulateClick(domClass + " input");
-      setInputValueAndTrigger(domClass + " input", "", "input");
-      await nextTick();
+      await setInputValueAndTrigger(domClass + " input", "");
       await simulateClick(domClass + " .o-selection-ok");
       expect(
         (model.getters.getChartDefinition(chartId) as ChartDefinition)[attrName]
@@ -426,9 +424,8 @@ describe("charts", () => {
     const hasTitle = fixture.querySelector(
       ".o-use-row-as-headers input[type=checkbox]"
     ) as HTMLInputElement;
-    setInputValueAndTrigger(chartType, "pie", "change");
-    await nextTick();
-    setInputValueAndTrigger(dataSeriesValues, "B2:B5", "change");
+    await setInputValueAndTrigger(chartType, "pie");
+    setInputValueAndTrigger(dataSeriesValues, "B2:B5");
     await click(hasTitle);
     // dataSetsHaveTitle is not propagated
     expect((mockChartData.data! as any).datasets[0].data).toEqual([
@@ -447,8 +444,7 @@ describe("charts", () => {
 
     createSheet(model, { sheetId: "42", activate: true });
     const chartType = fixture.querySelectorAll(".o-sidePanel .o-input")[0] as HTMLSelectElement;
-    setInputValueAndTrigger(chartType, "pie", "change");
-    await nextTick();
+    await setInputValueAndTrigger(chartType, "pie");
 
     expect(model.getters.getChart(chartId)?.sheetId).toBe(sheetId);
 
@@ -459,7 +455,7 @@ describe("charts", () => {
     const hasTitle = fixture.querySelector(
       ".o-use-row-as-headers input[type=checkbox]"
     ) as HTMLInputElement;
-    setInputValueAndTrigger(dataSeriesValues, "B2:B5", "change");
+    setInputValueAndTrigger(dataSeriesValues, "B2:B5");
     await simulateClick(hasTitle);
     expect(model.getters.getChart(chartId)?.sheetId).toBe(sheetId);
   });
@@ -485,8 +481,7 @@ describe("charts", () => {
 
     await simulateClick(".o-data-series .o-add-selection");
     const element = document.querySelectorAll(".o-data-series input")[0];
-    setInputValueAndTrigger(element, "C1:C4", "input");
-    await nextTick();
+    await setInputValueAndTrigger(element, "C1:C4");
 
     await simulateClick(".o-figure");
     await keyDown({ key: "Delete" });
@@ -564,8 +559,7 @@ describe("charts", () => {
 
     await simulateClick(".o-data-series .o-add-selection");
     const element = document.querySelectorAll(".o-data-series input")[1];
-    setInputValueAndTrigger(element, "C1:C4", "input");
-    await nextTick();
+    await setInputValueAndTrigger(element, "C1:C4");
     await simulateClick(".o-data-series .o-selection-ok");
     expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
       "B1:B4",
@@ -584,8 +578,7 @@ describe("charts", () => {
 
     await simulateClick(".o-data-series .o-add-selection");
     const element = document.querySelectorAll(".o-data-series input")[1];
-    setInputValueAndTrigger(element, "C1:D4", "input");
-    await nextTick();
+    await setInputValueAndTrigger(element, "C1:D4");
     await simulateClick(".o-data-series .o-selection-ok");
     expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
       "B1:B4",
@@ -619,8 +612,7 @@ describe("charts", () => {
 
     await simulateClick(".o-data-series .o-add-selection");
     const element = document.querySelectorAll(".o-data-series input")[1];
-    setInputValueAndTrigger(element, "1:2", "input");
-    await nextTick();
+    await setInputValueAndTrigger(element, "1:2");
     await simulateClick(".o-data-series .o-selection-ok");
     expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
       "1:1",
@@ -643,8 +635,7 @@ describe("charts", () => {
 
     await simulateClick(".o-data-series .o-add-selection");
     const element = document.querySelectorAll(".o-data-series input")[1];
-    setInputValueAndTrigger(element, "A:B", "input");
-    await nextTick();
+    await setInputValueAndTrigger(element, "A:B");
     await simulateClick(".o-data-series .o-selection-ok");
     expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
       "A:A",
@@ -663,8 +654,7 @@ describe("charts", () => {
         await openChartConfigSidePanel();
 
         await simulateClick(".o-data-labels input");
-        setInputValueAndTrigger(".o-data-labels input", "", "input");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-labels input", "");
 
         const expectedErrors = expectedResults.map((result) =>
           ChartTerms.Errors[result].toString()
@@ -681,8 +671,7 @@ describe("charts", () => {
         await openChartConfigSidePanel();
 
         await simulateClick(".o-data-series input");
-        setInputValueAndTrigger(".o-data-series input", "A1", "input");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-series input", "A1");
         expect(fixture.querySelectorAll(".o-data-series .o-selection-ok").length).toBe(1);
       }
     );
@@ -694,8 +683,7 @@ describe("charts", () => {
         await openChartConfigSidePanel();
 
         await simulateClick(".o-data-series input");
-        setInputValueAndTrigger(".o-data-series input", "This is not valid", "input");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-series input", "This is not valid");
         expect(fixture.querySelectorAll(".o-data-series .o-selection-ok").length).toBe(0);
       }
     );
@@ -705,8 +693,7 @@ describe("charts", () => {
       await openChartConfigSidePanel();
 
       await simulateClick(".o-data-series input");
-      setInputValueAndTrigger(".o-data-series input", "A1:A10--", "input");
-      await nextTick();
+      await setInputValueAndTrigger(".o-data-series input", "A1:A10--");
       await focusAndKeyDown(".o-data-series input", { key: "Enter" });
 
       expect(model.getters.getChartDefinition(chartId)).toMatchObject(TEST_CHART_DATA.basicChart);
@@ -719,13 +706,11 @@ describe("charts", () => {
         await openChartConfigSidePanel();
 
         await simulateClick(".o-data-series input");
-        setInputValueAndTrigger(".o-data-series input", "A1", "input");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-series input", "A1");
         await simulateClick(".o-data-series .o-selection-ok");
 
         await simulateClick(".o-data-series input");
-        setInputValueAndTrigger(".o-data-series input", "this is not valid", "input");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-series input", "this is not valid");
         await simulateClick(".o-data-series .o-selection-ko");
 
         expect((fixture.querySelector(".o-data-series input") as HTMLInputElement).value).toBe(
@@ -741,8 +726,7 @@ describe("charts", () => {
         await openChartConfigSidePanel();
 
         await simulateClick(".o-data-labels input");
-        setInputValueAndTrigger(".o-data-labels input", "A1", "input");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-labels input", "A1");
         await simulateClick(".o-data-labels .o-selection-ok");
 
         expect((fixture.querySelector(".o-data-labels input") as HTMLInputElement).value).toBe(
@@ -750,8 +734,7 @@ describe("charts", () => {
         );
 
         await simulateClick(".o-data-labels input");
-        setInputValueAndTrigger(".o-data-labels input", "this is not valid", "input");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-labels input", "this is not valid");
         await simulateClick(".o-data-labels .o-selection-ko");
 
         expect((fixture.querySelector(".o-data-labels input") as HTMLInputElement).value).toBe(
@@ -767,48 +750,37 @@ describe("charts", () => {
       });
 
       test("empty rangeMin", async () => {
-        setInputValueAndTrigger(".o-data-range-min", "", "input");
-        setInputValueAndTrigger(".o-data-range-min", "", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-min", "");
         expect(errorMessages()[0]).toEqual(
           ChartTerms.Errors[CommandResult.EmptyGaugeRangeMin].toString()
         );
       });
 
       test("NaN rangeMin", async () => {
-        setInputValueAndTrigger(".o-data-range-min", "I'm not a number", "input");
-        setInputValueAndTrigger(".o-data-range-min", "I'm not a number", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-min", "I'm not a number");
         expect(errorMessages()[0]).toEqual(
           ChartTerms.Errors[CommandResult.GaugeRangeMinNaN].toString()
         );
       });
 
       test("empty rangeMax", async () => {
-        setInputValueAndTrigger(".o-data-range-max", "", "input");
-        setInputValueAndTrigger(".o-data-range-max", "", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-max", "");
         expect(errorMessages()[0]).toEqual(
           ChartTerms.Errors[CommandResult.EmptyGaugeRangeMax].toString()
         );
       });
 
       test("NaN rangeMax", async () => {
-        setInputValueAndTrigger(".o-data-range-max", "I'm not a number", "input");
-        setInputValueAndTrigger(".o-data-range-max", "I'm not a number", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-max", "I'm not a number");
         expect(errorMessages()[0]).toEqual(
           ChartTerms.Errors[CommandResult.GaugeRangeMaxNaN].toString()
         );
       });
 
       test("rangeMin > rangeMax", async () => {
-        setInputValueAndTrigger(".o-data-range-min", "100", "input");
-        setInputValueAndTrigger(".o-data-range-min", "100", "change");
+        setInputValueAndTrigger(".o-data-range-min", "100");
 
-        setInputValueAndTrigger(".o-data-range-max", "0", "input");
-        setInputValueAndTrigger(".o-data-range-max", "0", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-max", "0");
         expect(errorMessages()[0]).toEqual(
           ChartTerms.Errors[CommandResult.GaugeRangeMinBiggerThanRangeMax].toString()
         );
@@ -816,9 +788,7 @@ describe("charts", () => {
 
       test("NaN LowerInflectionPoint", async () => {
         await simulateClick(".o-input-lowerInflectionPoint");
-        setInputValueAndTrigger(".o-input-lowerInflectionPoint", "I'm not a number", "input");
-        setInputValueAndTrigger(".o-input-lowerInflectionPoint", "I'm not a number", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-input-lowerInflectionPoint", "I'm not a number");
         expect(errorMessages()[0]).toEqual(
           ChartTerms.Errors[CommandResult.GaugeLowerInflectionPointNaN].toString()
         );
@@ -826,9 +796,7 @@ describe("charts", () => {
 
       test("NaN UpperInflectionPoint", async () => {
         await simulateClick(".o-input-upperInflectionPoint");
-        setInputValueAndTrigger(".o-input-upperInflectionPoint", "I'm not a number", "input");
-        setInputValueAndTrigger(".o-input-upperInflectionPoint", "I'm not a number", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-input-upperInflectionPoint", "I'm not a number");
         expect(errorMessages()[0]).toEqual(
           ChartTerms.Errors[CommandResult.GaugeUpperInflectionPointNaN].toString()
         );
@@ -841,15 +809,14 @@ describe("charts", () => {
 
       // empty dataset/key value
       await simulateClick(".o-data-series input");
-      setInputValueAndTrigger(".o-data-series input", "", "input");
-      await nextTick();
+      await setInputValueAndTrigger(".o-data-series input", "");
       await simulateClick(".o-data-series .o-selection-ok");
       expect(document.querySelector(".o-data-series input")?.classList).toContain("o-invalid");
       expect(document.querySelector(".o-data-labels input")?.classList).not.toContain("o-invalid");
 
       // invalid labels/baseline
       await simulateClick(".o-data-labels input");
-      setInputValueAndTrigger(".o-data-labels input", "Invalid Label Range", "input");
+      setInputValueAndTrigger(".o-data-labels input", "Invalid Label Range");
       await simulateClick(".o-data-labels .o-selection-ok");
       expect(document.querySelector(".o-data-series input")?.classList).toContain("o-invalid");
       expect(document.querySelector(".o-data-labels input")?.classList).toContain("o-invalid");
@@ -863,62 +830,47 @@ describe("charts", () => {
 
       test("empty dataRange", async () => {
         await simulateClick(".o-data-series input");
-        setInputValueAndTrigger(".o-data-series input", "", "input");
-        setInputValueAndTrigger(".o-data-series input", "", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-series input", "");
         await simulateClick(".o-data-series .o-selection-ok");
         expect(document.querySelector(".o-data-series input")?.classList).toContain("o-invalid");
       });
 
       test("empty rangeMin", async () => {
         await simulateClick(".o-panel-design");
-        setInputValueAndTrigger(".o-data-range-min", "", "input");
-        setInputValueAndTrigger(".o-data-range-min", "", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-min", "");
         expect(document.querySelector(".o-data-range-min")?.classList).toContain("o-invalid");
       });
 
       test("NaN rangeMin", async () => {
         await simulateClick(".o-panel-design");
-        setInputValueAndTrigger(".o-data-range-min", "bla bla bla", "input");
-        setInputValueAndTrigger(".o-data-range-min", "bla bla bla", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-min", "bla bla bla");
         expect(document.querySelector(".o-data-range-min")?.classList).toContain("o-invalid");
       });
 
       test("empty rangeMax", async () => {
         await simulateClick(".o-panel-design");
-        setInputValueAndTrigger(".o-data-range-max", "", "input");
-        setInputValueAndTrigger(".o-data-range-max", "", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-max", "");
         expect(document.querySelector(".o-data-range-max")?.classList).toContain("o-invalid");
       });
 
       test("NaN rangeMax", async () => {
         await simulateClick(".o-panel-design");
-        setInputValueAndTrigger(".o-data-range-max", "bla bla bla", "input");
-        setInputValueAndTrigger(".o-data-range-max", "bla bla bla", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-max", "bla bla bla");
         expect(document.querySelector(".o-data-range-max")?.classList).toContain("o-invalid");
       });
 
       test("rangeMin > rangeMax", async () => {
         await simulateClick(".o-panel-design");
-        setInputValueAndTrigger(".o-data-range-min", "100", "input");
-        setInputValueAndTrigger(".o-data-range-min", "100", "change");
+        setInputValueAndTrigger(".o-data-range-min", "100");
 
-        setInputValueAndTrigger(".o-data-range-max", "0", "input");
-        setInputValueAndTrigger(".o-data-range-max", "0", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-data-range-max", "0");
         expect(document.querySelector(".o-data-range-min")?.classList).toContain("o-invalid");
         expect(document.querySelector(".o-data-range-max")?.classList).toContain("o-invalid");
       });
 
       test("NaN LowerInflectionPoint", async () => {
         await simulateClick(".o-panel-design");
-        setInputValueAndTrigger(".o-input-lowerInflectionPoint", "bla bla bla", "input");
-        setInputValueAndTrigger(".o-input-lowerInflectionPoint", "bla bla bla", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-input-lowerInflectionPoint", "bla bla bla");
         expect(document.querySelector(".o-input-lowerInflectionPoint")?.classList).toContain(
           "o-invalid"
         );
@@ -926,9 +878,7 @@ describe("charts", () => {
 
       test("NaN UpperInflectionPoint", async () => {
         await simulateClick(".o-panel-design");
-        setInputValueAndTrigger(".o-input-upperInflectionPoint", "bla bla bla", "input");
-        setInputValueAndTrigger(".o-input-upperInflectionPoint", "bla bla bla", "change");
-        await nextTick();
+        await setInputValueAndTrigger(".o-input-upperInflectionPoint", "bla bla bla");
         expect(document.querySelector(".o-input-upperInflectionPoint")?.classList).toContain(
           "o-invalid"
         );

--- a/tests/find_and_replace/find_replace_side_panel_component.test.ts
+++ b/tests/find_and_replace/find_replace_side_panel_component.test.ts
@@ -57,8 +57,7 @@ describe("find and replace sidePanel component", () => {
     });
 
     test("disable next/previous/replace/replaceAll if searching on empty string", async () => {
-      setInputValueAndTrigger(selectors.inputSearch, "", "input");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.inputSearch, "");
       expect((document.querySelector(selectors.previousButton) as HTMLButtonElement).disabled).toBe(
         true
       );
@@ -90,7 +89,7 @@ describe("find and replace sidePanel component", () => {
 
     test("simple search", async () => {
       /** Fake timers use to control debounceSearch in Find and Replace */
-      setInputValueAndTrigger(selectors.inputSearch, "1", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "1");
       jest.runOnlyPendingTimers();
       await nextTick();
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
@@ -100,25 +99,25 @@ describe("find and replace sidePanel component", () => {
     });
 
     test("clicking on next", async () => {
-      setInputValueAndTrigger(selectors.inputSearch, "1", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "1");
       await click(fixture, selectors.nextButton);
       expect(dispatch).toHaveBeenCalledWith("SELECT_SEARCH_NEXT_MATCH");
     });
 
     test("Going to next with Enter key", async () => {
-      setInputValueAndTrigger(selectors.inputSearch, "1", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "1");
       await focusAndKeyDown(selectors.inputSearch, { key: "Enter" });
       expect(dispatch).toHaveBeenCalledWith("SELECT_SEARCH_NEXT_MATCH");
     });
 
     test("clicking on previous", async () => {
-      setInputValueAndTrigger(selectors.inputSearch, "1", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "1");
       await click(fixture, selectors.previousButton);
       expect(dispatch).toHaveBeenCalledWith("SELECT_SEARCH_PREVIOUS_MATCH");
     });
 
     test("search on empty string", async () => {
-      setInputValueAndTrigger(selectors.inputSearch, "", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "");
       jest.runOnlyPendingTimers();
       await nextTick();
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
@@ -128,7 +127,7 @@ describe("find and replace sidePanel component", () => {
     });
 
     test("Closing the sidepanel cancels the search", async () => {
-      setInputValueAndTrigger(selectors.inputSearch, "g", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "g");
       await simulateClick(".o-sidePanelClose");
       jest.runOnlyPendingTimers();
       await nextTick();
@@ -150,7 +149,7 @@ describe("find and replace sidePanel component", () => {
     test("search match count is displayed", async () => {
       setCellContent(model, "A1", "Hello");
       expect(fixture.querySelector(".o-input-count")).toBeNull();
-      setInputValueAndTrigger(selectors.inputSearch, "Hel", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "Hel");
       jest.runOnlyPendingTimers();
       await nextTick();
       expect(fixture.querySelector(".o-input-count")?.innerHTML).toBe("1 / 1");
@@ -158,13 +157,12 @@ describe("find and replace sidePanel component", () => {
 
     test("search match count is removed when input is cleared", async () => {
       setCellContent(model, "A1", "Hello");
-      setInputValueAndTrigger(selectors.inputSearch, "Hel", "input");
-      await nextTick(); // wait the next render to check if the count is displayed
+      await setInputValueAndTrigger(selectors.inputSearch, "Hel"); // wait the next render to check if the count is displayed
       expect(fixture.querySelector(".o-input-count")).toBeNull();
       jest.runOnlyPendingTimers();
       await nextTick();
       expect(fixture.querySelector(".o-input-count")?.innerHTML).toBe("1 / 1");
-      setInputValueAndTrigger(selectors.inputSearch, "", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "");
       jest.runOnlyPendingTimers();
       await nextTick();
       expect(fixture.querySelector(".o-input-count")).toBeNull();
@@ -172,7 +170,7 @@ describe("find and replace sidePanel component", () => {
 
     test("search without match displays no match count", async () => {
       expect(fixture.querySelector(".o-input-count")).toBeNull();
-      setInputValueAndTrigger(selectors.inputSearch, "a search term", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "a search term");
       jest.runOnlyPendingTimers();
       await nextTick();
       expect(fixture.querySelector(".o-input-count")?.innerHTML).toBe("0 / 0");
@@ -188,7 +186,7 @@ describe("find and replace sidePanel component", () => {
     test("Can search matching case", async () => {
       const dispatch = spyDispatch(parent);
 
-      setInputValueAndTrigger(selectors.inputSearch, "Hell", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "Hell");
       await click(fixture, selectors.checkBoxMatchingCase);
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
         searchOptions: { exactMatch: false, matchCase: true, searchFormulas: false },
@@ -199,7 +197,7 @@ describe("find and replace sidePanel component", () => {
     test("Can search matching entire cell", async () => {
       const dispatch = spyDispatch(parent);
 
-      setInputValueAndTrigger(selectors.inputSearch, "Hell", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "Hell");
       await click(fixture, selectors.checkBoxExactMatch);
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
         searchOptions: { exactMatch: true, matchCase: false, searchFormulas: false },
@@ -210,7 +208,7 @@ describe("find and replace sidePanel component", () => {
     test("can search in formulas", async () => {
       const dispatch = spyDispatch(parent);
 
-      setInputValueAndTrigger(selectors.inputSearch, "Hell", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "Hell");
       await click(fixture, selectors.checkBoxSearchFormulas);
       expect(dispatch).toHaveBeenCalledWith("UPDATE_SEARCH", {
         searchOptions: { exactMatch: false, matchCase: false, searchFormulas: true },
@@ -250,41 +248,41 @@ describe("find and replace sidePanel component", () => {
       await nextTick();
     });
     test("Can replace a simple text value", async () => {
-      setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "hello", "input");
-      setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "kikou", "input");
+      setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "hello");
+      setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "kikou");
       const dispatch = spyDispatch(parent);
       await click(fixture, selectors.replaceButton);
       expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "kikou" });
     });
 
     test("Can replace a value in a formula", async () => {
-      setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "2", "input");
+      setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "2");
       await click(fixture, selectors.checkBoxSearchFormulas);
-      setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "4", "input");
+      setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "4");
       const dispatch = spyDispatch(parent);
       await click(fixture, selectors.replaceButton);
       expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "4" });
     });
 
     test("formulas wont be modified if not looking in formulas or not modifying formulas", async () => {
-      setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "4", "input");
-      setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "2", "input");
+      setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "4");
+      setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "2");
       const dispatch = spyDispatch(parent);
       await click(fixture, selectors.replaceButton);
       expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "2" });
     });
 
     test("can replace all", async () => {
-      setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "hell", "input");
-      setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "kikou", "input");
+      setInputValueAndTrigger(document.querySelector(selectors.inputSearch), "hell");
+      setInputValueAndTrigger(document.querySelector(selectors.inputReplace), "kikou");
       const dispatch = spyDispatch(parent);
       await click(fixture, selectors.replaceAllButton);
       expect(dispatch).toHaveBeenCalledWith("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
     });
 
     test("Can replace with Enter key", async () => {
-      setInputValueAndTrigger(selectors.inputSearch, "hell", "input");
-      setInputValueAndTrigger(selectors.inputReplace, "kikou", "input");
+      setInputValueAndTrigger(selectors.inputSearch, "hell");
+      setInputValueAndTrigger(selectors.inputReplace, "kikou");
       const dispatch = spyDispatch(parent);
       await focusAndKeyDown(selectors.inputReplace, { key: "Enter" });
       expect(dispatch).toHaveBeenCalledWith("REPLACE_SEARCH", { replaceWith: "kikou" });

--- a/tests/formats/custom_currency_side_panel_component.test.ts
+++ b/tests/formats/custom_currency_side_panel_component.test.ts
@@ -75,8 +75,7 @@ describe("custom currency sidePanel component", () => {
       expect((document.querySelector(selectors.inputCode) as HTMLInputElement).value).toBe("");
       expect((document.querySelector(selectors.inputSymbol) as HTMLInputElement).value).toBe("");
 
-      setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "1");
 
       expect((document.querySelector(selectors.inputCode) as HTMLInputElement).value).toBe(code1);
       expect((document.querySelector(selectors.inputSymbol) as HTMLInputElement).value).toBe(
@@ -85,42 +84,35 @@ describe("custom currency sidePanel component", () => {
     });
 
     test("select currency in available currencies selector --> changes currency proposals", async () => {
-      setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "1");
       expect(document.querySelector(selectors.formatProposals)).toMatchSnapshot();
 
-      setInputValueAndTrigger(selectors.availableCurrencies, "2", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "2");
       expect(document.querySelector(selectors.formatProposals)).toMatchSnapshot();
     });
 
     test("select currency in available currencies selector --> does not change proposal selected index", async () => {
-      setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-      await nextTick();
-      setInputValueAndTrigger(selectors.formatProposals, "6", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "1");
+      await setInputValueAndTrigger(selectors.formatProposals, "6");
       expect((document.querySelector(selectors.formatProposals) as HTMLSelectElement).value).toBe(
         "6"
       );
 
-      setInputValueAndTrigger(selectors.availableCurrencies, "2", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "2");
       expect((document.querySelector(selectors.formatProposals) as HTMLSelectElement).value).toBe(
         "6"
       );
     });
 
     test("select first currency in available currencies selector --> remove code input and symbol input", async () => {
-      setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "1");
 
       expect((document.querySelector(selectors.inputCode) as HTMLInputElement).value).toBe(code1);
       expect((document.querySelector(selectors.inputSymbol) as HTMLInputElement).value).toBe(
         symbol1
       );
 
-      setInputValueAndTrigger(selectors.availableCurrencies, "0", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "0");
 
       expect((document.querySelector(selectors.inputCode) as HTMLInputElement).value).toBe("");
       expect((document.querySelector(selectors.inputSymbol) as HTMLInputElement).value).toBe("");
@@ -131,9 +123,8 @@ describe("custom currency sidePanel component", () => {
     // -------------------------------------------------------------------------
 
     test("disable formatProposals/applyFormat if inputSymbol and inputCode are empty", async () => {
-      setInputValueAndTrigger(selectors.inputSymbol, "$", "input");
-      setInputValueAndTrigger(selectors.inputCode, "", "input");
-      await nextTick();
+      setInputValueAndTrigger(selectors.inputSymbol, "$");
+      await setInputValueAndTrigger(selectors.inputCode, "");
       expect(
         (document.querySelector(selectors.formatProposals) as HTMLSelectElement).disabled
       ).toBe(false);
@@ -141,9 +132,8 @@ describe("custom currency sidePanel component", () => {
         false
       );
 
-      setInputValueAndTrigger(selectors.inputSymbol, "", "input");
-      setInputValueAndTrigger(selectors.inputCode, "USD", "input");
-      await nextTick();
+      setInputValueAndTrigger(selectors.inputSymbol, "");
+      await setInputValueAndTrigger(selectors.inputCode, "USD");
       expect(
         (document.querySelector(selectors.formatProposals) as HTMLSelectElement).disabled
       ).toBe(false);
@@ -151,9 +141,8 @@ describe("custom currency sidePanel component", () => {
         false
       );
 
-      setInputValueAndTrigger(selectors.inputSymbol, "  ", "input");
-      setInputValueAndTrigger(selectors.inputCode, "", "input");
-      await nextTick();
+      setInputValueAndTrigger(selectors.inputSymbol, "  ");
+      await setInputValueAndTrigger(selectors.inputCode, "");
       expect(
         (document.querySelector(selectors.formatProposals) as HTMLSelectElement).disabled
       ).toBe(true);
@@ -165,8 +154,7 @@ describe("custom currency sidePanel component", () => {
     test("disable formatProposals/applyFormat if selected cells formats are same that the select currency format", async () => {
       setSelection(model, ["A1", "A2"]);
       await nextTick();
-      setInputValueAndTrigger(selectors.inputSymbol, "$", "input");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.inputSymbol, "$");
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         false
       );
@@ -180,8 +168,7 @@ describe("custom currency sidePanel component", () => {
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         true
       );
-      setInputValueAndTrigger(selectors.inputSymbol, "€", "input");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.inputSymbol, "€");
       await click(fixture, selectors.applyFormat);
       setSelection(model, ["A1", "A2"]);
 
@@ -192,45 +179,38 @@ describe("custom currency sidePanel component", () => {
     });
 
     test("not disable formatProposals/applyFormat if apply proposal and select other proposal", async () => {
-      setInputValueAndTrigger(selectors.inputSymbol, "$", "input");
-      setInputValueAndTrigger(selectors.inputCode, "USD", "input");
-      await nextTick();
-      setInputValueAndTrigger(selectors.formatProposals, "1", "change");
-      await nextTick();
+      setInputValueAndTrigger(selectors.inputSymbol, "$");
+      await setInputValueAndTrigger(selectors.inputCode, "USD");
+      await setInputValueAndTrigger(selectors.formatProposals, "1");
       await click(fixture, selectors.applyFormat);
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         true
       );
 
-      setInputValueAndTrigger(selectors.formatProposals, "2", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.formatProposals, "2");
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         false
       );
 
-      setInputValueAndTrigger(selectors.formatProposals, "1", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.formatProposals, "1");
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         true
       );
     });
 
     test("not disable formatProposals/applyFormat if apply proposal and select other currency", async () => {
-      setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "1");
       await click(fixture, selectors.applyFormat);
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         true
       );
 
-      setInputValueAndTrigger(selectors.availableCurrencies, "2", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "2");
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         false
       );
 
-      setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "1");
       expect((document.querySelector(selectors.applyFormat) as HTMLButtonElement).disabled).toBe(
         true
       );
@@ -239,14 +219,12 @@ describe("custom currency sidePanel component", () => {
     test.each([selectors.inputCode, selectors.inputSymbol])(
       "change code input or symbol input --> init available currencies",
       async (selector) => {
-        setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-        await nextTick();
+        await setInputValueAndTrigger(selectors.availableCurrencies, "1");
         expect(
           (document.querySelector(selectors.availableCurrencies) as HTMLSelectElement).value
         ).toBe("1");
 
-        setInputValueAndTrigger(selector, "test", "input");
-        await nextTick();
+        await setInputValueAndTrigger(selector, "test");
         expect(
           (document.querySelector(selectors.availableCurrencies) as HTMLSelectElement).value
         ).toBe("0");
@@ -256,21 +234,17 @@ describe("custom currency sidePanel component", () => {
     test.each([selectors.inputCode, selectors.inputSymbol])(
       "change code input or symbol input --> change currency proposals",
       async (selector) => {
-        setInputValueAndTrigger(selectors.inputCode, "CODE", "input");
-        await nextTick();
-        setInputValueAndTrigger(selectors.inputSymbol, "SYMBOL", "input");
-        await nextTick();
+        await setInputValueAndTrigger(selectors.inputCode, "CODE");
+        await setInputValueAndTrigger(selectors.inputSymbol, "SYMBOL");
         expect(document.querySelector(selectors.formatProposals)).toMatchSnapshot();
 
-        setInputValueAndTrigger(selector, "TEST", "input");
-        await nextTick();
+        await setInputValueAndTrigger(selector, "TEST");
         expect(document.querySelector(selectors.formatProposals)).toMatchSnapshot();
       }
     );
 
     test("currency proposals uses locale format", async () => {
-      setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.availableCurrencies, "1");
       const proposals = [...document.querySelectorAll(selectors.formatProposalOptions)];
       expect(proposals.map((el) => el.textContent)).toEqual([
         "1,000µ",
@@ -299,16 +273,13 @@ describe("custom currency sidePanel component", () => {
     test.each([selectors.inputCode, selectors.inputSymbol])(
       "change code input or symbol input --> does not change proposal selected index",
       async (selector) => {
-        setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-        await nextTick();
-        setInputValueAndTrigger(selectors.formatProposals, "6", "change");
-        await nextTick();
+        await setInputValueAndTrigger(selectors.availableCurrencies, "1");
+        await setInputValueAndTrigger(selectors.formatProposals, "6");
         expect((document.querySelector(selectors.formatProposals) as HTMLSelectElement).value).toBe(
           "6"
         );
 
-        setInputValueAndTrigger(selector, "TEST", "input");
-        await nextTick();
+        await setInputValueAndTrigger(selector, "TEST");
         expect((document.querySelector(selectors.formatProposals) as HTMLSelectElement).value).toBe(
           "6"
         );
@@ -318,12 +289,10 @@ describe("custom currency sidePanel component", () => {
     test.each([selectors.inputCode, selectors.inputSymbol])(
       "have only one input filled --> display 4 proposals instead of 8",
       async (selector) => {
-        setInputValueAndTrigger(selectors.availableCurrencies, "1", "change");
-        await nextTick();
+        await setInputValueAndTrigger(selectors.availableCurrencies, "1");
         expect(document.querySelectorAll(selectors.formatProposals + " option").length).toBe(8);
 
-        setInputValueAndTrigger(selector, "  ", "input");
-        await nextTick();
+        await setInputValueAndTrigger(selector, "  ");
 
         expect(document.querySelectorAll(selectors.formatProposals + " option").length).toBe(4);
       }
@@ -342,12 +311,9 @@ describe("custom currency sidePanel component", () => {
       ["6", "[$USD $]#,##0"],
       ["7", "[$USD $]#,##0.00"],
     ])("format applied depends on selected proposal", async (proposalIndex, formatResult) => {
-      setInputValueAndTrigger(selectors.inputSymbol, "$", "input");
-      await nextTick();
-      setInputValueAndTrigger(selectors.inputCode, "USD", "input");
-      await nextTick();
-      setInputValueAndTrigger(selectors.formatProposals, proposalIndex, "change");
-      await nextTick();
+      await setInputValueAndTrigger(selectors.inputSymbol, "$");
+      await setInputValueAndTrigger(selectors.inputCode, "USD");
+      await setInputValueAndTrigger(selectors.formatProposals, proposalIndex);
       await click(fixture, selectors.applyFormat);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: model.getters.getActiveSheetId(),
@@ -376,10 +342,8 @@ describe("custom currency sidePanel component", () => {
       ])(
         "odd currency proposals depend on decimal places property",
         async (concernedIndex, decimalPlacesRegexp) => {
-          setInputValueAndTrigger(selectors.availableCurrencies, availableCurrencyIndex, "change");
-          await nextTick();
-          setInputValueAndTrigger(selectors.formatProposals, concernedIndex, "change");
-          await nextTick();
+          await setInputValueAndTrigger(selectors.availableCurrencies, availableCurrencyIndex);
+          await setInputValueAndTrigger(selectors.formatProposals, concernedIndex);
           await click(fixture, selectors.applyFormat);
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: model.getters.getActiveSheetId(),
@@ -410,10 +374,8 @@ describe("custom currency sidePanel component", () => {
       ])(
         "currency proposals depend on position property",
         async (concernedIndex, positionExpressionRegexp) => {
-          setInputValueAndTrigger(selectors.availableCurrencies, availableCurrencyIndex, "change");
-          await nextTick();
-          setInputValueAndTrigger(selectors.formatProposals, concernedIndex, "change");
-          await nextTick();
+          await setInputValueAndTrigger(selectors.availableCurrencies, availableCurrencyIndex);
+          await setInputValueAndTrigger(selectors.formatProposals, concernedIndex);
           await click(fixture, selectors.applyFormat);
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: model.getters.getActiveSheetId(),
@@ -428,14 +390,10 @@ describe("custom currency sidePanel component", () => {
       test.each([["1"], ["3"], ["5"], ["7"]])(
         "odd currency proposals have two decimal places when no available currency is selected",
         async (concernedIndex) => {
-          setInputValueAndTrigger(selectors.availableCurrencies, "0", "change");
-          await nextTick();
-          setInputValueAndTrigger(selectors.inputCode, "CODE", "input");
-          await nextTick();
-          setInputValueAndTrigger(selectors.inputSymbol, "SYMBOL", "input");
-          await nextTick();
-          setInputValueAndTrigger(selectors.formatProposals, concernedIndex, "change");
-          await nextTick();
+          await setInputValueAndTrigger(selectors.availableCurrencies, "0");
+          await setInputValueAndTrigger(selectors.inputCode, "CODE");
+          await setInputValueAndTrigger(selectors.inputSymbol, "SYMBOL");
+          await setInputValueAndTrigger(selectors.formatProposals, concernedIndex);
           await click(fixture, selectors.applyFormat);
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: model.getters.getActiveSheetId(),
@@ -457,14 +415,10 @@ describe("custom currency sidePanel component", () => {
       ])(
         "currency first four proposals start by expression placed after digits when no available currency is selected",
         async (concernedIndex, positionExpressionRegexp) => {
-          setInputValueAndTrigger(selectors.availableCurrencies, "0", "change");
-          await nextTick();
-          setInputValueAndTrigger(selectors.inputCode, "CODE", "input");
-          await nextTick();
-          setInputValueAndTrigger(selectors.inputSymbol, "SYMBOL", "input");
-          await nextTick();
-          setInputValueAndTrigger(selectors.formatProposals, concernedIndex, "change");
-          await nextTick();
+          await setInputValueAndTrigger(selectors.availableCurrencies, "0");
+          await setInputValueAndTrigger(selectors.inputCode, "CODE");
+          await setInputValueAndTrigger(selectors.inputSymbol, "SYMBOL");
+          await setInputValueAndTrigger(selectors.formatProposals, concernedIndex);
           await click(fixture, selectors.applyFormat);
           expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
             sheetId: model.getters.getActiveSheetId(),

--- a/tests/link/link_editor_component.test.ts
+++ b/tests/link/link_editor_component.test.ts
@@ -131,8 +131,8 @@ describe("link editor component", () => {
 
   test("insert link with an url and a label", async () => {
     await openLinkEditor(model, "A1");
-    setInputValueAndTrigger(labelInput(), "my label", "input");
-    setInputValueAndTrigger(urlInput(), "https://url.com", "input");
+    setInputValueAndTrigger(labelInput(), "my label");
+    setInputValueAndTrigger(urlInput(), "https://url.com");
     await simulateClick("button.o-save");
     const link = getEvaluatedCell(model, "A1").link;
     expect(link?.label).toBe("my label");
@@ -141,7 +141,7 @@ describe("link editor component", () => {
 
   test("insert link with only an url and no label", async () => {
     await openLinkEditor(model, "A1");
-    setInputValueAndTrigger(urlInput(), "https://url.com", "input");
+    setInputValueAndTrigger(urlInput(), "https://url.com");
     await simulateClick("button.o-save");
     const link = getEvaluatedCell(model, "A1").link;
     expect(link?.label).toBe("https://url.com");
@@ -163,8 +163,8 @@ describe("link editor component", () => {
   test("label is changed to canonical form in model", async () => {
     updateLocale(model, { ...DEFAULT_LOCALE, formulaArgSeparator: ";", decimalSeparator: "," });
     await openLinkEditor(model, "A1");
-    setInputValueAndTrigger(labelInput(), "3,15", "input");
-    setInputValueAndTrigger(urlInput(), "https://url.com", "input");
+    setInputValueAndTrigger(labelInput(), "3,15");
+    setInputValueAndTrigger(urlInput(), "https://url.com");
     await simulateClick("button.o-save");
     const evaluatedCell = getEvaluatedCell(model, "A1");
     expect(evaluatedCell).toMatchObject({
@@ -209,11 +209,9 @@ describe("link editor component", () => {
     await openLinkEditor(model, "A1");
     const saveButton = fixture.querySelector("button.o-save")!;
     expect(saveButton.hasAttribute("disabled")).toBe(true);
-    setInputValueAndTrigger(labelInput(), "my label", "input");
-    await nextTick();
+    await setInputValueAndTrigger(labelInput(), "my label");
     expect(saveButton.hasAttribute("disabled")).toBe(true);
-    setInputValueAndTrigger(urlInput(), "https://url.com", "input");
-    await nextTick();
+    await setInputValueAndTrigger(urlInput(), "https://url.com");
     expect(saveButton.hasAttribute("disabled")).toBe(false);
   });
 
@@ -258,14 +256,12 @@ describe("link editor component", () => {
       expect(fixture.querySelector(".o-link-editor")).toBeTruthy();
       expect(getCell(model, "A1")).toBeUndefined();
 
-      setInputValueAndTrigger(labelInput(), "my label", "input");
-      await nextTick();
+      await setInputValueAndTrigger(labelInput(), "my label");
       await keyDown({ key: "Enter" });
       expect(fixture.querySelector(".o-link-editor")).toBeTruthy();
       expect(getCell(model, "A1")).toBeUndefined();
 
-      setInputValueAndTrigger(urlInput(), "https://url.com", "input");
-      await nextTick();
+      await setInputValueAndTrigger(urlInput(), "https://url.com");
       await keyDown({ key: "Enter" });
       expect(fixture.querySelector(".o-link-editor")).toBeFalsy();
       expect(getCell(model, "A1")).toBeDefined();

--- a/tests/selection_input/selection_input_component.test.ts
+++ b/tests/selection_input/selection_input_component.test.ts
@@ -151,8 +151,7 @@ describe("Selection Input", () => {
     await simulateClick(fixture.querySelector("input")!);
     expect(fixture.querySelectorAll(".o-selection-ok").length).toBe(1);
     expect(fixture.querySelectorAll(".o-selection-ko").length).toBe(0);
-    setInputValueAndTrigger(fixture.querySelector("input")!, "A1", "input");
-    await nextTick();
+    await setInputValueAndTrigger(fixture.querySelector("input")!, "A1");
     expect(fixture.querySelectorAll(".o-selection-ok").length).toBe(1);
     expect(fixture.querySelectorAll(".o-selection-ko").length).toBe(1);
     await simulateClick(".o-selection-ok");
@@ -161,8 +160,7 @@ describe("Selection Input", () => {
     expect(fixture.querySelectorAll(".o-selection-ko").length).toBe(0);
 
     await simulateClick("input");
-    setInputValueAndTrigger(fixture.querySelector("input")!, "this is not valid", "input");
-    await nextTick();
+    await setInputValueAndTrigger(fixture.querySelector("input")!, "this is not valid");
     expect(fixture.querySelectorAll(".o-selection-ok").length).toBe(0);
     expect(fixture.querySelectorAll(".o-selection-ko").length).toBe(1);
   });

--- a/tests/settings/settings_side_panel.test.ts
+++ b/tests/settings/settings_side_panel.test.ts
@@ -41,7 +41,7 @@ describe("settings sidePanel component", () => {
 
     test("Can change locale", async () => {
       await mountSettingsSidePanel();
-      setInputValueAndTrigger(".o-settings-panel select", "fr_FR", "change");
+      setInputValueAndTrigger(".o-settings-panel select", "fr_FR");
       expect(model.getters.getLocale().code).toEqual("fr_FR");
     });
 
@@ -64,8 +64,7 @@ describe("settings sidePanel component", () => {
         dateTimePreview: "12/31/1899 02:24:00 PM",
       });
 
-      setInputValueAndTrigger(".o-settings-panel select", "fr_FR", "change");
-      await nextTick();
+      await setInputValueAndTrigger(".o-settings-panel select", "fr_FR");
       expect(getLocalePreview()).toEqual({
         numberPreview: "1 234 567,89",
         datePreview: "31/12/1899",

--- a/tests/sheet/sheet_manipulation_component.test.ts
+++ b/tests/sheet/sheet_manipulation_component.test.ts
@@ -330,7 +330,7 @@ describe("Adding rows footer at the end of sheet", () => {
     const sheetId = model.getters.getActiveSheetId();
     const numberOfRows = model.getters.getNumberRows(sheetId);
     const input = fixture.querySelector(".o-grid-add-rows input");
-    setInputValueAndTrigger(input, "10", "input");
+    setInputValueAndTrigger(input, "10");
     await click(fixture, ".o-grid-add-rows button");
     expect(model.getters.getNumberRows(sheetId)).toEqual(numberOfRows + 10);
   });
@@ -340,7 +340,7 @@ describe("Adding rows footer at the end of sheet", () => {
     const sheetId = model.getters.getActiveSheetId();
     const numberOfRows = model.getters.getNumberRows(sheetId);
     const input = fixture.querySelector(".o-grid-add-rows input")! as HTMLInputElement;
-    setInputValueAndTrigger(input, "10", "input");
+    setInputValueAndTrigger(input, "10");
     input.focus();
     await keyDown({ key: "Enter" });
     expect(model.getters.getNumberRows(sheetId)).toEqual(numberOfRows + 10);
@@ -351,7 +351,7 @@ describe("Adding rows footer at the end of sheet", () => {
     const sheetId = model.getters.getActiveSheetId();
     const numberOfRows = model.getters.getNumberRows(sheetId);
     const input = fixture.querySelector(".o-grid-add-rows input")!;
-    setInputValueAndTrigger(input, "0", "input");
+    setInputValueAndTrigger(input, "0");
     await click(fixture, ".o-grid-add-rows button");
     expect(fixture.querySelector(".o-validation-error")).toBeTruthy();
     expect(model.getters.getNumberRows(sheetId)).toEqual(numberOfRows);
@@ -362,7 +362,7 @@ describe("Adding rows footer at the end of sheet", () => {
     const sheetId = model.getters.getActiveSheetId();
     const numberOfRows = model.getters.getNumberRows(sheetId);
     const input = fixture.querySelector(".o-grid-add-rows input")!;
-    setInputValueAndTrigger(input, "10001", "input");
+    setInputValueAndTrigger(input, "10001");
     await click(fixture, ".o-grid-add-rows button");
     expect(fixture.querySelector(".o-validation-error")).toBeTruthy();
     expect(model.getters.getNumberRows(sheetId)).toEqual(numberOfRows);
@@ -373,7 +373,7 @@ describe("Adding rows footer at the end of sheet", () => {
     const sheetId = model.getters.getActiveSheetId();
     const numberOfRows = model.getters.getNumberRows(sheetId);
     const input = fixture.querySelector(".o-grid-add-rows input")!;
-    setInputValueAndTrigger(input, "abc", "input");
+    setInputValueAndTrigger(input, "abc");
     await click(fixture, ".o-grid-add-rows button");
     expect(fixture.querySelector(".o-validation-error")).toBeTruthy();
     expect(model.getters.getNumberRows(sheetId)).toEqual(numberOfRows);
@@ -382,7 +382,7 @@ describe("Adding rows footer at the end of sheet", () => {
   test("will scroll down to the new last row after adding new rows", async () => {
     await scrollGrid({ deltaY: 10000 });
     const input = fixture.querySelector(".o-grid-add-rows input");
-    setInputValueAndTrigger(input, "1000", "input");
+    setInputValueAndTrigger(input, "1000");
     await click(fixture, ".o-grid-add-rows button");
     const sheetId = model.getters.getActiveSheetId();
     const numberOfRows = model.getters.getNumberRows(sheetId);
@@ -393,7 +393,7 @@ describe("Adding rows footer at the end of sheet", () => {
     createSheet(model, { sheetId: "sheet2" });
     await scrollGrid({ deltaY: 10000 });
     const input = fixture.querySelector(".o-grid-add-rows input");
-    setInputValueAndTrigger(input, "1000", "input");
+    setInputValueAndTrigger(input, "1000");
     activateSheet(model, "sheet2");
     await nextTick();
     expect(fixture.querySelector<HTMLInputElement>(".o-grid-add-rows input")!.value).toBe("100");

--- a/tests/split_to_column/split_to_columns_panel.test.ts
+++ b/tests/split_to_column/split_to_columns_panel.test.ts
@@ -57,14 +57,14 @@ describe("split to columns sidePanel component", () => {
   });
 
   test("Selected separator is dispatched on confirm", () => {
-    setInputValueAndTrigger(".o-split-to-cols-panel select", ",", "change");
+    setInputValueAndTrigger(".o-split-to-cols-panel select", ",");
     click(confirmButton);
     expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
       separator: ",",
       addNewColumns: expect.any(Boolean),
     });
 
-    setInputValueAndTrigger(".o-split-to-cols-panel select", ";", "change");
+    setInputValueAndTrigger(".o-split-to-cols-panel select", ";");
     click(confirmButton);
     expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
       separator: ";",
@@ -75,12 +75,11 @@ describe("split to columns sidePanel component", () => {
   test("Custom separator", async () => {
     let input = fixture.querySelector('.o-split-to-cols-panel input[type="text"]')!;
     expect(input).toBeFalsy();
-    setInputValueAndTrigger(".o-split-to-cols-panel select", "custom", "change");
-    await nextTick();
+    await setInputValueAndTrigger(".o-split-to-cols-panel select", "custom");
 
     input = fixture.querySelector('.o-split-to-cols-panel input[type="text"]')!;
     expect(input).toBeTruthy();
-    setInputValueAndTrigger(input, "customSeparator", "input");
+    setInputValueAndTrigger(input, "customSeparator");
     click(confirmButton);
     expect(dispatch).toHaveBeenCalledWith("SPLIT_TEXT_INTO_COLUMNS", {
       separator: "customSeparator",
@@ -113,8 +112,7 @@ describe("split to columns sidePanel component", () => {
   });
 
   test("Empty custom separator : confirm button disabled but no error message", async () => {
-    setInputValueAndTrigger(".o-split-to-cols-panel select", "custom", "change");
-    await nextTick();
+    await setInputValueAndTrigger(".o-split-to-cols-panel select", "custom");
 
     expect(confirmButton.classList).toContain("o-disabled");
     expect(fixture.querySelectorAll(".o-validation-error")).toHaveLength(0);
@@ -123,7 +121,7 @@ describe("split to columns sidePanel component", () => {
   test("No separator in selection : confirm button disabled + error message", async () => {
     setSelection(model, ["A1"]);
     setCellContent(model, "A1", "hello");
-    setInputValueAndTrigger(".o-split-to-cols-panel select", " ", "change");
+    setInputValueAndTrigger(".o-split-to-cols-panel select", " ");
     setCheckboxValueAndTrigger(checkBox, false, "change");
     await nextTick();
 
@@ -134,7 +132,7 @@ describe("split to columns sidePanel component", () => {
   test("Warning if we will overwrite some content", async () => {
     setSelection(model, ["A1"]);
     setGrid(model, { A1: "hello there", B1: "content" });
-    setInputValueAndTrigger(".o-split-to-cols-panel select", " ", "change");
+    setInputValueAndTrigger(".o-split-to-cols-panel select", " ");
     setCheckboxValueAndTrigger(checkBox, false, "change");
     await nextTick();
 
@@ -145,7 +143,7 @@ describe("split to columns sidePanel component", () => {
   test("Warning not displayed if there's an error", async () => {
     setSelection(model, ["A1:B1"]);
     setGrid(model, { A1: "hello there", B1: "content" });
-    setInputValueAndTrigger(".o-split-to-cols-panel select", " ", "change");
+    setInputValueAndTrigger(".o-split-to-cols-panel select", " ");
     setCheckboxValueAndTrigger(checkBox, false, "change");
     await nextTick();
 
@@ -156,13 +154,11 @@ describe("split to columns sidePanel component", () => {
   test("Errors updated on separator selection change", async () => {
     setSelection(model, ["A1"]);
     setCellContent(model, "A1", "hello there");
-    setInputValueAndTrigger(".o-split-to-cols-panel select", " ", "change");
-    await nextTick();
+    await setInputValueAndTrigger(".o-split-to-cols-panel select", " ");
 
     expect(fixture.querySelectorAll(".o-validation-error")).toHaveLength(0);
 
-    setInputValueAndTrigger(".o-split-to-cols-panel select", ";", "change");
-    await nextTick();
+    await setInputValueAndTrigger(".o-split-to-cols-panel select", ";");
 
     expect(fixture.querySelectorAll(".o-validation-error")).toHaveLength(1);
   });

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -195,14 +195,20 @@ function dispatchEvent(selector: string | EventTarget, ev: Event) {
   }
 }
 
-export function setInputValueAndTrigger(
+export async function setInputValueAndTrigger(
   selector: DOMTarget,
   value: string,
-  eventType: string
-): void {
+  mode?: "onlyInput" | "onlyChange"
+) {
   const input = getTarget(selector) as HTMLInputElement;
   input.value = value;
-  input.dispatchEvent(new Event(eventType));
+  if (mode !== "onlyChange") {
+    input.dispatchEvent(new Event("input"));
+  }
+  if (mode !== "onlyInput") {
+    input.dispatchEvent(new Event("change"));
+  }
+  await nextTick();
 }
 
 export function setCheckboxValueAndTrigger(


### PR DESCRIPTION
## [REF] chart_test: improve test speed/readability

Slightly improve the testing speed of the chart component by
removing useless nextTick. Add helpers to open the chart side panels
without having 5 lines of codes and 5 nextTicks.

## [REF] tests: dispatch both input and change events

Currently in the test, we often only dispatch either an input or a change
event. But in practice, both events are fired when modifying an
input. This could lead to inconsistencies between the test and the
reality.

This commit changes the setInputValueAndTrigger to dispatch both events.
It also make the helper async with a nextTick at the end to shorten the
tests.


## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo