### PR TITLE
[FIX] cells: faster getter to get cell

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -278,12 +278,10 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
    * starting an async evaluation even if it has been moved or re-allocated
    */
   getCellById(cellId: UID): Cell | undefined {
-    for (const sheet of Object.values(this.cells)) {
-      if (sheet[cellId]) {
-        return sheet[cellId];
-      }
-    }
-    return undefined;
+    // this must be as fast as possible
+    const position = this.getters.getCellPosition(cellId);
+    const sheet = this.cells[position.sheetId];
+    return sheet[cellId];
   }
 
   /**


### PR DESCRIPTION
## Description:

getCellById self-time was ~13.6% and is now ~9.1% (average over 5 runs)

Task: : [3588401](https://www.odoo.com/web#id=3588401&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo