### PR TITLE
[FIX] clipboard: traceback on paste from copy after deleting that sheet

### DIFF
--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -134,6 +134,9 @@ export class DataValidationPlugin
   }
 
   getValidationRuleForCell({ sheetId, col, row }: CellPosition): DataValidationRule | undefined {
+    if (!this.rules[sheetId]) {
+      return undefined;
+    }
     for (const rule of this.rules[sheetId]) {
       for (const range of rule.ranges) {
         if (isInside(col, row, range.zone)) {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -240,6 +240,23 @@ describe("clipboard", () => {
     expect(getCell(model, "A2", sheet2Id)).toBe(undefined);
   });
 
+  test("can paste even if sheet containing copy zone has been deleted", () => {
+    const model = new Model();
+    const sheet1Id = model.getters.getActiveSheetId();
+    const sheet2Id = "sheet2";
+    createSheet(model, { sheetId: sheet2Id });
+
+    setCellContent(model, "A1", "Apple", sheet1Id);
+    setStyle(model, "A1", { bold: true });
+    copy(model, "A1");
+
+    activateSheet(model, sheet2Id);
+    deleteSheet(model, sheet1Id);
+    paste(model, "A2");
+    expect(getCellContent(model, "A2", sheet2Id)).toBe("Apple");
+    expect(getCell(model, "A2", sheet2Id)!.style).toEqual({ bold: true });
+  });
+
   test("can copy into a cell with style", () => {
     const model = new Model();
     // set value and style in B2


### PR DESCRIPTION
## Description:
If the sheet containing copy zone was deleted before paste, it lead to a
traceback.

The issue occurred since the method `getValidationRuleForCell` tried to access
the sheet of copied clipboard content, which now did not exist.

**Additional multi-user manipulation issues:**
i. "CREATE_SHEET"
ii."DUPLICATE_SHEET"

 **_Steps to reproduce_** :-
- User 1 performs (i) or (ii)
- User 2 copies some cells from newly created sheet and moves to some other sheet.
- User 1 performs undo (effectively deleting newly created sheet)
- User 2 hits "paste" => traceback due to same aforementioned reason.

This PR fixes these issues by tweaking the method to return the data validation
rules only if the sheet containing copy zone exists, else return undefined.
(just like how conditional format rules work)

Task: : [3580276](https://www.odoo.com/web#id=3580276&menu_id=4720&cids=2&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo