### PR TITLE
[FIX] F&R: Fix css rule 

### DIFF
--- a/src/components/side_panel/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace.ts
@@ -101,7 +101,7 @@ const CSS = css/* scss */ `
       }
       .o-input-count {
         width: fit-content;
-        padding: 4 0 4 4;
+        padding: 4px 0 4px 4px;
       }
     }
   }


### PR DESCRIPTION
The padding rule did not respect the web standards. It just happened to
work on our demo sheet because the page is run in quirks mode, a
mode that support web pages prior to the instoduction of the web
standards. This rule probably never worked when the component was
embedded in a "modern" web page.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo