### PR TITLE
[REM] sort,selection: remove duplicated code

### DIFF
--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -2,12 +2,14 @@ import { GRID_ICON_MARGIN, ICON_EDGE_LENGTH, PADDING_AUTORESIZE_HORIZONTAL } fro
 import {
   computeIconWidth,
   computeTextWidth,
+  isEqual,
   positions,
+  range,
   splitTextToWidth,
 } from "../../helpers/index";
 import { localizeFormula } from "../../helpers/locale";
-import { Command, CommandResult, LocalCommand, UID } from "../../types";
-import { CellPosition, HeaderIndex, Pixel, Style } from "../../types/misc";
+import { CellValueType, Command, CommandResult, LocalCommand, UID } from "../../types";
+import { CellPosition, HeaderIndex, Pixel, Style, Zone } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
 export class SheetUIPlugin extends UIPlugin {
@@ -17,6 +19,8 @@ export class SheetUIPlugin extends UIPlugin {
     "getTextWidth",
     "getCellText",
     "getCellMultiLineText",
+    "getContiguousZone",
+    "isCellEmpty",
   ] as const;
 
   private ctx = document.createElement("canvas").getContext("2d")!;
@@ -126,9 +130,55 @@ export class SheetUIPlugin extends UIPlugin {
     return isFilterHeader || hasListIcon;
   }
 
-  // ---------------------------------------------------------------------------
-  // Grid manipulation
-  // ---------------------------------------------------------------------------
+  /**
+   * Expands the given zone until bordered by empty cells or reached the sheet boundaries.
+   */
+  getContiguousZone(sheetId: UID, zoneToExpand: Zone): Zone {
+    /** Try to expand the zone by one col/row in any direction to include a new non-empty cell */
+    const expandZone = (zone: Zone): Zone => {
+      for (const col of range(zone.left, zone.right + 1)) {
+        if (!this.isCellEmpty({ sheetId, col, row: zone.top - 1 })) {
+          return { ...zone, top: zone.top - 1 };
+        }
+        if (!this.isCellEmpty({ sheetId, col, row: zone.bottom + 1 })) {
+          return { ...zone, bottom: zone.bottom + 1 };
+        }
+      }
+      for (const row of range(zone.top, zone.bottom + 1)) {
+        if (!this.isCellEmpty({ sheetId, col: zone.left - 1, row })) {
+          return { ...zone, left: zone.left - 1 };
+        }
+        if (!this.isCellEmpty({ sheetId, col: zone.right + 1, row })) {
+          return { ...zone, right: zone.right + 1 };
+        }
+      }
+      return zone;
+    };
+
+    let hasExpanded = false;
+    let zone = zoneToExpand;
+    do {
+      hasExpanded = false;
+      const newZone = expandZone(zone);
+      if (!isEqual(zone, newZone)) {
+        hasExpanded = true;
+        zone = newZone;
+        continue;
+      }
+    } while (hasExpanded);
+
+    return zone;
+  }
+
+  /**
+   * Check if a cell is empty. If the cell is part of a merge,
+   * check if the merge containing the cell is empty.
+   */
+  isCellEmpty(position: CellPosition): boolean {
+    const mainPosition = this.getters.getMainCellPosition(position);
+    const cell = this.getters.getEvaluatedCell(mainPosition);
+    return cell.type === CellValueType.empty;
+  }
 
   private getColMaxWidth(sheetId: UID, index: HeaderIndex): number {
     const cellsPositions = positions(this.getters.getColsZone(sheetId, index, index));


### PR DESCRIPTION
The code to expand a zone until there is only empty cells beside it was duplicated in both `sort.ts` and `selection_stream_processor.ts`.

This commit removes the duplicated code and uses the one in `selection_stream_processor.ts`. since it's simpler and shorter.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo