### PR TITLE
[REF] ClientTag: use t-if instead of opacity

### DIFF
--- a/src/components/collaborative_client_tag/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.ts
@@ -18,7 +18,6 @@ css/* scss */ `
     border-top-right-radius: 4px;
     font-size: ${DEFAULT_FONT_SIZE};
     color: white;
-    opacity: 0;
     pointer-events: none;
   }
 `;
@@ -39,7 +38,6 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
       left: `${x - 1}px`,
       border: `1px solid ${color}`,
       "background-color": color,
-      opacity: this.props.active ? "1 !important" : undefined,
     });
   }
 }

--- a/src/components/collaborative_client_tag/collaborative_client_tag.xml
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.xml
@@ -1,7 +1,5 @@
 <templates>
   <t t-name="o-spreadsheet-ClientTag">
-    <div>
-      <div class="o-client-tag" t-att-style="tagStyle" t-esc="props.name"/>
-    </div>
+    <div t-if="props.active" class="o-client-tag" t-att-style="tagStyle" t-esc="props.name"/>
   </t>
 </templates>

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -995,9 +995,9 @@ describe("Multi User selection", () => {
       client: { id: "david", name: "David", position: { sheetId, col: 1, row: 1 } },
     });
     await nextTick();
-    expect(getElComputedStyle(".o-client-tag", "opacity")).toBe("0");
+    expect(fixture.querySelector(".o-client-tag")).toBeNull();
     await hoverCell(model, "B2", 400);
-    expect(getElComputedStyle(".o-client-tag", "opacity")).toBe("1");
+    expect(document.querySelectorAll(".o-client-tag")).toHaveLength(1);
     expect(document.querySelector(".o-client-tag")?.textContent).toBe("David");
   });
 
@@ -1008,6 +1008,7 @@ describe("Multi User selection", () => {
       client: { id: "david", name: "David", position: { sheetId: "invalid", col: 1, row: 1 } },
     });
     await nextTick();
+    await hoverCell(model, "B2", 400);
     expect(document.querySelectorAll(".o-client-tag")).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Description:

Currently, the collaborative ClientTag is hidden using `opacity: 0`. This is not idiomatic owl. Using the `t-if` directive is the way to display (or not) a component.

This commit also removes a useless div nesting.
Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo