### PR TITLE
[IMP] evaluation: `evaluateFormula` no longer throws

### DIFF
--- a/src/plugins/ui/evaluation_conditional_format.ts
+++ b/src/plugins/ui/evaluation_conditional_format.ts
@@ -125,41 +125,37 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
     this.computedIcons[activeSheetId] = {};
     const computedStyle = this.computedStyles[activeSheetId];
     for (let cf of this.getters.getConditionalFormats(activeSheetId).reverse()) {
-      try {
-        switch (cf.rule.type) {
-          case "ColorScaleRule":
-            for (let range of cf.ranges) {
-              this.applyColorScale(range, cf.rule);
-            }
-            break;
-          case "IconSetRule":
-            for (let range of cf.ranges) {
-              this.applyIcon(range, cf.rule);
-            }
-            break;
-          default:
-            for (let ref of cf.ranges) {
-              const zone: Zone = this.getters.getRangeFromSheetXC(activeSheetId, ref).zone;
-              for (let row = zone.top; row <= zone.bottom; row++) {
-                for (let col = zone.left; col <= zone.right; col++) {
-                  const pr: (cell: Cell | undefined, rule: CellIsRule) => boolean =
-                    this.rulePredicate[cf.rule.type];
-                  let cell = this.getters.getCell(activeSheetId, col, row);
-                  if (pr && pr(cell, cf.rule)) {
-                    if (!computedStyle[col]) computedStyle[col] = [];
-                    // we must combine all the properties of all the CF rules applied to the given cell
-                    computedStyle[col][row] = Object.assign(
-                      computedStyle[col]?.[row] || {},
-                      cf.rule.style
-                    );
-                  }
+      switch (cf.rule.type) {
+        case "ColorScaleRule":
+          for (let range of cf.ranges) {
+            this.applyColorScale(range, cf.rule);
+          }
+          break;
+        case "IconSetRule":
+          for (let range of cf.ranges) {
+            this.applyIcon(range, cf.rule);
+          }
+          break;
+        default:
+          for (let ref of cf.ranges) {
+            const zone: Zone = this.getters.getRangeFromSheetXC(activeSheetId, ref).zone;
+            for (let row = zone.top; row <= zone.bottom; row++) {
+              for (let col = zone.left; col <= zone.right; col++) {
+                const pr: (cell: Cell | undefined, rule: CellIsRule) => boolean =
+                  this.rulePredicate[cf.rule.type];
+                let cell = this.getters.getCell(activeSheetId, col, row);
+                if (pr && pr(cell, cf.rule)) {
+                  if (!computedStyle[col]) computedStyle[col] = [];
+                  // we must combine all the properties of all the CF rules applied to the given cell
+                  computedStyle[col][row] = Object.assign(
+                    computedStyle[col]?.[row] || {},
+                    cf.rule.style
+                  );
                 }
               }
             }
-            break;
-        }
-      } catch (_) {
-        // we don't care about the errors within the evaluation of a rule
+          }
+          break;
       }
     }
   }
@@ -188,7 +184,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
         return percentile(rangeValues, Number(threshold.value) / 100, true);
       case "formula":
         const value = threshold.value && this.getters.evaluateFormula(threshold.value);
-        return !(value instanceof Promise) ? value : null;
+        return typeof value === "number" ? value : null;
       default:
         return null;
     }

--- a/tests/formulas/compiler.test.ts
+++ b/tests/formulas/compiler.test.ts
@@ -4,6 +4,7 @@ import { compile } from "../../src/formulas/index";
 import { functionRegistry } from "../../src/functions";
 import { createRange } from "../../src/helpers";
 import { ArgType, CompiledFormula } from "../../src/types";
+import { getCellError, setCellContent } from "../test_helpers";
 import { evaluateCell, evaluateCellFormat, restoreDefaultFunctions } from "../test_helpers/helpers";
 
 function compiledBaseFunction(formula: string): CompiledFormula {
@@ -283,47 +284,61 @@ describe("compile functions", () => {
 
       const m = new Model();
 
-      expect(() => m.getters.evaluateFormula("=?ANYEXPECTED(A1:A2)")).toThrowError(
+      setCellContent(m, "B1", "=?ANYEXPECTED(A1:A2)");
+      setCellContent(m, "B2", "=BOOLEANEXPECTED(A1:A2)");
+      setCellContent(m, "B3", "=DATEEXPECTED(A1:A2)");
+      setCellContent(m, "B4", "=NUMBEREXPECTED(A1:A2)");
+      setCellContent(m, "B5", "=STRINGEXPECTED(A1:A2)");
+      setCellContent(m, "B6", "=ANYEXPECTED(A1:A$2)");
+      setCellContent(m, "B7", "=ANYEXPECTED(sheet2!A1:A$2)");
+      setCellContent(m, "B8", "=A2:A3");
+      setCellContent(m, "B9", "=+A2:A3");
+      setCellContent(m, "B10", "=A1+A2:A3");
+      setCellContent(m, "B11", "=-A2:A3");
+      setCellContent(m, "B12", "=A1-A2:A3");
+      setCellContent(m, "B13", "=A1+A4*A5:A6-A2");
+      setCellContent(m, "B14", "=ANYEXPECTED(A1:A1)");
+
+      expect(getCellError(m, "B1")).toBe(
         "Function ANYEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
       );
-      expect(() => m.getters.evaluateFormula("=BOOLEANEXPECTED(A1:A2)")).toThrowError(
+      expect(getCellError(m, "B2")).toBe(
         "Function BOOLEANEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
       );
-      expect(() => m.getters.evaluateFormula("=DATEEXPECTED(A1:A2)")).toThrowError(
+      expect(getCellError(m, "B3")).toBe(
         "Function DATEEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
       );
-      expect(() => m.getters.evaluateFormula("=NUMBEREXPECTED(A1:A2)")).toThrowError(
+      expect(getCellError(m, "B4")).toBe(
         "Function NUMBEREXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
       );
-      expect(() => m.getters.evaluateFormula("=STRINGEXPECTED(A1:A2)")).toThrowError(
+      expect(getCellError(m, "B5")).toBe(
         "Function STRINGEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
       );
-
-      expect(() => m.getters.evaluateFormula("=ANYEXPECTED(A1:A$2)")).toThrowError(
+      expect(getCellError(m, "B6")).toBe(
         "Function ANYEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
       );
-      expect(() => m.getters.evaluateFormula("=ANYEXPECTED(sheet2!A1:A$2)")).toThrowError(
+      expect(getCellError(m, "B7")).toBe(
         "Function ANYEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
       );
-      expect(() => m.getters.evaluateFormula("=A2:A3")).toThrowError(
+      expect(getCellError(m, "B8")).toBe(
         "Function EQ expects its parameters to be single values or single cell references, not ranges."
       );
-      expect(() => m.getters.evaluateFormula("=+A2:A3")).toThrowError(
+      expect(getCellError(m, "B9")).toBe(
         "Function UPLUS expects its parameters to be single values or single cell references, not ranges."
       );
-      expect(() => m.getters.evaluateFormula("=A1+A2:A3")).toThrowError(
+      expect(getCellError(m, "B10")).toBe(
         "Function ADD expects its parameters to be single values or single cell references, not ranges."
       );
-      expect(() => m.getters.evaluateFormula("=-A2:A3")).toThrowError(
+      expect(getCellError(m, "B11")).toBe(
         "Function UMINUS expects its parameters to be single values or single cell references, not ranges."
       );
-      expect(() => m.getters.evaluateFormula("=A1-A2:A3")).toThrowError(
+      expect(getCellError(m, "B12")).toBe(
         "Function MINUS expects its parameters to be single values or single cell references, not ranges."
       );
-      expect(() => m.getters.evaluateFormula("=A1+A4*A5:A6-A2")).toThrowError(
+      expect(getCellError(m, "B13")).toBe(
         "Function MULTIPLY expects its parameters to be single values or single cell references, not ranges."
       );
-      expect(() => m.getters.evaluateFormula("=ANYEXPECTED(A1:A1)")).not.toThrow();
+      expect(getCellError(m, "B14")).toBeUndefined();
     });
   });
 

--- a/tests/functions/module_lookup.test.ts
+++ b/tests/functions/module_lookup.test.ts
@@ -12,8 +12,8 @@ describe("COLUMN formula", () => {
   test("functional test without grid context", () => {
     const model = new Model();
     setCellContent(model, "A1", "kikoulol");
-    expect(() => model.getters.evaluateFormula("=COLUMN()")).toThrow();
-    expect(() => model.getters.evaluateFormula("=COLUMN(A1)")).not.toThrow();
+    expect(model.getters.evaluateFormula("=COLUMN()")).toBe("#ERROR");
+    expect(model.getters.evaluateFormula("=COLUMN(A1)")).toBe(1);
   });
 
   test("functional tests on cell arguments", () => {
@@ -330,8 +330,8 @@ describe("ROW formula", () => {
   test("functional test without grid context", () => {
     const model = new Model();
     setCellContent(model, "A1", "kikoulol");
-    expect(() => model.getters.evaluateFormula("=ROW()")).toThrow();
-    expect(() => model.getters.evaluateFormula("=ROW(A1)")).not.toThrow();
+    expect(model.getters.evaluateFormula("=ROW()")).toBe("#ERROR");
+    expect(model.getters.evaluateFormula("=ROW(A1)")).toBe(1);
   });
 
   test("functional tests on cell arguments", () => {

--- a/tests/plugins/evaluation.test.ts
+++ b/tests/plugins/evaluation.test.ts
@@ -360,11 +360,9 @@ describe("evaluateCells", () => {
     expect(evaluateCell("A1", { A1: "=IF(A2<>0,1+1,sum(A2,A3))", A2: "0", A3: "10" })).toBe(10);
   });
 
-  test("evaluate formula throws when we pass an invalid formula", () => {
+  test("evaluate formula returns the cell error value when we pass an invalid formula", () => {
     let model = new Model();
-    expect(() => {
-      model.getters.evaluateFormula("=min(abc)");
-    }).toThrow();
+    expect(model.getters.evaluateFormula("=min(abc)")).toBe("#ERROR");
   });
 
   test("various expressions with boolean", () => {
@@ -1075,19 +1073,18 @@ describe("evaluate formula getter", () => {
     expect(model.getters.evaluateFormula("=Sheet2!A1")).toBe(11);
   });
 
-  // i think these formulas should throw
   test("in a not existing sheet", () => {
-    expect(() => model.getters.evaluateFormula("=Sheet99!A1")).toThrow();
+    expect(model.getters.evaluateFormula("=Sheet99!A1")).toBe("#ERROR");
   });
 
   test("evaluate a cell in error", () => {
     setCellContent(model, "A1", "=mqsdlkjfqsdf(((--");
-    expect(() => model.getters.evaluateFormula("=A1")).toThrow();
+    expect(model.getters.evaluateFormula("=A1")).toBe("#NAME?");
   });
 
   test("evaluate an invalid formula", () => {
     setCellContent(model, "A1", "=min(abc)");
-    expect(() => model.getters.evaluateFormula("=A1")).toThrow();
+    expect(model.getters.evaluateFormula("=A1")).toBe("#BAD_EXPR");
   });
 
   test("EVALUATE_CELLS with no argument re-evaluate all the cells", () => {

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -465,12 +465,12 @@ describe("Test XLSX export", () => {
               {
                 id: "14",
                 ranges: ["A1:A5"],
-                rule: { type: "CellIsRule", operator: "IsEmpty", style },
+                rule: { type: "CellIsRule", operator: "IsEmpty", values: [], style },
               },
               {
                 id: "15",
                 ranges: ["A1:A5"],
-                rule: { type: "CellIsRule", operator: "IsNotEmpty", style },
+                rule: { type: "CellIsRule", operator: "IsNotEmpty", values: [], style },
               },
               {
                 id: "16",


### PR DESCRIPTION
The getter `evaluateFormula` required to be wrapped in a try/catch statement to handle the evaluation errors but as this is quite error prone, we decided to change it to no longer throw. The getter will instead the value of the error that was previously thrown.

Task: 3576149

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo