### PR TITLE
[IMP] components: remove old static props declaration

### DIFF
--- a/src/components/action_button/action_button.ts
+++ b/src/components/action_button/action_button.ts
@@ -28,6 +28,13 @@ interface Props {
 
 export class ActionButton extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ActionButton";
+  static props = {
+    action: Object,
+    hasTriangleDownIcon: { type: Boolean, optional: true },
+    selectedColor: { type: String, optional: true },
+    class: { type: String, optional: true },
+    onClick: { type: Function, optional: true },
+  };
 
   private actionButton = createAction(this.props.action);
 
@@ -79,10 +86,3 @@ export class ActionButton extends Component<Props, SpreadsheetChildEnv> {
     return "";
   }
 }
-ActionButton.props = {
-  action: Object,
-  hasTriangleDownIcon: { type: Boolean, optional: true },
-  selectedColor: { type: String, optional: true },
-  class: { type: String, optional: true },
-  onClick: { type: Function, optional: true },
-};

--- a/src/components/animation/ripple.ts
+++ b/src/components/animation/ripple.ts
@@ -60,6 +60,20 @@ interface RectWithMargins extends Rect {
 
 class RippleEffect extends Component<RippleEffectProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-RippleEffect";
+  static props = {
+    x: String,
+    y: String,
+    color: String,
+    opacity: Number,
+    duration: Number,
+    width: Number,
+    height: Number,
+    offsetY: Number,
+    offsetX: Number,
+    allowOverflow: Boolean,
+    onAnimationEnd: Function,
+    style: String,
+  };
   private rippleRef = useRef("ripple");
 
   setup() {
@@ -97,23 +111,23 @@ class RippleEffect extends Component<RippleEffectProps, SpreadsheetChildEnv> {
   }
 }
 
-RippleEffect.props = {
-  x: String,
-  y: String,
-  color: String,
-  opacity: Number,
-  duration: Number,
-  width: Number,
-  height: Number,
-  offsetY: Number,
-  offsetX: Number,
-  allowOverflow: Boolean,
-  onAnimationEnd: Function,
-  style: String,
-};
-
 export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Ripple";
+  static props = {
+    color: { type: String, optional: true },
+    opacity: { type: Number, optional: true },
+    duration: { type: Number, optional: true },
+    ignoreClickPosition: { type: Boolean, optional: true },
+    width: { type: Number, optional: true },
+    height: { type: Number, optional: true },
+    offsetY: { type: Number, optional: true },
+    offsetX: { type: Number, optional: true },
+    allowOverflow: { type: Boolean, optional: true },
+    enabled: { type: Boolean, optional: true },
+    onAnimationEnd: { type: Function, optional: true },
+    slots: Object,
+    class: { type: String, optional: true },
+  };
   static components = { RippleEffect };
   static defaultProps = {
     color: "#aaaaaa",
@@ -209,19 +223,3 @@ export class Ripple extends Component<RippleProps, SpreadsheetChildEnv> {
     };
   }
 }
-
-Ripple.props = {
-  color: { type: String, optional: true },
-  opacity: { type: Number, optional: true },
-  duration: { type: Number, optional: true },
-  ignoreClickPosition: { type: Boolean, optional: true },
-  width: { type: Number, optional: true },
-  height: { type: Number, optional: true },
-  offsetY: { type: Number, optional: true },
-  offsetX: { type: Number, optional: true },
-  allowOverflow: { type: Boolean, optional: true },
-  enabled: { type: Boolean, optional: true },
-  onAnimationEnd: { type: Function, optional: true },
-  slots: Object,
-  class: { type: String, optional: true },
-};

--- a/src/components/autofill/autofill.ts
+++ b/src/components/autofill/autofill.ts
@@ -56,6 +56,10 @@ interface State {
 
 export class Autofill extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Autofill";
+  static props = {
+    position: Object,
+    isVisible: Boolean,
+  };
   state: State = useState({
     position: { left: 0, top: 0 },
     handler: false,
@@ -132,17 +136,11 @@ export class Autofill extends Component<Props, SpreadsheetChildEnv> {
   }
 }
 
-Autofill.props = {
-  position: Object,
-  isVisible: Boolean,
-};
-
 class TooltipComponent extends Component<Props> {
+  static props = {
+    content: String,
+  };
   static template = xml/* xml */ `
     <div t-esc="props.content"/>
   `;
 }
-
-TooltipComponent.props = {
-  content: String,
-};

--- a/src/components/border_editor/border_editor.ts
+++ b/src/components/border_editor/border_editor.ts
@@ -128,6 +128,17 @@ css/* scss */ `
 
 export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BorderEditor";
+  static props = {
+    class: { type: String, optional: true },
+    currentBorderColor: { type: String, optional: false },
+    currentBorderStyle: { type: String, optional: false },
+    currentBorderPosition: { type: String, optional: true },
+    onBorderColorPicked: Function,
+    onBorderStylePicked: Function,
+    onBorderPositionPicked: Function,
+    maxHeight: { type: Number, optional: true },
+    anchorRect: Object,
+  };
   static components = { ColorPickerWidget, Popover };
   BORDER_POSITIONS = BORDER_POSITIONS;
 
@@ -192,15 +203,3 @@ export class BorderEditor extends Component<BorderEditorProps, SpreadsheetChildE
     };
   }
 }
-
-BorderEditor.props = {
-  class: { type: String, optional: true },
-  currentBorderColor: { type: String, optional: false },
-  currentBorderStyle: { type: String, optional: false },
-  currentBorderPosition: { type: String, optional: true },
-  onBorderColorPicked: Function,
-  onBorderStylePicked: Function,
-  onBorderPositionPicked: Function,
-  maxHeight: { type: Number, optional: true },
-  anchorRect: Object,
-};

--- a/src/components/border_editor/border_editor_widget.ts
+++ b/src/components/border_editor/border_editor_widget.ts
@@ -19,6 +19,13 @@ interface State {
 
 export class BorderEditorWidget extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BorderEditorWidget";
+  static props = {
+    toggleBorderEditor: Function,
+    showBorderEditor: Boolean,
+    disabled: { type: Boolean, optional: true },
+    dropdownMaxHeight: { type: Number, optional: true },
+    class: { type: String, optional: true },
+  };
   static components = { BorderEditor };
 
   borderEditorButtonRef = useRef("borderEditorButton");
@@ -69,11 +76,3 @@ export class BorderEditorWidget extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 }
-
-BorderEditorWidget.props = {
-  toggleBorderEditor: Function,
-  showBorderEditor: Boolean,
-  disabled: { type: Boolean, optional: true },
-  dropdownMaxHeight: { type: Number, optional: true },
-  class: { type: String, optional: true },
-};

--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -76,6 +76,9 @@ interface BottomBarMenuState extends MenuState {
 
 export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BottomBar";
+  static props = {
+    onClick: Function,
+  };
   static components = { Menu, Ripple, BottomBarSheet, BottomBarStatistic };
 
   private bottomBarRef = useRef("bottomBar");
@@ -281,7 +284,3 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
     return this.sheetListRef.el.scrollWidth - this.sheetListRef.el.clientWidth;
   }
 }
-
-BottomBar.props = {
-  onClick: Function,
-};

--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -62,6 +62,12 @@ interface State {
 
 export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BottomBarSheet";
+  static props = {
+    sheetId: String,
+    openContextMenu: Function,
+    style: { type: String, optional: true },
+    onMouseDown: { type: Function, optional: true },
+  };
   static components = { Ripple };
   static defaultProps = {
     onMouseDown: () => {},
@@ -208,9 +214,3 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
     return this.env.model.getters.getSheetName(this.props.sheetId);
   }
 }
-BottomBarSheet.props = {
-  sheetId: String,
-  openContextMenu: Function,
-  style: { type: String, optional: true },
-  onMouseDown: { type: Function, optional: true },
-};

--- a/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -29,6 +29,10 @@ interface Props {
 
 export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-BottomBarStatisic";
+  static props = {
+    openContextMenu: Function,
+    closeContextMenu: Function,
+  };
   static components = { Ripple };
 
   selectedStatisticFn: string = "";
@@ -86,8 +90,3 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
     return fnName + ": " + (fnValue !== undefined ? formatValue(fnValue, { locale }) : "__");
   }
 }
-
-BottomBarStatistic.props = {
-  openContextMenu: Function,
-  closeContextMenu: Function,
-};

--- a/src/components/collaborative_client_tag/collaborative_client_tag.ts
+++ b/src/components/collaborative_client_tag/collaborative_client_tag.ts
@@ -23,6 +23,13 @@ css/* scss */ `
 `;
 export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ClientTag";
+  static props = {
+    active: Boolean,
+    name: String,
+    color: String,
+    col: Number,
+    row: Number,
+  };
   get tagStyle(): string {
     const { col, row, color } = this.props;
     const { height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
@@ -41,11 +48,3 @@ export class ClientTag extends Component<ClientTagProps, SpreadsheetChildEnv> {
     });
   }
 }
-
-ClientTag.props = {
-  active: Boolean,
-  name: String,
-  color: String,
-  col: Number,
-  row: Number,
-};

--- a/src/components/color_picker/color_picker.ts
+++ b/src/components/color_picker/color_picker.ts
@@ -223,6 +223,12 @@ interface State {
 
 export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColorPicker";
+  static props = {
+    onColorPicked: Function,
+    currentColor: { type: String, optional: true },
+    maxHeight: { type: Number, optional: true },
+    anchorRect: Object,
+  };
   static defaultProps = { currentColor: "" };
   static components = { Popover };
 
@@ -384,10 +390,3 @@ export class ColorPicker extends Component<ColorPickerProps, SpreadsheetChildEnv
     return isSameColor(color1, color2);
   }
 }
-
-ColorPicker.props = {
-  onColorPicked: Function,
-  currentColor: { type: String, optional: true },
-  maxHeight: { type: Number, optional: true },
-  anchorRect: Object,
-};

--- a/src/components/color_picker/color_picker_widget.ts
+++ b/src/components/color_picker/color_picker_widget.ts
@@ -52,6 +52,17 @@ css/* scss */ `
 
 export class ColorPickerWidget extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ColorPickerWidget";
+  static props = {
+    currentColor: { type: String, optional: true },
+    toggleColorPicker: Function,
+    showColorPicker: Boolean,
+    onColorPicked: Function,
+    icon: String,
+    title: { type: String, optional: true },
+    disabled: { type: Boolean, optional: true },
+    dropdownMaxHeight: { type: Number, optional: true },
+    class: { type: String, optional: true },
+  };
   static components = { ColorPicker };
 
   colorPickerButtonRef = useRef("colorPickerButton");
@@ -73,15 +84,3 @@ export class ColorPickerWidget extends Component<Props, SpreadsheetChildEnv> {
     };
   }
 }
-
-ColorPickerWidget.props = {
-  currentColor: { type: String, optional: true },
-  toggleColorPicker: Function,
-  showColorPicker: Boolean,
-  onColorPicked: Function,
-  icon: String,
-  title: { type: String, optional: true },
-  disabled: { type: Boolean, optional: true },
-  dropdownMaxHeight: { type: Number, optional: true },
-  class: { type: String, optional: true },
-};

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
@@ -33,12 +33,11 @@ interface Props {
 
 export class TextValueProvider extends Component<Props> {
   static template = "o-spreadsheet-TextValueProvider";
+  static props = {
+    values: Array,
+    selectedIndex: { type: Number, optional: true },
+    getHtmlContent: Function,
+    onValueSelected: Function,
+    onValueHovered: Function,
+  };
 }
-
-TextValueProvider.props = {
-  values: Array,
-  selectedIndex: { type: Number, optional: true },
-  getHtmlContent: Function,
-  onValueSelected: Function,
-  onValueHovered: Function,
-};

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -135,6 +135,16 @@ interface FunctionDescriptionState {
 
 export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Composer";
+  static props = {
+    focus: {
+      validate: (value: string) => ["inactive", "cellFocus", "contentFocus"].includes(value),
+    },
+    onComposerContentFocused: Function,
+    inputStyle: { type: String, optional: true },
+    rect: { type: Object, optional: true },
+    delimitation: { type: Object, optional: true },
+    onComposerUnmounted: { type: Function, optional: true },
+  };
   static components = { TextValueProvider, FunctionDescriptionProvider };
   static defaultProps = {
     inputStyle: "",
@@ -770,12 +780,3 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     this.autoCompleteState.getHtmlContent = (value) => [{ value }];
   }
 }
-
-Composer.props = {
-  focus: { validate: (value: string) => ["inactive", "cellFocus", "contentFocus"].includes(value) },
-  onComposerContentFocused: Function,
-  inputStyle: { type: String, optional: true },
-  rect: { type: Object, optional: true },
-  delimitation: { type: Object, optional: true },
-  onComposerUnmounted: { type: Function, optional: true },
-};

--- a/src/components/composer/formula_assistant/formula_assistant.ts
+++ b/src/components/composer/formula_assistant/formula_assistant.ts
@@ -47,6 +47,11 @@ interface AssistantState {
 
 export class FunctionDescriptionProvider extends Component<Props> {
   static template = "o-spreadsheet-FunctionDescriptionProvider";
+  static props = {
+    functionName: String,
+    functionDescription: Object,
+    argToFocus: Number,
+  };
   assistantState: AssistantState = useState({
     allowCellSelectionBehind: false,
   });
@@ -75,9 +80,3 @@ export class FunctionDescriptionProvider extends Component<Props> {
     }, 2000) as unknown as number;
   }
 }
-
-FunctionDescriptionProvider.props = {
-  functionName: String,
-  functionDescription: Object,
-  argToFocus: Number,
-};

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -58,6 +58,14 @@ interface Props {
  */
 export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GridComposer";
+  static props = {
+    focus: {
+      validate: (value: string) => ["inactive", "cellFocus", "contentFocus"].includes(value),
+    },
+    onComposerUnmounted: Function,
+    onComposerContentFocused: Function,
+    gridDims: Object,
+  };
   static components = { Composer };
 
   private gridComposerRef!: Ref<HTMLElement>;
@@ -188,10 +196,3 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 }
-
-GridComposer.props = {
-  focus: { validate: (value: string) => ["inactive", "cellFocus", "contentFocus"].includes(value) },
-  onComposerUnmounted: Function,
-  onComposerContentFocused: Function,
-  gridDims: Object,
-};

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -46,6 +46,12 @@ interface Props {
 
 export class TopBarComposer extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TopBarComposer";
+  static props = {
+    focus: {
+      validate: (value: string) => ["inactive", "cellFocus", "contentFocus"].includes(value),
+    },
+    onComposerContentFocused: Function,
+  };
   static components = { Composer };
 
   get composerStyle(): string {
@@ -70,8 +76,3 @@ export class TopBarComposer extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 }
-
-TopBarComposer.props = {
-  focus: { validate: (value: string) => ["inactive", "cellFocus", "contentFocus"].includes(value) },
-  onComposerContentFocused: Function,
-};

--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -41,6 +41,7 @@ let tKey = 1;
 
 export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SpreadsheetDashboard";
+  static props = {};
   static components = {
     GridOverlay,
     GridPopover,
@@ -172,5 +173,3 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
     return { ...this.canvasPosition, ...this.env.model.getters.getSheetViewDimensionWithHeaders() };
   }
 }
-
-SpreadsheetDashboard.props = {};

--- a/src/components/data_validation_overlay/data_validation_overlay.ts
+++ b/src/components/data_validation_overlay/data_validation_overlay.ts
@@ -6,6 +6,7 @@ import { DataValidationListIcon } from "./dv_list_icon/dv_list_icon";
 
 export class DataValidationOverlay extends Component<{}, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationOverlay";
+  static props = {};
   static components = { GridCellIcon, DataValidationCheckbox, DataValidationListIcon };
 
   get checkBoxCellPositions(): CellPosition[] {
@@ -18,5 +19,3 @@ export class DataValidationOverlay extends Component<{}, SpreadsheetChildEnv> {
       : this.env.model.getters.getDataValidationListCellsPositions();
   }
 }
-
-DataValidationOverlay.props = {};

--- a/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
+++ b/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
@@ -21,6 +21,9 @@ interface Props {
 
 export class DataValidationCheckbox extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationCheckbox";
+  static props = {
+    cellPosition: Object,
+  };
 
   onCheckboxChange(ev: Event) {
     const newValue = (ev.target as HTMLInputElement).checked;
@@ -38,7 +41,3 @@ export class DataValidationCheckbox extends Component<Props, SpreadsheetChildEnv
     return !!cell?.isFormula;
   }
 }
-
-DataValidationCheckbox.props = {
-  cellPosition: Object,
-};

--- a/src/components/data_validation_overlay/dv_list_icon/dv_list_icon.ts
+++ b/src/components/data_validation_overlay/dv_list_icon/dv_list_icon.ts
@@ -30,6 +30,9 @@ interface Props {
 
 export class DataValidationListIcon extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationListIcon";
+  static props = {
+    cellPosition: Object,
+  };
 
   onClick() {
     const { col, row } = this.props.cellPosition;
@@ -37,7 +40,3 @@ export class DataValidationListIcon extends Component<Props, SpreadsheetChildEnv
     this.env.startCellEdition();
   }
 }
-
-DataValidationListIcon.props = {
-  cellPosition: Object,
-};

--- a/src/components/error_tooltip/error_tooltip.ts
+++ b/src/components/error_tooltip/error_tooltip.ts
@@ -36,12 +36,11 @@ interface ErrorToolTipProps {
 export class ErrorToolTip extends Component<ErrorToolTipProps> {
   static maxSize = { maxHeight: ERROR_TOOLTIP_MAX_HEIGHT };
   static template = "o-spreadsheet-ErrorToolTip";
+  static props = {
+    errors: Array,
+    onClosed: { type: Function, optional: true },
+  };
 }
-
-ErrorToolTip.props = {
-  errors: Array,
-  onClosed: { type: Function, optional: true },
-};
 
 export const ErrorToolTipPopoverBuilder: PopoverBuilders = {
   onHover: (position, getters): CellPopoverComponent<typeof ErrorToolTip> => {

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -10,6 +10,9 @@ interface Props {
 
 export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartJsComponent";
+  static props = {
+    figure: Object,
+  };
 
   private canvas = useRef("graphContainer");
   private chart?: Chart;
@@ -71,7 +74,3 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
     this.chart!.update("active");
   }
 }
-
-ChartJsComponent.props = {
-  figure: Object,
-};

--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -10,6 +10,9 @@ interface Props {
 
 export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChart";
+  static props = {
+    figure: Object,
+  };
   private canvas = useRef("chartContainer");
 
   get runtime(): ScorecardChartRuntime {
@@ -30,7 +33,3 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
     drawScoreChart(config, canvas);
   }
 }
-
-ScorecardChart.props = {
-  figure: Object,
-};

--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -121,6 +121,13 @@ interface Props {
 
 export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FigureComponent";
+  static props = {
+    figure: Object,
+    style: { type: String, optional: true },
+    onFigureDeleted: { type: Function, optional: true },
+    onMouseDown: { type: Function, optional: true },
+    onClickAnchor: { type: Function, optional: true },
+  };
   static components = { Menu };
   static defaultProps = {
     onFigureDeleted: () => {},
@@ -278,11 +285,3 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
       .menuBuilder(this.props.figure.id, this.props.onFigureDeleted, this.env);
   }
 }
-
-FigureComponent.props = {
-  figure: Object,
-  style: { type: String, optional: true },
-  onFigureDeleted: { type: Function, optional: true },
-  onMouseDown: { type: Function, optional: true },
-  onClickAnchor: { type: Function, optional: true },
-};

--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -23,6 +23,10 @@ interface Props {
 
 export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartFigure";
+  static props = {
+    figure: Object,
+    onFigureDeleted: Function,
+  };
   static components = {};
 
   onDoubleClick() {
@@ -43,8 +47,3 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
     return component;
   }
 }
-
-ChartFigure.props = {
-  figure: Object,
-  onFigureDeleted: Function,
-};

--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -122,6 +122,9 @@ css/*SCSS*/ `
  */
 export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FiguresContainer";
+  static props = {
+    onFigureDeleted: Function,
+  };
   static components = { FigureComponent };
 
   dnd = useState<DndState>({
@@ -442,7 +445,3 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 }
-
-FiguresContainer.props = {
-  onFigureDeleted: Function,
-};

--- a/src/components/figures/figure_image/figure_image.ts
+++ b/src/components/figures/figure_image/figure_image.ts
@@ -8,6 +8,10 @@ interface Props {
 
 export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ImageFigure";
+  static props = {
+    figure: Object,
+    onFigureDeleted: Function,
+  };
   static components = {};
 
   // ---------------------------------------------------------------------------
@@ -22,8 +26,3 @@ export class ImageFigure extends Component<Props, SpreadsheetChildEnv> {
     return this.env.model.getters.getImagePath(this.figureId);
   }
 }
-
-ImageFigure.props = {
-  figure: Object,
-  onFigureDeleted: Function,
-};

--- a/src/components/filters/filter_icon/filter_icon.ts
+++ b/src/components/filters/filter_icon/filter_icon.ts
@@ -3,7 +3,7 @@ import { FILTERS_COLOR, GRID_ICON_EDGE_LENGTH } from "../../../constants";
 import { CellPosition, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
 
-const CSS = css/* scss */ `
+css/* scss */ `
   .o-filter-icon {
     color: ${FILTERS_COLOR};
     display: flex;
@@ -23,8 +23,10 @@ interface Props {
 }
 
 export class FilterIcon extends Component<Props, SpreadsheetChildEnv> {
-  static style = CSS;
   static template = "o-spreadsheet-FilterIcon";
+  static props = {
+    cellPosition: Object,
+  };
 
   onClick() {
     const position = this.props.cellPosition;
@@ -45,7 +47,3 @@ export class FilterIcon extends Component<Props, SpreadsheetChildEnv> {
     return this.env.model.getters.isFilterActive(this.props.cellPosition);
   }
 }
-
-FilterIcon.props = {
-  cellPosition: Object,
-};

--- a/src/components/filters/filter_icons_overlay/filter_icons_overlay.ts
+++ b/src/components/filters/filter_icons_overlay/filter_icons_overlay.ts
@@ -9,6 +9,9 @@ interface Props {
 
 export class FilterIconsOverlay extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterIconsOverlay";
+  static props = {
+    gridPosition: { type: Object, optional: true },
+  };
   static components = {
     GridCellIcon,
     FilterIcon,
@@ -23,7 +26,3 @@ export class FilterIconsOverlay extends Component<Props, SpreadsheetChildEnv> {
     return headerPositions.map((position) => ({ sheetId, ...position }));
   }
 }
-
-FilterIconsOverlay.props = {
-  gridPosition: { type: Object, optional: true },
-};

--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -1,5 +1,5 @@
 import { Component, onWillUpdateProps, useRef, useState } from "@odoo/owl";
-import { MENU_ITEM_HEIGHT, MENU_WIDTH } from "../../../constants";
+import { MENU_ITEM_HEIGHT } from "../../../constants";
 import { deepEquals, positions, toLowerCase } from "../../../helpers";
 import { fuzzyLookup } from "../../../helpers/search";
 import { Position, SortDirection, SpreadsheetChildEnv } from "../../../types";
@@ -123,8 +123,11 @@ interface State {
 }
 
 export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
-  static size = { width: MENU_WIDTH, height: FILTER_MENU_HEIGHT };
   static template = "o-spreadsheet-FilterMenu";
+  static props = {
+    filterPosition: Object,
+    onClosed: { type: Function, optional: true },
+  };
   static style = CSS;
   static components = { FilterMenuValueItem };
 
@@ -308,10 +311,6 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
     this.props.onClosed?.();
   }
 }
-FilterMenu.props = {
-  filterPosition: Object,
-  onClosed: { type: Function, optional: true },
-};
 
 export const FilterMenuPopoverBuilder: PopoverBuilders = {
   onOpen: (position, getters): CellPopoverComponent<typeof FilterMenu> => {

--- a/src/components/filters/filter_menu_item/filter_menu_value_item.ts
+++ b/src/components/filters/filter_menu_item/filter_menu_value_item.ts
@@ -24,6 +24,14 @@ css/*SCSS*/ `
 
 export class FilterMenuValueItem extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterMenuValueItem";
+  static props = {
+    value: String,
+    isChecked: Boolean,
+    isSelected: Boolean,
+    onMouseMove: Function,
+    onClick: Function,
+    scrolledTo: { type: String, optional: true },
+  };
 
   private itemRef = useRef("menuValueItem");
 
@@ -44,12 +52,3 @@ export class FilterMenuValueItem extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 }
-
-FilterMenuValueItem.props = {
-  value: String,
-  isChecked: Boolean,
-  isSelected: Boolean,
-  onMouseMove: Function,
-  onClick: Function,
-  scrolledTo: { type: String, optional: true },
-};

--- a/src/components/font_size_editor/font_size_editor.ts
+++ b/src/components/font_size_editor/font_size_editor.ts
@@ -44,6 +44,11 @@ css/* scss */ `
 
 export class FontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FontSizeEditor";
+  static props = {
+    onToggle: Function,
+    dropdownStyle: String,
+    class: String,
+  };
   static components = {};
   fontSizes = FONT_SIZES;
 
@@ -111,9 +116,3 @@ export class FontSizeEditor extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 }
-
-FontSizeEditor.props = {
-  onToggle: Function,
-  dropdownStyle: String,
-  class: String,
-};

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -110,6 +110,13 @@ interface Props {
 // -----------------------------------------------------------------------------
 export class Grid extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Grid";
+  static props = {
+    sidePanelIsOpen: Boolean,
+    exposeFocus: Function,
+    focusComposer: String,
+    onComposerContentFocused: Function,
+    onGridComposerCellFocused: Function,
+  };
   static components = {
     GridComposer,
     GridOverlay,
@@ -770,11 +777,3 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 }
-
-Grid.props = {
-  sidePanelIsOpen: Boolean,
-  exposeFocus: Function,
-  focusComposer: String,
-  onComposerContentFocused: Function,
-  onGridComposerCellFocused: Function,
-};

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.ts
@@ -26,6 +26,9 @@ interface Props {
 
 export class GridAddRowsFooter extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GridAddRowsFooter";
+  static props = {
+    focusGrid: Function,
+  };
   static components = { ValidationMessages };
   inputRef = useRef<HTMLInputElement>("inputRef");
   state = useState({
@@ -103,7 +106,3 @@ export class GridAddRowsFooter extends Component<Props, SpreadsheetChildEnv> {
     this.props.focusGrid();
   }
 }
-
-GridAddRowsFooter.props = {
-  focusGrid: Function,
-};

--- a/src/components/grid_cell_icon/grid_cell_icon.ts
+++ b/src/components/grid_cell_icon/grid_cell_icon.ts
@@ -10,7 +10,7 @@ import {
 } from "../../types";
 import { css, cssPropertiesToCss } from "../helpers";
 
-const CSS = css/* scss */ `
+css/* scss */ `
   .o-grid-cell-icon {
     width: ${GRID_ICON_EDGE_LENGTH}px;
     height: ${GRID_ICON_EDGE_LENGTH}px;
@@ -25,8 +25,14 @@ export interface GridCellIconProps {
 }
 
 export class GridCellIcon extends Component<GridCellIconProps, SpreadsheetChildEnv> {
-  static style = CSS;
   static template = "o-spreadsheet-GridCellIcon";
+  static props = {
+    cellPosition: Object,
+    horizontalAlign: { type: String, optional: true },
+    verticalAlign: { type: String, optional: true },
+    offset: { type: Object, optional: true },
+    slots: Object,
+  };
 
   get iconStyle() {
     const x = this.getIconHorizontalPosition();
@@ -89,11 +95,3 @@ export class GridCellIcon extends Component<GridCellIconProps, SpreadsheetChildE
     return !(rect.width === 0 || rect.height === 0);
   }
 }
-
-GridCellIcon.props = {
-  cellPosition: Object,
-  horizontalAlign: { type: String, optional: true },
-  verticalAlign: { type: String, optional: true },
-  offset: { type: Object, optional: true },
-  slots: Object,
-};

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -170,6 +170,16 @@ interface Props {
 
 export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GridOverlay";
+  static props = {
+    onCellHovered: { type: Function, optional: true },
+    onCellDoubleClicked: { type: Function, optional: true },
+    onCellClicked: { type: Function, optional: true },
+    onCellRightClicked: { type: Function, optional: true },
+    onGridResized: { type: Function, optional: true },
+    onFigureDeleted: { type: Function, optional: true },
+    onGridMoved: Function,
+    gridOverlayDimensions: String,
+  };
   static components = { FiguresContainer, DataValidationOverlay, GridAddRowsFooter };
   static defaultProps = {
     onCellHovered: () => {},
@@ -252,14 +262,3 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
     return [colIndex, rowIndex];
   }
 }
-
-GridOverlay.props = {
-  onCellHovered: { type: Function, optional: true },
-  onCellDoubleClicked: { type: Function, optional: true },
-  onCellClicked: { type: Function, optional: true },
-  onCellRightClicked: { type: Function, optional: true },
-  onGridResized: { type: Function, optional: true },
-  onFigureDeleted: { type: Function, optional: true },
-  onGridMoved: Function,
-  gridOverlayDimensions: String,
-};

--- a/src/components/grid_popover/grid_popover.ts
+++ b/src/components/grid_popover/grid_popover.ts
@@ -12,6 +12,12 @@ interface Props {
 }
 export class GridPopover extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GridPopover";
+  static props = {
+    hoveredCell: Object,
+    onClosePopover: Function,
+    onMouseWheel: Function,
+    gridRect: Object,
+  };
   static components = { Popover };
   zIndex = ComponentsImportance.GridPopover;
 
@@ -32,10 +38,3 @@ export class GridPopover extends Component<Props, SpreadsheetChildEnv> {
     };
   }
 }
-
-GridPopover.props = {
-  hoveredCell: Object,
-  onClosePopover: Function,
-  onMouseWheel: Function,
-  gridRect: Object,
-};

--- a/src/components/header_group/header_group.ts
+++ b/src/components/header_group/header_group.ts
@@ -52,6 +52,11 @@ css/* scss */ `
 
 abstract class AbstractHeaderGroup extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-HeaderGroup";
+  static props = {
+    group: Object,
+    layerOffset: Number,
+    openContextMenu: Function,
+  };
 
   abstract dimension: Dimension;
 
@@ -102,11 +107,6 @@ abstract class AbstractHeaderGroup extends Component<Props, SpreadsheetChildEnv>
     this.props.openContextMenu(position, menuItems);
   }
 }
-AbstractHeaderGroup.props = {
-  group: Object,
-  layerOffset: Number,
-  openContextMenu: Function,
-};
 
 export class RowGroup extends AbstractHeaderGroup {
   dimension: Dimension = "ROW";

--- a/src/components/header_group/header_group_container.ts
+++ b/src/components/header_group/header_group_container.ts
@@ -38,6 +38,10 @@ css/* scss */ `
 
 export class HeaderGroupContainer extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-HeaderGroupContainer";
+  static props = {
+    dimension: String,
+    layers: Array,
+  };
   static components = { RowGroup, ColGroup, Menu };
 
   menu: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
@@ -109,8 +113,3 @@ export class HeaderGroupContainer extends Component<Props, SpreadsheetChildEnv> 
     }
   }
 }
-
-HeaderGroupContainer.props = {
-  dimension: String,
-  layers: Array,
-};

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -46,6 +46,9 @@ interface ResizerProps {
 }
 
 abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildEnv> {
+  static props = {
+    onOpenContextMenu: Function,
+  };
   PADDING: number = 0;
   MAX_SIZE_MARGIN: number = 0;
   MIN_ELEMENT_SIZE: number = 0;
@@ -349,11 +352,11 @@ css/* scss */ `
   }
 `;
 
-AbstractResizer.props = {
-  onOpenContextMenu: Function,
-};
-
 export class ColResizer extends AbstractResizer {
+  static props = {
+    onOpenContextMenu: Function,
+  };
+
   static template = "o-spreadsheet-ColResizer";
 
   private colResizerRef!: Ref<HTMLElement>;
@@ -545,11 +548,10 @@ css/* scss */ `
   }
 `;
 
-ColResizer.props = {
-  onOpenContextMenu: Function,
-};
-
 export class RowResizer extends AbstractResizer {
+  static props = {
+    onOpenContextMenu: Function,
+  };
   static template = "o-spreadsheet-RowResizer";
 
   setup() {
@@ -700,11 +702,10 @@ css/* scss */ `
   }
 `;
 
-RowResizer.props = {
-  onOpenContextMenu: Function,
-};
-
 export class HeadersOverlay extends Component<any, SpreadsheetChildEnv> {
+  static props = {
+    onOpenContextMenu: Function,
+  };
   static template = "o-spreadsheet-HeadersOverlay";
   static components = { ColResizer, RowResizer };
 
@@ -712,7 +713,3 @@ export class HeadersOverlay extends Component<any, SpreadsheetChildEnv> {
     this.env.model.selection.selectAll();
   }
 }
-
-HeadersOverlay.props = {
-  onOpenContextMenu: Function,
-};

--- a/src/components/highlight/border/border.ts
+++ b/src/components/highlight/border/border.ts
@@ -25,6 +25,12 @@ interface Props {
 
 export class Border extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Border";
+  static props = {
+    zone: Object,
+    orientation: String,
+    isMoving: Boolean,
+    onMoveHighlight: Function,
+  };
   get style() {
     const isTop = ["n", "w", "e"].includes(this.props.orientation);
     const isLeft = ["n", "w", "s"].includes(this.props.orientation);
@@ -59,10 +65,3 @@ export class Border extends Component<Props, SpreadsheetChildEnv> {
     this.props.onMoveHighlight(ev.clientX, ev.clientY);
   }
 }
-
-Border.props = {
-  zone: Object,
-  orientation: String,
-  isMoving: Boolean,
-  onMoveHighlight: Function,
-};

--- a/src/components/highlight/corner/corner.ts
+++ b/src/components/highlight/corner/corner.ts
@@ -39,6 +39,13 @@ interface Props {
 
 export class Corner extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Corner";
+  static props = {
+    zone: Object,
+    color: String,
+    orientation: String,
+    isResizing: Boolean,
+    onResizeHighlight: Function,
+  };
   private isTop = this.props.orientation[0] === "n";
   private isLeft = this.props.orientation[1] === "w";
 
@@ -73,11 +80,3 @@ export class Corner extends Component<Props, SpreadsheetChildEnv> {
     this.props.onResizeHighlight(this.isLeft, this.isTop);
   }
 }
-
-Corner.props = {
-  zone: Object,
-  color: String,
-  orientation: String,
-  isResizing: Boolean,
-  onResizeHighlight: Function,
-};

--- a/src/components/highlight/highlight/highlight.ts
+++ b/src/components/highlight/highlight/highlight.ts
@@ -24,6 +24,10 @@ interface HighlightState {
 }
 export class Highlight extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Highlight";
+  static props = {
+    zone: Object,
+    color: String,
+  };
   static components = {
     Corner,
     Border,
@@ -142,8 +146,3 @@ export class Highlight extends Component<Props, SpreadsheetChildEnv> {
     dragAndDropBeyondTheViewport(this.env, mouseMove, mouseUp);
   }
 }
-
-Highlight.props = {
-  zone: Object,
-  color: String,
-};

--- a/src/components/icon_picker/icon_picker.ts
+++ b/src/components/icon_picker/icon_picker.ts
@@ -31,6 +31,9 @@ css/* scss */ `
 
 export class IconPicker extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-IconPicker";
+  static props = {
+    onIconPicked: Function,
+  };
   icons = ICONS;
   iconSets = ICON_SETS;
 
@@ -40,7 +43,3 @@ export class IconPicker extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 }
-
-IconPicker.props = {
-  onIconPicked: Function,
-};

--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -64,8 +64,12 @@ interface LinkDisplayProps {
 }
 
 export class LinkDisplay extends Component<LinkDisplayProps, SpreadsheetChildEnv> {
-  static components = { Menu };
   static template = "o-spreadsheet-LinkDisplay";
+  static props = {
+    cellPosition: Object,
+    onClosed: { type: Function, optional: true },
+  };
+  static components = { Menu };
 
   get cell(): EvaluatedCell {
     const { col, row } = this.props.cellPosition;
@@ -128,9 +132,4 @@ export const LinkCellPopoverBuilder: PopoverBuilders = {
       cellCorner: "BottomLeft",
     };
   },
-};
-
-LinkDisplay.props = {
-  cellPosition: Object,
-  onClosed: { type: Function, optional: true },
 };

--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -83,6 +83,10 @@ interface State {
 
 export class LinkEditor extends Component<LinkEditorProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-LinkEditor";
+  static props = {
+    cellPosition: Object,
+    onClosed: { type: Function, optional: true },
+  };
   static components = { Menu };
   menuItems = linkMenuRegistry.getMenuItems();
   private link: State = useState(this.defaultState);
@@ -190,9 +194,4 @@ export const LinkEditorPopoverBuilder: PopoverBuilders = {
       cellCorner: "BottomLeft",
     };
   },
-};
-
-LinkEditor.props = {
-  cellPosition: Object,
-  onClosed: { type: Function, optional: true },
 };

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -89,6 +89,15 @@ export interface MenuState {
 }
 export class Menu extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Menu";
+  static props = {
+    position: Object,
+    menuItems: Array,
+    depth: { type: Number, optional: true },
+    maxHeight: { type: Number, optional: true },
+    onClose: Function,
+    onMenuClicked: { type: Function, optional: true },
+    menuId: { type: String, optional: true },
+  };
 
   static components = { Menu, Popover };
   static defaultProps = {
@@ -265,13 +274,3 @@ export class Menu extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 }
-
-Menu.props = {
-  position: Object,
-  menuItems: Array,
-  depth: { type: Number, optional: true },
-  maxHeight: { type: Number, optional: true },
-  onClose: Function,
-  onMenuClicked: { type: Function, optional: true },
-  menuId: { type: String, optional: true },
-};

--- a/src/components/paint_format_button/paint_format_button.ts
+++ b/src/components/paint_format_button/paint_format_button.ts
@@ -7,6 +7,9 @@ interface Props {
 
 export class PaintFormatButton extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-PaintFormatButton";
+  static props = {
+    class: { type: String, optional: true },
+  };
 
   get isActive() {
     return this.env.model.getters.isPaintingFormat();
@@ -24,6 +27,3 @@ export class PaintFormatButton extends Component<Props, SpreadsheetChildEnv> {
     }
   }
 }
-PaintFormatButton.props = {
-  class: { type: String, optional: true },
-};

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -47,6 +47,19 @@ css/* scss */ `
 
 export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Popover";
+  static props = {
+    anchorRect: Object,
+    containerRect: { type: Object, optional: true },
+    positioning: { type: String, optional: true },
+    maxWidth: { type: Number, optional: true },
+    maxHeight: { type: Number, optional: true },
+    verticalOffset: { type: Number, optional: true },
+    onMouseWheel: { type: Function, optional: true },
+    onPopoverHidden: { type: Function, optional: true },
+    onPopoverMoved: { type: Function, optional: true },
+    zIndex: { type: Number, optional: true },
+    slots: Object,
+  };
   static defaultProps = {
     positioning: "BottomLeft",
     verticalOffset: 0,
@@ -114,20 +127,6 @@ export class Popover extends Component<PopoverProps, SpreadsheetChildEnv> {
     });
   }
 }
-
-Popover.props = {
-  anchorRect: Object,
-  containerRect: { type: Object, optional: true },
-  positioning: { type: String, optional: true },
-  maxWidth: { type: Number, optional: true },
-  maxHeight: { type: Number, optional: true },
-  verticalOffset: { type: Number, optional: true },
-  onMouseWheel: { type: Function, optional: true },
-  onPopoverHidden: { type: Function, optional: true },
-  onPopoverMoved: { type: Function, optional: true },
-  zIndex: { type: Number, optional: true },
-  slots: Object,
-};
 
 abstract class PopoverPositionContext {
   constructor(

--- a/src/components/scrollbar/scrollbar.ts
+++ b/src/components/scrollbar/scrollbar.ts
@@ -33,6 +33,14 @@ css/* scss */ `
 `;
 
 export class ScrollBar extends Component<Props> {
+  static props = {
+    width: { type: Number, optional: true },
+    height: { type: Number, optional: true },
+    direction: String,
+    position: Object,
+    offset: Number,
+    onScroll: Function,
+  };
   static template = xml/*xml*/ `
     <div
         t-attf-class="o-scrollbar {{props.direction}}"
@@ -83,12 +91,3 @@ export class ScrollBar extends Component<Props> {
     }
   }
 }
-
-ScrollBar.props = {
-  width: { type: Number, optional: true },
-  height: { type: Number, optional: true },
-  direction: String,
-  position: Object,
-  offset: Number,
-  onScroll: Function,
-};

--- a/src/components/scrollbar/scrollbar_horizontal.ts
+++ b/src/components/scrollbar/scrollbar_horizontal.ts
@@ -8,6 +8,9 @@ interface Props {
 }
 
 export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
+  static props = {
+    leftOffset: { type: Number, optional: true },
+  };
   static components = { ScrollBar };
   static template = xml/*xml*/ `
       <ScrollBar
@@ -55,7 +58,3 @@ export class HorizontalScrollBar extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 }
-
-HorizontalScrollBar.props = {
-  leftOffset: { type: Number, optional: true },
-};

--- a/src/components/scrollbar/scrollbar_vertical.ts
+++ b/src/components/scrollbar/scrollbar_vertical.ts
@@ -8,6 +8,9 @@ interface Props {
 }
 
 export class VerticalScrollBar extends Component<Props, SpreadsheetChildEnv> {
+  static props = {
+    topOffset: { type: Number, optional: true },
+  };
   static components = { ScrollBar };
   static template = xml/*xml*/ `
     <ScrollBar
@@ -55,7 +58,3 @@ export class VerticalScrollBar extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 }
-
-VerticalScrollBar.props = {
-  topOffset: { type: Number, optional: true },
-};

--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -100,6 +100,15 @@ interface SelectionRange extends Omit<RangeInputValue, "color"> {
  */
 export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SelectionInput";
+  static props = {
+    ranges: Function,
+    hasSingleRange: { type: Boolean, optional: true },
+    required: { type: Boolean, optional: true },
+    isInvalid: { type: Boolean, optional: true },
+    class: { type: String, optional: true },
+    onSelectionChanged: { type: Function, optional: true },
+    onSelectionConfirmed: { type: Function, optional: true },
+  };
   private id = uuidGenerator.uuidv4();
   private previousRanges: string[] = this.props.ranges() || [];
   private originSheet = this.env.model.getters.getActiveSheetId();
@@ -283,13 +292,3 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
     this.env.model.dispatch("UNFOCUS_SELECTION_INPUT");
   }
 }
-
-SelectionInput.props = {
-  ranges: Function,
-  hasSingleRange: { type: Boolean, optional: true },
-  required: { type: Boolean, optional: true },
-  isInvalid: { type: Boolean, optional: true },
-  class: { type: String, optional: true },
-  onSelectionChanged: { type: Function, optional: true },
-  onSelectionConfirmed: { type: Function, optional: true },
-};

--- a/src/components/side_panel/chart/building_blocks/color/color.ts
+++ b/src/components/side_panel/chart/building_blocks/color/color.ts
@@ -15,6 +15,11 @@ interface Props {
 export class ChartColor extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartColor";
   static components = { ColorPickerWidget, Section };
+  static props = {
+    currentColor: { type: String, optional: true },
+    onColorPicked: Function,
+  };
+
   private state!: State;
 
   setup() {
@@ -30,8 +35,3 @@ export class ChartColor extends Component<Props, SpreadsheetChildEnv> {
     this.state.pickerOpened = !this.state.pickerOpened;
   }
 }
-
-ChartColor.props = {
-  currentColor: { type: String, optional: true },
-  onColorPicked: Function,
-};

--- a/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
+++ b/src/components/side_panel/chart/building_blocks/data_series/data_series.ts
@@ -14,15 +14,14 @@ interface Props {
 export class ChartDataSeries extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartDataSeries";
   static components = { SelectionInput, Section };
+  static props = {
+    ranges: Function,
+    hasSingleRange: { type: Boolean, optional: true },
+    onSelectionChanged: Function,
+    onSelectionConfirmed: Function,
+  };
 
   get title() {
     return this.props.hasSingleRange ? _t("Data range") : _t("Data series");
   }
 }
-
-ChartDataSeries.props = {
-  ranges: Function,
-  hasSingleRange: { type: Boolean, optional: true },
-  onSelectionChanged: Function,
-  onSelectionConfirmed: Function,
-};

--- a/src/components/side_panel/chart/building_blocks/error_section/error_section.ts
+++ b/src/components/side_panel/chart/building_blocks/error_section/error_section.ts
@@ -10,8 +10,5 @@ interface Props {
 export class ChartErrorSection extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartErrorSection";
   static components = { Section, ValidationMessages };
+  static props = { messages: { type: Array, element: String } };
 }
-
-ChartErrorSection.props = {
-  messages: { type: Array, element: String },
-};

--- a/src/components/side_panel/chart/building_blocks/label_range/label_range.ts
+++ b/src/components/side_panel/chart/building_blocks/label_range/label_range.ts
@@ -23,19 +23,19 @@ interface Props {
 export class ChartLabelRange extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartLabelRange";
   static components = { SelectionInput, Checkbox, Section };
+  static props = {
+    title: { type: String, optional: true },
+    range: Function,
+    isInvalid: Boolean,
+    required: { type: Boolean, optional: true },
+    onSelectionChanged: Function,
+    onSelectionConfirmed: Function,
+    options: { type: Array, optional: true },
+  };
+
   static defaultProps: Partial<Props> = {
     title: _t("Categories / Labels"),
     options: [],
     required: false,
   };
 }
-
-ChartLabelRange.props = {
-  title: { type: String, optional: true },
-  range: Function,
-  isInvalid: Boolean,
-  required: { type: Boolean, optional: true },
-  onSelectionChanged: Function,
-  onSelectionConfirmed: Function,
-  options: { type: Array, optional: true },
-};

--- a/src/components/side_panel/chart/building_blocks/title/title.ts
+++ b/src/components/side_panel/chart/building_blocks/title/title.ts
@@ -11,13 +11,9 @@ interface Props {
 export class ChartTitle extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartTitle";
   static components = { ColorPickerWidget, Section };
+  static props = { title: String, update: Function };
 
   updateTitle(ev: InputEvent) {
     this.props.update((ev.target as HTMLInputElement).value);
   }
 }
-
-ChartTitle.props = {
-  title: String,
-  update: Function,
-};

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
@@ -20,6 +20,12 @@ interface PanelState {
 export class GaugeChartConfigPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GaugeChartConfigPanel";
   static components = { SelectionInput, ChartErrorSection, ChartDataSeries };
+  static props = {
+    figureId: String,
+    definition: Object,
+    updateChart: Function,
+    canUpdateChart: Function,
+  };
 
   private state: PanelState = useState({
     dataRangeDispatchResult: undefined,
@@ -57,10 +63,3 @@ export class GaugeChartConfigPanel extends Component<Props, SpreadsheetChildEnv>
     return this.dataRange || "";
   }
 }
-
-GaugeChartConfigPanel.props = {
-  figureId: String,
-  definition: Object,
-  updateChart: Function,
-  canUpdateChart: Function,
-};

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -67,6 +67,12 @@ interface PanelState {
 export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GaugeChartDesignPanel";
   static components = { ColorPickerWidget, ChartErrorSection, ChartColor, ChartTitle, Section };
+  static props = {
+    figureId: String,
+    definition: Object,
+    updateChart: Function,
+    canUpdateChart: Function,
+  };
 
   private state: PanelState = useState({
     openedMenu: undefined,
@@ -176,10 +182,3 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     this.state.openedMenu = undefined;
   }
 }
-
-GaugeChartDesignPanel.props = {
-  figureId: String,
-  definition: Object,
-  updateChart: Function,
-  canUpdateChart: Function,
-};

--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
@@ -44,6 +44,12 @@ export class LineBarPieConfigPanel extends Component<Props, SpreadsheetChildEnv>
     Checkbox,
     ChartErrorSection,
   };
+  static props = {
+    figureId: String,
+    definition: Object,
+    updateChart: Function,
+    canUpdateChart: Function,
+  };
 
   private state: ChartPanelState = useState({
     datasetDispatchResult: undefined,
@@ -167,10 +173,3 @@ export class LineBarPieConfigPanel extends Component<Props, SpreadsheetChildEnv>
     return undefined;
   }
 }
-
-LineBarPieConfigPanel.props = {
-  figureId: String,
-  definition: Object,
-  updateChart: Function,
-  canUpdateChart: Function,
-};

--- a/src/components/side_panel/chart/line_bar_pie_panel/design_panel.ts
+++ b/src/components/side_panel/chart/line_bar_pie_panel/design_panel.ts
@@ -24,6 +24,12 @@ interface Props {
 export class LineBarPieDesignPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-LineBarPieDesignPanel";
   static components = { ChartColor, ColorPickerWidget, ChartTitle, Section };
+  static props = {
+    figureId: String,
+    definition: Object,
+    updateChart: Function,
+    canUpdateChart: Function,
+  };
 
   get title() {
     return _t(this.props.definition.title);
@@ -45,10 +51,3 @@ export class LineBarPieDesignPanel extends Component<Props, SpreadsheetChildEnv>
     });
   }
 }
-
-LineBarPieDesignPanel.props = {
-  figureId: String,
-  definition: Object,
-  updateChart: Function,
-  canUpdateChart: Function,
-};

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -46,6 +46,7 @@ interface State {
 export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartPanel";
   static components = { Section };
+  static props = { onCloseSidePanel: Function };
 
   private state!: State;
 
@@ -143,7 +144,3 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
     this.state.panel = panel;
   }
 }
-
-ChartPanel.props = {
-  onCloseSidePanel: Function,
-};

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
@@ -22,6 +22,12 @@ interface PanelState {
 export class ScorecardChartConfigPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChartConfigPanel";
   static components = { SelectionInput, ValidationMessages, ChartErrorSection, Section };
+  static props = {
+    figureId: String,
+    definition: Object,
+    updateChart: Function,
+    canUpdateChart: Function,
+  };
 
   private state: PanelState = useState({
     keyValueDispatchResult: undefined,
@@ -91,10 +97,3 @@ export class ScorecardChartConfigPanel extends Component<Props, SpreadsheetChild
     this.props.updateChart(this.props.figureId, { baselineMode: ev.target.value });
   }
 }
-
-ScorecardChartConfigPanel.props = {
-  figureId: String,
-  definition: Object,
-  updateChart: Function,
-  canUpdateChart: Function,
-};

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
@@ -23,6 +23,12 @@ interface PanelState {
 export class ScorecardChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChartDesignPanel";
   static components = { ColorPickerWidget, ChartColor, ChartTitle, Section };
+  static props = {
+    figureId: String,
+    definition: Object,
+    updateChart: Function,
+    canUpdateChart: Function,
+  };
 
   private state: PanelState = useState({
     openedColorPicker: undefined,
@@ -75,10 +81,3 @@ export class ScorecardChartDesignPanel extends Component<Props, SpreadsheetChild
     this.state.openedColorPicker = undefined;
   }
 }
-
-ScorecardChartDesignPanel.props = {
-  figureId: String,
-  definition: Object,
-  updateChart: Function,
-  canUpdateChart: Function,
-};

--- a/src/components/side_panel/components/checkbox/checkbox.ts
+++ b/src/components/side_panel/components/checkbox/checkbox.ts
@@ -22,21 +22,17 @@ css/* scss */ `
 
 export class Checkbox extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet.Checkbox";
+  static props = {
+    label: { type: String, optional: true },
+    value: { type: Boolean, optional: true },
+    className: { type: String, optional: true },
+    name: { type: String, optional: true },
+    onChange: Function,
+  };
+  static defaultProps = { value: false };
 
   onChange(ev: InputEvent) {
     const value = (ev.target as HTMLInputElement).checked;
     this.props.onChange(value);
   }
 }
-
-Checkbox.props = {
-  label: { type: String, optional: true },
-  value: { type: Boolean, optional: true },
-  className: { type: String, optional: true },
-  name: { type: String, optional: true },
-  onChange: Function,
-};
-
-Checkbox.defaultProps = {
-  value: false,
-};

--- a/src/components/side_panel/components/section/section.ts
+++ b/src/components/side_panel/components/section/section.ts
@@ -7,9 +7,8 @@ interface Props {
 
 export class Section extends Component<Props, SpreadsheetChildEnv> {
   static template = "o_spreadsheet.Section";
+  static props = {
+    class: { type: String, optional: true },
+    slots: Object,
+  };
 }
-
-Section.props = {
-  class: { type: String, optional: true },
-  slots: Object,
-};

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -224,6 +224,10 @@ interface State {
 
 export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ConditionalFormattingEditor";
+  static props = {
+    editedCf: { type: Object, optional: true },
+    onExitEdition: Function,
+  };
   static components = {
     SelectionInput,
     IconPicker,
@@ -540,8 +544,3 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
     this.state.rules.iconSet.icons[target] = icon;
   }
 }
-
-ConditionalFormattingEditor.props = {
-  editedCf: { type: Object, optional: true },
-  onExitEdition: Function,
-};

--- a/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview_list/cf_preview_list.ts
@@ -85,6 +85,11 @@ interface Props {
 
 export class ConditionalFormatPreviewList extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ConditionalFormatPreviewList";
+  static props = {
+    conditionalFormats: Array,
+    onPreviewClick: Function,
+    onAddConditionalFormat: Function,
+  };
 
   icons = ICONS;
 
@@ -175,9 +180,3 @@ export class ConditionalFormatPreviewList extends Component<Props, SpreadsheetCh
     }
   }
 }
-
-ConditionalFormatPreviewList.props = {
-  conditionalFormats: Array,
-  onPreviewClick: Function,
-  onAddConditionalFormat: Function,
-};

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.ts
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.ts
@@ -18,6 +18,10 @@ interface State {
 
 export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ConditionalFormattingPanel";
+  static props = {
+    selection: { type: Object, optional: true },
+    onCloseSidePanel: Function,
+  };
   static components = {
     ConditionalFormatPreviewList,
     ConditionalFormattingEditor,
@@ -82,8 +86,3 @@ export class ConditionalFormattingPanel extends Component<Props, SpreadsheetChil
     this.state.editedCf = cf;
   }
 }
-
-ConditionalFormattingPanel.props = {
-  selection: { type: Object, optional: true },
-  onCloseSidePanel: Function,
-};

--- a/src/components/side_panel/custom_currency/custom_currency.ts
+++ b/src/components/side_panel/custom_currency/custom_currency.ts
@@ -34,6 +34,8 @@ interface State {
 export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-CustomCurrencyPanel";
   static components = { Section };
+  static props = { onCloseSidePanel: Function };
+
   private availableCurrencies!: Currency[];
   private state!: State;
 
@@ -173,7 +175,3 @@ export class CustomCurrencyPanel extends Component<Props, SpreadsheetChildEnv> {
     return currency.name + (currency.code ? ` (${currency.code})` : "");
   }
 }
-
-CustomCurrencyPanel.props = {
-  onCloseSidePanel: Function,
-};

--- a/src/components/side_panel/data_validation/data_validation_panel.ts
+++ b/src/components/side_panel/data_validation/data_validation_panel.ts
@@ -15,6 +15,9 @@ interface State {
 
 export class DataValidationPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationPanel";
+  static props = {
+    onCloseSidePanel: Function,
+  };
   static components = { DataValidationPreview, DataValidationEditor };
 
   state = useState<State>({ mode: "list", activeRule: undefined });
@@ -49,7 +52,3 @@ export class DataValidationPanel extends Component<Props, SpreadsheetChildEnv> {
     return this.env.model.getters.getDataValidationRules(sheetId);
   }
 }
-
-DataValidationPanel.props = {
-  onCloseSidePanel: Function,
-};

--- a/src/components/side_panel/data_validation/dv_criterion_form/dv_criterion_form.ts
+++ b/src/components/side_panel/data_validation/dv_criterion_form/dv_criterion_form.ts
@@ -10,6 +10,10 @@ interface Props<T extends DataValidationCriterion> {
 export abstract class DataValidationCriterionForm<
   T extends DataValidationCriterion = DataValidationCriterion
 > extends Component<Props<T>, SpreadsheetChildEnv> {
+  static props = {
+    criterion: Object,
+    onCriterionChanged: Function,
+  };
   setup() {
     onMounted(() => {
       interactiveStopEdition(this.env);
@@ -24,8 +28,3 @@ export abstract class DataValidationCriterionForm<
     this.props.onCriterionChanged(filteredCriterion);
   }
 }
-
-DataValidationCriterionForm.props = {
-  criterion: Object,
-  onCriterionChanged: Function,
-};

--- a/src/components/side_panel/data_validation/dv_criterion_form/dv_input/dv_input.ts
+++ b/src/components/side_panel/data_validation/dv_criterion_form/dv_input/dv_input.ts
@@ -28,6 +28,15 @@ css/* scss */ `
 
 export class DataValidationInput extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationInput";
+  static props = {
+    value: { type: String, optional: true },
+    criterionType: String,
+    onValueChanged: Function,
+    onKeyDown: { type: Function, optional: true },
+    focused: { type: Boolean, optional: true },
+    onBlur: { type: Function, optional: true },
+    onFocus: { type: Function, optional: true },
+  };
   static defaultProps = {
     value: "",
     onKeyDown: () => {},
@@ -79,13 +88,3 @@ export class DataValidationInput extends Component<Props, SpreadsheetChildEnv> {
     );
   }
 }
-
-DataValidationInput.props = {
-  value: { type: String, optional: true },
-  criterionType: String,
-  onValueChanged: Function,
-  onKeyDown: { type: Function, optional: true },
-  focused: { type: Boolean, optional: true },
-  onBlur: { type: Function, optional: true },
-  onFocus: { type: Function, optional: true },
-};

--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -39,6 +39,10 @@ interface State {
 export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationEditor";
   static components = { SelectionInput, SelectMenu, Section };
+  static props = {
+    rule: { type: Object, optional: true },
+    onExit: Function,
+  };
 
   state = useState<State>({ rule: this.defaultDataValidationRule });
 
@@ -133,8 +137,3 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
     return dataValidationPanelCriteriaRegistry.get(this.state.rule.criterion.type).component;
   }
 }
-
-DataValidationEditor.props = {
-  rule: { type: Object, optional: true },
-  onExit: Function,
-};

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
@@ -37,6 +37,10 @@ interface Props {
 
 export class DataValidationPreview extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-DataValidationPreview";
+  static props = {
+    onClick: Function,
+    rule: Object,
+  };
 
   deleteDataValidation() {
     const sheetId = this.env.model.getters.getActiveSheetId();
@@ -56,8 +60,3 @@ export class DataValidationPreview extends Component<Props, SpreadsheetChildEnv>
       .getPreview(this.props.rule.criterion, this.env.model.getters);
   }
 }
-
-DataValidationPreview.props = {
-  onClick: Function,
-  rule: Object,
-};

--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -42,6 +42,9 @@ interface Props {
 export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FindAndReplacePanel";
   static components = { SelectionInput, Section, Checkbox };
+  static props = {
+    onCloseSidePanel: Function,
+  };
 
   private debounceTimeoutId;
   private initialShowFormulaState: boolean = false;
@@ -212,7 +215,3 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 }
-
-FindAndReplacePanel.props = {
-  onCloseSidePanel: Function,
-};

--- a/src/components/side_panel/more_formats/more_formats.ts
+++ b/src/components/side_panel/more_formats/more_formats.ts
@@ -52,12 +52,11 @@ const DATE_FORMAT_ACTIONS = createActions([
 
 export class MoreFormatsPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-MoreFormatsPanel";
+  static props = {
+    onCloseSidePanel: Function,
+  };
 
   get dateFormatsActions() {
     return DATE_FORMAT_ACTIONS;
   }
 }
-
-MoreFormatsPanel.props = {
-  onCloseSidePanel: Function,
-};

--- a/src/components/side_panel/select_menu/select_menu.ts
+++ b/src/components/side_panel/select_menu/select_menu.ts
@@ -17,6 +17,11 @@ interface State {
 /** This component looks like a select input, but on click it opens a Menu with the items given as props instead of a dropdown */
 export class SelectMenu extends Component<SelectMenuProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SelectMenu";
+  static props = {
+    menuItems: Array,
+    selectedValue: String,
+    class: { type: String, optional: true },
+  };
   static components = { Menu };
 
   selectRef = useRef("select");
@@ -41,8 +46,3 @@ export class SelectMenu extends Component<SelectMenuProps, SpreadsheetChildEnv> 
     };
   }
 }
-SelectMenu.props = {
-  menuItems: Array,
-  selectedValue: String,
-  class: { type: String, optional: true },
-};

--- a/src/components/side_panel/settings/settings_panel.ts
+++ b/src/components/side_panel/settings/settings_panel.ts
@@ -18,6 +18,7 @@ css/* scss */ `
 export class SettingsPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SettingsPanel";
   static components = { Section };
+  static props = { onCloseSidePanel: Function };
 
   loadedLocales: Locale[] = [];
 
@@ -77,7 +78,3 @@ export class SettingsPanel extends Component<Props, SpreadsheetChildEnv> {
     return this.loadedLocales;
   }
 }
-
-SettingsPanel.props = {
-  onCloseSidePanel: Function,
-};

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -164,6 +164,11 @@ interface State {
 
 export class SidePanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SidePanel";
+  static props = {
+    component: String,
+    panelProps: { type: Object, optional: true },
+    onCloseSidePanel: Function,
+  };
   state!: State;
 
   setup() {
@@ -181,9 +186,3 @@ export class SidePanel extends Component<Props, SpreadsheetChildEnv> {
       : this.state.panel.title;
   }
 }
-
-SidePanel.props = {
-  component: String,
-  panelProps: { type: Object, optional: true },
-  onCloseSidePanel: Function,
-};

--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -38,6 +38,7 @@ interface State {
 export class SplitIntoColumnsPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SplitIntoColumnsPanel";
   static components = { ValidationMessages, Section, Checkbox };
+  static props = { onCloseSidePanel: Function };
 
   state = useState<State>({ separatorValue: "auto", addNewColumns: false, customSeparator: "" });
 
@@ -133,7 +134,3 @@ export class SplitIntoColumnsPanel extends Component<Props, SpreadsheetChildEnv>
     return !this.separatorValue || this.errorMessages.length > 0;
   }
 }
-
-SplitIntoColumnsPanel.props = {
-  onCloseSidePanel: Function,
-};

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -249,6 +249,9 @@ interface ComposerState {
 
 export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Spreadsheet";
+  static props = {
+    model: Object,
+  };
   static components = {
     TopBar,
     Grid,
@@ -507,7 +510,3 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     return this.env.model.getters.getVisibleGroupLayers(sheetId, "COL");
   }
 }
-
-Spreadsheet.props = {
-  model: Object,
-};

--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -139,6 +139,12 @@ css/* scss */ `
 
 export class TopBar extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TopBar";
+  static props = {
+    onClick: Function,
+    focusComposer: String,
+    onComposerContentFocused: Function,
+    dropdownMaxHeight: Number,
+  };
   get dropdownStyle() {
     return `max-height:${this.props.dropdownMaxHeight}px`;
   }
@@ -267,10 +273,3 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
     this.onClick();
   }
 }
-
-TopBar.props = {
-  onClick: Function,
-  focusComposer: String,
-  onComposerContentFocused: Function,
-  dropdownMaxHeight: Number,
-};

--- a/src/components/validation_messages/validation_messages.ts
+++ b/src/components/validation_messages/validation_messages.ts
@@ -21,6 +21,10 @@ css/* scss */ `
 `;
 export class ValidationMessages extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ValidationMessages";
+  static props = {
+    messages: Array,
+    msgType: String,
+  };
 
   get divClasses() {
     if (this.props.msgType === "warning") {
@@ -29,8 +33,3 @@ export class ValidationMessages extends Component<Props, SpreadsheetChildEnv> {
     return "o-validation-error text-danger";
   }
 }
-
-ValidationMessages.props = {
-  messages: Array,
-  msgType: String,
-};


### PR DESCRIPTION
To get in line with the Js framework guidelines, and to have something more modern, we will replace all the old static props declaration (`Grid.props = `) by more modern syntax (`static props = `).

Task: : [3679340](https://www.odoo.com/web#id=3679340&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo