### PR TITLE
[FIX] HeaderPositionsUIPlugin: cell wrapping for long text

### DIFF
--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -23,7 +23,7 @@ export function getDefaultCellHeight(
   colSize: number
 ) {
   if (!cell || !cell.content) return DEFAULT_CELL_HEIGHT;
-  const maxWidth = cell.style?.wrapping ? colSize - 2 * MIN_CELL_TEXT_MARGIN : undefined;
+  const maxWidth = cell.style?.wrapping === "wrap" ? colSize - 2 * MIN_CELL_TEXT_MARGIN : undefined;
 
   const numberOfLines = cell.isFormula
     ? 1

--- a/src/plugins/ui_stateful/header_positions.ts
+++ b/src/plugins/ui_stateful/header_positions.ts
@@ -23,9 +23,11 @@ export class HeaderPositionsUIPlugin extends UIPlugin {
         }
         break;
       case "UPDATE_CELL":
-        if ("content" in cmd || "format" in cmd || cmd.style?.fontSize !== undefined) {
+        if ("content" in cmd || "format" in cmd) {
           this.headerPositions = {};
           this.isDirty = true;
+        } else {
+          this.headerPositions[cmd.sheetId] = this.computeHeaderPositionsOfSheet(cmd.sheetId);
         }
         break;
       case "UPDATE_FILTER":


### PR DESCRIPTION
## Description:

Previously, wrapping a cell with extensive text led to rendering issues in the spreadsheet. Additionally, using `overflow` and `clip` needlessly increased the row height

This PR fixes the issue by adding a command within the plugin to compute the header position of the sheet when applying formatting. It also corrects the `maxWidth` of the cell within the `getDefaultCellHeight` method.

Task: : [3586615](https://www.odoo.com/web#id=3586615&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo