### PR TITLE
[FIX] evaluation: faster range matrix

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
@@ -11,6 +11,7 @@ import {
   EvaluatedCell,
   Format,
   Getters,
+  Matrix,
   MatrixArg,
   PrimitiveArg,
   Range,
@@ -160,22 +161,20 @@ class CompilationParametersBuilder {
 
     const height = _zone.bottom - _zone.top + 1;
     const width = _zone.right - _zone.left + 1;
-    const value: CellValue[][] = Array.from({ length: width }, () =>
-      Array.from({ length: height })
-    );
-    const format: Format[][] = Array.from({ length: width }, () => Array.from({ length: height }));
+    const value: Matrix<CellValue | undefined> = new Array(width);
+    const format: Matrix<Format> = new Array(width);
 
     // Performance issue: nested loop is faster than a map here
     for (let col = _zone.left; col <= _zone.right; col++) {
+      const colIndex = col - _zone.left;
+      value[colIndex] = new Array(height);
+      format[colIndex] = new Array(height);
       for (let row = _zone.top; row <= _zone.bottom; row++) {
-        const evaluatedCell = this.getEvaluatedCellIfNotEmpty({ sheetId: sheetId, col, row });
-        if (evaluatedCell) {
-          const colIndex = col - _zone.left;
-          const rowIndex = row - _zone.top;
-          value[colIndex][rowIndex] = evaluatedCell.value;
-          if (evaluatedCell.format !== undefined) {
-            format[colIndex][rowIndex] = evaluatedCell.format;
-          }
+        const evaluatedCell = this.getEvaluatedCellIfNotEmpty({ sheetId, col, row });
+        const rowIndex = row - _zone.top;
+        value[colIndex][rowIndex] = evaluatedCell?.value;
+        if (evaluatedCell?.format !== undefined) {
+          format[colIndex][rowIndex] = evaluatedCell.format;
         }
       }
     }


### PR DESCRIPTION


## Description:

`Array.from(...)` is slow because it creates and fills the entire array. `new Array(size)` doesn't fills the array. It leaves all elements `empty` (empty != undefined)

Here we are building two (possibly very large) 2d matrix. On HBA's spreadsheet, we were spending 500+ms building those matrices. Now it's basically 0

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo