### PR TITLE
[FIX] Autofill: Automatic autofill based on content

### DIFF
--- a/src/plugins/ui_feature/autofill.ts
+++ b/src/plugins/ui_feature/autofill.ts
@@ -277,19 +277,25 @@ export class AutofillPlugin extends UIPlugin {
     let col: HeaderIndex = zone.left;
     let row: HeaderIndex = zone.bottom;
     if (col > 0) {
-      let left = this.getters.getEvaluatedCell({ sheetId, col: col - 1, row });
-      while (left.type !== CellValueType.empty) {
+      let leftPosition = { sheetId, col: col - 1, row };
+      while (
+        this.getters.getEvaluatedCell(leftPosition).type !== CellValueType.empty ||
+        this.getters.getCell(leftPosition)?.content
+      ) {
         row += 1;
-        left = this.getters.getEvaluatedCell({ sheetId, col: col - 1, row });
+        leftPosition = { sheetId, col: col - 1, row };
       }
     }
     if (row === zone.bottom) {
       col = zone.right;
       if (col <= this.getters.getNumberCols(sheetId)) {
-        let right = this.getters.getEvaluatedCell({ sheetId, col: col + 1, row });
-        while (right.type !== CellValueType.empty) {
+        let rightPosition = { sheetId, col: col + 1, row };
+        while (
+          this.getters.getEvaluatedCell(rightPosition).type !== CellValueType.empty ||
+          this.getters.getCell(rightPosition)?.content
+        ) {
           row += 1;
-          right = this.getters.getEvaluatedCell({ sheetId, col: col + 1, row });
+          rightPosition = { sheetId, col: col + 1, row };
         }
       }
     }

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -473,6 +473,18 @@ describe("Autofill", () => {
     expect(getCell(model, "A5")).toBeUndefined();
   });
 
+  test("Auto-autofill considers cells with a content", () => {
+    setCellContent(model, "B2", "1");
+    setCellContent(model, "B3", '=""');
+    setCellContent(model, "B4", '=""');
+    setCellContent(model, "A2", "2");
+    setSelection(model, ["A2"]);
+    model.dispatch("AUTOFILL_AUTO");
+    expect(getCellContent(model, "A3")).toBe("2");
+    expect(getCellContent(model, "A4")).toBe("2");
+    expect(getCell(model, "A5")).toBeUndefined();
+  });
+
   test("autofill with merge in selection", () => {
     merge(model, "A1:A2");
     setCellContent(model, "A1", "1");


### PR DESCRIPTION
The Automatic autofill is supposed to consider the cells that are seemingly empty be still have some content (for instance, a formula resulting in an empty string). The behaviour was broken when we refactored the evaluation in `saas-16.1`.

Note that the current fix will no longer be correct once the spreading formulas will be introduced.

Task: 3592859

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo