### PR TITLE
[FIX] *: Support metaKey modifier in event handlers

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -29,6 +29,7 @@ import { FilterIconsOverlay } from "../filters/filter_icons_overlay/filter_icons
 import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
 import { HeadersOverlay } from "../headers_overlay/headers_overlay";
+import { isCtrlKey } from "../helpers/dom_helpers";
 import { dragAndDropBeyondTheViewport } from "../helpers/drag_and_drop";
 import { useGridDrawing } from "../helpers/draw_grid_hook";
 import { useAbsolutePosition } from "../helpers/position_hook";
@@ -404,9 +405,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     };
     const direction = arrowMap[ev.key];
     if (ev.shiftKey) {
-      this.env.model.selection.resizeAnchorZone(direction, ev.ctrlKey ? "end" : 1);
+      this.env.model.selection.resizeAnchorZone(direction, isCtrlKey(ev) ? "end" : 1);
     } else {
-      this.env.model.selection.moveAnchorCell(direction, ev.ctrlKey ? "end" : 1);
+      this.env.model.selection.moveAnchorCell(direction, isCtrlKey(ev) ? "end" : 1);
     }
 
     if (this.env.model.getters.isPaintingFormat()) {
@@ -423,8 +424,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     }
 
     let keyDownString = "";
-    if (ev.ctrlKey) keyDownString += "CTRL+";
-    if (ev.metaKey) keyDownString += "CTRL+";
+    if (isCtrlKey(ev)) keyDownString += "CTRL+";
     if (ev.altKey) keyDownString += "ALT+";
     if (ev.shiftKey) keyDownString += "SHIFT+";
     keyDownString += ev.key.toUpperCase();

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -337,9 +337,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   onCellClicked(
     col: HeaderIndex,
     row: HeaderIndex,
-    { ctrlKey, shiftKey }: { ctrlKey: boolean; shiftKey: boolean }
+    { addZone, expandZone }: { addZone: boolean; expandZone: boolean }
   ) {
-    if (ctrlKey) {
+    if (addZone) {
       this.env.model.dispatch("PREPARE_SELECTION_INPUT_EXPANSION");
     }
 
@@ -347,9 +347,9 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     if (this.env.model.getters.getEditionMode() === "editing") {
       this.env.model.dispatch("STOP_EDITION");
     }
-    if (shiftKey) {
+    if (expandZone) {
       this.env.model.selection.setAnchorCorner(col, row);
-    } else if (ctrlKey) {
+    } else if (addZone) {
       this.env.model.selection.addCellToSelection(col, row);
     } else {
       this.env.model.selection.selectCell(col, row);

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -9,6 +9,7 @@ import {
   SpreadsheetChildEnv,
 } from "../../types";
 import { FiguresContainer } from "../figures/figure_container/figure_container";
+import { isCtrlKey } from "../helpers/dom_helpers";
 import { useInterval } from "../helpers/time_hooks";
 
 function useCellHovered(
@@ -195,7 +196,10 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
       return;
     }
     const [col, row] = this.getCartesianCoordinates(ev);
-    this.props.onCellClicked(col, row, { shiftKey: ev.shiftKey, ctrlKey: ev.ctrlKey });
+    this.props.onCellClicked(col, row, {
+      shiftKey: ev.shiftKey,
+      ctrlKey: isCtrlKey(ev),
+    });
   }
 
   onDoubleClick(ev: MouseEvent) {

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -142,7 +142,7 @@ interface Props {
   onCellClicked: (
     col: HeaderIndex,
     row: HeaderIndex,
-    modifiers: { ctrlKey: boolean; shiftKey: boolean }
+    modifiers: { addZone: boolean; expandZone: boolean }
   ) => void;
   onCellRightClicked: (col: HeaderIndex, row: HeaderIndex, coordinates: DOMCoordinates) => void;
   onGridResized: (dimension: DOMDimension) => void;
@@ -197,8 +197,8 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
     }
     const [col, row] = this.getCartesianCoordinates(ev);
     this.props.onCellClicked(col, row, {
-      shiftKey: ev.shiftKey,
-      ctrlKey: isCtrlKey(ev),
+      expandZone: ev.shiftKey,
+      addZone: isCtrlKey(ev),
     });
   }
 

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -92,7 +92,7 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
 
   abstract _moveElements(): void;
 
-  abstract _selectElement(index: HeaderIndex, ctrlKey: boolean): void;
+  abstract _selectElement(index: HeaderIndex, addDistinctHeader: boolean): void;
 
   abstract _increaseSelection(index: HeaderIndex): void;
 
@@ -448,8 +448,11 @@ export class ColResizer extends AbstractResizer {
     }
   }
 
-  _selectElement(index: HeaderIndex, ctrlKey: boolean): void {
-    this.env.model.selection.selectColumn(index, ctrlKey ? "newAnchor" : "overrideSelection");
+  _selectElement(index: HeaderIndex, addDistinctHeader: boolean): void {
+    this.env.model.selection.selectColumn(
+      index,
+      addDistinctHeader ? "newAnchor" : "overrideSelection"
+    );
   }
 
   _increaseSelection(index: HeaderIndex): void {
@@ -646,8 +649,11 @@ export class RowResizer extends AbstractResizer {
     }
   }
 
-  _selectElement(index: HeaderIndex, ctrlKey: boolean): void {
-    this.env.model.selection.selectRow(index, ctrlKey ? "newAnchor" : "overrideSelection");
+  _selectElement(index: HeaderIndex, addDistinctHeader: boolean): void {
+    this.env.model.selection.selectRow(
+      index,
+      addDistinctHeader ? "newAnchor" : "overrideSelection"
+    );
   }
 
   _increaseSelection(index: HeaderIndex): void {

--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -20,6 +20,7 @@ import {
 } from "../../types/index";
 import { ContextMenuType } from "../grid/grid";
 import { css } from "../helpers/css";
+import { isCtrlKey } from "../helpers/dom_helpers";
 import { dragAndDropBeyondTheViewport, startDnd } from "../helpers/drag_and_drop";
 import { MergeErrorMessage } from "../translations_terms";
 
@@ -261,7 +262,7 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
     if (ev.shiftKey) {
       this._increaseSelection(index);
     } else {
-      this._selectElement(index, ev.ctrlKey);
+      this._selectElement(index, isCtrlKey(ev));
     }
     this.lastSelectedElementIndex = index;
 
@@ -276,7 +277,7 @@ abstract class AbstractResizer extends Component<ResizerProps, SpreadsheetChildE
       this.state.isSelecting = false;
       this.lastSelectedElementIndex = null;
       this.env.model.dispatch(
-        ev.ctrlKey ? "PREPARE_SELECTION_INPUT_EXPANSION" : "STOP_SELECTION_INPUT"
+        isCtrlKey(ev) ? "PREPARE_SELECTION_INPUT_EXPANSION" : "STOP_SELECTION_INPUT"
       );
       this._computeGrabDisplay(ev);
     };

--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -1,3 +1,5 @@
+const macRegex = /Mac/i;
+
 /**
  * Return true if the event was triggered from
  * a child element.
@@ -20,5 +22,14 @@ export function getOpenedMenus(): HTMLElement[] {
 }
 
 export function isMacOS(): boolean {
-  return navigator.userAgent.toUpperCase().indexOf("MAC") >= 0;
+  return Boolean(macRegex.test(navigator.userAgent));
+}
+
+/**
+ * @param {KeyboardEvent | MouseEvent} ev
+ * @returns Returns true if the event was triggered with the "ctrl" modifier pressed.
+ * On Mac, this is the "meta" or "command" key.
+ */
+export function isCtrlKey(ev: KeyboardEvent | MouseEvent): boolean {
+  return isMacOS() ? ev.metaKey : ev.ctrlKey;
 }

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -27,6 +27,7 @@ import { BottomBar } from "../bottom_bar/bottom_bar";
 import { SpreadsheetDashboard } from "../dashboard/dashboard";
 import { Grid } from "../grid/grid";
 import { css } from "../helpers/css";
+import { isCtrlKey } from "../helpers/dom_helpers";
 import { SidePanel } from "../side_panel/side_panel/side_panel";
 import { TopBar } from "../top_bar/top_bar";
 
@@ -277,7 +278,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
 
   onKeydown(ev: KeyboardEvent) {
     let keyDownString = "";
-    if (ev.ctrlKey || ev.metaKey) {
+    if (isCtrlKey(ev)) {
       keyDownString += "CTRL+";
     }
     keyDownString += ev.key.toUpperCase();

--- a/tests/components/drag_and_drop.test.ts
+++ b/tests/components/drag_and_drop.test.ts
@@ -17,7 +17,12 @@ import { edgeScrollDelay, triggerMouseEvent } from "../test_helpers/dom_helper";
 import { mountComponent, nextTick } from "../test_helpers/helpers";
 
 // As we test an isolated component, grid and gridOverlay won't exist
-jest.mock("../../src/components/helpers/dom_helpers", () => require("./__mocks__/dom_helpers"));
+jest.mock("../../src/components/helpers/dom_helpers", () => {
+  return {
+    ...jest.requireActual("../../src/components/helpers/dom_helpers"),
+    ...jest.requireActual("./__mocks__/dom_helpers"),
+  };
+});
 
 let model: Model;
 let sheetId: UID;

--- a/tests/components/highlight.test.ts
+++ b/tests/components/highlight.test.ts
@@ -22,7 +22,12 @@ jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("./__mocks__/content_editable_helper")
 );
 // As we test an isolated component, grid and gridOverlay won't exist
-jest.mock("../../src/components/helpers/dom_helpers", () => require("./__mocks__/dom_helpers"));
+jest.mock("../../src/components/helpers/dom_helpers", () => {
+  return {
+    ...jest.requireActual("../../src/components/helpers/dom_helpers"),
+    ...jest.requireActual("./__mocks__/dom_helpers"),
+  };
+});
 
 function getColStartPosition(col: number) {
   return model.getters.getColDimensions(model.getters.getActiveSheetId(), col).start;

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -17,6 +17,7 @@ import {
   clickCell,
   getElComputedStyle,
   hoverCell,
+  keyDown,
   rightClickCell,
   simulateClick,
   triggerMouseEvent,
@@ -174,6 +175,22 @@ describe("Spreadsheet", () => {
     );
     await nextTick();
     expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
+  });
+
+  test("Mac user use metaKey, not CtrlKey", async () => {
+    ({ model, parent, fixture } = await mountSpreadsheet({
+      model: new Model({ sheets: [{ id: "sh1" }] }),
+    }));
+    const mockUserAgent = jest.spyOn(navigator, "userAgent", "get");
+    mockUserAgent.mockImplementation(
+      () => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0"
+    );
+    await keyDown("F", { ctrlKey: true, bubbles: true });
+    expect(document.querySelectorAll(".o-sidePanel").length).toBe(0);
+    await nextTick();
+    await keyDown("F", { metaKey: true, bubbles: true });
+    expect(document.querySelectorAll(".o-sidePanel").length).toBe(1);
+    jest.restoreAllMocks();
   });
 
   test("Can instantiate a spreadsheet with a given client id-name", async () => {


### PR DESCRIPTION
The navigation & click handlers did not account for mac users. In general, the `ctrlKey` modifier is switched with `metaKey` for those users as some key combinations with `ctrlKey` are reserved by the system (i.e. `ctrlKey+click` triggers the context menu or `ctrlKey+ArrowLeft/Right` switches desktops by default).

This revision aims to adopt the same approcha as other spreadsheets (Excel Online & Google Sheets) to provide seamless experience and convince more people to adopt this library.

Task: 3606161

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo