### PR TITLE
[IMP] history: reduce memory allocation

### DIFF
--- a/src/history/factory.ts
+++ b/src/history/factory.ts
@@ -59,9 +59,9 @@ function revertChanges(revisions: readonly Revision[]) {
  * Apply the changes of the given HistoryChange to the state
  */
 function applyChange(change: HistoryChange, target: "before" | "after") {
-  let val = change.root as any;
-  let key = change.path[change.path.length - 1];
-  for (let pathIndex = 0; pathIndex < change.path.slice(0, -1).length; pathIndex++) {
+  let val = change.path[0];
+  const key = change.path[change.path.length - 1];
+  for (let pathIndex = 1; pathIndex < change.path.slice(0, -1).length; pathIndex++) {
     const p = change.path[pathIndex];
     if (val[p] === undefined) {
       const nextPath = change.path[pathIndex + 1];

--- a/src/state_observer.ts
+++ b/src/state_observer.ts
@@ -20,15 +20,16 @@ export class StateObserver {
     this.commands.push(command);
   }
 
-  addChange(...args: any[]) {
+  addChange(...args: [...HistoryChange["path"], any]) {
     const val: any = args.pop();
-    const [root, ...path] = args as [any, string | number];
+    const root = args[0];
     let value = root as any;
-    let key = path[path.length - 1];
-    for (let pathIndex = 0; pathIndex <= path.length - 2; pathIndex++) {
-      const p = path[pathIndex];
+    let key = args[args.length - 1];
+    const pathLength = args.length - 2;
+    for (let pathIndex = 1; pathIndex <= pathLength; pathIndex++) {
+      const p = args[pathIndex];
       if (value[p] === undefined) {
-        const nextPath = path[pathIndex + 1];
+        const nextPath = args[pathIndex + 1];
         value[p] = createEmptyStructure(nextPath);
       }
       value = value[p];
@@ -37,8 +38,7 @@ export class StateObserver {
       return;
     }
     this.changes.push({
-      root,
-      path,
+      path: args,
       before: value[key],
       after: val,
     });

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -9,8 +9,7 @@ export interface CreateRevisionOptions {
 }
 
 export interface HistoryChange {
-  root: any;
-  path: (string | number)[];
+  path: [any, ...(number | string)[]];
   before: any;
   after: any;
 }

--- a/tests/plugins/history.test.ts
+++ b/tests/plugins/history.test.ts
@@ -145,6 +145,7 @@ describe("history", () => {
       A: {},
     };
     expect(() => {
+      // @ts-expect-error
       history.addChange(state, "A", "B", true, 5);
     }).toThrow();
   });
@@ -155,6 +156,7 @@ describe("history", () => {
       A: {},
     };
     expect(() => {
+      // @ts-expect-error
       history.addChange(state, "A", "B", true, "C", 5);
     }).toThrow();
   });


### PR DESCRIPTION
Backport of d8d943bb363638912b86d0684b52ea3a02c364c7

`addChange` is used *a lot*, like *a lot, a lot*, for every mutation in core plugins. Its performance is key.

Currently `const [root, ...path] = args` creates a new array for `path`, the array is allocated, and must be garbage collected later.

On the large formula dataset, with 20k rows (520k cells), and adding a column before A, then reload the spreadsheet:

(average over 5 runs)

	minor GC	addChange
before	1609ms		1168ms
after	1094ms		753ms
	-32%		-35%

The memory usage also decreases: right after loading, memory was ~1725Mb and ~792Mb after running the GC. It's now ~1455Mb right after loading and ~670Mb after running the GC. (I'm not sure why it goes from 792Mb to 670Mb. Is it just thanks to the removed "root" key)

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo