### PR TITLE
[FIX] Charts: invalidate evaluation on UNDO/REDO

### DIFF
--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -1962,6 +1962,23 @@ describe("Chart evaluation", () => {
         .data![0]
     ).toBe("#REF");
   });
+
+  test("undo/redo invalidates the chart runtime", () => {
+    const chartId = "test";
+    setCellContent(model, "A1", "oui");
+    setCellContent(model, "A2", "non");
+    createChart(model, {}, chartId);
+
+    updateChart(model, chartId, { labelRange: "A1:A2" });
+    const chartRuntime1 = model.getters.getChartRuntime(chartId) as BarChartRuntime;
+    undo(model);
+    const chartRuntime2 = model.getters.getChartRuntime(chartId) as BarChartRuntime;
+    redo(model);
+    const chartRuntime3 = model.getters.getChartRuntime(chartId) as BarChartRuntime;
+    expect(chartRuntime1.chartJsConfig.data?.labels).toEqual(["oui", "non"]);
+    expect(chartRuntime2.chartJsConfig.data?.labels).toEqual([]);
+    expect(chartRuntime3.chartJsConfig.data?.labels).toEqual(["oui", "non"]);
+  });
 });
 
 describe("Cumulative Data line chart", () => {


### PR DESCRIPTION
Since [1], the commands "UNDO" and "REDO" no longer invalidate the chart evaluation. This was probably a mistake that was let through as it was not tested.

[1] https://github.com/odoo/o-spreadsheet/pull/2408

Task: 3578417

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo