### PR TITLE
[FIX] find&replace: Only switch sheet from the side panel

### DIFF
--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -108,7 +108,7 @@ export class FindAndReplacePlugin extends UIPlugin {
 
   finalize() {
     if (this.isSearchDirty) {
-      this.refreshSearch();
+      this.refreshSearch(false);
       this.isSearchDirty = false;
     }
   }
@@ -161,10 +161,10 @@ export class FindAndReplacePlugin extends UIPlugin {
   /**
    * refresh the matches according to the current search options
    */
-  private refreshSearch() {
+  private refreshSearch(jumpToMatchSheet = true) {
     this.selectedMatchIndex = null;
     this.findMatches();
-    this.selectNextCell(Direction.current);
+    this.selectNextCell(Direction.current, jumpToMatchSheet);
   }
 
   /**
@@ -258,7 +258,7 @@ export class FindAndReplacePlugin extends UIPlugin {
    * It is also used to keep coherence between the selected searchMatch
    * and selectedMatchIndex.
    */
-  private selectNextCell(indexChange: Direction) {
+  private selectNextCell(indexChange: Direction, jumpToMatchSheet = true) {
     const matches = this.searchMatches;
     if (!matches.length) {
       this.selectedMatchIndex = null;
@@ -284,7 +284,7 @@ export class FindAndReplacePlugin extends UIPlugin {
     const selectedMatch = matches[nextIndex];
 
     // Switch to the sheet where the match is located
-    if (this.getters.getActiveSheetId() !== selectedMatch.sheetId) {
+    if (jumpToMatchSheet && this.getters.getActiveSheetId() !== selectedMatch.sheetId) {
       this.dispatch("ACTIVATE_SHEET", {
         sheetIdFrom: this.getters.getActiveSheetId(),
         sheetIdTo: selectedMatch.sheetId,

--- a/tests/find_and_replace/find_and_replace_plugin.test.ts
+++ b/tests/find_and_replace/find_and_replace_plugin.test.ts
@@ -362,6 +362,17 @@ test("replace don't replace value resulting from array formula", () => {
   expect(getCellContent(model, "C1")).toBe("kikou");
 });
 
+test("Only change sheet on search related command", () => {
+  model = new Model();
+  setCellContent(model, "A1", "hello");
+  updateSearch(model, "hello");
+  createSheet(model, { sheetId: "sh2", activate: true });
+  expect(getMatches(model)).toHaveLength(1);
+  expect(getMatchIndex(model)).toStrictEqual(0);
+  setCellContent(model, "A1", "test");
+  expect(model.getters.getActiveSheetId()).toBe("sh2");
+});
+
 describe("next/previous cycle", () => {
   const sheetId1 = "s1";
   beforeEach(() => {


### PR DESCRIPTION
The recent improvement in [1] introduced a faulty behaviour, which is to try to dispatch commands in the finalize step of a dispatch. The functional intension was to let a user interact with the sheet and that such actions would automatically be mirrored in the f&r sidepanel. Ultimately, this would prove problematic as we need to perform the search in the finalize (because of the evaluation process) and that could lead to a tentative to switch sheets in order to let the user jump at the position of the match.

This revision addresses the issue by modifying the functional behaviour. As of now, if the currently selected match is not on the current sheet, the user will be redirected to the match position IIF they dispatch a "find&replace" related command (i.e. if they interact with the F&R sidepanel).

[1] https://github.com/odoo/o-spreadsheet/pull/2330

Task: 3618775

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo