### PR TITLE
[FIX] Spreadsheet: Allow shift-scroll to work on mac os

### DIFF
--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -18,3 +18,7 @@ export function gridOverlayPosition() {
 export function getOpenedMenus(): HTMLElement[] {
   return Array.from(document.querySelectorAll<HTMLElement>(".o-spreadsheet .o-menu"));
 }
+
+export function isMacOS(): boolean {
+  return navigator.userAgent.toUpperCase().indexOf("MAC") >= 0;
+}

--- a/src/components/helpers/wheel_hook.ts
+++ b/src/components/helpers/wheel_hook.ts
@@ -1,12 +1,13 @@
 import { DEFAULT_CELL_HEIGHT } from "../../constants";
+import { isMacOS } from "./dom_helpers";
 
 export function useWheelHandler(handler: (deltaX: number, deltaY: number) => void) {
   function normalize(val: number, deltaMode: number): number {
     return val * (deltaMode === 0 ? 1 : DEFAULT_CELL_HEIGHT);
   }
   const onMouseWheel = (ev: WheelEvent) => {
-    const deltaX = normalize(ev.shiftKey ? ev.deltaY : ev.deltaX, ev.deltaMode);
-    const deltaY = normalize(ev.shiftKey ? ev.deltaX : ev.deltaY, ev.deltaMode);
+    const deltaX = normalize(ev.shiftKey && !isMacOS() ? ev.deltaY : ev.deltaX, ev.deltaMode);
+    const deltaY = normalize(ev.shiftKey && !isMacOS() ? ev.deltaX : ev.deltaY, ev.deltaMode);
     handler(deltaX, deltaY);
   };
   return onMouseWheel;


### PR DESCRIPTION
On mac os, using the wheel of a mouse while pressing the `shiftKey`of the keyboard will automatically swap the event deltaX and deltaY[1].

This revision proposes to let MacOs do the swapping so we can have the same behaviour cross-platform by scrolling while pressing the `shift` key. This approach is consistent with the experience with both Excel Online and Google Sheets.

[1] Note that this only applies to external mouses. The trackpad of a macbook will behave 'windows-like' but it can track in both directions by default.

Task: 3603771

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo