### PR TITLE
[FIX] evaluation: cache ranges with errors

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
@@ -17,7 +17,7 @@ import {
   Range,
   ReferenceDenormalizer,
 } from "../../../types";
-import { InvalidReferenceError } from "../../../types/errors";
+import { EvaluationError, InvalidReferenceError } from "../../../types/errors";
 
 export type CompilationParameters = [ReferenceDenormalizer, EnsureRange, EvalContext];
 const functionMap = functionRegistry.mapping;
@@ -40,7 +40,7 @@ export function buildCompilationParameters(
 class CompilationParametersBuilder {
   evalContext: EvalContext;
 
-  private rangeCache: Record<string, MatrixArg> = {};
+  private rangeCache: Record<string, MatrixArg | EvaluationError> = {};
 
   constructor(
     context: ModelConfig["custom"],
@@ -111,24 +111,19 @@ class CompilationParametersBuilder {
     if (evaluatedCell === undefined) {
       return { value: null, format: this.getters.getCell(position)?.format };
     }
+    if (evaluatedCell.type === CellValueType.error) {
+      throw evaluatedCell.error;
+    }
     return evaluatedCell;
   }
 
   private getEvaluatedCellIfNotEmpty(position: CellPosition): EvaluatedCell | undefined {
-    const evaluatedCell = this.getEvaluatedCell(position);
+    const evaluatedCell = this.computeCell(position);
     if (evaluatedCell.type === CellValueType.empty) {
       const cell = this.getters.getCell(position);
       if (!cell || (!cell.isFormula && cell.content === "")) {
         return undefined;
       }
-    }
-    return evaluatedCell;
-  }
-
-  private getEvaluatedCell(position: CellPosition): EvaluatedCell {
-    const evaluatedCell = this.computeCell(position);
-    if (evaluatedCell.type === CellValueType.error) {
-      throw evaluatedCell.error;
     }
     return evaluatedCell;
   }
@@ -156,7 +151,11 @@ class CompilationParametersBuilder {
     const { top, left, bottom, right } = zone;
     const cacheKey = `${sheetId}-${top}-${left}-${bottom}-${right}`;
     if (cacheKey in this.rangeCache) {
-      return this.rangeCache[cacheKey];
+      const result = this.rangeCache[cacheKey];
+      if (result instanceof EvaluationError) {
+        throw result;
+      }
+      return result;
     }
 
     const height = _zone.bottom - _zone.top + 1;
@@ -171,6 +170,10 @@ class CompilationParametersBuilder {
       format[colIndex] = new Array(height);
       for (let row = _zone.top; row <= _zone.bottom; row++) {
         const evaluatedCell = this.getEvaluatedCellIfNotEmpty({ sheetId, col, row });
+        if (evaluatedCell?.type === CellValueType.error) {
+          this.rangeCache[cacheKey] = evaluatedCell.error;
+          throw evaluatedCell.error;
+        }
         const rowIndex = row - _zone.top;
         value[colIndex][rowIndex] = evaluatedCell?.value;
         if (evaluatedCell?.format !== undefined) {


### PR DESCRIPTION
If you reference a range which contains an error, the range is not cached.

Reported by RNG

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo