### PR TITLE
[FIX] Autofill: Automatic fill based on spreaded formula cells

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -137,6 +137,7 @@ import { Evaluator } from "./evaluator";
 export class EvaluationPlugin extends UIPlugin {
   static getters = [
     "evaluateFormula",
+    "getCorrespondingFormulaCell",
     "getRangeFormattedValues",
     "getRangeValues",
     "getRangeFormats",
@@ -294,7 +295,7 @@ export class EvaluationPlugin extends UIPlugin {
    * It could be the formula present in the cell itself or the
    * formula of the array formula that spreads to the cell
    */
-  private getCorrespondingFormulaCell(position: CellPosition): FormulaCell | undefined {
+  getCorrespondingFormulaCell(position: CellPosition): FormulaCell | undefined {
     const cell = this.getters.getCell(position);
 
     if (cell && cell.content) {

--- a/src/plugins/ui_feature/autofill.ts
+++ b/src/plugins/ui_feature/autofill.ts
@@ -5,7 +5,6 @@ import {
   AutofillModifier,
   AutofillResult,
   Cell,
-  CellValueType,
   Command,
   CommandResult,
   DIRECTION,
@@ -281,7 +280,7 @@ export class AutofillPlugin extends UIPlugin {
     if (col > 0) {
       let leftPosition = { sheetId, col: col - 1, row };
       while (
-        this.getters.getEvaluatedCell(leftPosition).type !== CellValueType.empty ||
+        this.getters.getCorrespondingFormulaCell(leftPosition) ||
         this.getters.getCell(leftPosition)?.content
       ) {
         row += 1;
@@ -293,7 +292,7 @@ export class AutofillPlugin extends UIPlugin {
       if (col <= this.getters.getNumberCols(sheetId)) {
         let rightPosition = { sheetId, col: col + 1, row };
         while (
-          this.getters.getEvaluatedCell(rightPosition).type !== CellValueType.empty ||
+          this.getters.getCorrespondingFormulaCell(rightPosition) ||
           this.getters.getCell(rightPosition)?.content
         ) {
           row += 1;

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -1,4 +1,5 @@
 import { Model } from "../../src";
+import { functionRegistry } from "../../src/functions";
 import { buildSheetLink, toCartesian, toZone } from "../../src/helpers";
 import { AutofillPlugin } from "../../src/plugins/ui_feature/autofill";
 import { Border, ConditionalFormat, Style } from "../../src/types";
@@ -517,6 +518,29 @@ describe("Autofill", () => {
     expect(getCellContent(model, "A3")).toBe("2");
     expect(getCellContent(model, "A4")).toBe("2");
     expect(getCell(model, "A5")).toBeUndefined();
+  });
+
+  test("Auto-autofill considers formula spreaded value", () => {
+    functionRegistry.add("SPREAD.EMPTY", {
+      description: "spreads empty values",
+      args: [],
+      returns: ["NUMBER"],
+      compute: function (): string[][] {
+        return [
+          ["", "", ""], // return 2 col, 3 row matrix
+          ["", "", ""],
+        ];
+      },
+      isExported: false,
+    });
+    setCellContent(model, "A1", "=SPREAD.EMPTY()");
+    setCellContent(model, "C1", "2");
+    setSelection(model, ["C1"]);
+    model.dispatch("AUTOFILL_AUTO");
+    expect(getCellContent(model, "C1")).toBe("2");
+    expect(getCellContent(model, "C2")).toBe("2");
+    expect(getCellContent(model, "C3")).toBe("2");
+    expect(getCell(model, "C4")).toBeUndefined();
   });
 
   test("autofill with merge in selection", () => {


### PR DESCRIPTION
Follow-up of 49d4820c to also consider the cells of a spreaded formula to automatically autofill values.

Task: 3626607

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo