### PR TITLE
[FIX] FindAndReplacePanel: horizontal scrollbar in sidepanel

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -24,6 +24,12 @@ css/* scss */ `
         padding: 4px 0 4px 4px;
       }
     }
+
+    .o-matches-count div {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
   }
 `;
 


### PR DESCRIPTION
## Description:

This PR addresses the issue where the sheet name being too long caused the horizontal scrollbar to appear in the side panel of the Find and Replace. The fix involves adding 'overflow-wrap: break-word;' to resolve this problem.

Task: : [3621086](https://www.odoo.com/web#id=3621086&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo