### PR TITLE
[FIX] export: faster border and style export

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_BORDER_DESC } from "../../constants";
-import { range, stringify, toCartesian, toXC, toZone } from "../../helpers/index";
+import { deepEquals, range, toCartesian, toXC, toZone } from "../../helpers/index";
 import {
   AddColumnsRowsCommand,
   Border,
@@ -506,7 +506,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
      */
     function getBorderId(border: Border) {
       for (let [key, value] of Object.entries(borders)) {
-        if (stringify(value) === stringify(border)) {
+        if (deepEquals(value, border)) {
           return parseInt(key, 10);
         }
       }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -1,7 +1,7 @@
 import { FORMULA_REF_IDENTIFIER, NULL_FORMAT } from "../../constants";
 import { cellFactory } from "../../helpers/cells/cell_factory";
 import { FormulaCell } from "../../helpers/cells/index";
-import { isInside, range, stringify, toCartesian, toXC } from "../../helpers/index";
+import { deepEquals, isInside, range, toCartesian, toXC } from "../../helpers/index";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -218,7 +218,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
      */
     function getStyleId(style: Style) {
       for (let [key, value] of Object.entries(styles)) {
-        if (stringify(value) === stringify(style)) {
+        if (deepEquals(value, style)) {
           return parseInt(key, 10);
         }
       }


### PR DESCRIPTION
## Description:

`deepEquals` is faster than comparing the stringified values. On a sheet provided by RNG, `getBorderId` goes from ~1.4s to ~250ms

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo