### PR TITLE
[IMP] demo: don't double crash on launch error

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -293,7 +293,7 @@ class Demo extends Component {
     const text = document.createTextNode(notification.text);
     div.appendChild(text);
     div.style = NOTIFICATION_STYLE;
-    const element = document.querySelector(".o-spreadsheet");
+    const element = document.querySelector(".o-spreadsheet") || document.body; // if we crash on launch, the spreadsheet is not mounted yet
     div.onclick = () => {
       element.removeChild(div);
     };


### PR DESCRIPTION
When an error occurs on launch, the demo would crash twice: once when the error is raised, and once when we tried to use `notifyUser` to display the error message. `notifyUser` tried to add a notification to the `o-spreadsheet` element, which was crashing since it wasn't mounted.

This commit fixes the issue by displaying notification on the document body rather than on the `o-spreadsheet` element.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo