### PR TITLE
[IMP] locale: change date format with locale

### DIFF
--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -6,6 +6,7 @@ import {
 } from "../constants";
 import { formatValue, roundFormat } from "../helpers";
 import { parseLiteral } from "../helpers/cells";
+import { getDateTimeFormat } from "../helpers/locale";
 import { _t } from "../translation";
 import {
   Align,
@@ -113,7 +114,7 @@ export const formatNumberDateTime = createFormatActionSpec({
   descriptionValue: EXAMPLE_DATE,
   format: (env) => {
     const locale = env.model.getters.getLocale();
-    return locale.dateFormat + " " + locale.timeFormat;
+    return getDateTimeFormat(locale);
   },
 });
 

--- a/src/components/side_panel/settings/settings_panel.ts
+++ b/src/components/side_panel/settings/settings_panel.ts
@@ -1,6 +1,6 @@
 import { Component, onWillStart } from "@odoo/owl";
 import { deepEquals, formatValue } from "../../../helpers";
-import { isValidLocale } from "../../../helpers/locale";
+import { getDateTimeFormat, isValidLocale } from "../../../helpers/locale";
 import { Locale, LocaleCode, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers";
 
@@ -47,7 +47,7 @@ export class SettingsPanel extends Component<Props, SpreadsheetChildEnv> {
 
   get dateTimeFormatPreview() {
     const locale = this.env.model.getters.getLocale();
-    const dateTimeFormat = locale.dateFormat + " " + locale.timeFormat;
+    const dateTimeFormat = getDateTimeFormat(locale);
     return formatValue(1.6, { format: dateTimeFormat, locale });
   }
 

--- a/src/functions/module_date.ts
+++ b/src/functions/module_date.ts
@@ -12,6 +12,7 @@ import {
   numberToJsDate,
   parseDateTime,
 } from "../helpers/dates";
+import { getDateTimeFormat } from "../helpers/locale";
 import { _t } from "../translation";
 import { AddFunctionDescription, ArgValue, CellValue, Maybe } from "../types";
 import { arg } from "./arguments";
@@ -623,7 +624,7 @@ export const NOW = {
   args: [],
   returns: ["DATE"],
   computeFormat: function () {
-    return this.locale.dateFormat + " " + this.locale.timeFormat;
+    return getDateTimeFormat(this.locale);
   },
   compute: function (): number {
     let today = new Date();

--- a/src/helpers/locale.ts
+++ b/src/helpers/locale.ts
@@ -1,4 +1,4 @@
-import { tokenize } from "../formulas";
+import { tokenize } from "../formulas/tokenizer";
 import { toNumber } from "../functions/helpers";
 import {
   ColorScaleThreshold,
@@ -295,4 +295,8 @@ function changeCFRuleThresholdLocale<T extends IconThreshold | ColorScaleThresho
   const modified = changeContentLocale(value);
   const newValue = threshold.type === "formula" ? modified.slice(1) : modified;
   return { ...threshold, value: newValue };
+}
+
+export function getDateTimeFormat(locale: Locale) {
+  return locale.dateFormat + " " + locale.timeFormat;
 }

--- a/src/plugins/core/settings.ts
+++ b/src/plugins/core/settings.ts
@@ -1,5 +1,12 @@
-import { isValidLocale } from "../../helpers/locale";
-import { CommandResult, CoreCommand, DEFAULT_LOCALE, Locale, WorkbookData } from "../../types";
+import { getDateTimeFormat, isValidLocale } from "../../helpers/locale";
+import {
+  CommandResult,
+  CoreCommand,
+  DEFAULT_LOCALE,
+  Format,
+  Locale,
+  WorkbookData,
+} from "../../types";
 import { CorePlugin } from "./../core_plugin";
 
 export class SettingsPlugin extends CorePlugin {
@@ -17,13 +24,42 @@ export class SettingsPlugin extends CorePlugin {
   handle(cmd: CoreCommand) {
     switch (cmd.type) {
       case "UPDATE_LOCALE":
-        this.history.update("locale", cmd.locale);
+        const oldLocale = this.locale;
+        const newLocale = cmd.locale;
+        this.history.update("locale", newLocale);
+        this.changeCellsDateFormatWithLocale(oldLocale, newLocale);
         break;
     }
   }
 
   getLocale(): Locale {
     return this.locale;
+  }
+
+  private changeCellsDateFormatWithLocale(oldLocale: Locale, newLocale: Locale) {
+    for (const sheetId of this.getters.getSheetIds()) {
+      for (const [cellId, cell] of Object.entries(this.getters.getCells(sheetId))) {
+        let formatToApply: Format | undefined;
+        if (cell.format === oldLocale.dateFormat) {
+          formatToApply = newLocale.dateFormat;
+        }
+        if (cell.format === oldLocale.timeFormat) {
+          formatToApply = newLocale.timeFormat;
+        }
+        if (cell.format === getDateTimeFormat(oldLocale)) {
+          formatToApply = getDateTimeFormat(newLocale);
+        }
+        if (formatToApply) {
+          const { col, row, sheetId } = this.getters.getCellPosition(cellId);
+          this.dispatch("UPDATE_CELL", {
+            col,
+            row,
+            sheetId,
+            format: formatToApply,
+          });
+        }
+      }
+    }
   }
 
   import(data: WorkbookData) {

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -18,7 +18,11 @@ import {
   updateSelectionOnDeletion,
   updateSelectionOnInsertion,
 } from "../../helpers/index";
-import { canonicalizeNumberContent, localizeFormula } from "../../helpers/locale";
+import {
+  canonicalizeNumberContent,
+  getDateTimeFormat,
+  localizeFormula,
+} from "../../helpers/locale";
 import { loopThroughReferenceType } from "../../helpers/reference_type";
 import { _t } from "../../translation";
 import {
@@ -515,7 +519,7 @@ export class EditionPlugin extends UIPlugin {
           // display a simplified and parsable string otherwise
           const timeFormat = Number.isInteger(value)
             ? locale.dateFormat
-            : locale.dateFormat + " " + locale.timeFormat;
+            : getDateTimeFormat(locale);
           return formatValue(value, { locale, format: timeFormat });
         }
         return this.numberComposerContent(value, format, locale);

--- a/tests/settings/settings_plugin.test.ts
+++ b/tests/settings/settings_plugin.test.ts
@@ -1,4 +1,5 @@
 import { CommandResult, Model } from "../../src";
+import { getDateTimeFormat } from "../../src/helpers/locale";
 import { DEFAULT_LOCALE, Locale } from "../../src/types/locale";
 import {
   redo,
@@ -8,7 +9,7 @@ import {
   updateLocale,
 } from "../test_helpers/commands_helpers";
 import { CUSTOM_LOCALE, FR_LOCALE } from "../test_helpers/constants";
-import { getCellContent } from "../test_helpers/getters_helpers";
+import { getCell, getCellContent } from "../test_helpers/getters_helpers";
 import { target } from "../test_helpers/helpers";
 
 describe("Settings plugin", () => {
@@ -101,6 +102,18 @@ describe("Settings plugin", () => {
       const locale = { ...CUSTOM_LOCALE, decimalSeparator: "♥" };
       updateLocale(model, locale);
       expect(getCellContent(model, "A1")).toEqual("9♥89");
+    });
+
+    test("Changing the locale changes the format of the cells that are formatted with the locale date(time) format", () => {
+      setFormat(model, DEFAULT_LOCALE.dateFormat, target("A1"));
+      setFormat(model, DEFAULT_LOCALE.timeFormat, target("A2"));
+      setFormat(model, getDateTimeFormat(DEFAULT_LOCALE), target("A3"));
+
+      const locale = { ...CUSTOM_LOCALE, dateFormat: "yyyy/mm/dd", timeFormat: "hh:mm" };
+      updateLocale(model, locale);
+      expect(getCell(model, "A1")?.format).toEqual("yyyy/mm/dd");
+      expect(getCell(model, "A2")?.format).toEqual("hh:mm");
+      expect(getCell(model, "A3")?.format).toEqual("yyyy/mm/dd hh:mm");
     });
   });
 });


### PR DESCRIPTION
## Description

This commit changes the date format of the cells when changing the locale.

This is currently done the dumbest way possible: check if the cell's format exactly match the previous locale's format, and if so, change it to the new locale's format. This works fine as long as the only date formats are the ones used in the topbar menu.

Further work can be done to support a conversion with more date formats that don't exactly match the locale's.

Task: : [3575516](https://www.odoo.com/web#id=3575516&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo