### PR TITLE
[FIX] text_helper: strikethrough wrong positioning

### DIFF
--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -249,14 +249,14 @@ export function drawDecoratedText(
   switch (context.textBaseline) {
     case "top":
       underlineY += boxHeight - 2 * strokeWidth;
-      strikeY += boxHeight - textHeight;
+      strikeY += boxHeight / 2 - strokeWidth;
       break;
     case "middle":
       underlineY += boxHeight / 2 - strokeWidth;
       break;
     case "alphabetic":
       underlineY += 2 * strokeWidth;
-      strikeY -= textHeight / 2 - strokeWidth / 2;
+      strikeY -= 3 * strokeWidth;
       break;
     case "bottom":
       underlineY = y;


### PR DESCRIPTION
## Description:

Previously, there was an issue with the rendering of strikethrough in the master version, which was caused by a computation error.
However, this issue has now been resolved by fixing the computation for strikethrough.

Task: : [3577044](https://www.odoo.com/web#id=3577044&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo