### PR TITLE
[REF] commands: change evaluation invalidation management

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -18,7 +18,7 @@ import {
   invalidateDependenciesCommands,
 } from "../../../types/index";
 import { UIPlugin, UIPluginConfig } from "../../ui_plugin";
-import { CoreViewCommand } from "./../../../types/commands";
+import { CoreViewCommand, invalidateEvaluationCommands } from "./../../../types/commands";
 import { Evaluator } from "./evaluator";
 
 //#region
@@ -165,7 +165,10 @@ export class EvaluationPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
 
   beforeHandle(cmd: Command) {
-    if (invalidateDependenciesCommands.has(cmd.type)) {
+    if (
+      invalidateEvaluationCommands.has(cmd.type) ||
+      invalidateDependenciesCommands.has(cmd.type)
+    ) {
       this.shouldRebuildDependenciesGraph = true;
     }
   }

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -25,7 +25,7 @@ import {
   isMatrix,
 } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
-import { CoreViewCommand } from "./../../types/commands";
+import { CoreViewCommand, invalidateEvaluationCommands } from "./../../types/commands";
 
 type ComputedStyles = { [col: HeaderIndex]: (Style | undefined)[] };
 type ComputedIcons = { [col: HeaderIndex]: (string | undefined)[] };
@@ -43,6 +43,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
 
   handle(cmd: CoreViewCommand) {
     if (
+      invalidateEvaluationCommands.has(cmd.type) ||
       invalidateCFEvaluationCommands.has(cmd.type) ||
       (cmd.type === "UPDATE_CELL" && ("content" in cmd || "format" in cmd))
     ) {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -119,13 +119,9 @@ export const invalidateEvaluationCommands = new Set<CommandTypes>([
   "UPDATE_LOCALE",
 ]);
 
-export const invalidateDependenciesCommands = new Set<CommandTypes>([
-  ...invalidateEvaluationCommands,
-  "MOVE_RANGES",
-]);
+export const invalidateDependenciesCommands = new Set<CommandTypes>(["MOVE_RANGES"]);
 
 export const invalidateCFEvaluationCommands = new Set<CommandTypes>([
-  ...invalidateEvaluationCommands,
   "DUPLICATE_SHEET",
   "EVALUATE_CELLS",
   "ADD_CONDITIONAL_FORMAT",


### PR DESCRIPTION
## Task Description

This PR aims to change the way we defined the `invalidateXXEvaluationCommands` sets, by listing only the commands related to a specific set in it, and then checking separately the different sets to invalidate the evaluation when needed.

## Related Task
- Task: [3607272](https://www.odoo.com/web#id=3607272&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo