### PR TITLE
[FIX] format: fix chaining of FORMAT.LARGE.NUMBER

### DIFF
--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -452,27 +452,32 @@ export function createLargeNumberFormat(
   postFix: string
 ): Format {
   const internalFormat = parseFormat(format || "#,##0");
-  const largeNumberFormat = internalFormat
-    .map((formatPart) => {
-      if (formatPart.type === "NUMBER") {
-        return [
-          {
-            ...formatPart,
-            format: {
-              ...formatPart.format,
-              magnitude,
-              decimalPart: undefined,
-            },
-          },
-          {
-            type: "STRING" as const,
-            format: postFix,
-          },
-        ];
-      }
-      return formatPart;
-    })
-    .flat();
+  const largeNumberFormat: InternalFormat = [];
+  for (let i = 0; i < internalFormat.length; i++) {
+    const formatPart = internalFormat[i];
+    if (formatPart.type !== "NUMBER") {
+      largeNumberFormat.push(formatPart);
+      continue;
+    }
+
+    largeNumberFormat.push({
+      ...formatPart,
+      format: {
+        ...formatPart.format,
+        magnitude,
+        decimalPart: undefined,
+      },
+    });
+    largeNumberFormat.push({
+      type: "STRING" as const,
+      format: postFix,
+    });
+
+    const nextFormatPart = internalFormat[i + 1];
+    if (nextFormatPart?.type === "STRING" && ["k", "m", "b"].includes(nextFormatPart.format)) {
+      i++;
+    }
+  }
   return convertInternalFormatToFormat(largeNumberFormat);
 }
 


### PR DESCRIPTION
## Description

Chaining FORMAT.LARGE.NUMBER formulas was adding the postfix multiple times. This commit fixes the issue by adding a check to see if the postfix is already present.

Task: : [3633947](https://www.odoo.com/web#id=3633947&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo