### PR TITLE
[FIX] line chart: non aligned checkbox label

### DIFF
--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -62,7 +62,7 @@
         </label>
       </div>
       <div class="o-section o-use-row-as-headers" t-if="calculateHeaderPosition()">
-        <label>
+        <label class="o-checkbox">
           <input
             type="checkbox"
             t-att-checked="props.definition.dataSetsHaveTitle"


### PR DESCRIPTION
Missing the `o-checkbox` class on the label of the checkbox.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo