### PR TITLE
[IMP] format: add plain text format

### DIFF
--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -13,6 +13,7 @@ import {
   CellValue,
   DEFAULT_LOCALE,
   Format,
+  PLAIN_TEXT_FORMAT,
   SpreadsheetChildEnv,
   VerticalAlign,
   Wrapping,
@@ -51,6 +52,12 @@ export const formatNumberAutomatic: ActionSpec = {
   name: _t("Automatic"),
   execute: (env) => setFormatter(env, ""),
   isActive: (env) => isAutomaticFormatSelected(env),
+};
+
+export const formatNumberPlainText: ActionSpec = {
+  name: _t("Plain text"),
+  execute: (env) => setFormatter(env, PLAIN_TEXT_FORMAT),
+  isActive: (env) => isFormatSelected(env, PLAIN_TEXT_FORMAT),
 };
 
 export const formatNumberNumber = createFormatActionSpec({

--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_ERROR_MESSAGE } from "../../constants";
-import { toNumber } from "../../functions/helpers";
+import { toNumber, toString } from "../../functions/helpers";
 import {
   BooleanCell,
   CellValue,
@@ -11,6 +11,7 @@ import {
   Locale,
   LocaleFormat,
   NumberCell,
+  PLAIN_TEXT_FORMAT,
 } from "../../types";
 import { CellErrorType, EvaluationError } from "../../types/errors";
 import { isDateTime } from "../dates";
@@ -23,6 +24,9 @@ export function evaluateLiteral(
   content: string | undefined,
   localeFormat: LocaleFormat
 ): EvaluatedCell {
+  if (localeFormat.format === PLAIN_TEXT_FORMAT) {
+    return textCell(content || "", localeFormat);
+  }
   return createEvaluatedCell(parseLiteral(content || "", localeFormat.locale), localeFormat);
 }
 
@@ -62,6 +66,10 @@ export function createEvaluatedCell(
 
 function _createEvaluatedCell(value: CellValue | null, localeFormat: LocaleFormat): EvaluatedCell {
   try {
+    if (localeFormat.format === PLAIN_TEXT_FORMAT) {
+      return textCell(toString(value), localeFormat);
+    }
+
     for (const builder of builders) {
       const evaluateCell = builder(value, localeFormat);
       if (evaluateCell) {

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -1,5 +1,14 @@
+import { toString } from "../functions/helpers";
 import { _t } from "../translation";
-import { CellValue, Currency, Format, FormattedValue, Locale, LocaleFormat } from "../types";
+import {
+  CellValue,
+  Currency,
+  Format,
+  FormattedValue,
+  Locale,
+  LocaleFormat,
+  PLAIN_TEXT_FORMAT,
+} from "../types";
 import { DEFAULT_LOCALE } from "./../types/locale";
 import { INITIAL_1900_DAY, isDateTime, numberToJsDate, parseDateTime } from "./dates";
 import { escapeRegExp, memoize } from "./misc";
@@ -112,6 +121,9 @@ function parseFormat(formatString: Format): InternalFormat {
  * Formats a cell value with its format.
  */
 export function formatValue(value: CellValue, { format, locale }: LocaleFormat): FormattedValue {
+  if (format === PLAIN_TEXT_FORMAT) {
+    return toString(value) || "";
+  }
   switch (typeof value) {
     case "string":
       return value;

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_STYLE } from "../../constants";
 import { Token, compile, tokenize } from "../../formulas";
+import { toString } from "../../functions/helpers";
 import { parseLiteral } from "../../helpers/cells";
 import {
   concat,
@@ -27,6 +28,7 @@ import {
   FormulaCell,
   HeaderIndex,
   LiteralCell,
+  PLAIN_TEXT_FORMAT,
   PositionDependentCommand,
   Range,
   RangeCompiledFormula,
@@ -526,7 +528,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     style: Style | undefined
   ): LiteralCell {
     const locale = this.getters.getLocale();
-    content = parseLiteral(content, locale).toString();
+    if (format !== PLAIN_TEXT_FORMAT) {
+      content = toString(parseLiteral(content, locale));
+    }
     return {
       id,
       content,

--- a/src/registries/menus/number_format_menu_registry.ts
+++ b/src/registries/menus/number_format_menu_registry.ts
@@ -9,6 +9,10 @@ numberFormatMenuRegistry
   .add("format_number_automatic", {
     ...ACTION_FORMAT.formatNumberAutomatic,
     sequence: 10,
+  })
+  .add("format_number_plain_text", {
+    ...ACTION_FORMAT.formatNumberPlainText,
+    sequence: 15,
     separator: true,
   })
   .add("format_number_number", {

--- a/src/types/format.ts
+++ b/src/types/format.ts
@@ -9,3 +9,5 @@ export interface LocaleFormat {
   locale: Locale;
   format?: Format;
 }
+
+export const PLAIN_TEXT_FORMAT: Format = "@"; // see OpenXML spec §18.8.31

--- a/src/xlsx/conversion/conversion_maps.ts
+++ b/src/xlsx/conversion/conversion_maps.ts
@@ -4,6 +4,7 @@ import {
   BorderStyle,
   ConditionalFormattingOperatorValues,
   ExcelChartType,
+  PLAIN_TEXT_FORMAT,
   ThresholdType,
   VerticalAlign,
 } from "../../types";
@@ -260,7 +261,7 @@ export const XLSX_FORMATS_CONVERSION_MAP: Record<number, string | undefined> = {
   46: "hhhh:mm:ss",
   47: "hhhh:mm:ss",
   48: undefined,
-  49: undefined,
+  49: PLAIN_TEXT_FORMAT,
 };
 
 /**

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -9,7 +9,7 @@ import {
   toZone,
 } from "../../helpers";
 import { withHttps } from "../../helpers/links";
-import { ExcelSheetData, ExcelWorkbookData, HeaderData } from "../../types";
+import { ExcelSheetData, ExcelWorkbookData, HeaderData, PLAIN_TEXT_FORMAT } from "../../types";
 import { XLSXStructure, XMLAttributes, XMLString } from "../../types/xlsx";
 import { XLSX_RELATION_TYPE } from "../constants";
 import {
@@ -84,10 +84,11 @@ export function addRows(
           ({ attrs: additionalAttrs, node: cellNode } = addContent(label, construct.sharedStrings));
         } else if (cell.content && cell.content !== "") {
           const isTableHeader = isCellTableHeader(c, r, sheet);
+          const isPlainText = !!(cell.format && data.formats[cell.format] === PLAIN_TEXT_FORMAT);
           ({ attrs: additionalAttrs, node: cellNode } = addContent(
             cell.content,
             construct.sharedStrings,
-            isTableHeader
+            isTableHeader || isPlainText
           ));
         }
         attributes.push(...additionalAttrs);

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -614,6 +614,29 @@ exports[`TopBar component can set cell format 1`] = `
             
           </div>
         </div>
+        
+        <div
+          class="o-menu-item d-flex align-items-center"
+          data-name="format_number_plain_text"
+          title="Plain text"
+        >
+          <div
+            class="d-flex w-100"
+          >
+            <div
+              class="o-menu-item-icon align-middle"
+            />
+            
+            <div
+              class="o-menu-item-name align-middle text-truncate"
+            >
+              Plain text
+            </div>
+            
+            
+            
+          </div>
+        </div>
         <div
           class="o-separator"
         />

--- a/tests/composer/edition_plugin.test.ts
+++ b/tests/composer/edition_plugin.test.ts
@@ -1167,6 +1167,21 @@ describe("edition", () => {
           jsDateToRoundNumber(new Date(2020, 0, 30)).toString()
         );
       });
+
+      test("Changing the locale after inputting a localized date does not change the date value", () => {
+        updateLocale(model, FR_LOCALE);
+        editCell(model, "A1", "30/01/2020");
+        expect(getCell(model, "A1")?.format).toBe("dd/mm/yyyy");
+        expect(getEvaluatedCell(model, "A1").value).toBe(
+          jsDateToRoundNumber(new Date(2020, 0, 30))
+        );
+
+        updateLocale(model, DEFAULT_LOCALE);
+        expect(getCell(model, "A1")?.format).toBe("m/d/yyyy");
+        expect(getEvaluatedCell(model, "A1").value).toBe(
+          jsDateToRoundNumber(new Date(2020, 0, 30))
+        );
+      });
     });
   });
 });

--- a/tests/formats/plain_text_format.test.ts
+++ b/tests/formats/plain_text_format.test.ts
@@ -1,0 +1,85 @@
+import { Model } from "../../src";
+import { DEFAULT_LOCALE, PLAIN_TEXT_FORMAT } from "../../src/types";
+import { setCellContent, setFormat, updateLocale } from "../test_helpers/commands_helpers";
+import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
+import { FR_LOCALE } from "./../test_helpers/constants";
+
+let model: Model;
+beforeEach(() => {
+  model = new Model();
+});
+
+describe("Plain text format", () => {
+  test.each([
+    ["hello", "hello", "hello"],
+    ["5", 5, "5"],
+    ["=5", 5, "5"],
+    ["9.15", 9.15, "9.15"],
+    ["TRUE", true, "TRUE"],
+    ["false", false, "FALSE"],
+    ["12/20/2015", 42358, "42358"],
+    ["20/20/2015", "20/20/2015", "20/20/2015"], // invalid date
+    ["=SUM(3, 5)", 8, "8"],
+    ["=DATE(2022, 06, 30)", 44742, "44742"],
+  ])(
+    "Set plain text format to a cell %s %s %s",
+    (cellContent: string, beforePlainText: string | boolean | number, plainTextValue: string) => {
+      setCellContent(model, "A1", cellContent);
+      expect(getEvaluatedCell(model, "A1").value).toBe(beforePlainText);
+
+      setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+      expect(getEvaluatedCell(model, "A1").value).toBe(plainTextValue);
+    }
+  );
+
+  test.each([
+    ["hello", "hello"],
+    ["5", "5"],
+    ["00005", "00005"],
+    ["=5", "5"],
+    ["9.15", "9.15"],
+    ["TRUE", "TRUE"],
+    ["false", "false"],
+    ["12/20/2015", "12/20/2015"],
+    ["=SUM(3, 5)", "8"],
+    ["=DATE(2022, 06, 30)", "44742"],
+  ])(
+    "Set content to a cell formatted with plain text %s %s: text should be kept as is, not parsed",
+    (inputValue: string, expectedCellValue: string) => {
+      setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+      setCellContent(model, "A1", inputValue);
+      expect(getEvaluatedCell(model, "A1").value).toBe(expectedCellValue);
+    }
+  );
+
+  test("Input localized date on a plain text cell", () => {
+    updateLocale(model, FR_LOCALE);
+    setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+    setCellContent(model, "A1", "30/05/2015");
+
+    expect(getCell(model, "A1")?.content).toBe("30/05/2015");
+    expect(getEvaluatedCell(model, "A1").value).toBe("30/05/2015");
+
+    setCellContent(model, "A2", "=A1+1");
+    expect(getEvaluatedCell(model, "A2").value).toBe("42155"); // Not pretty, but same behavior as Excel
+
+    updateLocale(model, DEFAULT_LOCALE);
+    expect(getCell(model, "A1")?.content).toBe("30/05/2015");
+    expect(getEvaluatedCell(model, "A1").value).toBe("30/05/2015");
+
+    // Kind of a wrong behavior, but it's an edge case that would be difficult to fix
+    expect(getEvaluatedCell(model, "A2").value).toBe("#ERROR");
+  });
+
+  test("can export/import plain text format", () => {
+    setFormat(model, "A1", PLAIN_TEXT_FORMAT);
+    setCellContent(model, "A1", "00009");
+
+    expect(getCellContent(model, "A1")).toBe("00009");
+    const exported = model.exportData();
+
+    const importedModel = new Model(exported);
+    expect(getCell(importedModel, "A1")?.format).toBe(PLAIN_TEXT_FORMAT);
+    expect(getCellContent(importedModel, "A1")).toBe("00009");
+  });
+});

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -6,7 +6,14 @@ import {
   markdownLink,
   toZone,
 } from "../../src/helpers";
-import { Border, CellIsRule, DEFAULT_LOCALE, IconSetRule, Style } from "../../src/types";
+import {
+  Border,
+  CellIsRule,
+  DEFAULT_LOCALE,
+  IconSetRule,
+  PLAIN_TEXT_FORMAT,
+  Style,
+} from "../../src/types";
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
 import { LineChartDefinition } from "../../src/types/chart/line_chart";
 import { PieChartDefinition } from "../../src/types/chart/pie_chart";
@@ -861,6 +868,7 @@ test.each([
   ["#,##0.00[$MM/DD/YYYY]", "#,##0.00[$MM/DD/YYYY]", "0.00MM/DD/YYYY"],
   ["[$₪-40D] #,##0.00", "[$₪] #,##0.00", "₪0.00"],
   ['"€"#,##0.00 "€"', undefined, "0"],
+  ["@", PLAIN_TEXT_FORMAT, "0"],
 ])("convert format %s", async (excelFormat, convertedFormat, expectedValue) => {
   expect(
     convertXlsxFormat(80, [{ id: 80, format: excelFormat }], new XLSXImportWarningManager())


### PR DESCRIPTION
## Description

Add a "Plain Text" format that force the value to be an unformatted string.

Task: : [3609540](https://www.odoo.com/web#id=3609540&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo