### PR TITLE
[FIX] Find&Replace: always recompute search on sheet change

### DIFF
--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -100,12 +100,8 @@ export class FindAndReplacePlugin extends UIPlugin {
       case "ADD_COLUMNS_ROWS":
       case "EVALUATE_CELLS":
       case "UPDATE_CELL":
-        this.isSearchDirty = true;
-        break;
       case "ACTIVATE_SHEET":
-        if (this.searchOptions.searchScope === "activeSheet") {
-          this.isSearchDirty = true;
-        }
+        this.isSearchDirty = true;
         break;
     }
   }

--- a/tests/find_and_replace/find_and_replace_plugin.test.ts
+++ b/tests/find_and_replace/find_and_replace_plugin.test.ts
@@ -312,6 +312,23 @@ describe("basic search", () => {
     expect(getMatches(model)).toHaveLength(2);
     expect(getMatchIndex(model)).toStrictEqual(0);
   });
+
+  test("Switching sheet properly recomputes search results and shows them in the viewport", () => {
+    setCellContent(model, "A2", "Hello");
+    setCellContent(model, "A3", "Hello");
+    createSheet(model, { sheetId: "s2" });
+    setCellContent(model, "Z100", "hello", "s2");
+    updateSearch(model, "hello", { searchScope: "allSheets" });
+    expect(model.getters.getActiveSheetMatchesCount()).toBe(2);
+    expect(model.getters.getAllSheetMatchesCount()).toBe(3);
+    expect(model.getters.getSpecificRangeMatchesCount()).toBe(0);
+    expect(model.getters.getActiveMainViewport()).toMatchObject(toZone("A1:K44"));
+    activateSheet(model, "s2");
+    expect(model.getters.getActiveSheetMatchesCount()).toBe(1);
+    expect(model.getters.getAllSheetMatchesCount()).toBe(3);
+    expect(model.getters.getSpecificRangeMatchesCount()).toBe(0);
+    expect(model.getters.getActiveMainViewport()).toMatchObject(toZone("Q58:Z100"));
+  });
 });
 
 test("simple search with array formula", () => {
@@ -696,7 +713,6 @@ describe("number of match counts", () => {
     createSheet(model, { sheetId: sheet2 });
     setCellContent(model, "A1", "hello", sheet2);
     setCellContent(model, "A2", "=SUM(2,2)", sheet2);
-    setCellContent(model, "A3", "hell", sheet2);
   });
 
   test.each(["allSheets", "activeSheet"] as const)(
@@ -704,7 +720,7 @@ describe("number of match counts", () => {
     (scope) => {
       updateSearch(model, "hell", { searchScope: scope });
       expect(model.getters.getActiveSheetMatchesCount()).toBe(2);
-      expect(model.getters.getAllSheetMatchesCount()).toBe(4);
+      expect(model.getters.getAllSheetMatchesCount()).toBe(3);
     }
   );
 
@@ -714,7 +730,7 @@ describe("number of match counts", () => {
       specificRange: toRangeData("s1", "A1:B2"),
     });
     expect(model.getters.getActiveSheetMatchesCount()).toBe(2);
-    expect(model.getters.getAllSheetMatchesCount()).toBe(4);
+    expect(model.getters.getAllSheetMatchesCount()).toBe(3);
     expect(model.getters.getSpecificRangeMatchesCount()).toBe(1);
   });
 });


### PR DESCRIPTION
The search results were only computed on sheet change when we were in the 'active sheet' mode.

Task: 3635912

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo