### PR TITLE
Master highlight add command adrm

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -61,6 +61,8 @@ export interface ActionSpec {
    */
   separator?: boolean;
   textColor?: Color;
+  onStartHover?: (env: SpreadsheetChildEnv) => void;
+  onStopHover?: (env: SpreadsheetChildEnv) => void;
 }
 
 export interface Action {
@@ -78,6 +80,8 @@ export interface Action {
   children: (env: SpreadsheetChildEnv) => Action[];
   separator: boolean;
   textColor?: Color;
+  onStartHover?: (env: SpreadsheetChildEnv) => void;
+  onStopHover?: (env: SpreadsheetChildEnv) => void;
 }
 
 export type ActionBuilder = (env: SpreadsheetChildEnv) => ActionSpec[];
@@ -117,5 +121,7 @@ export function createAction(item: ActionSpec): Action {
     description: typeof description === "function" ? description : () => description || "",
     textColor: item.textColor,
     sequence: item.sequence || 0,
+    onStartHover: item.onStartHover,
+    onStopHover: item.onStopHover,
   };
 }

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -60,7 +60,8 @@
         <Autofill position="getAutofillPosition()" isVisible="isAutofillVisible"/>
       </t>
       <t t-foreach="env.model.getters.getHighlights()" t-as="highlight" t-key="highlight_index">
-        <t t-if="highlight.sheetId === env.model.getters.getActiveSheetId()">
+        <t
+          t-if="highlight.sheetId === env.model.getters.getActiveSheetId() and highlight.interactive">
           <Highlight zone="highlight.zone" color="highlight.color"/>
         </t>
       </t>

--- a/src/components/helpers/highlight_hook.ts
+++ b/src/components/helpers/highlight_hook.ts
@@ -1,0 +1,29 @@
+import { Component, onMounted, onWillUnmount, useComponent, useEffect } from "@odoo/owl";
+import { highlightRegistry } from "../../registries/highlight_registry";
+import { Highlight, Ref, SpreadsheetChildEnv } from "../../types";
+import { useHoveredElement } from "./listener_hook";
+
+export function useHighlightsOnHover(ref: Ref<HTMLElement>, getHighlights: () => Highlight[]) {
+  const hoverState = useHoveredElement(ref);
+  const component = useComponent() as Component<any, SpreadsheetChildEnv>;
+
+  const triggerRender = () => {
+    component.env.model.dispatch("RENDER_CANVAS");
+  };
+
+  useHighlights(() => (hoverState.hovered ? getHighlights() : []));
+  useEffect(triggerRender, () => [hoverState.hovered]);
+}
+
+export function useHighlights(getHighlights: () => Highlight[]) {
+  const component = useComponent() as Component<any, SpreadsheetChildEnv>;
+  const id = component.env.model.uuidGenerator.uuidv4();
+  onMounted(() => {
+    highlightRegistry.add(id, getHighlights);
+    component.env.model.dispatch("RENDER_CANVAS");
+  });
+  onWillUnmount(() => {
+    highlightRegistry.remove(id);
+    component.env.model.dispatch("RENDER_CANVAS");
+  });
+}

--- a/src/components/helpers/listener_hook.ts
+++ b/src/components/helpers/listener_hook.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "@odoo/owl";
+import { useEffect, useState } from "@odoo/owl";
 import { Ref } from "../../types";
 
 /**
@@ -20,4 +20,11 @@ export function useRefListener(
     },
     () => [ref.el]
   );
+}
+
+export function useHoveredElement(ref: Ref<HTMLElement>) {
+  const state = useState({ hovered: false });
+  useRefListener(ref, "mouseenter", () => (state.hovered = true));
+  useRefListener(ref, "mouseleave", () => (state.hovered = false));
+  return state;
 }

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -1,4 +1,11 @@
-import { Component, onWillUpdateProps, useExternalListener, useRef, useState } from "@odoo/owl";
+import {
+  Component,
+  onWillUnmount,
+  onWillUpdateProps,
+  useExternalListener,
+  useRef,
+  useState,
+} from "@odoo/owl";
 import { Action } from "../../actions/action";
 import {
   BG_HOVER_COLOR,
@@ -101,6 +108,8 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     menuItems: [],
   });
   private menuRef = useRef("menu");
+  private hoveredMenu: Action | undefined = undefined;
+
   private position: DOMCoordinates = useAbsoluteBoundingRect(this.menuRef);
 
   setup() {
@@ -110,6 +119,9 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
       if (nextProps.menuItems !== this.props.menuItems) {
         this.closeSubMenu();
       }
+    });
+    onWillUnmount(() => {
+      this.hoveredMenu?.onStopHover?.(this.env);
     });
   }
 
@@ -222,7 +234,7 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
    * If the given menu is not disabled, open it's submenu at the
    * correct position according to available surrounding space.
    */
-  openSubMenu(menu: Action, menuIndex: number, ev: MouseEvent) {
+  openSubMenu(menu: Action, ev: MouseEvent) {
     const parentMenuEl = ev.currentTarget as HTMLElement;
     if (!parentMenuEl) return;
     const y = parentMenuEl.getBoundingClientRect().top;
@@ -245,24 +257,31 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     this.subMenu.parentMenu = undefined;
   }
 
-  onClickMenu(menu: Action, menuIndex: number, ev: MouseEvent) {
+  onClickMenu(menu: Action, ev: MouseEvent) {
     if (this.isEnabled(menu)) {
       if (this.isRoot(menu)) {
-        this.openSubMenu(menu, menuIndex, ev);
+        this.openSubMenu(menu, ev);
       } else {
         this.activateMenu(menu);
       }
     }
   }
 
-  onMouseOver(menu: Action, position: Pixel, ev: MouseEvent) {
+  onMouseEnter(menu: Action, ev: MouseEvent) {
+    this.hoveredMenu = menu;
+    menu.onStartHover?.(this.env);
     if (this.isEnabled(menu)) {
       if (this.isRoot(menu)) {
-        this.openSubMenu(menu, position, ev);
+        this.openSubMenu(menu, ev);
       } else {
         this.closeSubMenu();
       }
     }
+  }
+
+  onMouseLeave(menu: Action) {
+    this.hoveredMenu = undefined;
+    menu.onStopHover?.(this.env);
   }
 }
 

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -16,8 +16,9 @@
             <div
               t-att-title="getName(menuItem)"
               t-att-data-name="menuItem.id"
-              t-on-click="(ev) => this.onClickMenu(menuItem, menuItem_index, ev)"
-              t-on-mouseover="(ev) => this.onMouseOver(menuItem, menuItem_index, ev)"
+              t-on-click="(ev) => this.onClickMenu(menuItem, ev)"
+              t-on-mouseenter="(ev) => this.onMouseEnter(menuItem, ev)"
+              t-on-mouseleave="(ev) => this.onMouseLeave(menuItem)"
               class="o-menu-item d-flex align-items-center"
               t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem)}"
               t-att-style="getColor(menuItem)">

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
@@ -1,0 +1,134 @@
+import { Component } from "@odoo/owl";
+import { colorNumberString } from "../../../../helpers";
+import { _t } from "../../../../translation";
+import { ConditionalFormat, SpreadsheetChildEnv } from "../../../../types";
+import { cellStyleToCss, css, cssPropertiesToCss } from "../../../helpers";
+import { ICONS } from "../../../icons/icons";
+import { CellIsOperators, CfTerms } from "../../../translations_terms";
+
+css/* scss */ `
+  .o-cf-preview {
+    &.o-cf-cursor-ptr {
+      cursor: pointer;
+    }
+
+    border-bottom: 1px solid #ccc;
+    height: 60px;
+    padding: 10px;
+    position: relative;
+    cursor: pointer;
+    &:hover,
+    &.o-cf-dragging {
+      background-color: #ebebeb;
+    }
+
+    &:not(:hover) .o-cf-delete-button {
+      display: none;
+    }
+    .o-cf-preview-icon {
+      border: 1px solid lightgrey;
+      position: absolute;
+      height: 50px;
+      width: 50px;
+    }
+    .o-cf-preview-description {
+      left: 65px;
+      margin-bottom: auto;
+      margin-right: 8px;
+      margin-top: auto;
+      position: relative;
+      width: 142px;
+      .o-cf-preview-description-rule {
+        margin-bottom: 4px;
+        font-weight: 600;
+        color: #303030;
+        max-height: 2.8em;
+        line-height: 1.4em;
+      }
+      .o-cf-preview-range {
+        font-size: 12px;
+      }
+    }
+    .o-cf-delete {
+      left: 90%;
+      top: 39%;
+      position: absolute;
+    }
+    &:not(:hover):not(.o-cf-dragging) .o-cf-drag-handle {
+      display: none !important;
+    }
+    .o-cf-drag-handle {
+      left: -8px;
+      cursor: move;
+      .o-icon {
+        width: 6px;
+        height: 30px;
+      }
+    }
+  }
+`;
+interface Props {
+  conditionalFormat: ConditionalFormat;
+  onPreviewClick: () => void;
+  onMouseDown: (ev: MouseEvent) => void;
+  class: string;
+}
+
+export class ConditionalFormatPreview extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-ConditionalFormatPreview";
+
+  icons = ICONS;
+
+  getPreviewImageStyle(): string {
+    const rule = this.props.conditionalFormat.rule;
+    if (rule.type === "CellIsRule") {
+      return cssPropertiesToCss(cellStyleToCss(rule.style));
+    } else if (rule.type === "ColorScaleRule") {
+      const minColor = colorNumberString(rule.minimum.color);
+      const midColor = rule.midpoint ? colorNumberString(rule.midpoint.color) : null;
+      const maxColor = colorNumberString(rule.maximum.color);
+      const baseString = "background-image: linear-gradient(to right, ";
+      return midColor
+        ? baseString + minColor + ", " + midColor + ", " + maxColor + ")"
+        : baseString + minColor + ", " + maxColor + ")";
+    }
+    return "";
+  }
+
+  getDescription(): string {
+    const cf = this.props.conditionalFormat;
+    switch (cf.rule.type) {
+      case "CellIsRule":
+        const description = CellIsOperators[cf.rule.operator];
+        if (cf.rule.values.length === 1) {
+          return `${description} ${cf.rule.values[0]}`;
+        }
+        if (cf.rule.values.length === 2) {
+          return _t("%s %s and %s", description, cf.rule.values[0], cf.rule.values[1]);
+        }
+        return description;
+      case "ColorScaleRule":
+        return CfTerms.ColorScale;
+      case "IconSetRule":
+        return CfTerms.IconSet;
+    }
+  }
+
+  deleteConditionalFormat() {
+    this.env.model.dispatch("REMOVE_CONDITIONAL_FORMAT", {
+      id: this.props.conditionalFormat.id,
+      sheetId: this.env.model.getters.getActiveSheetId(),
+    });
+  }
+
+  onMouseDown(event: MouseEvent) {
+    this.props.onMouseDown(event);
+  }
+}
+
+ConditionalFormatPreview.props = {
+  conditionalFormat: Object,
+  onPreviewClick: Function,
+  onMouseDown: Function,
+  class: String,
+};

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
@@ -1,8 +1,10 @@
-import { Component } from "@odoo/owl";
+import { Component, useRef } from "@odoo/owl";
+import { HIGHLIGHT_COLOR } from "../../../../constants";
 import { colorNumberString } from "../../../../helpers";
 import { _t } from "../../../../translation";
-import { ConditionalFormat, SpreadsheetChildEnv } from "../../../../types";
+import { ConditionalFormat, Highlight, SpreadsheetChildEnv } from "../../../../types";
 import { cellStyleToCss, css, cssPropertiesToCss } from "../../../helpers";
+import { useHighlightsOnHover } from "../../../helpers/highlight_hook";
 import { ICONS } from "../../../icons/icons";
 import { CellIsOperators, CfTerms } from "../../../translations_terms";
 
@@ -79,6 +81,12 @@ export class ConditionalFormatPreview extends Component<Props, SpreadsheetChildE
 
   icons = ICONS;
 
+  private ref = useRef("cfPreview");
+
+  setup() {
+    useHighlightsOnHover(this.ref, this.getHighlights.bind(this));
+  }
+
   getPreviewImageStyle(): string {
     const rule = this.props.conditionalFormat.rule;
     if (rule.type === "CellIsRule") {
@@ -123,6 +131,16 @@ export class ConditionalFormatPreview extends Component<Props, SpreadsheetChildE
 
   onMouseDown(event: MouseEvent) {
     this.props.onMouseDown(event);
+  }
+
+  private getHighlights(): Highlight[] {
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    return this.props.conditionalFormat.ranges.map((range) => ({
+      sheetId,
+      zone: this.env.model.getters.getRangeFromSheetXC(sheetId, range).zone,
+      color: HIGHLIGHT_COLOR,
+      noFill: true,
+    }));
   }
 }
 

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
@@ -3,6 +3,7 @@
     <t t-set="cf" t-value="props.conditionalFormat"/>
     <div
       class="o-cf-preview w-100"
+      t-ref="cfPreview"
       t-att-class="props.class"
       t-att-data-id="cf.id"
       t-on-click="props.onPreviewClick"

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
@@ -1,0 +1,47 @@
+<templates>
+  <t t-name="o-spreadsheet-ConditionalFormatPreview">
+    <t t-set="cf" t-value="props.conditionalFormat"/>
+    <div
+      class="o-cf-preview w-100"
+      t-att-class="props.class"
+      t-att-data-id="cf.id"
+      t-on-click="props.onPreviewClick"
+      t-on-mousedown="(ev) => this.onMouseDown(ev)">
+      <div class="position-relative h-100 w-100 d-flex align-items-center">
+        <div class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted">
+          <t t-call="o-spreadsheet-Icon.THIN_DRAG_HANDLE"/>
+        </div>
+        <t t-if="cf.rule.type==='IconSetRule'">
+          <div class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2">
+            <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.upper].template}}"/>
+            <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.middle].template}}"/>
+            <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.lower].template}}"/>
+          </div>
+        </t>
+        <t t-else="">
+          <div
+            t-att-style="getPreviewImageStyle(cf.rule)"
+            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2">
+            123
+          </div>
+        </t>
+        <div class="o-cf-preview-description">
+          <div class="o-cf-preview-ruletype">
+            <div class="o-cf-preview-description-rule text-truncate">
+              <t t-esc="getDescription(cf)"/>
+            </div>
+          </div>
+          <div class="o-cf-preview-range text-truncate" t-esc="cf.ranges"/>
+        </div>
+        <div class="o-cf-delete">
+          <div
+            class="o-cf-delete-button text-muted"
+            t-on-click.stop="(ev) => this.deleteConditionalFormat(cf, ev)"
+            title="Remove rule">
+            <t t-call="o-spreadsheet-Icon.TRASH"/>
+          </div>
+        </div>
+      </div>
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
@@ -1,82 +1,11 @@
 import { Component, onWillUpdateProps, useRef } from "@odoo/owl";
-import { colorNumberString, deepEquals } from "../../../../helpers";
-import { _t } from "../../../../translation";
-import {
-  ColorScaleRule,
-  ConditionalFormat,
-  SingleColorRules,
-  SpreadsheetChildEnv,
-  UID,
-} from "../../../../types";
-import { cellStyleToCss, css, cssPropertiesToCss } from "../../../helpers";
+import { deepEquals } from "../../../../helpers";
+import { ConditionalFormat, SpreadsheetChildEnv, UID } from "../../../../types";
 import { getBoundingRectAsPOJO } from "../../../helpers/dom_helpers";
 import { useDragAndDropListItems } from "../../../helpers/drag_and_drop_hook";
 import { ICONS } from "../../../icons/icons";
-import { CellIsOperators, CfTerms } from "../../../translations_terms";
+import { ConditionalFormatPreview } from "../cf_preview/cf_preview";
 
-css/* scss */ `
-  .o-cf-preview-list {
-    .o-cf-preview {
-      &.o-cf-cursor-ptr {
-        cursor: pointer;
-      }
-
-      border-bottom: 1px solid #ccc;
-      height: 60px;
-      padding: 10px;
-      position: relative;
-      cursor: pointer;
-      &:hover,
-      &.o-cf-dragging {
-        background-color: #ebebeb;
-      }
-
-      &:not(:hover) .o-cf-delete-button {
-        display: none;
-      }
-      .o-cf-preview-icon {
-        border: 1px solid lightgrey;
-        position: absolute;
-        height: 50px;
-        width: 50px;
-      }
-      .o-cf-preview-description {
-        left: 65px;
-        margin-bottom: auto;
-        margin-right: 8px;
-        margin-top: auto;
-        position: relative;
-        width: 142px;
-        .o-cf-preview-description-rule {
-          margin-bottom: 4px;
-          font-weight: 600;
-          color: #303030;
-          max-height: 2.8em;
-          line-height: 1.4em;
-        }
-        .o-cf-preview-range {
-          font-size: 12px;
-        }
-      }
-      .o-cf-delete {
-        left: 90%;
-        top: 39%;
-        position: absolute;
-      }
-      &:not(:hover):not(.o-cf-dragging) .o-cf-drag-handle {
-        display: none !important;
-      }
-      .o-cf-drag-handle {
-        left: -8px;
-        cursor: move;
-        .o-icon {
-          width: 6px;
-          height: 30px;
-        }
-      }
-    }
-  }
-`;
 interface Props {
   conditionalFormats: ConditionalFormat[];
   onPreviewClick: (cf: ConditionalFormat) => void;
@@ -85,6 +14,7 @@ interface Props {
 
 export class ConditionalFormatPreviewList extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ConditionalFormatPreviewList";
+  static components = { ConditionalFormatPreview };
 
   icons = ICONS;
 
@@ -103,49 +33,8 @@ export class ConditionalFormatPreviewList extends Component<Props, SpreadsheetCh
     return this.dragAndDrop.itemsStyle[cf.id] || "";
   }
 
-  getPreviewImageStyle(rule: SingleColorRules | ColorScaleRule): string {
-    if (rule.type === "CellIsRule") {
-      return cssPropertiesToCss(cellStyleToCss(rule.style));
-    } else if (rule.type === "ColorScaleRule") {
-      const minColor = colorNumberString(rule.minimum.color);
-      const midColor = rule.midpoint ? colorNumberString(rule.midpoint.color) : null;
-      const maxColor = colorNumberString(rule.maximum.color);
-      const baseString = "background-image: linear-gradient(to right, ";
-      return midColor
-        ? baseString + minColor + ", " + midColor + ", " + maxColor + ")"
-        : baseString + minColor + ", " + maxColor + ")";
-    }
-    return "";
-  }
-
-  getDescription(cf: ConditionalFormat): string {
-    switch (cf.rule.type) {
-      case "CellIsRule":
-        const description = CellIsOperators[cf.rule.operator];
-        if (cf.rule.values.length === 1) {
-          return `${description} ${cf.rule.values[0]}`;
-        }
-        if (cf.rule.values.length === 2) {
-          return _t("%s %s and %s", description, cf.rule.values[0], cf.rule.values[1]);
-        }
-        return description;
-      case "ColorScaleRule":
-        return CfTerms.ColorScale;
-      case "IconSetRule":
-        return CfTerms.IconSet;
-    }
-  }
-
-  deleteConditionalFormat(cf: ConditionalFormat) {
-    this.env.model.dispatch("REMOVE_CONDITIONAL_FORMAT", {
-      id: cf.id,
-      sheetId: this.env.model.getters.getActiveSheetId(),
-    });
-  }
-
-  onMouseDown(cf: ConditionalFormat, event: MouseEvent) {
+  onPreviewMouseDown(cf: ConditionalFormat, event: MouseEvent) {
     if (event.button !== 0) return;
-
     const previewRects = Array.from(this.cfListRef.el!.children).map((previewEl) =>
       getBoundingRectAsPOJO(previewEl)
     );

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.xml
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.xml
@@ -2,58 +2,21 @@
   <t t-name="o-spreadsheet-ConditionalFormatPreviewList">
     <div class="o-cf-preview-list h-100 overflow-auto" t-ref="cfList">
       <t t-foreach="props.conditionalFormats" t-as="cf" t-key="cf.id">
-        <t t-call="o-spreadsheet-ConditionalFormattingPanelPreview"/>
+        <div
+          class="o-cf-preview-container d-flex position-relative"
+          t-att-style="getPreviewDivStyle(cf)">
+          <ConditionalFormatPreview
+            conditionalFormat="cf"
+            class="dragAndDrop.draggedItemId === cf.id ? 'o-cf-dragging' : ''"
+            onMouseDown="(ev) => this.onPreviewMouseDown(cf, ev)"
+            onPreviewClick="() => props.onPreviewClick(cf)"
+          />
+        </div>
       </t>
       <div
         class="btn btn-link o-sidePanel-btn-link o-cf-add float-end"
         t-on-click.prevent.stop="props.onAddConditionalFormat">
         + Add another rule
-      </div>
-    </div>
-  </t>
-
-  <t t-name="o-spreadsheet-ConditionalFormattingPanelPreview">
-    <div
-      class="o-cf-preview d-flex position-relative"
-      t-att-class="{ 'o-cf-dragging': dragAndDrop.draggedItemId === cf.id }"
-      t-att-style="getPreviewDivStyle(cf)"
-      t-att-data-id="cf.id"
-      t-on-click="(ev) => props.onPreviewClick(cf)"
-      t-on-mousedown="(ev) => this.onMouseDown(cf, ev)">
-      <div class="position-relative h-100 w-100 d-flex align-items-center">
-        <div class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted">
-          <t t-call="o-spreadsheet-Icon.THIN_DRAG_HANDLE"/>
-        </div>
-        <t t-if="cf.rule.type==='IconSetRule'">
-          <div class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2">
-            <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.upper].template}}"/>
-            <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.middle].template}}"/>
-            <t t-call="o-spreadsheet-Icon.{{icons[cf.rule.icons.lower].template}}"/>
-          </div>
-        </t>
-        <t t-else="">
-          <div
-            t-att-style="getPreviewImageStyle(cf.rule)"
-            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2">
-            123
-          </div>
-        </t>
-        <div class="o-cf-preview-description">
-          <div class="o-cf-preview-ruletype">
-            <div class="o-cf-preview-description-rule text-truncate">
-              <t t-esc="getDescription(cf)"/>
-            </div>
-          </div>
-          <div class="o-cf-preview-range text-truncate" t-esc="cf.ranges"/>
-        </div>
-        <div class="o-cf-delete">
-          <div
-            class="o-cf-delete-button text-muted"
-            t-on-click.stop="(ev) => this.deleteConditionalFormat(cf, ev)"
-            title="Remove rule">
-            <t t-call="o-spreadsheet-Icon.TRASH"/>
-          </div>
-        </div>
       </div>
     </div>
   </t>

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
@@ -1,8 +1,9 @@
-import { Component } from "@odoo/owl";
-import { FIGURE_BORDER_COLOR } from "../../../../constants";
+import { Component, useRef } from "@odoo/owl";
+import { FIGURE_BORDER_COLOR, HIGHLIGHT_COLOR } from "../../../../constants";
 import { dataValidationEvaluatorRegistry } from "../../../../registries/data_validation_registry";
-import { DataValidationRule, SpreadsheetChildEnv } from "../../../../types";
+import { DataValidationRule, Highlight, SpreadsheetChildEnv } from "../../../../types";
 import { css } from "../../../helpers";
+import { useHighlightsOnHover } from "../../../helpers/highlight_hook";
 
 css/* scss */ `
   .o-sidePanel {
@@ -38,9 +39,24 @@ interface Props {
 export class DataValidationPreview extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationPreview";
 
+  private ref = useRef("dvPreview");
+
+  setup() {
+    useHighlightsOnHover(this.ref, this.getHighlights.bind(this));
+  }
+
   deleteDataValidation() {
     const sheetId = this.env.model.getters.getActiveSheetId();
     this.env.model.dispatch("REMOVE_DATA_VALIDATION_RULE", { sheetId, id: this.props.rule.id });
+  }
+
+  private getHighlights(): Highlight[] {
+    return this.props.rule.ranges.map((range) => ({
+      sheetId: this.env.model.getters.getActiveSheetId(),
+      zone: range.zone,
+      color: HIGHLIGHT_COLOR,
+      noFill: true,
+    }));
   }
 
   get rangesString(): string {

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.xml
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-DataValidationPreview">
-    <div class="o-dv-preview p-3" t-on-click="props.onClick">
+    <div class="o-dv-preview p-3" t-on-click="props.onClick" t-ref="dvPreview">
       <div class="d-flex justify-content-between">
         <div class="o-dv-container d-flex flex-column">
           <div class="o-dv-preview-description fw-bold text-truncate" t-esc="descriptionString"/>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,7 @@ export const GRID_BORDER_COLOR = "#E2E3E3";
 export const FROZEN_PANE_HEADER_BORDER_COLOR = "#BCBCBC";
 export const FROZEN_PANE_BORDER_COLOR = "#DADFE8";
 export const COMPOSER_ASSISTANT_COLOR = "#9B359B";
+export const HIGHLIGHT_COLOR = "#FE019A";
 
 // Color picker defaults as upper case HEX to match `toHex`helper
 export const COLOR_PICKER_DEFAULTS: Color[] = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { ChartFigure } from "./components/figures/figure_chart/figure_chart";
 import { Grid } from "./components/grid/grid";
 import { GridOverlay } from "./components/grid_overlay/grid_overlay";
 import { useDragAndDropListItems } from "./components/helpers/drag_and_drop_hook";
+import { useHighlights, useHighlightsOnHover } from "./components/helpers/highlight_hook";
 import { Menu } from "./components/menu/menu";
 import { SelectionInput } from "./components/selection_input/selection_input";
 import {
@@ -28,6 +29,7 @@ import {
   DEFAULT_CELL_WIDTH,
   HEADER_HEIGHT,
   HEADER_WIDTH,
+  HIGHLIGHT_COLOR,
   MIN_COL_WIDTH,
   MIN_ROW_HEIGHT,
   SCROLLBAR_WIDTH,
@@ -46,6 +48,7 @@ import {
   colorToRGBA,
   computeTextWidth,
   createCurrencyFormat,
+  deepEquals,
   formatValue,
   isDefined,
   isMarkdownLink,
@@ -53,6 +56,7 @@ import {
   lettersToNumber,
   markdownLink,
   numberToLetters,
+  overlap,
   parseMarkdownLink,
   positionToZone,
   rgbaToHex,
@@ -60,6 +64,7 @@ import {
   toUnboundedZone,
   toXC,
   toZone,
+  union,
 } from "./helpers/index";
 import { openLink, urlRegistry, urlRepresentation } from "./helpers/links";
 import {
@@ -74,6 +79,7 @@ import {
   statefulUIPluginRegistry,
 } from "./plugins/index";
 import { clickableCellRegistry } from "./registries/cell_clickable_registry";
+import { highlightRegistry } from "./registries/highlight_registry";
 import {
   autofillModifiersRegistry,
   autofillRulesRegistry,
@@ -188,6 +194,7 @@ export const registries = {
   numberFormatMenuRegistry,
   repeatLocalCommandTransformRegistry,
   repeatCommandTransformRegistry,
+  highlightRegistry,
 };
 export const helpers = {
   arg,
@@ -223,6 +230,9 @@ export const helpers = {
   createAction,
   createActions,
   transformRangeData,
+  deepEquals,
+  overlap,
+  union,
 };
 
 export const links = {
@@ -255,6 +265,8 @@ export const components = {
 
 export const hooks = {
   useDragAndDropListItems,
+  useHighlights,
+  useHighlightsOnHover,
 };
 
 export function addFunction(functionName: string, functionDescription: AddFunctionDescription) {
@@ -267,4 +279,5 @@ export function addFunction(functionName: string, functionDescription: AddFuncti
 
 export const constants = {
   DEFAULT_LOCALE,
+  HIGHLIGHT_COLOR,
 };

--- a/src/plugins/ui_feature/highlight.ts
+++ b/src/plugins/ui_feature/highlight.ts
@@ -2,6 +2,7 @@ import { isEqual, zoneToDimension } from "../../helpers/index";
 import { highlightRegistry } from "../../registries/highlight_registry";
 import { GridRenderingContext, Highlight, LAYERS } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
+import { RendererPlugin } from "./renderer";
 
 /**
  * HighlightPlugin
@@ -55,10 +56,10 @@ export class HighlightPlugin extends UIPlugin {
 
   drawGrid(renderingContext: GridRenderingContext) {
     // rendering selection highlights
-    const { ctx, thinLineWidth } = renderingContext;
+    const { ctx } = renderingContext;
 
     const sheetId = this.getters.getActiveSheetId();
-    const lineWidth = 3 * thinLineWidth;
+    const lineWidth = 2;
     ctx.lineWidth = lineWidth;
     /**
      * We only need to draw the highlights of the current sheet.
@@ -77,11 +78,12 @@ export class HighlightPlugin extends UIPlugin {
       const { x, y, width, height } = this.getters.getVisibleRect(h.zone);
       if (width > 0 && height > 0) {
         ctx.strokeStyle = h.color!;
-        ctx.strokeRect(x + lineWidth / 2, y + lineWidth / 2, width - lineWidth, height - lineWidth);
+        /** + 0.5 offset to have sharp lines. See comment in {@link RendererPlugin#drawBorders} for more details */
+        ctx.strokeRect(x + 0.5, y + 0.5, width, height);
         ctx.globalCompositeOperation = "source-over";
         if (!h.noFill) {
           ctx.fillStyle = h.color! + "20";
-          ctx.fillRect(x + lineWidth, y + lineWidth, width - 2 * lineWidth, height - 2 * lineWidth);
+          ctx.fillRect(x, y, width, height);
         }
       }
     }

--- a/src/plugins/ui_feature/highlight.ts
+++ b/src/plugins/ui_feature/highlight.ts
@@ -1,4 +1,5 @@
 import { isEqual, zoneToDimension } from "../../helpers/index";
+import { highlightRegistry } from "../../registries/highlight_registry";
 import { GridRenderingContext, Highlight, LAYERS } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
 
@@ -15,7 +16,10 @@ export class HighlightPlugin extends UIPlugin {
 
   getHighlights(): Highlight[] {
     return this.prepareHighlights(
-      this.getters.getComposerHighlights().concat(this.getters.getSelectionInputHighlights())
+      highlightRegistry
+        .getAll()
+        .map((highlightGetter) => highlightGetter())
+        .flat()
     );
   }
 
@@ -75,8 +79,10 @@ export class HighlightPlugin extends UIPlugin {
         ctx.strokeStyle = h.color!;
         ctx.strokeRect(x + lineWidth / 2, y + lineWidth / 2, width - lineWidth, height - lineWidth);
         ctx.globalCompositeOperation = "source-over";
-        ctx.fillStyle = h.color! + "20";
-        ctx.fillRect(x + lineWidth, y + lineWidth, width - 2 * lineWidth, height - 2 * lineWidth);
+        if (!h.noFill) {
+          ctx.fillStyle = h.color! + "20";
+          ctx.fillRect(x + lineWidth, y + lineWidth, width - 2 * lineWidth, height - 2 * lineWidth);
+        }
       }
     }
   }

--- a/src/plugins/ui_feature/selection_input.ts
+++ b/src/plugins/ui_feature/selection_input.ts
@@ -274,6 +274,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
         zone: this.getters.getRangeFromSheetXC(this.inputSheetId, xc).zone,
         sheetId: (sheetName && this.getters.getSheetIdByName(sheetName)) || this.inputSheetId,
         color,
+        interactive: true,
       };
     });
   }

--- a/src/plugins/ui_feature/selection_inputs_manager.ts
+++ b/src/plugins/ui_feature/selection_inputs_manager.ts
@@ -1,4 +1,5 @@
 import { positionToZone, rangeReference, splitReference } from "../../helpers/index";
+import { highlightRegistry } from "../../registries/highlight_registry";
 import { Command, CommandResult, Highlight, LAYERS, LocalCommand, UID } from "../../types/index";
 import { UIPlugin, UIPluginConfig } from "../ui_plugin";
 import { RangeInputValue, SelectionInputPlugin } from "./selection_input";
@@ -12,12 +13,7 @@ import { RangeInputValue, SelectionInputPlugin } from "./selection_input";
  */
 export class SelectionInputsManagerPlugin extends UIPlugin {
   static layers = [LAYERS.Highlights];
-  static getters = [
-    "getSelectionInput",
-    "getSelectionInputValue",
-    "isRangeValid",
-    "getSelectionInputHighlights",
-  ] as const;
+  static getters = ["getSelectionInput", "getSelectionInputValue", "isRangeValid"] as const;
 
   private inputs: Record<UID, SelectionInputPlugin> = {};
   private focusedInputId: UID | null = null;
@@ -28,7 +24,9 @@ export class SelectionInputsManagerPlugin extends UIPlugin {
 
   constructor(private config: UIPluginConfig) {
     super(config);
+    highlightRegistry.add("selection_input", this.getSelectionInputHighlights.bind(this));
   }
+
   // ---------------------------------------------------------------------------
   // Command Handling
   // ---------------------------------------------------------------------------
@@ -142,7 +140,7 @@ export class SelectionInputsManagerPlugin extends UIPlugin {
     return this.inputs[id].getSelectionInputValue();
   }
 
-  getSelectionInputHighlights(): Highlight[] {
+  private getSelectionInputHighlights(): Highlight[] {
     if (!this.focusedInputId) {
       return [];
     }

--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -24,6 +24,7 @@ import {
   localizeFormula,
 } from "../../helpers/locale";
 import { loopThroughReferenceType } from "../../helpers/reference_type";
+import { highlightRegistry } from "../../registries/highlight_registry";
 import { _t } from "../../translation";
 import {
   AddColumnsRowsCommand,
@@ -46,7 +47,7 @@ import {
   Zone,
 } from "../../types";
 import { SelectionEvent } from "../../types/event_stream";
-import { UIPlugin } from "../ui_plugin";
+import { UIPlugin, UIPluginConfig } from "../ui_plugin";
 
 export type EditionMode =
   | "editing"
@@ -69,7 +70,6 @@ export class EditionPlugin extends UIPlugin {
     "getComposerSelection",
     "getCurrentTokens",
     "getTokenAtCursor",
-    "getComposerHighlights",
     "getCurrentEditedCell",
     "getCycledReference",
     "getAutoCompleteDataValidationValues",
@@ -85,6 +85,11 @@ export class EditionPlugin extends UIPlugin {
   private selectionEnd: number = 0;
   private initialContent: string | undefined = "";
   private colorIndexByRange: { [xc: string]: number } = {};
+
+  constructor(args: UIPluginConfig) {
+    super(args);
+    highlightRegistry.add("composer", this.getComposerHighlights.bind(this));
+  }
 
   // ---------------------------------------------------------------------------
   // Command Handling
@@ -710,7 +715,7 @@ export class EditionPlugin extends UIPlugin {
   /**
    * Highlight all ranges that can be found in the composer content.
    */
-  getComposerHighlights(): Highlight[] {
+  private getComposerHighlights(): Highlight[] {
     if (!this.currentContent.startsWith("=") || this.mode === "inactive") {
       return [];
     }
@@ -725,6 +730,7 @@ export class EditionPlugin extends UIPlugin {
         zone: range.zone,
         color: rangeColor(rangeString),
         sheetId: range.sheetId,
+        interactive: true,
       };
     });
   }

--- a/src/registries/highlight_registry.ts
+++ b/src/registries/highlight_registry.ts
@@ -1,0 +1,4 @@
+import { Highlight } from "../types";
+import { Registry } from "./registry";
+
+export const highlightRegistry = new Registry<() => Highlight[]>();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1008,6 +1008,10 @@ export interface SplitTextIntoColumnsCommand {
   force?: boolean;
 }
 
+export interface RenderCanvasCommand {
+  type: "RENDER_CANVAS";
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1159,7 +1163,8 @@ export type LocalCommand =
   | UpdateFilterCommand
   | SplitTextIntoColumnsCommand
   | RemoveDuplicatesCommand
-  | TrimWhitespaceCommand;
+  | TrimWhitespaceCommand
+  | RenderCanvasCommand;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -229,6 +229,8 @@ export interface Highlight {
   zone: Zone;
   sheetId: UID;
   color: Color | null;
+  interactive?: boolean;
+  noFill?: boolean;
 }
 
 export interface PaneDivision {

--- a/tests/__snapshots__/renderer_plugin.test.ts.snap
+++ b/tests/__snapshots__/renderer_plugin.test.ts.snap
@@ -1309,7 +1309,7 @@ exports[`renderer snapshot for a simple grid rendering 1`] = `
   "context.save()",
   "context.restore()",
   "context.save()",
-  "context.lineWidth=1.2000000000000002;",
+  "context.lineWidth=2;",
   "context.restore()",
   "context.save()",
   "context.restore()",

--- a/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
+++ b/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
@@ -11,169 +11,177 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
       class="o-cf-preview-list h-100 overflow-auto"
     >
       <div
-        class="o-cf-preview d-flex position-relative"
-        data-id="1"
+        class="o-cf-preview-container d-flex position-relative"
         style=""
       >
         <div
-          class="position-relative h-100 w-100 d-flex align-items-center"
+          class="o-cf-preview w-100"
+          data-id="1"
         >
           <div
-            class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted"
-          >
-            <svg
-              class="o-icon"
-              fill="currentColor"
-              viewBox="0 0 4 16"
-            >
-              <circle
-                cx="2"
-                cy="3.5"
-                r="1"
-              />
-              <circle
-                cx="2"
-                cy="6.5"
-                r="1"
-              />
-              <circle
-                cx="2"
-                cy="9.5"
-                r="1"
-              />
-              <circle
-                cx="2"
-                cy="12.5"
-                r="1"
-              />
-            </svg>
-          </div>
-          
-          <div
-            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2"
-            style="background:#FF0000;"
-          >
-             123 
-          </div>
-          
-          <div
-            class="o-cf-preview-description"
+            class="position-relative h-100 w-100 d-flex align-items-center"
           >
             <div
-              class="o-cf-preview-ruletype"
+              class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted"
+            >
+              <svg
+                class="o-icon"
+                fill="currentColor"
+                viewBox="0 0 4 16"
+              >
+                <circle
+                  cx="2"
+                  cy="3.5"
+                  r="1"
+                />
+                <circle
+                  cx="2"
+                  cy="6.5"
+                  r="1"
+                />
+                <circle
+                  cx="2"
+                  cy="9.5"
+                  r="1"
+                />
+                <circle
+                  cx="2"
+                  cy="12.5"
+                  r="1"
+                />
+              </svg>
+            </div>
+            
+            <div
+              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2"
+              style="background:#FF0000;"
+            >
+               123 
+            </div>
+            
+            <div
+              class="o-cf-preview-description"
             >
               <div
-                class="o-cf-preview-description-rule text-truncate"
+                class="o-cf-preview-ruletype"
               >
-                Is equal to 2
+                <div
+                  class="o-cf-preview-description-rule text-truncate"
+                >
+                  Is equal to 2
+                </div>
+              </div>
+              <div
+                class="o-cf-preview-range text-truncate"
+              >
+                A1:A2
               </div>
             </div>
             <div
-              class="o-cf-preview-range text-truncate"
+              class="o-cf-delete"
             >
-              A1:A2
-            </div>
-          </div>
-          <div
-            class="o-cf-delete"
-          >
-            <div
-              class="o-cf-delete-button text-muted"
-              title="Remove rule"
-            >
-              <svg
-                class="o-cf-icon trash"
-                viewBox="0 0 448 512"
+              <div
+                class="o-cf-delete-button text-muted"
+                title="Remove rule"
               >
-                <path
-                  d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
-                  fill="currentColor"
-                />
-              </svg>
+                <svg
+                  class="o-cf-icon trash"
+                  viewBox="0 0 448 512"
+                >
+                  <path
+                    d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
-        class="o-cf-preview d-flex position-relative"
-        data-id="2"
+        class="o-cf-preview-container d-flex position-relative"
         style=""
       >
         <div
-          class="position-relative h-100 w-100 d-flex align-items-center"
+          class="o-cf-preview w-100"
+          data-id="2"
         >
           <div
-            class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted"
-          >
-            <svg
-              class="o-icon"
-              fill="currentColor"
-              viewBox="0 0 4 16"
-            >
-              <circle
-                cx="2"
-                cy="3.5"
-                r="1"
-              />
-              <circle
-                cx="2"
-                cy="6.5"
-                r="1"
-              />
-              <circle
-                cx="2"
-                cy="9.5"
-                r="1"
-              />
-              <circle
-                cx="2"
-                cy="12.5"
-                r="1"
-              />
-            </svg>
-          </div>
-          
-          <div
-            class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2"
-            style="background-image: linear-gradient(to right, #FF00FF, #123456)"
-          >
-             123 
-          </div>
-          
-          <div
-            class="o-cf-preview-description"
+            class="position-relative h-100 w-100 d-flex align-items-center"
           >
             <div
-              class="o-cf-preview-ruletype"
+              class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted"
+            >
+              <svg
+                class="o-icon"
+                fill="currentColor"
+                viewBox="0 0 4 16"
+              >
+                <circle
+                  cx="2"
+                  cy="3.5"
+                  r="1"
+                />
+                <circle
+                  cx="2"
+                  cy="6.5"
+                  r="1"
+                />
+                <circle
+                  cx="2"
+                  cy="9.5"
+                  r="1"
+                />
+                <circle
+                  cx="2"
+                  cy="12.5"
+                  r="1"
+                />
+              </svg>
+            </div>
+            
+            <div
+              class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2"
+              style="background-image: linear-gradient(to right, #FF00FF, #123456)"
+            >
+               123 
+            </div>
+            
+            <div
+              class="o-cf-preview-description"
             >
               <div
-                class="o-cf-preview-description-rule text-truncate"
+                class="o-cf-preview-ruletype"
               >
-                Color scale
+                <div
+                  class="o-cf-preview-description-rule text-truncate"
+                >
+                  Color scale
+                </div>
+              </div>
+              <div
+                class="o-cf-preview-range text-truncate"
+              >
+                B1:B5
               </div>
             </div>
             <div
-              class="o-cf-preview-range text-truncate"
+              class="o-cf-delete"
             >
-              B1:B5
-            </div>
-          </div>
-          <div
-            class="o-cf-delete"
-          >
-            <div
-              class="o-cf-delete-button text-muted"
-              title="Remove rule"
-            >
-              <svg
-                class="o-cf-icon trash"
-                viewBox="0 0 448 512"
+              <div
+                class="o-cf-delete-button text-muted"
+                title="Remove rule"
               >
-                <path
-                  d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
-                  fill="currentColor"
-                />
-              </svg>
+                <svg
+                  class="o-cf-icon trash"
+                  viewBox="0 0 448 512"
+                >
+                  <path
+                    d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </div>
             </div>
           </div>
         </div>

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -114,10 +114,11 @@ describe("UI of conditional formats", () => {
   let sheetId: UID;
 
   mockGetBoundingClientRect({
-    "o-cf-preview": (el: HTMLElement) => ({
+    "o-cf-preview-container": (el: HTMLElement) => ({
       y:
-        model.getters.getConditionalFormats(sheetId).findIndex((cf) => cf.id === el.dataset.id) *
-        100,
+        model.getters
+          .getConditionalFormats(sheetId)
+          .findIndex((cf) => cf.id === (el.firstChild as HTMLElement).dataset.id) * 100,
       height: 100,
     }),
     "o-cf-preview-list": () => ({
@@ -438,7 +439,7 @@ describe("UI of conditional formats", () => {
       const previewEl = fixture.querySelector<HTMLElement>(`.o-cf-preview[data-id="1"]`)!;
       await dragElement(previewEl, { x: 0, y: 200 });
 
-      expect(previewEl.style.transition).toBe("top 0s");
+      expect(previewEl.parentElement!.style.transition).toBe("top 0s");
       model.dispatch("ADD_CONDITIONAL_FORMAT", {
         cf: createEqualCF("2", { bold: true, fillColor: "#ff0000" }, "99"),
         ranges: toRangesData(sheetId, "C1:C5"),

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -1,6 +1,7 @@
 import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { ConditionalFormattingPanel } from "../../src/components/side_panel/conditional_formatting/conditional_formatting";
+import { HIGHLIGHT_COLOR } from "../../src/constants";
 import { toZone } from "../../src/helpers";
 import { ConditionalFormatPlugin } from "../../src/plugins/core/conditional_format";
 import { CellIsRule, CommandResult, SpreadsheetChildEnv, UID } from "../../src/types";
@@ -12,7 +13,13 @@ import {
   setSelection,
   updateLocale,
 } from "../test_helpers/commands_helpers";
-import { click, dragElement, keyDown, setInputValueAndTrigger } from "../test_helpers/dom_helper";
+import {
+  click,
+  dragElement,
+  keyDown,
+  setInputValueAndTrigger,
+  triggerMouseEvent,
+} from "../test_helpers/dom_helper";
 import {
   createColorScale,
   createEqualCF,
@@ -193,6 +200,23 @@ describe("UI of conditional formats", () => {
       expect(previews[2].querySelector(selectors.description.ruletype.rule)!.textContent).toBe(
         "Is equal to 1,5"
       );
+    });
+
+    test("Ranges of hovered previews are highlighted", async () => {
+      expect(model.getters.getHighlights()).toEqual([]);
+      triggerMouseEvent(selectors.listPreview, "mouseenter");
+      expect(model.getters.getHighlights()).toMatchObject([
+        { zone: toZone("A1:A2"), color: HIGHLIGHT_COLOR },
+      ]);
+      triggerMouseEvent(selectors.listPreview, "mouseleave");
+      expect(model.getters.getHighlights()).toEqual([]);
+    });
+
+    test("Highlights are removed when cf preview is unmounted", async () => {
+      triggerMouseEvent(selectors.listPreview, "mouseenter");
+      expect(model.getters.getHighlights()).not.toEqual([]);
+      await click(fixture.querySelectorAll(selectors.listPreview)[0]);
+      expect(model.getters.getHighlights()).toEqual([]);
     });
 
     test("can edit an existing CellIsRule", async () => {

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -399,10 +399,10 @@ describe("Context Menu internal tests", () => {
       },
     ]);
     await renderContextMenu(300, 300, { menuItems });
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root']", "mouseenter");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='action']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='action']", "mouseenter");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
   });
@@ -411,10 +411,10 @@ describe("Context Menu internal tests", () => {
     await renderContextMenu(300, 300, { menuItems: cellMenuRegistry.getMenuItems() });
     const menuItem = fixture.querySelector(".o-menu div[data-name='paste_special']");
     expect(menuItem?.classList).not.toContain("o-menu-item-active");
-    triggerMouseEvent(menuItem, "mouseover");
+    triggerMouseEvent(menuItem, "mouseenter");
     await nextTick();
     expect(menuItem?.classList).toContain("o-menu-item-active");
-    triggerMouseEvent(".o-menu div[data-name='paste_value_only']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='paste_value_only']", "mouseenter");
     await nextTick();
     expect(menuItem?.classList).toContain("o-menu-item-active");
   });
@@ -460,17 +460,17 @@ describe("Context Menu internal tests", () => {
     model.updateMode("readonly");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='root']")!.classList).toContain("disabled");
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root']", "mouseenter");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu']")).toBeFalsy();
   });
 
   test("submenu does not close when sub item hovered", async () => {
     await renderContextMenu(300, 300, { menuItems: subMenu });
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root']", "mouseenter");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='subMenu1']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='subMenu1']", "mouseenter");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu1']")).toBeTruthy();
   });
@@ -594,12 +594,12 @@ describe("Context Menu internal tests", () => {
     ]);
     await renderContextMenu(300, 300, { menuItems });
 
-    triggerMouseEvent(".o-menu div[data-name='root_1']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root_1']", "mouseenter");
     await nextTick();
-    triggerMouseEvent(".o-menu div[data-name='root_1_1']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root_1_1']", "mouseenter");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu_1']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='root_2']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root_2']", "mouseenter");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='subMenu_1']")).toBeFalsy();
     expect(fixture.querySelector(".o-menu div[data-name='root_2_1']")).toBeTruthy();
@@ -637,10 +637,10 @@ describe("Context Menu internal tests", () => {
       },
     ]);
     await renderContextMenu(300, 300, { menuItems });
-    triggerMouseEvent(".o-menu div[data-name='root']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='root']", "mouseenter");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='menu_1']")).toBeTruthy();
-    triggerMouseEvent(".o-menu div[data-name='menu_1']", "mouseover");
+    triggerMouseEvent(".o-menu div[data-name='menu_1']", "mouseenter");
     await nextTick();
     expect(fixture.querySelector(".o-menu div[data-name='visible_submenu_1']")).toBeTruthy();
     expect(fixture.querySelector(".o-menu div[data-name='invisible_submenu_1']")).toBeFalsy();
@@ -716,6 +716,41 @@ describe("Context Menu internal tests", () => {
     parent.render(true);
     await nextTick();
     expect(fixture.querySelector(".search-icon")).toBeNull();
+  });
+
+  test("Menu hover callbacks are called", async () => {
+    const onStartHover = jest.fn(() => {});
+    const onStopHover = jest.fn(() => {});
+    const menuItems: Action[] = createActions([
+      {
+        id: "menuItem",
+        name: "menuItem",
+        onStartHover,
+        onStopHover,
+      },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+
+    triggerMouseEvent("div[data-name='menuItem']", "mouseenter");
+    expect(onStartHover).toHaveBeenCalled();
+    triggerMouseEvent("div[data-name='menuItem']", "mouseleave");
+    expect(onStopHover).toHaveBeenCalled();
+  });
+
+  test("Callback onStopHover is called when the component is unmounted", async () => {
+    const onStopHover = jest.fn(() => {});
+    const menuItems: Action[] = createActions([
+      {
+        id: "menuItem",
+        name: "menuItem",
+        onStopHover,
+      },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+
+    triggerMouseEvent("div[data-name='menuItem']", "mouseenter");
+    parent.__owl__.destroy();
+    expect(onStopHover).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## [IMP] highlight: add highlight on hover in side panels

This commit make it so the ranges of conditional formats/data validation
are highlighted when hovering over the corresponding entry in the side
panel.

Also add the possibility to add hover callbacks on menu items.

## [REF] conditional_format: split list panel and cf preview

This commit put the CF preview in a separate component.

Task: : [3571796](https://www.odoo.com/web#id=3571796&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo