### PR TITLE
[FIX] XLSX: Exported image dimension

### DIFF
--- a/src/xlsx/functions/drawings.ts
+++ b/src/xlsx/functions/drawings.ts
@@ -102,13 +102,13 @@ function figureCoordinates(
   position: number
 ): { index: number; offset: number } {
   let currentPosition = 0;
-  for (const [headerIndex, header] of Object.entries(headers)) {
+  for (const [headerIndex, header] of headers.entries()) {
     if (currentPosition <= position && position < currentPosition + header.size!) {
       return {
-        index: parseInt(headerIndex),
+        index: headerIndex,
         offset: convertDotValueToEMU(position - currentPosition + FIGURE_BORDER_WIDTH),
       };
-    } else {
+    } else if (headerIndex < headers.length - 1) {
       currentPosition += header.size!;
     }
   }

--- a/tests/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/__snapshots__/xlsx_export.test.ts.snap
@@ -898,7 +898,7 @@ Object {
                 24
             </xdr:col>
             <xdr:colOff>
-                57150
+                971550
             </xdr:colOff>
             <xdr:row>
                 0
@@ -912,7 +912,7 @@ Object {
                 24
             </xdr:col>
             <xdr:colOff>
-                5162550
+                6076950
             </xdr:colOff>
             <xdr:row>
                 14
@@ -11292,13 +11292,13 @@ Object {
                 24
             </xdr:col>
             <xdr:colOff>
-                953423925
+                954338325
             </xdr:colOff>
             <xdr:row>
                 24
             </xdr:row>
             <xdr:rowOff>
-                956557650
+                956776725
             </xdr:rowOff>
         </xdr:to>
         <xdr:pic>


### PR DESCRIPTION
There was a calculation  error for the dimension of an image when the latter was adjacent to the end of a sheet.

Task: /

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo