### PR TITLE
[FIX] BottomBarSheet: renaming a sheet with styled content

### DIFF
--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -19,7 +19,7 @@
           t-on-dblclick="() => this.onDblClick()"
           t-on-focusout="() => this.onFocusOut()"
           t-on-keydown="(ev) => this.onKeyDown(ev)"
-          t-att-contenteditable="state.isEditing.toString()"
+          t-att-contenteditable="state.isEditing ? 'plaintext-only': 'false'"
         />
         <span class="o-sheet-icon ms-1" t-on-click.stop="(ev) => this.onIconClick(ev)">
           <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -244,7 +244,7 @@ describe("BottomBar component", () => {
       expect(sheetName.getAttribute("contenteditable")).toEqual("false");
       triggerMouseEvent(sheetName, "dblclick");
       await nextTick();
-      expect(sheetName.getAttribute("contenteditable")).toEqual("true");
+      expect(sheetName.getAttribute("contenteditable")).toEqual("plaintext-only");
       expect(document.activeElement).toEqual(sheetName);
     });
 
@@ -253,7 +253,7 @@ describe("BottomBar component", () => {
       await nextTick();
       await click(fixture, ".o-menu-item[data-name='rename'");
       const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
-      expect(sheetName.getAttribute("contenteditable")).toEqual("true");
+      expect(sheetName.getAttribute("contenteditable")).toEqual("plaintext-only");
       expect(document.activeElement).toEqual(sheetName);
     });
 


### PR DESCRIPTION
## Description:

Modified the span element to be contenteditable in plain-text only, resolving the traceback issue during sheet renaming.

Task: : [3621086](https://www.odoo.com/web#id=3621086&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo