### PR TITLE
[IMP] tests: pre-compile owl templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ debug.log
 .git.cache
 *.xlsx
 tests/__xlsx__/xlsx_demo_data/xl/printerSettings
+tools/owl_templates/_compiled/*

--- a/package.json
+++ b/package.json
@@ -127,6 +127,8 @@
       "node"
     ],
     "workerIdleMemoryLimit": "800MB",
+    "globalSetup": "<rootDir>/tests/setup/jest_global_setup.ts",
+    "globalTeardown": "<rootDir>/tests/setup/jest_global_teardown.ts",
     "setupFilesAfterEnv": [
       "<rootDir>/tests/setup/jest.setup.ts"
     ]

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -28,3 +28,7 @@ tests/
 │  ├─ find_and_replace_component.test.ts
 ├─ readme.md
 ```
+
+## Owl Templates
+
+In an effort to run the tests faster, we pre-compile the owl templates before running the tests. This is done by running the `compileOwlTemplates` script in the `package.json` file. This script compiles all the owl templates in the `src` folder into the `tools/owl_templates/_compiled/owl_compiled_templates.cjs` file.

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -1,17 +1,23 @@
 /**
  * This file will be run before each test file
  */
+import { App } from "@odoo/owl";
 import { setDefaultSheetViewSize } from "../../src/constants";
 import { setTranslationMethod } from "../../src/translation";
-import { getParsedOwlTemplateBundle } from "../../tools/bundle_xml/bundle_xml_templates.cjs";
+import { getCompiledTemplates } from "../../tools/owl_templates/compile_templates.cjs";
 import "./canvas.mock";
 import "./jest_extend";
 import "./resize_observer.mock";
 
-export let OWL_TEMPLATES: Document;
+function registerOwlTemplates() {
+  const templates = getCompiledTemplates();
+  for (const tName in templates) {
+    App.registerTemplate(tName, templates[tName]);
+  }
+}
 
 beforeAll(() => {
-  OWL_TEMPLATES = getParsedOwlTemplateBundle();
+  registerOwlTemplates();
   setDefaultSheetViewSize(1000);
   setTranslationMethod(
     (str, ...values) => str,

--- a/tests/setup/jest_global_setup.ts
+++ b/tests/setup/jest_global_setup.ts
@@ -1,0 +1,5 @@
+import { writeTemplatesToFile } from "../../tools/owl_templates/compile_templates.cjs";
+
+module.exports = function () {
+  writeTemplatesToFile();
+};

--- a/tests/setup/jest_global_teardown.ts
+++ b/tests/setup/jest_global_teardown.ts
@@ -1,0 +1,5 @@
+import { deleteCompiledTemplatesFile } from "../../tools/owl_templates/compile_templates.cjs";
+
+module.exports = function () {
+  deleteCompiledTemplatesFile();
+};

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -52,7 +52,7 @@ import { Image } from "../../src/types/image";
 import { XLSXExport } from "../../src/types/xlsx";
 import { isXLSXExportXMLFile } from "../../src/xlsx/helpers/xlsx_helper";
 import { FileStore } from "../__mocks__/mock_file_store";
-import { OWL_TEMPLATES, registerCleanup } from "../setup/jest.setup";
+import { registerCleanup } from "../setup/jest.setup";
 import { MockClipboard } from "./clipboard";
 import { redo, setCellContent, setFormat, setStyle, undo } from "./commands_helpers";
 import { getCellContent, getEvaluatedCell } from "./getters_helpers";
@@ -178,7 +178,6 @@ export async function mountComponent<Props extends { [key: string]: any }>(
   const env = makeTestEnv({ ...optionalArgs.env, model: model });
   const props = optionalArgs.props || ({} as Props);
   const app = new App(component, { props, env, test: true, translateFn: _t });
-  app.addTemplates(OWL_TEMPLATES);
   const fixture = optionalArgs?.fixture || makeTestFixture();
   const parent = await app.mount(fixture);
 

--- a/tools/owl_templates/compile_templates.cjs
+++ b/tools/owl_templates/compile_templates.cjs
@@ -1,0 +1,91 @@
+const fs = require("fs");
+const path = require("path");
+const { getParsedOwlTemplateBundle } = require("../bundle_xml/bundle_xml_templates.cjs");
+
+const TEMPLATE_FILE_PATH = path.join(__dirname, "./_compiled/owl_compiled_templates.cjs");
+
+function importOwl() {
+  // Owl need some web globals to work properly. Import them from JSDOM if we are in node and that JSDOM is not loaded.
+  if (global.window) {
+    return require("@odoo/owl");
+  }
+  const jsdom = require("jsdom");
+  const defaultHtml =
+    '<!doctype html><html><head><meta charset="utf-8"></head><body></body></html>';
+  const document = new jsdom.JSDOM(defaultHtml, {});
+
+  const window = document.window;
+  global.window = document.window;
+  global.document = window.document;
+  global.Element = window.Element;
+  global.DOMTokenList = window.DOMTokenList;
+  global.Node = window.Node;
+  global.CharacterData = window.CharacterData;
+  global.DOMParser = window.DOMParser;
+  window.requestAnimationFrame = () => {};
+
+  return require("@odoo/owl");
+}
+
+// Taken from OWL repo
+// https://github.com/odoo/owl/blob/398df543feb0349ec5c7b38824c6a51d00ab6a45/tools/compile_xml.js#L54
+const a = "·-_,:;";
+const p = new RegExp(a.split("").join("|"), "g");
+function slugify(str) {
+  return str
+    .replace(/\//g, "") // remove /
+    .replace(/\./g, "_") // Replace . with _
+    .replace(p, (c) => "_") // Replace special characters
+    .replace(/&/g, "_and_") // Replace & with ‘and’
+    .replace(/[^\w\-]+/g, ""); // Remove all non-word characters
+}
+
+function compileTemplates() {
+  const owl = importOwl();
+  const parsedXMl = getParsedOwlTemplateBundle();
+  const app = new owl.App(owl.Component, {});
+  const compiledTemplates = {};
+  for (const template of parsedXMl.querySelectorAll("[t-name]")) {
+    const name = template.getAttribute("t-name");
+    const fn = app._compileTemplate(name, template);
+    compiledTemplates[name] = fn;
+  }
+
+  return compiledTemplates;
+}
+
+function writeCompiledTemplatesToFile() {
+  const templates = compileTemplates();
+  const templatesStr = [];
+  for (const tName in templates) {
+    const fnName = slugify(tName);
+    const fnString = templates[tName].toString().replace("anonymous", fnName);
+    const str = `"${tName}": ${fnString},\n`;
+    templatesStr.push(str);
+  }
+
+  const templateFileStr = `exports.templates = {\n ${templatesStr.join("\n")} \n}`;
+
+  const dir = path.dirname(TEMPLATE_FILE_PATH);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(TEMPLATE_FILE_PATH, templateFileStr);
+}
+
+function getCompiledTemplates() {
+  if (!fs.existsSync(TEMPLATE_FILE_PATH)) {
+    writeCompiledTemplatesToFile();
+  }
+
+  const { templates } = require(TEMPLATE_FILE_PATH);
+  return templates;
+}
+
+function deleteCompiledTemplatesFile() {
+  fs.unlinkSync(TEMPLATE_FILE_PATH);
+}
+
+exports.writeTemplatesToFile = writeCompiledTemplatesToFile;
+exports.getCompiledTemplates = getCompiledTemplates;
+exports.deleteCompiledTemplatesFile = deleteCompiledTemplatesFile;


### PR DESCRIPTION
This commit adds a pre-compile step for owl templates to the tests. This speeds up the test a lot.

Performances:
Before: "npm run test": ~103s
After: "npm run test": ~88s (-15%)

(There seems to be more improvements on better CPUs)

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo