### PR TITLE
[FIX] sheet_interactive: rename sheet in readonly mode

### DIFF
--- a/src/helpers/ui/sheet_interactive.ts
+++ b/src/helpers/ui/sheet_interactive.ts
@@ -9,7 +9,7 @@ export function interactiveRenameSheet(env: SpreadsheetChildEnv, sheetId: UID, e
     if (name === null || name === placeholder) {
       return;
     }
-    if (name === "") {
+    if (name.trim() === "") {
       interactiveRenameSheet(env, sheetId, _lt("The sheet name cannot be empty."));
     }
     const result = env.model.dispatch("RENAME_SHEET", { sheetId, name });

--- a/tests/helpers/ui.test.ts
+++ b/tests/helpers/ui.test.ts
@@ -61,6 +61,7 @@ function getCellsObject(model: Model, sheetId: UID) {
 describe("Interactive rename sheet", () => {
   test.each([
     ["", "The sheet name cannot be empty."],
+    ["   ", "The sheet name cannot be empty."],
     [
       "hééélo///",
       "Some used characters are not allowed in a sheet name (Forbidden characters are ' * ? / \\ [ ]).",


### PR DESCRIPTION
## Description:

This PR addresses two distinct issues identified in the current codebase.

**Commit 1:**
- Resolves an issue where renaming a sheet with whitespace failed to trigger the sheet rename dialog.
- Implements whitespace trimming for sheet names to ensure the dialog opens as intended.

**Commit 2:**
- The commit rectifies an issue where users in readonly mode were able to invoke the sheet renaming dialog by double clicking on its name. However, they were unable to complete the renaming process in readonly mode.
- Introduces an early return, preventing the invocation of the renaming dialog altogether when the application is in readonly mode.


Task: : [3621086](https://www.odoo.com/web#id=3621086&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo