### PR TITLE
[FIX] model: don't flatten command result

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -339,7 +339,10 @@ export class Model extends owl.core.EventBus implements CommandDispatcher {
    */
   private checkDispatchAllowed(command: Command): DispatchResult {
     const results = this.handlers.map((handler) => handler.allowDispatch(command));
-    return new DispatchResult(results.flat());
+    if (results.some((r) => r !== CommandResult.Success)) {
+      return new DispatchResult(results.flat());
+    }
+    return DispatchResult.Success;
   }
 
   private finalize() {


### PR DESCRIPTION
`array.flat()` is slow because it creates a new array (and allocates memory)

With this commit, we only execute `array.flat()` if the command as been refused by one of the plugins (for possibly several resons)

`checkDispatchAllowed` self-time could take up to 4% of the total time when loading a spreadsheet with lots of initial revisions.

Now it's 0.0% :)

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo