### PR TITLE
[IMP] cell: Remove useless uuid generation for performance

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -28,6 +28,7 @@ const nbspRegexp = new RegExp(String.fromCharCode(160), "g");
 interface CoreState {
   // this.cells[sheetId][cellId] --> cell|undefined
   cells: Record<UID, Record<UID, Cell | undefined>>;
+  nextId: number;
 }
 
 /**
@@ -46,6 +47,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     "getCellById",
   ] as const;
 
+  readonly nextId = 1;
   public readonly cells: { [sheetId: string]: { [id: string]: Cell } } = {};
   private createCell = cellFactory(this.getters);
 
@@ -239,7 +241,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   ): Cell {
     const style = (cellData.style && normalizedStyles[cellData.style]) || undefined;
     const format = (cellData.format && normalizedFormats[cellData.format]) || undefined;
-    const cellId = this.uuidGenerator.uuidv4();
+    const cellId = this.getNextUid();
     const properties = { format, style };
     return this.createCell(cellId, cellData?.content || "", properties, sheetId);
   }
@@ -412,6 +414,12 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     return format;
   }
 
+  private getNextUid() {
+    const id = this.nextId.toString();
+    this.history.update("nextId", this.nextId + 1);
+    return id;
+  }
+
   private updateCell(sheetId: UID, col: HeaderIndex, row: HeaderIndex, after: UpdateCellData) {
     const before = this.getters.getCell(sheetId, col, row);
     const hasContent = "content" in after || "formula" in after;
@@ -453,7 +461,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       return;
     }
 
-    const cellId = before?.id || this.uuidGenerator.uuidv4();
+    const cellId = before?.id || this.getNextUid();
     const didContentChange = hasContent;
     const properties = { format, style };
     const cell = this.createCell(cellId, afterContent, properties, sheetId);


### PR DESCRIPTION
Backport of 3a897a36a7f445cbd48cc45cbcdd3c618b8d4a48

The cells ids are generated using random UUIDS but those are only 'runtime', they are not stored in the exported data and not used in any command whatsoever. Generating the uuids is a bit costy and in this specific case, can be replaced with an incremental id generator.

When inserting a large list (4000 leads) into a spreadsheet it takes more than 31% of the total time.

Benchmark:
----------

Copy/pasting 26k cells:

With *uuid*: 4.95 sec

With *incremental id*: 2.23 sec

Note that this is not an issue at start up since `uuidv4()` is shortcut to an incremental id generator at that moment.

All-in-all,  the uuid generator only makes sense for persistent ids.

Task 2987517

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [2987517](https://www.odoo.com/web#id=2987517&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo