### PR TITLE
[REF] cell: remove useless getter

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -53,7 +53,6 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   static getters = [
     "zoneToXC",
     "getCells",
-    "getFormulaCellContent",
     "getTranslatedCellFormula",
     "getCellStyle",
     "getCellById",
@@ -291,17 +290,16 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   /*
    * Reconstructs the original formula string based on a normalized form and its dependencies
    */
-  getFormulaCellContent(
+  private getFormulaCellContent(
     sheetId: UID,
     compiledFormula: RangeCompiledFormula,
-    dependencies?: Range[]
+    dependencies: Range[]
   ): string {
-    const ranges = dependencies || compiledFormula.dependencies;
     let rangeIndex = 0;
     return concat(
       compiledFormula.tokens.map((token) => {
         if (token.type === "REFERENCE") {
-          const range = ranges[rangeIndex++];
+          const range = dependencies[rangeIndex++];
           return this.getters.getRangeString(range, sheetId);
         }
         return token.value;


### PR DESCRIPTION

## Description:

the method `getFormulaCellContent` is no longer used outside the plugin => it doesn't need to be a getter

Task: : [3586686](https://www.odoo.com/web#id=3586686&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo