### PR TITLE
[FIX] evaluation: fix incorrect invalidation

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -186,9 +186,6 @@ export class Evaluator {
   }
 
   private setEvaluatedCell(positionId: PositionId, evaluatedCell: EvaluatedCell) {
-    if (this.nextPositionsToUpdate.has(positionId)) {
-      this.nextPositionsToUpdate.delete(positionId);
-    }
     this.evaluatedCells.set(positionId, evaluatedCell);
   }
 

--- a/tests/plugins/evaluation_formula_array.test.ts
+++ b/tests/plugins/evaluation_formula_array.test.ts
@@ -653,8 +653,8 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "C1", "=MFILL(2,1,B1+1)");
       expect(getEvaluatedCell(model, "A1").value).toBe(31);
       expect(getEvaluatedCell(model, "B1").value).toBe(31);
-      expect(getEvaluatedCell(model, "C1").value).toBe(30);
-      expect(getEvaluatedCell(model, "D1").value).toBe(30);
+      expect(getEvaluatedCell(model, "C1").value).toBe(32);
+      expect(getEvaluatedCell(model, "D1").value).toBe(32);
     });
 
     test("have collision when spread size zone change", () => {
@@ -675,6 +675,26 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "B3").value).toBe(42);
 
       expect(getEvaluatedCell(model, "A3").value).toBe("#ERROR");
+    });
+
+    test("recompute cell depending on spread values computed in between", () => {
+      const model = new Model({
+        sheets: [
+          {
+            name: "sheet1",
+            cells: { A1: { content: "=sheet2!A4" } },
+          },
+          {
+            name: "sheet2",
+            cells: {
+              A1: { content: "=MFILL(1,3,42)" },
+              A4: { content: "=MEDIAN(A2:A3)" }, // depends only on spread values (not on sheet2!A1)
+            },
+          },
+        ],
+      });
+      // initially, cells are evaluated in this order: [sheet1!A1, sheet2!A1, sheet2!A4]
+      expect(getEvaluatedCell(model, "A1").value).toBe(42);
     });
   });
 


### PR DESCRIPTION
## Description:

Steps to reproduce: look at the test.

Here is what happens:
- initially, all cells are being evaluated, in this order: [sheet1!A1, sheet2!A1, sheet2!A4]

1) When sheet!A1 is evaluated, it evaluates its dependency sheet2!A4. MEDIAN(A2:A3) function results with an error because A2:A3 is empty (the array formula MFILL is not spread yet)

2) Then sheet2!A1 is evaluated, which marks sheet2!A4 as to be re-evaluated at the next iteration because it depends on A2:A3 which was just filled with values.

3) The third cell in the list, sheet2!A4, is computed. But it's been already been computed at the first step (the result is an error). Nothing wrong at this point.
The issue comes when we store the value in `setEvaluatedCell`: we remove the cell from `setEvaluatedCell`! It means it will never be recomputed at the next iteration.

With this commit, because we no longer remove cells from the next iteration, the maximum iteration number is increased by one.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo