### PR TITLE
[IMP] menu: allow to add a secondary icon to a menu

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -38,6 +38,10 @@ export interface ActionSpec {
    */
   icon?: string | ((env: SpreadsheetChildEnv) => string);
   /**
+   * Can be defined to display another icon on the right of the item.
+   */
+  secondaryIcon?: string | ((env: SpreadsheetChildEnv) => string);
+  /**
    * is the action allowed when running spreadsheet in readonly mode
    */
   isReadonlyAllowed?: boolean;
@@ -68,6 +72,7 @@ export interface Action {
   isEnabled: (env: SpreadsheetChildEnv) => boolean;
   isActive?: (env: SpreadsheetChildEnv) => boolean;
   icon: (env: SpreadsheetChildEnv) => string;
+  secondaryIcon: (env: SpreadsheetChildEnv) => string;
   isReadonlyAllowed: boolean;
   execute?: (env: SpreadsheetChildEnv) => unknown;
   children: (env: SpreadsheetChildEnv) => Action[];
@@ -89,6 +94,7 @@ export function createAction(item: ActionSpec): Action {
   const children = item.children;
   const description = item.description;
   const icon = item.icon;
+  const secondaryIcon = item.secondaryIcon;
   return {
     id: item.id || uuidGenerator.uuidv4(),
     name: typeof name === "function" ? name : () => name,
@@ -107,6 +113,7 @@ export function createAction(item: ActionSpec): Action {
     isReadonlyAllowed: item.isReadonlyAllowed || false,
     separator: item.separator || false,
     icon: typeof icon === "function" ? icon : () => icon || "",
+    secondaryIcon: typeof secondaryIcon === "function" ? secondaryIcon : () => secondaryIcon || "",
     description: typeof description === "function" ? description : () => description || "",
     textColor: item.textColor,
     sequence: item.sequence || 0,

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -3,11 +3,9 @@ import {
   ComponentsImportance,
   HEADER_HEIGHT,
   HEADER_WIDTH,
-  ICON_EDGE_LENGTH,
   MIN_COL_WIDTH,
   MIN_ROW_HEIGHT,
   SELECTION_BORDER_COLOR,
-  UNHIDE_ICON_EDGE_LENGTH,
 } from "../../constants";
 import {
   CommandResult,
@@ -19,7 +17,7 @@ import {
   SpreadsheetChildEnv,
 } from "../../types/index";
 import { ContextMenuType } from "../grid/grid";
-import { css } from "../helpers/css";
+import { css, cssPropertiesToCss } from "../helpers/css";
 import { dragAndDropBeyondTheViewport, startDnd } from "../helpers/drag_and_drop";
 import { MergeErrorMessage } from "../translations_terms";
 
@@ -334,21 +332,14 @@ css/* scss */ `
       height: 10000px;
       background-color: ${SELECTION_BORDER_COLOR};
     }
-    .o-unhide {
-      width: ${UNHIDE_ICON_EDGE_LENGTH}px;
-      height: ${UNHIDE_ICON_EDGE_LENGTH}px;
-      position: absolute;
-      overflow: hidden;
-      border-radius: 2px;
-      top: calc(${HEADER_HEIGHT}px / 2 - ${UNHIDE_ICON_EDGE_LENGTH}px / 2);
+    .o-unhide-buttons {
+      width: fit-content;
+      gap: 5px;
+      transform: translate(-50%, 0);
     }
     .o-unhide:hover {
       z-index: ${ComponentsImportance.Grid + 1};
       background-color: lightgrey;
-    }
-    .o-unhide > svg {
-      position: relative;
-      top: calc(${UNHIDE_ICON_EDGE_LENGTH}px / 2 - ${ICON_EDGE_LENGTH}px / 2);
     }
   }
 `;
@@ -486,8 +477,8 @@ export class ColResizer extends AbstractResizer {
     });
   }
 
-  unhideStyleValue(hiddenIndex: HeaderIndex): Pixel {
-    return this._getDimensionsInViewport(hiddenIndex).start;
+  getUnhideButtonStyle(hiddenIndex: HeaderIndex): string {
+    return cssPropertiesToCss({ left: this._getDimensionsInViewport(hiddenIndex).start + "px" });
   }
 }
 
@@ -534,18 +525,9 @@ css/* scss */ `
       height: 1px;
       background-color: ${SELECTION_BORDER_COLOR};
     }
-    .o-unhide {
-      width: ${UNHIDE_ICON_EDGE_LENGTH}px;
-      height: ${UNHIDE_ICON_EDGE_LENGTH}px;
-      position: absolute;
-      overflow: hidden;
-      border-radius: 2px;
-      left: calc(${HEADER_WIDTH}px - ${UNHIDE_ICON_EDGE_LENGTH}px - 2px);
-    }
-    .o-unhide > svg {
-      position: relative;
-      left: calc(${UNHIDE_ICON_EDGE_LENGTH}px / 2 - ${ICON_EDGE_LENGTH}px / 2);
-      top: calc(${UNHIDE_ICON_EDGE_LENGTH}px / 2 - ${ICON_EDGE_LENGTH}px / 2);
+    .o-unhide-buttons {
+      height: fit-content;
+      transform: translate(0, -50%);
     }
     .o-unhide:hover {
       z-index: ${ComponentsImportance.Grid + 1};
@@ -687,8 +669,8 @@ export class RowResizer extends AbstractResizer {
     });
   }
 
-  unhideStyleValue(hiddenIndex: HeaderIndex): Pixel {
-    return this._getDimensionsInViewport(hiddenIndex).start;
+  getUnhideButtonStyle(hiddenIndex: HeaderIndex): string {
+    return cssPropertiesToCss({ top: this._getDimensionsInViewport(hiddenIndex).start + "px" });
   }
 }
 

--- a/src/components/headers_overlay/headers_overlay.xml
+++ b/src/components/headers_overlay/headers_overlay.xml
@@ -41,25 +41,27 @@
         t-foreach="env.model.getters.getHiddenRowsGroups(env.model.getters.getActiveSheetId())"
         t-as="hiddenItem"
         t-key="hiddenItem_index">
-        <t t-if="!hiddenItem.includes(0)">
-          <div
-            class="o-unhide"
-            t-att-data-index="hiddenItem_index"
-            t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) - 17}}px;"
-            t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>
-          </div>
-        </t>
-        <t
-          t-if="!hiddenItem.includes(env.model.getters.getNumberRows(env.model.getters.getActiveSheetId())-1)">
-          <div
-            class="o-unhide"
-            t-att-data-index="hiddenItem_index"
-            t-attf-style="top:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
-            t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
-          </div>
-        </t>
+        <div
+          class="o-unhide-buttons position-relative float-end"
+          t-att-style="getUnhideButtonStyle(hiddenItem[0])">
+          <t t-if="!hiddenItem.includes(0)">
+            <div
+              class="o-unhide rounded mb-1"
+              t-att-data-index="hiddenItem_index"
+              t-on-click="() => this.unhide(hiddenItem)">
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>
+            </div>
+          </t>
+          <t
+            t-if="!hiddenItem.includes(env.model.getters.getNumberRows(env.model.getters.getActiveSheetId())-1)">
+            <div
+              class="o-unhide rounded"
+              t-att-data-index="hiddenItem_index"
+              t-on-click="() => this.unhide(hiddenItem)">
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
+            </div>
+          </t>
+        </div>
       </t>
     </div>
   </t>
@@ -98,25 +100,27 @@
         t-foreach="env.model.getters.getHiddenColsGroups(env.model.getters.getActiveSheetId())"
         t-as="hiddenItem"
         t-key="hiddenItem_index">
-        <t t-if="!hiddenItem.includes(0)">
-          <div
-            class="o-unhide"
-            t-att-data-index="hiddenItem_index"
-            t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) - 17}}px; margin-right:6px;"
-            t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_LEFT"/>
-          </div>
-        </t>
-        <t
-          t-if="!hiddenItem.includes(env.model.getters.getNumberCols(env.model.getters.getActiveSheetId())-1)">
-          <div
-            class="o-unhide"
-            t-att-data-index="hiddenItem_index"
-            t-attf-style="left:{{unhideStyleValue(hiddenItem[0]) + 3}}px;"
-            t-on-click="() => this.unhide(hiddenItem)">
-            <t t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
-          </div>
-        </t>
+        <div
+          class="o-unhide-buttons position-relative h-100 d-flex align-items-center"
+          t-att-style="getUnhideButtonStyle(hiddenItem[0])">
+          <t t-if="!hiddenItem.includes(0)">
+            <div
+              class="o-unhide rounded"
+              t-att-data-index="hiddenItem_index"
+              t-on-click="() => this.unhide(hiddenItem)">
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_LEFT"/>
+            </div>
+          </t>
+          <t
+            t-if="!hiddenItem.includes(env.model.getters.getNumberCols(env.model.getters.getActiveSheetId())-1)">
+            <div
+              class="o-unhide rounded"
+              t-att-data-index="hiddenItem_index"
+              t-on-click="() => this.unhide(hiddenItem)">
+              <t t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
+            </div>
+          </t>
+        </div>
       </t>
     </div>
   </t>

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -303,23 +303,23 @@
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.TRIANGLE_DOWN">
-    <svg class="o-icon">
-      <polygon fill="currentColor" points="0 0 4 4 8 0" transform="translate(5 7)"/>
+    <svg class="o-icon" viewBox="0 0 18 18">
+      <polygon fill="currentColor" points="5 7 9 11 13 7"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.TRIANGLE_UP">
-    <svg class="o-icon">
-      <polygon fill="currentColor" points="4 0 0 4 8 4" transform="translate(5 7)"/>
+    <svg class="o-icon" transform="rotate(180)">
+      <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.TRIANGLE_RIGHT">
-    <svg class="o-icon">
-      <polygon fill="currentColor" points="0 0 4 4 0 8" transform="translate(5 5)"/>
+    <svg class="o-icon" transform="rotate(-90)">
+      <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.TRIANGLE_LEFT">
-    <svg class="o-icon">
-      <polygon fill="currentColor" points="4 0 0 4 4 8" transform="translate(5 5)"/>
+    <svg class="o-icon" transform="rotate(90)" viewBox="0 0 18 18">
+      <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
     </svg>
   </t>
   <t t-name="o-spreadsheet-Icon.BOLD">

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -26,11 +26,9 @@ css/* scss */ `
     padding: ${MENU_VERTICAL_PADDING}px 0px;
     width: ${MENU_WIDTH}px;
     box-sizing: border-box !important;
+    user-select: none;
 
     .o-menu-item {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
       box-sizing: border-box;
       height: ${MENU_ITEM_HEIGHT}px;
       padding: ${MENU_ITEM_PADDING_VERTICAL}px ${MENU_ITEM_PADDING_HORIZONTAL}px;
@@ -41,19 +39,11 @@ css/* scss */ `
         min-width: 40%;
       }
 
-      &.o-menu-root {
-        display: flex;
-        justify-content: space-between;
-      }
-
       .o-menu-item-icon {
         display: inline-block;
         margin: 0px 8px 0px 0px;
         width: ${MENU_ITEM_HEIGHT - 2 * MENU_ITEM_PADDING_VERTICAL}px;
         line-height: ${MENU_ITEM_HEIGHT - 2 * MENU_ITEM_PADDING_VERTICAL}px;
-      }
-      .o-menu-item-root {
-        width: 10px;
       }
 
       &:not(.disabled) {

--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -18,7 +18,7 @@
               t-att-data-name="menuItem.id"
               t-on-click="(ev) => this.onClickMenu(menuItem, menuItem_index, ev)"
               t-on-mouseover="(ev) => this.onMouseOver(menuItem, menuItem_index, ev)"
-              class="o-menu-item"
+              class="o-menu-item d-flex align-items-center"
               t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem)}"
               t-att-style="getColor(menuItem)">
               <div class="d-flex w-100">
@@ -32,10 +32,16 @@
                   class="o-menu-item-description ms-auto text-truncate"
                   t-esc="description"
                 />
+                <t t-set="secondaryIcon" t-value="menuItem.secondaryIcon(env)"/>
                 <div
                   t-if="isMenuRoot"
                   class="o-menu-item-root align-middle ms-auto"
                   t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"
+                />
+                <div
+                  t-elif="secondaryIcon"
+                  class="o-menu-item-root align-middle ms-auto"
+                  t-call="{{secondaryIcon}}"
                 />
               </div>
             </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   chartSidePanelComponentRegistry,
 } from "./components/side_panel/chart";
 import { ChartPanel } from "./components/side_panel/chart/main_chart_panel/main_chart_panel";
+import { ValidationMessages } from "./components/validation_messages/validation_messages";
 import {
   BOTTOMBAR_HEIGHT,
   DEFAULT_CELL_HEIGHT,
@@ -249,6 +250,7 @@ export const components = {
   FigureComponent,
   Menu,
   SelectionInput,
+  ValidationMessages,
 };
 
 export const hooks = {

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -221,11 +221,11 @@ exports[`TopBar component can set cell format 1`] = `
               
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
               >
                 <polygon
                   fill="currentColor"
-                  points="0 0 4 4 8 0"
-                  transform="translate(5 7)"
+                  points="5 7 9 11 13 7"
                 />
               </svg>
               
@@ -250,11 +250,11 @@ exports[`TopBar component can set cell format 1`] = `
                 <span>
                   <svg
                     class="o-icon"
+                    viewBox="0 0 18 18"
                   >
                     <polygon
                       fill="currentColor"
-                      points="0 0 4 4 8 0"
-                      transform="translate(5 7)"
+                      points="5 7 9 11 13 7"
                     />
                   </svg>
                 </span>
@@ -440,11 +440,11 @@ exports[`TopBar component can set cell format 1`] = `
                 
                 <svg
                   class="o-icon"
+                  viewBox="0 0 18 18"
                 >
                   <polygon
                     fill="currentColor"
-                    points="0 0 4 4 8 0"
-                    transform="translate(5 7)"
+                    points="5 7 9 11 13 7"
                   />
                 </svg>
                 
@@ -475,11 +475,11 @@ exports[`TopBar component can set cell format 1`] = `
                 
                 <svg
                   class="o-icon"
+                  viewBox="0 0 18 18"
                 >
                   <polygon
                     fill="currentColor"
-                    points="0 0 4 4 8 0"
-                    transform="translate(5 7)"
+                    points="5 7 9 11 13 7"
                   />
                 </svg>
                 
@@ -510,11 +510,11 @@ exports[`TopBar component can set cell format 1`] = `
                 
                 <svg
                   class="o-icon"
+                  viewBox="0 0 18 18"
                 >
                   <polygon
                     fill="currentColor"
-                    points="0 0 4 4 8 0"
-                    transform="translate(5 7)"
+                    points="5 7 9 11 13 7"
                   />
                 </svg>
                 
@@ -1114,11 +1114,11 @@ exports[`TopBar component simple rendering 1`] = `
           
           <svg
             class="o-icon"
+            viewBox="0 0 18 18"
           >
             <polygon
               fill="currentColor"
-              points="0 0 4 4 8 0"
-              transform="translate(5 7)"
+              points="5 7 9 11 13 7"
             />
           </svg>
           
@@ -1143,11 +1143,11 @@ exports[`TopBar component simple rendering 1`] = `
             <span>
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
               >
                 <polygon
                   fill="currentColor"
-                  points="0 0 4 4 8 0"
-                  transform="translate(5 7)"
+                  points="5 7 9 11 13 7"
                 />
               </svg>
             </span>
@@ -1333,11 +1333,11 @@ exports[`TopBar component simple rendering 1`] = `
             
             <svg
               class="o-icon"
+              viewBox="0 0 18 18"
             >
               <polygon
                 fill="currentColor"
-                points="0 0 4 4 8 0"
-                transform="translate(5 7)"
+                points="5 7 9 11 13 7"
               />
             </svg>
             
@@ -1368,11 +1368,11 @@ exports[`TopBar component simple rendering 1`] = `
             
             <svg
               class="o-icon"
+              viewBox="0 0 18 18"
             >
               <polygon
                 fill="currentColor"
-                points="0 0 4 4 8 0"
-                transform="translate(5 7)"
+                points="5 7 9 11 13 7"
               />
             </svg>
             
@@ -1403,11 +1403,11 @@ exports[`TopBar component simple rendering 1`] = `
             
             <svg
               class="o-icon"
+              viewBox="0 0 18 18"
             >
               <polygon
                 fill="currentColor"
-                points="0 0 4 4 8 0"
-                transform="translate(5 7)"
+                points="5 7 9 11 13 7"
               />
             </svg>
             

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -583,7 +583,7 @@ exports[`TopBar component can set cell format 1`] = `
       >
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_number_automatic"
           title="Automatic"
         >
@@ -611,6 +611,7 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         <div
@@ -619,7 +620,7 @@ exports[`TopBar component can set cell format 1`] = `
         
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_number_number"
           title="Number"
         >
@@ -642,11 +643,12 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_number_percent"
           title="Percent"
         >
@@ -669,6 +671,7 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         <div
@@ -677,7 +680,7 @@ exports[`TopBar component can set cell format 1`] = `
         
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_number_currency"
           title="Currency"
         >
@@ -700,11 +703,12 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_number_currency_rounded"
           title="Currency rounded"
         >
@@ -727,11 +731,12 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_custom_currency"
           title="Custom currency"
         >
@@ -749,6 +754,7 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         <div
@@ -757,7 +763,7 @@ exports[`TopBar component can set cell format 1`] = `
         
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_number_date"
           title="Date"
         >
@@ -780,11 +786,12 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_number_time"
           title="Time"
         >
@@ -807,11 +814,12 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_number_date_time"
           title="Date time"
         >
@@ -834,11 +842,12 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="format_number_duration"
           title="Duration"
         >
@@ -861,6 +870,7 @@ exports[`TopBar component can set cell format 1`] = `
             </div>
             
             
+            
           </div>
         </div>
         <div
@@ -869,7 +879,7 @@ exports[`TopBar component can set cell format 1`] = `
         
         
         <div
-          class="o-menu-item"
+          class="o-menu-item d-flex align-items-center"
           data-name="more_formats"
           title="More date formats"
         >
@@ -885,6 +895,7 @@ exports[`TopBar component can set cell format 1`] = `
             >
               More date formats
             </div>
+            
             
             
           </div>

--- a/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
+++ b/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
@@ -6,7 +6,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
 >
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="Sum"
     title="Sum: 24"
   >
@@ -21,11 +21,12 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="Avg"
     title="Avg: 24"
   >
@@ -40,11 +41,12 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="Min"
     title="Min: 24"
   >
@@ -59,11 +61,12 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="Max"
     title="Max: 24"
   >
@@ -78,11 +81,12 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="Count"
     title="Count: 1"
   >
@@ -97,11 +101,12 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="Count Numbers"
     title="Count Numbers: 1"
   >
@@ -114,6 +119,7 @@ exports[`BottomBar component Can open the list of statistics 1`] = `
       >
         Count Numbers: 1
       </div>
+      
       
       
     </div>

--- a/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
+++ b/tests/bottom_bar/__snapshots__/bottom_bar_component.test.ts.snap
@@ -232,11 +232,11 @@ exports[`BottomBar component simple rendering 1`] = `
             >
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
               >
                 <polygon
                   fill="currentColor"
-                  points="0 0 4 4 8 0"
-                  transform="translate(5 7)"
+                  points="5 7 9 11 13 7"
                 />
               </svg>
             </span>

--- a/tests/colors/__snapshots__/color_picker_component.test.ts.snap
+++ b/tests/colors/__snapshots__/color_picker_component.test.ts.snap
@@ -485,12 +485,17 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       >
         <svg
           class="o-icon"
+          transform="rotate(180)"
         >
-          <polygon
-            fill="currentColor"
-            points="4 0 0 4 8 4"
-            transform="translate(5 7)"
-          />
+          <svg
+            class="o-icon"
+            viewBox="0 0 18 18"
+          >
+            <polygon
+              fill="currentColor"
+              points="5 7 9 11 13 7"
+            />
+          </svg>
         </svg>
       </div>
     </div>

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
 >
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="cut"
     title="Cut"
   >
@@ -38,11 +38,12 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="copy"
     title="Copy"
   >
@@ -74,11 +75,12 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="paste"
     title="Paste"
   >
@@ -110,11 +112,12 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item o-menu-root"
+    class="o-menu-item d-flex align-items-center o-menu-root"
     data-name="paste_special"
     title="Paste special"
   >
@@ -159,6 +162,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
         </svg>
       </div>
       
+      
     </div>
   </div>
   <div
@@ -167,7 +171,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="add_row_before"
     title="Insert row"
   >
@@ -194,11 +198,12 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="add_column_before"
     title="Insert column"
   >
@@ -225,11 +230,12 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item o-menu-root"
+    class="o-menu-item d-flex align-items-center o-menu-root"
     data-name="insert_cell"
     title="Insert cells"
   >
@@ -274,6 +280,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
         </svg>
       </div>
       
+      
     </div>
   </div>
   <div
@@ -282,7 +289,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="delete_row"
     title="Delete row 8"
   >
@@ -309,11 +316,12 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="delete_column"
     title="Delete column C"
   >
@@ -340,11 +348,12 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       </div>
       
       
+      
     </div>
   </div>
   
   <div
-    class="o-menu-item o-menu-root"
+    class="o-menu-item d-flex align-items-center o-menu-root"
     data-name="delete_cell"
     title="Delete cells"
   >
@@ -389,6 +398,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
         </svg>
       </div>
       
+      
     </div>
   </div>
   <div
@@ -397,7 +407,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
   
   
   <div
-    class="o-menu-item"
+    class="o-menu-item d-flex align-items-center"
     data-name="insert_link"
     title="Insert link"
   >
@@ -422,6 +432,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       >
         Insert link
       </div>
+      
       
       
     </div>

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -145,12 +145,17 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       >
         <svg
           class="o-icon"
+          transform="rotate(-90)"
         >
-          <polygon
-            fill="currentColor"
-            points="0 0 4 4 0 8"
-            transform="translate(5 5)"
-          />
+          <svg
+            class="o-icon"
+            viewBox="0 0 18 18"
+          >
+            <polygon
+              fill="currentColor"
+              points="5 7 9 11 13 7"
+            />
+          </svg>
         </svg>
       </div>
       
@@ -255,12 +260,17 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       >
         <svg
           class="o-icon"
+          transform="rotate(-90)"
         >
-          <polygon
-            fill="currentColor"
-            points="0 0 4 4 0 8"
-            transform="translate(5 5)"
-          />
+          <svg
+            class="o-icon"
+            viewBox="0 0 18 18"
+          >
+            <polygon
+              fill="currentColor"
+              points="5 7 9 11 13 7"
+            />
+          </svg>
         </svg>
       </div>
       
@@ -365,12 +375,17 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       >
         <svg
           class="o-icon"
+          transform="rotate(-90)"
         >
-          <polygon
-            fill="currentColor"
-            points="0 0 4 4 0 8"
-            transform="translate(5 5)"
-          />
+          <svg
+            class="o-icon"
+            viewBox="0 0 18 18"
+          >
+            <polygon
+              fill="currentColor"
+              points="5 7 9 11 13 7"
+            />
+          </svg>
         </svg>
       </div>
       

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -682,7 +682,7 @@ describe("Context Menu internal tests", () => {
     expect(fixture.querySelector("div[data-name='menuItem']")).toBeFalsy();
   });
 
-  test("Menu icon slot is visibile if one of the children has an icon", async () => {
+  test("Menu icon slot is visible if one of the children has an icon", async () => {
     let visible = false;
     const menuItems = createActions([
       {
@@ -699,6 +699,23 @@ describe("Context Menu internal tests", () => {
     parent.render(true);
     await nextTick();
     expect(fixture.querySelectorAll(".o-menu-item-icon").length).toBe(2);
+  });
+
+  test("Can display a secondary icon", async () => {
+    let visible = true;
+    const menuItems = createActions([
+      {
+        name: "child1",
+        secondaryIcon: () => (visible ? "o-spreadsheet-Icon.SEARCH" : ""),
+        execute: () => {},
+      },
+    ]);
+    await renderContextMenu(300, 300, { menuItems });
+    expect(fixture.querySelector(".search-icon")).not.toBeNull();
+    visible = false;
+    parent.render(true);
+    await nextTick();
+    expect(fixture.querySelector(".search-icon")).toBeNull();
   });
 });
 

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -222,11 +222,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
             
             <svg
               class="o-icon"
+              viewBox="0 0 18 18"
             >
               <polygon
                 fill="currentColor"
-                points="0 0 4 4 8 0"
-                transform="translate(5 7)"
+                points="5 7 9 11 13 7"
               />
             </svg>
             
@@ -251,11 +251,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               <span>
                 <svg
                   class="o-icon"
+                  viewBox="0 0 18 18"
                 >
                   <polygon
                     fill="currentColor"
-                    points="0 0 4 4 8 0"
-                    transform="translate(5 7)"
+                    points="5 7 9 11 13 7"
                   />
                 </svg>
               </span>
@@ -441,11 +441,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
               >
                 <polygon
                   fill="currentColor"
-                  points="0 0 4 4 8 0"
-                  transform="translate(5 7)"
+                  points="5 7 9 11 13 7"
                 />
               </svg>
               
@@ -476,11 +476,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
               >
                 <polygon
                   fill="currentColor"
-                  points="0 0 4 4 8 0"
-                  transform="translate(5 7)"
+                  points="5 7 9 11 13 7"
                 />
               </svg>
               
@@ -511,11 +511,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               
               <svg
                 class="o-icon"
+                viewBox="0 0 18 18"
               >
                 <polygon
                   fill="currentColor"
-                  points="0 0 4 4 8 0"
-                  transform="translate(5 7)"
+                  points="5 7 9 11 13 7"
                 />
               </svg>
               
@@ -826,11 +826,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
               >
                 <svg
                   class="o-icon"
+                  viewBox="0 0 18 18"
                 >
                   <polygon
                     fill="currentColor"
-                    points="0 0 4 4 8 0"
-                    transform="translate(5 7)"
+                    points="5 7 9 11 13 7"
                   />
                 </svg>
               </span>


### PR DESCRIPTION
## [IMP] menu: allow to add a secondary icon to a menu:

This commit allows to add a secondary icon to a menu. This icon is
displayed on the right of the menu item.

Also take the occasion to bootstrap-ify the menu component.

## [IMP] headers overlay: simplify CSS & use bootstrap

This commit simplifies the CSS of the headers overlay and uses
bootstrap classes instead of custom ones.

This also improves the "ARROW-*" icons by centering the actual icon
inside the SVGs.


Task: : [3487684](https://www.odoo.com/web#id=3487684&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo