### PR TITLE
[IMP] tests: use `setStyle` and `setFormat` helpers

### DIFF
--- a/tests/cells/merges_plugin.test.ts
+++ b/tests/cells/merges_plugin.test.ts
@@ -14,6 +14,7 @@ import {
   selectCell,
   setAnchorCorner,
   setCellContent,
+  setStyle,
   setZoneBorders,
   unMerge,
   undo,
@@ -152,13 +153,8 @@ describe("merges", () => {
     expect(getSelectionAnchorCellXc(model)).toBe("C3");
     expect(getCellsXC(model)).toEqual(["B2"]);
     expect(getCell(model, "B2")!.style).not.toBeDefined();
-    const sheet1 = model.getters.getSheetIds()[0];
 
-    model.dispatch("SET_FORMATTING", {
-      sheetId: sheet1,
-      target: model.getters.getSelectedZones(),
-      style: { fillColor: "#333" },
-    });
+    setStyle(model, "B2:C3", { fillColor: "#333" });
 
     expect(getCellsXC(model)).toEqual(["B2", "B3", "C2", "C3"]);
     expect(getCell(model, "B2")!.style).toBeDefined();
@@ -305,11 +301,8 @@ describe("merges", () => {
   test("merging => unmerging  : cell styles are overridden even if the top left cell had no style", () => {
     const model = new Model();
 
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("B1"),
-      style: { fillColor: "red" },
-    });
+    setStyle(model, "B1", { fillColor: "red" });
+
     merge(model, "A1:B1");
     expect(getStyle(model, "A1")).toEqual({});
     expect(getStyle(model, "B1")).toEqual({});
@@ -320,18 +313,12 @@ describe("merges", () => {
 
   test("merging => setting background color => unmerging", () => {
     const model = new Model();
-    const sheet1 = model.getters.getSheetIds()[0];
 
     setAnchorCorner(model, "B1");
-
     expect(model.getters.getSelectedZones()[0]).toEqual({ top: 0, left: 0, right: 1, bottom: 0 });
 
     merge(model, "A1:B1");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: sheet1,
-      target: [{ left: 0, right: 1, top: 0, bottom: 0 }],
-      style: { fillColor: "red" },
-    });
+    setStyle(model, "A1:B1", { fillColor: "red" });
 
     expect(getStyle(model, "A1")).toEqual({ fillColor: "red" });
     expect(getStyle(model, "B1")).toEqual({ fillColor: "red" });
@@ -343,13 +330,8 @@ describe("merges", () => {
 
   test("setting background color => merging => unmerging", () => {
     const model = new Model();
-    const sheet1 = model.getters.getSheetIds()[0];
     setAnchorCorner(model, "B1");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: sheet1,
-      target: [{ left: 0, right: 1, top: 0, bottom: 0 }],
-      style: { fillColor: "red" },
-    });
+    setStyle(model, "A1:B1", { fillColor: "red" });
 
     expect(getStyle(model, "A1")).toEqual({ fillColor: "red" });
     expect(getStyle(model, "B1")).toEqual({ fillColor: "red" });
@@ -365,12 +347,7 @@ describe("merges", () => {
 
   test("setting background color to topleft => merging => unmerging", () => {
     const model = new Model();
-    const sheet1 = model.getters.getSheetIds()[0];
-    model.dispatch("SET_FORMATTING", {
-      sheetId: sheet1,
-      target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
-      style: { fillColor: "red" },
-    });
+    setStyle(model, "A1", { fillColor: "red" });
     setAnchorCorner(model, "B1");
 
     expect(getStyle(model, "A1")).toEqual({ fillColor: "red" });
@@ -470,14 +447,10 @@ describe("merges", () => {
 
   test("setting border to topleft => setting style => merging => unmerging", () => {
     const model = new Model();
-    const sheet1 = model.getters.getSheetIds()[0];
     setZoneBorders(model, { position: "external" }, ["A1"]);
-    model.dispatch("SET_FORMATTING", {
-      sheetId: sheet1,
-      target: [toZone("A1")],
-      style: { fillColor: "red" },
-    });
+    setStyle(model, "A1", { fillColor: "red" });
     merge(model, "A1:B1");
+
     expect(getBorder(model, "A1")).toEqual({
       left: DEFAULT_BORDER_DESC,
       bottom: DEFAULT_BORDER_DESC,

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -182,14 +182,8 @@ describe("clipboard", () => {
 
   test("can copy a cell with style", () => {
     const model = new Model();
-    const sheet1 = model.getters.getActiveSheetId();
     setCellContent(model, "B2", "b2");
-    selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: sheet1,
-      target: target("B2"),
-      style: { bold: true },
-    });
+    setStyle(model, "B2", { bold: true });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
     copy(model, "B2");
@@ -280,15 +274,10 @@ describe("clipboard", () => {
 
   test("can copy from an empty cell into a cell with style", () => {
     const model = new Model();
-    const sheet1 = model.getters.getActiveSheetId();
     // set value and style in B2
     setCellContent(model, "B2", "b2");
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: sheet1,
-      target: target("B2"),
-      style: { bold: true },
-    });
+    setStyle(model, "B2", { bold: true });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
     // set value in A1, select and copy it
@@ -331,11 +320,7 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "B2", "0.451");
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
-      format: "0.00%",
-    });
+    setFormat(model, "B2", "0.00%");
     expect(getCellContent(model, "B2")).toBe("45.10%");
 
     copy(model, "B2");
@@ -451,12 +436,7 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("B2"),
-      style: { bold: true },
-    });
-
+    setStyle(model, "B2", { bold: true });
     cut(model, "B2");
     paste(model, "C2");
 
@@ -1036,11 +1016,7 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("B2"),
-      style: { bold: true },
-    });
+    setStyle(model, "B2", { bold: true });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
     copy(model, "B2");
@@ -1052,12 +1028,8 @@ describe("clipboard", () => {
   test("can copy and paste format", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
+    setStyle(model, "B2", { bold: true });
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("B2"),
-      style: { bold: true },
-    });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
     copy(model, "B2");
@@ -1070,12 +1042,8 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
     setCellContent(model, "C2", "c2");
+    setStyle(model, "B2", { bold: true });
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("B2"),
-      style: { bold: true },
-    });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
     copy(model, "B2");
@@ -1088,12 +1056,8 @@ describe("clipboard", () => {
   test("can undo a paste format", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
+    setStyle(model, "B2", { bold: true });
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("B2"),
-      style: { bold: true },
-    });
     copy(model, "B2");
     paste(model, "C2", "onlyFormat");
 
@@ -1116,12 +1080,8 @@ describe("clipboard", () => {
   test("can copy a cell with a style and paste as value", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
+    setStyle(model, "B2", { bold: true });
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("B2"),
-      style: { bold: true },
-    });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
     copy(model, "B2");
@@ -1176,11 +1136,7 @@ describe("clipboard", () => {
     setCellContent(model, "B2", "b2");
     setCellContent(model, "C3", "c3");
     selectCell(model, "C3");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 2, right: 2, top: 2, bottom: 2 }],
-      style: { bold: true },
-    });
+    setStyle(model, "C3", { bold: true });
     expect(getCell(model, "C3")!.style).toEqual({ bold: true });
 
     copy(model, "B2");
@@ -1209,11 +1165,11 @@ describe("clipboard", () => {
   test("paste as value does not remove number format", () => {
     const model = new Model();
     setCellContent(model, "B2", "0.451");
-    setFormat(model, "0.00%", target("B2"));
+    setFormat(model, "B2", "0.00%");
     expect(getCellContent(model, "B2")).toBe("45.10%");
 
     setCellContent(model, "C3", "42");
-    setFormat(model, "#,##0.00", target("C3"));
+    setFormat(model, "C3", "#,##0.00");
     expect(getCellContent(model, "C3")).toBe("42.00");
 
     copy(model, "B2");
@@ -1325,11 +1281,7 @@ describe("clipboard", () => {
     const model = new Model();
     setCellContent(model, "B2", "b2");
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("B2"),
-      style: { bold: true },
-    });
+    setStyle(model, "B2", { bold: true });
     copy(model, "B2");
     paste(model, "C2", "asValue");
 
@@ -1535,11 +1487,7 @@ describe("clipboard", () => {
     // write something in B2 and set its format
     setCellContent(model, "B2", "b2");
     selectCell(model, "B2");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("B2"),
-      style: { bold: true },
-    });
+    setStyle(model, "B2", { bold: true });
     expect(getCell(model, "B2")!.style).toEqual({ bold: true });
 
     // select A1 and copy format

--- a/tests/collaborative/collaborative_history.test.ts
+++ b/tests/collaborative/collaborative_history.test.ts
@@ -16,6 +16,7 @@ import {
   redo,
   setCellContent,
   setSelection,
+  setStyle,
   snapshot,
   undo,
   unfreezeColumns,
@@ -141,11 +142,7 @@ describe("Collaborative local history", () => {
   test("Add a column and set a formatting on it", () => {
     addColumns(alice, "before", "C", 4);
     undo(alice);
-    bob.dispatch("SET_FORMATTING", {
-      sheetId: bob.getters.getActiveSheetId(),
-      target: [toZone("H2:J6")],
-      style: { fillColor: "#121212" },
-    });
+    setStyle(bob, "H2:J6", { fillColor: "#121212" });
     expect([alice, bob, charlie]).toHaveSynchronizedExportedData();
     expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getStyle(user, "H2"), {
       fillColor: "#121212",
@@ -894,11 +891,7 @@ describe("Collaborative local history", () => {
     addColumns(charlie, "before", "B", 1);
     network.concurrent(() => {
       undo(charlie);
-      bob.dispatch("SET_FORMATTING", {
-        sheetId: "Sheet1",
-        target: target("A1"),
-        style: { bold: true },
-      });
+      setStyle(bob, "A1", { bold: true });
     });
     expect(all).toHaveSynchronizedValue((user) => getCell(user, "A1")?.style, { bold: true });
     expect(all).toHaveSynchronizedValue((user) => getCell(user, "B1")?.style, undefined);

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -16,6 +16,7 @@ import {
   resizeRows,
   selectCell,
   setCellContent,
+  setStyle,
 } from "../test_helpers/commands_helpers";
 import {
   click,
@@ -516,19 +517,15 @@ describe("Grid composer", () => {
     test("Inherits the style of the cell", async () => {
       const fontSize = FONT_SIZES[0];
       const color = "#123456";
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
-        style: {
-          textColor: color,
-          fillColor: color,
-          fontSize,
-          bold: true,
-          italic: true,
-          strikethrough: true,
-          underline: true,
-          align: "right",
-        },
+      setStyle(model, "A1", {
+        textColor: color,
+        fillColor: color,
+        fontSize,
+        bold: true,
+        italic: true,
+        strikethrough: true,
+        underline: true,
+        align: "right",
       });
       await typeInComposerGrid("Hello");
       const gridComposer = fixture.querySelector(".o-grid-composer")! as HTMLElement;
@@ -573,19 +570,15 @@ describe("Grid composer", () => {
     test("Does not inherit style of the cell", async () => {
       const fontSize = FONT_SIZES[0];
       const color = "#123456";
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A1")],
-        style: {
-          textColor: color,
-          fillColor: color,
-          fontSize,
-          bold: true,
-          italic: true,
-          strikethrough: true,
-          underline: true,
-          align: "right",
-        },
+      setStyle(model, "A1", {
+        textColor: color,
+        fillColor: color,
+        fontSize,
+        bold: true,
+        italic: true,
+        strikethrough: true,
+        underline: true,
+        align: "right",
       });
       await typeInComposerGrid("=");
       const gridComposer = fixture.querySelector(".o-grid-composer")! as HTMLElement;

--- a/tests/composer/edition_plugin.test.ts
+++ b/tests/composer/edition_plugin.test.ts
@@ -28,7 +28,6 @@ import {
   getEvaluatedCell,
 } from "../test_helpers/getters_helpers"; // to have getcontext mocks
 import "../test_helpers/helpers";
-import { target } from "../test_helpers/helpers";
 
 describe("edition", () => {
   test("adding and removing a cell (by setting its content to empty string", () => {
@@ -693,11 +692,7 @@ describe("edition", () => {
 
   test("type a number in percent formatted empty cell", () => {
     const model = new Model();
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      format: "0.00%",
-    });
+    setFormat(model, "A1", "0.00%");
     model.dispatch("START_EDITION", { text: "12" });
     expect(model.getters.getCurrentContent()).toBe("12%");
     expect(model.getters.getComposerSelection()).toEqual({ start: 2, end: 2 });
@@ -729,11 +724,7 @@ describe("edition", () => {
 
   test("empty cell with percent format is displayed empty", () => {
     const model = new Model();
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      format: "0.00%",
-    });
+    setFormat(model, "A1", "0.00%");
     model.dispatch("START_EDITION");
     expect(model.getters.getCurrentContent()).toBe("");
     expect(model.getters.getComposerSelection()).toEqual({ start: 0, end: 0 });
@@ -756,7 +747,7 @@ describe("edition", () => {
   test("Numbers in the composer are displayed without number of digit format", () => {
     const model = new Model();
     setCellContent(model, "A1", "0.123456789123");
-    setFormat(model, "#,##0.00", target("A1"));
+    setFormat(model, "A1", "#,##0.00");
     selectCell(model, "A1");
     expect(model.getters.getCurrentContent()).toBe("0.123456789123");
   });
@@ -825,7 +816,7 @@ describe("edition", () => {
   test("non-parsable date format displays a simplified and parsable value", () => {
     const model = new Model();
     setCellContent(model, "A1", "1");
-    setFormat(model, "dddd d mmmm yyyy", target("A1"));
+    setFormat(model, "A1", "dddd d mmmm yyyy");
     expect(getEvaluatedCell(model, "A1").formattedValue).toBe("Sunday 31 December 1899");
     expect(model.getters.getCurrentContent()).toBe("12/31/1899");
   });
@@ -833,7 +824,7 @@ describe("edition", () => {
   test("non-parsable date time format displays a simplified and parsable value", () => {
     const model = new Model();
     setCellContent(model, "A1", "1.5");
-    setFormat(model, "dddd d mmmm yyyy hh:mm:ss a", target("A1"));
+    setFormat(model, "A1", "dddd d mmmm yyyy hh:mm:ss a");
     expect(getEvaluatedCell(model, "A1").formattedValue).toBe(
       "Sunday 31 December 1899 12:00:00 PM"
     );

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -21,7 +21,6 @@ import { getStyle } from "../test_helpers/getters_helpers";
 import {
   createColorScale,
   createEqualCF,
-  target,
   toCellPosition,
   toRangesData,
 } from "../test_helpers/helpers";
@@ -408,7 +407,7 @@ describe("conditional format", () => {
       sheetId,
     });
     expect(getStyle(model, "A1")).toEqual({});
-    setFormat(model, "mm/dd/yyyy", target("A2"));
+    setFormat(model, "A2", "mm/dd/yyyy");
     expect(getStyle(model, "A1")).toEqual({
       fillColor: "#FF0000",
     });

--- a/tests/data_filter/filter_evaluation_plugin.test.ts
+++ b/tests/data_filter/filter_evaluation_plugin.test.ts
@@ -16,7 +16,6 @@ import {
   setZoneBorders,
   updateFilter,
 } from "../test_helpers/commands_helpers";
-import { target } from "../test_helpers/helpers";
 
 describe("Filter Evaluation Plugin", () => {
   let model: Model;
@@ -25,6 +24,7 @@ describe("Filter Evaluation Plugin", () => {
   beforeEach(() => {
     model = new Model();
     sheetId = model.getters.getActiveSheetId();
+
     setCellContent(model, "A1", "A1");
     setCellContent(model, "A2", "A2");
     setCellContent(model, "A3", "A3");
@@ -52,7 +52,7 @@ describe("Filter Evaluation Plugin", () => {
 
   test("Filters use the formatted value of the cells", () => {
     setCellContent(model, "A2", "2");
-    setFormat(model, "m/d/yyyy", target("A2"));
+    setFormat(model, "A2", "m/d/yyyy");
     updateFilter(model, "A2", ["1/1/1900"]);
     expect(model.getters.isRowHidden(sheetId, 1)).toEqual(true);
   });

--- a/tests/data_filter/filter_menu_component.test.ts
+++ b/tests/data_filter/filter_menu_component.test.ts
@@ -13,7 +13,7 @@ import {
   setInputValueAndTrigger,
   simulateClick,
 } from "../test_helpers/dom_helper";
-import { getCellsObject, mountSpreadsheet, nextTick, target } from "../test_helpers/helpers";
+import { getCellsObject, mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 async function openFilterMenu() {
   await simulateClick(".o-filter-icon");
@@ -102,7 +102,7 @@ describe("Filter menu component", () => {
     });
 
     test("We display the formated value of the cells", async () => {
-      setFormat(model, "m/d/yyyy", target("A4"));
+      setFormat(model, "A4", "m/d/yyyy");
       await openFilterMenu();
       const values = getFilterMenuValues();
       expect(values.map((val) => val.value)).toEqual(["(Blanks)", "1", "1/1/1900"]);
@@ -153,7 +153,7 @@ describe("Filter menu component", () => {
     });
 
     test("Confirm button updates the filter with formatted cell value", async () => {
-      setFormat(model, "m/d/yyyy", target("A4"));
+      setFormat(model, "A4", "m/d/yyyy");
       expect(model.getters.getFilterValues({ sheetId, col: 0, row: 0 })).toEqual([]);
       await openFilterMenu();
       await simulateClick(".o-filter-menu-value:nth-of-type(2)");

--- a/tests/data_validation/evaluation_data_validation_plugin.test.ts
+++ b/tests/data_validation/evaluation_data_validation_plugin.test.ts
@@ -6,7 +6,6 @@ import {
   setCellContent,
   setFormat,
 } from "../test_helpers/commands_helpers";
-import { target } from "../test_helpers/helpers";
 
 describe("Data validation evaluation", () => {
   let model: Model;
@@ -128,13 +127,13 @@ describe("Data validation evaluation", () => {
   });
 
   test("data validation is updated on cell format change", () => {
-    setFormat(model, "0.00", target("A2"));
+    setFormat(model, "A2", "0.00");
     addDataValidation(model, "A1", "id", { type: "textContains", values: ["m"] });
 
     setCellContent(model, "A1", '=CELL("format", A2)');
     expect(model.getters.isDataValidationInvalid(A1)).toEqual(true);
 
-    setFormat(model, "mm/dd/yyyy", target("A2"));
+    setFormat(model, "A2", "mm/dd/yyyy");
     expect(model.getters.isDataValidationInvalid(A1)).toEqual(false);
   });
 });

--- a/tests/evaluation/evaluation.test.ts
+++ b/tests/evaluation/evaluation.test.ts
@@ -17,6 +17,8 @@ import {
   deleteColumns,
   paste,
   setCellContent,
+  setFormat,
+  setStyle,
   updateLocale,
 } from "../test_helpers/commands_helpers";
 import { FR_LOCALE } from "../test_helpers/constants";
@@ -26,12 +28,7 @@ import {
   getCellError,
   getEvaluatedCell,
 } from "../test_helpers/getters_helpers";
-import {
-  evaluateCell,
-  evaluateGrid,
-  restoreDefaultFunctions,
-  target,
-} from "../test_helpers/helpers";
+import { evaluateCell, evaluateGrid, restoreDefaultFunctions } from "../test_helpers/helpers";
 import resetAllMocks = jest.resetAllMocks;
 
 describe("evaluateCells", () => {
@@ -279,11 +276,7 @@ describe("evaluateCells", () => {
     let cell = getEvaluatedCell(model, "A1") as ErrorCell;
     const error = cell.error.message;
     const value = cell.value;
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
-      format: "#,##0",
-    });
+    setFormat(model, "A1", "#,##0");
     cell = getEvaluatedCell(model, "A1") as ErrorCell;
     expect(cell.type).toBe(CellValueType.error);
     expect(cell.error.message).toBe(error);
@@ -1043,15 +1036,10 @@ describe("evaluateCells", () => {
 
   test("evaluate empty colored cell", () => {
     const model = new Model();
-    const sheetId = model.getters.getActiveSheetId();
     setCellContent(model, "A2", "=A1");
     expect(getEvaluatedCell(model, "A2").value).toBe(0);
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1"),
-      style: {
-        fillColor: "#a7d08c",
-      },
+    setStyle(model, "A1", {
+      fillColor: "#a7d08c",
     });
     setCellContent(model, "A12", "this re-evaluates cells");
     expect(getCellContent(model, "A2")).toBe("0");

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -26,7 +26,7 @@ import {
   setFormat,
 } from "../test_helpers/commands_helpers";
 import { getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
-import { restoreDefaultFunctions, target } from "../test_helpers/helpers";
+import { restoreDefaultFunctions } from "../test_helpers/helpers";
 
 let model: Model;
 describe("evaluate formulas that return an array", () => {
@@ -113,7 +113,7 @@ describe("evaluate formulas that return an array", () => {
         ],
       });
 
-      setFormat(model, "0%", target("A1:A2"));
+      setFormat(model, "A1:A2", "0%");
       setCellContent(model, "A1", "=MATRIX.2.2()");
 
       expect(getCellContent(model, "A1")).toBe("100%");
@@ -135,7 +135,7 @@ describe("evaluate formulas that return an array", () => {
         computeFormat: () => "0.00",
       });
 
-      setFormat(model, "0%", target("A1:A2"));
+      setFormat(model, "A1:A2", "0%");
       setCellContent(model, "A1", "=MATRIX.2.2()");
 
       expect(getCellContent(model, "A1")).toBe("#ERROR");
@@ -186,8 +186,8 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "A1", "42");
       setCellContent(model, "A2", "24");
 
-      setFormat(model, "0%", target("A1"));
-      setFormat(model, "0.00", target("A2"));
+      setFormat(model, "A1", "0%");
+      setFormat(model, "A2", "0.00");
 
       setCellContent(model, "B1", "=MATRIX(A1:A2)");
 

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -1,6 +1,6 @@
 import { ChartType, TooltipItem } from "chart.js";
 import { CommandResult, Model } from "../../../src";
-import { toZone, zoneToXc } from "../../../src/helpers";
+import { zoneToXc } from "../../../src/helpers";
 import { ChartDefinition, UID } from "../../../src/types";
 import {
   BarChartDefinition,
@@ -1814,11 +1814,7 @@ describe("Linear/Time charts", () => {
   });
 
   test("time axis for line/bar chart with date labels", () => {
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("C2:C5")],
-      format: "m/d/yyyy",
-    });
+    setFormat(model, "C2:C5", "m/d/yyyy");
     createChart(
       model,
       {
@@ -1871,7 +1867,7 @@ describe("Linear/Time charts", () => {
       },
       chartId
     );
-    setFormat(model, "mm/dd/yyyy", target("C2:C3"));
+    setFormat(model, "C2:C3", "mm/dd/yyyy");
     setCellContent(model, "C2", "1/1/2022");
 
     setCellContent(model, "C3", "1/1/2025");
@@ -1886,7 +1882,7 @@ describe("Linear/Time charts", () => {
     chart = (model.getters.getChartRuntime(chartId) as any).chartJsConfig;
     expect(chart.options!.scales!.x!.time!.unit).toEqual("day");
 
-    setFormat(model, "hh:mm:ss", target("C2:C3"));
+    setFormat(model, "C2:C3", "hh:mm:ss");
 
     setCellContent(model, "C3", "1/1/2022 00:00:15");
     chart = (model.getters.getChartRuntime(chartId) as any).chartJsConfig;
@@ -1902,11 +1898,7 @@ describe("Linear/Time charts", () => {
   });
 
   test("date chart: empty label with a value is replaced by arbitrary label with no value", () => {
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("C2:C5")],
-      format: "m/d/yyyy",
-    });
+    setFormat(model, "C2:C5", "m/d/yyyy");
     createChart(
       model,
       {
@@ -1983,11 +1975,7 @@ describe("Linear/Time charts", () => {
   });
 
   test("snapshot test of chartJS configuration for date chart", () => {
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("C2:C5")],
-      format: "m/d/yyyy",
-    });
+    setFormat(model, "C2:C5", "m/d/yyyy");
     createChart(
       model,
       {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1,7 +1,7 @@
 import { CommandResult, Model, Spreadsheet } from "../../../src";
 import { ChartTerms } from "../../../src/components/translations_terms";
 import { BACKGROUND_CHART_COLOR } from "../../../src/constants";
-import { toHex, toZone } from "../../../src/helpers";
+import { toHex } from "../../../src/helpers";
 import { ChartDefinition } from "../../../src/types";
 import { BarChartDefinition } from "../../../src/types/chart/bar_chart";
 import { LineChartDefinition } from "../../../src/types/chart/line_chart";
@@ -10,6 +10,7 @@ import {
   createGaugeChart,
   createScorecardChart,
   createSheet,
+  setFormat,
   setStyle,
   updateChart,
 } from "../../test_helpers/commands_helpers";
@@ -1000,11 +1001,7 @@ describe("charts", () => {
     });
 
     test("labelAsText checkbox displayed for date labels", async () => {
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("C2:C4")],
-        format: "m/d/yyyy",
-      });
+      setFormat(model, "C2:C4", "m/d/yyyy");
       createTestChart("basicChart");
       updateChart(model, chartId, { type: "line", labelRange: "C2:C4", dataSets: ["B2:B4"] });
       await openChartConfigSidePanel();
@@ -1029,11 +1026,7 @@ describe("charts", () => {
 
     test("labelAsText checkbox not displayed for text labels with date format", async () => {
       createTestChart("basicChart");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [toZone("A2:A4")],
-        format: "m/d/yyyy",
-      });
+      setFormat(model, "C2:C4", "m/d/yyyy");
       updateChart(model, chartId, { type: "line", labelRange: "A2:A4", dataSets: ["B2:B4"] });
       await openChartConfigSidePanel();
 

--- a/tests/figures/chart/common_chart_plugin.test.ts
+++ b/tests/figures/chart/common_chart_plugin.test.ts
@@ -8,8 +8,9 @@ import {
   createScorecardChart,
   createSheet,
   setCellContent,
+  setStyle,
 } from "../../test_helpers/commands_helpers";
-import { createEqualCF, target, toRangesData } from "../../test_helpers/helpers";
+import { createEqualCF, toRangesData } from "../../test_helpers/helpers";
 
 describe("Single cell chart background color", () => {
   let model: Model;
@@ -31,11 +32,7 @@ describe("Single cell chart background color", () => {
   }
 
   function addFillToA1(color: Color) {
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1"),
-      style: { fillColor: color },
-    });
+    setStyle(model, "A1", { fillColor: color });
   }
 
   function createTestChart(chartType: string, mainCell: string, background?: Color) {

--- a/tests/figures/chart/gauge_chart_plugin.test.ts
+++ b/tests/figures/chart/gauge_chart_plugin.test.ts
@@ -12,8 +12,8 @@ import {
   createSheet,
   deleteSheet,
   redo,
-  selectCell,
   setCellContent,
+  setFormat,
   undo,
   updateChart,
 } from "../../test_helpers/commands_helpers";
@@ -573,12 +573,7 @@ describe("Chart design configuration", () => {
 
   test("displayed value respect dataRange format value", () => {
     setCellContent(model, "A1", "0.42");
-    selectCell(model, "A1");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: model.getters.getSelectedZones(),
-      format: "0.00%",
-    });
+    setFormat(model, "A1", "0.00%");
     createGaugeChart(model, defaultChart, "1");
     const chart = (model.getters.getChartRuntime("1") as GaugeChartRuntime)!.chartJsConfig;
     const displayedValue = chart.options!.valueLabel!.formatter!;

--- a/tests/figures/chart/scorecard_chart_component.test.ts
+++ b/tests/figures/chart/scorecard_chart_component.test.ts
@@ -12,11 +12,12 @@ import { MockCanvasRenderingContext2D } from "../../setup/canvas.mock";
 import {
   createScorecardChart,
   setCellContent,
+  setFormat,
   setStyle,
   updateChart,
 } from "../../test_helpers/commands_helpers";
 import { getCellContent } from "../../test_helpers/getters_helpers";
-import { target, toRangesData } from "../../test_helpers/helpers";
+import { toRangesData } from "../../test_helpers/helpers";
 
 let model: Model;
 let chartId: string;
@@ -193,11 +194,7 @@ describe("Scorecard charts computation", () => {
   test("Key value is displayed with the cell evaluated format", () => {
     createScorecardChart(model, { keyValue: "C1" }, chartId);
     setCellContent(model, "C1", "=A1");
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1"),
-      format: "0%",
-    });
+    setFormat(model, "A1", "0%");
     const chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.key?.text).toEqual("200%");
   });
@@ -208,11 +205,7 @@ describe("Scorecard charts computation", () => {
     let chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.baseline?.text).toEqual((0.12).toLocaleString());
 
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("B2"),
-      format: "[$$]#,##0.00",
-    });
+    setFormat(model, "B2", "[$$]#,##0.00");
     chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.baseline?.text).toEqual("$0.12");
   });
@@ -227,11 +220,7 @@ describe("Scorecard charts computation", () => {
 
   test("Baseline with lot of decimal isn't truncated if the cell has a format", () => {
     createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("B2"),
-      format: "[$$]#,####0.0000",
-    });
+    setFormat(model, "B2", "[$$]#,####0.0000");
     const chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.baseline?.text).toEqual("$0.1234");
   });
@@ -242,27 +231,19 @@ describe("Scorecard charts computation", () => {
       { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
       chartId
     );
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("B1"),
-      format: "[$$]#,####0.0000",
-    });
+    setFormat(model, "B2", "[$$]#,####0.0000");
     const chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.baseline?.text).toEqual("100%");
   });
 
   test("Key value and baseline are displayed with the cell style", () => {
     createScorecardChart(model, { keyValue: "A1", baseline: "A1" }, chartId);
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1"),
-      style: {
-        textColor: "#FF0000",
-        bold: true,
-        italic: true,
-        strikethrough: true,
-        underline: true,
-      },
+    setStyle(model, "A1", {
+      textColor: "#FF0000",
+      bold: true,
+      italic: true,
+      strikethrough: true,
+      underline: true,
     });
     const chartDesign = getChartDesign(model, chartId, sheetId);
     for (const style of [chartDesign.key?.style, chartDesign.baseline?.style]) {
@@ -293,12 +274,8 @@ describe("Scorecard charts computation", () => {
       { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },
       chartId
     );
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1"),
-      style: { bold: true },
-      format: "0.0",
-    });
+    setStyle(model, "A1", { bold: true });
+    setFormat(model, "A1", "0.0");
     const chartDesign = getChartDesign(model, chartId, sheetId);
     expect(chartDesign.baseline?.style.font.includes("bold")).toBeFalsy();
     expect(chartDesign.baseline?.text).toEqual("100%");
@@ -482,14 +459,10 @@ describe("Scorecard charts rendering", () => {
   });
 
   test("Key value and baseline are displayed with the cell style", () => {
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1"),
-      style: {
-        textColor: "#FF0000",
-        bold: true,
-        italic: true,
-      },
+    setStyle(model, "A1", {
+      textColor: "#FF0000",
+      bold: true,
+      italic: true,
     });
     createScorecardChart(model, { keyValue: "A1", baseline: "A1" }, chartId);
     renderScorecardChart(model, chartId, sheetId, canvas);
@@ -501,12 +474,8 @@ describe("Scorecard charts rendering", () => {
   });
 
   test("Baseline mode percentage don't inherit of the style of the cell", () => {
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A1"),
-      style: { bold: true },
-      format: "0.0",
-    });
+    setStyle(model, "A1", { bold: true });
+    setFormat(model, "A1", "0.0");
     createScorecardChart(
       model,
       { keyValue: "A1", baseline: "B1", baselineMode: "percentage" },

--- a/tests/formats/formatting_plugin.test.ts
+++ b/tests/formats/formatting_plugin.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../src/constants";
 import { arg, functionRegistry } from "../../src/functions";
 import { toString } from "../../src/functions/helpers";
-import { fontSizeInPixels, toCartesian, toZone } from "../../src/helpers";
+import { fontSizeInPixels, toCartesian } from "../../src/helpers";
 import { Model } from "../../src/model";
 import {
   Arg,
@@ -33,15 +33,15 @@ import {
   setAnchorCorner,
   setCellContent,
   setFormat,
-  setSelection,
   setStyle,
 } from "../test_helpers/commands_helpers";
 import { getCell, getCellContent, getEvaluatedCell } from "../test_helpers/getters_helpers";
+import { target } from "../test_helpers/helpers";
 
-function setDecimal(model: Model, step: SetDecimalStep) {
+function setDecimal(model: Model, targetXc: string, step: SetDecimalStep) {
   model.dispatch("SET_DECIMAL", {
     sheetId: model.getters.getActiveSheetId(),
-    target: model.getters.getSelectedZones(),
+    target: target(targetXc),
     step: step,
   });
 }
@@ -51,8 +51,7 @@ describe("formatting values (with formatters)", () => {
     const model = new Model();
     setCellContent(model, "A1", "3");
     expect(getCellContent(model, "A1")).toBe("3");
-    selectCell(model, "A1");
-    setFormat(model, "0.00%");
+    setFormat(model, "A1", "0.00%");
     expect(getCell(model, "A1")!.format).toBe("0.00%");
     expect(getCellContent(model, "A1")).toBe("300.00%");
   });
@@ -61,8 +60,7 @@ describe("formatting values (with formatters)", () => {
     const model = new Model();
     setCellContent(model, "A1", "3 14 2014");
     expect(getCellContent(model, "A1")).toBe("3 14 2014");
-    selectCell(model, "A1");
-    setFormat(model, "mm/dd/yyyy");
+    setFormat(model, "A1", "mm/dd/yyyy");
     expect(getCell(model, "A1")!.format).toBe("mm/dd/yyyy");
     expect(getCellContent(model, "A1")).toBe("03/14/2014");
   });
@@ -71,8 +69,7 @@ describe("formatting values (with formatters)", () => {
     const model = new Model();
     setCellContent(model, "A1", "1");
     expect(getCellContent(model, "A1")).toBe("1");
-    selectCell(model, "A1");
-    setFormat(model, "mm/dd/yyyy");
+    setFormat(model, "A1", "mm/dd/yyyy");
     expect(getCell(model, "A1")!.format).toBe("mm/dd/yyyy");
     expect(getCellContent(model, "A1")).toBe("12/31/1899");
   });
@@ -81,8 +78,7 @@ describe("formatting values (with formatters)", () => {
     const model = new Model();
     setCellContent(model, "A1", "1/1/2000");
     expect(getCellContent(model, "A1")).toBe("1/1/2000");
-    selectCell(model, "A1");
-    setFormat(model, "0.00%");
+    setFormat(model, "A1", "0.00%");
     expect(getCell(model, "A1")!.format).toBe("0.00%");
     expect(getCellContent(model, "A1")).toBe("3652600.00%");
   });
@@ -90,7 +86,7 @@ describe("formatting values (with formatters)", () => {
   test("can set a format to an empty cell", () => {
     const model = new Model();
     selectCell(model, "A1");
-    setFormat(model, "0.00%");
+    setFormat(model, "A1", "0.00%");
     expect(getCell(model, "A1")!.format).toBe("0.00%");
     expect(getCellContent(model, "A1")).toBe("");
     setCellContent(model, "A1", "0.431");
@@ -100,8 +96,7 @@ describe("formatting values (with formatters)", () => {
   test("can set the default format to a cell with value = 0", () => {
     const model = new Model();
     setCellContent(model, "A1", "0");
-    selectCell(model, "A1");
-    setFormat(model, "");
+    setFormat(model, "A1", "");
     expect(getCell(model, "A1")!.format).not.toBeDefined();
     expect(getCellContent(model, "A1")).toBe("0");
   });
@@ -109,36 +104,32 @@ describe("formatting values (with formatters)", () => {
   test("can clear a format in a non empty cell", () => {
     const model = new Model();
     setCellContent(model, "A1", "3");
-    selectCell(model, "A1");
-    setFormat(model, "0.00%");
+    setFormat(model, "A1", "0.00%");
     expect(getCell(model, "A1")!.format).toBeDefined();
     expect(getCellContent(model, "A1")).toBe("300.00%");
-    setFormat(model, "");
+    setFormat(model, "A1", "");
     expect(getCellContent(model, "A1")).toBe("3");
     expect(getCell(model, "A1")!.format).not.toBeDefined();
   });
 
   test("can clear a format in an empty cell", () => {
     const model = new Model();
-    selectCell(model, "A1");
-    setFormat(model, "0.00%");
+    setFormat(model, "A1", "0.00%");
     expect(getCell(model, "A1")!.format).toBe("0.00%");
-    setFormat(model, "");
+    setFormat(model, "A1", "");
     expect(getCell(model, "A1")).toBeUndefined();
   });
 
   test("setting an empty format in an empty cell does nothing", () => {
     const model = new Model();
-    selectCell(model, "A1");
-    setFormat(model, "");
+    setFormat(model, "A1", "");
     expect(getCell(model, "A1")).toBeUndefined();
   });
 
   test("does not format errors", () => {
     const model = new Model();
     setCellContent(model, "A1", "3");
-    selectCell(model, "A1");
-    setFormat(model, "0.00%");
+    setFormat(model, "A1", "0.00%");
     expect(getCellContent(model, "A1")).toBe("300.00%");
     setCellContent(model, "A1", "=A1");
     expect(getCellContent(model, "A1")).toBe("#CYCLE");
@@ -147,27 +138,22 @@ describe("formatting values (with formatters)", () => {
   test("Can set number format to text value", () => {
     const model = new Model();
     setCellContent(model, "A1", "Test");
-    selectCell(model, "A1");
-    setFormat(model, "0.00%");
+    setFormat(model, "A1", "0.00%");
     expect(getCellContent(model, "A1")).toBe("Test");
   });
 
   test("Can set date format to text value", () => {
     const model = new Model();
     setCellContent(model, "A1", "Test");
-    selectCell(model, "A1");
-    setFormat(model, "mm/dd/yyyy");
+    setFormat(model, "A1", "mm/dd/yyyy");
     expect(getCellContent(model, "A1")).toBe("Test");
   });
 
   test("Cannot set format in invalid sheet", () => {
     const model = new Model();
-    expect(
-      model.dispatch("SET_FORMATTING", {
-        sheetId: "invalid sheet Id",
-        target: [toZone("A1")],
-      })
-    ).toBeCancelledBecause(CommandResult.InvalidSheetId);
+    expect(setFormat(model, "A1", "", "invalid sheet Id")).toBeCancelledBecause(
+      CommandResult.InvalidSheetId
+    );
   });
 
   test("SET_DECIMAL considers the evaluated format to infer the decimal position", () => {
@@ -185,7 +171,7 @@ describe("formatting values (with formatters)", () => {
     const model = new Model();
     setCellContent(model, "A1", '=SET.DYN.FORMAT(5, "0.00")');
     selectCell(model, "A1");
-    setDecimal(model, 1);
+    setDecimal(model, "A1", 1);
     expect(getCell(model, "A1")?.format).toBe("0.000");
     functionRegistry.remove("SET.DYN.FORMAT");
   });
@@ -195,19 +181,19 @@ describe("formatting values (with formatters)", () => {
     setCellContent(model, "A1", "10.123456789123");
     expect(getEvaluatedCell(model, "A1")?.formattedValue).toEqual("10.12345679");
 
-    setDecimal(model, 1);
+    setDecimal(model, "A1", 1);
     expect(getCell(model, "A1")?.format).toBe("0." + "0".repeat(9));
     expect(getEvaluatedCell(model, "A1")?.formattedValue).toEqual("10.123456789");
 
-    setDecimal(model, -1);
+    setDecimal(model, "A1", -1);
     expect(getCell(model, "A1")?.format).toBe("0." + "0".repeat(8));
     expect(getEvaluatedCell(model, "A1")?.formattedValue).toEqual("10.12345679");
 
-    setDecimal(model, -1);
+    setDecimal(model, "A1", -1);
     expect(getCell(model, "A1")?.format).toBe("0." + "0".repeat(7));
     expect(getEvaluatedCell(model, "A1")?.formattedValue).toEqual("10.1234568");
 
-    setDecimal(model, 1);
+    setDecimal(model, "A1", 1);
     expect(getCell(model, "A1")?.format).toBe("0." + "0".repeat(8));
     expect(getEvaluatedCell(model, "A1")?.formattedValue).toEqual("10.12345679");
   });
@@ -235,7 +221,7 @@ describe("formatting values (when change decimal)", () => {
     setCellContent(model, "A1", "kikou");
     expect(getCellContent(model, "A1")).toBe("kikou");
     selectCell(model, "A1");
-    setDecimal(model, 1);
+    setDecimal(model, "A1", 1);
     expect(getCell(model, "A1")!.format).toBe(undefined);
     expect(getCellContent(model, "A1")).toBe("kikou");
   });
@@ -249,7 +235,7 @@ describe("formatting values (when change decimal)", () => {
       target: model.getters.getSelectedZones(),
     });
     expect(getCell(model, "A1")!.format).toBe("0%");
-    setDecimal(model, 1);
+    setDecimal(model, "A1", 1);
     expect(getCell(model, "A1")!.format).toBe("0%");
   });
 
@@ -269,26 +255,26 @@ describe("formatting values (when change decimal)", () => {
 
       setCellContent(model, "A1", "42");
       selectCell(model, "A1");
-      setFormat(model, oneDecimal);
-      setDecimal(model, 1);
+      setFormat(model, "A1", oneDecimal);
+      setDecimal(model, "A1", 1);
       expect(getCell(model, "A1")!.format).toBe(twoDecimal);
 
       setCellContent(model, "A2", "42");
       selectCell(model, "A2");
-      setFormat(model, oneDecimal);
-      setDecimal(model, -1);
+      setFormat(model, "A2", oneDecimal);
+      setDecimal(model, "A2", -1);
       expect(getCell(model, "A2")!.format).toBe(noneDecimal);
 
       setCellContent(model, "A3", "42");
       selectCell(model, "A3");
-      setFormat(model, noneDecimal);
-      setDecimal(model, 1);
+      setFormat(model, "A3", noneDecimal);
+      setDecimal(model, "A3", 1);
       expect(getCell(model, "A3")!.format).toBe(oneDecimal);
 
       setCellContent(model, "A4", "42");
       selectCell(model, "A4");
-      setFormat(model, noneDecimal);
-      setDecimal(model, -1);
+      setFormat(model, "A4", noneDecimal);
+      setDecimal(model, "A4", -1);
       expect(getCell(model, "A4")!.format).toBe(noneDecimal);
     }
   );
@@ -299,25 +285,25 @@ describe("formatting values (when change decimal)", () => {
     setCellContent(model, "A1", "123");
     expect(getCell(model, "A1")!.format).toBe(undefined);
     selectCell(model, "A1");
-    setDecimal(model, 1);
+    setDecimal(model, "A1", 1);
     expect(getCell(model, "A1")!.format).toBe("0.0");
 
     setCellContent(model, "A2", "456");
     expect(getCell(model, "A2")!.format).toBe(undefined);
     selectCell(model, "A2");
-    setDecimal(model, -1);
+    setDecimal(model, "A2", -1);
     expect(getCell(model, "A2")!.format).toBe("0");
 
     setCellContent(model, "B1", "123.456");
     expect(getCell(model, "B1")!.format).toBe(undefined);
     selectCell(model, "B1");
-    setDecimal(model, 1);
+    setDecimal(model, "B1", 1);
     expect(getCell(model, "B1")!.format).toBe("0.0000");
 
     setCellContent(model, "B2", "456.789");
     expect(getCell(model, "B2")!.format).toBe(undefined);
     selectCell(model, "B2");
-    setDecimal(model, -1);
+    setDecimal(model, "B2", -1);
     expect(getCell(model, "B2")!.format).toBe("0.00");
   });
 
@@ -327,35 +313,32 @@ describe("formatting values (when change decimal)", () => {
     const nineteenZerosA1 = "0.0000000000000000000";
     const twentyZerosA1 = "0.00000000000000000000";
     setCellContent(model, "A1", "123");
-    selectCell(model, "A1");
-    setFormat(model, nineteenZerosA1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
+    setFormat(model, "A1", nineteenZerosA1);
+    setDecimal(model, "A1", 1);
+    setDecimal(model, "A1", 1);
+    setDecimal(model, "A1", 1);
     expect(getCell(model, "A1")!.format).toBe(twentyZerosA1);
 
     const seventeenZerosB1 = "0.00000000000000000%";
     const twentyZerosB1 = "0.00000000000000000000%";
     setCellContent(model, "B1", "9%");
-    selectCell(model, "B1");
-    setFormat(model, seventeenZerosB1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
+    setFormat(model, "B1", seventeenZerosB1);
+    setDecimal(model, "B1", 1);
+    setDecimal(model, "B1", 1);
+    setDecimal(model, "B1", 1);
+    setDecimal(model, "B1", 1);
+    setDecimal(model, "B1", 1);
+    setDecimal(model, "B1", 1);
     expect(getCell(model, "B1")!.format).toBe(twentyZerosB1);
 
     const eighteenZerosC1 = "#,##0.000000000000000000";
     const twentyZerosC1 = "#,##0.00000000000000000000";
     setCellContent(model, "C1", "3456.789");
-    selectCell(model, "C1");
-    setFormat(model, eighteenZerosC1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
-    setDecimal(model, 1);
+    setFormat(model, "C1", eighteenZerosC1);
+    setDecimal(model, "C1", 1);
+    setDecimal(model, "C1", 1);
+    setDecimal(model, "C1", 1);
+    setDecimal(model, "C1", 1);
     expect(getCell(model, "C1")!.format).toBe(twentyZerosC1);
   });
 
@@ -365,8 +348,7 @@ describe("formatting values (when change decimal)", () => {
     // give values ​​with different formats
 
     setCellContent(model, "A2", "Hey Jude");
-    selectCell(model, "A2");
-    setFormat(model, "0.00%");
+    setFormat(model, "A2", "0.00%");
     expect(getCellContent(model, "A2")).toBe("Hey Jude");
 
     setCellContent(model, "A3", "12/12/2012");
@@ -383,7 +365,7 @@ describe("formatting values (when change decimal)", () => {
 
     // increase decimalFormat on the selection
 
-    setDecimal(model, 1);
+    setDecimal(model, "A1:C3", 1);
 
     expect(getCellContent(model, "A2")).toBe("Hey Jude");
     expect(getCellContent(model, "A3")).toBe("12/12/2012");
@@ -399,8 +381,7 @@ describe("formatting values (when change decimal)", () => {
     setCellContent(model, "A1", "100%");
     setCellContent(model, "B1", "$190.12");
     setCellContent(model, "C1", "$21");
-    setSelection(model, ["A1:C1"]);
-    setDecimal(model, 1);
+    setDecimal(model, "A1:C1", 1);
     expect(getCellContent(model, "A1")).toEqual("100.0%");
     expect(getCellContent(model, "B1")).toEqual("$190.120");
     expect(getCellContent(model, "C1")).toEqual("$21.0");
@@ -414,8 +395,8 @@ describe("formatting values (when change decimal)", () => {
     setCellContent(model, "A3", "100%");
     setCellContent(model, "B3", "$190.12");
     setCellContent(model, "C3", "$21");
-    setSelection(model, ["A1:C1", "A3:C3"]);
-    setDecimal(model, 1);
+    setDecimal(model, "A1:C1", 1);
+    setDecimal(model, "A3:C3", 1);
     expect(getCellContent(model, "A1")).toEqual("100.0%");
     expect(getCellContent(model, "B1")).toEqual("$190.120");
     expect(getCellContent(model, "C1")).toEqual("$21.0");
@@ -539,7 +520,7 @@ describe("Autoresize", () => {
     resizeRows(model, [0, 2], DEFAULT_CELL_HEIGHT + 30);
     setCellContent(model, "A1", "test");
     setCellContent(model, "A3", "test");
-    model.dispatch("SET_FORMATTING", { sheetId, target: [toZone("A3")], style: { fontSize: 24 } });
+    setStyle(model, "A3", { fontSize: 24 });
     model.dispatch("AUTORESIZE_ROWS", { sheetId, rows: [0, 2] });
     expect(model.getters.getRowSize(sheetId, 0)).toBe(DEFAULT_CELL_HEIGHT);
     expect(model.getters.getRowSize(sheetId, 2)).toBe(fontSizeInPixels(24) + vPadding);

--- a/tests/formats/more_formats_side_panel.test.ts
+++ b/tests/formats/more_formats_side_panel.test.ts
@@ -31,7 +31,7 @@ describe("more formats side panel component", () => {
 
   test("format is active when mounting panel", async () => {
     const model = new Model();
-    setFormat(model, "dddd d mmmm yyyy");
+    setFormat(model, "A1", "dddd d mmmm yyyy");
     await mountFormatPanel(model);
     const button = fixture.querySelector('div[data-name="Full week day and month"]');
     expect(fixture.querySelectorAll(".check-icon svg")).toHaveLength(1);

--- a/tests/functions/module_array.test.ts
+++ b/tests/functions/module_array.test.ts
@@ -7,7 +7,6 @@ import {
   evaluateCell,
   getRangeFormatsAsMatrix,
   getRangeValuesAsMatrix,
-  target,
 } from "../test_helpers/helpers";
 
 describe("ARRAY.CONSTRAIN function", () => {
@@ -1286,8 +1285,8 @@ describe("TRANSPOSE function", () => {
   test("Format is transposed", () => {
     const grid = { A1: "1", A2: "5" };
     const model = createModelFromGrid(grid);
-    setFormat(model, "0.00", target("A1"));
-    setFormat(model, "0.000", target("A2"));
+    setFormat(model, "A1", "0.00");
+    setFormat(model, "A2", "0.000");
     setCellContent(model, "D1", "=TRANSPOSE(A1:A2)");
     expect(getRangeFormatsAsMatrix(model, "D1:E1")).toEqual([["0.00", "0.000"]]);
   });

--- a/tests/functions/module_info.test.ts
+++ b/tests/functions/module_info.test.ts
@@ -1,7 +1,7 @@
 import { Model } from "../../src";
 import { createSheet, setCellContent, setFormat } from "../test_helpers/commands_helpers";
 import { getCellContent } from "../test_helpers/getters_helpers";
-import { createModelFromGrid, evaluateCell, setGrid, target } from "../test_helpers/helpers";
+import { createModelFromGrid, evaluateCell, setGrid } from "../test_helpers/helpers";
 
 describe("CELL formula", () => {
   test("CELL takes 2 arguments", () => {
@@ -86,8 +86,8 @@ describe("CELL formula", () => {
       B3: "9",
     };
     const model = new Model();
-    setFormat(model, "d/m/yyyy", target("B1"));
-    setFormat(model, "0.00", target("C1"));
+    setFormat(model, "B1", "d/m/yyyy");
+    setFormat(model, "C1", "0.00");
     setGrid(model, grid);
 
     expect(getCellContent(model, "A1")).toBe("d/m/yyyy");

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -65,13 +65,7 @@ import {
   getSelectionAnchorCellXc,
   getStyle,
 } from "../test_helpers/getters_helpers";
-import {
-  mockChart,
-  mountSpreadsheet,
-  nextTick,
-  target,
-  typeInComposerGrid,
-} from "../test_helpers/helpers";
+import { mockChart, mountSpreadsheet, nextTick, typeInComposerGrid } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 jest.mock("../../src/components/composer/content_editable_helper", () =>
   require("../__mocks__/content_editable_helper")
@@ -245,11 +239,7 @@ describe("Grid component", () => {
       { key: "F4", ctrlKey: false },
       { key: "Y", ctrlKey: true },
     ])("can undo/redo with keyboard CTRL+Z/%s", async (redoKey) => {
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
-        style: { fillColor: "red" },
-      });
+      setStyle(model, "A1", { fillColor: "red" });
       expect(getCell(model, "A1")!.style).toBeDefined();
       keyDown({ key: "z", ctrlKey: true });
       expect(getCell(model, "A1")).toBeUndefined();
@@ -259,11 +249,7 @@ describe("Grid component", () => {
     });
 
     test("can undo/redo with keyboard (uppercase version)", async () => {
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
-        style: { fillColor: "red" },
-      });
+      setStyle(model, "A1", { fillColor: "red" });
       expect(getCell(model, "A1")!.style).toBeDefined();
       keyDown({ key: "Z", ctrlKey: true });
       expect(getCell(model, "A1")).toBeUndefined();
@@ -366,11 +352,7 @@ describe("Grid component", () => {
     test("clean formatting with CTRL+SHIFT+<", async () => {
       const style = { fillColor: "red", align: "right" as Align, bold: true };
       setCellContent(model, "A1", "hello");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
-        style,
-      });
+      setStyle(model, "A1", style);
       expect(getCell(model, "A1")!.style).toEqual(style);
       document.activeElement!.dispatchEvent(
         new KeyboardEvent("keydown", { key: "<", ctrlKey: true, shiftKey: true, bubbles: true })
@@ -382,11 +364,7 @@ describe("Grid component", () => {
     test("clean formatting with CTRL+<", async () => {
       const style = { fillColor: "red", align: "right" as Align, bold: true };
       setCellContent(model, "A1", "hello");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 0, right: 0, top: 0, bottom: 0 }],
-        style,
-      });
+      setStyle(model, "A1", style);
       expect(getCell(model, "A1")!.style).toEqual(style);
       document.activeElement!.dispatchEvent(
         new KeyboardEvent("keydown", { key: "<", ctrlKey: true, bubbles: true })
@@ -843,11 +821,7 @@ describe("Grid component", () => {
     test("can paste format with mouse once", async () => {
       setCellContent(model, "B2", "b2");
       selectCell(model, "B2");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: target("B2"),
-        style: { bold: true },
-      });
+      setStyle(model, "B2", { bold: true });
       model.dispatch("ACTIVATE_PAINT_FORMAT", { persistent: false });
       gridMouseEvent(model, "mousedown", "C8");
       expect(getCell(model, "C8")).toBeUndefined();
@@ -863,11 +837,7 @@ describe("Grid component", () => {
     test("can keep the paint format mode persistently", async () => {
       setCellContent(model, "B2", "b2");
       selectCell(model, "B2");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: target("B2"),
-        style: { bold: true },
-      });
+      setStyle(model, "B2", { bold: true });
       model.dispatch("ACTIVATE_PAINT_FORMAT", { persistent: true });
       gridMouseEvent(model, "mousedown", "C8");
       expect(getCell(model, "C8")).toBeUndefined();
@@ -883,11 +853,7 @@ describe("Grid component", () => {
     test("can paste format with key", async () => {
       setCellContent(model, "B2", "b2");
       selectCell(model, "B2");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: target("B2"),
-        style: { bold: true },
-      });
+      setStyle(model, "B2", { bold: true });
       model.dispatch("ACTIVATE_PAINT_FORMAT", { persistent: false });
       expect(getCell(model, "C2")).toBeUndefined();
       keyDown({ key: "ArrowRight" });
@@ -897,11 +863,7 @@ describe("Grid component", () => {
     test("can exit the paint format mode via ESC key", async () => {
       setCellContent(model, "B2", "b2");
       selectCell(model, "B2");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: target("B2"),
-        style: { bold: true },
-      });
+      setStyle(model, "B2", { bold: true });
       model.dispatch("ACTIVATE_PAINT_FORMAT", { persistent: false });
       keyDown({ key: "Escape" });
       gridMouseEvent(model, "mousedown", "C8");
@@ -913,17 +875,9 @@ describe("Grid component", () => {
     test("in persistent mode, updating the style of origin cell won't change the copied style", async () => {
       setCellContent(model, "B2", "b2");
       selectCell(model, "B2");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: target("B2"),
-        style: { bold: true },
-      });
+      setStyle(model, "B2", { bold: true });
       model.dispatch("ACTIVATE_PAINT_FORMAT", { persistent: true });
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: target("B2"),
-        style: { bold: false },
-      });
+      setStyle(model, "B2", { bold: false });
 
       gridMouseEvent(model, "mousedown", "D8");
       expect(getCell(model, "D8")).toBeUndefined();
@@ -1456,11 +1410,7 @@ describe("Copy paste keyboard shortcut", () => {
   test("can paste as value with CTRL+SHIFT+V", async () => {
     const content = "things";
     setCellContent(model, "A1", content);
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { fillColor: "red", align: "right", bold: true },
-    });
+    setStyle(model, "A1", { fillColor: "red", align: "right", bold: true });
     selectCell(model, "A1");
     document.body.dispatchEvent(getClipboardEvent("copy", clipboardData));
     // Fake OS clipboard should have the same content

--- a/tests/model/core.test.ts
+++ b/tests/model/core.test.ts
@@ -16,7 +16,9 @@ import {
   setAnchorCorner,
   setCellContent,
   setCellFormat,
+  setFormat,
   setSelection,
+  setStyle,
   setZoneBorders,
   undo,
 } from "../test_helpers/commands_helpers";
@@ -210,30 +212,17 @@ describe("core", () => {
       const model = new Model();
       setCellContent(model, "A1", "0");
       selectCell(model, "A1");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: model.getters.getSelectedZones(),
-        format: "0.00000",
-      });
+      setFormat(model, "A1", "0.00000");
       expect(getCellContent(model, "A1")).toBe("0.00000");
       setCellContent(model, "A2", "0");
-      selectCell(model, "A2");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: model.getters.getSelectedZones(),
-        format: "0.00%",
-      });
+      setFormat(model, "A2", "0.00%");
       expect(getCellContent(model, "A2")).toBe("0.00%");
     });
 
     test("evaluate properly a cell with a style just recently applied", () => {
       const model = new Model();
       setCellContent(model, "A1", "=sum(A2) + 1");
-      model.dispatch("SET_FORMATTING", {
-        sheetId: model.getters.getActiveSheetId(),
-        target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
-        style: { bold: true },
-      });
+      setStyle(model, "A1", { bold: true });
       expect(getCellContent(model, "A1")).toEqual("1");
     });
 
@@ -597,12 +586,7 @@ describe("history", () => {
   test("can delete a cell with a style", () => {
     const model = new Model();
     setCellContent(model, "A1", "3");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
-      style: { bold: true },
-    });
-
+    setStyle(model, "A1", { bold: true });
     expect(getCellContent(model, "A1")).toBe("3");
 
     model.dispatch("DELETE_CONTENT", {
@@ -629,11 +613,7 @@ describe("history", () => {
   test("can delete a cell with a format", () => {
     const model = new Model();
     setCellContent(model, "A1", "3");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [{ left: 0, top: 0, right: 0, bottom: 0 }],
-      format: "#,##0.00",
-    });
+    setFormat(model, "A1", "#,##0.00");
 
     expect(getCellContent(model, "A1")).toBe("3.00");
 

--- a/tests/remove_duplicates/remove_duplicates_plugin.test.ts
+++ b/tests/remove_duplicates/remove_duplicates_plugin.test.ts
@@ -1,7 +1,7 @@
 import { CommandResult } from "../../src";
 import { toZone } from "../../src/helpers";
 import { getCell, getEvaluatedCell } from "../test_helpers";
-import { merge, selectCell, setFormat, setSelection } from "../test_helpers/commands_helpers";
+import { merge, setFormat, setSelection } from "../test_helpers/commands_helpers";
 import {
   createModelFromGrid,
   getRangeFormatsAsMatrix,
@@ -100,11 +100,8 @@ describe("remove duplicates", () => {
       B4: "42",
     };
     const model = createModelFromGrid(grid);
-    selectCell(model, "B2");
-    setFormat(model, "0.00%");
-
-    selectCell(model, "B4");
-    setFormat(model, "#,##0[$€]");
+    setFormat(model, "B2", "0.00%");
+    setFormat(model, "B4", "#,##0[$€]");
 
     expect(getRangeValuesAsMatrix(model, "B2:B4")).toEqual([[42], [42], [42]]);
     expect(getRangeFormatsAsMatrix(model, "B2:B4")).toEqual([["0.00%"], [""], ["#,##0[$€]"]]);

--- a/tests/renderer_plugin.test.ts
+++ b/tests/renderer_plugin.test.ts
@@ -276,11 +276,7 @@ describe("renderer", () => {
     const model = new Model();
 
     setCellContent(model, "A1", "1");
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { fontSize: 36 },
-    });
+    setStyle(model, "A1", { fontSize: 36 });
 
     let textAligns: string[] = [];
     let ctx = new MockGridRenderingContext(model, 1000, 1000, {
@@ -345,11 +341,8 @@ describe("renderer", () => {
 
   test("fillstyle of cell will be rendered", () => {
     const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 3 }] });
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1")],
-      style: { fillColor: "#DC6CDF" },
-    });
+
+    setStyle(model, "A1", { fillColor: "#DC6CDF" });
 
     let fillStyle: any[] = [];
     let fillStyleColor1Called = false;
@@ -383,23 +376,14 @@ describe("renderer", () => {
     expect(fillStyle).toEqual([{ color: "#DC6CDF", h: 23, w: 96, x: 0, y: 0 }]);
 
     fillStyle = [];
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1")],
-      style: { fillColor: "#DC6CDE" },
-    });
+    setStyle(model, "A1", { fillColor: "#DC6CDE" });
     model.drawGrid(ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDE", h: 23, w: 96, x: 0, y: 0 }]);
   });
 
   test("fillstyle of merge will be rendered for all cells in merge", () => {
     const model = new Model({ sheets: [{ colNumber: 1, rowNumber: 3 }] });
-    const sheetId = model.getters.getActiveSheetId();
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: [toZone("A1")],
-      style: { fillColor: "#DC6CDF" },
-    });
+    setStyle(model, "A1", { fillColor: "#DC6CDF" });
     merge(model, "A1:A3");
 
     let fillStyle: any[] = [];
@@ -434,11 +418,7 @@ describe("renderer", () => {
     expect(fillStyle).toEqual([{ color: "#DC6CDF", h: 3 * 23, w: 96, x: 0, y: 0 }]);
 
     fillStyle = [];
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: [toZone("A1")],
-      style: { fillColor: "#DC6CDE" },
-    });
+    setStyle(model, "A1", { fillColor: "#DC6CDE" });
     model.drawGrid(ctx);
     expect(fillStyle).toEqual([{ color: "#DC6CDE", h: 3 * 23, w: 96, x: 0, y: 0 }]);
   });
@@ -710,11 +690,8 @@ describe("renderer", () => {
 
   test("functions with centered content are aligned to the left", () => {
     const model = new Model();
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { align: "center" },
-    });
+    setStyle(model, "A1", { align: "center" });
+
     setCellContent(model, "A1", "=SUM(1,2)");
     model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
     let textAligns: string[] = [];
@@ -1561,31 +1538,19 @@ describe("renderer", () => {
 
     // vertical top point
     let verticalStartPoints: any[] = [];
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { verticalAlign: "top" },
-    });
+    setStyle(model, "A1", { verticalAlign: "top" });
     model.drawGrid(ctx);
     expect(verticalStartPoints[0]).toEqual(5);
 
     // vertical middle point
     verticalStartPoints = [];
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { verticalAlign: "middle" },
-    });
+    setStyle(model, "A1", { verticalAlign: "middle" });
     model.drawGrid(ctx);
     expect(verticalStartPoints[0]).toEqual(18);
 
     // vertical bottom point
     verticalStartPoints = [];
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { verticalAlign: "bottom" },
-    });
+    setStyle(model, "A1", { verticalAlign: "bottom" });
     model.drawGrid(ctx);
     expect(verticalStartPoints[0]).toEqual(30);
   });
@@ -1616,39 +1581,23 @@ describe("renderer", () => {
       },
     });
 
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { wrapping: "wrap" },
-    });
+    setStyle(model, "A1", { wrapping: "wrap" });
 
     // with verticalAlign top
     let verticalStartPoints: any[] = [];
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { verticalAlign: "top" },
-    });
+    setStyle(model, "A1", { verticalAlign: "top" });
     model.drawGrid(ctx);
     expect(verticalStartPoints[0]).toEqual(5);
 
     // with verticalAlign middle
     verticalStartPoints = [];
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { verticalAlign: "middle" },
-    });
+    setStyle(model, "A1", { verticalAlign: "middle" });
     model.drawGrid(ctx);
     expect(verticalStartPoints[0]).toEqual(5);
 
     // with verticalAlign bottom
     verticalStartPoints = [];
-    model.dispatch("SET_FORMATTING", {
-      sheetId: model.getters.getActiveSheetId(),
-      target: target("A1"),
-      style: { verticalAlign: "bottom" },
-    });
+    setStyle(model, "A1", { verticalAlign: "bottom" });
     model.drawGrid(ctx);
     expect(verticalStartPoints[0]).toEqual(5);
   });

--- a/tests/settings/settings_plugin.test.ts
+++ b/tests/settings/settings_plugin.test.ts
@@ -10,7 +10,6 @@ import {
 } from "../test_helpers/commands_helpers";
 import { CUSTOM_LOCALE, FR_LOCALE } from "../test_helpers/constants";
 import { getCell, getCellContent } from "../test_helpers/getters_helpers";
-import { target } from "../test_helpers/helpers";
 
 describe("Settings plugin", () => {
   let model: Model;
@@ -66,7 +65,7 @@ describe("Settings plugin", () => {
 
     test("locale thousand separator", () => {
       setCellContent(model, "A1", "1000000");
-      setFormat(model, "#,##0", target("A1"));
+      setFormat(model, "A1", "#,##0");
       expect(getCellContent(model, "A1")).toEqual("1,000,000");
 
       const locale = { ...CUSTOM_LOCALE, thousandsSeparator: "¤" };
@@ -76,7 +75,7 @@ describe("Settings plugin", () => {
 
     test("locale decimal separator", () => {
       setCellContent(model, "A1", "9.89");
-      setFormat(model, "#,##0.00", target("A1"));
+      setFormat(model, "A1", "#,##0.00");
       expect(getCellContent(model, "A1")).toEqual("9.89");
 
       const locale = { ...CUSTOM_LOCALE, decimalSeparator: "♥" };
@@ -86,7 +85,7 @@ describe("Settings plugin", () => {
 
     test("locale thousand separator", () => {
       setCellContent(model, "A1", "1000000");
-      setFormat(model, "#,##0", target("A1"));
+      setFormat(model, "A1", "#,##0");
       expect(getCellContent(model, "A1")).toEqual("1,000,000");
 
       const locale = { ...CUSTOM_LOCALE, thousandsSeparator: "¤" };
@@ -96,7 +95,7 @@ describe("Settings plugin", () => {
 
     test("locale decimal separator", () => {
       setCellContent(model, "A1", "9.89");
-      setFormat(model, "#,##0.00", target("A1"));
+      setFormat(model, "A1", "#,##0.00");
       expect(getCellContent(model, "A1")).toEqual("9.89");
 
       const locale = { ...CUSTOM_LOCALE, decimalSeparator: "♥" };
@@ -105,9 +104,9 @@ describe("Settings plugin", () => {
     });
 
     test("Changing the locale changes the format of the cells that are formatted with the locale date(time) format", () => {
-      setFormat(model, DEFAULT_LOCALE.dateFormat, target("A1"));
-      setFormat(model, DEFAULT_LOCALE.timeFormat, target("A2"));
-      setFormat(model, getDateTimeFormat(DEFAULT_LOCALE), target("A3"));
+      setFormat(model, "A1", DEFAULT_LOCALE.dateFormat);
+      setFormat(model, "A2", DEFAULT_LOCALE.timeFormat);
+      setFormat(model, "A3", getDateTimeFormat(DEFAULT_LOCALE));
 
       const locale = { ...CUSTOM_LOCALE, dateFormat: "yyyy/mm/dd", timeFormat: "hh:mm" };
       updateLocale(model, locale);

--- a/tests/sheet/sheet_manipulation_plugin.test.ts
+++ b/tests/sheet/sheet_manipulation_plugin.test.ts
@@ -23,6 +23,7 @@ import {
   selectCell,
   setCellContent,
   setSelection,
+  setStyle,
   setZoneBorders,
   undo,
   unfreezeColumns,
@@ -40,7 +41,6 @@ import {
   getCellsObject,
   getMergeCellMap,
   makeTestFixture,
-  target,
   testUndoRedo,
 } from "../test_helpers/helpers";
 let model: Model;
@@ -1555,12 +1555,7 @@ describe("Delete cell", () => {
 
   test("Undo/redo is correctly supported", () => {
     setCellContent(model, "A2", "=A3");
-    const sheetId = model.getters.getActiveSheetId();
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A3"),
-      style: { fillColor: "orange" },
-    });
+    setStyle(model, "A3", { fillColor: "orange" });
     testUndoRedo(model, expect, "DELETE_CELL", { zone: toZone("A1"), dimension: "ROW" });
   });
 
@@ -1653,12 +1648,7 @@ describe("Insert cell", () => {
 
   test("Undo/redo is correctly supported", () => {
     setCellContent(model, "A2", "=A3");
-    const sheetId = model.getters.getActiveSheetId();
-    model.dispatch("SET_FORMATTING", {
-      sheetId,
-      target: target("A3"),
-      style: { fillColor: "orange" },
-    });
+    setStyle(model, "A3", { fillColor: "orange" });
     testUndoRedo(model, expect, "INSERT_CELL", { zone: toZone("A1"), dimension: "ROW" });
   });
 });

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -42,7 +42,7 @@ import {
   updateFilter,
 } from "../test_helpers/commands_helpers";
 import { getActiveSheetFullScrollInfo } from "../test_helpers/getters_helpers";
-import { getPlugin, target } from "../test_helpers/helpers";
+import { getPlugin } from "../test_helpers/helpers";
 
 let model: Model;
 
@@ -856,7 +856,7 @@ describe("Viewport of Simple sheet", () => {
     setCellContent(model, "B1", "5");
     expect(model.getters.getActiveMainViewport()).not.toEqual(oldViewport);
     oldViewport = { ...model.getters.getActiveMainViewport() };
-    setFormat(model, "0.00%", target("A5"));
+    setFormat(model, "A5", "0.00%");
     expect(model.getters.getActiveMainViewport()).not.toEqual(oldViewport);
   });
 

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -915,13 +915,13 @@ export function deleteFilter(
 
 export function setFormat(
   model: Model,
+  targetXc: string,
   format: string,
-  target = model.getters.getSelectedZones(),
   sheetId = model.getters.getActiveSheetId()
 ) {
-  model.dispatch("SET_FORMATTING", {
+  return model.dispatch("SET_FORMATTING", {
     sheetId,
-    target,
+    target: target(targetXc),
     format,
   });
 }

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -273,7 +273,7 @@ export function setGrid(model: Model, grid: GridDescr) {
 export function setGridFormat(model: Model, grid: GridFormatDescr) {
   for (const [xc, format] of Object.entries(grid)) {
     if (format === undefined) continue;
-    setFormat(model, format, target(xc));
+    setFormat(model, xc, format);
   }
 }
 

--- a/tests/xlsx/xlsx_import_export.test.ts
+++ b/tests/xlsx/xlsx_import_export.test.ts
@@ -22,9 +22,11 @@ import {
   resizeColumns,
   resizeRows,
   setCellContent,
+  setFormat,
+  setStyle,
 } from "../test_helpers/commands_helpers";
 import { getBorder, getCell, getEvaluatedCell } from "../test_helpers/getters_helpers";
-import { target, toRangesData } from "../test_helpers/helpers";
+import { toRangesData } from "../test_helpers/helpers";
 
 /**
  * Testing to export a model to xlsx then import this xlsx
@@ -120,7 +122,7 @@ describe("Export data to xlsx then import it", () => {
     { fillColor: "#151515" },
     { wrapping: "wrap" as Wrapping },
   ])("Cell style %s", (style: Style) => {
-    model.dispatch("SET_FORMATTING", { sheetId, target: target("A1"), style });
+    setStyle(model, "A1", style);
     const importedModel = exportToXlsxThenImport(model);
     expect(getCell(importedModel, "A1")!.style).toMatchObject(style);
   });
@@ -141,7 +143,7 @@ describe("Export data to xlsx then import it", () => {
   test.each(["0.00%", "#,##0.00", "m/d/yyyy", "m/d/yyyy hh:mm:ss", "#,##0.00 [$€]"])(
     "Cell format %s",
     (format: string) => {
-      model.dispatch("SET_FORMATTING", { sheetId, target: target("A1"), format });
+      setFormat(model, "A1", format);
       const importedModel = exportToXlsxThenImport(model);
       expect(importedModel.getters.getEvaluatedCell({ sheetId, col: 0, row: 0 }).format).toEqual(
         format


### PR DESCRIPTION
The command helpers were added but the existing tests were not adapted. Note that we still call the raw command in some tests where we use both payloads.

This revision also changes the signature of `setFormat` to match the other command helpers.

Task: 3650109

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo