### PR TITLE
[FIX] error tooltip: display more of the error message

### DIFF
--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -19,10 +19,6 @@ css/* scss */ `
 
     .o-error-tooltip-message {
       overflow: hidden;
-      display: -webkit-box; /* Limit to 3 lines */
-      -webkit-line-clamp: 3;
-      line-clamp: 3;
-      -webkit-box-orient: vertical;
     }
   }
 `;


### PR DESCRIPTION
## Description

With the introduction of data validation, the error messages could grow to any arbitrary length. Se we decided to put a limit to the length of the error message displayed in the tooltip (3 lines).

The problem was that 3 lines was a bit too restrictive, and that the truncated part of the error message could contain important information.

This commit changes the default display to 5 lines, and display everything on hover.

Task: : [3599337](https://www.odoo.com/web#id=3599337&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo