### PR TITLE
[IMP] translations: Do not translate template strings

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -164,7 +164,7 @@ export function compile(formula: string): CompiledFormula {
       const code = new FunctionCodeBuilder(scope);
       if (ast.type !== "REFERENCE" && !(ast.type === "BIN_OPERATION" && ast.value === ":")) {
         if (isMeta) {
-          throw new BadExpressionError(_t(`Argument must be a reference to a cell or range.`));
+          throw new BadExpressionError(_t("Argument must be a reference to a cell or range."));
         }
       }
       if (ast.debug) {

--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -569,7 +569,7 @@ export function visitMatchingRanges(
 
   if (countArg % 2 === 1) {
     throw new Error(
-      _t(`Function [[FUNCTION_NAME]] expects criteria_range and criterion to be in pairs.`)
+      _t("Function [[FUNCTION_NAME]] expects criteria_range and criterion to be in pairs.")
     );
   }
 
@@ -587,7 +587,7 @@ export function visitMatchingRanges(
       criteriaRange[0].length !== dimCol
     ) {
       throw new Error(
-        _t(`Function [[FUNCTION_NAME]] expects criteria_range to have the same dimension`)
+        _t("Function [[FUNCTION_NAME]] expects criteria_range to have the same dimension")
       );
     }
 

--- a/src/functions/module_custom.ts
+++ b/src/functions/module_custom.ts
@@ -8,7 +8,7 @@ import { toNumber } from "./helpers";
 // FORMAT.LARGE.NUMBER
 // -----------------------------------------------------------------------------
 export const FORMAT_LARGE_NUMBER = {
-  description: _t(`Apply a large number format`),
+  description: _t("Apply a large number format"),
   args: [
     arg("value (number)", _t("The number.")),
     arg(

--- a/src/functions/module_date.ts
+++ b/src/functions/module_date.ts
@@ -75,7 +75,7 @@ export const DATE = {
 
     assert(
       () => result >= 0,
-      _t(`The function [[FUNCTION_NAME]] result must be greater than or equal 01/01/1900.`)
+      _t("The function [[FUNCTION_NAME]] result must be greater than or equal 01/01/1900.")
     );
 
     return result;
@@ -104,7 +104,7 @@ export const DATEDIF = {
     arg(
       "unit (string)",
       _t(
-        `A text abbreviation for unit of time. Accepted values are "Y" (the number of whole years between start_date and end_date), "M" (the number of whole months between start_date and end_date), "D" (the number of days between start_date and end_date), "MD" (the number of days between start_date and end_date after subtracting whole months), "YM" (the number of whole months between start_date and end_date after subtracting whole years), "YD" (the number of days between start_date and end_date, assuming start_date and end_date were no more than one year apart).`
+        'A text abbreviation for unit of time. Accepted values are "Y" (the number of whole years between start_date and end_date), "M" (the number of whole months between start_date and end_date), "D" (the number of days between start_date and end_date), "MD" (the number of days between start_date and end_date after subtracting whole months), "YM" (the number of whole months between start_date and end_date after subtracting whole years), "YD" (the number of days between start_date and end_date, assuming start_date and end_date were no more than one year apart).'
       )
     ),
   ],
@@ -679,7 +679,7 @@ export const TIME = {
 
     _hour %= 24;
 
-    assert(() => _hour >= 0, _t(`The function [[FUNCTION_NAME]] result cannot be negative`));
+    assert(() => _hour >= 0, _t("The function [[FUNCTION_NAME]] result cannot be negative"));
 
     return _hour / 24 + _minute / (24 * 60) + _second / (24 * 60 * 60);
   },

--- a/src/functions/module_filter.ts
+++ b/src/functions/module_filter.ts
@@ -27,7 +27,7 @@ function sortMatrix(
     assert(
       () => value !== undefined,
       _t(
-        `Value for parameter %d is missing, while the function [[FUNCTION_NAME]] expect a number or a range.`,
+        "Value for parameter %d is missing, while the function [[FUNCTION_NAME]] expect a number or a range.",
         i + 1
       )
     );
@@ -42,8 +42,8 @@ function sortMatrix(
       assert(
         () => sortColumn.length === 1 && sortColumn[0].length === nRows,
         _t(
-          `Wrong size for %s. Expected a range of size 1x%s. Got %sx%s.`,
-          `sort_column{i + 1}`,
+          "Wrong size for %s. Expected a range of size 1x%s. Got %sx%s.",
+          `sort_column${i + 1}`,
           nRows,
           sortColumn.length,
           sortColumn[0].length
@@ -142,7 +142,7 @@ export const FILTER = {
 
     assert(
       () => _conditions.every((cond) => cond.length === _array.length),
-      _t(`FILTER has mismatched sizes on the range and conditions.`)
+      _t("FILTER has mismatched sizes on the range and conditions.")
     );
 
     const result: Matrix<ValueAndFormat> = [];
@@ -226,12 +226,12 @@ export const SORTN: AddFunctionDescription = {
     ...sortingCriteria: (ValueAndFormat | Matrix<ValueAndFormat>)[]
   ): any {
     const _n = toNumber(n?.value ?? 1, this.locale);
-    assert(() => _n >= 0, _t(`Wrong value of 'n'. Expected a positive number. Got %s.`, _n));
+    assert(() => _n >= 0, _t("Wrong value of 'n'. Expected a positive number. Got %s.", _n));
     const _displayTiesMode = toNumber(displayTiesMode?.value ?? 0, this.locale);
     assert(
       () => _displayTiesMode >= 0 && _displayTiesMode <= 3,
       _t(
-        `Wrong value of 'display_ties_mode'. Expected a positive number between 0 and 3. Got %s.`,
+        "Wrong value of 'display_ties_mode'. Expected a positive number between 0 and 3. Got %s.",
         _displayTiesMode
       )
     );

--- a/src/functions/module_financial.ts
+++ b/src/functions/module_financial.ts
@@ -113,7 +113,7 @@ function newtonMethod(
     if (isNaN(y)) {
       assert(
         () => count < maxIterations && nanFallback !== undefined,
-        _t(`Function [[FUNCTION_NAME]] didn't find any result.`)
+        _t("Function [[FUNCTION_NAME]] didn't find any result.")
       );
       count++;
       x = nanFallback!(previousFallback);
@@ -124,7 +124,7 @@ function newtonMethod(
     xDelta = Math.abs(newX - x);
     x = newX;
     yEqual0 = xDelta < epsMax || Math.abs(y) < epsMax;
-    assert(() => count < maxIterations, _t(`Function [[FUNCTION_NAME]] didn't find any result.`));
+    assert(() => count < maxIterations, _t("Function [[FUNCTION_NAME]] didn't find any result."));
     count++;
   } while (!yEqual0);
   return x;

--- a/src/functions/module_logical.ts
+++ b/src/functions/module_logical.ts
@@ -30,7 +30,7 @@ export const AND = {
       acc = acc && arg;
       return acc;
     });
-    assert(() => foundBoolean, _t(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => foundBoolean, _t("[[FUNCTION_NAME]] has no valid input data."));
     return acc;
   },
   isExported: true,
@@ -186,7 +186,7 @@ export const IFS = {
   computeValueAndFormat: function (...values: (() => Maybe<ValueAndFormat>)[]): ValueAndFormat {
     assert(
       () => values.length % 2 === 0,
-      _t(`Wrong number of arguments. Expected an even number of arguments.`)
+      _t("Wrong number of arguments. Expected an even number of arguments.")
     );
     for (let n = 0; n < values.length - 1; n += 2) {
       if (toBoolean(values[n]()?.value)) {
@@ -200,7 +200,7 @@ export const IFS = {
         return result;
       }
     }
-    throw new Error(_t(`No match.`));
+    throw new Error(_t("No match."));
   },
   isExported: true,
 } satisfies AddFunctionDescription;
@@ -251,7 +251,7 @@ export const OR = {
       acc = acc || arg;
       return !acc;
     });
-    assert(() => foundBoolean, _t(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => foundBoolean, _t("[[FUNCTION_NAME]] has no valid input data."));
     return acc;
   },
   isExported: true,
@@ -296,7 +296,7 @@ export const XOR = {
       acc = acc ? !arg : arg;
       return true; // no stop condition
     });
-    assert(() => foundBoolean, _t(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => foundBoolean, _t("[[FUNCTION_NAME]] has no valid input data."));
     return acc;
   },
   isExported: true,

--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -149,7 +149,7 @@ export const COLUMNS = {
 // -----------------------------------------------------------------------------
 
 export const HLOOKUP = {
-  description: _t(`Horizontal lookup`),
+  description: _t("Horizontal lookup"),
   args: [
     arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
     arg(
@@ -256,7 +256,7 @@ export const INDEX: AddFunctionDescription = {
 // -----------------------------------------------------------------------------
 
 export const LOOKUP = {
-  description: _t(`Look up a value.`),
+  description: _t("Look up a value."),
   args: [
     arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
     arg(
@@ -335,7 +335,7 @@ export const LOOKUP = {
 // -----------------------------------------------------------------------------
 const DEFAULT_SEARCH_TYPE = 1;
 export const MATCH = {
-  description: _t(`Position of item in range that matches value.`),
+  description: _t("Position of item in range that matches value."),
   args: [
     arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
     arg("range (any, range)", _t("The one-dimensional array to be searched.")),
@@ -436,7 +436,7 @@ export const ROWS = {
 // -----------------------------------------------------------------------------
 
 export const VLOOKUP = {
-  description: _t(`Vertical lookup.`),
+  description: _t("Vertical lookup."),
   args: [
     arg("search_key (any)", _t("The value to search for. For example, 42, 'Cats', or I24.")),
     arg(
@@ -498,7 +498,7 @@ export const VLOOKUP = {
 // -----------------------------------------------------------------------------
 export const XLOOKUP = {
   description: _t(
-    `Search a range for a match and return the corresponding item from a second range.`
+    "Search a range for a match and return the corresponding item from a second range."
   ),
   args: [
     arg("search_key (any)", _t("The value to search for.")),

--- a/src/functions/module_math.ts
+++ b/src/functions/module_math.ts
@@ -213,7 +213,7 @@ export const ATAN2 = {
     const _y = toNumber(y, this.locale);
     assert(
       () => _x !== 0 || _y !== 0,
-      _t(`Function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
     return Math.atan2(_y, _x);
   },
@@ -249,7 +249,7 @@ export const ATANH = {
 // CEILING
 // -----------------------------------------------------------------------------
 export const CEILING = {
-  description: _t(`Rounds number up to nearest multiple of factor.`),
+  description: _t("Rounds number up to nearest multiple of factor."),
   args: [
     arg("value (number)", _t("The value to round up to the nearest integer multiple of factor.")),
     arg(
@@ -279,7 +279,7 @@ export const CEILING = {
 // CEILING.MATH
 // -----------------------------------------------------------------------------
 export const CEILING_MATH = {
-  description: _t(`Rounds number up to nearest multiple of factor.`),
+  description: _t("Rounds number up to nearest multiple of factor."),
   args: [
     arg(
       "number (number)",
@@ -330,7 +330,7 @@ export const CEILING_MATH = {
 // CEILING.PRECISE
 // -----------------------------------------------------------------------------
 export const CEILING_PRECISE = {
-  description: _t(`Rounds number up to nearest multiple of factor.`),
+  description: _t("Rounds number up to nearest multiple of factor."),
   args: [
     arg(
       "number (number)",
@@ -386,7 +386,7 @@ export const COT = {
     const _angle = toNumber(angle, this.locale);
     assert(
       () => _angle !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
     return 1 / Math.tan(_angle);
   },
@@ -404,7 +404,7 @@ export const COTH = {
     const _value = toNumber(value, this.locale);
     assert(
       () => _value !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
     return 1 / Math.tanh(_value);
   },
@@ -578,7 +578,7 @@ export const CSC = {
     const _angle = toNumber(angle, this.locale);
     assert(
       () => _angle !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
     return 1 / Math.sin(_angle);
   },
@@ -596,7 +596,7 @@ export const CSCH = {
     const _value = toNumber(value, this.locale);
     assert(
       () => _value !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
     return 1 / Math.sinh(_value);
   },
@@ -651,7 +651,7 @@ export const DECIMAL = {
 // DEGREES
 // -----------------------------------------------------------------------------
 export const DEGREES = {
-  description: _t(`Converts an angle value in radians to degrees.`),
+  description: _t("Converts an angle value in radians to degrees."),
   args: [arg("angle (number)", _t("The angle to convert from radians to degrees."))],
   returns: ["NUMBER"],
   compute: function (angle: Maybe<CellValue>): number {
@@ -664,7 +664,7 @@ export const DEGREES = {
 // EXP
 // -----------------------------------------------------------------------------
 export const EXP = {
-  description: _t(`Euler's number, e (~2.718) raised to a power.`),
+  description: _t("Euler's number, e (~2.718) raised to a power."),
   args: [arg("value (number)", _t("The exponent to raise e."))],
   returns: ["NUMBER"],
   compute: function (value: Maybe<CellValue>): number {
@@ -677,7 +677,7 @@ export const EXP = {
 // FLOOR
 // -----------------------------------------------------------------------------
 export const FLOOR = {
-  description: _t(`Rounds number down to nearest multiple of factor.`),
+  description: _t("Rounds number down to nearest multiple of factor."),
   args: [
     arg("value (number)", _t("The value to round down to the nearest integer multiple of factor.")),
     arg(
@@ -707,7 +707,7 @@ export const FLOOR = {
 // FLOOR.MATH
 // -----------------------------------------------------------------------------
 export const FLOOR_MATH = {
-  description: _t(`Rounds number down to nearest multiple of factor.`),
+  description: _t("Rounds number down to nearest multiple of factor."),
   args: [
     arg(
       "number (number)",
@@ -757,7 +757,7 @@ export const FLOOR_MATH = {
 // FLOOR.PRECISE
 // -----------------------------------------------------------------------------
 export const FLOOR_PRECISE = {
-  description: _t(`Rounds number down to nearest multiple of factor.`),
+  description: _t("Rounds number down to nearest multiple of factor."),
   args: [
     arg(
       "number (number)",
@@ -783,7 +783,7 @@ export const FLOOR_PRECISE = {
 // ISEVEN
 // -----------------------------------------------------------------------------
 export const ISEVEN = {
-  description: _t(`Whether the provided value is even.`),
+  description: _t("Whether the provided value is even."),
   args: [arg("value (number)", _t("The value to be verified as even."))],
   returns: ["BOOLEAN"],
   compute: function (value: Maybe<CellValue>): boolean {
@@ -798,7 +798,7 @@ export const ISEVEN = {
 // ISO.CEILING
 // -----------------------------------------------------------------------------
 export const ISO_CEILING = {
-  description: _t(`Rounds number up to nearest multiple of factor.`),
+  description: _t("Rounds number up to nearest multiple of factor."),
   args: [
     arg(
       "number (number)",
@@ -824,7 +824,7 @@ export const ISO_CEILING = {
 // ISODD
 // -----------------------------------------------------------------------------
 export const ISODD = {
-  description: _t(`Whether the provided value is even.`),
+  description: _t("Whether the provided value is even."),
   args: [arg("value (number)", _t("The value to be verified as even."))],
   returns: ["BOOLEAN"],
   compute: function (value: Maybe<CellValue>): boolean {
@@ -839,7 +839,7 @@ export const ISODD = {
 // LN
 // -----------------------------------------------------------------------------
 export const LN = {
-  description: _t(`The logarithm of a number, base e (euler's number).`),
+  description: _t("The logarithm of a number, base e (euler's number)."),
   args: [arg("value (number)", _t("The value for which to calculate the logarithm, base e."))],
   returns: ["NUMBER"],
   compute: function (value: Maybe<CellValue>): number {
@@ -854,7 +854,7 @@ export const LN = {
 // MOD
 // -----------------------------------------------------------------------------
 export const MOD = {
-  description: _t(`Modulo (remainder) operator.`),
+  description: _t("Modulo (remainder) operator."),
   args: [
     arg("dividend (number)", _t("The number to be divided to find the remainder.")),
     arg("divisor (number)", _t("The number to divide by.")),
@@ -901,7 +901,7 @@ export const MUNIT = {
 // ODD
 // -----------------------------------------------------------------------------
 export const ODD = {
-  description: _t(`Rounds a number up to the nearest odd integer.`),
+  description: _t("Rounds a number up to the nearest odd integer."),
   args: [arg("value (number)", _t("The value to round to the next greatest odd number."))],
   returns: ["NUMBER"],
   computeFormat: (number: Maybe<ValueAndFormat>) => number?.format,
@@ -919,7 +919,7 @@ export const ODD = {
 // PI
 // -----------------------------------------------------------------------------
 export const PI = {
-  description: _t(`The number pi.`),
+  description: _t("The number pi."),
   args: [],
   returns: ["NUMBER"],
   compute: function (): number {
@@ -932,7 +932,7 @@ export const PI = {
 // POWER
 // -----------------------------------------------------------------------------
 export const POWER = {
-  description: _t(`A number raised to a power.`),
+  description: _t("A number raised to a power."),
   args: [
     arg("base (number)", _t("The number to raise to the exponent power.")),
     arg("exponent (number)", _t("The exponent to raise base to.")),
@@ -1144,7 +1144,7 @@ export const ROUND = {
 // ROUNDDOWN
 // -----------------------------------------------------------------------------
 export const ROUNDDOWN = {
-  description: _t(`Rounds down a number.`),
+  description: _t("Rounds down a number."),
   args: [
     arg(
       "value (number)",
@@ -1180,7 +1180,7 @@ export const ROUNDDOWN = {
 // ROUNDUP
 // -----------------------------------------------------------------------------
 export const ROUNDUP = {
-  description: _t(`Rounds up a number.`),
+  description: _t("Rounds up a number."),
   args: [
     arg("value (number)", _t("The value to round to places number of places, always rounding up.")),
     arg(

--- a/src/functions/module_operators.ts
+++ b/src/functions/module_operators.ts
@@ -8,7 +8,7 @@ import { POWER } from "./module_math";
 // ADD
 // -----------------------------------------------------------------------------
 export const ADD = {
-  description: _t(`Sum of two numbers.`),
+  description: _t("Sum of two numbers."),
   args: [
     arg("value1 (number)", _t("The first addend.")),
     arg("value2 (number)", _t("The second addend.")),
@@ -25,7 +25,7 @@ export const ADD = {
 // CONCAT
 // -----------------------------------------------------------------------------
 export const CONCAT = {
-  description: _t(`Concatenation of two values.`),
+  description: _t("Concatenation of two values."),
   args: [
     arg("value1 (string)", _t("The value to which value2 will be appended.")),
     arg("value2 (string)", _t("The value to append to value1.")),
@@ -41,7 +41,7 @@ export const CONCAT = {
 // DIVIDE
 // -----------------------------------------------------------------------------
 export const DIVIDE = {
-  description: _t(`One number divided by another.`),
+  description: _t("One number divided by another."),
   args: [
     arg("dividend (number)", _t("The number to be divided.")),
     arg("divisor (number)", _t("The number to divide by.")),
@@ -66,7 +66,7 @@ function isEmpty(value: Maybe<CellValue>): boolean {
 const getNeutral = { number: 0, string: "", boolean: false };
 
 export const EQ = {
-  description: _t(`Equal.`),
+  description: _t("Equal."),
   args: [
     arg("value1 (any)", _t("The first value.")),
     arg("value2 (any)", _t("The value to test against value1 for equality.")),
@@ -113,7 +113,7 @@ function applyRelationalOperator(
 }
 
 export const GT = {
-  description: _t(`Strictly greater than.`),
+  description: _t("Strictly greater than."),
   args: [
     arg("value1 (any)", _t("The value to test as being greater than value2.")),
     arg("value2 (any)", _t("The second value.")),
@@ -130,7 +130,7 @@ export const GT = {
 // GTE
 // -----------------------------------------------------------------------------
 export const GTE = {
-  description: _t(`Greater than or equal to.`),
+  description: _t("Greater than or equal to."),
   args: [
     arg("value1 (any)", _t("The value to test as being greater than or equal to value2.")),
     arg("value2 (any)", _t("The second value.")),
@@ -147,7 +147,7 @@ export const GTE = {
 // LT
 // -----------------------------------------------------------------------------
 export const LT = {
-  description: _t(`Less than.`),
+  description: _t("Less than."),
   args: [
     arg("value1 (any)", _t("The value to test as being less than value2.")),
     arg("value2 (any)", _t("The second value.")),
@@ -162,7 +162,7 @@ export const LT = {
 // LTE
 // -----------------------------------------------------------------------------
 export const LTE = {
-  description: _t(`Less than or equal to.`),
+  description: _t("Less than or equal to."),
   args: [
     arg("value1 (any)", _t("The value to test as being less than or equal to value2.")),
     arg("value2 (any)", _t("The second value.")),
@@ -177,7 +177,7 @@ export const LTE = {
 // MINUS
 // -----------------------------------------------------------------------------
 export const MINUS = {
-  description: _t(`Difference of two numbers.`),
+  description: _t("Difference of two numbers."),
   args: [
     arg("value1 (number)", _t("The minuend, or number to be subtracted from.")),
     arg("value2 (number)", _t("The subtrahend, or number to subtract from value1.")),
@@ -194,7 +194,7 @@ export const MINUS = {
 // MULTIPLY
 // -----------------------------------------------------------------------------
 export const MULTIPLY = {
-  description: _t(`Product of two numbers`),
+  description: _t("Product of two numbers"),
   args: [
     arg("factor1 (number)", _t("The first multiplicand.")),
     arg("factor2 (number)", _t("The second multiplicand.")),
@@ -211,7 +211,7 @@ export const MULTIPLY = {
 // NE
 // -----------------------------------------------------------------------------
 export const NE = {
-  description: _t(`Not equal.`),
+  description: _t("Not equal."),
   args: [
     arg("value1 (any)", _t("The first value.")),
     arg("value2 (any)", _t("The value to test against value1 for inequality.")),
@@ -226,7 +226,7 @@ export const NE = {
 // POW
 // -----------------------------------------------------------------------------
 export const POW = {
-  description: _t(`A number raised to a power.`),
+  description: _t("A number raised to a power."),
   args: [
     arg("base (number)", _t("The number to raise to the exponent power.")),
     arg("exponent (number)", _t("The exponent to raise base to.")),
@@ -241,7 +241,7 @@ export const POW = {
 // UMINUS
 // -----------------------------------------------------------------------------
 export const UMINUS = {
-  description: _t(`A number with the sign reversed.`),
+  description: _t("A number with the sign reversed."),
   args: [
     arg(
       "value (number)",
@@ -259,7 +259,7 @@ export const UMINUS = {
 // UNARY_PERCENT
 // -----------------------------------------------------------------------------
 export const UNARY_PERCENT = {
-  description: _t(`Value interpreted as a percentage.`),
+  description: _t("Value interpreted as a percentage."),
   args: [arg("percentage (number)", _t("The value to interpret as a percentage."))],
   returns: ["NUMBER"],
   compute: function (percentage: Maybe<CellValue>): number {
@@ -271,7 +271,7 @@ export const UNARY_PERCENT = {
 // UPLUS
 // -----------------------------------------------------------------------------
 export const UPLUS = {
-  description: _t(`A specified number, unchanged.`),
+  description: _t("A specified number, unchanged."),
   args: [arg("value (any)", _t("The number to return."))],
   returns: ["ANY"],
   computeFormat: (value: Maybe<ValueAndFormat>) => value?.format,

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -77,7 +77,7 @@ function covariance(dataY: ArgValue, dataX: ArgValue, isSample: boolean): number
 
   assert(
     () => count !== 0 && (!isSample || count !== 1),
-    _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+    _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
   );
 
   let sumY = 0;
@@ -115,7 +115,7 @@ function variance(args: ArgValue[], isSample: boolean, textAs0: boolean, locale:
 
   assert(
     () => count !== 0 && (!isSample || count !== 1),
-    _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+    _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
   );
 
   const average = sum / count;
@@ -134,7 +134,7 @@ function centile(
   const _percent = toNumber(percent, locale);
   assert(
     () => (isInclusive ? 0 <= _percent && _percent <= 1 : 0 < _percent && _percent < 1),
-    _t(`Function [[FUNCTION_NAME]] parameter 2 value is out of range.`)
+    _t("Function [[FUNCTION_NAME]] parameter 2 value is out of range.")
   );
   let sortedArray: number[] = [];
   let index: number;
@@ -153,13 +153,13 @@ function centile(
       count++;
     }
   });
-  assert(() => count !== 0, _t(`[[FUNCTION_NAME]] has no valid input data.`));
+  assert(() => count !== 0, _t("[[FUNCTION_NAME]] has no valid input data."));
 
   if (!isInclusive) {
     // 2nd argument must be between 1/(n+1) and n/(n+1) with n the number of data
     assert(
       () => 1 / (count + 1) <= _percent && _percent <= count / (count + 1),
-      _t(`Function [[FUNCTION_NAME]] parameter 2 value is out of range.`)
+      _t("Function [[FUNCTION_NAME]] parameter 2 value is out of range.")
     );
   }
 
@@ -291,7 +291,7 @@ function polynomialRegression(
   assertSameNumberOfElements(flatX, flatY);
   assert(
     () => order >= 1,
-    _t(`Function [[FUNCTION_NAME]] A regression of order less than 1 cannot be possible.`)
+    _t("Function [[FUNCTION_NAME]] A regression of order less than 1 cannot be possible.")
   );
 
   const yMatrix = [flatY];
@@ -378,7 +378,7 @@ export const AVEDEV = {
     );
     assert(
       () => count !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
     const average = sum / count;
     return reduceNumbers(values, (acc, a) => acc + Math.abs(average - a), 0, this.locale) / count;
@@ -390,7 +390,7 @@ export const AVEDEV = {
 // AVERAGE
 // -----------------------------------------------------------------------------
 export const AVERAGE = {
-  description: _t(`Numerical average value in a dataset, ignoring text.`),
+  description: _t("Numerical average value in a dataset, ignoring text."),
   args: [
     arg(
       "value1 (number, range<number>)",
@@ -418,7 +418,7 @@ export const AVERAGE = {
     );
     assert(
       () => count !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
     return sum / count;
   },
@@ -428,13 +428,13 @@ export const AVERAGE = {
 // -----------------------------------------------------------------------------
 // AVERAGE.WEIGHTED
 // -----------------------------------------------------------------------------
-const rangeError = _t(`[[FUNCTION_NAME]] has mismatched range sizes.`);
+const rangeError = _t("[[FUNCTION_NAME]] has mismatched range sizes.");
 const negativeWeightError = _t(
-  `[[FUNCTION_NAME]] expects the weight to be positive or equal to 0.`
+  "[[FUNCTION_NAME]] expects the weight to be positive or equal to 0."
 );
 
 export const AVERAGE_WEIGHTED = {
-  description: _t(`Weighted average.`),
+  description: _t("Weighted average."),
   args: [
     arg("values (number, range<number>)", _t("Values to average.")),
     arg("weights (number, range<number>)", _t("Weights for each corresponding value.")),
@@ -455,7 +455,7 @@ export const AVERAGE_WEIGHTED = {
     let weight;
     assert(
       () => values.length % 2 === 0,
-      _t(`Wrong number of Argument[]. Expected an even number of Argument[].`)
+      _t("Wrong number of Argument[]. Expected an even number of Argument[].")
     );
     for (let n = 0; n < values.length - 1; n += 2) {
       value = values[n];
@@ -479,7 +479,7 @@ export const AVERAGE_WEIGHTED = {
             // typeof subValue or subWeight can be 'number' or 'undefined'
             assert(
               () => subValueIsNumber === subWeightIsNumber,
-              _t(`[[FUNCTION_NAME]] expects number values.`)
+              _t("[[FUNCTION_NAME]] expects number values.")
             );
 
             if (subWeightIsNumber) {
@@ -502,7 +502,7 @@ export const AVERAGE_WEIGHTED = {
 
     assert(
       () => count !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
 
     return sum / count;
@@ -513,7 +513,7 @@ export const AVERAGE_WEIGHTED = {
 // AVERAGEA
 // -----------------------------------------------------------------------------
 export const AVERAGEA = {
-  description: _t(`Numerical average value in a dataset.`),
+  description: _t("Numerical average value in a dataset."),
   args: [
     arg(
       "value1 (number, range<number>)",
@@ -541,7 +541,7 @@ export const AVERAGEA = {
     );
     assert(
       () => count !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
     return sum / count;
   },
@@ -552,7 +552,7 @@ export const AVERAGEA = {
 // AVERAGEIF
 // -----------------------------------------------------------------------------
 export const AVERAGEIF = {
-  description: _t(`Average of values depending on criteria.`),
+  description: _t("Average of values depending on criteria."),
   args: [
     arg("criteria_range (number, range<number>)", _t("The range to check against criterion.")),
     arg("criterion (string)", _t("The pattern or test to apply to criteria_range.")),
@@ -587,7 +587,7 @@ export const AVERAGEIF = {
 
     assert(
       () => count !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
 
     return sum / count;
@@ -599,7 +599,7 @@ export const AVERAGEIF = {
 // AVERAGEIFS
 // -----------------------------------------------------------------------------
 export const AVERAGEIFS = {
-  description: _t(`Average of values depending on multiple criteria.`),
+  description: _t("Average of values depending on multiple criteria."),
   args: [
     arg("average_range (range)", _t("The range to average.")),
     arg("criteria_range1 (range)", _t("The range to check against criterion1.")),
@@ -628,7 +628,7 @@ export const AVERAGEIFS = {
     );
     assert(
       () => count !== 0,
-      _t(`Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.`)
+      _t("Evaluation of function [[FUNCTION_NAME]] caused a divide by zero error.")
     );
     return sum / count;
   },
@@ -639,7 +639,7 @@ export const AVERAGEIFS = {
 // COUNT
 // -----------------------------------------------------------------------------
 export const COUNT = {
-  description: _t(`The number of numeric values in dataset.`),
+  description: _t("The number of numeric values in dataset."),
   args: [
     arg(
       "value1 (number, range<number>)",
@@ -679,7 +679,7 @@ export const COUNT = {
 // COUNTA
 // -----------------------------------------------------------------------------
 export const COUNTA = {
-  description: _t(`The number of values in a dataset.`),
+  description: _t("The number of values in a dataset."),
   args: [
     arg("value1 (any, range)", _t("The first value or range to consider when counting.")),
     arg(
@@ -701,7 +701,7 @@ export const COUNTA = {
 // Note: Unlike the VAR function which corresponds to the variance over a sample (VAR.S),
 // the COVAR function corresponds to the covariance over an entire population (COVAR.P)
 export const COVAR = {
-  description: _t(`The covariance of a dataset.`),
+  description: _t("The covariance of a dataset."),
   args: [
     arg("data_y (any, range)", _t("The range representing the array or matrix of dependent data.")),
     arg(
@@ -720,7 +720,7 @@ export const COVAR = {
 // COVARIANCE.P
 // -----------------------------------------------------------------------------
 export const COVARIANCE_P = {
-  description: _t(`The covariance of a dataset.`),
+  description: _t("The covariance of a dataset."),
   args: [
     arg("data_y (any, range)", _t("The range representing the array or matrix of dependent data.")),
     arg(
@@ -739,7 +739,7 @@ export const COVARIANCE_P = {
 // COVARIANCE.S
 // -----------------------------------------------------------------------------
 export const COVARIANCE_S = {
-  description: _t(`The sample covariance of a dataset.`),
+  description: _t("The sample covariance of a dataset."),
   args: [
     arg("data_y (any, range)", _t("The range representing the array or matrix of dependent data.")),
     arg(
@@ -892,7 +892,7 @@ export const LARGE = {
       }
     });
     const result = largests.shift();
-    assert(() => result !== undefined, _t(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => result !== undefined, _t("[[FUNCTION_NAME]] has no valid input data."));
     assert(
       () => count >= _n,
       _t("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n)
@@ -1652,7 +1652,7 @@ export const SMALL = {
       }
     });
     const result = largests.pop();
-    assert(() => result !== undefined, _t(`[[FUNCTION_NAME]] has no valid input data.`));
+    assert(() => result !== undefined, _t("[[FUNCTION_NAME]] has no valid input data."));
     assert(
       () => count >= _n,
       _t("Function [[FUNCTION_NAME]] parameter 2 value (%s) is out of range.", _n)

--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -110,7 +110,7 @@ export const FIND = {
     const _textToSearch = toString(textToSearch);
     const _startingAt = toNumber(startingAt, this.locale);
 
-    assert(() => _textToSearch !== "", _t(`The text_to_search must be non-empty.`));
+    assert(() => _textToSearch !== "", _t("The text_to_search must be non-empty."));
     assert(
       () => _startingAt >= 1,
       _t("The starting_at (%s) must be greater than or equal to 1.", _startingAt.toString())
@@ -360,7 +360,7 @@ export const SEARCH = {
     const _textToSearch = toString(textToSearch).toLowerCase();
     const _startingAt = toNumber(startingAt, this.locale);
 
-    assert(() => _textToSearch !== "", _t(`The text_to_search must be non-empty.`));
+    assert(() => _textToSearch !== "", _t("The text_to_search must be non-empty."));
     assert(
       () => _startingAt >= 1,
       _t("The starting_at (%s) must be greater than or equal to 1.", _startingAt.toString())


### PR DESCRIPTION
template strings do not react very well to the translations. It's one of the reasons it's prohibited to introduce new occurences of this on Odoo (see for instance https://runbot.odoo.com/runbot/build/52844695).

This revision gets rid of the template strings in the translations.

Task: /

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo