### PR TITLE
[FIX] Highlight: prevent default `mousedown` behaviour

### DIFF
--- a/src/components/highlight/border/border.xml
+++ b/src/components/highlight/border/border.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-Border" owl="1">
     <div
       class="o-border"
-      t-on-mousedown="onMouseDown"
+      t-on-mousedown.prevent="onMouseDown"
       t-att-style="style"
       t-att-class="{
           'o-moving': props.isMoving,

--- a/src/components/highlight/corner/corner.xml
+++ b/src/components/highlight/corner/corner.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-Corner" owl="1">
     <div
       class="o-corner"
-      t-on-mousedown="onMouseDown"
+      t-on-mousedown.prevent="onMouseDown"
       t-att-style="style"
       t-att-class="{
           'o-resizing': props.isResizing,


### PR DESCRIPTION
Just like in commit a3b2e7cb, we need to prevent the default mousedown behaviour while interacting with the `Highlight`Component as it can be active at the same time as the `Composer`.

Task: /

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo