### PR TITLE
essai print component

### DIFF
--- a/demo/main.css
+++ b/demo/main.css
@@ -7,3 +7,11 @@ body {
     "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji" !important;
 }
+
+@media print {
+  .o-spreadsheet-print {
+    top: 0;
+    left: 0;
+    position: absolute;
+  }
+}

--- a/demo/main.css
+++ b/demo/main.css
@@ -7,6 +7,3 @@ body {
     "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji" !important;
 }
-.o-spreadsheet {
-  height: 100%;
-}

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -2,6 +2,7 @@
   <t t-name="o-spreadsheet-Spreadsheet">
     <div
       class="o-spreadsheet"
+      t-if="!env.model.getters.isPrintMode()"
       t-on-keydown="(ev) => !env.isDashboard() and this.onKeydown(ev)"
       t-att-style="getStyle()">
       <t t-if="env.isDashboard()">
@@ -45,5 +46,8 @@
         <BottomBar onClick="() => this.focusGrid()"/>
       </t>
     </div>
+    <t t-else="">
+      <SpreadsheetPrint canvasSize="() => this.getPrintRect()"/>
+    </t>
   </t>
 </templates>

--- a/src/components/spreadsheet_print/spreadsheet_print.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print.ts
@@ -1,0 +1,35 @@
+import { Component, onMounted, useRef } from "@odoo/owl";
+import { FIGURE_BORDER_COLOR } from "../../constants";
+import { DOMCoordinates, DOMDimension, SpreadsheetChildEnv } from "../../types/index";
+import { FiguresContainer } from "../figures/figure_container/figure_container";
+import { css } from "../helpers";
+import { useGridDrawing } from "../helpers/draw_grid_hook";
+
+interface Props {
+  canvasSize: () => DOMDimension;
+}
+
+css/*SCSS*/ `
+  .o-spreadsheet-print {
+    .o-figure-border {
+      border: 3px solid ${FIGURE_BORDER_COLOR} !important;
+    }
+  }
+`;
+
+export class SpreadsheetPrint extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-SpreadsheetPrint";
+  static components = { FiguresContainer };
+  onMouseWheel!: (ev: WheelEvent) => void;
+  canvasPosition!: DOMCoordinates;
+  containerRef = useRef("container");
+
+  setup() {
+    useGridDrawing("canvas", this.env.model, () => this.props.canvasSize());
+    onMounted(() => {
+      window.print();
+    });
+  }
+}
+
+SpreadsheetPrint.props = { canvasSize: Function };

--- a/src/components/spreadsheet_print/spreadsheet_print.ts
+++ b/src/components/spreadsheet_print/spreadsheet_print.ts
@@ -2,7 +2,7 @@ import { Component, onMounted, useRef } from "@odoo/owl";
 import { FIGURE_BORDER_COLOR } from "../../constants";
 import { DOMCoordinates, DOMDimension, SpreadsheetChildEnv } from "../../types/index";
 import { FiguresContainer } from "../figures/figure_container/figure_container";
-import { css } from "../helpers";
+import { css, cssPropertiesToCss } from "../helpers";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
 
 interface Props {
@@ -28,6 +28,14 @@ export class SpreadsheetPrint extends Component<Props, SpreadsheetChildEnv> {
     useGridDrawing("canvas", this.env.model, () => this.props.canvasSize());
     onMounted(() => {
       window.print();
+    });
+  }
+
+  get containerStyle() {
+    const { width, height } = this.props.canvasSize();
+    return cssPropertiesToCss({
+      width: `${width}px`,
+      height: `${height}px`,
     });
   }
 }

--- a/src/components/spreadsheet_print/spreadsheet_print.xml
+++ b/src/components/spreadsheet_print/spreadsheet_print.xml
@@ -1,0 +1,8 @@
+<templates>
+  <t t-name="o-spreadsheet-SpreadsheetPrint">
+    <div class="o-spreadsheet-print" t-ref="container">
+      <canvas t-ref="canvas"/>
+      <FiguresContainer onFigureDeleted="() => {}"/>
+    </div>
+  </t>
+</templates>

--- a/src/components/spreadsheet_print/spreadsheet_print.xml
+++ b/src/components/spreadsheet_print/spreadsheet_print.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-SpreadsheetPrint">
-    <div class="o-spreadsheet-print" t-ref="container">
+    <div class="o-spreadsheet-print" t-ref="container" t-att-style="containerStyle">
       <canvas t-ref="canvas"/>
       <FiguresContainer onFigureDeleted="() => {}"/>
     </div>

--- a/src/plugins/ui_feature/renderer.ts
+++ b/src/plugins/ui_feature/renderer.ts
@@ -128,7 +128,7 @@ export class RendererPlugin extends UIPlugin {
         this.drawFrozenPanes(renderingContext);
         break;
       case LAYERS.Headers:
-        if (!this.getters.isDashboard()) {
+        if (this.getters.visibleHeaders()) {
           this.drawHeaders(renderingContext);
           this.drawFrozenPanesHeaders(renderingContext);
         }
@@ -504,8 +504,8 @@ export class RendererPlugin extends UIPlugin {
 
     const { x: offsetCorrectionX, y: offsetCorrectionY } =
       this.getters.getMainViewportCoordinates();
-    const widthCorrection = this.getters.isDashboard() ? 0 : HEADER_WIDTH;
-    const heightCorrection = this.getters.isDashboard() ? 0 : HEADER_HEIGHT;
+    const widthCorrection = this.getters.visibleHeaders() ? 0 : HEADER_WIDTH;
+    const heightCorrection = this.getters.visibleHeaders() ? 0 : HEADER_HEIGHT;
     ctx.lineWidth = 6 * thinLineWidth;
     ctx.strokeStyle = FROZEN_PANE_HEADER_BORDER_COLOR;
     ctx.beginPath();
@@ -535,8 +535,8 @@ export class RendererPlugin extends UIPlugin {
     const viewport = { left, right, top, bottom };
 
     const rect = this.getters.getVisibleRect(viewport);
-    const widthCorrection = this.getters.isDashboard() ? 0 : HEADER_WIDTH;
-    const heightCorrection = this.getters.isDashboard() ? 0 : HEADER_HEIGHT;
+    const widthCorrection = this.getters.visibleHeaders() ? 0 : HEADER_WIDTH;
+    const heightCorrection = this.getters.visibleHeaders() ? 0 : HEADER_HEIGHT;
     ctx.lineWidth = 6 * thinLineWidth;
     ctx.strokeStyle = FROZEN_PANE_BORDER_COLOR;
     ctx.beginPath();

--- a/src/plugins/ui_feature/ui_options.ts
+++ b/src/plugins/ui_feature/ui_options.ts
@@ -1,10 +1,17 @@
-import { Command } from "../../types/index";
+import { Command, Pixel, Rect } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
+
+interface SheetViewState {
+  viewRect: Rect;
+  offset: { scrollX: Pixel; scrollY: Pixel };
+}
 
 export class UIOptionsPlugin extends UIPlugin {
   static getters = ["shouldShowFormulas", "visibleHeaders", "isPrintMode"] as const;
   private showFormulas: boolean = false;
   private printMode: boolean = false;
+
+  sheetViewState: SheetViewState | undefined = undefined;
 
   // ---------------------------------------------------------------------------
   // Command Handling
@@ -17,6 +24,17 @@ export class UIOptionsPlugin extends UIPlugin {
         break;
       case "SET_PRINT_MODE":
         this.printMode = cmd.active;
+        if (cmd.active) {
+          this.sheetViewState = {
+            //remove fullSheetViewRect or keep in favor of printRect?
+            viewRect: this.getters.getVisibleSheetViewRect(),
+            offset: this.getters.getActiveSheetDOMScrollInfo(),
+          };
+          this.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 0, offsetY: 0 });
+          this.dispatch("RESIZE_SHEETVIEW", {
+            ...this.getPrintRect(),
+          });
+        }
         break;
     }
   }
@@ -35,5 +53,14 @@ export class UIOptionsPlugin extends UIPlugin {
 
   isPrintMode(): boolean {
     return this.printMode;
+  }
+
+  private getPrintRect(): Rect {
+    const { x, y } = this.getters.getFullSheetViewRect();
+    const sheetId = this.getters.getActiveSheetId();
+    const { bottom, right } = this.getters.getSheetZone(sheetId);
+    const { end: width } = this.getters.getColDimensions(sheetId, right);
+    const { end: height } = this.getters.getRowDimensions(sheetId, bottom);
+    return { x, y, width, height };
   }
 }

--- a/src/plugins/ui_feature/ui_options.ts
+++ b/src/plugins/ui_feature/ui_options.ts
@@ -2,8 +2,9 @@ import { Command } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
 export class UIOptionsPlugin extends UIPlugin {
-  static getters = ["shouldShowFormulas"] as const;
+  static getters = ["shouldShowFormulas", "visibleHeaders", "isPrintMode"] as const;
   private showFormulas: boolean = false;
+  private printMode: boolean = false;
 
   // ---------------------------------------------------------------------------
   // Command Handling
@@ -14,6 +15,9 @@ export class UIOptionsPlugin extends UIPlugin {
       case "SET_FORMULA_VISIBILITY":
         this.showFormulas = cmd.show;
         break;
+      case "SET_PRINT_MODE":
+        this.printMode = cmd.active;
+        break;
     }
   }
 
@@ -23,5 +27,13 @@ export class UIOptionsPlugin extends UIPlugin {
 
   shouldShowFormulas(): boolean {
     return this.showFormulas;
+  }
+
+  visibleHeaders(): boolean {
+    return !this.getters.isDashboard() && !this.printMode;
+  }
+
+  isPrintMode(): boolean {
+    return this.printMode;
   }
 }

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -764,7 +764,7 @@ export class GridSelectionPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
 
   drawGrid(renderingContext: GridRenderingContext) {
-    if (this.getters.isDashboard()) {
+    if (this.getters.isDashboard() || this.getters.isPrintMode()) {
       return;
     }
     const { ctx, thinLineWidth } = renderingContext;

--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -1,4 +1,4 @@
-import { getDefaultSheetViewSize } from "../../constants";
+import { getDefaultSheetViewSize, HEADER_HEIGHT, HEADER_WIDTH } from "../../constants";
 import { clip, findCellInNewZone, isDefined, range } from "../../helpers";
 import { scrollDelay } from "../../helpers/index";
 import { InternalViewport } from "../../helpers/internal_viewport";
@@ -7,9 +7,9 @@ import {
   CellPosition,
   Command,
   CommandResult,
+  Dimension,
   DOMCoordinates,
   DOMDimension,
-  Dimension,
   EdgeScrollInfo,
   Figure,
   HeaderIndex,
@@ -98,6 +98,8 @@ export class SheetViewPlugin extends UIPlugin {
     "getSheetViewVisibleRows",
     "getFrozenSheetViewRatio",
     "isPositionVisible",
+    "getFullSheetViewRect",
+    "getVisibleSheetViewRect",
   ] as const;
 
   readonly viewports: Record<UID, SheetViewports | undefined> = {};
@@ -349,6 +351,33 @@ export class SheetViewPlugin extends UIPlugin {
     const x = this.getters.getColDimensions(sheetId, xSplit).start;
     const y = this.getters.getRowDimensions(sheetId, ySplit).start;
     return { x, y, width, height };
+  }
+
+  getFullSheetViewRect(): Rect {
+    const sheetId = this.getters.getActiveSheetId();
+    this.ensureMainViewportExist(sheetId);
+    const width =
+      this.viewports[sheetId]!.bottomRight.getMaxSize().width +
+      (this.viewports[sheetId]!.bottomLeft?.getMaxSize().width || 0);
+    const height =
+      this.viewports[sheetId]!.bottomRight.getMaxSize().height +
+      (this.viewports[sheetId]!.topRight?.getMaxSize().height || 0);
+    const x =
+      this.getters.getColDimensions(sheetId, 0).start +
+      (this.getters.visibleHeaders() ? 0 : HEADER_WIDTH);
+    const y =
+      this.getters.getRowDimensions(sheetId, 0).start +
+      (this.getters.visibleHeaders() ? 0 : HEADER_HEIGHT);
+    return { x, y, width, height };
+  }
+
+  getVisibleSheetViewRect(): Rect {
+    return {
+      x: this.gridOffsetX,
+      y: this.gridOffsetY,
+      width: this.sheetViewWidth,
+      height: this.sheetViewHeight,
+    };
   }
 
   private getMaximumSheetOffset(): { maxOffsetX: Pixel; maxOffsetY: Pixel } {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -156,6 +156,8 @@ export const readonlyAllowedCommands = new Set<CommandTypes>([
   "CLOSE_CELL_POPOVER",
 
   "UPDATE_FILTER",
+
+  "SET_PRINT_MODE",
 ]);
 
 export const coreTypes = new Set<CoreCommandTypes>([
@@ -1006,6 +1008,11 @@ export interface SplitTextIntoColumnsCommand {
   force?: boolean;
 }
 
+export interface SetPrintModeCommand {
+  type: "SET_PRINT_MODE";
+  active: boolean;
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1157,7 +1164,8 @@ export type LocalCommand =
   | UpdateFilterCommand
   | SplitTextIntoColumnsCommand
   | RemoveDuplicatesCommand
-  | TrimWhitespaceCommand;
+  | TrimWhitespaceCommand
+  | SetPrintModeCommand;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -91,7 +91,7 @@ export async function doubleClick(el: Element, selector: string = "") {
 export async function hoverCell(model: Model, xc: string, delay: number) {
   const zone = toZone(xc);
   let { x, y } = model.getters.getVisibleRect(zone);
-  if (!model.getters.isDashboard()) {
+  if (model.getters.visibleHeaders()) {
     x -= HEADER_WIDTH;
     y -= HEADER_HEIGHT;
   }
@@ -111,7 +111,7 @@ export async function clickCell(
     throw new Error(`You can't click on ${xc} because it is not visible`);
   }
   let { x, y } = model.getters.getVisibleRect(zone);
-  if (!model.getters.isDashboard()) {
+  if (model.getters.visibleHeaders()) {
     x -= HEADER_WIDTH;
     y -= HEADER_HEIGHT;
   }
@@ -126,7 +126,7 @@ export async function gridMouseEvent(
 ) {
   const zone = toZone(xc);
   let { x, y } = model.getters.getVisibleRect(zone);
-  if (!model.getters.isDashboard()) {
+  if (model.getters.visibleHeaders()) {
     x -= HEADER_WIDTH;
     y -= HEADER_HEIGHT;
   }


### PR DESCRIPTION
We cannot rerender a component in the before rint so our 'only chance' is either to :
- capture the print shortcut and redirect the user to our own page
- find a way to disable the resizeOBserver which doesn't help right now and I don't know why yet.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo