### PR TITLE
[IMP] evaluation: improve perfs of `getCorrespondingFormulaCell`

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -53,6 +53,10 @@ export const functionCache: { [key: string]: Omit<CompiledFormula, "dependencies
 
 export function compile(formula: string): CompiledFormula {
   const tokens = rangeTokenize(formula);
+  return compileTokens(tokens);
+}
+
+export function compileTokens(tokens: Token[]): CompiledFormula {
   const { dependencies, constantValues } = formulaArguments(tokens);
   const cacheKey = compilationCacheKey(tokens, dependencies, constantValues);
   if (!functionCache[cacheKey]) {

--- a/src/helpers/clipboard/clipboard_cells_state.ts
+++ b/src/helpers/clipboard/clipboard_cells_state.ts
@@ -403,8 +403,7 @@ export class ClipboardCellsState extends ClipboardCellsAbstractState {
           sheetId,
           col - origin.position.col,
           row - origin.position.row,
-          origin.cell.compiledFormula,
-          origin.cell.dependencies
+          origin.cell.compiledFormula
         );
       }
       this.dispatch("UPDATE_CELL", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,8 +111,14 @@ export const __info__ = {};
 export { Revision } from "./collaborative/revisions";
 export { Spreadsheet } from "./components/index";
 export { setDefaultSheetViewSize } from "./constants";
-export { compile, functionCache } from "./formulas/compiler";
-export { astToFormula, convertAstNodes, iterateAstNodes, parse } from "./formulas/parser";
+export { compile, compileTokens, functionCache } from "./formulas/compiler";
+export {
+  astToFormula,
+  convertAstNodes,
+  iterateAstNodes,
+  parse,
+  parseTokens,
+} from "./formulas/parser";
 export { tokenize } from "./formulas/tokenizer";
 export { AbstractChart } from "./helpers/figures/charts";
 export { findCellInNewZone } from "./helpers/zones";

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -1,4 +1,5 @@
-import { compile, isExportableToExcel } from "../../../formulas/index";
+import { compileTokens } from "../../../formulas/compiler";
+import { Token, compile, isExportableToExcel } from "../../../formulas/index";
 import { getItemId, positions, toXC } from "../../../helpers/index";
 import {
   CellPosition,
@@ -317,10 +318,9 @@ export class EvaluationPlugin extends UIPlugin {
   getCorrespondingFormulaCell(position: CellPosition): FormulaCell | undefined {
     const cell = this.getters.getCell(position);
 
-    if (cell && cell.content) {
-      if (cell.isFormula && !isBadExpression(cell.content)) {
-        return cell;
-      }
+    if (cell && cell.isFormula) {
+      return isBadExpression(cell.compiledFormula.tokens) ? undefined : cell;
+    } else if (cell && cell.content) {
       return undefined;
     }
 
@@ -345,9 +345,9 @@ export class EvaluationPlugin extends UIPlugin {
   }
 }
 
-function isBadExpression(formula: string): boolean {
+function isBadExpression(tokens: Token[]): boolean {
   try {
-    compile(formula);
+    compileTokens(tokens);
     return false;
   } catch (error) {
     return true;

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -242,7 +242,7 @@ export class Evaluator {
       return toXC(position.col, position.row);
     };
     const formulaReturn = cellData.compiledFormula.execute(
-      cellData.dependencies,
+      cellData.compiledFormula.dependencies,
       ...this.compilationParams
     );
 
@@ -386,7 +386,7 @@ export class Evaluator {
       return [];
     }
     const dependencies: PositionId[] = [];
-    for (const range of cell.dependencies) {
+    for (const range of cell.compiledFormula.dependencies) {
       if (range.invalidSheetName || range.invalidXc) {
         continue;
       }

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -130,10 +130,12 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
                         sheetId,
                         col - zone.left,
                         row - zone.top,
-                        compiledFormula,
-                        compiledFormula.dependencies.map((d) =>
-                          this.getters.getRangeFromSheetXC(sheetId, d)
-                        )
+                        {
+                          ...compiledFormula,
+                          dependencies: compiledFormula.dependencies.map((d) =>
+                            this.getters.getRangeFromSheetXC(sheetId, d)
+                          ),
+                        }
                       );
                     }
                     return value;

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -219,8 +219,12 @@ export class EvaluationDataValidationPlugin extends UIPlugin {
           sheetId,
           offset.col,
           offset.row,
-          formula,
-          formula.dependencies.map((d) => this.getters.getRangeFromSheetXC(sheetId, d))
+          {
+            ...formula,
+            dependencies: formula.dependencies.map((d) =>
+              this.getters.getRangeFromSheetXC(sheetId, d)
+            ),
+          }
         );
 
         const evaluated = this.getters.evaluateFormula(sheetId, translatedFormula);

--- a/src/plugins/ui_feature/sort.ts
+++ b/src/plugins/ui_feature/sort.ts
@@ -301,8 +301,7 @@ export class SortPlugin extends UIPlugin {
               sheetId,
               0,
               newRow - position.row,
-              cell.compiledFormula,
-              cell.dependencies
+              cell.compiledFormula
             );
           }
           newCellValues.style = cell.style;

--- a/src/registries/autofill_modifiers.ts
+++ b/src/registries/autofill_modifiers.ts
@@ -103,13 +103,7 @@ autofillModifiersRegistry
         return { cellData: {} };
       }
       const sheetId = data.sheetId;
-      const content = getters.getTranslatedCellFormula(
-        sheetId,
-        x,
-        y,
-        cell.compiledFormula,
-        cell.dependencies
-      );
+      const content = getters.getTranslatedCellFormula(sheetId, x, y, cell.compiledFormula);
       return {
         cellData: {
           border: data.border,

--- a/src/types/cells.ts
+++ b/src/types/cells.ts
@@ -1,7 +1,6 @@
 import { EvaluationError } from "./errors";
 import { Format, FormattedValue } from "./format";
-import { CompiledFormula, Link, Style, UID } from "./misc";
-import { Range } from "./range";
+import { Link, RangeCompiledFormula, Style, UID } from "./misc";
 
 interface CellAttributes {
   readonly id: UID;
@@ -19,8 +18,7 @@ export interface LiteralCell extends CellAttributes {
 
 export interface FormulaCell extends CellAttributes {
   readonly isFormula: true;
-  readonly compiledFormula: CompiledFormula;
-  readonly dependencies: Range[];
+  readonly compiledFormula: RangeCompiledFormula;
 }
 
 export type Cell = LiteralCell | FormulaCell;

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -176,6 +176,10 @@ export interface CompiledFormula {
   dependencies: string[];
 }
 
+export interface RangeCompiledFormula extends Omit<CompiledFormula, "dependencies"> {
+  dependencies: Range[];
+}
+
 export type Matrix<T = unknown> = T[][];
 export type ValueAndFormat = { value: CellValue; format?: Format };
 

--- a/tests/evaluation/formulas.test.ts
+++ b/tests/evaluation/formulas.test.ts
@@ -13,13 +13,7 @@ function moveFormula(model: Model, formula: string, offsetX: number, offsetY: nu
   const sheetId = model.getters.getActiveSheetId();
   setCellContent(model, "A1", formula);
   const cell = getCell(model, "A1") as FormulaCell;
-  return model.getters.getTranslatedCellFormula(
-    sheetId,
-    offsetX,
-    offsetY,
-    cell.compiledFormula,
-    cell.dependencies
-  );
+  return model.getters.getTranslatedCellFormula(sheetId, offsetX, offsetY, cell.compiledFormula);
 }
 
 describe("createAdaptedRanges", () => {


### PR DESCRIPTION
## [FIX] cell: update cell tokens and dependencies

Before this commit, when creating a new FormulaCell we compiled the
formula, and in the cell we stored the CompiledFormula, that contained
the tokens and the dependencies.

The problem was that the tokens were not updated when the formula
dependencies changed because of sheet manipulation. The cell's formula
dependencies wasn't updated either, and the dependencies info was
confusingly duplicated in `cell.compiledFormula.dependencies` (static
strings) and `cell.dependencies` (Ranges objects that we update).

This commit:
1) removes the `cell.dependencies` property, the dependencies are now
only stored in the CompiledFormula (as Ranges instead of strings)
2) replaces the raw `REFERENCE` tokens in the cell's formula by smarter
tokens that reference the range corresponding the the reference[1]. This
means that when a range is updated, the token content is updated too.

[1] we could also keep simple tokens, and update them/re-tokenize the
formulas on sheet manipulation, but this would be slower.

## [IMP] evaluation: improve perfs of `getCorrespondingFormulaCell`

The getter `getCorrespondingFormulaCell` was tokenizing the cell's content (via `compile`), which took a bit of time. But this is useless, as we already have the tokens in the formula cell.

Task: : [3584306](https://www.odoo.com/web#id=3584306&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo