### PR TITLE
[FIX] cells,borders: cancel useless commands

### DIFF
--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1112,6 +1112,7 @@ export const enum CommandResult {
   ChartDoesNotExist,
   InvalidHeaderIndex,
   InvalidQuantity,
+  NoChanges,
 }
 
 export interface CommandHandler<T> {

--- a/tests/plugins/borders.test.ts
+++ b/tests/plugins/borders.test.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_BORDER_DESC as b, DEFAULT_BORDER_DESC } from "../../src/constants";
 import { Model } from "../../src/model";
-import { BorderDescr } from "../../src/types/index";
+import { BorderDescr, CommandResult } from "../../src/types/index";
 import {
   addColumns,
   addRows,
@@ -10,6 +10,7 @@ import {
   selectCell,
   setAnchorCorner,
   setBorder,
+  setBorders,
   setCellContent,
   undo,
 } from "../test_helpers/commands_helpers";
@@ -97,6 +98,21 @@ describe("borders", () => {
     setBorder(model, "clear");
 
     expect(getCell(model, "C3")).toBeUndefined();
+  });
+
+  test("set the same border twice is cancelled", () => {
+    const model = new Model();
+    const border = { top: DEFAULT_BORDER_DESC };
+    setBorders(model, "A1", border);
+    expect(setBorders(model, "A1", border)).toBeCancelledBecause(CommandResult.NoChanges);
+  });
+
+  test("reset border when there is no border is cancelled", () => {
+    const model = new Model();
+    expect(setBorders(model, "A1", undefined)).toBeCancelledBecause(CommandResult.NoChanges);
+    expect(setBorders(model, "A1", { top: undefined })).toBeCancelledBecause(
+      CommandResult.NoChanges
+    );
   });
 
   test("can set all borders in a zone", () => {

--- a/tests/plugins/cell.test.ts
+++ b/tests/plugins/cell.test.ts
@@ -3,12 +3,15 @@ import { LINK_COLOR } from "../../src/constants";
 import { buildSheetLink } from "../../src/helpers";
 import { CellValueType, CommandResult, LinkCell } from "../../src/types";
 import {
+  clearCell,
   copy,
   createSheet,
   deleteSheet,
   paste,
   renameSheet,
   setCellContent,
+  setCellFormat,
+  setStyle,
   undo,
 } from "../test_helpers/commands_helpers";
 import { getCell, getCellText } from "../test_helpers/getters_helpers";
@@ -55,15 +58,46 @@ describe("getCellText", () => {
     expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
   });
 
+  test("clear content", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "hello");
+    clearCell(model, "A1");
+    expect(getCell(model, "A1")).toBeUndefined();
+  });
+
+  test("clear style", () => {
+    const model = new Model();
+    setStyle(model, "A1", { bold: true });
+    clearCell(model, "A1");
+    expect(getCell(model, "A1")).toBeUndefined();
+  });
+
+  test("clear format", () => {
+    const model = new Model();
+    setCellFormat(model, "A1", "#,##0.0");
+    clearCell(model, "A1");
+    expect(getCell(model, "A1")).toBeUndefined();
+  });
+
+  test("clear content, style and format", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "hello");
+    setStyle(model, "A1", { bold: true });
+    setCellFormat(model, "A1", "#,##0.0");
+    clearCell(model, "A1");
+    expect(getCell(model, "A1")).toBeUndefined();
+  });
+
   test("clear cell outside of sheet", () => {
     const model = new Model();
-    const sheetId = model.getters.getActiveSheetId();
-    const result = model.dispatch("CLEAR_CELL", {
-      sheetId,
-      col: 9999,
-      row: 9999,
-    });
+    const result = clearCell(model, "AAA999");
     expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
+  });
+
+  test("clear cell is cancelled if there is nothing on the cell", () => {
+    const model = new Model();
+    const result = clearCell(model, "A1");
+    expect(result).toBeCancelledBecause(CommandResult.NoChanges);
   });
 });
 

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -2,6 +2,7 @@ import { isInside, lettersToNumber, toCartesian, toZone } from "../../src/helper
 import { Model } from "../../src/model";
 import {
   AnchorZone,
+  Border,
   BorderCommand,
   ChartDefinition,
   ClipboardPasteOptions,
@@ -430,6 +431,21 @@ export function setBorder(model: Model, border: BorderCommand, xc?: string) {
   });
 }
 
+export function setBorders(
+  model: Model,
+  xc: string,
+  border?: Border,
+  sheetId: UID = model.getters.getActiveSheetId()
+) {
+  const { col, row } = toCartesian(xc);
+  return model.dispatch("SET_BORDER", {
+    sheetId,
+    col,
+    row,
+    border,
+  });
+}
+
 /**
  * Clear a cell
  */
@@ -439,7 +455,7 @@ export function clearCell(
   sheetId: UID = model.getters.getActiveSheetId()
 ) {
   const { col, row } = toCartesian(xc);
-  model.dispatch("CLEAR_CELL", { col, row, sheetId });
+  return model.dispatch("CLEAR_CELL", { col, row, sheetId });
 }
 
 /**


### PR DESCRIPTION
Try to move a column with lots of empty cells: there are lots and lots of SET_BORDERS and CLEAR_CELL commands which are doing nothing because there are no borders to set or the cell is already cleared.

If the column has thousands of rows, the revision size is be huuuged, with thousands of useless commands.
Reducing the size improves: network payload size and the loading of initial revisions.

With this commit, the useless SET_BORDERS and CLEAR_CELL commands are cancelled (and therefore never part of the revision)

Task: 3603259

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo