### PR TITLE
[IMP] find & replace: make the feature into a store

### DIFF
--- a/src/components/helpers/draw_grid_hook.ts
+++ b/src/components/helpers/draw_grid_hook.ts
@@ -1,11 +1,14 @@
 import { useEffect, useRef } from "@odoo/owl";
 import { Model } from "../..";
 import { CANVAS_SHIFT } from "../../constants";
-import { DOMDimension } from "../../types";
+import { useStore } from "../../store_engine";
+import { RenderersManagerStore } from "../../stores/renderer_manager_store";
+import { DOMDimension, RENDERING_LAYERS } from "../../types";
 
 export function useGridDrawing(refName: string, model: Model, canvasSize: () => DOMDimension) {
   const canvasRef = useRef(refName);
   useEffect(drawGrid);
+  const rendererManager = useStore(RenderersManagerStore);
 
   function drawGrid() {
     const canvas = canvasRef.el as HTMLCanvasElement;
@@ -31,6 +34,9 @@ export function useGridDrawing(refName: string, model: Model, canvasSize: () => 
     // http://diveintohtml5.info/canvas.html#pixel-madness
     ctx.translate(-CANVAS_SHIFT, -CANVAS_SHIFT);
     ctx.scale(dpr, dpr);
-    model.drawGrid(renderingContext);
+    for (const layer of RENDERING_LAYERS) {
+      model.drawGrid(renderingContext, layer);
+      rendererManager.drawLayer(renderingContext, layer);
+    }
   }
 }

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -8,16 +8,18 @@
             type="text"
             t-ref="searchInput"
             class="o-input o-input-with-count"
-            t-on-input="onInput"
+            t-on-input="onSearchInput"
             t-on-focus="onFocusSearch"
             t-on-keydown="onKeydownSearch"
           />
           <div class="o-input-count" t-if="hasSearchResult">
-            <t t-esc="env.model.getters.getCurrentSelectedMatchIndex()+1"/>
+            <t t-esc="store.selectedMatchIndex+1"/>
             /
-            <t t-esc="env.model.getters.getSearchMatches().length"/>
+            <t t-esc="store.searchMatches.length"/>
           </div>
-          <div t-elif="!pendingSearch and toSearch !== ''" class="o-input-count">0 / 0</div>
+          <div t-elif="!store.pendingSearch and store.toSearch !== ''" class="o-input-count">
+            0 / 0
+          </div>
         </div>
         <select
           class="o-input o-type-selector o-type-range-selector mt-3 mb-3"
@@ -62,7 +64,7 @@
             <span>Search in formulas</span>
           </label>
         </div>
-        <div class="o-matches-count mt-4" t-if="toSearch !== ''">
+        <div class="o-matches-count mt-4" t-if="store.toSearch !== ''">
           <div t-if="searchOptions.searchScope === 'specificRange' and dataRange != ''">
             <t t-esc="specificRangeMatchesCount"/>
           </div>
@@ -77,11 +79,14 @@
       <div class="o-sidePanelButtons">
         <button
           t-att-disabled="!hasSearchResult"
-          t-on-click="onSelectPreviousCell"
+          t-on-click="() => store.selectPreviousMatch()"
           class="o-button">
           Previous
         </button>
-        <button t-att-disabled="!hasSearchResult" t-on-click="onSelectNextCell" class="o-button">
+        <button
+          t-att-disabled="!hasSearchResult"
+          t-on-click="() => store.selectNextMatch()"
+          class="o-button">
           Next
         </button>
       </div>
@@ -91,22 +96,22 @@
           <input
             type="text"
             class="o-input o-input-without-count"
-            t-ref="replaceInput"
             t-on-keydown="onKeydownReplace"
+            t-model="store.toReplace"
           />
         </div>
       </div>
 
       <div class="o-sidePanelButtons" t-if="!env.model.getters.isReadonly()">
         <button
-          t-att-disabled="env.model.getters.getCurrentSelectedMatchIndex() === null"
-          t-on-click="replace"
+          t-att-disabled="store.selectedMatchIndex === null"
+          t-on-click="() => store.replace()"
           class="o-button">
           Replace
         </button>
         <button
-          t-att-disabled="env.model.getters.getCurrentSelectedMatchIndex() === null"
-          t-on-click="replaceAll"
+          t-att-disabled="store.selectedMatchIndex === null"
+          t-on-click="() => store.replaceAll()"
           class="o-button">
           Replace all
         </button>

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -1,0 +1,348 @@
+import { debounce, getSearchRegex, isInside, positionToZone } from "../../../helpers";
+import { Get } from "../../../store_engine";
+import { RendererStore } from "../../../stores/renderer_store";
+import { CellPosition, Color, Command, GridRenderingContext, LAYERS } from "../../../types";
+import { SearchOptions } from "../../../types/find_and_replace";
+
+const BORDER_COLOR: Color = "#8B008B";
+const BACKGROUND_COLOR: Color = "#8B008B33";
+
+enum Direction {
+  previous = -1,
+  current = 0,
+  next = 1,
+}
+
+export class FindAndReplaceStore extends RendererStore {
+  get layers(): LAYERS[] {
+    return [LAYERS.Search];
+  }
+
+  private allSheetsMatches: CellPosition[] = [];
+  private activeSheetMatches: CellPosition[] = [];
+  private specificRangeMatches: CellPosition[] = [];
+
+  private currentSearchRegex: RegExp | null = null;
+  private isSearchDirty = false;
+  private initialShowFormulaState: boolean;
+
+  // fixme: why do we make selectedMatchIndex on top of a selected
+  // property in the matches?
+  selectedMatchIndex: number | null = null;
+  toSearch: string = "";
+  toReplace: string = "";
+  searchOptions: SearchOptions = {
+    matchCase: false,
+    exactMatch: false,
+    searchFormulas: false,
+    searchScope: "allSheets",
+    specificRange: undefined,
+  };
+
+  updateSearchContent = debounce(this._updateSearchContent.bind(this), 200);
+
+  constructor(get: Get) {
+    super(get);
+    this.initialShowFormulaState = this.model.getters.shouldShowFormulas();
+    this.searchOptions.searchFormulas = this.initialShowFormulaState;
+  }
+
+  dispose(): void {
+    super.dispose();
+    this.model.dispatch("SET_FORMULA_VISIBILITY", { show: this.initialShowFormulaState });
+    this.updateSearchContent.stopDebounce();
+  }
+
+  get searchMatches(): CellPosition[] {
+    switch (this.searchOptions.searchScope) {
+      case "allSheets":
+        return this.allSheetsMatches;
+      case "activeSheet":
+        return this.activeSheetMatches;
+      case "specificRange":
+        return this.specificRangeMatches;
+    }
+  }
+
+  private _updateSearchContent(toSearch: string) {
+    this._updateSearch(toSearch, this.searchOptions);
+  }
+
+  updateSearchOptions(searchOptions: Partial<SearchOptions>) {
+    this._updateSearch(this.toSearch, { ...this.searchOptions, ...searchOptions });
+  }
+
+  searchFormulas(showFormula: boolean) {
+    this.model.dispatch("SET_FORMULA_VISIBILITY", { show: showFormula });
+    this.updateSearchOptions({ searchFormulas: showFormula });
+  }
+
+  selectPreviousMatch() {
+    this.selectNextCell(Direction.previous);
+  }
+
+  selectNextMatch() {
+    this.selectNextCell(Direction.next);
+  }
+
+  get pendingSearch() {
+    return this.updateSearchContent.isDebouncePending();
+  }
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "SET_FORMULA_VISIBILITY":
+        this.updateSearchOptions({ searchFormulas: cmd.show });
+        break;
+      case "UNDO":
+      case "REDO":
+      case "REMOVE_FILTER_TABLE":
+      case "UPDATE_FILTER":
+      case "REMOVE_COLUMNS_ROWS":
+      case "HIDE_COLUMNS_ROWS":
+      case "UNHIDE_COLUMNS_ROWS":
+      case "ADD_COLUMNS_ROWS":
+      case "EVALUATE_CELLS":
+      case "UPDATE_CELL":
+        this.isSearchDirty = true;
+        break;
+      case "ACTIVATE_SHEET":
+        if (this.searchOptions.searchScope === "activeSheet") {
+          this.isSearchDirty = true;
+        }
+        break;
+    }
+  }
+
+  finalize() {
+    if (this.isSearchDirty) {
+      this.refreshSearch();
+      this.isSearchDirty = false;
+    }
+  }
+
+  get allSheetMatchesCount(): number {
+    return this.allSheetsMatches.length;
+  }
+
+  get activeSheetMatchesCount(): number {
+    return this.activeSheetMatches.length;
+  }
+
+  get specificRangeMatchesCount(): number {
+    return this.specificRangeMatches.length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Search
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Will update the current searchOptions and accordingly update the regex.
+   * It will then search for matches using the regex and store them.
+   */
+  private _updateSearch(toSearch: string, searchOptions: SearchOptions) {
+    this.searchOptions = searchOptions;
+    if (toSearch !== this.toSearch) {
+      this.selectedMatchIndex = null;
+    }
+    this.toSearch = toSearch;
+    this.currentSearchRegex = getSearchRegex(this.toSearch, this.searchOptions);
+    this.refreshSearch();
+  }
+
+  /**
+   * refresh the matches according to the current search options
+   */
+  private refreshSearch() {
+    this.selectedMatchIndex = null;
+    this.findMatches();
+    this.selectNextCell(Direction.current);
+  }
+
+  private getSheetsInSearchOrder() {
+    switch (this.searchOptions.searchScope) {
+      case "allSheets":
+        const sheetIds = this.getters.getSheetIds();
+        const activeSheetIndex = sheetIds.findIndex((id) => id === this.getters.getActiveSheetId());
+        return [
+          sheetIds[activeSheetIndex],
+          ...sheetIds.slice(activeSheetIndex + 1),
+          ...sheetIds.slice(0, activeSheetIndex),
+        ];
+        break;
+      case "activeSheet":
+        return [this.getters.getActiveSheetId()];
+      case "specificRange":
+        const specificRange = this.searchOptions.specificRange;
+        if (!specificRange) {
+          return [];
+        }
+        return specificRange ? [specificRange.sheetId] : [];
+    }
+  }
+
+  /**
+   * Find matches using the current regex
+   */
+  private findMatches() {
+    const matches: CellPosition[] = [];
+    if (this.toSearch) {
+      for (const sheetId of this.getters.getSheetIds()) {
+        matches.push(...this.findMatchesInSheet(sheetId));
+      }
+    }
+
+    // set results
+    this.allSheetsMatches = matches;
+    this.activeSheetMatches = matches.filter(
+      (match) => match.sheetId === this.getters.getActiveSheetId()
+    );
+    if (this.searchOptions.specificRange) {
+      const { sheetId, zone } = this.searchOptions.specificRange;
+      this.specificRangeMatches = matches.filter(
+        (match) => match.sheetId === sheetId && isInside(match.col, match.row, zone)
+      );
+    } else {
+      this.specificRangeMatches = [];
+    }
+  }
+
+  private findMatchesInSheet(sheetId: string) {
+    const matches: CellPosition[] = [];
+
+    const { left, right, top, bottom } = this.getters.getSheetZone(sheetId);
+
+    for (let row = top; row <= bottom; row++) {
+      for (let col = left; col <= right; col++) {
+        const isColHidden = this.getters.isColHidden(sheetId, col);
+        const isRowHidden = this.getters.isRowHidden(sheetId, row);
+        if (isColHidden || isRowHidden) {
+          continue;
+        }
+        const cellPosition: CellPosition = { sheetId, col, row };
+        if (this.currentSearchRegex?.test(this.getSearchableString(cellPosition))) {
+          const match: CellPosition = { sheetId, col, row };
+          matches.push(match);
+        }
+      }
+    }
+    return matches;
+  }
+
+  /**
+   * Changes the selected search cell. Given a direction it will
+   * Change the selection to the previous, current or nextCell,
+   * if it exists otherwise it will set the selectedMatchIndex to null.
+   * It will also reset the index to 0 if the search has changed.
+   * It is also used to keep coherence between the selected searchMatch
+   * and selectedMatchIndex.
+   */
+  private selectNextCell(indexChange: Direction) {
+    const matches = this.searchMatches;
+    if (!matches.length) {
+      this.selectedMatchIndex = null;
+      return;
+    }
+    let nextIndex: number;
+    if (this.selectedMatchIndex === null) {
+      let nextMatchIndex = -1;
+      // if search is not available in current sheet will select in next sheet
+      for (const sheetId of this.getSheetsInSearchOrder()) {
+        nextMatchIndex = matches.findIndex((match) => match.sheetId === sheetId);
+        if (nextMatchIndex !== -1) {
+          break;
+        }
+      }
+      nextIndex = nextMatchIndex;
+    } else {
+      nextIndex = this.selectedMatchIndex + indexChange;
+    }
+    // loop index value inside the array (index -1 => last index)
+    nextIndex = (nextIndex + matches.length) % matches.length;
+    this.selectedMatchIndex = nextIndex;
+    const selectedMatch = matches[nextIndex];
+
+    // Switch to the sheet where the match is located
+    if (this.getters.getActiveSheetId() !== selectedMatch.sheetId) {
+      this.model.dispatch("ACTIVATE_SHEET", {
+        sheetIdFrom: this.getters.getActiveSheetId(),
+        sheetIdTo: selectedMatch.sheetId,
+      });
+    }
+    // we want grid selection to capture the selection stream
+    this.model.selection.getBackToDefault();
+    this.model.selection.selectCell(selectedMatch.col, selectedMatch.row);
+  }
+
+  /**
+   * Replace the value of the currently selected match
+   */
+  replace() {
+    if (this.selectedMatchIndex === null) {
+      return;
+    }
+
+    this.model.dispatch("REPLACE_SEARCH", {
+      searchString: this.toSearch,
+      replaceWith: this.toReplace,
+      matches: [this.searchMatches[this.selectedMatchIndex]],
+      searchOptions: this.searchOptions,
+    });
+    this.selectNextCell(Direction.next);
+  }
+  /**
+   * Apply the replace function to all the matches one time.
+   */
+  replaceAll() {
+    this.model.dispatch("REPLACE_SEARCH", {
+      searchString: this.toSearch,
+      replaceWith: this.toReplace,
+      matches: this.searchMatches,
+      searchOptions: this.searchOptions,
+    });
+  }
+
+  private getSearchableString(position: CellPosition): string {
+    return this.getters.getCellText(position, this.searchOptions.searchFormulas);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Grid rendering
+  // ---------------------------------------------------------------------------
+
+  draw(renderingContext: GridRenderingContext) {
+    const { ctx } = renderingContext;
+    const sheetId = this.getters.getActiveSheetId();
+
+    for (const [index, match] of this.searchMatches.entries()) {
+      if (match.sheetId !== sheetId) {
+        continue; // Skip drawing matches from other sheets
+      }
+
+      const zone = positionToZone(match);
+      const zoneWithMerge = this.getters.expandZone(sheetId, zone);
+
+      const { x, y, width, height } = this.getters.getVisibleRect(zoneWithMerge);
+      if (width > 0 && height > 0) {
+        ctx.fillStyle = BACKGROUND_COLOR;
+        ctx.fillRect(x, y, width, height);
+        if (index === this.selectedMatchIndex) {
+          ctx.strokeStyle = BORDER_COLOR;
+          ctx.strokeRect(x, y, width, height);
+        }
+      }
+    }
+
+    // TODO: use Highlights helpers/stores when the Highlight PR is merged
+    if (this.searchOptions.searchScope === "specificRange") {
+      const range = this.searchOptions.specificRange;
+      if (!range || range.sheetId !== sheetId) {
+        return;
+      }
+      const { x, y, width, height } = this.getters.getVisibleRect(range.zone);
+      ctx.strokeStyle = BORDER_COLOR;
+      ctx.strokeRect(x, y, width, height);
+    }
+  }
+}

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -33,8 +33,7 @@ import {
 import { ImageProvider } from "../../helpers/figures/images/image_provider";
 import { Model } from "../../model";
 import { ComposerSelection } from "../../plugins/ui_stateful/edition";
-import { ModelStore } from "../../store_engine/spreadsheet_store";
-import { useStoreProvider } from "../../store_engine/store_hooks";
+import { ModelStore, useStoreProvider } from "../../store_engine";
 import { _t } from "../../translation";
 import { HeaderGroup, InformationNotification, Pixel, SpreadsheetChildEnv } from "../../types";
 import { BottomBar } from "../bottom_bar/bottom_bar";

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -33,6 +33,8 @@ import {
 import { ImageProvider } from "../../helpers/figures/images/image_provider";
 import { Model } from "../../model";
 import { ComposerSelection } from "../../plugins/ui_stateful/edition";
+import { ModelStore } from "../../store_engine/spreadsheet_store";
+import { useStoreProvider } from "../../store_engine/store_hooks";
 import { _t } from "../../translation";
 import { HeaderGroup, InformationNotification, Pixel, SpreadsheetChildEnv } from "../../types";
 import { BottomBar } from "../bottom_bar/bottom_bar";
@@ -279,6 +281,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
   }
 
   setup() {
+    const stores = useStoreProvider();
     this.sidePanel = useState({ isOpen: false, panelProps: {} });
     this.composer = useState({
       topBarFocus: "inactive",
@@ -337,6 +340,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     onPatched(() => {
       this.checkViewportSize();
     });
+    stores.inject(ModelStore, this.model);
   }
 
   get focusTopBarComposer(): Omit<ComposerFocusType, "cellFocus"> {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -3,7 +3,8 @@
 //------------------------------------------------------------------------------
 import { NEWLINE } from "../constants";
 import { ConsecutiveIndexes, Lazy, UID } from "../types";
-import { Cloneable } from "./../types/misc";
+import { SearchOptions } from "../types/find_and_replace";
+import { Cloneable, DebouncedFunction } from "./../types/misc";
 /**
  * Stringify an object, like JSON.stringify, except that the first level of keys
  * is ordered.
@@ -274,22 +275,26 @@ export function getItemId<T>(item: T, itemsDic: { [id: number]: T }) {
 }
 
 /**
- * This method comes from owl 1 as it was removed in owl 2
- *
  * Returns a function, that, as long as it continues to be invoked, will not
  * be triggered. The function will be called after it stops being called for
  * N milliseconds. If `immediate` is passed, trigger the function on the
  * leading edge, instead of the trailing.
  *
+ * Also decorate the argument function with two methods: stopDebounce and isDebouncePending.
+ *
  * Inspired by https://davidwalsh.name/javascript-debounce-function
  */
-export function debounce(func: Function, wait: number, immediate?: boolean): Function {
-  let timeout;
-  return function (this: any): void {
+export function debounce<T extends (...args: any) => void>(
+  func: T,
+  wait: number,
+  immediate?: boolean
+): DebouncedFunction<T> {
+  let timeout: any | undefined = undefined;
+  const debounced = function (this: any): void {
     const context = this;
     const args = arguments;
     function later() {
-      timeout = null;
+      timeout = undefined;
       if (!immediate) {
         func.apply(context, args);
       }
@@ -301,6 +306,11 @@ export function debounce(func: Function, wait: number, immediate?: boolean): Fun
       func.apply(context, args);
     }
   };
+  debounced.isDebouncePending = () => timeout !== undefined;
+  debounced.stopDebounce = () => {
+    clearTimeout(timeout);
+  };
+  return debounced as DebouncedFunction<T>;
 }
 
 /*
@@ -501,4 +511,16 @@ export function isNumberBetween(value: number, min: number, max: number): boolea
     return isNumberBetween(value, max, min);
   }
   return value >= min && value <= max;
+}
+
+/**
+ * Get a Regex for the find & replace that matches the given search string and options.
+ */
+export function getSearchRegex(searchStr: string, searchOptions: SearchOptions): RegExp {
+  let searchValue = escapeRegExp(searchStr);
+  const flags = !searchOptions.matchCase ? "i" : "";
+  if (searchOptions.exactMatch) {
+    searchValue = `^${searchValue}$`;
+  }
+  return RegExp(searchValue, flags);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,6 @@ import {
   numberFormatMenuRegistry,
   otRegistry,
   rowMenuRegistry,
-  sidePanelRegistry,
   topbarComponentRegistry,
   topbarMenuRegistry,
 } from "./registries/index";
@@ -97,6 +96,7 @@ import {
   repeatCommandTransformRegistry,
   repeatLocalCommandTransformRegistry,
 } from "./registries/repeat_commands_registry";
+import { sidePanelRegistry } from "./registries/side_panel_registry";
 import { AddFunctionDescription } from "./types";
 import { CellErrorLevel, EvaluationError } from "./types/errors";
 import { DEFAULT_LOCALE } from "./types/locale";

--- a/src/model.ts
+++ b/src/model.ts
@@ -468,6 +468,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       h.finalize();
     }
     this.status = Status.Ready;
+    this.trigger("command-finalized");
   }
 
   /**
@@ -572,6 +573,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       }
       handler.handle(command);
     }
+    this.trigger("command-dispatched", command);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -1,18 +1,8 @@
-import { escapeRegExp } from "../../helpers";
+import { getSearchRegex } from "../../helpers";
 import { canonicalizeNumberContent } from "../../helpers/locale";
-import { isInside } from "../../helpers/zones";
-import { SearchOptions, SearchOptionsInternal } from "../../types/find_and_replace";
-import { CellPosition, Color, Command, GridRenderingContext, LAYERS } from "../../types/index";
+import { SearchOptions } from "../../types/find_and_replace";
+import { CellPosition, Command, LAYERS } from "../../types/index";
 import { UIPlugin } from "../ui_plugin";
-
-const BORDER_COLOR: Color = "#8B008B";
-const BACKGROUND_COLOR: Color = "#8B008B33";
-
-enum Direction {
-  previous = -1,
-  current = 0,
-  next = 1,
-}
 
 /**
  * Find and Replace Plugin
@@ -26,385 +16,41 @@ enum Direction {
 
 export class FindAndReplacePlugin extends UIPlugin {
   static layers = [LAYERS.Search];
-  static getters = [
-    "getSearchMatches",
-    "getCurrentSelectedMatchIndex",
-    "getSearchOptions",
-    "getAllSheetMatchesCount",
-    "getActiveSheetMatchesCount",
-    "getSpecificRangeMatchesCount",
-  ] as const;
-
-  private allSheetsMatches: CellPosition[] = [];
-  private activeSheetMatches: CellPosition[] = [];
-  private specificRangeMatches: CellPosition[] = [];
-
-  // fixme: why do we make selectedMatchIndex on top of a selected
-  // property in the matches?
-  private selectedMatchIndex: number | null = null;
-  private currentSearchRegex: RegExp | null = null;
-  private searchOptions: SearchOptionsInternal = {
-    matchCase: false,
-    exactMatch: false,
-    searchFormulas: false,
-    searchScope: "allSheets",
-    specificRange: undefined,
-  };
-  private toSearch: string = "";
-  private isSearchDirty = false;
-
-  get searchMatches(): CellPosition[] {
-    switch (this.searchOptions.searchScope) {
-      case "allSheets":
-        return this.allSheetsMatches;
-      case "activeSheet":
-        return this.activeSheetMatches;
-      case "specificRange":
-        return this.specificRangeMatches;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Command Handling
-  // ---------------------------------------------------------------------------
+  static getters = [] as const;
 
   handle(cmd: Command) {
     switch (cmd.type) {
-      case "UPDATE_SEARCH":
-        const rangeData = cmd.searchOptions.specificRange;
-        const specificRange = rangeData && this.getters.getRangeFromRangeData(rangeData);
-        this.updateSearch(cmd.toSearch, { ...cmd.searchOptions, specificRange });
-        break;
-      case "CLEAR_SEARCH":
-        this.clearSearch();
-        break;
-      case "SELECT_SEARCH_PREVIOUS_MATCH":
-        this.selectNextCell(Direction.previous);
-        break;
-      case "SELECT_SEARCH_NEXT_MATCH":
-        this.selectNextCell(Direction.next);
-        break;
       case "REPLACE_SEARCH":
-        this.replace(cmd.replaceWith);
-        break;
-      case "REPLACE_ALL_SEARCH":
-        this.replaceAll(cmd.replaceWith);
-        break;
-      case "UNDO":
-      case "REDO":
-      case "REMOVE_FILTER_TABLE":
-      case "UPDATE_FILTER":
-      case "REMOVE_COLUMNS_ROWS":
-      case "HIDE_COLUMNS_ROWS":
-      case "UNHIDE_COLUMNS_ROWS":
-      case "ADD_COLUMNS_ROWS":
-      case "EVALUATE_CELLS":
-      case "UPDATE_CELL":
-        this.isSearchDirty = true;
-        break;
-      case "ACTIVATE_SHEET":
-        if (this.searchOptions.searchScope === "activeSheet") {
-          this.isSearchDirty = true;
+        for (const match of cmd.matches) {
+          this.replaceMatch(match, cmd.searchString, cmd.replaceWith, cmd.searchOptions);
         }
         break;
     }
   }
 
-  finalize() {
-    if (this.isSearchDirty) {
-      this.refreshSearch();
-      this.isSearchDirty = false;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Getters
-  // ---------------------------------------------------------------------------
-
-  getSearchMatches(): CellPosition[] {
-    return this.searchMatches;
-  }
-
-  getCurrentSelectedMatchIndex(): number | null {
-    return this.selectedMatchIndex;
-  }
-  getSearchOptions(): SearchOptions {
-    return { ...this.searchOptions, specificRange: this.searchOptions.specificRange?.rangeData };
-  }
-
-  getAllSheetMatchesCount(): number {
-    return this.allSheetsMatches.length;
-  }
-
-  getActiveSheetMatchesCount(): number {
-    return this.activeSheetMatches.length;
-  }
-
-  getSpecificRangeMatchesCount(): number {
-    return this.specificRangeMatches.length;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Search
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Will update the current searchOptions and accordingly update the regex.
-   * It will then search for matches using the regex and store them.
-   */
-  private updateSearch(toSearch: string, searchOptions: SearchOptionsInternal) {
-    this.searchOptions = searchOptions;
-    if (toSearch !== this.toSearch) {
-      this.selectedMatchIndex = null;
-    }
-    this.toSearch = toSearch;
-    this.updateRegex();
-    this.refreshSearch();
-  }
-
-  /**
-   * refresh the matches according to the current search options
-   */
-  private refreshSearch() {
-    this.selectedMatchIndex = null;
-    this.findMatches();
-    this.selectNextCell(Direction.current);
-  }
-
-  /**
-   * Updates the regex based on the current searchOptions and
-   * the value toSearch
-   */
-  private updateRegex() {
-    let searchValue = escapeRegExp(this.toSearch);
-    const flags = !this.searchOptions.matchCase ? "i" : "";
-    if (this.searchOptions.exactMatch) {
-      searchValue = `^${searchValue}$`;
-    }
-    this.currentSearchRegex = RegExp(searchValue, flags);
-  }
-
-  private getSheetsInSearchOrder() {
-    switch (this.searchOptions.searchScope) {
-      case "allSheets":
-        const sheetIds = this.getters.getSheetIds();
-        const activeSheetIndex = sheetIds.findIndex((id) => id === this.getters.getActiveSheetId());
-        return [
-          sheetIds[activeSheetIndex],
-          ...sheetIds.slice(activeSheetIndex + 1),
-          ...sheetIds.slice(0, activeSheetIndex),
-        ];
-        break;
-      case "activeSheet":
-        return [this.getters.getActiveSheetId()];
-      case "specificRange":
-        const specificRange = this.searchOptions.specificRange;
-        if (!specificRange) {
-          return [];
-        }
-        return specificRange ? [specificRange.sheetId] : [];
-    }
-  }
-
-  /**
-   * Find matches using the current regex
-   */
-  private findMatches() {
-    const matches: CellPosition[] = [];
-    if (this.toSearch) {
-      for (const sheetId of this.getters.getSheetIds()) {
-        matches.push(...this.findMatchesInSheet(sheetId));
-      }
-    }
-
-    // set results
-    this.allSheetsMatches = matches;
-    this.activeSheetMatches = matches.filter(
-      (match) => match.sheetId === this.getters.getActiveSheetId()
-    );
-    if (this.searchOptions.specificRange) {
-      const { sheetId, zone } = this.searchOptions.specificRange;
-      this.specificRangeMatches = matches.filter(
-        (match) => match.sheetId === sheetId && isInside(match.col, match.row, zone)
-      );
-    } else {
-      this.specificRangeMatches = [];
-    }
-  }
-
-  private findMatchesInSheet(sheetId: string) {
-    const matches: CellPosition[] = [];
-
-    const { left, right, top, bottom } = this.getters.getSheetZone(sheetId);
-
-    for (let row = top; row <= bottom; row++) {
-      for (let col = left; col <= right; col++) {
-        const isColHidden = this.getters.isColHidden(sheetId, col);
-        const isRowHidden = this.getters.isRowHidden(sheetId, row);
-        if (isColHidden || isRowHidden) {
-          continue;
-        }
-        const cellPosition: CellPosition = { sheetId, col, row };
-        if (this.currentSearchRegex?.test(this.getSearchableString(cellPosition))) {
-          const match: CellPosition = { sheetId, col, row };
-          matches.push(match);
-        }
-      }
-    }
-    return matches;
-  }
-
-  /**
-   * Changes the selected search cell. Given a direction it will
-   * Change the selection to the previous, current or nextCell,
-   * if it exists otherwise it will set the selectedMatchIndex to null.
-   * It will also reset the index to 0 if the search has changed.
-   * It is also used to keep coherence between the selected searchMatch
-   * and selectedMatchIndex.
-   */
-  private selectNextCell(indexChange: Direction) {
-    const matches = this.searchMatches;
-    if (!matches.length) {
-      this.selectedMatchIndex = null;
-      return;
-    }
-    let nextIndex: number;
-    if (this.selectedMatchIndex === null) {
-      let nextMatchIndex = -1;
-      // if search is not available in current sheet will select in next sheet
-      for (const sheetId of this.getSheetsInSearchOrder()) {
-        nextMatchIndex = matches.findIndex((match) => match.sheetId === sheetId);
-        if (nextMatchIndex !== -1) {
-          break;
-        }
-      }
-      nextIndex = nextMatchIndex;
-    } else {
-      nextIndex = this.selectedMatchIndex + indexChange;
-    }
-    // loop index value inside the array (index -1 => last index)
-    nextIndex = (nextIndex + matches.length) % matches.length;
-    this.selectedMatchIndex = nextIndex;
-    const selectedMatch = matches[nextIndex];
-
-    // Switch to the sheet where the match is located
-    if (this.getters.getActiveSheetId() !== selectedMatch.sheetId) {
-      this.dispatch("ACTIVATE_SHEET", {
-        sheetIdFrom: this.getters.getActiveSheetId(),
-        sheetIdTo: selectedMatch.sheetId,
-      });
-    }
-    // we want grid selection to capture the selection stream
-    this.selection.getBackToDefault();
-    this.selection.selectCell(selectedMatch.col, selectedMatch.row);
-  }
-
-  private clearSearch() {
-    this.toSearch = "";
-    this.selectedMatchIndex = null;
-    this.currentSearchRegex = null;
-    this.allSheetsMatches = [];
-    this.activeSheetMatches = [];
-    this.specificRangeMatches = [];
-    this.searchOptions = {
-      matchCase: false,
-      exactMatch: false,
-      searchFormulas: false,
-      searchScope: "allSheets",
-      specificRange: undefined,
-    };
-  }
-
-  // ---------------------------------------------------------------------------
-  // Replace
-  // ---------------------------------------------------------------------------
-  private replaceMatch(selectedMatch: CellPosition, replaceWith: string) {
-    if (!this.currentSearchRegex) {
-      return;
-    }
-
+  private replaceMatch(
+    selectedMatch: CellPosition,
+    searchString: string,
+    replaceWith: string,
+    searchOptions: SearchOptions
+  ) {
     const cell = this.getters.getCell(selectedMatch);
     if (!cell?.content) {
       return;
     }
 
-    if (cell?.isFormula && !this.searchOptions.searchFormulas) {
+    if (cell?.isFormula && !searchOptions.searchFormulas) {
       return;
     }
-    const replaceRegex = new RegExp(
-      this.currentSearchRegex.source,
-      this.currentSearchRegex.flags + "g"
+
+    const searchRegex = getSearchRegex(searchString, searchOptions);
+    const replaceRegex = new RegExp(searchRegex.source, searchRegex.flags + "g");
+    const toReplace: string | null = this.getters.getCellText(
+      selectedMatch,
+      searchOptions.searchFormulas
     );
-    const toReplace: string | null = this.getSearchableString(selectedMatch);
     const content = toReplace.replace(replaceRegex, replaceWith);
     const canonicalContent = canonicalizeNumberContent(content, this.getters.getLocale());
     this.dispatch("UPDATE_CELL", { ...selectedMatch, content: canonicalContent });
-  }
-
-  /**
-   * Replace the value of the currently selected match
-   */
-  private replace(replaceWith: string) {
-    if (this.selectedMatchIndex === null) {
-      return;
-    }
-
-    const selectedMatch = this.searchMatches[this.selectedMatchIndex];
-
-    this.replaceMatch(selectedMatch, replaceWith);
-    this.selectNextCell(Direction.next);
-  }
-  /**
-   * Apply the replace function to all the matches one time.
-   */
-  private replaceAll(replaceWith: string) {
-    const matchCount = this.searchMatches.length;
-    for (let i = 0; i < matchCount; i++) {
-      this.replaceMatch(this.searchMatches[i], replaceWith);
-    }
-  }
-
-  private getSearchableString(position: CellPosition): string {
-    return this.getters.getCellText(position, this.searchOptions.searchFormulas);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Grid rendering
-  // ---------------------------------------------------------------------------
-
-  drawGrid(renderingContext: GridRenderingContext) {
-    const { ctx } = renderingContext;
-    const sheetId = this.getters.getActiveSheetId();
-
-    for (const [index, match] of this.searchMatches.entries()) {
-      if (match.sheetId !== sheetId) {
-        continue; // Skip drawing matches from other sheets
-      }
-
-      const merge = this.getters.getMerge({ sheetId, col: match.col, row: match.row });
-      const left = merge ? merge.left : match.col;
-      const right = merge ? merge.right : match.col;
-      const top = merge ? merge.top : match.row;
-      const bottom = merge ? merge.bottom : match.row;
-      const { x, y, width, height } = this.getters.getVisibleRect({ top, left, right, bottom });
-      if (width > 0 && height > 0) {
-        ctx.fillStyle = BACKGROUND_COLOR;
-        ctx.fillRect(x, y, width, height);
-        if (index === this.selectedMatchIndex) {
-          ctx.strokeStyle = BORDER_COLOR;
-          ctx.strokeRect(x, y, width, height);
-        }
-      }
-    }
-
-    if (this.searchOptions.searchScope === "specificRange") {
-      const range = this.searchOptions.specificRange;
-      if (!range || range.sheetId !== sheetId) {
-        return;
-      }
-      const { x, y, width, height } = this.getters.getVisibleRect(range.zone);
-      ctx.strokeStyle = BORDER_COLOR;
-      ctx.strokeRect(x, y, width, height);
-    }
   }
 }

--- a/src/registries/index.ts
+++ b/src/registries/index.ts
@@ -7,5 +7,4 @@ export * from "./figure_registry";
 export * from "./inverse_command_registry";
 export * from "./menus/index";
 export * from "./ot_registry";
-export * from "./side_panel_registry";
 export * from "./topbar_component_registry";

--- a/src/store_engine/README.md
+++ b/src/store_engine/README.md
@@ -1,0 +1,214 @@
+# Managing application state with stores
+
+- [Managing application state with stores](#managing-application-state-with-stores)
+  - [Defining a store](#defining-a-store)
+  - [Using a store in a component](#using-a-store-in-a-component)
+  - [Store dependencies](#store-dependencies)
+  - [When to use a store and when to use a plugin?](#when-to-use-a-store-and-when-to-use-a-plugin)
+- [When to use a store and when to use a plugin?](#when-to-use-a-store-and-when-to-use-a-plugin-1)
+  - [Best practices](#best-practices)
+    - [Command-query separation](#command-query-separation)
+    - [DOM events](#dom-events)
+  - [Spreadsheet store for reacting to commands](#spreadsheet-store-for-reacting-to-commands)
+  - [Local store](#local-store)
+  - [Injecting external resources as a store](#injecting-external-resources-as-a-store)
+
+In a typical OWL application, data is passed top-down (from parent to child) via props. However, this approach can become cumbersome for certain types of props that are required by many components within the application.
+
+Stores provide a way to share values like these between components without the need to pass props explicitly through every level of the component tree.
+
+Using stores also decouples the state and how it changes from individual components, making it easier to manage and update application-wide data.
+
+They can also be used for individual components to decouple their UI and their business logic, allowing to test the business logic separatly.
+
+Read also the ["why"](./why.md).
+
+## Defining a store
+
+To illustrate how stores work, let's consider a scenario where you want to display notifications from multiple components in the application. To achieve this, you can define a simple store called `NotificationStore`, which holds the notification state and provides methods to show and hide notifications.
+
+```ts
+class NotificationStore extends ReactiveStore {
+  notificationMessage: string = "";
+  type: "info" | "warning" | "error" = "info";
+
+  show(type: "info" | "warning" | "error", message: string) {
+    this.notificationMessage = message;
+    this.type = type;
+  }
+
+  hide() {
+    this.notificationMessage = "";
+  }
+}
+```
+
+That's it ! You don't need to do anything else.
+
+> Note: `ReactiveStore` is required for OWL to react to state changes in the store. In the o-spreadsheet application, you probably want to use `SpreadsheetStore` instead of `ReactiveStore`. `SpreadsheetStore` is described [below](#spreadsheet-store-for-reacting-to-commands).
+
+## Using a store in a component
+
+First you need to use the `useStoreProvider()` hook on your application root component.
+
+```ts
+class RootComponent extends Component {
+  setup() {
+    useStoreProvider();
+  }
+}
+```
+
+Then, to use a store in any component, you just need to use the `useStore` hook and provide it with the store class, like `useStore(NotificationStore)`. You can access the same instance of the store each time the hook is called with the same store class.
+
+```ts
+import { Component, xml } from "@odoo/owl";
+import { NotificationStore } from "./notification_store";
+
+class MyComponent extends Component {
+  static template = xml`
+    <button t-on-click="onButtonClicked">Show notification</button>
+  `;
+  private notification: Store<NotificationStore>;
+
+  setup() {
+    this.notification = useStore(NotificationStore);
+  }
+
+  onButtonClicked() {
+    this.notification.show("info", "the button was clicked!");
+  }
+}
+```
+
+## Store dependencies
+
+You may have multiple stores that need to interact with each other. Stores allow you to create and manage these store dependencies effectively. Each store can access other stores by using the `get` method, which provides an instance of the required store.
+
+For example, let's consider two stores: `MyStoreA` and `MyStoreB`. If `MyStoreB` needs to interact with `MyStoreA`, it can do so by accessing the instance of `MyStoreA` using the `get` method.
+
+```ts
+class MyStoreA extends ReactiveStore {
+  // ...
+}
+
+class MyStoreB extends ReactiveStore {
+  private storeA = this.get(MyStoreA);
+
+  doSomething() {
+    // can interact with `this.storeA`
+  }
+}
+```
+
+## When to use a store and when to use a plugin?
+
+If the feature implies updating the core state of the spreadsheet (updates core plugins), you should use a plugin.
+
+If the state of your feature is purely UI, both stores and UI plugins are options.
+
+Plugins are the default go to solution.
+
+Does the feature needs to add a state?
+
+- no => don't use a store, you probably just needs getters in plugins.
+- yes:
+  - is the state derived only from state in plugins? (e.g. evaluated cells are derived from cell content and formulas) => use a plugin.
+  - is the business logic depending on state in a store => use a store
+  - is the state shared by multiple components? => use a store
+  - is the state owned by the component? => use a local store
+
+# When to use a store and when to use a plugin?
+
+Choosing between a store and a plugin depends on the nature of the feature you're implementing. Follow these guidelines for clarity:
+
+1. **Updating Core State:**
+
+   - If the feature involves updating the core state of the spreadsheet (e.g., core plugins), choose a **plugin**.
+
+2. **UI-Only Features:**
+   For features that purely impact the UI, both **stores** and **UI plugins** are viable options depending on the use case.
+
+   - **No Need for Additional State:**
+     - If the feature doesn't require adding new state, consider using **getters in plugins**.
+   - **Need for Additional State:**
+     - **Derived State:**
+       - If the state can be derived solely from state in plugins (e.g., evaluated cells from content and formulas), opt for a **plugin**.
+     - **Business Logic Dependency:**
+       - If the business logic relies on state in another store, choose a **store**.
+     - **Shared State:**
+       - If the state is shared by multiple components, prefer a **store**.
+     - **Component-Owned State:**
+       - If the state is owned by a specific component, use a **local store**.
+
+## Best practices
+
+### Command-query separation
+
+Stores should follow the **[Command-query separation (CQS)](https://en.wikipedia.org/wiki/Command%E2%80%93query_separation)** principle.
+
+CQS principle helps in designing more maintainable and predictable code. By following this separation, you can reason more easily about how state changes and how rendering is based on the current state. It is also the architecture for o-spreadsheet plugins.
+
+To apply the CQS principle to stores, they should have the following characteristics:
+
+- **write-only methods** (commands): methods should never return anything, they can only update internal state.
+- **readonly properties** (queries): properties can never be changed by components or other stores directly
+
+> Notes:
+>
+> - you can have computed properties by using javascript getters.
+>
+> - if you are using TypeScript, `useStore` and `get` enforce these principles with the generic `Store` type.
+
+### DOM events
+
+DOM events are associated with components, and stores should remain unaware of them. If there is a need to interrupt an event or prevent its default behavior (using `ev.stopPropagation()` or `ev.preventDefault()`), such actions should be performed within the component.
+
+## Spreadsheet store for reacting to commands
+
+In some cases, you may need to react to specific commands and update the store's internal state accordingly. To achieve this, a store can inherit from `SpreadsheetStore`, which provides the necessary functionality for reacting to commands.
+
+```ts
+class MyStore extends SpreadsheetStore {
+  handle(cmd: Command) {
+    // You can update the store's internal state here based on the command received.
+  }
+  finalize() {
+    // called after the command (and all its sub-commands) have been handled.
+  }
+}
+```
+
+The `handle` method allows you to handle various commands and manage the store's state accordingly.
+
+## Local store
+
+In addition to application-wide stores, stores also provides a convenient way to manage state that is specific to individual components. These local stores bring the advantages of decoupling the component from its business logic and how it changes, making it easier to reason about, maintain and test.
+
+To create a local store, you can use the `useLocalStore` hook. It creates a new store instance bound to the component and automatically disposes of the store when the component unmounts.
+
+To implement a local store, your store class must implement the `Disposable` interface, which requires the implementation of a `dispose` method. The `dispose` method is called when the component unmounts and is used to perform any necessary cleanup, such as unsubscribing from event handlers or releasing external resources, avoiding memory leaks.
+
+> Note: `SpreadsheetStore` is already a `Disposable` and automatically unsubscribes from model commands when it's disposed.
+
+## Injecting external resources as a store
+
+Sometimes, a store may depend on an external resource that is not a store itself. To inject such an external resource into a store, you can use a trick. First, create a "fake" store using `createMetaStore`, which acts as a placeholder for the injected resource. Then, in the (root) component where the real external resource is available, inject it to replace the "fake" store.
+
+Let's take an example where we want to inject a spreadsheet Model instance into a store called ModelStore.
+
+```ts
+// Create a "fake"/"empty" store to act as a placeholder
+export const ModelStore = createMetaStore<Model>("Model");
+
+// In the root component where the Model is available, inject it into the ModelStore
+class RootComponent extends Component {
+  setup() {
+    const stores = useStoreProvider();
+    stores.inject(ModelStore, this.props.model); // Inject the real Model instance
+  }
+}
+```
+
+Now, when you request the `ModelStore` in another store or component (using `this.get(ModelStore)` or `useStore(ModelStore)`), you will get the injected `Model` instance. This allows you to use external resources seamlessly within your stores.
+It can also allow to mock a store in unit tests.

--- a/src/store_engine/dependency_container.ts
+++ b/src/store_engine/dependency_container.ts
@@ -1,0 +1,55 @@
+import { Get, StoreConstructor, StoreParams } from "./store";
+
+/**
+ * A type-safe dependency container
+ */
+export class DependencyContainer {
+  private dependencies: Map<StoreConstructor, any> = new Map();
+  private factory = new StoreFactory(this.get.bind(this));
+
+  /**
+   * Injects a store instance in the dependency container.
+   * Useful for injecting an external store that is not created by the container.
+   * Also useful for mocking a store.
+   */
+  inject<T extends StoreConstructor>(Store: T, instance: InstanceType<T>): void {
+    this.dependencies.set(Store, instance);
+  }
+
+  /**
+   * Get an instance of a store.
+   */
+  get<T>(Store: StoreConstructor<T>): T {
+    if (!this.dependencies.has(Store)) {
+      this.dependencies.set(Store, this.instantiate(Store));
+    }
+    return this.dependencies.get(Store);
+  }
+
+  instantiate<T>(Store: StoreConstructor<T>, ...args: StoreParams<StoreConstructor<T>>): T {
+    return this.factory.build(Store, ...args);
+  }
+}
+
+class StoreFactory {
+  private pendingBuilds: Set<StoreConstructor<any>> = new Set();
+
+  constructor(private get: Get) {}
+  /**
+   * Build a store instance and get all its dependencies
+   * while detecting and preventing circular dependencies
+   */
+  build<T>(Store: StoreConstructor<T>, ...args: StoreParams<StoreConstructor<T>>): T {
+    if (this.pendingBuilds.has(Store)) {
+      throw new Error(
+        `Circular dependency detected: ${[...this.pendingBuilds, Store]
+          .map((s) => s.name)
+          .join(" -> ")}`
+      );
+    }
+    this.pendingBuilds.add(Store);
+    const instance = new Store(this.get, ...args);
+    this.pendingBuilds.delete(Store);
+    return instance;
+  }
+}

--- a/src/store_engine/index.ts
+++ b/src/store_engine/index.ts
@@ -1,0 +1,4 @@
+export * from "./dependency_container";
+export * from "./spreadsheet_store";
+export * from "./store";
+export * from "./store_hooks";

--- a/src/store_engine/spreadsheet_store.ts
+++ b/src/store_engine/spreadsheet_store.ts
@@ -1,0 +1,24 @@
+import { Model } from "../model";
+import { Command } from "../types";
+import { Disposable, Get, ReactiveStore, createMetaStore } from "./store";
+
+export const ModelStore = createMetaStore<Model>("Model");
+
+export class SpreadsheetStore extends ReactiveStore implements Disposable {
+  protected model = this.get(ModelStore);
+  protected getters = this.model.getters;
+
+  constructor(get: Get) {
+    super(get);
+    this.model.on("command-dispatched", this, this.handle);
+    this.model.on("command-finalized", this, this.finalize);
+  }
+
+  protected handle(cmd: Command) {}
+  protected finalize() {}
+
+  dispose() {
+    this.model.off("command-dispatched", this);
+    this.model.off("command-finalized", this);
+  }
+}

--- a/src/store_engine/store.ts
+++ b/src/store_engine/store.ts
@@ -1,0 +1,85 @@
+import { reactive } from "@odoo/owl";
+
+/**
+ * An injectable store constructor
+ */
+export interface StoreConstructor<T = any, A extends unknown[] = unknown[]> {
+  new (get: Get, ...args: A): T;
+}
+
+/**
+ * A store constructor for a store that implements the Disposable interface.
+ * Useful for local stores that need to be disposed when the component unmounts.
+ */
+export interface LocalStoreConstructor<
+  T extends Disposable = any,
+  A extends unknown[] = unknown[]
+> {
+  new (get: Get, ...args: A): T;
+}
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export type StoreParams<T extends StoreConstructor> = SkipFirst<ConstructorParameters<T>>;
+
+/**
+ * A function used to inject dependencies in a store constructor
+ */
+export type Get = <T extends StoreConstructor<any>>(
+  Store: T
+) => T extends StoreConstructor<infer I> ? Store<I> : never;
+
+/**
+ * Remove the first element of a tuple
+ * @example
+ * type A = SkipFirst<[number, string, boolean]> // [string, boolean]
+ */
+type SkipFirst<T extends any[]> = T extends [any, ...infer U] ? U : never;
+
+/**
+ * TODO
+ */
+export function createMetaStore<T extends unknown>(storeName: string): StoreConstructor<T> {
+  class MetaStore {
+    constructor(get: Get) {
+      throw new Error(`This is a meta store for ${storeName}, it cannot be instantiated.
+Did you forget to inject your store instance?
+
+const stores = useStoreProvider();
+const myStore = stores.inject(MyMetaStore, storeInstance);
+`);
+    }
+  }
+  return MetaStore as StoreConstructor<T>;
+}
+
+export type Store<T> = CQS<T>;
+
+/**
+ * Command Query Separation [1,2] implementation with types.
+ *
+ * Mapped type applying CQS principles to an object by forcing
+ * - methods (commands) to never return anything, effectively making them write-only,
+ * - all properties (queries) to be read-only [3]
+ *
+ * [1] https://martinfowler.com/bliki/CommandQuerySeparation.html
+ * [2] https://en.wikipedia.org/wiki/Command%E2%80%93query_separation
+ * [3] in an ideal world, they would be deeply read-only, but that's not possible natively in TypeScript
+ */
+type CQS<T> = {
+  readonly [key in keyof T]: NeverReturns<T[key]>;
+};
+
+/**
+ * Force any function to never return anything, effectively
+ * making it write-only.
+ */
+type NeverReturns<T> = T extends (...args: any[]) => any ? (...args: Parameters<T>) => void : T;
+
+export class ReactiveStore {
+  constructor(protected get: Get) {
+    return reactive(this);
+  }
+}

--- a/src/store_engine/store.ts
+++ b/src/store_engine/store.ts
@@ -68,7 +68,7 @@ export type Store<T> = CQS<T>;
  * [2] https://en.wikipedia.org/wiki/Command%E2%80%93query_separation
  * [3] in an ideal world, they would be deeply read-only, but that's not possible natively in TypeScript
  */
-type CQS<T> = {
+export type CQS<T> = {
   readonly [key in keyof T]: NeverReturns<T[key]>;
 };
 

--- a/src/store_engine/store_hooks.ts
+++ b/src/store_engine/store_hooks.ts
@@ -1,0 +1,50 @@
+import { onWillUnmount, useEnv, useState, useSubEnv } from "@odoo/owl";
+import { DependencyContainer } from "./dependency_container";
+import { LocalStoreConstructor, Store, StoreConstructor, StoreParams } from "./store";
+
+/**
+ * This hook should be used at the root of your app to provide the store container.
+ */
+export function useStoreProvider() {
+  const env = useEnv();
+  if (env.__spreadsheet_stores__ instanceof DependencyContainer) {
+    return env.__spreadsheet_stores__;
+  }
+  const container = new DependencyContainer();
+  useSubEnv({
+    __spreadsheet_stores__: container,
+    getStore: container.get.bind(container),
+  });
+  return container;
+}
+
+type Env = ReturnType<typeof useEnv>;
+
+/**
+ * Get the instance of a store.
+ */
+export function useStore<T extends StoreConstructor>(Store: T): Store<InstanceType<T>> {
+  const env: Env = useEnv();
+  const container = getDependencyContainer(env);
+  return useState(container.get(Store));
+}
+
+// useComponentStore ?
+export function useLocalStore<T extends LocalStoreConstructor<any>>(
+  Store: T,
+  ...args: StoreParams<T>
+): Store<InstanceType<T>> {
+  const env = useEnv();
+  const container = getDependencyContainer(env);
+  const store = useState(container.instantiate(Store, ...args));
+  onWillUnmount(() => store.dispose());
+  return store;
+}
+
+function getDependencyContainer(env: Env) {
+  const container = env.__spreadsheet_stores__;
+  if (!(container instanceof DependencyContainer)) {
+    throw new Error("No store provider found. Did you forget to call useStoreProvider()?");
+  }
+  return container;
+}

--- a/src/stores/renderer_manager_store.ts
+++ b/src/stores/renderer_manager_store.ts
@@ -1,0 +1,36 @@
+import { ModelStore, ReactiveStore } from "../store_engine";
+import { GridRenderingContext, LAYERS } from "../types";
+import { RendererStore } from "./renderer_store";
+
+export class RenderersManagerStore extends ReactiveStore {
+  protected model = this.get(ModelStore);
+  private renderers: Partial<Record<LAYERS, RendererStore[]>> = {};
+
+  register(renderer: RendererStore) {
+    for (const layer of renderer.layers) {
+      if (!this.renderers[layer]) {
+        this.renderers[layer] = [];
+      }
+      this.renderers[layer]!.push(renderer);
+    }
+  }
+
+  unRegister(renderer: RendererStore) {
+    for (const layer of Object.keys(this.renderers)) {
+      this.renderers[layer] = this.renderers[layer].filter((r: RendererStore) => r !== renderer);
+    }
+  }
+
+  triggerRender() {
+    this.model.dispatch("RENDER_CANVAS", {});
+  }
+
+  drawLayer(ctx: GridRenderingContext, layer: LAYERS) {
+    const renderers = this.renderers[layer];
+    if (renderers) {
+      for (const renderer of renderers) {
+        renderer.draw(ctx, layer);
+      }
+    }
+  }
+}

--- a/src/stores/renderer_store.ts
+++ b/src/stores/renderer_store.ts
@@ -1,0 +1,23 @@
+import { Get, SpreadsheetStore } from "../store_engine";
+import { GridRenderingContext, LAYERS } from "../types";
+import { RenderersManagerStore } from "./renderer_manager_store";
+
+export abstract class RendererStore extends SpreadsheetStore {
+  protected rendererManager = this.get(RenderersManagerStore);
+
+  constructor(get: Get) {
+    super(get);
+    this.rendererManager.register(this);
+  }
+
+  dispose() {
+    this.rendererManager.unRegister(this);
+  }
+
+  triggerRender() {
+    this.rendererManager.triggerRender();
+  }
+
+  abstract get layers(): LAYERS[];
+  abstract draw(ctx: GridRenderingContext, layer: LAYERS): void;
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -18,6 +18,7 @@ import {
 import {
   Border,
   BorderData,
+  CellPosition,
   Color,
   Dimension,
   HeaderIndex,
@@ -141,11 +142,6 @@ export const readonlyAllowedCommands = new Set<CommandTypes>([
 
   "RESIZE_SHEETVIEW",
   "SET_VIEWPORT_OFFSET",
-
-  "SELECT_SEARCH_NEXT_MATCH",
-  "SELECT_SEARCH_PREVIOUS_MATCH",
-  "UPDATE_SEARCH",
-  "CLEAR_SEARCH",
 
   "EVALUATE_CELLS",
 
@@ -893,31 +889,12 @@ export interface SelectFigureCommand {
   id: UID;
 }
 
-export interface UpdateSearchCommand {
-  type: "UPDATE_SEARCH";
-  toSearch: string;
-  searchOptions: SearchOptions;
-}
-
-export interface ClearSearchCommand {
-  type: "CLEAR_SEARCH";
-}
-
-export interface SelectSearchPreviousCommand {
-  type: "SELECT_SEARCH_PREVIOUS_MATCH";
-}
-
-export interface SelectSearchNextCommand {
-  type: "SELECT_SEARCH_NEXT_MATCH";
-}
-
 export interface ReplaceSearchCommand {
   type: "REPLACE_SEARCH";
+  searchString: string;
   replaceWith: string;
-}
-export interface ReplaceAllSearchCommand {
-  type: "REPLACE_ALL_SEARCH";
-  replaceWith: string;
+  searchOptions: SearchOptions;
+  matches: CellPosition[];
 }
 
 export interface SortCommand {
@@ -1141,12 +1118,7 @@ export type LocalCommand =
   | ShowFormulaCommand
   | AutofillAutoCommand
   | SelectFigureCommand
-  | UpdateSearchCommand
-  | ClearSearchCommand
-  | SelectSearchPreviousCommand
-  | SelectSearchNextCommand
   | ReplaceSearchCommand
-  | ReplaceAllSearchCommand
   | SortCommand
   | SetDecimalCommand
   | ResizeViewportCommand

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1008,6 +1008,10 @@ export interface SplitTextIntoColumnsCommand {
   force?: boolean;
 }
 
+export interface RenderCanvasCommand {
+  type: "RENDER_CANVAS";
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1159,7 +1163,8 @@ export type LocalCommand =
   | UpdateFilterCommand
   | SplitTextIntoColumnsCommand
   | RemoveDuplicatesCommand
-  | TrimWhitespaceCommand;
+  | TrimWhitespaceCommand
+  | RenderCanvasCommand;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -1,5 +1,6 @@
 import { Model } from "..";
 import { ClipboardInterface } from "../helpers/clipboard/navigator_clipboard_wrapper";
+import { Get } from "../store_engine";
 import { Currency } from "./currency";
 import { ImageProviderInterface } from "./files";
 import { Locale } from "./locale";
@@ -33,4 +34,5 @@ export interface SpreadsheetChildEnv extends SpreadsheetEnv {
   startCellEdition: (content?: string) => void;
   loadCurrencies?: () => Promise<Currency[]>;
   loadLocales: () => Promise<Locale[]>;
+  getStore: Get;
 }

--- a/src/types/find_and_replace.ts
+++ b/src/types/find_and_replace.ts
@@ -1,13 +1,9 @@
-import { Range, RangeData } from "./range";
+import { Range } from "./range";
 
 export interface SearchOptions {
   matchCase: boolean;
   exactMatch: boolean;
   searchFormulas: boolean;
   searchScope: "allSheets" | "activeSheet" | "specificRange";
-  specificRange?: RangeData;
-}
-
-export interface SearchOptionsInternal extends Omit<SearchOptions, "specificRange"> {
   specificRange?: Range;
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -357,3 +357,8 @@ export interface Offset {
   col: number;
   row: number;
 }
+
+export type DebouncedFunction<T> = T & {
+  stopDebounce: () => void;
+  isDebouncePending: () => boolean;
+};

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -90,6 +90,16 @@ export const enum LAYERS {
   Selection,
   Headers, // Probably keep this at the end
 }
+export const RENDERING_LAYERS: LAYERS[] = [
+  LAYERS.Background,
+  LAYERS.Highlights,
+  LAYERS.Clipboard,
+  LAYERS.Search,
+  LAYERS.Chart,
+  LAYERS.Autofill,
+  LAYERS.Selection,
+  LAYERS.Headers,
+];
 
 export interface EdgeScrollInfo {
   canEdgeScroll: boolean;

--- a/tests/__mocks__/mock_misc_helpers.ts
+++ b/tests/__mocks__/mock_misc_helpers.ts
@@ -1,0 +1,11 @@
+import { DebouncedFunction } from "../../src/types";
+
+/** Mocked debounce that doesn't actually do any debouncing, but just calls the function directly */
+export function debounce<T extends (...args: any) => void>(func: T): DebouncedFunction<T> {
+  const debounced = function (this: any): void {
+    func.apply(this, arguments);
+  };
+  debounced.isDebouncePending = () => false;
+  debounced.stopDebounce = () => {};
+  return debounced as DebouncedFunction<T>;
+}

--- a/tests/data_validation/data_validation_checkbox_component.test.ts
+++ b/tests/data_validation/data_validation_checkbox_component.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src";
 import { addDataValidation, setCellContent, setStyle } from "../test_helpers/commands_helpers";
 import { getStyle } from "../test_helpers/getters_helpers";
+import { drawGrid } from "../test_helpers/helpers";
 import { MockGridRenderingContext } from "../test_helpers/renderer_helpers";
 
 describe("Checkbox in model", () => {
@@ -46,14 +47,14 @@ describe("Checkbox in model", () => {
     test("Valid checkbox value is not rendered", () => {
       addDataValidation(model, "B2", "id", { type: "isBoolean", values: [] });
       setCellContent(model, "B2", "TRUE");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(renderedTexts).not.toContain("TRUE");
     });
 
     test("Invalid checkbox value is rendered", () => {
       addDataValidation(model, "B2", "id", { type: "isBoolean", values: [] });
       setCellContent(model, "B2", "hello");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(renderedTexts).toContain("hello");
     });
   });

--- a/tests/data_validation/data_validation_checkbox_plugin.test.ts
+++ b/tests/data_validation/data_validation_checkbox_plugin.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src";
 import { addDataValidation, setCellContent, setStyle } from "../test_helpers/commands_helpers";
 import { getStyle } from "../test_helpers/getters_helpers";
+import { drawGrid } from "../test_helpers/helpers";
 import { MockGridRenderingContext } from "../test_helpers/renderer_helpers";
 
 describe("Checkbox in model", () => {
@@ -46,14 +47,14 @@ describe("Checkbox in model", () => {
     test("Valid checkbox value is not rendered", () => {
       addDataValidation(model, "B2", "id", { type: "isBoolean", values: [] });
       setCellContent(model, "B2", "TRUE");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(renderedTexts).not.toContain("TRUE");
     });
 
     test("Invalid checkbox value is rendered", () => {
       addDataValidation(model, "B2", "id", { type: "isBoolean", values: [] });
       setCellContent(model, "B2", "hello");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(renderedTexts).toContain("hello");
     });
   });

--- a/tests/find_and_replace/find_and_replace_plugin.test.ts
+++ b/tests/find_and_replace/find_and_replace_plugin.test.ts
@@ -1,6 +1,8 @@
 import { Model } from "../../src";
+import { FindAndReplaceStore } from "../../src/components/side_panel/find_and_replace/find_and_replace_store";
 import { functionRegistry } from "../../src/functions";
 import { toZone } from "../../src/helpers";
+import { DependencyContainer, ModelStore } from "../../src/store_engine";
 import { UID } from "../../src/types";
 import { SearchOptions } from "../../src/types/find_and_replace";
 import { DEFAULT_LOCALE } from "../../src/types/locale";
@@ -27,13 +29,17 @@ import {
   getCellContent,
   getCellText,
 } from "../test_helpers/getters_helpers";
-import { toRangeData } from "../test_helpers/helpers";
+
+// Disable debounce for tests
+jest.mock("../../src/helpers/misc.ts", () => {
+  return {
+    ...jest.requireActual("../../src/helpers/misc.ts"),
+    ...jest.requireActual("../__mocks__/mock_misc_helpers.ts"),
+  };
+});
 
 let model: Model;
-
-function getSearchOptions() {
-  return model.getters.getSearchOptions();
-}
+let store: FindAndReplaceStore;
 
 function p(xc: string) {
   const z = toZone(xc);
@@ -44,26 +50,32 @@ function match(sheetId: UID, xc: string) {
   return { sheetId, ...p(xc) };
 }
 
-function getMatches(model: Model) {
-  return model.getters.getSearchMatches();
-}
-
-function getMatchIndex(model: Model) {
-  return model.getters.getCurrentSelectedMatchIndex();
-}
-
 function updateSearch(model: Model, toSearch: string, options: Partial<SearchOptions> = {}) {
-  const searchOptions = { ...getSearchOptions(), ...options };
-  return model.dispatch("UPDATE_SEARCH", { toSearch, searchOptions });
+  const searchOptions = { ...store.searchOptions, ...options };
+  store.updateSearchContent(toSearch);
+  store.updateSearchOptions(searchOptions);
 }
+
+function replaceSearch(replaceWith: string) {
+  store.toReplace = replaceWith;
+  store.replace();
+}
+
+function replaceAll(replaceWith: string) {
+  store.toReplace = replaceWith;
+  store.replaceAll();
+}
+
+const sheetId1 = "s1";
+const sheetId2 = "s2";
+beforeEach(() => {
+  model = new Model({ sheets: [{ id: sheetId1 }] });
+  const container = new DependencyContainer();
+  container.inject(ModelStore, model);
+  store = container.get(FindAndReplaceStore);
+});
 
 describe("basic search", () => {
-  const sheetId1 = "s1";
-  const sheetId2 = "s2";
-  beforeEach(() => {
-    model = new Model({ sheets: [{ id: sheetId1 }] });
-  });
-
   test("simple search for search scope activeSheet", () => {
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "test");
@@ -71,11 +83,11 @@ describe("basic search", () => {
     setCellContent(model, "A1", "test");
     setCellContent(model, "A2", "test");
     updateSearch(model, "test", { searchScope: "activeSheet" });
-    expect(getMatches(model)).toEqual([match("sh2", "A1"), match("sh2", "A2")]);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toEqual([match("sh2", "A1"), match("sh2", "A2")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     activateSheet(model, sheetId1);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2")]);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A2")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
   });
 
   test("simple search for search scope allSheet", () => {
@@ -83,8 +95,8 @@ describe("basic search", () => {
     createSheet(model, { sheetId: "sh2" });
     setCellContent(model, "A2", "test", "sh2");
     updateSearch(model, "test");
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toEqual([match(sheetId1, "A2"), match("sh2", "A2")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toEqual([match(sheetId1, "A2"), match("sh2", "A2")]);
   });
 
   test("simple search for search scope specificRange", () => {
@@ -92,16 +104,16 @@ describe("basic search", () => {
     setCellContent(model, "A2", "test");
     updateSearch(model, "test", {
       searchScope: "specificRange",
-      specificRange: toRangeData(sheetId1, "A1:B1"),
+      specificRange: model.getters.getRangeFromSheetXC(sheetId1, "A1:B1"),
     });
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1")]);
   });
 
   test("search with a regexp characters", () => {
     setCellContent(model, "A1", "hello (world).*");
     updateSearch(model, "hello (world).*");
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1")]);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1")]);
   });
 
   test("Update search automatically select the first match", () => {
@@ -116,12 +128,12 @@ describe("basic search", () => {
     setCellContent(model, "A2", "Hello1");
     setCellContent(model, "A3", "=111");
     updateSearch(model, "hello", { searchScope: "activeSheet" });
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
-    expect(getMatchIndex(model)).toStrictEqual(1);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "A2")]);
+    store.selectNextMatch();
+    expect(store.selectedMatchIndex).toStrictEqual(1);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "A2")]);
     updateSearch(model, "1", { searchScope: "activeSheet" });
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2"), match(sheetId1, "A3")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A2"), match(sheetId1, "A3")]);
   });
 
   test("change the search for allSheet searchScope", () => {
@@ -131,12 +143,12 @@ describe("basic search", () => {
     setCellContent(model, "A1", "=111", sheetId2);
 
     updateSearch(model, "hello");
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
-    expect(getMatchIndex(model)).toStrictEqual(1);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "A2")]);
+    store.selectNextMatch();
+    expect(store.selectedMatchIndex).toStrictEqual(1);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "A2")]);
     updateSearch(model, "1");
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2"), match(sheetId2, "A1")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A2"), match(sheetId2, "A1")]);
   });
 
   test("change the search for specificRange searchScope", () => {
@@ -145,26 +157,26 @@ describe("basic search", () => {
     setCellContent(model, "A2", "=111", sheetId2);
     updateSearch(model, "hello", {
       searchScope: "specificRange",
-      specificRange: toRangeData(sheetId2, "A1:A3"),
+      specificRange: model.getters.getRangeFromSheetXC(sheetId2, "A1:A3"),
     });
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
-    expect(getMatches(model)).toHaveLength(0);
+    store.selectNextMatch();
+    expect(store.searchMatches).toHaveLength(0);
     expect(model.getters.getActiveSheetId()).toBe(sheetId1);
     updateSearch(model, "1");
     expect(model.getters.getActiveSheetId()).toBe(sheetId2);
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId2, "A2")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId2, "A2")]);
   });
 
   test("refresh search when cell is updated", async () => {
     setCellContent(model, "A1", "hello");
     updateSearch(model, "hello");
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1")]);
     setCellContent(model, "B1", "hello");
     setCellContent(model, "B2", '="hello"');
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "B1"),
       match(sheetId1, "B2"),
@@ -182,37 +194,28 @@ describe("basic search", () => {
     setCellContent(model, "A1", "hello");
     setCellContent(model, "B1", "=GETVALUE()");
     updateSearch(model, "hello");
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1")]);
     value = "hello";
     model.dispatch("EVALUATE_CELLS", { sheetId: model.getters.getActiveSheetId() });
     expect(getCellContent(model, "B1")).toBe(value);
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "B1")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "B1")]);
   });
 
   test("search on empty string does not match anything", () => {
     setCellContent(model, "A1", "hello");
     updateSearch(model, "");
-    expect(model.getters.getSearchMatches()).toHaveLength(0);
+    expect(store.searchMatches).toHaveLength(0);
   });
 
   test("search on empty string clears matches", () => {
     setCellContent(model, "A1", "hello");
     setCellContent(model, "A2", "hello");
     updateSearch(model, "hello");
-    expect(model.getters.getSearchMatches()).toHaveLength(2);
+    expect(store.searchMatches).toHaveLength(2);
     updateSearch(model, "");
-    expect(model.getters.getSearchMatches()).toHaveLength(0);
-  });
-
-  test("Can clear the search completely", () => {
-    setCellContent(model, "A1", "hello");
-    setCellContent(model, "A2", "hello");
-    updateSearch(model, "hello");
-    expect(model.getters.getSearchMatches()).toHaveLength(2);
-    model.dispatch("CLEAR_SEARCH");
-    expect(model.getters.getSearchMatches()).toHaveLength(0);
+    expect(store.searchMatches).toHaveLength(0);
   });
 
   test("search begins from current sheet with index starting at the first sheet in allSheets search scope", () => {
@@ -224,8 +227,8 @@ describe("basic search", () => {
     activateSheet(model, sheetId2);
     updateSearch(model, "1");
     expect(getActivePosition(model)).toBe("A2");
-    expect(getMatchIndex(model)).toStrictEqual(2);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(2);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
       match(sheetId2, "A2"),
@@ -238,64 +241,64 @@ describe("basic search", () => {
     setCellContent(model, "A2", "=111", sheetId2);
     updateSearch(model, "1", { searchScope: "activeSheet" });
     expect(getActivePosition(model)).toBe("A3");
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A3")]);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A3")]);
     activateSheet(model, "s2");
     expect(getActivePosition(model)).toBe("A2");
-    expect(getMatches(model)).toStrictEqual([match(sheetId2, "A2")]);
+    expect(store.searchMatches).toStrictEqual([match(sheetId2, "A2")]);
   });
 
   test("Update search if column or row is added", () => {
     setCellContent(model, "A3", "1");
     setCellContent(model, "A4", "1");
     updateSearch(model, "1");
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A3"), match(sheetId1, "A4")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A3"), match(sheetId1, "A4")]);
     addRows(model, "after", 1, 1);
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A4"), match(sheetId1, "A5")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A4"), match(sheetId1, "A5")]);
   });
 
   test("Search is updated if column or row is removed", () => {
     setCellContent(model, "A2", "1");
     setCellContent(model, "A3", "111");
     updateSearch(model, "1");
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
-    expect(getMatchIndex(model)).toStrictEqual(1);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2"), match(sheetId1, "A3")]);
+    store.selectNextMatch();
+    expect(store.selectedMatchIndex).toStrictEqual(1);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A2"), match(sheetId1, "A3")]);
     deleteRows(model, [1]);
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match(sheetId1, "A2")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A2")]);
   });
 
   test("Update search upon undo/redo operations, which can update the cell", () => {
     setCellContent(model, "A2", "1");
     setCellContent(model, "A3", "1");
     updateSearch(model, "1");
-    expect(getMatches(model)).toHaveLength(2);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(2);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     deleteRows(model, [1]);
-    expect(getMatches(model)).toHaveLength(1);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(1);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     undo(model);
-    expect(getMatches(model)).toHaveLength(2);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(2);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     redo(model);
-    expect(getMatches(model)).toHaveLength(1);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(1);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
   });
 
   test("hidden cells should not be included in match", () => {
     setCellContent(model, "A2", "1");
     setCellContent(model, "A3", "1");
     updateSearch(model, "1");
-    expect(getMatches(model)).toHaveLength(2);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(2);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     hideRows(model, [1]);
-    expect(getMatches(model)).toHaveLength(1);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(1);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     unhideRows(model, [1]);
-    expect(getMatches(model)).toHaveLength(2);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(2);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
   });
 
   test("Need to update search if updating or removing the filter", () => {
@@ -303,38 +306,47 @@ describe("basic search", () => {
     setCellContent(model, "A3", "=111");
     createFilter(model, "A1:A6");
     updateSearch(model, "1");
-    expect(getMatches(model)).toHaveLength(2);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(2);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     updateFilter(model, "A1", ["1"]);
-    expect(getMatches(model)).toHaveLength(1);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(1);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     deleteFilter(model, "A1:A6");
-    expect(getMatches(model)).toHaveLength(2);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(2);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+  });
+
+  test("Store update search content method is debounced and debounce timeout is cleared on dispose", () => {
+    const debouncedSearch = store.updateSearchContent;
+    expect(typeof debouncedSearch).toBe("function");
+    expect(debouncedSearch.isDebouncePending).toBeTruthy();
+    expect(debouncedSearch.stopDebounce).toBeTruthy();
+
+    const spyStopDebounce = jest.spyOn(debouncedSearch, "stopDebounce");
+    store.dispose();
+    expect(spyStopDebounce).toHaveBeenCalled();
   });
 });
 
 test("simple search with array formula", () => {
-  model = new Model({ sheets: [{ id: "sh1" }] });
   setCellContent(model, "A1", "hell0");
   setCellContent(model, "A2", "hello");
   setCellContent(model, "A3", "=1");
   setCellContent(model, "B1", "=TRANSPOSE(A1:A3)");
   updateSearch(model, "hello");
-  expect(getMatchIndex(model)).toStrictEqual(0);
-  expect(getMatches(model)).toStrictEqual([match("sh1", "C1"), match("sh1", "A2")]);
+  expect(store.selectedMatchIndex).toStrictEqual(0);
+  expect(store.searchMatches).toStrictEqual([match("s1", "C1"), match("s1", "A2")]);
 });
 
 test("replace don't replace value resulting from array formula", () => {
-  model = new Model();
   setCellContent(model, "A1", "hell0");
   setCellContent(model, "A2", "hello");
   setCellContent(model, "A3", "=1");
   setCellContent(model, "B1", "=TRANSPOSE(A1:A3)");
   updateSearch(model, "hello");
-  model.dispatch("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
-  expect(getMatches(model)).toHaveLength(0);
-  expect(getMatchIndex(model)).toStrictEqual(null);
+  replaceAll("kikou");
+  expect(store.searchMatches).toHaveLength(0);
+  expect(store.selectedMatchIndex).toStrictEqual(null);
   // Check that the original value has correctly been replaced
   expect(getCellContent(model, "A2")).toBe("kikou");
   // Check that the array formula has not been modified : If nothing has
@@ -346,17 +358,15 @@ test("replace don't replace value resulting from array formula", () => {
 });
 
 describe("next/previous cycle", () => {
-  const sheetId1 = "s1";
   beforeEach(() => {
-    model = new Model({ sheets: [{ id: sheetId1 }] });
     setCellContent(model, "A1", "1");
     setCellContent(model, "A2", "1");
     setCellContent(model, "A3", "1");
   });
   test("Next will select the next match", () => {
     updateSearch(model, "1");
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
-    expect(getMatches(model)).toStrictEqual([
+    store.selectNextMatch();
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
@@ -364,9 +374,9 @@ describe("next/previous cycle", () => {
   });
   test("Next than previous will cancel each other", () => {
     updateSearch(model, "1");
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
-    model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
-    expect(getMatches(model)).toStrictEqual([
+    store.selectNextMatch();
+    store.selectPreviousMatch();
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
@@ -376,42 +386,42 @@ describe("next/previous cycle", () => {
   test("search will cycle with next", () => {
     updateSearch(model, "1");
     expect(getActivePosition(model)).toBe("A1");
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
     ]);
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
+    store.selectNextMatch();
     expect(getActivePosition(model)).toBe("A2");
-    expect(getMatchIndex(model)).toStrictEqual(1);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(1);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
     ]);
 
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
+    store.selectNextMatch();
     expect(getActivePosition(model)).toBe("A3");
-    expect(getMatchIndex(model)).toStrictEqual(2);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(2);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
     ]);
 
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
+    store.selectNextMatch();
     expect(getActivePosition(model)).toBe("A1");
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
     ]);
 
-    model.dispatch("SELECT_SEARCH_NEXT_MATCH");
+    store.selectNextMatch();
     expect(getActivePosition(model)).toBe("A2");
-    expect(getMatchIndex(model)).toStrictEqual(1);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(1);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
@@ -420,44 +430,44 @@ describe("next/previous cycle", () => {
   test("search will cycle with previous", () => {
     updateSearch(model, "1");
     expect(getActivePosition(model)).toBe("A1");
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
     ]);
 
-    model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
+    store.selectPreviousMatch();
     expect(getActivePosition(model)).toBe("A3");
-    expect(getMatchIndex(model)).toStrictEqual(2);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(2);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
     ]);
 
-    model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
+    store.selectPreviousMatch();
     expect(getActivePosition(model)).toBe("A2");
-    expect(getMatchIndex(model)).toStrictEqual(1);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(1);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
     ]);
 
-    model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
+    store.selectPreviousMatch();
     expect(getActivePosition(model)).toBe("A1");
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
     ]);
 
-    model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
+    store.selectPreviousMatch();
     expect(getActivePosition(model)).toBe("A3");
-    expect(getMatchIndex(model)).toStrictEqual(2);
-    expect(getMatches(model)).toStrictEqual([
+    expect(store.selectedMatchIndex).toStrictEqual(2);
+    expect(store.searchMatches).toStrictEqual([
       match(sheetId1, "A1"),
       match(sheetId1, "A2"),
       match(sheetId1, "A3"),
@@ -467,51 +477,49 @@ describe("next/previous cycle", () => {
 
 describe("next/previous with single match", () => {
   beforeEach(() => {
-    model = new Model();
     setCellContent(model, "A1", "1");
     updateSearch(model, "1", { searchScope: "activeSheet" });
   });
 
-  test.each(["SELECT_SEARCH_NEXT_MATCH", "SELECT_SEARCH_PREVIOUS_MATCH"] as const)(
+  test.each(["selectNext", "selectPrevious"] as const)(
     "%s after changing selection will re-select the match",
     (cmd) => {
       setSelection(model, ["B3"]);
       expect(model.getters.getSelectedZones()).toEqual([toZone("B3")]);
-      model.dispatch(cmd);
+      cmd === "selectNext" ? store.selectNextMatch() : store.selectPreviousMatch();
       expect(model.getters.getSelectedZones()).toEqual([toZone("A1")]);
     }
   );
 
-  test("UPDATE_SEARCH after changing selection will re-select the match", () => {
+  test("Updating search after changing selection will re-select the match", () => {
     setSelection(model, ["B3"]);
     expect(model.getters.getSelectedZones()).toEqual([toZone("B3")]);
     updateSearch(model, "1");
     expect(model.getters.getSelectedZones()).toEqual([toZone("A1")]);
   });
 
-  test.each(["SELECT_SEARCH_NEXT_MATCH", "SELECT_SEARCH_PREVIOUS_MATCH"] as const)(
+  test.each(["selectNext", "selectPrevious"] as const)(
     "%s after scrolling will re-scroll to the match",
     (cmd) => {
       const viewportAfterSearch = model.getters.getActiveMainViewport();
       setViewportOffset(model, 1000, 1000);
       expect(model.getters.getActiveMainViewport()).not.toMatchObject(viewportAfterSearch);
-      model.dispatch(cmd);
+      cmd === "selectNext" ? store.selectNextMatch() : store.selectPreviousMatch();
       expect(model.getters.getActiveMainViewport()).toMatchObject(viewportAfterSearch);
     }
   );
 
-  test("UPDATE_SEARCH after scrolling will re-scroll to the match", () => {
+  test("Updating search after scrolling will re-scroll to the match", () => {
     const viewportAfterSearch = model.getters.getActiveMainViewport();
     setViewportOffset(model, 1000, 1000);
     expect(model.getters.getActiveMainViewport()).not.toMatchObject(viewportAfterSearch);
-    model.dispatch("UPDATE_SEARCH", { toSearch: "1", searchOptions: getSearchOptions() });
+    updateSearch(model, "1");
     expect(model.getters.getActiveMainViewport()).toMatchObject(viewportAfterSearch);
   });
 });
 
 describe("search options", () => {
   beforeEach(() => {
-    model = new Model();
     setCellContent(model, "A1", "hello=sum");
     setCellContent(model, "A2", "Hello");
     setCellContent(model, "A3", "=SUM(1,3)");
@@ -521,155 +529,144 @@ describe("search options", () => {
 
   test("Can search matching case", () => {
     updateSearch(model, "Hell", { matchCase: true });
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A2"), match("Sheet1", "A5")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A2"), match(sheetId1, "A5")]);
   });
 
   test("Can search matching entire cell", () => {
     updateSearch(model, "Hell", { exactMatch: true });
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A4"), match("Sheet1", "A5")]);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A4"), match(sheetId1, "A5")]);
   });
 
   test("Can search in formulas", () => {
     updateSearch(model, "Hell", { searchFormulas: true });
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match("Sheet1", "A1"),
-      match("Sheet1", "A2"),
-      match("Sheet1", "A4"),
-      match("Sheet1", "A5"),
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A4"),
+      match(sheetId1, "A5"),
     ]);
   });
 
   test("Can search in formulas(2)", () => {
     updateSearch(model, "4", { searchFormulas: false });
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A3")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A3")]);
     updateSearch(model, "4", { searchFormulas: true });
-    expect(getMatches(model)).toStrictEqual([]);
-    expect(getMatchIndex(model)).toBe(null);
+    expect(store.searchMatches).toStrictEqual([]);
+    expect(store.selectedMatchIndex).toBe(null);
   });
 
   test("Combine matching case / matching entire cell / search in formulas", () => {
     updateSearch(model, "hell");
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([
-      match("Sheet1", "A1"),
-      match("Sheet1", "A2"),
-      match("Sheet1", "A4"),
-      match("Sheet1", "A5"),
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([
+      match(sheetId1, "A1"),
+      match(sheetId1, "A2"),
+      match(sheetId1, "A4"),
+      match(sheetId1, "A5"),
     ]);
     //match case
     updateSearch(model, "hell", { matchCase: true });
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A1"), match("Sheet1", "A4")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "A4")]);
 
     //match case + exact match
     updateSearch(model, "hell", { matchCase: true, exactMatch: true });
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A4")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A4")]);
 
     //change input and remove match case + exact match and add look in formula
-    updateSearch(model, "hell", { matchCase: false, exactMatch: false, searchFormulas: true });
-    model.dispatch("UPDATE_SEARCH", { toSearch: "SUM", searchOptions: getSearchOptions() });
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A1"), match("Sheet1", "A3")]);
+    updateSearch(model, "SUM", { matchCase: false, exactMatch: false, searchFormulas: true });
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "A3")]);
 
     //add match case
-    updateSearch(model, "hell", { matchCase: true, searchFormulas: true });
-    model.dispatch("UPDATE_SEARCH", { toSearch: "SUM", searchOptions: getSearchOptions() });
-    expect(getMatchIndex(model)).toStrictEqual(0);
-    expect(getMatches(model)).toStrictEqual([match("Sheet1", "A3")]);
+    updateSearch(model, "SUM", { matchCase: true, searchFormulas: true });
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+    expect(store.searchMatches).toStrictEqual([match(sheetId1, "A3")]);
   });
 });
 
 describe("Replace", () => {
   test("Can replace a simple text value", () => {
-    model = new Model();
     setCellContent(model, "A1", "hello");
     updateSearch(model, "hello");
-    model.dispatch("REPLACE_SEARCH", { replaceWith: "kikou" });
-    expect(getMatches(model)).toHaveLength(0);
-    expect(getMatchIndex(model)).toStrictEqual(null);
+    replaceSearch("kikou");
+    expect(store.searchMatches).toHaveLength(0);
+    expect(store.selectedMatchIndex).toStrictEqual(null);
     expect(getCellText(model, "A1")).toBe("kikou");
   });
 
   test("Can replace a value in a formula", () => {
-    model = new Model();
     setCellContent(model, "A1", "=SUM(2,2)");
     updateSearch(model, "2", { searchFormulas: true, searchScope: "activeSheet" });
-    model.dispatch("REPLACE_SEARCH", { replaceWith: "4" });
-    expect(model.getters.getSearchMatches()).toHaveLength(0);
-    expect(model.getters.getCurrentSelectedMatchIndex()).toStrictEqual(null);
+    replaceSearch("4");
+    expect(store.searchMatches).toHaveLength(0);
+    expect(store.selectedMatchIndex).toStrictEqual(null);
     expect(getCellText(model, "A1")).toBe("=SUM(4,4)");
   });
 
   test("Replaced value is changed to canonical form in model", () => {
-    model = new Model();
     setCellContent(model, "A1", "=SUM(2,2)");
     updateLocale(model, { ...DEFAULT_LOCALE, decimalSeparator: ",", formulaArgSeparator: ";" });
     updateSearch(model, "2", { searchFormulas: true, searchScope: "activeSheet" });
-    model.dispatch("REPLACE_SEARCH", { replaceWith: "2,5" });
-    expect(getMatches(model)).toHaveLength(1);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    replaceSearch("2,5");
+    expect(store.searchMatches).toHaveLength(1);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     expect(getCell(model, "A1")?.content).toBe("=SUM(2.5,2.5)");
   });
 
   test("formulas wont be modified if not looking in formulas or not modifying formulas", () => {
-    model = new Model();
     setCellContent(model, "A1", "=SUM(2,2)");
     updateSearch(model, "4");
-    expect(getMatches(model)).toHaveLength(1);
-    model.dispatch("REPLACE_SEARCH", { replaceWith: "2" });
-    expect(getMatches(model)).toHaveLength(1);
-    expect(getMatchIndex(model)).toStrictEqual(0);
+    expect(store.searchMatches).toHaveLength(1);
+    replaceSearch("2");
+    expect(store.searchMatches).toHaveLength(1);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
     expect(getCellText(model, "A1")).toBe("=SUM(2,2)");
   });
 
   test("Replace all in activeSheet", () => {
-    model = new Model();
     const sheetId2 = "test";
     createSheet(model, { sheetId: sheetId2 });
     setCellContent(model, "A1", "hello");
     setCellContent(model, "A1", "hello", sheetId2);
     updateSearch(model, "hell", { searchScope: "activeSheet" });
-    model.dispatch("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
-    expect(getMatches(model)).toHaveLength(0);
-    expect(getMatchIndex(model)).toStrictEqual(null);
+    replaceAll("kikou");
+    expect(store.searchMatches).toHaveLength(0);
+    expect(store.selectedMatchIndex).toStrictEqual(null);
     expect(getCellText(model, "A1")).toBe("kikouo");
     expect(getCellText(model, "A1", sheetId2)).toBe("hello");
   });
 
   test("Replace all in allSheet", () => {
-    model = new Model();
     const sheetId2 = "test";
     createSheet(model, { sheetId: sheetId2 });
     setCellContent(model, "A1", "hello");
     setCellContent(model, "A1", "hello", sheetId2);
     updateSearch(model, "hell", { searchScope: "allSheets" });
-    model.dispatch("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
-    expect(getMatches(model)).toHaveLength(0);
-    expect(getMatchIndex(model)).toStrictEqual(null);
+    replaceAll("kikou");
+    expect(store.searchMatches).toHaveLength(0);
+    expect(store.selectedMatchIndex).toStrictEqual(null);
     expect(getCellText(model, "A1")).toBe("kikouo");
     expect(getCellText(model, "A1", sheetId2)).toBe("kikouo");
   });
 
   test("Replace all in specificRange", () => {
-    const sheetId1 = "sh1";
-    model = new Model({ sheets: [{ id: sheetId1 }] });
-    const sheetId2 = "test";
     createSheet(model, { sheetId: sheetId2 });
     setCellContent(model, "A1", "hello");
     setCellContent(model, "A1", "hello", sheetId2);
     setCellContent(model, "B1", "hello", sheetId2);
     updateSearch(model, "hell", {
       searchScope: "specificRange",
-      specificRange: toRangeData(sheetId2, "A1:A3"),
+      specificRange: model.getters.getRangeFromSheetXC(sheetId2, "A1:A3"),
     });
     updateSearch(model, "hell", { searchScope: "specificRange" });
-    model.dispatch("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
-    expect(getMatches(model)).toHaveLength(0);
-    expect(getMatchIndex(model)).toStrictEqual(null);
+    replaceAll("kikou");
+    expect(store.searchMatches).toHaveLength(0);
+    expect(store.selectedMatchIndex).toStrictEqual(null);
     expect(getCellText(model, "A1", sheetId1)).toBe("hello");
     expect(getCellText(model, "A1", sheetId2)).toBe("kikouo");
     expect(getCellText(model, "B1", sheetId2)).toBe("hello");
@@ -678,43 +675,41 @@ describe("Replace", () => {
   test("replace all won't update the active cell", () => {
     updateSearch(model, "hell");
     expect(getActivePosition(model)).toBe("A1");
-    model.dispatch("REPLACE_ALL_SEARCH", { replaceWith: "kikou" });
-    expect(model.getters.getSearchMatches()).toHaveLength(0);
-    expect(model.getters.getCurrentSelectedMatchIndex()).toStrictEqual(null);
+    replaceAll("kikou");
+    expect(store.searchMatches).toHaveLength(0);
+    expect(store.selectedMatchIndex).toStrictEqual(null);
     expect(getActivePosition(model)).toBe("A1");
   });
 });
 
 describe("number of match counts", () => {
   beforeEach(() => {
-    const sheet1 = "s1";
-    model = new Model({ sheets: [{ id: sheet1 }] });
     setCellContent(model, "A1", "hello");
     setCellContent(model, "A2", "=SUM(2,2)");
     setCellContent(model, "A3", "hell");
-    const sheet2 = "s2";
-    createSheet(model, { sheetId: sheet2 });
-    setCellContent(model, "A1", "hello", sheet2);
-    setCellContent(model, "A2", "=SUM(2,2)", sheet2);
-    setCellContent(model, "A3", "hell", sheet2);
+
+    createSheet(model, { sheetId: sheetId2 });
+    setCellContent(model, "A1", "hello", sheetId2);
+    setCellContent(model, "A2", "=SUM(2,2)", sheetId2);
+    setCellContent(model, "A3", "hell", sheetId2);
   });
 
   test.each(["allSheets", "activeSheet"] as const)(
     "number of match counts return number of search in allSheet, currentSheet for %s search scope",
     (scope) => {
       updateSearch(model, "hell", { searchScope: scope });
-      expect(model.getters.getActiveSheetMatchesCount()).toBe(2);
-      expect(model.getters.getAllSheetMatchesCount()).toBe(4);
+      expect(store.activeSheetMatchesCount).toBe(2);
+      expect(store.allSheetMatchesCount).toBe(4);
     }
   );
 
   test("number of match counts return number of search for specificScope search scope", () => {
     updateSearch(model, "hell", {
       searchScope: "specificRange",
-      specificRange: toRangeData("s1", "A1:B2"),
+      specificRange: model.getters.getRangeFromSheetXC("s1", "A1:B2"),
     });
-    expect(model.getters.getActiveSheetMatchesCount()).toBe(2);
-    expect(model.getters.getAllSheetMatchesCount()).toBe(4);
-    expect(model.getters.getSpecificRangeMatchesCount()).toBe(1);
+    expect(store.activeSheetMatchesCount).toBe(2);
+    expect(store.allSheetMatchesCount).toBe(4);
+    expect(store.specificRangeMatchesCount).toBe(1);
   });
 });

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -1558,6 +1558,19 @@ describe("Menu Item actions", () => {
     });
   });
 
+  test("View -> show formulas", async () => {
+    const path_gridlines = ["view", "view_formulas"];
+    expect(model.getters.shouldShowFormulas()).toBe(false);
+
+    expect(getName(path_gridlines, env)).toBe("Show formulas");
+    doAction(path_gridlines, env);
+    expect(model.getters.shouldShowFormulas()).toBe(true);
+
+    expect(getName(path_gridlines, env)).toBe("Hide formulas");
+    doAction(path_gridlines, env);
+    expect(model.getters.shouldShowFormulas()).toBe(false);
+  });
+
   describe("View -> group headers", () => {
     const groupColsPath = ["view", "group_headers", "group_columns"];
     const groupRowsPath = ["view", "group_headers", "group_rows"];

--- a/tests/renderer_plugin.test.ts
+++ b/tests/renderer_plugin.test.ts
@@ -36,7 +36,7 @@ import {
   setZoneBorders,
 } from "./test_helpers/commands_helpers";
 import { getCell } from "./test_helpers/getters_helpers";
-import { createEqualCF, getPlugin, target, toRangesData } from "./test_helpers/helpers";
+import { createEqualCF, drawGrid, getPlugin, target, toRangesData } from "./test_helpers/helpers";
 import { watchClipboardOutline } from "./test_helpers/renderer_helpers";
 
 MockCanvasRenderingContext2D.prototype.measureText = function (text: string) {
@@ -118,7 +118,7 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(instructions).toMatchSnapshot();
   });
 
@@ -173,7 +173,7 @@ describe("renderer", () => {
 
     test("Color of headers containing the selection", () => {
       setSelection(model, ["A1"]);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const fillColHeaderInstr = getFirstColHeaderFillColor();
       expect(fillColHeaderInstr).toEqual(BACKGROUND_HEADER_SELECTED_COLOR);
       const fillRowHeaderInstr = getFirstRowHeaderFillColor();
@@ -182,7 +182,7 @@ describe("renderer", () => {
 
     test("Color of active headers", () => {
       setSelection(model, ["A1:B2"]);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const fillColHeaderInstr = getFirstColHeaderFillColor();
       expect(fillColHeaderInstr).toEqual(BACKGROUND_HEADER_ACTIVE_COLOR);
       const fillRowHeaderInstr = getFirstRowHeaderFillColor();
@@ -192,7 +192,7 @@ describe("renderer", () => {
     test("Color of headers that contains a filter", () => {
       createFilter(model, "A1:B2");
       setSelection(model, ["B2"]); // by default the cell A1 was selected
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const fillColHeaderInstr = getFirstColHeaderFillColor();
       expect(fillColHeaderInstr).toEqual(BACKGROUND_HEADER_FILTER_COLOR);
       const fillRowHeaderInstr = getFirstRowHeaderFillColor();
@@ -202,7 +202,7 @@ describe("renderer", () => {
     test("Color of headers that contain a filter + are selected", () => {
       createFilter(model, "A1:B2");
       setSelection(model, ["A1"]);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const fillColHeaderInstr = getFirstColHeaderFillColor();
       expect(fillColHeaderInstr).toEqual(BACKGROUND_HEADER_SELECTED_FILTER_COLOR);
       const fillRowHeaderInstr = getFirstRowHeaderFillColor();
@@ -212,7 +212,7 @@ describe("renderer", () => {
     test("Headers that contain a filter + are selected", () => {
       createFilter(model, "A1:B2");
       setSelection(model, ["A1"]);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const fillColHeaderInstr = getFirstColHeaderFillColor();
       expect(fillColHeaderInstr).toEqual(BACKGROUND_HEADER_SELECTED_FILTER_COLOR);
       const fillRowHeaderInstr = getFirstRowHeaderFillColor();
@@ -222,7 +222,7 @@ describe("renderer", () => {
     test("Headers that contain a filter + are active", () => {
       createFilter(model, "A1:B2");
       setSelection(model, ["A1:B2"]);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const fillColHeaderInstr = getFirstColHeaderFillColor();
       expect(fillColHeaderInstr).toEqual(FILTERS_COLOR);
       const fillRowHeaderInstr = getFirstRowHeaderFillColor();
@@ -245,12 +245,12 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["right", "right", "center"]); // center for headers
 
     textAligns = [];
     setCellContent(model, "A1", "asdf");
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["left", "left", "center"]); // center for headers
   });
 
@@ -268,7 +268,7 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["right", "center"]); // center for headers
   });
 
@@ -291,7 +291,7 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["right", "center"]); // center for headers
   });
 
@@ -333,13 +333,13 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["left", "left", "left", "left", "center"]); // A1-C1-A2-C2 and center for headers
 
     textAligns = [];
     setCellContent(model, "A1", "1");
     setCellContent(model, "C1", "1");
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["right", "right", "right", "right", "center"]); // A1-C1-A2-C2 and center for headers
   });
 
@@ -379,7 +379,7 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDF", h: 23, w: 96, x: 0, y: 0 }]);
 
     fillStyle = [];
@@ -388,7 +388,7 @@ describe("renderer", () => {
       target: [toZone("A1")],
       style: { fillColor: "#DC6CDE" },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDE", h: 23, w: 96, x: 0, y: 0 }]);
   });
 
@@ -430,7 +430,7 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDF", h: 3 * 23, w: 96, x: 0, y: 0 }]);
 
     fillStyle = [];
@@ -439,7 +439,7 @@ describe("renderer", () => {
       target: [toZone("A1")],
       style: { fillColor: "#DC6CDE" },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDE", h: 3 * 23, w: 96, x: 0, y: 0 }]);
   });
 
@@ -468,12 +468,12 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([]);
 
     fillStyle = [];
     setCellContent(model, "A1", "1");
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDF", h: 23, w: 96, x: 0, y: 0 }]);
   });
 
@@ -502,12 +502,12 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([]);
 
     fillStyle = [];
     setCellContent(model, "A1", "1");
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDF", h: 23 * 3, w: 96, x: 0, y: 0 }]);
   });
 
@@ -526,14 +526,14 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     expect(textAligns).toEqual(["right", "right", "center"]); // center for headers
 
     setCellContent(model, "A1", "asdf");
 
     textAligns = [];
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["left", "left", "center"]); // center for headers
   });
 
@@ -551,12 +551,12 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["right", "right", "center"]); // center for headers
 
     textAligns = [];
     setCellContent(model, "A1", "true");
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["center", "center", "center"]); // center for headers
   });
 
@@ -604,13 +604,13 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["left", "left", "left", "left", "center"]); // A1-C1-A2:B2-C2:D2 and center for headers
 
     textAligns = [];
     setCellContent(model, "A1", "1");
     setCellContent(model, "C1", "1");
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["right", "left", "right", "right", "center"]); // A1-C1-A2:B2-C2:D2 and center for headers. C1 is stil lin overflow
   });
 
@@ -629,14 +629,14 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     expect(textAligns).toEqual(["right", "right", "center"]); // center for headers
 
     setCellContent(model, "A1", "false");
 
     textAligns = [];
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(textAligns).toEqual(["center", "center", "center"]); // center for headers
   });
 
@@ -654,7 +654,7 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     // 1 center for headers, 1 for cell content
     expect(textAligns).toEqual(["center", "center"]);
@@ -674,7 +674,7 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     // 1 center for headers, 1 for cell content
     expect(textAligns).toEqual(["right", "center"]);
@@ -698,7 +698,7 @@ describe("renderer", () => {
     const getCellTextMock = jest.fn(() => "=SUM(1,2)");
     model.getters.getCellText = getCellTextMock;
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     // 1 center for headers, 1 for cell content
     expect(textAligns).toEqual(["left", "center"]);
@@ -730,7 +730,7 @@ describe("renderer", () => {
     const getCellTextMock = jest.fn(() => "=SUM(1,2)");
     model.getters.getCellText = getCellTextMock;
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     // 1 center for headers, 1 for cell content
     expect(textAligns).toEqual(["left", "center"]);
@@ -757,7 +757,7 @@ describe("renderer", () => {
       },
     });
 
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([]);
     fillStyle = [];
     const sheetId = model.getters.getActiveSheetId();
@@ -767,7 +767,7 @@ describe("renderer", () => {
       sheetId,
     });
     expect(result).toBeSuccessfullyDispatched();
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDF", h: 23, w: 96, x: 0, y: 0 }]);
   });
 
@@ -789,7 +789,7 @@ describe("renderer", () => {
       });
 
       let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
 
       box = getBoxFromText(model, overflowingContent);
       // no clip
@@ -798,14 +798,14 @@ describe("renderer", () => {
 
       // no clipping at the left
       setCellContent(model, "A1", "Content at the left");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       box = getBoxFromText(model, overflowingContent);
       expect(box.clipRect).toBeUndefined();
       expect(box.isOverflow).toBeTruthy();
 
       // clipping at the right
       setCellContent(model, "C1", "Content at the right");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       box = getBoxFromText(model, overflowingContent);
       expect(box.clipRect).toEqual({
         x: DEFAULT_CELL_WIDTH,
@@ -835,7 +835,7 @@ describe("renderer", () => {
       });
 
       let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
 
       box = getBoxFromText(model, overflowingNumber);
       // no clip
@@ -844,14 +844,14 @@ describe("renderer", () => {
 
       // no clipping at the left
       setCellContent(model, "A1", "Content at the left");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       box = getBoxFromText(model, overflowingNumber);
       expect(box.clipRect).toBeUndefined();
       expect(box.isOverflow).toBeTruthy();
 
       // clipping at the right
       setCellContent(model, "C1", "Content at the right");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       box = getBoxFromText(model, overflowingNumber);
       expect(box.clipRect).toEqual({
         x: DEFAULT_CELL_WIDTH,
@@ -879,7 +879,7 @@ describe("renderer", () => {
     });
 
     let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     box = getBoxFromText(model, overflowingText);
     // no clip
@@ -888,14 +888,14 @@ describe("renderer", () => {
 
     // no clipping at the right
     setCellContent(model, "C1", "Content at the left");
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     box = getBoxFromText(model, overflowingText);
     expect(box.clipRect).toBeUndefined();
     expect(box.isOverflow).toBeTruthy();
 
     // clipping at the left
     setCellContent(model, "A1", "Content at the right");
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     box = getBoxFromText(model, overflowingText);
     expect(box.clipRect).toEqual({
       x: DEFAULT_CELL_WIDTH,
@@ -922,7 +922,7 @@ describe("renderer", () => {
       styles: { 1: { align: "center" } },
     });
     const ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     const centeredBox = getBoxFromText(model, overflowingContent);
     expect(centeredBox.clipRect).toEqual({
@@ -950,7 +950,7 @@ describe("renderer", () => {
       styles: { 2: { align: "center" } },
     });
     const ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     const centeredBox = getBoxFromText(model, overflowingContent);
     const cell = getCell(model, "C1")!;
@@ -985,7 +985,7 @@ describe("renderer", () => {
       });
 
       let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
 
       box = getBoxFromText(model, overflowingText);
       expect(box.clipRect).toEqual({
@@ -1018,7 +1018,7 @@ describe("renderer", () => {
     });
 
     const ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     const box = getBoxFromText(model, overflowingText);
     expect(box.clipRect).toEqual({
@@ -1048,7 +1048,7 @@ describe("renderer", () => {
       });
 
       let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
 
       box = getBoxFromText(model, overflowingText);
       expect(box.clipRect).toEqual({
@@ -1079,7 +1079,7 @@ describe("renderer", () => {
       });
 
       let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
 
       box = getBoxFromText(model, overflowingText);
       expect(box.clipRect).toEqual({
@@ -1109,13 +1109,13 @@ describe("renderer", () => {
     });
 
     let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     box = getBoxFromText(model, overflowingText);
     expect(box.clipRect).toBeUndefined();
 
     resizeRows(model, [0], Math.floor(fontSizeInPixels(fontSize) / 2));
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     box = getBoxFromText(model, overflowingText);
     expect(box.clipRect).toEqual({
       x: 0,
@@ -1136,7 +1136,7 @@ describe("renderer", () => {
     resizeColumns(model, ["A"], 10);
 
     let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
 
     expect(getBoxFromText(model, overflowingText).clipRect).toEqual({
       x: 0,
@@ -1173,7 +1173,7 @@ describe("renderer", () => {
     });
 
     let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     box = getBoxFromText(model, cellContent);
     const maxIconBoxWidth = box.image!.size + MIN_CF_ICON_MARGIN;
     expect(box.image!.clipIcon).toEqual({
@@ -1190,7 +1190,7 @@ describe("renderer", () => {
     });
 
     resizeColumns(model, ["A"], maxIconBoxWidth - 3);
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     box = getBoxFromText(model, cellContent);
     expect(box.image!.clipIcon).toEqual({
       x: 0,
@@ -1216,7 +1216,7 @@ describe("renderer", () => {
     addDataValidation(model, "B1", "id", { type: "isBoolean", values: [] });
 
     const ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     box = getBoxFromText(model, cellContent);
     const expectedClipRect = { x: 0, y: 0, width: 10, height: DEFAULT_CELL_HEIGHT };
     expect(box.clipRect).toEqual(expectedClipRect);
@@ -1226,7 +1226,7 @@ describe("renderer", () => {
       values: ["a"],
       displayStyle: "arrow",
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     box = getBoxFromText(model, cellContent);
     expect(box.clipRect).toEqual(expectedClipRect);
   });
@@ -1265,7 +1265,7 @@ describe("renderer", () => {
       }
 
       let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const box = getBoxFromText(model, cellContent);
       expect(box.clipRect).toEqual(
         expectedClipRectZone ? model.getters.getVisibleRect(expectedClipRectZone) : undefined
@@ -1290,7 +1290,7 @@ describe("renderer", () => {
       }
 
       let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const box = getBoxFromText(model, cellContent);
       const cell = getCell(model, "B2")!;
       const textWidth = model.getters.getTextWidth(cell.content, cell.style || {});
@@ -1334,7 +1334,7 @@ describe("renderer", () => {
       setZoneBorders(model, { position: "left" }, ["E1"]);
 
       let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const box = getBoxFromText(model, cellContent);
       expect(box.clipRect).toEqual(
         expectedClipRectZone ? model.getters.getVisibleRect(expectedClipRectZone) : undefined
@@ -1350,7 +1350,7 @@ describe("renderer", () => {
     let ctx = new MockGridRenderingContext(model, 1000, 1000, {});
     let text = "a".repeat(10 - MIN_CELL_TEXT_MARGIN);
     setCellContent(model, "A1", text);
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     box = getBoxFromText(model, text);
     expect(box.clipRect).toBeUndefined();
 
@@ -1358,7 +1358,7 @@ describe("renderer", () => {
     ctx = new MockGridRenderingContext(model, 1000, 1000, {});
     text = "a".repeat(10);
     setCellContent(model, "A1", text);
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     box = getBoxFromText(model, text);
     expect(box.clipRect).toEqual({ x: 0, y: 0, width: 10, height: DEFAULT_CELL_HEIGHT });
   });
@@ -1369,12 +1369,12 @@ describe("renderer", () => {
       const model = new Model();
       copy(model, ...targetXc.split(","));
       const { ctx, isDotOutlined, reset } = watchClipboardOutline(model);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const copiedTarget = target(targetXc);
       expect(isDotOutlined(copiedTarget)).toBeTruthy();
       paste(model, "A10");
       reset();
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(isDotOutlined(copiedTarget)).toBeFalsy();
     }
   );
@@ -1385,13 +1385,13 @@ describe("renderer", () => {
       const model = new Model();
       copy(model, ...targetXc.split(","));
       const { ctx, isDotOutlined, reset } = watchClipboardOutline(model);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const copiedTarget = target(targetXc);
       const expectedOutlinedZone = copiedTarget.slice(-1);
       expect(isDotOutlined(expectedOutlinedZone)).toBeTruthy();
       paste(model, "A10");
       reset();
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(isDotOutlined(expectedOutlinedZone)).toBeFalsy();
     }
   );
@@ -1404,12 +1404,12 @@ describe("renderer", () => {
     const model = new Model();
     copy(model, "A1:A2");
     const { ctx, isDotOutlined, reset } = watchClipboardOutline(model);
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     const copiedTarget = target("A1:A2");
     expect(isDotOutlined(copiedTarget)).toBeTruthy();
     coreOperation(model);
     reset();
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(isDotOutlined(copiedTarget)).toBeFalsy();
   });
 
@@ -1456,7 +1456,7 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     const boxA1 = getBoxFromText(model, "#N/A"); //NotAvailableError => Shouldn't display
     expect(boxA1.isError).toBeFalsy();
     const boxB1 = getBoxFromText(model, "#CYCLE"); //CycleError => Should display
@@ -1495,14 +1495,14 @@ describe("renderer", () => {
 
     // Default Model displaying grid lines
     strokeColors = [];
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(strokeColors).toContain(CELL_BORDER_COLOR);
     expect(strokeColors).toContain(SELECTION_BORDER_COLOR);
 
     // dashboard mode
     model.updateMode("dashboard");
     strokeColors = [];
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(strokeColors).toEqual([]);
   });
 
@@ -1524,14 +1524,14 @@ describe("renderer", () => {
 
     // Default Model displaying grid lines
     strokeColors = [];
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(strokeColors).toContain(CELL_BORDER_COLOR);
     expect(strokeColors).toContain(SELECTION_BORDER_COLOR);
 
     // model without grid lines
     model.dispatch("SET_GRID_LINES_VISIBILITY", { sheetId: "Sheet1", areGridLinesVisible: false });
     strokeColors = [];
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(strokeColors).toEqual([
       SELECTION_BORDER_COLOR, // selection drawGrid
       SELECTION_BORDER_COLOR, // selection drawGrid
@@ -1566,7 +1566,7 @@ describe("renderer", () => {
       target: target("A1"),
       style: { verticalAlign: "top" },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(verticalStartPoints[0]).toEqual(5);
 
     // vertical middle point
@@ -1576,7 +1576,7 @@ describe("renderer", () => {
       target: target("A1"),
       style: { verticalAlign: "middle" },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(verticalStartPoints[0]).toEqual(18);
 
     // vertical bottom point
@@ -1586,7 +1586,7 @@ describe("renderer", () => {
       target: target("A1"),
       style: { verticalAlign: "bottom" },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(verticalStartPoints[0]).toEqual(30);
   });
 
@@ -1629,7 +1629,7 @@ describe("renderer", () => {
       target: target("A1"),
       style: { verticalAlign: "top" },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(verticalStartPoints[0]).toEqual(5);
 
     // with verticalAlign middle
@@ -1639,7 +1639,7 @@ describe("renderer", () => {
       target: target("A1"),
       style: { verticalAlign: "middle" },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(verticalStartPoints[0]).toEqual(5);
 
     // with verticalAlign bottom
@@ -1649,7 +1649,7 @@ describe("renderer", () => {
       target: target("A1"),
       style: { verticalAlign: "bottom" },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(verticalStartPoints[0]).toEqual(5);
   });
 
@@ -1687,7 +1687,7 @@ describe("renderer", () => {
 
     test("Non-overflowing cell have no overflowing background", () => {
       setCellContent(model, "A1", "Short text");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(getCellOverflowingBackgroundDims()).toBeUndefined();
     });
 
@@ -1695,7 +1695,7 @@ describe("renderer", () => {
       const overflowingText = "Text longer than a column";
       setCellContent(model, "A1", overflowingText);
       resizeColumns(model, ["A"], 10);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const box = getBoxFromText(model, overflowingText);
       expect(getCellOverflowingBackgroundDims()).toMatchObject({
         x: box.x + ctx.thinLineWidth / 2,
@@ -1711,7 +1711,7 @@ describe("renderer", () => {
 
       setCellContent(model, "A1", longLine + NEWLINE + longerLine);
       resizeColumns(model, ["A"], 10);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const box = getBoxFromText(model, longLine + " " + longerLine);
       expect(getCellOverflowingBackgroundDims()).toMatchObject({
         x: box.x + ctx.thinLineWidth / 2,
@@ -1727,7 +1727,7 @@ describe("renderer", () => {
       setCellContent(model, "A1", overflowingText);
       setStyle(model, "A1", { fontSize });
       resizeRows(model, [0], Math.floor(fontSizeInPixels(fontSize) / 2));
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const box = getBoxFromText(model, overflowingText);
       expect(getCellOverflowingBackgroundDims()).toMatchObject({
         x: box.x + ctx.thinLineWidth / 2,
@@ -1764,7 +1764,7 @@ describe("renderer", () => {
       // Split length = 14 - 2*MIN_CELL_TEXT_MARGIN = 6 letters (1 letter = 1px in the tests)
       const splittedText = ["ThisIs", "AVeryV", "eryLon", "gText"];
 
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(renderedTexts.slice(0, 4)).toEqual(splittedText);
     });
 
@@ -1774,13 +1774,13 @@ describe("renderer", () => {
       setStyle(model, "A1", { wrapping: "wrap" });
       resizeColumns(model, ["A"], 16);
 
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(renderedTexts.slice(0, 5)).toEqual(["W Word2", "W3", "WordThat", "IsTooLon", "g"]);
     });
 
     test("Texts with newlines are displayed over multiple lines", () => {
       setCellContent(model, "A1", "Line1\nLine2\rLine3\r\nLine4");
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       expect(renderedTexts.slice(0, 4)).toEqual(["Line1", "Line2", "Line3", "Line4"]);
     });
 
@@ -1790,7 +1790,7 @@ describe("renderer", () => {
 
       setCellContent(model, "A1", longLine + NEWLINE + longerLine);
       resizeColumns(model, ["A"], 10);
-      model.drawGrid(ctx);
+      drawGrid(model, ctx);
       const box = getBoxFromText(model, longLine + " " + longerLine);
       expect(box.isOverflow).toBeTruthy();
       expect(box.content?.width).toEqual(longerLine.length + MIN_CELL_TEXT_MARGIN);
@@ -1836,7 +1836,7 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(renderedBorders).toEqual({
       [colors.left]: {
         start: [0, 0],
@@ -1894,7 +1894,7 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(borderRenderingContext).toEqual([[1, []]]);
   });
 
@@ -1936,7 +1936,7 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(borderRenderingContext).toEqual([[2, []]]);
   });
 
@@ -1977,7 +1977,7 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(borderRenderingContext).toEqual([[3, []]]);
   });
 
@@ -2018,7 +2018,7 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(borderRenderingContext).toEqual([[1, [[1, 3]]]]);
   });
 
@@ -2059,7 +2059,7 @@ describe("renderer", () => {
         }
       },
     });
-    model.drawGrid(ctx);
+    drawGrid(model, ctx);
     expect(borderRenderingContext).toEqual([[1, [[1, 1]]]]);
   });
 });

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -1,7 +1,6 @@
 import { Component, xml } from "@odoo/owl";
 import { Spreadsheet } from "../../src";
-import { sidePanelRegistry } from "../../src/registries/index";
-import { SidePanelContent } from "../../src/registries/side_panel_registry";
+import { SidePanelContent, sidePanelRegistry } from "../../src/registries/side_panel_registry";
 import { createSheet } from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
 import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -28,6 +28,7 @@ import { ComposerSelection } from "../../src/plugins/ui_stateful";
 import { topbarMenuRegistry } from "../../src/registries";
 import { MenuItemRegistry } from "../../src/registries/menu_items_registry";
 import { Registry } from "../../src/registries/registry";
+import { DependencyContainer } from "../../src/store_engine";
 import { _t } from "../../src/translation";
 import {
   CellPosition,
@@ -41,7 +42,9 @@ import {
   DEFAULT_LOCALES,
   EvaluatedCell,
   Format,
+  GridRenderingContext,
   Matrix,
+  RENDERING_LAYERS,
   RangeData,
   SpreadsheetChildEnv,
   Style,
@@ -125,6 +128,7 @@ export function makeTestFixture() {
 }
 
 export function makeTestEnv(mockEnv: Partial<SpreadsheetChildEnv> = {}): SpreadsheetChildEnv {
+  const container = new DependencyContainer();
   return {
     model: mockEnv.model || new Model(),
     isDashboard: mockEnv.isDashboard || (() => false),
@@ -144,6 +148,9 @@ export function makeTestEnv(mockEnv: Partial<SpreadsheetChildEnv> = {}): Spreads
         return [] as Currency[];
       }),
     loadLocales: mockEnv.loadLocales || (async () => DEFAULT_LOCALES),
+    getStore: container.get.bind(container),
+    // @ts-ignore
+    __spreadsheet_stores__: container,
   };
 }
 
@@ -786,4 +793,10 @@ export function getDataValidationRules(model: Model, sheetId = model.getters.get
     ...rule,
     ranges: rule.ranges.map((range) => model.getters.getRangeString(range, sheetId)),
   }));
+}
+
+export function drawGrid(model: Model, ctx: GridRenderingContext) {
+  for (const layer of RENDERING_LAYERS) {
+    model.drawGrid(ctx, layer);
+  }
 }

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -829,25 +829,6 @@ describe("TopBar - CF", () => {
     ).toBeFalsy();
   });
 });
-describe("Topbar - View", () => {
-  test("Setting show formula from topbar should retain its state even it's changed via f&r side panel upon closing", async () => {
-    const { model, fixture, env } = await mountSpreadsheet();
-    await click(fixture, ".o-topbar-menu[data-id='view']");
-    await click(fixture, ".o-menu-item[data-name='view_formulas']");
-    expect(model.getters.shouldShowFormulas()).toBe(true);
-    env.openSidePanel("FindAndReplace");
-    await nextTick();
-    expect(model.getters.shouldShowFormulas()).toBe(true);
-    await nextTick();
-    await click(
-      fixture,
-      ".o-sidePanel .o-sidePanelBody .o-find-and-replace .o-section:nth-child(1) .o-checkbox:nth-child(3) input"
-    );
-    expect(model.getters.shouldShowFormulas()).toBe(false);
-    await click(fixture, ".o-sidePanel .o-sidePanelHeader .o-sidePanelClose");
-    expect(model.getters.shouldShowFormulas()).toBe(true);
-  });
-});
 
 describe("Topbar - menu item resizing with viewport", () => {
   test("color picker of fill color in top bar is resized with screen size change", async () => {


### PR DESCRIPTION
## Description:

Transform (most of) the find & replace feature into a store.

Pros:
+ very simple/dumb component
+ no need to bother cleaning the search state. We just throw the local store away
+ easy to manage change in formula visibility since we can hangle commands (no need to useEffect)
+ no need for commands just so sync the state between the component/plugin

Cons:
- one more file (find_and_replace_store.ts) to manage, so it's slighly harder to find where is the business code. 
- probably something we wanted to avoid anyway, but we cannot simply test `expect(command).toHaveBeenDispatched()` as there is no command. And neither can we test the plugin state with getter.
- lost git blame history while displacing the component's code in the store


Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo