### PR TITLE
[FIX] CF,DV: re-evaluate after updating cell format

### DIFF
--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -44,7 +44,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
   handle(cmd: CoreViewCommand) {
     if (
       invalidateCFEvaluationCommands.has(cmd.type) ||
-      (cmd.type === "UPDATE_CELL" && "content" in cmd)
+      (cmd.type === "UPDATE_CELL" && ("content" in cmd || "format" in cmd))
     ) {
       this.isStale = true;
     }

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -52,7 +52,7 @@ export class EvaluationDataValidationPlugin extends UIPlugin {
     if (
       invalidateEvaluationCommands.has(cmd.type) ||
       cmd.type === "EVALUATE_CELLS" ||
-      (cmd.type === "UPDATE_CELL" && "content" in cmd)
+      (cmd.type === "UPDATE_CELL" && ("content" in cmd || "format" in cmd))
     ) {
       this.validationResults = {};
       return;

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -11,6 +11,7 @@ import {
   deleteRows,
   redo,
   setCellContent,
+  setFormat,
   setStyle,
   undo,
   updateLocale,
@@ -20,6 +21,7 @@ import { getStyle } from "../test_helpers/getters_helpers";
 import {
   createColorScale,
   createEqualCF,
+  target,
   toCellPosition,
   toRangesData,
 } from "../test_helpers/helpers";
@@ -393,6 +395,20 @@ describe("conditional format", () => {
     setCellContent(model, "A1", "1");
     expect(getStyle(model, "A1")).toEqual({});
     setCellContent(model, "A1", "=A2");
+    expect(getStyle(model, "A1")).toEqual({
+      fillColor: "#FF0000",
+    });
+  });
+
+  test("works after format update that updates a value", () => {
+    setCellContent(model, "A1", '=CELL("format", A2)');
+    model.dispatch("ADD_CONDITIONAL_FORMAT", {
+      cf: createEqualCF("mm/dd/yyyy", { fillColor: "#FF0000" }, "1"),
+      ranges: toRangesData(sheetId, "A1"),
+      sheetId,
+    });
+    expect(getStyle(model, "A1")).toEqual({});
+    setFormat(model, "mm/dd/yyyy", target("A2"));
     expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });

--- a/tests/data_validation/evaluation_data_validation_plugin.test.ts
+++ b/tests/data_validation/evaluation_data_validation_plugin.test.ts
@@ -4,7 +4,9 @@ import {
   addDataValidation,
   duplicateSheet,
   setCellContent,
+  setFormat,
 } from "../test_helpers/commands_helpers";
+import { target } from "../test_helpers/helpers";
 
 describe("Data validation evaluation", () => {
   let model: Model;
@@ -123,5 +125,16 @@ describe("Data validation evaluation", () => {
       setCellContent(model, "B2", "1/1/2020");
       expect(model.getters.isDataValidationInvalid({ sheetId, col: 1, row: 1 })).toEqual(false);
     });
+  });
+
+  test("data validation is updated on cell format change", () => {
+    setFormat(model, "0.00", target("A2"));
+    addDataValidation(model, "A1", "id", { type: "textContains", values: ["m"] });
+
+    setCellContent(model, "A1", '=CELL("format", A2)');
+    expect(model.getters.isDataValidationInvalid(A1)).toEqual(true);
+
+    setFormat(model, "mm/dd/yyyy", target("A2"));
+    expect(model.getters.isDataValidationInvalid(A1)).toEqual(false);
   });
 });


### PR DESCRIPTION
Since the introduction of the `CELL` function (d0972d162), changing the format of a cell can change the value of other cells. It should thus re-evaluate the data validation and the conditional formatting.

## Description:

Since the introduction of the `CELL` function (d0972d162), changing the format of a cell can change the value of other cells. It should thus re-evaluate the data validation and the conditional formatting.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo