### PR TITLE
[FIX] evaluation: avoid .shift()

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
@@ -61,10 +61,10 @@ export class FormulaDependencyGraph {
    */
   getCellsDependingOn(positionIds: Iterable<PositionId>): Set<PositionId> {
     const visited: JetSet<PositionId> = new JetSet<PositionId>();
-    const queue: PositionId[] = Array.from(positionIds);
+    const queue: PositionId[] = Array.from(positionIds).reverse();
 
     while (queue.length > 0) {
-      const node = queue.shift()!;
+      const node = queue.pop()!;
       visited.add(node);
 
       const adjacentNodes = this.inverseDependencies.get(node) || new Set<PositionId>();


### PR DESCRIPTION
## Description:

.shift() is slow because it moves every array items each time

With this fix, given a sheet of 52K cells, when duplicating the sheet `getCellsDependingOn` self-time goes from ~16% (250+ms) of the total time to less than `1.5%`
Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_lt("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo