### PR TITLE
[FIX] Cell: Fix detection of markdown links

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -177,7 +177,7 @@ export function isDateTime(str: string): boolean {
   return parseDateTime(str) !== null;
 }
 
-const MARKDOWN_LINK_REGEX = /^\[([^\[]+)\]\((.+)\)$/;
+const MARKDOWN_LINK_REGEX = /^\[(.+)\]\((.+)\)$/;
 //link must start with http or https
 //https://stackoverflow.com/a/3809435/4760614
 const WEB_LINK_REGEX =

--- a/tests/plugins/cell.test.ts
+++ b/tests/plugins/cell.test.ts
@@ -119,15 +119,22 @@ describe("link cell", () => {
       const cell = getCell(model, "A1");
       expect(cell?.evaluated.value).toBe(markdown);
       expect(cell?.evaluated.type).toBe(CellValueType.text);
+      expect(cell?.isLink()).toBeFalsy();
     }
   );
 
-  test("a markdown link in a markdown link", () => {
+  test.each([
+    ["[label](url)", "label", "https://url"],
+    ["[[label](link)](http://odoo.com)", "[label](link)", "http://odoo.com"],
+    ["[lab[el](url)", "lab[el", "https://url"],
+    ["[lab]el](url)", "lab]el", "https://url"],
+    ["[[label]](url)", "[label]", "https://url"],
+  ])("valid markdown %s is recognized as link", (markdown, label, link) => {
     const model = new Model();
-    setCellContent(model, "A1", `[[label](link)](http://odoo.com)`);
-    const cell = getCell(model, "A1");
-    expect(cell?.evaluated.type).toBe(CellValueType.text);
-    expect(cell?.content).toBe("[[label](link)](http://odoo.com)");
+    setCellContent(model, "A1", markdown);
+    const cell = getCell(model, "A1") as LinkCell;
+    expect(cell.link.label).toBe(label);
+    expect(cell.link.url).toBe(link);
   });
 
   test("can create a sheet link", () => {


### PR DESCRIPTION
The current regex of markdown link would purposely discard any `[label](link)` combination for which the label contained an opening bracket `[`, the reason behind it was to reject strings for which the label itself contained a markdown link as the markdown spec [1] specifies that we capture square brackets immediately followed by parenthesis. However, we should still support a label that contains closed square brackets (e.g. `[Label has [brackets]](link)`. Applying the proper rule to detect an exact link would be more costy than the current regex and considering that it will be called on all evaluated cell when reevaluated.

Since the current regex is too restrictive, this revision relaxes it with the downside that it will now also capture strings that are technically not exact markdown links but better have false positive than false negatives. The regex also becomes simpler.

[1] https://spec-md.com/#sec-Links

Task: 3628780

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo