### PR TITLE
[FIX] cells,borders: cancell useless commands

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -1,5 +1,13 @@
 import { DEFAULT_BORDER_DESC } from "../../constants";
-import { isDefined, range, stringify, toCartesian, toXC, toZone } from "../../helpers/index";
+import {
+  deepEquals,
+  isDefined,
+  range,
+  stringify,
+  toCartesian,
+  toXC,
+  toZone,
+} from "../../helpers/index";
 import {
   AddColumnsRowsCommand,
   Border,
@@ -8,9 +16,11 @@ import {
   BorderPosition,
   CellPosition,
   Color,
-  Command,
+  CommandResult,
+  CoreCommand,
   ExcelWorkbookData,
   HeaderIndex,
+  SetBorderCommand,
   UID,
   WorkbookData,
   Zone,
@@ -35,7 +45,16 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   // Command Handling
   // ---------------------------------------------------------------------------
 
-  handle(cmd: Command) {
+  allowDispatch(cmd: CoreCommand) {
+    switch (cmd.type) {
+      case "SET_BORDER":
+        return this.checkBordersUnchanged(cmd);
+      default:
+        return CommandResult.Success;
+    }
+  }
+
+  handle(cmd: CoreCommand) {
     switch (cmd.type) {
       case "ADD_MERGE":
         for (const zone of cmd.target) {
@@ -517,6 +536,16 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     } else if (bordersTopLeft?.right) {
       this.setBorders(sheetId, [{ ...zone, left: right }], "right", bordersTopLeft.right);
     }
+  }
+
+  private checkBordersUnchanged(cmd: SetBorderCommand) {
+    const currentBorder = this.getCellBorder(cmd);
+    const areAllNewBordersUndefined =
+      !cmd.border?.bottom && !cmd.border?.left && !cmd.border?.right && !cmd.border?.top;
+    if ((!currentBorder && areAllNewBordersUndefined) || deepEquals(currentBorder, cmd.border)) {
+      return CommandResult.NoChanges;
+    }
+    return CommandResult.Success;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -18,6 +18,7 @@ import {
   Cell,
   CellData,
   CellPosition,
+  ClearCellCommand,
   CommandResult,
   CompiledFormula,
   CoreCommand,
@@ -26,6 +27,7 @@ import {
   FormulaCell,
   HeaderIndex,
   LiteralCell,
+  PositionDependentCommand,
   Range,
   RangeCompiledFormula,
   RangePart,
@@ -90,11 +92,15 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   // Command Handling
   // ---------------------------------------------------------------------------
 
-  allowDispatch(cmd: CoreCommand): CommandResult {
+  allowDispatch(cmd: CoreCommand): CommandResult | CommandResult[] {
     switch (cmd.type) {
       case "UPDATE_CELL":
+        return this.checkCellOutOfSheet(cmd);
       case "CLEAR_CELL":
-        return this.checkCellOutOfSheet(cmd.sheetId, cmd.col, cmd.row);
+        return this.checkValidations(
+          cmd,
+          this.chainValidations(this.checkCellOutOfSheet, this.checkUselessClearCell)
+        );
       default:
         return CommandResult.Success;
     }
@@ -609,11 +615,21 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     };
   }
 
-  private checkCellOutOfSheet(sheetId: UID, col: HeaderIndex, row: HeaderIndex): CommandResult {
+  private checkCellOutOfSheet(cmd: PositionDependentCommand): CommandResult {
+    const { sheetId, col, row } = cmd;
     const sheet = this.getters.tryGetSheet(sheetId);
     if (!sheet) return CommandResult.InvalidSheetId;
     const sheetZone = this.getters.getSheetZone(sheetId);
     return isInside(col, row, sheetZone) ? CommandResult.Success : CommandResult.TargetOutOfSheet;
+  }
+
+  private checkUselessClearCell(cmd: ClearCellCommand): CommandResult {
+    const cell = this.getters.getCell(cmd);
+    if (!cell) return CommandResult.NoChanges;
+    if (!cell.content && !cell.style && !cell.format) {
+      return CommandResult.NoChanges;
+    }
+    return CommandResult.Success;
   }
 }
 

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -120,8 +120,8 @@ export class ClipboardPlugin extends UIPlugin {
         this.lastPasteState = this.state;
         if (this.paintFormatStatus === "oneOff") {
           this.paintFormatStatus = "inactive";
-          this.status = "invisible";
         }
+        this.status = "invisible";
         break;
       case "COPY_PASTE_CELLS_ABOVE":
         {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1312,6 +1312,7 @@ export const enum CommandResult {
   InvalidNumberOfCriterionValues = "InvalidNumberOfCriterionValues",
   BlockingValidationRule = "BlockingValidationRule",
   InvalidCopyPasteSelection = "InvalidCopyPasteSelection",
+  NoChanges = "NoChanges",
 }
 
 export interface CommandHandler<T> {

--- a/tests/borders/border_plugin.test.ts
+++ b/tests/borders/border_plugin.test.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_BORDER_DESC } from "../../src/constants";
 import { Model } from "../../src/model";
-import { BorderDescr } from "../../src/types/index";
+import { BorderDescr, CommandResult } from "../../src/types/index";
 import {
   addColumns,
   addRows,
@@ -9,6 +9,7 @@ import {
   paste,
   selectCell,
   setAnchorCorner,
+  setBorders,
   setCellContent,
   setZoneBorders,
   undo,
@@ -97,6 +98,21 @@ describe("borders", () => {
     setZoneBorders(model, { position: "clear" });
 
     expect(getCell(model, "C3")).toBeUndefined();
+  });
+
+  test("set the same border twice is cancelled", () => {
+    const model = new Model();
+    const border = { top: DEFAULT_BORDER_DESC };
+    setBorders(model, "A1", border);
+    expect(setBorders(model, "A1", border)).toBeCancelledBecause(CommandResult.NoChanges);
+  });
+
+  test("reset border when there is no border is cancelled", () => {
+    const model = new Model();
+    expect(setBorders(model, "A1", undefined)).toBeCancelledBecause(CommandResult.NoChanges);
+    expect(setBorders(model, "A1", { top: undefined })).toBeCancelledBecause(
+      CommandResult.NoChanges
+    );
   });
 
   test("can set all borders in a zone", () => {

--- a/tests/cells/cell_plugin.test.ts
+++ b/tests/cells/cell_plugin.test.ts
@@ -6,6 +6,7 @@ import { CellValueType, CommandResult } from "../../src/types";
 import {
   addColumns,
   addRows,
+  clearCell,
   copy,
   createSheet,
   deleteColumns,
@@ -15,6 +16,7 @@ import {
   renameSheet,
   setCellContent,
   setCellFormat,
+  setStyle,
   undo,
 } from "../test_helpers/commands_helpers";
 import {
@@ -67,15 +69,46 @@ describe("getCellText", () => {
     expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
   });
 
+  test("clear content", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "hello");
+    clearCell(model, "A1");
+    expect(getCell(model, "A1")).toBeUndefined();
+  });
+
+  test("clear style", () => {
+    const model = new Model();
+    setStyle(model, "A1", { bold: true });
+    clearCell(model, "A1");
+    expect(getCell(model, "A1")).toBeUndefined();
+  });
+
+  test("clear format", () => {
+    const model = new Model();
+    setCellFormat(model, "A1", "#,##0.0");
+    clearCell(model, "A1");
+    expect(getCell(model, "A1")).toBeUndefined();
+  });
+
+  test("clear content, style and format", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "hello");
+    setStyle(model, "A1", { bold: true });
+    setCellFormat(model, "A1", "#,##0.0");
+    clearCell(model, "A1");
+    expect(getCell(model, "A1")).toBeUndefined();
+  });
+
   test("clear cell outside of sheet", () => {
     const model = new Model();
-    const sheetId = model.getters.getActiveSheetId();
-    const result = model.dispatch("CLEAR_CELL", {
-      sheetId,
-      col: 9999,
-      row: 9999,
-    });
+    const result = clearCell(model, "AAA999");
     expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
+  });
+
+  test("clear cell is cancelled if there is nothing on the cell", () => {
+    const model = new Model();
+    const result = clearCell(model, "A1");
+    expect(result).toBeCancelledBecause(CommandResult.NoChanges);
   });
 });
 

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -2,6 +2,7 @@ import { isInside, lettersToNumber, toCartesian, toZone } from "../../src/helper
 import { Model } from "../../src/model";
 import {
   AnchorZone,
+  Border,
   BorderData,
   ChartDefinition,
   ClipboardPasteOptions,
@@ -528,6 +529,21 @@ export function setZoneBorders(model: Model, border: BorderData, xcs?: string[])
   });
 }
 
+export function setBorders(
+  model: Model,
+  xc: string,
+  border?: Border,
+  sheetId: UID = model.getters.getActiveSheetId()
+) {
+  const { col, row } = toCartesian(xc);
+  return model.dispatch("SET_BORDER", {
+    sheetId,
+    col,
+    row,
+    border,
+  });
+}
+
 /**
  * Clear a cell
  */
@@ -537,7 +553,7 @@ export function clearCell(
   sheetId: UID = model.getters.getActiveSheetId()
 ) {
   const { col, row } = toCartesian(xc);
-  model.dispatch("CLEAR_CELL", { col, row, sheetId });
+  return model.dispatch("CLEAR_CELL", { col, row, sheetId });
 }
 
 /**


### PR DESCRIPTION

## Description:

Try to move a column with lots of empty cells: there are lots and lots of SET_BORDERS and CLEAR_CELL commands which are doing nothing because there are no borders to set or the cell is already cleared.

If the column has thousands of rows, the revision size will be huuuged, with thousands of useless commands.

With this commit, the useless SET_BORDERS and CLEAR_CELL commands are cancelled (and therefore never part of the revision)

Task: : [3603259](https://www.odoo.com/web#id=3603259&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo