### PR TITLE
[FIX] find_and_replace: take array formula result into account

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -147,6 +147,7 @@ export class EvaluationPlugin extends UIPlugin {
     "getEvaluatedCell",
     "getEvaluatedCells",
     "getEvaluatedCellsInZone",
+    "getSpreadPositionsOf",
   ] as const;
 
   private shouldRebuildDependenciesGraph = true;
@@ -269,6 +270,10 @@ export class EvaluationPlugin extends UIPlugin {
     return positions(zone).map(({ col, row }) =>
       this.getters.getEvaluatedCell({ sheetId, col, row })
     );
+  }
+
+  getSpreadPositionsOf(position: CellPosition): CellPosition[] {
+    return this.evaluator.getSpreadPositionsOf(position);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -54,6 +54,16 @@ export class Evaluator {
     );
   }
 
+  getSpreadPositionsOf(position: CellPosition): CellPosition[] {
+    const positionId = this.encodePosition(position);
+    if (!this.spreadingRelations.isArrayFormula(positionId)) {
+      return [];
+    }
+    return Array.from(this.spreadingRelations.getArrayResultPositionIds(positionId)).map(
+      this.decodePosition.bind(this)
+    );
+  }
+
   getArrayFormulaSpreadingOn(position: CellPosition): CellPosition | undefined {
     const positionId = this.encodePosition(position);
     const formulaPosition = this.getArrayFormulaSpreadingOnId(positionId);


### PR DESCRIPTION
## Task Description
Currently, in the find and replace results, we only look for matches in the cell directly, ignoring the values spread by an array formula. This PR aims to fix it, taking these values into account in the search, but also avoiding to replace them in a "FIND_AND_REPLACE_ALL" cycle, as writing a new value in these cells would avoid the array formula to spread.

## Related Task
- Task: [3413999](https://www.odoo.com/web#id=3413999&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
- Retarget of https://github.com/odoo/o-spreadsheet/pull/3007/ to 17.0

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo