### PR TITLE
[FIX] SelectionInput: release overriden input

### DIFF
--- a/src/plugins/ui_feature/selection_inputs_manager.ts
+++ b/src/plugins/ui_feature/selection_inputs_manager.ts
@@ -148,6 +148,9 @@ export class SelectionInputsManagerPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
 
   private initInput(id: UID, initialRanges: string[], inputHasSingleRange: boolean = false) {
+    if (this.inputs[id]) {
+      this.unfocus();
+    }
     this.inputs[id] = new SelectionInputPlugin(this.config, initialRanges, inputHasSingleRange);
     if (initialRanges.length === 0) {
       const input = this.inputs[id];

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -509,4 +509,18 @@ describe("Selection Input", () => {
     await nextTick();
     expect(fixture.querySelectorAll(".o-selection-ok").length).toBe(1);
   });
+
+  test("Reset selection button reset the selection input and remove focus", async () => {
+    const { model } = await createSelectionInput({ initialRanges: ["C4", "A1"] });
+    const input = fixture.querySelector("input")!;
+    await simulateClick(input);
+    setInputValueAndTrigger(input, "C5:D9", "input");
+    await nextTick();
+    expect(input.value).toBe("C5:D9");
+
+    await simulateClick(".o-selection-ko");
+    expect(input.value).toBe("C4");
+
+    expect(model.getters.isGridSelectionActive()).toBeTruthy();
+  });
 });


### PR DESCRIPTION
When we replace a selection input by another one with the same id but while providing initial ranges, the previous input was not automatically released from the selection which led to a weird state where the selection processor was captured by an Owner that was no longer referenced in the plugins/components environment (kind of an orphan object). This was overlooked in pr #2858.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo