### PR TITLE
[IMP] Menu: wait to close submenu

### DIFF
--- a/src/components/helpers/time_hooks.ts
+++ b/src/components/helpers/time_hooks.ts
@@ -1,8 +1,13 @@
-import { useEffect } from "@odoo/owl";
+import { onWillUnmount, useEffect } from "@odoo/owl";
 
 interface IntervalTimer {
   pause: () => void;
   resume: () => void;
+}
+
+interface Timeout {
+  clear: () => void;
+  schedule: (callback: () => void, delay: number) => void;
 }
 
 /**
@@ -28,5 +33,27 @@ export function useInterval(callback: () => void, delay: number): IntervalTimer 
         intervalId = setInterval(callback, delay);
       }
     },
+  };
+}
+
+/**
+ * Calls a callback function with a time delay
+ */
+export function useTimeOut(): Timeout {
+  let timeOutId: NodeJS.Timeout | undefined;
+  function clear() {
+    if (timeOutId !== undefined) {
+      clearTimeout(timeOutId);
+      timeOutId = undefined;
+    }
+  }
+  function schedule(callback: () => void, delay: number) {
+    clear();
+    timeOutId = setTimeout(callback, delay);
+  }
+  onWillUnmount(clear);
+  return {
+    clear,
+    schedule,
   };
 }

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -7,6 +7,7 @@
         t-on-scroll="onScroll"
         t-on-wheel.stop=""
         t-on-click.stop=""
+        t-on-mouseover="onMouseOverMainMenu"
         t-on-contextmenu.prevent="">
         <t t-foreach="menuItemsAndSeparators" t-as="menuItem" t-key="menuItem_index">
           <div t-if="menuItem === 'separator'" class="o-separator"/>
@@ -18,9 +19,10 @@
               t-att-data-name="menuItem.id"
               t-on-click="(ev) => this.onClickMenu(menuItem, ev)"
               t-on-mouseenter="(ev) => this.onMouseEnter(menuItem, ev)"
+              t-on-mouseover="(ev) => this.onMouseOver(menuItem, ev)"
               t-on-mouseleave="(ev) => this.onMouseLeave(menuItem)"
-              class="o-menu-item d-flex align-items-center"
-              t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem)}"
+              class="o-menu-item d-flex justify-content-between align-items-center"
+              t-att-class="{'disabled': !isMenuEnabled, 'o-menu-item-active': isActive(menuItem)}"
               t-att-style="getColor(menuItem)">
               <div class="d-flex w-100">
                 <div t-if="childrenHaveIcon" class="o-menu-item-icon align-middle">
@@ -56,8 +58,9 @@
         depth="props.depth + 1"
         maxHeight="props.maxHeight"
         onMenuClicked="props.onMenuClicked"
-        onClose="() => this.close()"
+        onClose.bind="close"
         menuId="props.menuId"
+        onMouseOver.bind="onMouseOverChildMenu"
       />
     </Popover>
   </t>

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -639,7 +639,7 @@ exports[`TopBar component can set cell format 1`] = `
       >
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_automatic"
           title="Automatic"
         >
@@ -673,7 +673,7 @@ exports[`TopBar component can set cell format 1`] = `
         </div>
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_plain_text"
           title="Plain text"
         >
@@ -700,7 +700,7 @@ exports[`TopBar component can set cell format 1`] = `
         
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_number"
           title="Number"
         >
@@ -728,7 +728,7 @@ exports[`TopBar component can set cell format 1`] = `
         </div>
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_percent"
           title="Percent"
         >
@@ -760,7 +760,7 @@ exports[`TopBar component can set cell format 1`] = `
         
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_currency"
           title="Currency"
         >
@@ -788,7 +788,7 @@ exports[`TopBar component can set cell format 1`] = `
         </div>
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_currency_rounded"
           title="Currency rounded"
         >
@@ -816,7 +816,7 @@ exports[`TopBar component can set cell format 1`] = `
         </div>
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_custom_currency"
           title="Custom currency"
         >
@@ -843,7 +843,7 @@ exports[`TopBar component can set cell format 1`] = `
         
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_date"
           title="Date"
         >
@@ -871,7 +871,7 @@ exports[`TopBar component can set cell format 1`] = `
         </div>
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_time"
           title="Time"
         >
@@ -899,7 +899,7 @@ exports[`TopBar component can set cell format 1`] = `
         </div>
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_date_time"
           title="Date time"
         >
@@ -927,7 +927,7 @@ exports[`TopBar component can set cell format 1`] = `
         </div>
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="format_number_duration"
           title="Duration"
         >
@@ -959,7 +959,7 @@ exports[`TopBar component can set cell format 1`] = `
         
         
         <div
-          class="o-menu-item d-flex align-items-center"
+          class="o-menu-item d-flex justify-content-between align-items-center"
           data-name="more_formats"
           title="More date formats"
         >

--- a/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
+++ b/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
@@ -6,7 +6,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
 >
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="Sum"
     title="Sum: 24"
   >
@@ -26,7 +26,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="Avg"
     title="Avg: 24"
   >
@@ -46,7 +46,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="Min"
     title="Min: 24"
   >
@@ -66,7 +66,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="Max"
     title="Max: 24"
   >
@@ -86,7 +86,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="Count"
     title="Count: 1"
   >
@@ -106,7 +106,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="Count Numbers"
     title="Count Numbers: 1"
   >

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
 >
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="cut"
     title="Cut"
   >
@@ -44,7 +44,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="copy"
     title="Copy"
   >
@@ -82,7 +82,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="paste"
     title="Paste"
   >
@@ -120,7 +120,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center o-menu-root"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="paste_special"
     title="Paste special"
   >
@@ -177,7 +177,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="add_row_before"
     title="Insert row"
   >
@@ -210,7 +210,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="add_column_before"
     title="Insert column"
   >
@@ -243,7 +243,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center o-menu-root"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="insert_cell"
     title="Insert cells"
   >
@@ -300,7 +300,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="delete_row"
     title="Delete row 8"
   >
@@ -333,7 +333,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="delete_column"
     title="Delete column C"
   >
@@ -366,7 +366,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   </div>
   
   <div
-    class="o-menu-item d-flex align-items-center o-menu-root"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="delete_cell"
     title="Delete cells"
   >
@@ -423,7 +423,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   
   
   <div
-    class="o-menu-item d-flex align-items-center"
+    class="o-menu-item d-flex justify-content-between align-items-center"
     data-name="insert_link"
     title="Insert link"
   >

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -4,7 +4,7 @@ import { MIN_DELAY, lettersToNumber, scrollDelay, toZone } from "../../src/helpe
 import { DOMCoordinates, Pixel } from "../../src/types";
 import { nextTick } from "./helpers";
 
-type DOMTarget = string | Element | Document | Window | null;
+export type DOMTarget = string | Element | Document | Window | null;
 
 export async function simulateClick(
   selector: DOMTarget,
@@ -38,7 +38,7 @@ export async function simulateClick(
   await nextTick();
 }
 
-function getTarget(target: DOMTarget): Element | Document | Window {
+export function getTarget(target: DOMTarget): Element | Document | Window {
   if (target === null) {
     throw new Error("Target is null");
   }


### PR DESCRIPTION
## Task Description

When overing an item in a menu, we open the corresponding submenu (if present). Sometimes, when going "too fast" to go from the item to its submenu, we mistakingly over another item in the same parent menu, closing then the submenu. This task aims to add a delay to close a submenu and open another submenu, in the same way as Google Sheet.

## Related Task
Task: [2930428](https://www.odoo.com/web#id=2930428&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo