### PR TITLE
[FIX] FilterEvaluationPlugin: hide all rows with data filter and grouping

### DIFF
--- a/src/plugins/core/header_visibility.ts
+++ b/src/plugins/core/header_visibility.ts
@@ -162,9 +162,18 @@ export class HeaderVisibilityPlugin extends CorePlugin {
   }
 
   private getAllVisibleHeaders(sheetId: UID, dimension: Dimension): HeaderIndex[] {
-    return range(0, this.hiddenHeaders[sheetId][dimension].length).filter(
-      (i) => !this.hiddenHeaders[sheetId][dimension][i]
-    );
+    const headers: HeaderIndex[] = range(0, this.getters.getNumberHeaders(sheetId, dimension));
+
+    const foldedHeaders: HeaderIndex[] = [];
+    this.getters.getHeaderGroups(sheetId, dimension).forEach((group) => {
+      if (group.isFolded) {
+        foldedHeaders.push(...range(group.start, group.end + 1));
+      }
+    });
+
+    return headers.filter((i) => {
+      return !this.hiddenHeaders[sheetId][dimension][i] && !foldedHeaders.includes(i);
+    });
   }
 
   import(data: WorkbookData) {

--- a/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/src/plugins/ui_stateful/filter_evaluation.ts
@@ -73,6 +73,12 @@ export class FilterEvaluationPlugin extends UIPlugin {
         break;
       case "HIDE_COLUMNS_ROWS":
       case "UNHIDE_COLUMNS_ROWS":
+      case "GROUP_HEADERS":
+      case "UNGROUP_HEADERS":
+      case "FOLD_HEADER_GROUP":
+      case "UNFOLD_HEADER_GROUP":
+      case "FOLD_ALL_HEADER_GROUPS":
+      case "UNFOLD_ALL_HEADER_GROUPS":
         this.updateHiddenRows();
         break;
       case "UPDATE_FILTER":

--- a/tests/data_filter/filter_evaluation_plugin.test.ts
+++ b/tests/data_filter/filter_evaluation_plugin.test.ts
@@ -7,6 +7,8 @@ import {
   createFilter,
   deleteFilter,
   deleteRows,
+  foldHeaderGroup,
+  groupHeaders,
   hideColumns,
   hideRows,
   setCellContent,
@@ -200,5 +202,39 @@ describe("Filter Evaluation Plugin", () => {
 
     expect(model.getters.isRowFiltered(sheetId, 1)).toEqual(true);
     expect(model.getters.isRowFiltered(sheetId, 2)).toEqual(true);
+  });
+
+  test("Folding a group after filtering some rows doesn't hide all rows of the sheet", () => {
+    const model = new Model({ sheets: [{ colNumber: 5, rowNumber: 5 }] });
+    const sheetId = model.getters.getActiveSheetId();
+
+    groupHeaders(model, "ROW", 0, 3);
+
+    createFilter(model, "A4:A5");
+    setCellContent(model, "A5", "Hi");
+    updateFilter(model, "A4", ["Hi"]);
+
+    expect(model.getters.isRowFiltered(sheetId, 4)).toEqual(true);
+    foldHeaderGroup(model, "ROW", 0, 3);
+    expect(model.getters.isRowFiltered(sheetId, 4)).toEqual(false);
+  });
+
+  test("Grouping headers after filtering some rows doesn't break the data filter state", () => {
+    const model = new Model({ sheets: [{ colNumber: 8, rowNumber: 8 }] });
+    const sheetId = model.getters.getActiveSheetId();
+
+    groupHeaders(model, "ROW", 0, 5);
+
+    createFilter(model, "A6:A8");
+    setCellContent(model, "A7", "Hi");
+    setCellContent(model, "A8", "Hi");
+    updateFilter(model, "A6", ["Hi"]);
+
+    foldHeaderGroup(model, "ROW", 0, 5);
+    groupHeaders(model, "ROW", 6, 7);
+
+    expect(model.getters.getHeaderGroups(sheetId, "ROW")).toMatchObject([{ start: 0, end: 7 }]);
+    expect(model.getters.isRowFiltered(sheetId, 6)).toEqual(true);
+    expect(model.getters.isRowFiltered(sheetId, 7)).toEqual(true);
   });
 });

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -9,9 +9,11 @@ import { DEFAULT_LOCALES } from "../../src/types/locale";
 import {
   copy,
   createFilter,
+  foldHeaderGroup,
   freezeColumns,
   freezeRows,
   groupColumns,
+  groupHeaders,
   groupRows,
   hideColumns,
   hideRows,
@@ -310,6 +312,17 @@ describe("Menu Item actions", () => {
       selectRow(model, 4, "newAnchor");
       selectRow(model, lastRow, "updateAnchor");
 
+      expect(getNode(path).isVisible(env)).toBeFalsy();
+    });
+
+    test("Delete row option unavailable when selecting all rows with folded row grouping", () => {
+      const lastRow = model.getters.getNumberRows(sheetId) - 1;
+
+      groupHeaders(model, "ROW", 0, 2, sheetId);
+      foldHeaderGroup(model, "ROW", 0, 2, sheetId);
+
+      selectRow(model, 3, "newAnchor");
+      selectRow(model, lastRow, "updateAnchor");
       expect(getNode(path).isVisible(env)).toBeFalsy();
     });
   });
@@ -1419,6 +1432,17 @@ describe("Menu Item actions", () => {
         elements: Array.from(Array(model.getters.getNumberRows(sheetId)).keys()),
         dimension: "ROW",
       });
+    });
+
+    test("Hide row option unavailable when selecting all rows with folded row grouping", () => {
+      const lastRow = model.getters.getNumberRows(sheetId) - 1;
+
+      groupHeaders(model, "ROW", 0, 2, sheetId);
+      foldHeaderGroup(model, "ROW", 0, 2, sheetId);
+
+      selectRow(model, 3, "newAnchor");
+      selectRow(model, lastRow, "updateAnchor");
+      expect(getNode(hidePath, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });
 
     describe("Filters", () => {


### PR DESCRIPTION
## Description:

This PR addresses two distinct issues, one related to the Filter Evaluation Plugin and the other to the Header Visibility Plugin. 

#### Commit 1:

Previously, when filtering and grouping rows in the sheet, folding a group resulted in hiding all rows on the sheet, which was not the intended behavior. 

This PR addresses this issue by disabling the data filter when folding a group to prevent the unintended hiding of all rows.

#### Commit 2:

In the past, the Header Visibility Plugin had a problem where certain options like 'Hide rows' and 'Delete rows' were accessible in the context menu even when some rows were folded and tries to hide all other rows. This could disrupt the functionality of the sheet. 

To fix this issue, Include folded rows within the getter used by menu registries, ensuring that the "Hide" and "Delete" options are correctly hidden when necessary.

Task: : [3560662](https://www.odoo.com/web#id=3560662&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo