### PR TITLE
[FIX] chart: time axis broken for days scale

### DIFF
--- a/src/helpers/chart_date.ts
+++ b/src/helpers/chart_date.ts
@@ -97,7 +97,7 @@ function getFormatMinDisplayUnit(format: LuxonFormat): TimeUnit {
     return "minute";
   } else if (format.includes("h") || format.includes("H")) {
     return "hour";
-  } else if (format.includes("D")) {
+  } else if (format.includes("d")) {
     return "day";
   } else if (format.includes("M")) {
     return "month";


### PR DESCRIPTION
## Description

The time axis for line/bar chart wasn't working when the dates were dates separated by a few days, and that the time axis unit should have been "day".

This happen since our switch from moment to Luxon, we didn't adapt the `getFormatMinDisplayUnit` function.

Task: : [3619195](https://www.odoo.com/web#id=3619195&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo