### PR TITLE
[FIX] evaluation: track dependencies with R-tree 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.6",
-        "bootstrap": "^5.1.3"
+        "bootstrap": "^5.1.3",
+        "rbush": "^3.0.1"
       },
       "devDependencies": {
         "@prettier/plugin-xml": "^2.0.1",
@@ -19,6 +20,7 @@
         "@types/chart.js": "2.9.3",
         "@types/jest": "^27.0.1",
         "@types/node": "^13.13.23",
+        "@types/rbush": "^3.0.3",
         "babel-eslint": "^10.1.0",
         "body-parser": "^1.19.0",
         "chart.js": "2.9.3",
@@ -1481,6 +1483,12 @@
       "version": "2.7.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/rbush": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-3.0.3.tgz",
+      "integrity": "sha512-lX55lR0iYCgapxD3IrgujpQA1zDxwZI5qMRelKvmKAsSMplFVr7wmMpG7/6+Op2tjrgEex8o3vjg8CRDrRNYxg==",
+      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -8619,6 +8627,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
     "node_modules/random-bytes": {
       "version": "1.0.0",
       "dev": true,
@@ -8655,6 +8668,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/chart.js": "2.9.3",
     "@types/jest": "^27.0.1",
     "@types/node": "^13.13.23",
+    "@types/rbush": "^3.0.3",
     "babel-eslint": "^10.1.0",
     "body-parser": "^1.19.0",
     "chart.js": "2.9.3",
@@ -100,7 +101,8 @@
   },
   "dependencies": {
     "@odoo/owl": "2.2.6",
-    "bootstrap": "^5.1.3"
+    "bootstrap": "^5.1.3",
+    "rbush": "^3.0.1"
   },
   "jest": {
     "roots": [

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -24,6 +24,7 @@ import {
 import { CellErrorType, CircularDependencyError, EvaluationError } from "../../../types/errors";
 import { buildCompilationParameters, CompilationParameters } from "./compilation_parameters";
 import { FormulaDependencyGraph } from "./formula_dependency_graph";
+import { RTreeBoundingBox } from "./r_tree";
 import { SpreadingRelation } from "./spreading_relation";
 
 type PositionDict<T> = Map<PositionId, T>;
@@ -38,10 +39,10 @@ const MAX_ITERATION = 30;
 export class Evaluator {
   private readonly getters: Getters;
   private compilationParams: CompilationParameters;
-  private readonly positionEncoder = new PositionBitsEncoder();
+  private readonly encoder = new PositionBitsEncoder();
 
   private evaluatedCells: PositionDict<EvaluatedCell> = new Map();
-  private formulaDependencies = lazy(new FormulaDependencyGraph());
+  private formulaDependencies = lazy(new FormulaDependencyGraph(this.encoder));
   private blockedArrayFormulas = new Set<PositionId>();
   private spreadingRelations = new SpreadingRelation();
 
@@ -56,19 +57,19 @@ export class Evaluator {
 
   getEvaluatedCell(position: CellPosition): EvaluatedCell {
     return (
-      this.evaluatedCells.get(this.encodePosition(position)) ||
+      this.evaluatedCells.get(this.encoder.encode(position)) ||
       createEvaluatedCell("", { locale: this.getters.getLocale() })
     );
   }
 
   getArrayFormulaSpreadingOn(position: CellPosition): CellPosition | undefined {
-    const positionId = this.encodePosition(position);
+    const positionId = this.encoder.encode(position);
     const formulaPosition = this.getArrayFormulaSpreadingOnId(positionId);
-    return formulaPosition !== undefined ? this.decodePosition(formulaPosition) : undefined;
+    return formulaPosition !== undefined ? this.encoder.decode(formulaPosition) : undefined;
   }
 
   getEvaluatedPositions(): CellPosition[] {
-    return [...this.evaluatedCells.keys()].map(this.decodePosition.bind(this));
+    return [...this.evaluatedCells.keys()].map((p) => this.encoder.decode(p));
   }
 
   private getArrayFormulaSpreadingOnId(positionId: PositionId): PositionId | undefined {
@@ -82,7 +83,7 @@ export class Evaluator {
   }
 
   updateDependencies(position: CellPosition) {
-    const positionId = this.encodePosition(position);
+    const positionId = this.encoder.encode(position);
     this.formulaDependencies().removeAllDependencies(positionId);
     const dependencies = this.getDirectDependencies(positionId);
     this.formulaDependencies().addDependencies(positionId, dependencies);
@@ -98,12 +99,12 @@ export class Evaluator {
   }
 
   evaluateCells(positions: CellPosition[]) {
-    const cells: PositionId[] = positions.map(this.encodePosition.bind(this));
+    const cells: PositionId[] = positions.map((p) => this.encoder.encode(p));
     const cellsToCompute = new JetSet<PositionId>(cells);
-    const arrayFormulas = this.getArrayFormulasImpactedByChangesOf(cells);
+    const arrayFormulasPositionIds = this.getArrayFormulasImpactedByChangesOf(cells);
     cellsToCompute.add(...this.getCellsDependingOn(cells));
-    cellsToCompute.add(...arrayFormulas);
-    cellsToCompute.add(...this.getCellsDependingOn(arrayFormulas));
+    cellsToCompute.add(...arrayFormulasPositionIds);
+    cellsToCompute.add(...this.getCellsDependingOn(arrayFormulasPositionIds));
     this.evaluate(cellsToCompute);
   }
 
@@ -131,12 +132,16 @@ export class Evaluator {
     this.blockedArrayFormulas = new Set<PositionId>();
     this.spreadingRelations = new SpreadingRelation();
     this.formulaDependencies = lazy(() => {
-      const dependencyGraph = new FormulaDependencyGraph();
-      for (const positionId of this.getAllCells()) {
-        const dependencies = this.getDirectDependencies(positionId);
-        dependencyGraph.addDependencies(positionId, dependencies);
-      }
-      return dependencyGraph;
+      const dependencies = [...this.getAllCells()].flatMap((positionId) =>
+        this.getDirectDependencies(positionId).map((range) => ({
+          data: positionId,
+          boundingBox: {
+            zone: range.zone,
+            sheetId: range.sheetId,
+          },
+        }))
+      );
+      return new FormulaDependencyGraph(this.encoder, dependencies);
     });
   }
 
@@ -161,7 +166,7 @@ export class Evaluator {
     for (const sheetId of this.getters.getSheetIds()) {
       const cellIds = this.getters.getCells(sheetId);
       for (const cellId in cellIds) {
-        positionIds.add(this.encodePosition(this.getters.getCellPosition(cellId)));
+        positionIds.add(this.encoder.encode(this.getters.getCellPosition(cellId)));
       }
     }
     return positionIds;
@@ -237,7 +242,7 @@ export class Evaluator {
   }
 
   private computeAndSave(position: CellPosition) {
-    const positionId = this.encodePosition(position);
+    const positionId = this.encoder.encode(position);
     const evaluatedCell = this.computeCell(positionId);
     if (!this.evaluatedCells.has(positionId)) {
       this.setEvaluatedCell(positionId, evaluatedCell);
@@ -329,16 +334,16 @@ export class Evaluator {
     col,
     row,
   }: CellPosition): (i: number, j: number) => void {
-    const arrayFormulaPositionId = this.encodePosition({ sheetId, col, row });
+    const arrayFormulaPositionId = this.encoder.encode({ sheetId, col, row });
     return (i: number, j: number) => {
       const position = { sheetId, col: i + col, row: j + row };
-      const resultPositionId = this.encodePosition(position);
+      const resultPositionId = this.encoder.encode(position);
       this.spreadingRelations.addRelation({ resultPositionId, arrayFormulaPositionId });
     };
   }
 
   private checkCollision({ sheetId, col, row }: CellPosition): (i: number, j: number) => void {
-    const formulaPositionId = this.encodePosition({ sheetId, col, row });
+    const formulaPositionId = this.encoder.encode({ sheetId, col, row });
     return (i: number, j: number) => {
       const position = { sheetId: sheetId, col: i + col, row: j + row };
       const rawCell = this.getters.getCell(position);
@@ -372,7 +377,7 @@ export class Evaluator {
         locale: this.getters.getLocale(),
       });
 
-      const positionId = this.encodePosition(position);
+      const positionId = this.encoder.encode(position);
 
       this.setEvaluatedCell(positionId, evaluatedCell);
 
@@ -404,38 +409,24 @@ export class Evaluator {
   //                 COMMON FUNCTIONALITY
   // ----------------------------------------------------------
 
-  private getDirectDependencies(positionId: PositionId): PositionId[] {
+  private getDirectDependencies(positionId: PositionId): Range[] {
     const cell = this.getCell(positionId);
     if (!cell?.isFormula) {
       return [];
     }
-    const dependencies: PositionId[] = [];
-    for (const range of cell.dependencies) {
-      if (range.invalidSheetName || range.invalidXc) {
-        continue;
-      }
-      const sheetId = range.sheetId;
-      forEachPositionsInZone(range.zone, (col, row) => {
-        dependencies.push(this.encodePosition({ sheetId, col, row }));
-      });
-    }
-    return dependencies;
+    return cell.dependencies;
   }
 
   private getCellsDependingOn(positionIds: Iterable<PositionId>): Iterable<PositionId> {
-    return this.formulaDependencies().getCellsDependingOn(positionIds);
+    const ranges: RTreeBoundingBox[] = [];
+    for (const positionId of positionIds) {
+      ranges.push(this.encoder.decodeToBoundingBox(positionId));
+    }
+    return this.formulaDependencies().getCellsDependingOn(ranges);
   }
 
   private getCell(positionId: PositionId): Cell | undefined {
-    return this.getters.getCell(this.decodePosition(positionId));
-  }
-
-  private encodePosition(position: CellPosition): PositionId {
-    return this.positionEncoder.encode(position);
-  }
-
-  private decodePosition(positionId: PositionId): CellPosition {
-    return this.positionEncoder.decode(positionId);
+    return this.getters.getCell(this.encoder.decode(positionId));
   }
 }
 
@@ -500,7 +491,7 @@ function assertFormulaReturnHasConsistentDimensions(formulaReturn: FormulaReturn
  *
  * this binary sequence is the integer 13194160504836
  */
-class PositionBitsEncoder {
+export class PositionBitsEncoder {
   private readonly sheetMapping: Record<string, PositionId> = {};
   private readonly inverseSheetMapping = new Map<PositionId, string>();
 
@@ -522,12 +513,25 @@ class PositionBitsEncoder {
     return (this.encodeSheet(sheetId) << 42n) | (BigInt(col) << 21n) | BigInt(row);
   }
 
+  encodeBoundingBox({ sheetId, zone }: RTreeBoundingBox): PositionId[] {
+    const positions: PositionId[] = [];
+    forEachPositionsInZone(zone, (col, row) => {
+      positions.push(this.encode({ sheetId, col, row }));
+    });
+    return positions;
+  }
+
   decode(id: PositionId): CellPosition {
     // keep only the last 21 bits by AND-ing the bit sequence with 21 ones
     const row = Number(id & 0b111111111111111111111n);
     const col = Number((id >> 21n) & 0b111111111111111111111n);
     const sheetId = this.decodeSheet(id >> 42n);
     return { sheetId, col, row };
+  }
+
+  decodeToBoundingBox(id: PositionId): RTreeBoundingBox {
+    const { sheetId, col, row } = this.decode(id);
+    return { sheetId, zone: { left: col, top: row, right: col, bottom: row } };
   }
 
   private encodeSheet(sheetId: UID): PositionId {

--- a/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
@@ -1,56 +1,49 @@
 import { JetSet } from "../../../helpers";
-import { PositionId } from "./evaluator";
+import { PositionBitsEncoder, PositionId } from "./evaluator";
+import { RTreeBoundingBox, RTreeItem, SpreadsheetRTree } from "./r_tree";
 
 /**
- * This class is an implementation of a dependency Graph.
+ * Implementation of a dependency Graph.
  * The graph is used to evaluate the cells in the correct
  * order, and should be updated each time a cell's content is modified
  *
+ * It uses an R-Tree data structure to efficiently find dependent cells.
  */
 export class FormulaDependencyGraph {
-  /**
-   * Internal structure:
-   * - key: a cell position (encoded as an integer)
-   * - value: a set of cell positions that depends on the key
-   *
-   * Given
-   * - A1:"= B1 + SQRT(B2)"
-   * - C1:"= B1";
-   * - C2:"= C1"
-   *
-   * we will have something like:
-   * - B1 ---> (A1, C1)   meaning A1 and C1 depends on B1
-   * - B2 ---> (A1)       meaning A1 depends on B2
-   * - C1 ---> (C2)       meaning C2 depends on C1
-   */
-  private readonly inverseDependencies: Map<PositionId, Set<PositionId>> = new Map();
-  private readonly dependencies: Map<PositionId, PositionId[]> = new Map();
+  private readonly dependencies: Map<PositionId, RTreeItem<PositionId>[]> = new Map();
+  private readonly rTree: SpreadsheetRTree<PositionId>;
+
+  constructor(private readonly encoder: PositionBitsEncoder, data: RTreeItem<PositionId>[] = []) {
+    this.rTree = new SpreadsheetRTree(data);
+  }
 
   removeAllDependencies(formulaPositionId: PositionId) {
-    const dependencies = this.dependencies.get(formulaPositionId);
-    if (!dependencies) {
+    const ranges = this.dependencies.get(formulaPositionId);
+    if (!ranges) {
       return;
     }
-    for (const dependency of dependencies) {
-      this.inverseDependencies.get(dependency)?.delete(formulaPositionId);
+    for (const range of ranges) {
+      this.rTree.remove(range);
     }
     this.dependencies.delete(formulaPositionId);
   }
 
-  addDependencies(formulaPositionId: PositionId, dependencies: PositionId[]): void {
-    for (const dependency of dependencies) {
-      const inverseDependencies = this.inverseDependencies.get(dependency);
-      if (inverseDependencies) {
-        inverseDependencies.add(formulaPositionId);
-      } else {
-        this.inverseDependencies.set(dependency, new Set([formulaPositionId]));
-      }
+  addDependencies(formulaPositionId: PositionId, dependencies: RTreeBoundingBox[]): void {
+    const rTreeItems = dependencies.map(({ sheetId, zone }) => ({
+      data: formulaPositionId,
+      boundingBox: {
+        zone,
+        sheetId,
+      },
+    }));
+    for (const item of rTreeItems) {
+      this.rTree.insert(item);
     }
     const existingDependencies = this.dependencies.get(formulaPositionId);
     if (existingDependencies) {
-      existingDependencies.push(...dependencies);
+      existingDependencies.push(...rTreeItems);
     } else {
-      this.dependencies.set(formulaPositionId, dependencies);
+      this.dependencies.set(formulaPositionId, rTreeItems);
     }
   }
 
@@ -59,22 +52,22 @@ export class FormulaDependencyGraph {
    * in the correct order they should be evaluated.
    * This is called a topological ordering (excluding cycles)
    */
-  getCellsDependingOn(positionIds: Iterable<PositionId>): Set<PositionId> {
+  getCellsDependingOn(ranges: RTreeBoundingBox[]): Set<PositionId> {
     const visited: JetSet<PositionId> = new JetSet<PositionId>();
-    const queue: PositionId[] = Array.from(positionIds).reverse();
+    const queue: RTreeBoundingBox[] = Array.from(ranges).reverse();
 
     while (queue.length > 0) {
-      const node = queue.pop()!;
-      visited.add(node);
+      const range = queue.pop()!;
+      visited.add(...this.encoder.encodeBoundingBox(range));
 
-      const adjacentNodes = this.inverseDependencies.get(node) || new Set<PositionId>();
-      for (const adjacentNode of adjacentNodes) {
-        if (!visited.has(adjacentNode)) {
-          queue.push(adjacentNode);
+      const impactedPositionIds = this.rTree.search(range).map((dep) => dep.data);
+      for (const positionId of impactedPositionIds) {
+        if (!visited.has(positionId)) {
+          queue.push(this.encoder.decodeToBoundingBox(positionId));
         }
       }
     }
-    visited.delete(...positionIds);
+    visited.delete(...ranges.flatMap((r) => this.encoder.encodeBoundingBox(r)));
     return visited;
   }
 }

--- a/src/plugins/ui_core_views/cell_evaluation/r_tree.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/r_tree.ts
@@ -1,0 +1,173 @@
+import RBush from "rbush";
+
+import { deepEquals } from "../../../helpers";
+import { UID, Zone } from "../../../types";
+
+/**
+ * R-Tree Data Structure
+ *
+ * R-Tree is a spatial data structure used for efficient indexing and querying
+ * of multi-dimensional objects, particularly in geometric and spatial applications.
+ *
+ * It organizes objects into a tree hierarchy, grouping nearby objects together
+ * in bounding boxes. Each node in the tree represents a bounding box that
+ * contains its child nodes or leaf objects. This hierarchical structure allows
+ * for faster spatial queries.
+ *
+ * @see https://en.wikipedia.org/wiki/R-tree
+ *
+ * Consider a 2D Space with four zones: A, B, C, D
+ * +--------------------------+
+ * |                          |
+ * |   +---+     +-------+    |
+ * |   | A |     |   B   |    |
+ * |   +---+     +-------+    |
+ * |                          |
+ * |                          |
+ * |          +---+           |
+ * |          | C |           |
+ * |          +---+           |
+ * |      +-----------+       |
+ * |      |     D     |       |
+ * |      +-----------+       |
+ * |                          |
+ * +--------------------------+
+ *
+ * It groups together zones that are spatially close into a minimum bounding box.
+ * For example, A and B are grouped together in rectangle R1, and C and D are grouped
+ * in R2.
+ *
+ * R0
+ * +--------------------------+
+ * |   R1                     |
+ * |   +-----------------+    |
+ * |   | A |     |   B   |    |
+ * |   +-----------------+    |
+ * |                          |
+ * |      R2                  |
+ * |      +---+---+---+       |
+ * |      |   | C |   |       |
+ * |      |   +---+   |       |
+ * |      +-----------+       |
+ * |      |     D     |       |
+ * |      +-----------+       |
+ * |                          |
+ * +--------------------------+
+ *
+ * The tree would look like this:
+ *          R0
+ *         /  \
+ *        /    \
+ *       R1     R2
+ *       |      |
+ *      A,B    C,D
+
+ * Choosing how to group the zones is crucial for the performance of the tree.
+ * Key considerations include avoiding excessive empty space coverage and minimizing overlap
+ * to reduce the number of subtrees processed during searches.
+ *
+ * Various heuristics exist for determining the optimal grouping strategy, such as "least enlargement"
+ * which prioritizes grouping nodes resulting in the smallest increase in bounding box size. In cases where
+ * the choice cannot be made based on this criterion due to the same enlargement for different groupings,
+ * we then evaluate "least area," aiming to minimize the overall area of bounding boxes.
+ *
+ * This implementation is tailored for spreadsheet use, indexing objects associated
+ * with a zone and a sheet.
+ *
+ * It uses the RBush library under the hood. One 2D RBush R-tree per sheet.
+ * @see https://github.com/mourner/rbush
+ */
+export class SpreadsheetRTree<T> {
+  /**
+   * One 2D R-tree per sheet
+   */
+  private rTrees: Record<UID, RBush<RTreeItem<T>>> = {};
+
+  /**
+   * Bulk-inserts the given items into the tree. Bulk insertion is usually ~2-3 times
+   * faster than inserting items one by one. After bulk loading (bulk insertion into
+   * an empty tree), subsequent query performance is also ~20-30% better.
+   */
+  constructor(items: RTreeItem[] = []) {
+    const rangesPerSheet = {};
+    for (const item of items) {
+      const sheetId = item.boundingBox.sheetId;
+      if (!rangesPerSheet[sheetId]) {
+        rangesPerSheet[sheetId] = [];
+      }
+      rangesPerSheet[sheetId].push(item);
+    }
+    for (const sheetId in rangesPerSheet) {
+      this.rTrees[sheetId] = new ZoneRBush();
+      this.rTrees[sheetId].load(rangesPerSheet[sheetId]); // bulk-insert
+    }
+  }
+
+  insert(item: RTreeItem<T>) {
+    const sheetId = item.boundingBox.sheetId;
+    if (!this.rTrees[sheetId]) {
+      this.rTrees[sheetId] = new ZoneRBush();
+    }
+    this.rTrees[sheetId].insert(item);
+  }
+
+  search({ zone, sheetId }: RTreeBoundingBox): RTreeItem<T>[] {
+    if (!this.rTrees[sheetId]) {
+      return [];
+    }
+    return this.rTrees[sheetId].search({
+      minX: zone.left,
+      minY: zone.top,
+      maxX: zone.right,
+      maxY: zone.bottom,
+    });
+  }
+
+  remove(item: RTreeItem<T>) {
+    const sheetId = item.boundingBox.sheetId;
+    if (!this.rTrees[sheetId]) {
+      return;
+    }
+    this.rTrees[sheetId].remove(item, deepEquals);
+  }
+}
+
+/**
+ * RBush extension to use zones as bounding boxes
+ */
+class ZoneRBush<T> extends RBush<RTreeItem<T>> {
+  toBBox({ boundingBox }: RTreeItem) {
+    const zone = boundingBox.zone;
+    return {
+      minX: zone.left,
+      minY: zone.top,
+      maxX: zone.right,
+      maxY: zone.bottom,
+    };
+  }
+  compareMinX(a: RTreeItem, b: RTreeItem) {
+    return a.boundingBox.zone.left - b.boundingBox.zone.left;
+  }
+  compareMinY(a: RTreeItem, b: RTreeItem) {
+    return a.boundingBox.zone.top - b.boundingBox.zone.top;
+  }
+}
+
+/**
+ * Data associated with a range to be indexed in a R-tree
+ */
+export interface RTreeItem<T = unknown> {
+  /**
+   * A bounding box to locate the item in the space
+   */
+  boundingBox: RTreeBoundingBox;
+  /**
+   * Any arbitrary data associated with the bounding box
+   */
+  data: T;
+}
+
+export interface RTreeBoundingBox {
+  sheetId: UID;
+  zone: Zone;
+}


### PR DESCRIPTION
## Description:

Currently, when building the dependency graph for a cell with the formula
`=SUM(A1:A1000)`, we iterate through each position in the range `A1:A1000` to
create the inverse dependency mapping. However, when the range is very large,
and many such formulas exist, the process can take a significant amount of
time (quadratic C x R, where C is the number of cells and R is the size of the
range(s)).

We found 3 spreadsheets on our production database which are unusable because
building the dependency graph never finishes. This commit brings that time
down to a fraction of a second.

One noteworthy observation is that a complete inverse dependency mapping is
unnecessary, as only a small subset of cells is likely to ever be updated.

The objective of this commit is to avoid the construction of the entire
inverse mapping while still maintaining an efficient method to identify
impacted cells when a zone on which it depends is modified.

The chosen strategy uses an R-tree[^1] data structure to index the dependency
relations and efficiently locate the cells when necessary.

Since implementing an R-tree is non-trivial and existing implementations are
available, we opt for the R-tree provided by the rbush[^2] library.
This library is ~500 lines of code, appears stable, and is widely used
(1.2 million weekly npm downloads).

[^1]: https://en.wikipedia.org/wiki/R-tree
[^2]: https://github.com/mourner/rbush


Task: : [3646902](https://www.odoo.com/web#id=3646902&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo