### PR TITLE
[FIX] ClipboardFigureState: paste chart after sheet delete

### DIFF
--- a/src/helpers/clipboard/clipboard_figure_state.ts
+++ b/src/helpers/clipboard/clipboard_figure_state.ts
@@ -69,7 +69,16 @@ export class ClipboardFigureState implements ClipboardState {
       y: this.getters.getRowDimensions(sheetId, target[0].top).start,
     };
 
-    const newChart = this.copiedChart.copyInSheetId(sheetId);
+    let copiedChart;
+    if (!this.getters.tryGetSheet(this.sheetId)) {
+      copiedChart = this.copiedChart;
+      copiedChart.dataSets = [];
+      copiedChart.labelRange = "";
+      copiedChart.title = "";
+    } else {
+      copiedChart = this.copiedChart.copyInSheetId(sheetId);
+    }
+
     const newId = new UuidGenerator().uuidv4();
 
     this.dispatch("CREATE_CHART", {
@@ -77,7 +86,7 @@ export class ClipboardFigureState implements ClipboardState {
       sheetId,
       position,
       size: { height: this.copiedFigure.height, width: this.copiedFigure.width },
-      definition: newChart.getDefinition(),
+      definition: copiedChart.getDefinition(),
     });
 
     if (this.operation === "CUT") {

--- a/tests/plugins/clipboard_figure.test.ts
+++ b/tests/plugins/clipboard_figure.test.ts
@@ -7,6 +7,7 @@ import {
   createChart,
   createSheet,
   cut,
+  deleteSheet,
   paste,
   setCellContent,
   setSelection,
@@ -135,6 +136,29 @@ describe("Clipboard for figures", () => {
     const newChartId = model.getters.getFigures("42")[0].id;
     expect(model.getters.getChartDefinition(newChartId)).toEqual(chartDef);
     expect(model.getters.getFigures(sheetId)).toHaveLength(0);
+  });
+
+  test("Can paste chart on another sheet after sheet is deleted", () => {
+    const model = new Model();
+    const chartId = "thisIsAnId";
+    createChart(model, { dataSets: ["A1:A5"], labelRange: "", title: "CHECK" }, chartId);
+    const chartDef = model.getters.getChartDefinition(chartId) as BarChartDefinition;
+    expect(chartDef.dataSets).toEqual(["A1:A5"]);
+
+    model.dispatch("SELECT_FIGURE", { id: chartId });
+    copy(model);
+    createSheet(model, { sheetId: "42" });
+    activateSheet(model, "42");
+    deleteSheet(model, "Sheet1");
+    paste(model, "A1");
+    const newChartId = model.getters.getFigures("42")[0].id;
+    expect(model.getters.getChartDefinition(newChartId)).toEqual({
+      ...chartDef,
+      dataSetsHaveTitle: false,
+      title: "",
+      dataSets: [],
+      labelRange: undefined,
+    });
   });
 
   describe("Paste command result", () => {


### PR DESCRIPTION
## Description:

Previously when attempting to copy and paste a chart to another sheet after deleting the source sheet resulted in an error. Now empty chart is pasted if the source sheet is deleted.

Task: : [3618758](https://www.odoo.com/web#id=3618758&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo