### PR TITLE
Master export header groups adrm

### DIFF
--- a/src/plugins/core/header_visibility.ts
+++ b/src/plugins/core/header_visibility.ts
@@ -207,7 +207,7 @@ export class HeaderVisibilityPlugin extends CorePlugin {
           if (sheet.rows[row] === undefined) {
             sheet.rows[row] = {};
           }
-          sheet.rows[row].isHidden = this.hiddenHeaders[sheet.id]["ROW"][row];
+          sheet.rows[row].isHidden ||= this.hiddenHeaders[sheet.id]["ROW"][row];
         }
       }
 
@@ -219,7 +219,7 @@ export class HeaderVisibilityPlugin extends CorePlugin {
           if (sheet.cols[col] === undefined) {
             sheet.cols[col] = {};
           }
-          sheet.cols[col].isHidden = this.hiddenHeaders[sheet.id]["COL"][col];
+          sheet.cols[col].isHidden ||= this.hiddenHeaders[sheet.id]["COL"][col];
         }
       }
     }

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -76,11 +76,18 @@ export interface ExcelCellData extends CellData {
   isFormula: Boolean;
   computedFormat?: Format;
 }
-export interface ExcelSheetData extends Omit<SheetData, "figureTables"> {
+export interface ExcelSheetData extends Omit<SheetData, "figureTables" | "cols" | "rows"> {
   cells: { [key: string]: ExcelCellData | undefined };
   charts: FigureData<ExcelChartDefinition>[];
   images: FigureData<Image>[];
   filterTables: ExcelFilterTableData[];
+  cols: { [key: number]: ExcelHeaderData };
+  rows: { [key: number]: ExcelHeaderData };
+}
+
+export interface ExcelHeaderData extends HeaderData {
+  outlineLevel?: number;
+  collapsed?: boolean;
 }
 
 export interface FilterTableData {

--- a/src/types/xlsx.ts
+++ b/src/types/xlsx.ts
@@ -34,9 +34,11 @@ import { ExcelFigureSize } from "./figure";
  *  - images (XLSXImageFile): §20.2.2.5 (pic)
  *  - merge (string): §18.3.1.55 (mergeCell)
  *  - number format (XLSXNumFormat) : §18.8.30 (numFmt)
+ *  - outline properties (XLSXOutlineProperties): §18.3.1.31 (outlinePr)
  *  - rows (XLSXRow): §18.3.1.73 (row)
  *  - sheet (XLSXWorksheet): §18.3.1.99 (worksheet)
  *  - sheet format (XLSXSheetFormat): §18.3.1.81 (sheetFormatPr)
+ *  - sheet properties (XLSXSheetProperties): §18.3.1.82 (sheetPr)
  *  - sheet view (XLSXSheetView): §18.3.1.87 (sheetFormatPr)
  *  - sheet workbook info (XLSXSheetWorkbookInfo): §18.2.19 (sheet)
  *  - style, for cell (XLSXStyle): §18.8.45 (xf)
@@ -219,6 +221,7 @@ export interface XLSXWorksheet {
   isVisible: boolean;
   sheetViews: XLSXSheetView[];
   sheetFormat?: XLSXSheetFormat;
+  sheetProperties?: XLSXSheetProperties;
   cols: XLSXColumn[];
   rows: XLSXRow[];
   cfs: XLSXConditionalFormat[];
@@ -251,6 +254,8 @@ export interface XLSXColumn {
   bestFit?: boolean;
   hidden?: boolean;
   styleIndex?: number;
+  outlineLevel?: number;
+  collapsed?: boolean;
 }
 export interface XLSXRow {
   index: number;
@@ -259,6 +264,8 @@ export interface XLSXRow {
   hidden?: boolean;
   cells: XLSXCell[];
   styleIndex?: number;
+  outlineLevel?: number;
+  collapsed?: boolean;
 }
 
 export interface XLSXFormula {
@@ -621,4 +628,13 @@ export interface XLSXSheetWorkbookInfo {
   sheetId: string;
   sheetName: string;
   state: XLSXSheetState;
+}
+
+export interface XLSXSheetProperties {
+  outlinePr?: XLSXOutlineProperties;
+}
+
+export interface XLSXOutlineProperties {
+  summaryBelow: boolean;
+  summaryRight: boolean;
 }

--- a/src/xlsx/extraction/sheet_extractor.ts
+++ b/src/xlsx/extraction/sheet_extractor.ts
@@ -7,8 +7,10 @@ import {
   XLSXFormula,
   XLSXHyperLink,
   XLSXImportFile,
+  XLSXOutlineProperties,
   XLSXRow,
   XLSXSheetFormat,
+  XLSXSheetProperties,
   XLSXSheetState,
   XLSXSheetView,
   XLSXSheetWorkbookInfo,
@@ -48,6 +50,7 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
           sheetName: this.extractSheetName(),
           sheetViews: this.extractSheetViews(sheetElement),
           sheetFormat: this.extractSheetFormat(sheetElement),
+          sheetProperties: this.extractSheetProperties(sheetElement),
           cols: this.extractCols(sheetElement),
           rows: this.extractRows(sheetElement),
           sharedFormulas: this.extractSharedFormulas(sheetElement),
@@ -227,6 +230,26 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
     };
   }
 
+  private extractSheetProperties(worksheet: Element): XLSXSheetProperties | undefined {
+    const propertiesElement = this.querySelector(worksheet, "sheetPr");
+    if (!propertiesElement) return undefined;
+
+    return {
+      outlinePr: this.extractSheetOutlineProperties(propertiesElement),
+    };
+  }
+
+  private extractSheetOutlineProperties(
+    sheetProperties: Element
+  ): XLSXOutlineProperties | undefined {
+    const properties = this.querySelector(sheetProperties, "outlinePr");
+    if (!properties) return undefined;
+
+    return {
+      summaryBelow: this.extractAttr(properties, "summaryBelow", { default: true }).asBool()!,
+      summaryRight: this.extractAttr(properties, "summaryRight", { default: true }).asBool()!,
+    };
+  }
   private extractCols(worksheet: Element): XLSXColumn[] {
     return this.mapOnElements(
       { parent: worksheet, query: "cols col" },
@@ -239,6 +262,8 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
           min: this.extractAttr(colElement, "min", { required: true })?.asNum()!,
           max: this.extractAttr(colElement, "max", { required: true })?.asNum()!,
           styleIndex: this.extractAttr(colElement, "style")?.asNum(),
+          outlineLevel: this.extractAttr(colElement, "outlineLevel")?.asNum(),
+          collapsed: this.extractAttr(colElement, "collapsed")?.asBool(),
         };
       }
     );
@@ -255,6 +280,8 @@ export class XlsxSheetExtractor extends XlsxBaseExtractor {
           customHeight: this.extractAttr(rowElement, "customHeight")?.asBool(),
           hidden: this.extractAttr(rowElement, "hidden")?.asBool(),
           styleIndex: this.extractAttr(rowElement, "s")?.asNum(),
+          outlineLevel: this.extractAttr(rowElement, "outlineLevel")?.asNum(),
+          collapsed: this.extractAttr(rowElement, "collapsed")?.asBool(),
         };
       }
     );

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -58,12 +58,12 @@ export function addRows(
   for (let r = 0; r < sheet.rowNumber; r++) {
     const rowAttrs: XMLAttributes = [["r", r + 1]];
     const row = sheet.rows[r] || {};
-    // Always force our own row height
-    rowAttrs.push(
-      ["ht", convertHeightToExcel(row.size || DEFAULT_CELL_HEIGHT)],
-      ["customHeight", 1],
-      ["hidden", row.isHidden ? 1 : 0]
-    );
+    if (row.size && row.size !== DEFAULT_CELL_HEIGHT) {
+      rowAttrs.push(["ht", convertHeightToExcel(row.size)], ["customHeight", 1]);
+    }
+    if (row.isHidden) {
+      rowAttrs.push(["hidden", 1]);
+    }
     const cellNodes: XMLString[] = [];
     for (let c = 0; c < sheet.colNumber; c++) {
       const xc = toXC(c, r);

--- a/src/xlsx/helpers/misc.ts
+++ b/src/xlsx/helpers/misc.ts
@@ -1,3 +1,5 @@
+import { Dimension, ExcelHeaderData, ExcelSheetData } from "../../types";
+
 /**
  * Get the relative path between two files
  *
@@ -59,4 +61,22 @@ export function fixXlsxUnicode(str: string): string {
   return str.replace(/_x([0-9a-zA-Z]{4})_/g, (match, code) => {
     return String.fromCharCode(parseInt(code, 16));
   });
+}
+
+/** Get a header in the SheetData. Create the header if it doesn't exist in the SheetData */
+export function getSheetDataHeader(
+  sheetData: ExcelSheetData,
+  dimension: Dimension,
+  index: number
+): ExcelHeaderData {
+  if (dimension === "COL") {
+    if (!sheetData.cols[index]) {
+      sheetData.cols[index] = {};
+    }
+    return sheetData.cols[index];
+  }
+  if (!sheetData.rows[index]) {
+    sheetData.rows[index] = {};
+  }
+  return sheetData.rows[index];
 }

--- a/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet3.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/worksheets/sheet3.xml
@@ -1,15 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" xmlns:xr2="http://schemas.microsoft.com/office/spreadsheetml/2015/revision2" xmlns:xr3="http://schemas.microsoft.com/office/spreadsheetml/2016/revision3" mc:Ignorable="x14ac xr xr2 xr3" xr:uid="{36512477-1430-4815-A265-D41BD5674A3A}">
   <dimension ref="A1:H5"/>
+  <sheetPr>
+    <outlinePr summaryBelow="1" summaryRight="0"/>
+  </sheetPr>
   <sheetViews>
     <sheetView workbookViewId="0">
       <selection activeCell="H2" sqref="H2"/>
     </sheetView>
   </sheetViews>
-  <sheetFormatPr defaultColWidth="9.140625" defaultRowHeight="12.75" x14ac:dyDescent="0.2"/>
+  <sheetFormatPr defaultColWidth="9.140625" defaultRowHeight="12.75" x14ac:dyDescent="0.2" outlineLevelRow="2" outlineLevelCol="2" />
   <cols>
     <col min="3" max="3" width="0" hidden="1" customWidth="1"/>
     <col min="6" max="6" width="14.28515625" customWidth="1"/>
+    <col min="10" max="10" width="9.140625" outlineLevel="1"/>
+    <col min="11" max="11" width="9.140625" outlineLevel="1" collapsed="1"/>
+    <col min="12" max="14" width="0" hidden="1" outlineLevel="2"/>
+    <col min="15" max="15" width="9.140625" outlineLevel="1"/>
+    <col min="16" max="18" width="9.140625" outlineLevel="1"/>
   </cols>
   <sheetData>
     <row r="1" spans="1:8" x14ac:dyDescent="0.2">
@@ -60,6 +68,15 @@
         <v>360</v>
       </c>
     </row>
+    <row r="10" outlineLevel="1" x14ac:dyDescent="0.2"/>
+    <row r="11" outlineLevel="1" x14ac:dyDescent="0.2"/>
+    <row r="12" hidden="1" outlineLevel="2" x14ac:dyDescent="0.2"/>
+    <row r="13" hidden="1" outlineLevel="2" x14ac:dyDescent="0.2"/>
+    <row r="14" hidden="1" outlineLevel="2" x14ac:dyDescent="0.2"/>
+    <row r="15" outlineLevel="1" collapsed="1" x14ac:dyDescent="0.2"/>
+    <row r="16" outlineLevel="1" x14ac:dyDescent="0.2"/>
+    <row r="17" outlineLevel="1" x14ac:dyDescent="0.2"/>
+    <row r="18" outlineLevel="1" x14ac:dyDescent="0.2"/>
   </sheetData>
   <mergeCells count="1">
     <mergeCell ref="D1:E2"/>

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -11325,6 +11325,604 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
 }
 `;
 
+exports[`Test XLSX export Header grouping export Nested grouped headers 1`] = `
+{
+  "files": [
+    {
+      "content": "<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets>
+        <sheet state="visible" name="Sheet1" sheetId="1" r:id="rId1"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    {
+      "content": "<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheetViews>
+        <sheetView showGridLines="1" workbookViewId="0">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight="17.25" defaultColWidth="13.73"/>
+    <cols>
+        <col min="1" max="1" width="13.73" customWidth="1" hidden="0" outlineLevel="1"/>
+        <col min="2" max="2" width="13.73" customWidth="1" hidden="1" outlineLevel="2"/>
+        <col min="3" max="3" width="13.73" customWidth="1" hidden="1" outlineLevel="2"/>
+        <col min="4" max="4" width="13.73" customWidth="1" hidden="1" outlineLevel="2"/>
+        <col min="5" max="5" width="13.73" customWidth="1" hidden="0" outlineLevel="1" collapsed="1"/>
+        <col min="6" max="6" width="13.73" customWidth="1" hidden="0" outlineLevel="1"/>
+        <col min="7" max="7" width="13.73" customWidth="1" hidden="0" outlineLevel="1"/>
+        <col min="8" max="8" width="13.73" customWidth="1" hidden="0"/>
+        <col min="9" max="9" width="13.73" customWidth="1" hidden="0"/>
+        <col min="10" max="10" width="13.73" customWidth="1" hidden="0"/>
+        <col min="11" max="11" width="13.73" customWidth="1" hidden="0"/>
+        <col min="12" max="12" width="13.73" customWidth="1" hidden="0"/>
+        <col min="13" max="13" width="13.73" customWidth="1" hidden="0"/>
+        <col min="14" max="14" width="13.73" customWidth="1" hidden="0"/>
+        <col min="15" max="15" width="13.73" customWidth="1" hidden="0"/>
+        <col min="16" max="16" width="13.73" customWidth="1" hidden="0"/>
+        <col min="17" max="17" width="13.73" customWidth="1" hidden="0"/>
+        <col min="18" max="18" width="13.73" customWidth="1" hidden="0"/>
+        <col min="19" max="19" width="13.73" customWidth="1" hidden="0"/>
+        <col min="20" max="20" width="13.73" customWidth="1" hidden="0"/>
+        <col min="21" max="21" width="13.73" customWidth="1" hidden="0"/>
+        <col min="22" max="22" width="13.73" customWidth="1" hidden="0"/>
+        <col min="23" max="23" width="13.73" customWidth="1" hidden="0"/>
+        <col min="24" max="24" width="13.73" customWidth="1" hidden="0"/>
+        <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
+        <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
+    </cols>
+    <sheetData>
+    </sheetData>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <numFmts count="0">
+    </numFmts>
+    <fonts count="1">
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Calibri"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left>
+            </left>
+            <right>
+            </right>
+            <top>
+            </top>
+            <bottom>
+            </bottom>
+            <diagonal>
+            </diagonal>
+        </border>
+    </borders>
+    <cellXfs count="1">
+        <xf numFmtId="0" fillId="0" fontId="0" borderId="0" applyAlignment="1">
+            <alignment vertical="bottom"/>
+        </xf>
+    </cellXfs>
+    <dxfs count="0">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    {
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="0" uniqueCount="0">
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+    <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
+    <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    {
+      "content": "<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="avif" ContentType="image/avif"/>
+    <Default Extension="bmp" ContentType="image/bmp"/>
+    <Default Extension="gif" ContentType="image/gif"/>
+    <Default Extension="ico" ContentType="image/vnd.microsoft.icon"/>
+    <Default Extension="jpeg" ContentType="image/jpeg"/>
+    <Default Extension="png" ContentType="image/png"/>
+    <Default Extension="tiff" ContentType="image/tiff"/>
+    <Default Extension="webp" ContentType="image/webp"/>
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
+exports[`Test XLSX export Header grouping export Nested grouped headers 2`] = `
+{
+  "files": [
+    {
+      "content": "<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets>
+        <sheet state="visible" name="Sheet1" sheetId="1" r:id="rId1"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    {
+      "content": "<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheetViews>
+        <sheetView showGridLines="1" workbookViewId="0">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight="17.25" defaultColWidth="13.73"/>
+    <cols>
+        <col min="1" max="1" width="13.73" customWidth="1" hidden="0"/>
+        <col min="2" max="2" width="13.73" customWidth="1" hidden="0"/>
+        <col min="3" max="3" width="13.73" customWidth="1" hidden="0"/>
+        <col min="4" max="4" width="13.73" customWidth="1" hidden="0"/>
+        <col min="5" max="5" width="13.73" customWidth="1" hidden="0"/>
+        <col min="6" max="6" width="13.73" customWidth="1" hidden="0"/>
+        <col min="7" max="7" width="13.73" customWidth="1" hidden="0"/>
+        <col min="8" max="8" width="13.73" customWidth="1" hidden="0"/>
+        <col min="9" max="9" width="13.73" customWidth="1" hidden="0"/>
+        <col min="10" max="10" width="13.73" customWidth="1" hidden="0"/>
+        <col min="11" max="11" width="13.73" customWidth="1" hidden="0"/>
+        <col min="12" max="12" width="13.73" customWidth="1" hidden="0"/>
+        <col min="13" max="13" width="13.73" customWidth="1" hidden="0"/>
+        <col min="14" max="14" width="13.73" customWidth="1" hidden="0"/>
+        <col min="15" max="15" width="13.73" customWidth="1" hidden="0"/>
+        <col min="16" max="16" width="13.73" customWidth="1" hidden="0"/>
+        <col min="17" max="17" width="13.73" customWidth="1" hidden="0"/>
+        <col min="18" max="18" width="13.73" customWidth="1" hidden="0"/>
+        <col min="19" max="19" width="13.73" customWidth="1" hidden="0"/>
+        <col min="20" max="20" width="13.73" customWidth="1" hidden="0"/>
+        <col min="21" max="21" width="13.73" customWidth="1" hidden="0"/>
+        <col min="22" max="22" width="13.73" customWidth="1" hidden="0"/>
+        <col min="23" max="23" width="13.73" customWidth="1" hidden="0"/>
+        <col min="24" max="24" width="13.73" customWidth="1" hidden="0"/>
+        <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
+        <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
+    </cols>
+    <sheetData>
+        <row r="1" outlineLevel="1">
+        </row>
+        <row r="2" hidden="1" outlineLevel="2">
+        </row>
+        <row r="3" hidden="1" outlineLevel="2">
+        </row>
+        <row r="4" hidden="1" outlineLevel="2">
+        </row>
+        <row r="5" outlineLevel="1" collapsed="1">
+        </row>
+        <row r="6" outlineLevel="1">
+        </row>
+        <row r="7" outlineLevel="1">
+        </row>
+    </sheetData>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <numFmts count="0">
+    </numFmts>
+    <fonts count="1">
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Calibri"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left>
+            </left>
+            <right>
+            </right>
+            <top>
+            </top>
+            <bottom>
+            </bottom>
+            <diagonal>
+            </diagonal>
+        </border>
+    </borders>
+    <cellXfs count="1">
+        <xf numFmtId="0" fillId="0" fontId="0" borderId="0" applyAlignment="1">
+            <alignment vertical="bottom"/>
+        </xf>
+    </cellXfs>
+    <dxfs count="0">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    {
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="0" uniqueCount="0">
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+    <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
+    <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    {
+      "content": "<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="avif" ContentType="image/avif"/>
+    <Default Extension="bmp" ContentType="image/bmp"/>
+    <Default Extension="gif" ContentType="image/gif"/>
+    <Default Extension="ico" ContentType="image/vnd.microsoft.icon"/>
+    <Default Extension="jpeg" ContentType="image/jpeg"/>
+    <Default Extension="png" ContentType="image/png"/>
+    <Default Extension="tiff" ContentType="image/tiff"/>
+    <Default Extension="webp" ContentType="image/webp"/>
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
+exports[`Test XLSX export Header grouping export Simple grouped headers 1`] = `
+{
+  "files": [
+    {
+      "content": "<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets>
+        <sheet state="visible" name="Sheet1" sheetId="1" r:id="rId1"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    {
+      "content": "<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheetViews>
+        <sheetView showGridLines="1" workbookViewId="0">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight="17.25" defaultColWidth="13.73"/>
+    <cols>
+        <col min="1" max="1" width="13.73" customWidth="1" hidden="0"/>
+        <col min="2" max="2" width="13.73" customWidth="1" hidden="0"/>
+        <col min="3" max="3" width="13.73" customWidth="1" hidden="0"/>
+        <col min="4" max="4" width="13.73" customWidth="1" hidden="0"/>
+        <col min="5" max="5" width="13.73" customWidth="1" hidden="0"/>
+        <col min="6" max="6" width="13.73" customWidth="1" hidden="0"/>
+        <col min="7" max="7" width="13.73" customWidth="1" hidden="0"/>
+        <col min="8" max="8" width="13.73" customWidth="1" hidden="0"/>
+        <col min="9" max="9" width="13.73" customWidth="1" hidden="0"/>
+        <col min="10" max="10" width="13.73" customWidth="1" hidden="0"/>
+        <col min="11" max="11" width="13.73" customWidth="1" hidden="0"/>
+        <col min="12" max="12" width="13.73" customWidth="1" hidden="0"/>
+        <col min="13" max="13" width="13.73" customWidth="1" hidden="0"/>
+        <col min="14" max="14" width="13.73" customWidth="1" hidden="0"/>
+        <col min="15" max="15" width="13.73" customWidth="1" hidden="0"/>
+        <col min="16" max="16" width="13.73" customWidth="1" hidden="0"/>
+        <col min="17" max="17" width="13.73" customWidth="1" hidden="0"/>
+        <col min="18" max="18" width="13.73" customWidth="1" hidden="0"/>
+        <col min="19" max="19" width="13.73" customWidth="1" hidden="0"/>
+        <col min="20" max="20" width="13.73" customWidth="1" hidden="0"/>
+        <col min="21" max="21" width="13.73" customWidth="1" hidden="0"/>
+        <col min="22" max="22" width="13.73" customWidth="1" hidden="0"/>
+        <col min="23" max="23" width="13.73" customWidth="1" hidden="0"/>
+        <col min="24" max="24" width="13.73" customWidth="1" hidden="0"/>
+        <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
+        <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
+    </cols>
+    <sheetData>
+        <row r="1" hidden="1" outlineLevel="1">
+        </row>
+        <row r="2" hidden="1" outlineLevel="1">
+        </row>
+        <row r="3" hidden="1" outlineLevel="1">
+        </row>
+        <row r="4" collapsed="1">
+        </row>
+    </sheetData>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <numFmts count="0">
+    </numFmts>
+    <fonts count="1">
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Calibri"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left>
+            </left>
+            <right>
+            </right>
+            <top>
+            </top>
+            <bottom>
+            </bottom>
+            <diagonal>
+            </diagonal>
+        </border>
+    </borders>
+    <cellXfs count="1">
+        <xf numFmtId="0" fillId="0" fontId="0" borderId="0" applyAlignment="1">
+            <alignment vertical="bottom"/>
+        </xf>
+    </cellXfs>
+    <dxfs count="0">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    {
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="0" uniqueCount="0">
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+    <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
+    <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    {
+      "content": "<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="avif" ContentType="image/avif"/>
+    <Default Extension="bmp" ContentType="image/bmp"/>
+    <Default Extension="gif" ContentType="image/gif"/>
+    <Default Extension="ico" ContentType="image/vnd.microsoft.icon"/>
+    <Default Extension="jpeg" ContentType="image/jpeg"/>
+    <Default Extension="png" ContentType="image/png"/>
+    <Default Extension="tiff" ContentType="image/tiff"/>
+    <Default Extension="webp" ContentType="image/webp"/>
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
+exports[`Test XLSX export Header grouping export Simple grouped headers 2`] = `
+{
+  "files": [
+    {
+      "content": "<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets>
+        <sheet state="visible" name="Sheet1" sheetId="1" r:id="rId1"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    {
+      "content": "<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheetViews>
+        <sheetView showGridLines="1" workbookViewId="0">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight="17.25" defaultColWidth="13.73"/>
+    <cols>
+        <col min="1" max="1" width="13.73" customWidth="1" hidden="1" outlineLevel="1"/>
+        <col min="2" max="2" width="13.73" customWidth="1" hidden="1" outlineLevel="1"/>
+        <col min="3" max="3" width="13.73" customWidth="1" hidden="1" outlineLevel="1"/>
+        <col min="4" max="4" width="13.73" customWidth="1" hidden="0" collapsed="1"/>
+        <col min="5" max="5" width="13.73" customWidth="1" hidden="0"/>
+        <col min="6" max="6" width="13.73" customWidth="1" hidden="0"/>
+        <col min="7" max="7" width="13.73" customWidth="1" hidden="0"/>
+        <col min="8" max="8" width="13.73" customWidth="1" hidden="0"/>
+        <col min="9" max="9" width="13.73" customWidth="1" hidden="0"/>
+        <col min="10" max="10" width="13.73" customWidth="1" hidden="0"/>
+        <col min="11" max="11" width="13.73" customWidth="1" hidden="0"/>
+        <col min="12" max="12" width="13.73" customWidth="1" hidden="0"/>
+        <col min="13" max="13" width="13.73" customWidth="1" hidden="0"/>
+        <col min="14" max="14" width="13.73" customWidth="1" hidden="0"/>
+        <col min="15" max="15" width="13.73" customWidth="1" hidden="0"/>
+        <col min="16" max="16" width="13.73" customWidth="1" hidden="0"/>
+        <col min="17" max="17" width="13.73" customWidth="1" hidden="0"/>
+        <col min="18" max="18" width="13.73" customWidth="1" hidden="0"/>
+        <col min="19" max="19" width="13.73" customWidth="1" hidden="0"/>
+        <col min="20" max="20" width="13.73" customWidth="1" hidden="0"/>
+        <col min="21" max="21" width="13.73" customWidth="1" hidden="0"/>
+        <col min="22" max="22" width="13.73" customWidth="1" hidden="0"/>
+        <col min="23" max="23" width="13.73" customWidth="1" hidden="0"/>
+        <col min="24" max="24" width="13.73" customWidth="1" hidden="0"/>
+        <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
+        <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
+    </cols>
+    <sheetData>
+    </sheetData>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <numFmts count="0">
+    </numFmts>
+    <fonts count="1">
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Calibri"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left>
+            </left>
+            <right>
+            </right>
+            <top>
+            </top>
+            <bottom>
+            </bottom>
+            <diagonal>
+            </diagonal>
+        </border>
+    </borders>
+    <cellXfs count="1">
+        <xf numFmtId="0" fillId="0" fontId="0" borderId="0" applyAlignment="1">
+            <alignment vertical="bottom"/>
+        </xf>
+    </cellXfs>
+    <dxfs count="0">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    {
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="0" uniqueCount="0">
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+    <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
+    <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    {
+      "content": "<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="avif" ContentType="image/avif"/>
+    <Default Extension="bmp" ContentType="image/bmp"/>
+    <Default Extension="gif" ContentType="image/gif"/>
+    <Default Extension="ico" ContentType="image/vnd.microsoft.icon"/>
+    <Default Extension="jpeg" ContentType="image/jpeg"/>
+    <Default Extension="png" ContentType="image/png"/>
+    <Default Extension="tiff" ContentType="image/tiff"/>
+    <Default Extension="webp" ContentType="image/webp"/>
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
 exports[`Test XLSX export Images image larger than the sheet 1`] = `
 {
   "files": [

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -381,7 +381,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -393,7 +393,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -410,7 +410,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -427,7 +427,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -444,7 +444,7 @@ exports[`Test XLSX export Charts Chart legend is set to none position 1`] = `
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -977,7 +977,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -989,7 +989,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -1006,7 +1006,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -1023,7 +1023,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -1040,7 +1040,7 @@ exports[`Test XLSX export Charts Export chart overflowing outside the sheet 1`] 
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -1573,7 +1573,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -1585,7 +1585,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -1602,7 +1602,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -1619,7 +1619,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -1636,7 +1636,7 @@ exports[`Test XLSX export Charts chart dataset without title 1`] = `
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -3025,7 +3025,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -3037,7 +3037,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -3054,7 +3054,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -3071,7 +3071,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -3088,7 +3088,7 @@ exports[`Test XLSX export Charts chart font color is white with a dark backgroun
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -3688,7 +3688,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -3700,7 +3700,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -3717,7 +3717,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -3734,7 +3734,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -3751,7 +3751,7 @@ exports[`Test XLSX export Charts charts in different sheets 1`] = `
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -5023,7 +5023,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -5035,7 +5035,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -5052,7 +5052,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -5069,7 +5069,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -5086,7 +5086,7 @@ exports[`Test XLSX export Charts multiple charts in the same sheet 1`] = `
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -5897,7 +5897,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4' 
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -5909,7 +5909,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4' 
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -5926,7 +5926,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4' 
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -5943,7 +5943,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4' 
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -5960,7 +5960,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4' 
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -6507,7 +6507,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4',
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -6519,7 +6519,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4',
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -6536,7 +6536,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4',
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -6553,7 +6553,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4',
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -6570,7 +6570,7 @@ exports[`Test XLSX export Charts simple bar chart with dataset [ 'Sheet1!B1:B4',
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -7079,7 +7079,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -7091,7 +7091,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -7108,7 +7108,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -7125,7 +7125,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -7142,7 +7142,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -7692,7 +7692,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -7704,7 +7704,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -7721,7 +7721,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -7738,7 +7738,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -7755,7 +7755,7 @@ exports[`Test XLSX export Charts simple line chart with dataset [ 'Sheet1!B1:B4'
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -8181,7 +8181,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4' 
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -8193,7 +8193,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4' 
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -8210,7 +8210,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4' 
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -8227,7 +8227,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4' 
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -8244,7 +8244,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4' 
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -8744,7 +8744,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4',
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -8756,7 +8756,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4',
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -8773,7 +8773,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4',
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -8790,7 +8790,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4',
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -8807,7 +8807,7 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4',
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -9354,7 +9354,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
         <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="B1" s="1" t="s">
                 <v>
                     0
@@ -9366,7 +9366,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     2
@@ -9383,7 +9383,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     3
@@ -9400,7 +9400,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     4
@@ -9417,7 +9417,7 @@ exports[`Test XLSX export Charts stacked bar chart 1`] = `
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     5
@@ -9658,7 +9658,7 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1" t="s">
                 <v>
                     0
@@ -9675,7 +9675,7 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="1">
+        <row r="2" hidden="1">
             <c r="A2" s="1">
                 <v>
                     5
@@ -9692,7 +9692,7 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="1">
+        <row r="3" hidden="1">
             <c r="A3" s="1">
                 <v>
                     5
@@ -9704,7 +9704,7 @@ exports[`Test XLSX export Export data filters Export data filters snapshot 1`] =
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1">
                 <v>
                     78
@@ -9863,7 +9863,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
         <col min="2" max="2" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1">
                 <v>
                     1
@@ -9875,7 +9875,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1">
                 <v>
                     42
@@ -9887,7 +9887,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="b">
                 <v>
                     1
@@ -9899,7 +9899,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1">
                 <v>
                     0
@@ -9911,7 +9911,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Conditional f
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     0
@@ -10528,7 +10528,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="B2" s="1" t="s">
                 <v>
                     0
@@ -10547,7 +10547,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="K2" s="4">
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="F3" s="5" t="s">
                 <v>
                     3
@@ -10560,7 +10560,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="L3" s="8">
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="B4" s="9" t="s">
                 <v>
                     4
@@ -10578,7 +10578,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="L4" s="8">
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="F5" s="12" t="s">
                 <v>
                     6
@@ -10591,7 +10591,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="L5" s="8">
             </c>
         </row>
-        <row r="6" ht="17.25" customHeight="1" hidden="0">
+        <row r="6">
             <c r="F6" s="13" t="s">
                 <v>
                     7
@@ -10604,7 +10604,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="L6" s="8">
             </c>
         </row>
-        <row r="7" ht="17.25" customHeight="1" hidden="0">
+        <row r="7">
             <c r="F7" s="3" t="s">
                 <v>
                     8
@@ -10617,7 +10617,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="L7" s="8">
             </c>
         </row>
-        <row r="8" ht="17.25" customHeight="1" hidden="0">
+        <row r="8">
             <c r="F8" s="14" t="s">
                 <v>
                     9
@@ -10626,7 +10626,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="K8" s="15">
             </c>
         </row>
-        <row r="9" ht="17.25" customHeight="1" hidden="0">
+        <row r="9">
             <c r="F9" s="3" t="s">
                 <v>
                     10
@@ -10639,7 +10639,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="L9" s="18">
             </c>
         </row>
-        <row r="10" ht="17.25" customHeight="1" hidden="0">
+        <row r="10">
             <c r="F10" s="3" t="s">
                 <v>
                     11
@@ -10648,20 +10648,20 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="K10" s="19">
             </c>
         </row>
-        <row r="12" ht="17.25" customHeight="1" hidden="0">
+        <row r="12">
             <c r="D12" s="3" t="s">
                 <v>
                     12
                 </v>
             </c>
         </row>
-        <row r="19" ht="17.25" customHeight="1" hidden="0">
+        <row r="19">
             <c r="E19" s="4">
             </c>
             <c r="G19" s="4">
             </c>
         </row>
-        <row r="20" ht="17.25" customHeight="1" hidden="0">
+        <row r="20">
             <c r="B20" s="6">
             </c>
             <c r="C20" s="8" t="s">
@@ -10684,7 +10684,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="H20" s="8">
             </c>
         </row>
-        <row r="21" ht="17.25" customHeight="1" hidden="0">
+        <row r="21">
             <c r="A21" s="3" t="s">
                 <v>
                     16
@@ -10693,112 +10693,112 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
             <c r="G21" s="20">
             </c>
         </row>
-        <row r="23" ht="17.25" customHeight="1" hidden="0">
+        <row r="23">
             <c r="C23" s="22">
                 <v>
                     0.43
                 </v>
             </c>
         </row>
-        <row r="24" ht="17.25" customHeight="1" hidden="0">
+        <row r="24">
             <c r="C24" s="23">
                 <v>
                     10
                 </v>
             </c>
         </row>
-        <row r="25" ht="17.25" customHeight="1" hidden="0">
+        <row r="25">
             <c r="C25" s="23">
                 <v>
                     10.123
                 </v>
             </c>
         </row>
-        <row r="27" ht="17.25" customHeight="1" hidden="0">
+        <row r="27">
             <c r="A27" s="3" t="s">
                 <v>
                     17
                 </v>
             </c>
         </row>
-        <row r="28" ht="17.25" customHeight="1" hidden="0">
+        <row r="28">
             <c r="A28" s="3" t="s">
                 <v>
                     18
                 </v>
             </c>
         </row>
-        <row r="29" ht="17.25" customHeight="1" hidden="0">
+        <row r="29">
             <c r="A29" s="3" t="s">
                 <v>
                     19
                 </v>
             </c>
         </row>
-        <row r="30" ht="17.25" customHeight="1" hidden="0">
+        <row r="30">
             <c r="A30" s="3" t="s">
                 <v>
                     20
                 </v>
             </c>
         </row>
-        <row r="31" ht="17.25" customHeight="1" hidden="0">
+        <row r="31">
             <c r="A31" s="3" t="s">
                 <v>
                     21
                 </v>
             </c>
         </row>
-        <row r="32" ht="17.25" customHeight="1" hidden="0">
+        <row r="32">
             <c r="A32" s="3" t="s">
                 <v>
                     22
                 </v>
             </c>
         </row>
-        <row r="33" ht="17.25" customHeight="1" hidden="0">
+        <row r="33">
             <c r="A33" s="3" t="s">
                 <v>
                     23
                 </v>
             </c>
         </row>
-        <row r="34" ht="17.25" customHeight="1" hidden="0">
+        <row r="34">
             <c r="A34" s="3" t="s">
                 <v>
                     24
                 </v>
             </c>
         </row>
-        <row r="35" ht="17.25" customHeight="1" hidden="0">
+        <row r="35">
             <c r="A35" s="3" t="s">
                 <v>
                     25
                 </v>
             </c>
         </row>
-        <row r="36" ht="17.25" customHeight="1" hidden="0">
+        <row r="36">
             <c r="A36" s="3" t="s">
                 <v>
                     26
                 </v>
             </c>
         </row>
-        <row r="37" ht="17.25" customHeight="1" hidden="0">
+        <row r="37">
             <c r="A37" s="3">
                 <f>
                     "this is a quote: """
                 </f>
             </c>
         </row>
-        <row r="38" ht="17.25" customHeight="1" hidden="0">
+        <row r="38">
             <c r="A38" s="3">
                 <f>
                     '&lt;Sheet2&gt;'!B2
                 </f>
             </c>
         </row>
-        <row r="39" ht="17.25" customHeight="1" hidden="0">
+        <row r="39">
             <c r="A39" s="3" t="str">
                 <f>
                     A39
@@ -10808,7 +10808,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
                 </v>
             </c>
         </row>
-        <row r="40" ht="17.25" customHeight="1" hidden="0">
+        <row r="40">
             <c r="A40" s="3">
                 <f>
                     (1+2)/3
@@ -10856,7 +10856,7 @@ exports[`Test XLSX export Generic sheets (style, hidden, size, cf) Simple model 
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="B2" s="3">
                 <v>
                     42
@@ -13225,7 +13225,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1" t="s">
                 <v>
                     0
@@ -13262,7 +13262,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1">
                 <f>
                     ABS(-5.5)
@@ -13299,7 +13299,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1">
                 <f>
                     ACOS(1)
@@ -13336,7 +13336,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1">
                 <f>
                     ACOSH(2)
@@ -13373,7 +13373,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1">
                 <f>
                     _xlfn.ACOT(1)
@@ -13415,7 +13415,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="6" ht="17.25" customHeight="1" hidden="0">
+        <row r="6">
             <c r="A6" s="1">
                 <f>
                     _xlfn.ACOTH(2)
@@ -13452,7 +13452,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="7" ht="17.25" customHeight="1" hidden="0">
+        <row r="7">
             <c r="A7" s="1">
                 <f>
                     AND(TRUE,TRUE)
@@ -13489,7 +13489,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="8" ht="17.25" customHeight="1" hidden="0">
+        <row r="8">
             <c r="A8" s="1">
                 <f>
                     ASIN(0.5)
@@ -13526,7 +13526,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="9" ht="17.25" customHeight="1" hidden="0">
+        <row r="9">
             <c r="A9" s="1">
                 <f>
                     ASINH(2)
@@ -13558,14 +13558,14 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="10" ht="17.25" customHeight="1" hidden="0">
+        <row r="10">
             <c r="A10" s="1">
                 <f>
                     ATAN(1)
                 </f>
             </c>
         </row>
-        <row r="11" ht="17.25" customHeight="1" hidden="0">
+        <row r="11">
             <c r="A11" s="1">
                 <f>
                     ATAN2(-1,0)
@@ -13577,7 +13577,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="12" ht="17.25" customHeight="1" hidden="0">
+        <row r="12">
             <c r="A12" s="1">
                 <f>
                     ATANH(0.7)
@@ -13609,7 +13609,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="13" ht="17.25" customHeight="1" hidden="0">
+        <row r="13">
             <c r="A13" s="1">
                 <f>
                     AVEDEV(I2:I9)
@@ -13641,1085 +13641,1085 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
                 </v>
             </c>
         </row>
-        <row r="14" ht="17.25" customHeight="1" hidden="0">
+        <row r="14">
             <c r="A14" s="1">
                 <f>
                     AVERAGE(H2:H9)
                 </f>
             </c>
         </row>
-        <row r="15" ht="17.25" customHeight="1" hidden="0">
+        <row r="15">
             <c r="A15" s="1">
                 <f>
                     AVERAGEA(G2:H9)
                 </f>
             </c>
         </row>
-        <row r="16" ht="17.25" customHeight="1" hidden="0">
+        <row r="16">
             <c r="A16" s="1">
                 <f>
                     AVERAGEIF(J2:J9,"&gt;150000")
                 </f>
             </c>
         </row>
-        <row r="17" ht="17.25" customHeight="1" hidden="0">
+        <row r="17">
             <c r="A17" s="1">
                 <f>
                     AVERAGEIFS(I2:I9,H2:H9,"&gt;=30",K2:K9,"&lt;10")
                 </f>
             </c>
         </row>
-        <row r="18" ht="17.25" customHeight="1" hidden="0">
+        <row r="18">
             <c r="A18" s="1">
                 <f>
                     CEILING(20.4,1)
                 </f>
             </c>
         </row>
-        <row r="19" ht="17.25" customHeight="1" hidden="0">
+        <row r="19">
             <c r="A19" s="1">
                 <f>
                     _xlfn.CEILING.MATH(-5.5,1,0)
                 </f>
             </c>
         </row>
-        <row r="20" ht="17.25" customHeight="1" hidden="0">
+        <row r="20">
             <c r="A20" s="1">
                 <f>
                     _xlfn.CEILING.PRECISE(230,100)
                 </f>
             </c>
         </row>
-        <row r="21" ht="17.25" customHeight="1" hidden="0">
+        <row r="21">
             <c r="A21" s="1">
                 <f>
                     CHAR(74)
                 </f>
             </c>
         </row>
-        <row r="22" ht="17.25" customHeight="1" hidden="0">
+        <row r="22">
             <c r="A22" s="1">
                 <f>
                     COLUMN(C4)
                 </f>
             </c>
         </row>
-        <row r="23" ht="17.25" customHeight="1" hidden="0">
+        <row r="23">
             <c r="A23" s="1">
                 <f>
                     COLUMNS(A5:D12)
                 </f>
             </c>
         </row>
-        <row r="24" ht="17.25" customHeight="1" hidden="0">
+        <row r="24">
             <c r="A24" s="1">
                 <f>
                     _xlfn.CONCAT(1,23)
                 </f>
             </c>
         </row>
-        <row r="25" ht="17.25" customHeight="1" hidden="0">
+        <row r="25">
             <c r="A25" s="1">
                 <f>
                     CONCATENATE("BUT, ","MICHEL")
                 </f>
             </c>
         </row>
-        <row r="26" ht="17.25" customHeight="1" hidden="0">
+        <row r="26">
             <c r="A26" s="1">
                 <f>
                     COS(PI()/3)
                 </f>
             </c>
         </row>
-        <row r="27" ht="17.25" customHeight="1" hidden="0">
+        <row r="27">
             <c r="A27" s="1">
                 <f>
                     COSH(2)
                 </f>
             </c>
         </row>
-        <row r="28" ht="17.25" customHeight="1" hidden="0">
+        <row r="28">
             <c r="A28" s="1">
                 <f>
                     _xlfn.COT(PI()/6)
                 </f>
             </c>
         </row>
-        <row r="29" ht="17.25" customHeight="1" hidden="0">
+        <row r="29">
             <c r="A29" s="1">
                 <f>
                     _xlfn.COTH(0.5)
                 </f>
             </c>
         </row>
-        <row r="30" ht="17.25" customHeight="1" hidden="0">
+        <row r="30">
             <c r="A30" s="1">
                 <f>
                     COUNT(1,"a","5","2021-03-14")
                 </f>
             </c>
         </row>
-        <row r="31" ht="17.25" customHeight="1" hidden="0">
+        <row r="31">
             <c r="A31" s="1">
                 <f>
                     COUNTA(1,"a","5","2021-03-14")
                 </f>
             </c>
         </row>
-        <row r="32" ht="17.25" customHeight="1" hidden="0">
+        <row r="32">
             <c r="A32" s="1">
                 <f>
                     COUNTBLANK("","1",3,FALSE)
                 </f>
             </c>
         </row>
-        <row r="33" ht="17.25" customHeight="1" hidden="0">
+        <row r="33">
             <c r="A33" s="1">
                 <f>
                     COUNTIF(H2:H9,"&gt;30")
                 </f>
             </c>
         </row>
-        <row r="34" ht="17.25" customHeight="1" hidden="0">
+        <row r="34">
             <c r="A34" s="1">
                 <f>
                     COUNTIFS(H2:H9,"&gt;25",K2:K9,"&lt;4")
                 </f>
             </c>
         </row>
-        <row r="35" ht="17.25" customHeight="1" hidden="0">
+        <row r="35">
             <c r="A35" s="1">
                 <f>
                     COVAR(H2:H9,K2:K9)
                 </f>
             </c>
         </row>
-        <row r="36" ht="17.25" customHeight="1" hidden="0">
+        <row r="36">
             <c r="A36" s="1">
                 <f>
                     _xlfn.COVARIANCE.P(K2:K9,H2:H9)
                 </f>
             </c>
         </row>
-        <row r="37" ht="17.25" customHeight="1" hidden="0">
+        <row r="37">
             <c r="A37" s="1">
                 <f>
                     _xlfn.COVARIANCE.P(I2:I9,J2:J9)
                 </f>
             </c>
         </row>
-        <row r="38" ht="17.25" customHeight="1" hidden="0">
+        <row r="38">
             <c r="A38" s="1">
                 <f>
                     _xlfn.CSC(PI()/4)
                 </f>
             </c>
         </row>
-        <row r="39" ht="17.25" customHeight="1" hidden="0">
+        <row r="39">
             <c r="A39" s="1">
                 <f>
                     _xlfn.CSCH(PI()/3)
                 </f>
             </c>
         </row>
-        <row r="40" ht="17.25" customHeight="1" hidden="0">
+        <row r="40">
             <c r="A40" s="1">
                 <f>
                     DATE(2020,5,25)
                 </f>
             </c>
         </row>
-        <row r="41" ht="17.25" customHeight="1" hidden="0">
+        <row r="41">
             <c r="A41" s="1">
                 <f>
                     DATEVALUE("1969-08-15")
                 </f>
             </c>
         </row>
-        <row r="42" ht="17.25" customHeight="1" hidden="0">
+        <row r="42">
             <c r="A42" s="1">
                 <f>
                     DAVERAGE(G1:K9,"Tot. Score",J12:J13)
                 </f>
             </c>
         </row>
-        <row r="43" ht="17.25" customHeight="1" hidden="0">
+        <row r="43">
             <c r="A43" s="1">
                 <f>
                     DAY("2020-03-17")
                 </f>
             </c>
         </row>
-        <row r="44" ht="17.25" customHeight="1" hidden="0">
+        <row r="44">
             <c r="A44" s="1">
                 <f>
                     _xlfn.DAYS("2022-03-17","2021-03-17")
                 </f>
             </c>
         </row>
-        <row r="45" ht="17.25" customHeight="1" hidden="0">
+        <row r="45">
             <c r="A45" s="1">
                 <f>
                     DCOUNT(G1:K9,"Name",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="46" ht="17.25" customHeight="1" hidden="0">
+        <row r="46">
             <c r="A46" s="1">
                 <f>
                     DCOUNTA(G1:K9,"Name",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="47" ht="17.25" customHeight="1" hidden="0">
+        <row r="47">
             <c r="A47" s="1">
                 <f>
                     _xlfn.DECIMAL(20,16)
                 </f>
             </c>
         </row>
-        <row r="48" ht="17.25" customHeight="1" hidden="0">
+        <row r="48">
             <c r="A48" s="1">
                 <f>
                     DEGREES(PI()/4)
                 </f>
             </c>
         </row>
-        <row r="49" ht="17.25" customHeight="1" hidden="0">
+        <row r="49">
             <c r="A49" s="1">
                 <f>
                     DGET(G1:K9,"Hours Played",G12:G13)
                 </f>
             </c>
         </row>
-        <row r="50" ht="17.25" customHeight="1" hidden="0">
+        <row r="50">
             <c r="A50" s="1">
                 <f>
                     DMAX(G1:K9,"Tot. Score",I12:I13)
                 </f>
             </c>
         </row>
-        <row r="51" ht="17.25" customHeight="1" hidden="0">
+        <row r="51">
             <c r="A51" s="1">
                 <f>
                     DMIN(G1:K9,"Tot. Score",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="52" ht="17.25" customHeight="1" hidden="0">
+        <row r="52">
             <c r="A52" s="1">
                 <f>
                     DPRODUCT(G1:K9,"Age",K12:K13)
                 </f>
             </c>
         </row>
-        <row r="53" ht="17.25" customHeight="1" hidden="0">
+        <row r="53">
             <c r="A53" s="1">
                 <f>
                     DSTDEV(G1:K9,"Age",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="54" ht="17.25" customHeight="1" hidden="0">
+        <row r="54">
             <c r="A54" s="1">
                 <f>
                     DSTDEVP(G1:K9,"Age",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="55" ht="17.25" customHeight="1" hidden="0">
+        <row r="55">
             <c r="A55" s="1">
                 <f>
                     DSUM(G1:K9,"Age",I12:I13)
                 </f>
             </c>
         </row>
-        <row r="56" ht="17.25" customHeight="1" hidden="0">
+        <row r="56">
             <c r="A56" s="1">
                 <f>
                     DVAR(G1:K9,"Hours Played",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="57" ht="17.25" customHeight="1" hidden="0">
+        <row r="57">
             <c r="A57" s="1">
                 <f>
                     DVARP(G1:K9,"Hours Played",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="58" ht="17.25" customHeight="1" hidden="0">
+        <row r="58">
             <c r="A58" s="1">
                 <f>
                     EDATE("1969-07-22",-2)
                 </f>
             </c>
         </row>
-        <row r="59" ht="17.25" customHeight="1" hidden="0">
+        <row r="59">
             <c r="A59" s="1">
                 <f>
                     EOMONTH("2020-07-21",1)
                 </f>
             </c>
         </row>
-        <row r="60" ht="17.25" customHeight="1" hidden="0">
+        <row r="60">
             <c r="A60" s="1">
                 <f>
                     EXACT("AbsSdf%","AbsSdf%")
                 </f>
             </c>
         </row>
-        <row r="61" ht="17.25" customHeight="1" hidden="0">
+        <row r="61">
             <c r="A61" s="1">
                 <f>
                     EXP(4)
                 </f>
             </c>
         </row>
-        <row r="62" ht="17.25" customHeight="1" hidden="0">
+        <row r="62">
             <c r="A62" s="1">
                 <f>
                     FIND("A","qbdahbaazo A")
                 </f>
             </c>
         </row>
-        <row r="63" ht="17.25" customHeight="1" hidden="0">
+        <row r="63">
             <c r="A63" s="1">
                 <f>
                     FLOOR(5.5,2)
                 </f>
             </c>
         </row>
-        <row r="64" ht="17.25" customHeight="1" hidden="0">
+        <row r="64">
             <c r="A64" s="1">
                 <f>
                     _xlfn.FLOOR.MATH(-5.55,2,1)
                 </f>
             </c>
         </row>
-        <row r="65" ht="17.25" customHeight="1" hidden="0">
+        <row r="65">
             <c r="A65" s="1">
                 <f>
                     _xlfn.FLOOR.PRECISE(199,100)
                 </f>
             </c>
         </row>
-        <row r="66" ht="17.25" customHeight="1" hidden="0">
+        <row r="66">
             <c r="A66" s="1">
                 <f>
                     HLOOKUP("Tot. Score",H1:K9,4,FALSE)
                 </f>
             </c>
         </row>
-        <row r="67" ht="17.25" customHeight="1" hidden="0">
+        <row r="67">
             <c r="A67" s="1">
                 <f>
                     HOUR("02:14:56")
                 </f>
             </c>
         </row>
-        <row r="68" ht="17.25" customHeight="1" hidden="0">
+        <row r="68">
             <c r="A68" s="1">
                 <f>
                     IF(TRUE,"TABOURET","JAMBON")
                 </f>
             </c>
         </row>
-        <row r="69" ht="17.25" customHeight="1" hidden="0">
+        <row r="69">
             <c r="A69" s="1">
                 <f>
                     IFERROR(0/0,"no diving by zero.")
                 </f>
             </c>
         </row>
-        <row r="70" ht="17.25" customHeight="1" hidden="0">
+        <row r="70">
             <c r="A70" s="1">
                 <f>
                     _xlfn.IFS($H2&gt;$H3,"first player is older",$H3&gt;$H2,"second player is older")
                 </f>
             </c>
         </row>
-        <row r="71" ht="17.25" customHeight="1" hidden="0">
+        <row r="71">
             <c r="A71" s="1">
                 <f>
                     ISERROR(0/0)
                 </f>
             </c>
         </row>
-        <row r="72" ht="17.25" customHeight="1" hidden="0">
+        <row r="72">
             <c r="A72" s="1">
                 <f>
                     ISEVEN(3)
                 </f>
             </c>
         </row>
-        <row r="73" ht="17.25" customHeight="1" hidden="0">
+        <row r="73">
             <c r="A73" s="1">
                 <f>
                     ISLOGICAL("TRUE")
                 </f>
             </c>
         </row>
-        <row r="74" ht="17.25" customHeight="1" hidden="0">
+        <row r="74">
             <c r="A74" s="1">
                 <f>
                     ISNONTEXT(TRUE)
                 </f>
             </c>
         </row>
-        <row r="75" ht="17.25" customHeight="1" hidden="0">
+        <row r="75">
             <c r="A75" s="1">
                 <f>
                     ISNUMBER(1231.5)
                 </f>
             </c>
         </row>
-        <row r="76" ht="17.25" customHeight="1" hidden="0">
+        <row r="76">
             <c r="A76" s="1">
                 <f>
                     ISO.CEILING(-7.89)
                 </f>
             </c>
         </row>
-        <row r="77" ht="17.25" customHeight="1" hidden="0">
+        <row r="77">
             <c r="A77" s="1">
                 <f>
                     ISODD(4)
                 </f>
             </c>
         </row>
-        <row r="78" ht="17.25" customHeight="1" hidden="0">
+        <row r="78">
             <c r="A78" s="1">
                 <f>
                     _xlfn.ISOWEEKNUM("2016-01-03")
                 </f>
             </c>
         </row>
-        <row r="79" ht="17.25" customHeight="1" hidden="0">
+        <row r="79">
             <c r="A79" s="1">
                 <f>
                     ISTEXT("123")
                 </f>
             </c>
         </row>
-        <row r="80" ht="17.25" customHeight="1" hidden="0">
+        <row r="80">
             <c r="A80" s="1">
                 <f>
                     LARGE(H2:H9,3)
                 </f>
             </c>
         </row>
-        <row r="81" ht="17.25" customHeight="1" hidden="0">
+        <row r="81">
             <c r="A81" s="1">
                 <f>
                     LEFT("Mich",4)
                 </f>
             </c>
         </row>
-        <row r="82" ht="17.25" customHeight="1" hidden="0">
+        <row r="82">
             <c r="A82" s="1">
                 <f>
                     LEN("anticonstitutionnellement")
                 </f>
             </c>
         </row>
-        <row r="83" ht="17.25" customHeight="1" hidden="0">
+        <row r="83">
             <c r="A83" s="1">
                 <f>
                     ROUND(LN(2),5)
                 </f>
             </c>
         </row>
-        <row r="84" ht="17.25" customHeight="1" hidden="0">
+        <row r="84">
             <c r="A84" s="1">
                 <f>
                     LOOKUP(42,H2:J9)
                 </f>
             </c>
         </row>
-        <row r="85" ht="17.25" customHeight="1" hidden="0">
+        <row r="85">
             <c r="A85" s="1">
                 <f>
                     LOWER("オAドB")
                 </f>
             </c>
         </row>
-        <row r="86" ht="17.25" customHeight="1" hidden="0">
+        <row r="86">
             <c r="A86" s="1">
                 <f>
                     MATCH(42,H2:H9,0)
                 </f>
             </c>
         </row>
-        <row r="87" ht="17.25" customHeight="1" hidden="0">
+        <row r="87">
             <c r="A87" s="1">
                 <f>
                     MAX(N1:N8)
                 </f>
             </c>
         </row>
-        <row r="88" ht="17.25" customHeight="1" hidden="0">
+        <row r="88">
             <c r="A88" s="1">
                 <f>
                     MAXA(N1:N8)
                 </f>
             </c>
         </row>
-        <row r="89" ht="17.25" customHeight="1" hidden="0">
+        <row r="89">
             <c r="A89" s="1">
                 <f>
                     _xlfn.MAXIFS(H2:H9,K2:K9,"&lt;20",K2:K9,"&lt;&gt;4")
                 </f>
             </c>
         </row>
-        <row r="90" ht="17.25" customHeight="1" hidden="0">
+        <row r="90">
             <c r="A90" s="1">
                 <f>
                     MEDIAN(-1,6,7,234,163845)
                 </f>
             </c>
         </row>
-        <row r="91" ht="17.25" customHeight="1" hidden="0">
+        <row r="91">
             <c r="A91" s="1">
                 <f>
                     MIN(N1:N8)
                 </f>
             </c>
         </row>
-        <row r="92" ht="17.25" customHeight="1" hidden="0">
+        <row r="92">
             <c r="A92" s="1">
                 <f>
                     MINA(N1:N8)
                 </f>
             </c>
         </row>
-        <row r="93" ht="17.25" customHeight="1" hidden="0">
+        <row r="93">
             <c r="A93" s="1">
                 <f>
                     _xlfn.MINIFS(J2:J9,H2:H9,"&gt;20")
                 </f>
             </c>
         </row>
-        <row r="94" ht="17.25" customHeight="1" hidden="0">
+        <row r="94">
             <c r="A94" s="1">
                 <f>
                     MINUTE(0.126)
                 </f>
             </c>
         </row>
-        <row r="95" ht="17.25" customHeight="1" hidden="0">
+        <row r="95">
             <c r="A95" s="1">
                 <f>
                     MOD(42,12)
                 </f>
             </c>
         </row>
-        <row r="96" ht="17.25" customHeight="1" hidden="0">
+        <row r="96">
             <c r="A96" s="1">
                 <f>
                     MONTH("1954-05-02")
                 </f>
             </c>
         </row>
-        <row r="97" ht="17.25" customHeight="1" hidden="0">
+        <row r="97">
             <c r="A97" s="1">
                 <f>
                     NETWORKDAYS("2013-01-01","2013-02-01")
                 </f>
             </c>
         </row>
-        <row r="98" ht="17.25" customHeight="1" hidden="0">
+        <row r="98">
             <c r="A98" s="1">
                 <f>
                     NETWORKDAYS.INTL("2013-01-01","2013-02-01","0000111")
                 </f>
             </c>
         </row>
-        <row r="99" ht="17.25" customHeight="1" hidden="0">
+        <row r="99">
             <c r="A99" s="1">
                 <f>
                     NOT(FALSE)
                 </f>
             </c>
         </row>
-        <row r="100" ht="17.25" customHeight="1" hidden="0">
+        <row r="100">
             <c r="A100" s="1">
                 <f>
                     NOW()
                 </f>
             </c>
         </row>
-        <row r="101" ht="17.25" customHeight="1" hidden="0">
+        <row r="101">
             <c r="A101" s="1">
                 <f>
                     ODD(4)
                 </f>
             </c>
         </row>
-        <row r="102" ht="17.25" customHeight="1" hidden="0">
+        <row r="102">
             <c r="A102" s="1">
                 <f>
                     OR("true",FALSE)
                 </f>
             </c>
         </row>
-        <row r="103" ht="17.25" customHeight="1" hidden="0">
+        <row r="103">
             <c r="A103" s="1">
                 <f>
                     PERCENTILE(N1:N5,1)
                 </f>
             </c>
         </row>
-        <row r="104" ht="17.25" customHeight="1" hidden="0">
+        <row r="104">
             <c r="A104" s="1">
                 <f>
                     _xlfn.PERCENTILE.EXC(N1:N5,0.5)
                 </f>
             </c>
         </row>
-        <row r="105" ht="17.25" customHeight="1" hidden="0">
+        <row r="105">
             <c r="A105" s="1">
                 <f>
                     _xlfn.PERCENTILE.INC(N1:N5,0)
                 </f>
             </c>
         </row>
-        <row r="106" ht="17.25" customHeight="1" hidden="0">
+        <row r="106">
             <c r="A106" s="1">
                 <f>
                     PI()
                 </f>
             </c>
         </row>
-        <row r="107" ht="17.25" customHeight="1" hidden="0">
+        <row r="107">
             <c r="A107" s="1">
                 <f>
                     POWER(42,2)
                 </f>
             </c>
         </row>
-        <row r="108" ht="17.25" customHeight="1" hidden="0">
+        <row r="108">
             <c r="A108" s="1">
                 <f>
                     PRODUCT(1,2,3)
                 </f>
             </c>
         </row>
-        <row r="109" ht="17.25" customHeight="1" hidden="0">
+        <row r="109">
             <c r="A109" s="1">
                 <f>
                     QUARTILE(N1:N5,0)
                 </f>
             </c>
         </row>
-        <row r="110" ht="17.25" customHeight="1" hidden="0">
+        <row r="110">
             <c r="A110" s="1">
                 <f>
                     _xlfn.QUARTILE.EXC(N1:N5,1)
                 </f>
             </c>
         </row>
-        <row r="111" ht="17.25" customHeight="1" hidden="0">
+        <row r="111">
             <c r="A111" s="1">
                 <f>
                     _xlfn.QUARTILE.INC(N1:N5,4)
                 </f>
             </c>
         </row>
-        <row r="112" ht="17.25" customHeight="1" hidden="0">
+        <row r="112">
             <c r="A112" s="1">
                 <f>
                     RAND()
                 </f>
             </c>
         </row>
-        <row r="113" ht="17.25" customHeight="1" hidden="0">
+        <row r="113">
             <c r="A113" s="1">
                 <f>
                     RANDBETWEEN(1.1,2)
                 </f>
             </c>
         </row>
-        <row r="114" ht="17.25" customHeight="1" hidden="0">
+        <row r="114">
             <c r="A114" s="1">
                 <f>
                     REPLACE("ABZ",2,1,"Y")
                 </f>
             </c>
         </row>
-        <row r="115" ht="17.25" customHeight="1" hidden="0">
+        <row r="115">
             <c r="A115" s="1">
                 <f>
                     RIGHT("kikou",2)
                 </f>
             </c>
         </row>
-        <row r="116" ht="17.25" customHeight="1" hidden="0">
+        <row r="116">
             <c r="A116" s="1">
                 <f>
                     ROUND(49.9,1)
                 </f>
             </c>
         </row>
-        <row r="117" ht="17.25" customHeight="1" hidden="0">
+        <row r="117">
             <c r="A117" s="1">
                 <f>
                     ROUNDDOWN(42,-1)
                 </f>
             </c>
         </row>
-        <row r="118" ht="17.25" customHeight="1" hidden="0">
+        <row r="118">
             <c r="A118" s="1">
                 <f>
                     ROUNDUP(-1.6,0)
                 </f>
             </c>
         </row>
-        <row r="119" ht="17.25" customHeight="1" hidden="0">
+        <row r="119">
             <c r="A119" s="1">
                 <f>
                     ROW(A234)
                 </f>
             </c>
         </row>
-        <row r="120" ht="17.25" customHeight="1" hidden="0">
+        <row r="120">
             <c r="A120" s="1">
                 <f>
                     ROWS(B3:C40)
                 </f>
             </c>
         </row>
-        <row r="121" ht="17.25" customHeight="1" hidden="0">
+        <row r="121">
             <c r="A121" s="1">
                 <f>
                     SEARCH("C","ABCD")
                 </f>
             </c>
         </row>
-        <row r="122" ht="17.25" customHeight="1" hidden="0">
+        <row r="122">
             <c r="A122" s="1">
                 <f>
                     _xlfn.SEC(PI()/3)
                 </f>
             </c>
         </row>
-        <row r="123" ht="17.25" customHeight="1" hidden="0">
+        <row r="123">
             <c r="A123" s="1">
                 <f>
                     _xlfn.SECH(1)
                 </f>
             </c>
         </row>
-        <row r="124" ht="17.25" customHeight="1" hidden="0">
+        <row r="124">
             <c r="A124" s="1">
                 <f>
                     SECOND("00:21:42")
                 </f>
             </c>
         </row>
-        <row r="125" ht="17.25" customHeight="1" hidden="0">
+        <row r="125">
             <c r="A125" s="1">
                 <f>
                     SIN(PI()/6)
                 </f>
             </c>
         </row>
-        <row r="126" ht="17.25" customHeight="1" hidden="0">
+        <row r="126">
             <c r="A126" s="1">
                 <f>
                     SINH(1)
                 </f>
             </c>
         </row>
-        <row r="127" ht="17.25" customHeight="1" hidden="0">
+        <row r="127">
             <c r="A127" s="1">
                 <f>
                     SMALL(H2:H9,3)
                 </f>
             </c>
         </row>
-        <row r="128" ht="17.25" customHeight="1" hidden="0">
+        <row r="128">
             <c r="A128" s="1">
                 <f>
                     SQRT(4)
                 </f>
             </c>
         </row>
-        <row r="129" ht="17.25" customHeight="1" hidden="0">
+        <row r="129">
             <c r="A129" s="1">
                 <f>
                     STDEV(-2,0,2)
                 </f>
             </c>
         </row>
-        <row r="130" ht="17.25" customHeight="1" hidden="0">
+        <row r="130">
             <c r="A130" s="1">
                 <f>
                     _xlfn.STDEV.P(2,4)
                 </f>
             </c>
         </row>
-        <row r="131" ht="17.25" customHeight="1" hidden="0">
+        <row r="131">
             <c r="A131" s="1">
                 <f>
                     _xlfn.STDEV.S(2,4,6)
                 </f>
             </c>
         </row>
-        <row r="132" ht="17.25" customHeight="1" hidden="0">
+        <row r="132">
             <c r="A132" s="1">
                 <f>
                     STDEVA(TRUE,3,5)
                 </f>
             </c>
         </row>
-        <row r="133" ht="17.25" customHeight="1" hidden="0">
+        <row r="133">
             <c r="A133" s="1">
                 <f>
                     STDEVP(2,5,8)
                 </f>
             </c>
         </row>
-        <row r="134" ht="17.25" customHeight="1" hidden="0">
+        <row r="134">
             <c r="A134" s="1">
                 <f>
                     STDEVPA(TRUE,4,7)
                 </f>
             </c>
         </row>
-        <row r="135" ht="17.25" customHeight="1" hidden="0">
+        <row r="135">
             <c r="A135" s="1">
                 <f>
                     SUBSTITUTE("SAP is best","SAP","Odoo")
                 </f>
             </c>
         </row>
-        <row r="136" ht="17.25" customHeight="1" hidden="0">
+        <row r="136">
             <c r="A136" s="1">
                 <f>
                     SUM(1,2,3,4,5)
                 </f>
             </c>
         </row>
-        <row r="137" ht="17.25" customHeight="1" hidden="0">
+        <row r="137">
             <c r="A137" s="1">
                 <f>
                     SUMIF(K2:K9,"&lt;100")
                 </f>
             </c>
         </row>
-        <row r="138" ht="17.25" customHeight="1" hidden="0">
+        <row r="138">
             <c r="A138" s="1">
                 <f>
                     SUMIFS(H2:H9,K2:K9,"&lt;100")
                 </f>
             </c>
         </row>
-        <row r="139" ht="17.25" customHeight="1" hidden="0">
+        <row r="139">
             <c r="A139" s="1">
                 <f>
                     TAN(PI()/4)
                 </f>
             </c>
         </row>
-        <row r="140" ht="17.25" customHeight="1" hidden="0">
+        <row r="140">
             <c r="A140" s="1">
                 <f>
                     TANH(1)
                 </f>
             </c>
         </row>
-        <row r="141" ht="17.25" customHeight="1" hidden="0">
+        <row r="141">
             <c r="A141" s="1">
                 <f>
                     _xlfn.TEXTJOIN("-",TRUE,"","1","A","%")
                 </f>
             </c>
         </row>
-        <row r="142" ht="17.25" customHeight="1" hidden="0">
+        <row r="142">
             <c r="A142" s="1">
                 <f>
                     TIME(9,11,31)
                 </f>
             </c>
         </row>
-        <row r="143" ht="17.25" customHeight="1" hidden="0">
+        <row r="143">
             <c r="A143" s="1">
                 <f>
                     TIMEVALUE("18:00:00")
                 </f>
             </c>
         </row>
-        <row r="144" ht="17.25" customHeight="1" hidden="0">
+        <row r="144">
             <c r="A144" s="1">
                 <f>
                     TODAY()
                 </f>
             </c>
         </row>
-        <row r="145" ht="17.25" customHeight="1" hidden="0">
+        <row r="145">
             <c r="A145" s="1">
                 <f>
                     TRIM(" Jean Ticonstitutionnalise ")
                 </f>
             </c>
         </row>
-        <row r="146" ht="17.25" customHeight="1" hidden="0">
+        <row r="146">
             <c r="A146" s="1">
                 <f>
                     TRUNC(42.42,1)
                 </f>
             </c>
         </row>
-        <row r="147" ht="17.25" customHeight="1" hidden="0">
+        <row r="147">
             <c r="A147" s="1">
                 <f>
                     UPPER("grrrr !")
                 </f>
             </c>
         </row>
-        <row r="148" ht="17.25" customHeight="1" hidden="0">
+        <row r="148">
             <c r="A148" s="1">
                 <f>
                     VAR(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="149" ht="17.25" customHeight="1" hidden="0">
+        <row r="149">
             <c r="A149" s="1">
                 <f>
                     _xlfn.VAR.P(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="150" ht="17.25" customHeight="1" hidden="0">
+        <row r="150">
             <c r="A150" s="1">
                 <f>
                     _xlfn.VAR.S(2,5,8)
                 </f>
             </c>
         </row>
-        <row r="151" ht="17.25" customHeight="1" hidden="0">
+        <row r="151">
             <c r="A151" s="1">
                 <f>
                     VARA(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="152" ht="17.25" customHeight="1" hidden="0">
+        <row r="152">
             <c r="A152" s="1">
                 <f>
                     VARP(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="153" ht="17.25" customHeight="1" hidden="0">
+        <row r="153">
             <c r="A153" s="1">
                 <f>
                     VARPA(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="154" ht="17.25" customHeight="1" hidden="0">
+        <row r="154">
             <c r="A154" s="1">
                 <f>
                     VLOOKUP("NotACheater",G1:K9,3,FALSE)
                 </f>
             </c>
         </row>
-        <row r="155" ht="17.25" customHeight="1" hidden="0">
+        <row r="155">
             <c r="A155" s="1">
                 <f>
                     WEEKDAY("2021-06-12")
                 </f>
             </c>
         </row>
-        <row r="156" ht="17.25" customHeight="1" hidden="0">
+        <row r="156">
             <c r="A156" s="1">
                 <f>
                     WEEKNUM("2021-06-29")
                 </f>
             </c>
         </row>
-        <row r="157" ht="17.25" customHeight="1" hidden="0">
+        <row r="157">
             <c r="A157" s="1">
                 <f>
                     WORKDAY("2021-03-15",6)
                 </f>
             </c>
         </row>
-        <row r="158" ht="17.25" customHeight="1" hidden="0">
+        <row r="158">
             <c r="A158" s="1">
                 <f>
                     WORKDAY.INTL("2021-03-15",6,"0111111")
                 </f>
             </c>
         </row>
-        <row r="159" ht="17.25" customHeight="1" hidden="0">
+        <row r="159">
             <c r="A159" s="1">
                 <f>
                     _xlfn.XOR(FALSE,TRUE,FALSE,FALSE)
                 </f>
             </c>
         </row>
-        <row r="160" ht="17.25" customHeight="1" hidden="0">
+        <row r="160">
             <c r="A160" s="1">
                 <f>
                     YEAR("2012-03-12")
                 </f>
             </c>
         </row>
-        <row r="161" ht="17.25" customHeight="1" hidden="0">
+        <row r="161">
             <c r="A161" s="1">
                 <f>
                     DELTA(1,1)
                 </f>
             </c>
         </row>
-        <row r="162" ht="17.25" customHeight="1" hidden="0">
+        <row r="162">
             <c r="A162" s="1">
                 <f>
                     NA()
                 </f>
             </c>
         </row>
-        <row r="163" ht="17.25" customHeight="1" hidden="0">
+        <row r="163">
             <c r="A163" s="1">
                 <f>
                     ISNA(A162)
                 </f>
             </c>
         </row>
-        <row r="164" ht="17.25" customHeight="1" hidden="0">
+        <row r="164">
             <c r="A164" s="1">
                 <f>
                     ISERR(A162)
                 </f>
             </c>
         </row>
-        <row r="165" ht="17.25" customHeight="1" hidden="0">
+        <row r="165">
             <c r="A165" s="1">
                 <f>
                     HYPERLINK("https://www.odoo.com","Odoo")
                 </f>
             </c>
         </row>
-        <row r="166" ht="17.25" customHeight="1" hidden="0">
+        <row r="166">
             <c r="A166" s="1">
                 <f>
                     ADDRESS(27,53,4,FALSE,"sheet!")
                 </f>
             </c>
         </row>
-        <row r="167" ht="17.25" customHeight="1" hidden="0">
+        <row r="167">
             <c r="A167" s="1">
                 <f>
                     DATEDIF("2002-01-01","2002-01-02","D")
                 </f>
             </c>
         </row>
-        <row r="168" ht="17.25" customHeight="1" hidden="0">
+        <row r="168">
             <c r="A168" s="1">
                 <f>
                     RANDARRAY(2,2)
@@ -14728,7 +14728,7 @@ exports[`Test XLSX export formulas All exportable formulas 1`] = `
             <c r="B168" s="1">
             </c>
         </row>
-        <row r="169" ht="17.25" customHeight="1" hidden="0">
+        <row r="169">
             <c r="A169" s="1">
             </c>
             <c r="B169" s="1">
@@ -14984,147 +14984,147 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1" t="s">
                 <v>
                     0
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1">
                 <v>
                     4
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     1
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1">
                 <v>
                     66
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1">
                 <v>
                     2
                 </v>
             </c>
         </row>
-        <row r="6" ht="17.25" customHeight="1" hidden="0">
+        <row r="6">
             <c r="A6" s="1" t="b">
                 <v>
                     1
                 </v>
             </c>
         </row>
-        <row r="7" ht="17.25" customHeight="1" hidden="0">
+        <row r="7">
             <c r="A7" s="1" t="b">
                 <v>
                     1
                 </v>
             </c>
         </row>
-        <row r="8" ht="17.25" customHeight="1" hidden="0">
+        <row r="8">
             <c r="A8" s="1" t="b">
                 <v>
                     1
                 </v>
             </c>
         </row>
-        <row r="9" ht="17.25" customHeight="1" hidden="0">
+        <row r="9">
             <c r="A9" s="1" t="s">
                 <v>
                     2
                 </v>
             </c>
         </row>
-        <row r="10" ht="17.25" customHeight="1" hidden="0">
+        <row r="10">
             <c r="A10" s="1" t="b">
                 <v>
                     1
                 </v>
             </c>
         </row>
-        <row r="11" ht="17.25" customHeight="1" hidden="0">
+        <row r="11">
             <c r="A11" s="1">
                 <v>
                     18
                 </v>
             </c>
         </row>
-        <row r="12" ht="17.25" customHeight="1" hidden="0">
+        <row r="12">
             <c r="A12" s="1">
                 <v>
                     84
                 </v>
             </c>
         </row>
-        <row r="13" ht="17.25" customHeight="1" hidden="0">
+        <row r="13">
             <c r="A13" s="1" t="b">
                 <v>
                     1
                 </v>
             </c>
         </row>
-        <row r="14" ht="17.25" customHeight="1" hidden="0">
+        <row r="14">
             <c r="A14" s="1">
                 <v>
                     27
                 </v>
             </c>
         </row>
-        <row r="15" ht="17.25" customHeight="1" hidden="0">
+        <row r="15">
             <c r="A15" s="1">
                 <v>
                     3
                 </v>
             </c>
         </row>
-        <row r="16" ht="17.25" customHeight="1" hidden="0">
+        <row r="16">
             <c r="A16" s="1">
                 <v>
                     0.04
                 </v>
             </c>
         </row>
-        <row r="17" ht="17.25" customHeight="1" hidden="0">
+        <row r="17">
             <c r="A17" s="1">
                 <v>
                     42
                 </v>
             </c>
         </row>
-        <row r="18" ht="17.25" customHeight="1" hidden="0">
+        <row r="18">
             <c r="A18" s="1">
                 <v>
                     2.5
                 </v>
             </c>
         </row>
-        <row r="19" ht="17.25" customHeight="1" hidden="0">
+        <row r="19">
             <c r="A19" s="1">
                 <v>
                     213
                 </v>
             </c>
         </row>
-        <row r="20" ht="17.25" customHeight="1" hidden="0">
+        <row r="20">
             <c r="A20" s="1">
                 <v>
                     0
                 </v>
             </c>
         </row>
-        <row r="21" ht="17.25" customHeight="1" hidden="0">
+        <row r="21">
             <c r="A21" s="2">
                 <v>
                     1000
@@ -15340,7 +15340,7 @@ exports[`Test XLSX export formulas Multi-Sheet export async functions without cr
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1">
                 <v>
                     5
@@ -15500,7 +15500,7 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1">
                 <f>
                     SUM(Sheet2!A1)
@@ -15548,7 +15548,7 @@ exports[`Test XLSX export formulas Multi-Sheet export functions with cross refer
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1">
                 <v>
                     5
@@ -15708,7 +15708,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1" t="s">
                 <v>
                     0
@@ -15745,7 +15745,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1">
                 <f>
                     ABS(-5.5)
@@ -15782,7 +15782,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1">
                 <f>
                     ACOS(1)
@@ -15819,7 +15819,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1">
                 <f>
                     ACOSH(2)
@@ -15856,7 +15856,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1">
                 <f>
                     _xlfn.ACOT(1)
@@ -15898,7 +15898,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="6" ht="17.25" customHeight="1" hidden="0">
+        <row r="6">
             <c r="A6" s="1">
                 <f>
                     _xlfn.ACOTH(2)
@@ -15935,7 +15935,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="7" ht="17.25" customHeight="1" hidden="0">
+        <row r="7">
             <c r="A7" s="1">
                 <f>
                     AND(TRUE,TRUE)
@@ -15972,7 +15972,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="8" ht="17.25" customHeight="1" hidden="0">
+        <row r="8">
             <c r="A8" s="1">
                 <f>
                     ASIN(0.5)
@@ -16009,7 +16009,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="9" ht="17.25" customHeight="1" hidden="0">
+        <row r="9">
             <c r="A9" s="1">
                 <f>
                     ASINH(2)
@@ -16041,14 +16041,14 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="10" ht="17.25" customHeight="1" hidden="0">
+        <row r="10">
             <c r="A10" s="1">
                 <f>
                     ATAN(1)
                 </f>
             </c>
         </row>
-        <row r="11" ht="17.25" customHeight="1" hidden="0">
+        <row r="11">
             <c r="A11" s="1">
                 <f>
                     ATAN2(-1,0)
@@ -16060,7 +16060,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="12" ht="17.25" customHeight="1" hidden="0">
+        <row r="12">
             <c r="A12" s="1">
                 <f>
                     ATANH(0.7)
@@ -16092,7 +16092,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="13" ht="17.25" customHeight="1" hidden="0">
+        <row r="13">
             <c r="A13" s="1">
                 <f>
                     AVEDEV(I2:I9)
@@ -16124,1085 +16124,1085 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
                 </v>
             </c>
         </row>
-        <row r="14" ht="17.25" customHeight="1" hidden="0">
+        <row r="14">
             <c r="A14" s="1">
                 <f>
                     AVERAGE(H2:H9)
                 </f>
             </c>
         </row>
-        <row r="15" ht="17.25" customHeight="1" hidden="0">
+        <row r="15">
             <c r="A15" s="1">
                 <f>
                     AVERAGEA(G2:H9)
                 </f>
             </c>
         </row>
-        <row r="16" ht="17.25" customHeight="1" hidden="0">
+        <row r="16">
             <c r="A16" s="1">
                 <f>
                     AVERAGEIF(J2:J9,"&gt;150000")
                 </f>
             </c>
         </row>
-        <row r="17" ht="17.25" customHeight="1" hidden="0">
+        <row r="17">
             <c r="A17" s="1">
                 <f>
                     AVERAGEIFS(I2:I9,H2:H9,"&gt;=30",K2:K9,"&lt;10")
                 </f>
             </c>
         </row>
-        <row r="18" ht="17.25" customHeight="1" hidden="0">
+        <row r="18">
             <c r="A18" s="1">
                 <f>
                     CEILING(20.4,1)
                 </f>
             </c>
         </row>
-        <row r="19" ht="17.25" customHeight="1" hidden="0">
+        <row r="19">
             <c r="A19" s="1">
                 <f>
                     _xlfn.CEILING.MATH(-5.5,1,0)
                 </f>
             </c>
         </row>
-        <row r="20" ht="17.25" customHeight="1" hidden="0">
+        <row r="20">
             <c r="A20" s="1">
                 <f>
                     _xlfn.CEILING.PRECISE(230,100)
                 </f>
             </c>
         </row>
-        <row r="21" ht="17.25" customHeight="1" hidden="0">
+        <row r="21">
             <c r="A21" s="1">
                 <f>
                     CHAR(74)
                 </f>
             </c>
         </row>
-        <row r="22" ht="17.25" customHeight="1" hidden="0">
+        <row r="22">
             <c r="A22" s="1">
                 <f>
                     COLUMN(C4)
                 </f>
             </c>
         </row>
-        <row r="23" ht="17.25" customHeight="1" hidden="0">
+        <row r="23">
             <c r="A23" s="1">
                 <f>
                     COLUMNS(A5:D12)
                 </f>
             </c>
         </row>
-        <row r="24" ht="17.25" customHeight="1" hidden="0">
+        <row r="24">
             <c r="A24" s="1">
                 <f>
                     _xlfn.CONCAT(1,23)
                 </f>
             </c>
         </row>
-        <row r="25" ht="17.25" customHeight="1" hidden="0">
+        <row r="25">
             <c r="A25" s="1">
                 <f>
                     CONCATENATE("BUT, ","MICHEL")
                 </f>
             </c>
         </row>
-        <row r="26" ht="17.25" customHeight="1" hidden="0">
+        <row r="26">
             <c r="A26" s="1">
                 <f>
                     COS(PI()/3)
                 </f>
             </c>
         </row>
-        <row r="27" ht="17.25" customHeight="1" hidden="0">
+        <row r="27">
             <c r="A27" s="1">
                 <f>
                     COSH(2)
                 </f>
             </c>
         </row>
-        <row r="28" ht="17.25" customHeight="1" hidden="0">
+        <row r="28">
             <c r="A28" s="1">
                 <f>
                     _xlfn.COT(PI()/6)
                 </f>
             </c>
         </row>
-        <row r="29" ht="17.25" customHeight="1" hidden="0">
+        <row r="29">
             <c r="A29" s="1">
                 <f>
                     _xlfn.COTH(0.5)
                 </f>
             </c>
         </row>
-        <row r="30" ht="17.25" customHeight="1" hidden="0">
+        <row r="30">
             <c r="A30" s="1">
                 <f>
                     COUNT(1,"a","5","2021-03-14")
                 </f>
             </c>
         </row>
-        <row r="31" ht="17.25" customHeight="1" hidden="0">
+        <row r="31">
             <c r="A31" s="1">
                 <f>
                     COUNTA(1,"a","5","2021-03-14")
                 </f>
             </c>
         </row>
-        <row r="32" ht="17.25" customHeight="1" hidden="0">
+        <row r="32">
             <c r="A32" s="1">
                 <f>
                     COUNTBLANK("","1",3,FALSE)
                 </f>
             </c>
         </row>
-        <row r="33" ht="17.25" customHeight="1" hidden="0">
+        <row r="33">
             <c r="A33" s="1">
                 <f>
                     COUNTIF(H2:H9,"&gt;30")
                 </f>
             </c>
         </row>
-        <row r="34" ht="17.25" customHeight="1" hidden="0">
+        <row r="34">
             <c r="A34" s="1">
                 <f>
                     COUNTIFS(H2:H9,"&gt;25",K2:K9,"&lt;4")
                 </f>
             </c>
         </row>
-        <row r="35" ht="17.25" customHeight="1" hidden="0">
+        <row r="35">
             <c r="A35" s="1">
                 <f>
                     COVAR(H2:H9,K2:K9)
                 </f>
             </c>
         </row>
-        <row r="36" ht="17.25" customHeight="1" hidden="0">
+        <row r="36">
             <c r="A36" s="1">
                 <f>
                     _xlfn.COVARIANCE.P(K2:K9,H2:H9)
                 </f>
             </c>
         </row>
-        <row r="37" ht="17.25" customHeight="1" hidden="0">
+        <row r="37">
             <c r="A37" s="1">
                 <f>
                     _xlfn.COVARIANCE.P(I2:I9,J2:J9)
                 </f>
             </c>
         </row>
-        <row r="38" ht="17.25" customHeight="1" hidden="0">
+        <row r="38">
             <c r="A38" s="1">
                 <f>
                     _xlfn.CSC(PI()/4)
                 </f>
             </c>
         </row>
-        <row r="39" ht="17.25" customHeight="1" hidden="0">
+        <row r="39">
             <c r="A39" s="1">
                 <f>
                     _xlfn.CSCH(PI()/3)
                 </f>
             </c>
         </row>
-        <row r="40" ht="17.25" customHeight="1" hidden="0">
+        <row r="40">
             <c r="A40" s="1">
                 <f>
                     DATE(2020,5,25)
                 </f>
             </c>
         </row>
-        <row r="41" ht="17.25" customHeight="1" hidden="0">
+        <row r="41">
             <c r="A41" s="1">
                 <f>
                     DATEVALUE("1969-08-15")
                 </f>
             </c>
         </row>
-        <row r="42" ht="17.25" customHeight="1" hidden="0">
+        <row r="42">
             <c r="A42" s="1">
                 <f>
                     DAVERAGE(G1:K9,"Tot. Score",J12:J13)
                 </f>
             </c>
         </row>
-        <row r="43" ht="17.25" customHeight="1" hidden="0">
+        <row r="43">
             <c r="A43" s="1">
                 <f>
                     DAY("2020-03-17")
                 </f>
             </c>
         </row>
-        <row r="44" ht="17.25" customHeight="1" hidden="0">
+        <row r="44">
             <c r="A44" s="1">
                 <f>
                     _xlfn.DAYS("2022-03-17","2021-03-17")
                 </f>
             </c>
         </row>
-        <row r="45" ht="17.25" customHeight="1" hidden="0">
+        <row r="45">
             <c r="A45" s="1">
                 <f>
                     DCOUNT(G1:K9,"Name",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="46" ht="17.25" customHeight="1" hidden="0">
+        <row r="46">
             <c r="A46" s="1">
                 <f>
                     DCOUNTA(G1:K9,"Name",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="47" ht="17.25" customHeight="1" hidden="0">
+        <row r="47">
             <c r="A47" s="1">
                 <f>
                     _xlfn.DECIMAL(20,16)
                 </f>
             </c>
         </row>
-        <row r="48" ht="17.25" customHeight="1" hidden="0">
+        <row r="48">
             <c r="A48" s="1">
                 <f>
                     DEGREES(PI()/4)
                 </f>
             </c>
         </row>
-        <row r="49" ht="17.25" customHeight="1" hidden="0">
+        <row r="49">
             <c r="A49" s="1">
                 <f>
                     DGET(G1:K9,"Hours Played",G12:G13)
                 </f>
             </c>
         </row>
-        <row r="50" ht="17.25" customHeight="1" hidden="0">
+        <row r="50">
             <c r="A50" s="1">
                 <f>
                     DMAX(G1:K9,"Tot. Score",I12:I13)
                 </f>
             </c>
         </row>
-        <row r="51" ht="17.25" customHeight="1" hidden="0">
+        <row r="51">
             <c r="A51" s="1">
                 <f>
                     DMIN(G1:K9,"Tot. Score",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="52" ht="17.25" customHeight="1" hidden="0">
+        <row r="52">
             <c r="A52" s="1">
                 <f>
                     DPRODUCT(G1:K9,"Age",K12:K13)
                 </f>
             </c>
         </row>
-        <row r="53" ht="17.25" customHeight="1" hidden="0">
+        <row r="53">
             <c r="A53" s="1">
                 <f>
                     DSTDEV(G1:K9,"Age",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="54" ht="17.25" customHeight="1" hidden="0">
+        <row r="54">
             <c r="A54" s="1">
                 <f>
                     DSTDEVP(G1:K9,"Age",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="55" ht="17.25" customHeight="1" hidden="0">
+        <row r="55">
             <c r="A55" s="1">
                 <f>
                     DSUM(G1:K9,"Age",I12:I13)
                 </f>
             </c>
         </row>
-        <row r="56" ht="17.25" customHeight="1" hidden="0">
+        <row r="56">
             <c r="A56" s="1">
                 <f>
                     DVAR(G1:K9,"Hours Played",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="57" ht="17.25" customHeight="1" hidden="0">
+        <row r="57">
             <c r="A57" s="1">
                 <f>
                     DVARP(G1:K9,"Hours Played",H12:H13)
                 </f>
             </c>
         </row>
-        <row r="58" ht="17.25" customHeight="1" hidden="0">
+        <row r="58">
             <c r="A58" s="1">
                 <f>
                     EDATE("1969-07-22",-2)
                 </f>
             </c>
         </row>
-        <row r="59" ht="17.25" customHeight="1" hidden="0">
+        <row r="59">
             <c r="A59" s="1">
                 <f>
                     EOMONTH("2020-07-21",1)
                 </f>
             </c>
         </row>
-        <row r="60" ht="17.25" customHeight="1" hidden="0">
+        <row r="60">
             <c r="A60" s="1">
                 <f>
                     EXACT("AbsSdf%","AbsSdf%")
                 </f>
             </c>
         </row>
-        <row r="61" ht="17.25" customHeight="1" hidden="0">
+        <row r="61">
             <c r="A61" s="1">
                 <f>
                     EXP(4)
                 </f>
             </c>
         </row>
-        <row r="62" ht="17.25" customHeight="1" hidden="0">
+        <row r="62">
             <c r="A62" s="1">
                 <f>
                     FIND("A","qbdahbaazo A")
                 </f>
             </c>
         </row>
-        <row r="63" ht="17.25" customHeight="1" hidden="0">
+        <row r="63">
             <c r="A63" s="1">
                 <f>
                     FLOOR(5.5,2)
                 </f>
             </c>
         </row>
-        <row r="64" ht="17.25" customHeight="1" hidden="0">
+        <row r="64">
             <c r="A64" s="1">
                 <f>
                     _xlfn.FLOOR.MATH(-5.55,2,1)
                 </f>
             </c>
         </row>
-        <row r="65" ht="17.25" customHeight="1" hidden="0">
+        <row r="65">
             <c r="A65" s="1">
                 <f>
                     _xlfn.FLOOR.PRECISE(199,100)
                 </f>
             </c>
         </row>
-        <row r="66" ht="17.25" customHeight="1" hidden="0">
+        <row r="66">
             <c r="A66" s="1">
                 <f>
                     HLOOKUP("Tot. Score",H1:K9,4,FALSE)
                 </f>
             </c>
         </row>
-        <row r="67" ht="17.25" customHeight="1" hidden="0">
+        <row r="67">
             <c r="A67" s="1">
                 <f>
                     HOUR("02:14:56")
                 </f>
             </c>
         </row>
-        <row r="68" ht="17.25" customHeight="1" hidden="0">
+        <row r="68">
             <c r="A68" s="1">
                 <f>
                     IF(TRUE,"TABOURET","JAMBON")
                 </f>
             </c>
         </row>
-        <row r="69" ht="17.25" customHeight="1" hidden="0">
+        <row r="69">
             <c r="A69" s="1">
                 <f>
                     IFERROR(0/0,"no diving by zero.")
                 </f>
             </c>
         </row>
-        <row r="70" ht="17.25" customHeight="1" hidden="0">
+        <row r="70">
             <c r="A70" s="1">
                 <f>
                     _xlfn.IFS($H2&gt;$H3,"first player is older",$H3&gt;$H2,"second player is older")
                 </f>
             </c>
         </row>
-        <row r="71" ht="17.25" customHeight="1" hidden="0">
+        <row r="71">
             <c r="A71" s="1">
                 <f>
                     ISERROR(0/0)
                 </f>
             </c>
         </row>
-        <row r="72" ht="17.25" customHeight="1" hidden="0">
+        <row r="72">
             <c r="A72" s="1">
                 <f>
                     ISEVEN(3)
                 </f>
             </c>
         </row>
-        <row r="73" ht="17.25" customHeight="1" hidden="0">
+        <row r="73">
             <c r="A73" s="1">
                 <f>
                     ISLOGICAL("TRUE")
                 </f>
             </c>
         </row>
-        <row r="74" ht="17.25" customHeight="1" hidden="0">
+        <row r="74">
             <c r="A74" s="1">
                 <f>
                     ISNONTEXT(TRUE)
                 </f>
             </c>
         </row>
-        <row r="75" ht="17.25" customHeight="1" hidden="0">
+        <row r="75">
             <c r="A75" s="1">
                 <f>
                     ISNUMBER(1231.5)
                 </f>
             </c>
         </row>
-        <row r="76" ht="17.25" customHeight="1" hidden="0">
+        <row r="76">
             <c r="A76" s="1">
                 <f>
                     ISO.CEILING(-7.89)
                 </f>
             </c>
         </row>
-        <row r="77" ht="17.25" customHeight="1" hidden="0">
+        <row r="77">
             <c r="A77" s="1">
                 <f>
                     ISODD(4)
                 </f>
             </c>
         </row>
-        <row r="78" ht="17.25" customHeight="1" hidden="0">
+        <row r="78">
             <c r="A78" s="1">
                 <f>
                     _xlfn.ISOWEEKNUM("2016-01-03")
                 </f>
             </c>
         </row>
-        <row r="79" ht="17.25" customHeight="1" hidden="0">
+        <row r="79">
             <c r="A79" s="1">
                 <f>
                     ISTEXT("123")
                 </f>
             </c>
         </row>
-        <row r="80" ht="17.25" customHeight="1" hidden="0">
+        <row r="80">
             <c r="A80" s="1">
                 <f>
                     LARGE(H2:H9,3)
                 </f>
             </c>
         </row>
-        <row r="81" ht="17.25" customHeight="1" hidden="0">
+        <row r="81">
             <c r="A81" s="1">
                 <f>
                     LEFT("Mich",4)
                 </f>
             </c>
         </row>
-        <row r="82" ht="17.25" customHeight="1" hidden="0">
+        <row r="82">
             <c r="A82" s="1">
                 <f>
                     LEN("anticonstitutionnellement")
                 </f>
             </c>
         </row>
-        <row r="83" ht="17.25" customHeight="1" hidden="0">
+        <row r="83">
             <c r="A83" s="1">
                 <f>
                     ROUND(LN(2),5)
                 </f>
             </c>
         </row>
-        <row r="84" ht="17.25" customHeight="1" hidden="0">
+        <row r="84">
             <c r="A84" s="1">
                 <f>
                     LOOKUP(42,H2:J9)
                 </f>
             </c>
         </row>
-        <row r="85" ht="17.25" customHeight="1" hidden="0">
+        <row r="85">
             <c r="A85" s="1">
                 <f>
                     LOWER("オAドB")
                 </f>
             </c>
         </row>
-        <row r="86" ht="17.25" customHeight="1" hidden="0">
+        <row r="86">
             <c r="A86" s="1">
                 <f>
                     MATCH(42,H2:H9,0)
                 </f>
             </c>
         </row>
-        <row r="87" ht="17.25" customHeight="1" hidden="0">
+        <row r="87">
             <c r="A87" s="1">
                 <f>
                     MAX(N1:N8)
                 </f>
             </c>
         </row>
-        <row r="88" ht="17.25" customHeight="1" hidden="0">
+        <row r="88">
             <c r="A88" s="1">
                 <f>
                     MAXA(N1:N8)
                 </f>
             </c>
         </row>
-        <row r="89" ht="17.25" customHeight="1" hidden="0">
+        <row r="89">
             <c r="A89" s="1">
                 <f>
                     _xlfn.MAXIFS(H2:H9,K2:K9,"&lt;20",K2:K9,"&lt;&gt;4")
                 </f>
             </c>
         </row>
-        <row r="90" ht="17.25" customHeight="1" hidden="0">
+        <row r="90">
             <c r="A90" s="1">
                 <f>
                     MEDIAN(-1,6,7,234,163845)
                 </f>
             </c>
         </row>
-        <row r="91" ht="17.25" customHeight="1" hidden="0">
+        <row r="91">
             <c r="A91" s="1">
                 <f>
                     MIN(N1:N8)
                 </f>
             </c>
         </row>
-        <row r="92" ht="17.25" customHeight="1" hidden="0">
+        <row r="92">
             <c r="A92" s="1">
                 <f>
                     MINA(N1:N8)
                 </f>
             </c>
         </row>
-        <row r="93" ht="17.25" customHeight="1" hidden="0">
+        <row r="93">
             <c r="A93" s="1">
                 <f>
                     _xlfn.MINIFS(J2:J9,H2:H9,"&gt;20")
                 </f>
             </c>
         </row>
-        <row r="94" ht="17.25" customHeight="1" hidden="0">
+        <row r="94">
             <c r="A94" s="1">
                 <f>
                     MINUTE(0.126)
                 </f>
             </c>
         </row>
-        <row r="95" ht="17.25" customHeight="1" hidden="0">
+        <row r="95">
             <c r="A95" s="1">
                 <f>
                     MOD(42,12)
                 </f>
             </c>
         </row>
-        <row r="96" ht="17.25" customHeight="1" hidden="0">
+        <row r="96">
             <c r="A96" s="1">
                 <f>
                     MONTH("1954-05-02")
                 </f>
             </c>
         </row>
-        <row r="97" ht="17.25" customHeight="1" hidden="0">
+        <row r="97">
             <c r="A97" s="1">
                 <f>
                     NETWORKDAYS("2013-01-01","2013-02-01")
                 </f>
             </c>
         </row>
-        <row r="98" ht="17.25" customHeight="1" hidden="0">
+        <row r="98">
             <c r="A98" s="1">
                 <f>
                     NETWORKDAYS.INTL("2013-01-01","2013-02-01","0000111")
                 </f>
             </c>
         </row>
-        <row r="99" ht="17.25" customHeight="1" hidden="0">
+        <row r="99">
             <c r="A99" s="1">
                 <f>
                     NOT(FALSE)
                 </f>
             </c>
         </row>
-        <row r="100" ht="17.25" customHeight="1" hidden="0">
+        <row r="100">
             <c r="A100" s="1">
                 <f>
                     NOW()
                 </f>
             </c>
         </row>
-        <row r="101" ht="17.25" customHeight="1" hidden="0">
+        <row r="101">
             <c r="A101" s="1">
                 <f>
                     ODD(4)
                 </f>
             </c>
         </row>
-        <row r="102" ht="17.25" customHeight="1" hidden="0">
+        <row r="102">
             <c r="A102" s="1">
                 <f>
                     OR("true",FALSE)
                 </f>
             </c>
         </row>
-        <row r="103" ht="17.25" customHeight="1" hidden="0">
+        <row r="103">
             <c r="A103" s="1">
                 <f>
                     PERCENTILE(N1:N5,1)
                 </f>
             </c>
         </row>
-        <row r="104" ht="17.25" customHeight="1" hidden="0">
+        <row r="104">
             <c r="A104" s="1">
                 <f>
                     _xlfn.PERCENTILE.EXC(N1:N5,0.5)
                 </f>
             </c>
         </row>
-        <row r="105" ht="17.25" customHeight="1" hidden="0">
+        <row r="105">
             <c r="A105" s="1">
                 <f>
                     _xlfn.PERCENTILE.INC(N1:N5,0)
                 </f>
             </c>
         </row>
-        <row r="106" ht="17.25" customHeight="1" hidden="0">
+        <row r="106">
             <c r="A106" s="1">
                 <f>
                     PI()
                 </f>
             </c>
         </row>
-        <row r="107" ht="17.25" customHeight="1" hidden="0">
+        <row r="107">
             <c r="A107" s="1">
                 <f>
                     POWER(42,2)
                 </f>
             </c>
         </row>
-        <row r="108" ht="17.25" customHeight="1" hidden="0">
+        <row r="108">
             <c r="A108" s="1">
                 <f>
                     PRODUCT(1,2,3)
                 </f>
             </c>
         </row>
-        <row r="109" ht="17.25" customHeight="1" hidden="0">
+        <row r="109">
             <c r="A109" s="1">
                 <f>
                     QUARTILE(N1:N5,0)
                 </f>
             </c>
         </row>
-        <row r="110" ht="17.25" customHeight="1" hidden="0">
+        <row r="110">
             <c r="A110" s="1">
                 <f>
                     _xlfn.QUARTILE.EXC(N1:N5,1)
                 </f>
             </c>
         </row>
-        <row r="111" ht="17.25" customHeight="1" hidden="0">
+        <row r="111">
             <c r="A111" s="1">
                 <f>
                     _xlfn.QUARTILE.INC(N1:N5,4)
                 </f>
             </c>
         </row>
-        <row r="112" ht="17.25" customHeight="1" hidden="0">
+        <row r="112">
             <c r="A112" s="1">
                 <f>
                     RAND()
                 </f>
             </c>
         </row>
-        <row r="113" ht="17.25" customHeight="1" hidden="0">
+        <row r="113">
             <c r="A113" s="1">
                 <f>
                     RANDBETWEEN(1.1,2)
                 </f>
             </c>
         </row>
-        <row r="114" ht="17.25" customHeight="1" hidden="0">
+        <row r="114">
             <c r="A114" s="1">
                 <f>
                     REPLACE("ABZ",2,1,"Y")
                 </f>
             </c>
         </row>
-        <row r="115" ht="17.25" customHeight="1" hidden="0">
+        <row r="115">
             <c r="A115" s="1">
                 <f>
                     RIGHT("kikou",2)
                 </f>
             </c>
         </row>
-        <row r="116" ht="17.25" customHeight="1" hidden="0">
+        <row r="116">
             <c r="A116" s="1">
                 <f>
                     ROUND(49.9,1)
                 </f>
             </c>
         </row>
-        <row r="117" ht="17.25" customHeight="1" hidden="0">
+        <row r="117">
             <c r="A117" s="1">
                 <f>
                     ROUNDDOWN(42,-1)
                 </f>
             </c>
         </row>
-        <row r="118" ht="17.25" customHeight="1" hidden="0">
+        <row r="118">
             <c r="A118" s="1">
                 <f>
                     ROUNDUP(-1.6,0)
                 </f>
             </c>
         </row>
-        <row r="119" ht="17.25" customHeight="1" hidden="0">
+        <row r="119">
             <c r="A119" s="1">
                 <f>
                     ROW(A234)
                 </f>
             </c>
         </row>
-        <row r="120" ht="17.25" customHeight="1" hidden="0">
+        <row r="120">
             <c r="A120" s="1">
                 <f>
                     ROWS(B3:C40)
                 </f>
             </c>
         </row>
-        <row r="121" ht="17.25" customHeight="1" hidden="0">
+        <row r="121">
             <c r="A121" s="1">
                 <f>
                     SEARCH("C","ABCD")
                 </f>
             </c>
         </row>
-        <row r="122" ht="17.25" customHeight="1" hidden="0">
+        <row r="122">
             <c r="A122" s="1">
                 <f>
                     _xlfn.SEC(PI()/3)
                 </f>
             </c>
         </row>
-        <row r="123" ht="17.25" customHeight="1" hidden="0">
+        <row r="123">
             <c r="A123" s="1">
                 <f>
                     _xlfn.SECH(1)
                 </f>
             </c>
         </row>
-        <row r="124" ht="17.25" customHeight="1" hidden="0">
+        <row r="124">
             <c r="A124" s="1">
                 <f>
                     SECOND("00:21:42")
                 </f>
             </c>
         </row>
-        <row r="125" ht="17.25" customHeight="1" hidden="0">
+        <row r="125">
             <c r="A125" s="1">
                 <f>
                     SIN(PI()/6)
                 </f>
             </c>
         </row>
-        <row r="126" ht="17.25" customHeight="1" hidden="0">
+        <row r="126">
             <c r="A126" s="1">
                 <f>
                     SINH(1)
                 </f>
             </c>
         </row>
-        <row r="127" ht="17.25" customHeight="1" hidden="0">
+        <row r="127">
             <c r="A127" s="1">
                 <f>
                     SMALL(H2:H9,3)
                 </f>
             </c>
         </row>
-        <row r="128" ht="17.25" customHeight="1" hidden="0">
+        <row r="128">
             <c r="A128" s="1">
                 <f>
                     SQRT(4)
                 </f>
             </c>
         </row>
-        <row r="129" ht="17.25" customHeight="1" hidden="0">
+        <row r="129">
             <c r="A129" s="1">
                 <f>
                     STDEV(-2,0,2)
                 </f>
             </c>
         </row>
-        <row r="130" ht="17.25" customHeight="1" hidden="0">
+        <row r="130">
             <c r="A130" s="1">
                 <f>
                     _xlfn.STDEV.P(2,4)
                 </f>
             </c>
         </row>
-        <row r="131" ht="17.25" customHeight="1" hidden="0">
+        <row r="131">
             <c r="A131" s="1">
                 <f>
                     _xlfn.STDEV.S(2,4,6)
                 </f>
             </c>
         </row>
-        <row r="132" ht="17.25" customHeight="1" hidden="0">
+        <row r="132">
             <c r="A132" s="1">
                 <f>
                     STDEVA(TRUE,3,5)
                 </f>
             </c>
         </row>
-        <row r="133" ht="17.25" customHeight="1" hidden="0">
+        <row r="133">
             <c r="A133" s="1">
                 <f>
                     STDEVP(2,5,8)
                 </f>
             </c>
         </row>
-        <row r="134" ht="17.25" customHeight="1" hidden="0">
+        <row r="134">
             <c r="A134" s="1">
                 <f>
                     STDEVPA(TRUE,4,7)
                 </f>
             </c>
         </row>
-        <row r="135" ht="17.25" customHeight="1" hidden="0">
+        <row r="135">
             <c r="A135" s="1">
                 <f>
                     SUBSTITUTE("SAP is best","SAP","Odoo")
                 </f>
             </c>
         </row>
-        <row r="136" ht="17.25" customHeight="1" hidden="0">
+        <row r="136">
             <c r="A136" s="1">
                 <f>
                     SUM(1,2,3,4,5)
                 </f>
             </c>
         </row>
-        <row r="137" ht="17.25" customHeight="1" hidden="0">
+        <row r="137">
             <c r="A137" s="1">
                 <f>
                     SUMIF(K2:K9,"&lt;100")
                 </f>
             </c>
         </row>
-        <row r="138" ht="17.25" customHeight="1" hidden="0">
+        <row r="138">
             <c r="A138" s="1">
                 <f>
                     SUMIFS(H2:H9,K2:K9,"&lt;100")
                 </f>
             </c>
         </row>
-        <row r="139" ht="17.25" customHeight="1" hidden="0">
+        <row r="139">
             <c r="A139" s="1">
                 <f>
                     TAN(PI()/4)
                 </f>
             </c>
         </row>
-        <row r="140" ht="17.25" customHeight="1" hidden="0">
+        <row r="140">
             <c r="A140" s="1">
                 <f>
                     TANH(1)
                 </f>
             </c>
         </row>
-        <row r="141" ht="17.25" customHeight="1" hidden="0">
+        <row r="141">
             <c r="A141" s="1">
                 <f>
                     _xlfn.TEXTJOIN("-",TRUE,"","1","A","%")
                 </f>
             </c>
         </row>
-        <row r="142" ht="17.25" customHeight="1" hidden="0">
+        <row r="142">
             <c r="A142" s="1">
                 <f>
                     TIME(9,11,31)
                 </f>
             </c>
         </row>
-        <row r="143" ht="17.25" customHeight="1" hidden="0">
+        <row r="143">
             <c r="A143" s="1">
                 <f>
                     TIMEVALUE("18:00:00")
                 </f>
             </c>
         </row>
-        <row r="144" ht="17.25" customHeight="1" hidden="0">
+        <row r="144">
             <c r="A144" s="1">
                 <f>
                     TODAY()
                 </f>
             </c>
         </row>
-        <row r="145" ht="17.25" customHeight="1" hidden="0">
+        <row r="145">
             <c r="A145" s="1">
                 <f>
                     TRIM(" Jean Ticonstitutionnalise ")
                 </f>
             </c>
         </row>
-        <row r="146" ht="17.25" customHeight="1" hidden="0">
+        <row r="146">
             <c r="A146" s="1">
                 <f>
                     TRUNC(42.42,1)
                 </f>
             </c>
         </row>
-        <row r="147" ht="17.25" customHeight="1" hidden="0">
+        <row r="147">
             <c r="A147" s="1">
                 <f>
                     UPPER("grrrr !")
                 </f>
             </c>
         </row>
-        <row r="148" ht="17.25" customHeight="1" hidden="0">
+        <row r="148">
             <c r="A148" s="1">
                 <f>
                     VAR(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="149" ht="17.25" customHeight="1" hidden="0">
+        <row r="149">
             <c r="A149" s="1">
                 <f>
                     _xlfn.VAR.P(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="150" ht="17.25" customHeight="1" hidden="0">
+        <row r="150">
             <c r="A150" s="1">
                 <f>
                     _xlfn.VAR.S(2,5,8)
                 </f>
             </c>
         </row>
-        <row r="151" ht="17.25" customHeight="1" hidden="0">
+        <row r="151">
             <c r="A151" s="1">
                 <f>
                     VARA(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="152" ht="17.25" customHeight="1" hidden="0">
+        <row r="152">
             <c r="A152" s="1">
                 <f>
                     VARP(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="153" ht="17.25" customHeight="1" hidden="0">
+        <row r="153">
             <c r="A153" s="1">
                 <f>
                     VARPA(K1:K5)
                 </f>
             </c>
         </row>
-        <row r="154" ht="17.25" customHeight="1" hidden="0">
+        <row r="154">
             <c r="A154" s="1">
                 <f>
                     VLOOKUP("NotACheater",G1:K9,3,FALSE)
                 </f>
             </c>
         </row>
-        <row r="155" ht="17.25" customHeight="1" hidden="0">
+        <row r="155">
             <c r="A155" s="1">
                 <f>
                     WEEKDAY("2021-06-12")
                 </f>
             </c>
         </row>
-        <row r="156" ht="17.25" customHeight="1" hidden="0">
+        <row r="156">
             <c r="A156" s="1">
                 <f>
                     WEEKNUM("2021-06-29")
                 </f>
             </c>
         </row>
-        <row r="157" ht="17.25" customHeight="1" hidden="0">
+        <row r="157">
             <c r="A157" s="1">
                 <f>
                     WORKDAY("2021-03-15",6)
                 </f>
             </c>
         </row>
-        <row r="158" ht="17.25" customHeight="1" hidden="0">
+        <row r="158">
             <c r="A158" s="1">
                 <f>
                     WORKDAY.INTL("2021-03-15",6,"0111111")
                 </f>
             </c>
         </row>
-        <row r="159" ht="17.25" customHeight="1" hidden="0">
+        <row r="159">
             <c r="A159" s="1">
                 <f>
                     _xlfn.XOR(FALSE,TRUE,FALSE,FALSE)
                 </f>
             </c>
         </row>
-        <row r="160" ht="17.25" customHeight="1" hidden="0">
+        <row r="160">
             <c r="A160" s="1">
                 <f>
                     YEAR("2012-03-12")
                 </f>
             </c>
         </row>
-        <row r="161" ht="17.25" customHeight="1" hidden="0">
+        <row r="161">
             <c r="A161" s="1">
                 <f>
                     DELTA(1,1)
                 </f>
             </c>
         </row>
-        <row r="162" ht="17.25" customHeight="1" hidden="0">
+        <row r="162">
             <c r="A162" s="1">
                 <f>
                     NA()
                 </f>
             </c>
         </row>
-        <row r="163" ht="17.25" customHeight="1" hidden="0">
+        <row r="163">
             <c r="A163" s="1">
                 <f>
                     ISNA(A162)
                 </f>
             </c>
         </row>
-        <row r="164" ht="17.25" customHeight="1" hidden="0">
+        <row r="164">
             <c r="A164" s="1">
                 <f>
                     ISERR(A162)
                 </f>
             </c>
         </row>
-        <row r="165" ht="17.25" customHeight="1" hidden="0">
+        <row r="165">
             <c r="A165" s="1">
                 <f>
                     HYPERLINK("https://www.odoo.com","Odoo")
                 </f>
             </c>
         </row>
-        <row r="166" ht="17.25" customHeight="1" hidden="0">
+        <row r="166">
             <c r="A166" s="1">
                 <f>
                     ADDRESS(27,53,4,FALSE,"sheet!")
                 </f>
             </c>
         </row>
-        <row r="167" ht="17.25" customHeight="1" hidden="0">
+        <row r="167">
             <c r="A167" s="1">
                 <f>
                     DATEDIF("2002-01-01","2002-01-02","D")
                 </f>
             </c>
         </row>
-        <row r="168" ht="17.25" customHeight="1" hidden="0">
+        <row r="168">
             <c r="A168" s="1">
                 <f>
                     RANDARRAY(2,2)
@@ -17211,7 +17211,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
             <c r="B168" s="1">
             </c>
         </row>
-        <row r="169" ht="17.25" customHeight="1" hidden="0">
+        <row r="169">
             <c r="A169" s="1">
             </c>
             <c r="B169" s="1">
@@ -17258,7 +17258,7 @@ exports[`Test XLSX export formulas Multi-Sheets exportable functions 1`] = `
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1" t="s">
                 <v>
                     20
@@ -17522,14 +17522,14 @@ exports[`Test XLSX export formulas Non exportable formulas are exported even wit
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1">
                 <v>
                     0
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="b">
                 <v>
                     0
@@ -17686,35 +17686,35 @@ exports[`Test XLSX export link cells 1`] = `
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1" t="s">
                 <v>
                     0
                 </v>
             </c>
         </row>
-        <row r="2" ht="17.25" customHeight="1" hidden="0">
+        <row r="2">
             <c r="A2" s="1" t="s">
                 <v>
                     0
                 </v>
             </c>
         </row>
-        <row r="3" ht="17.25" customHeight="1" hidden="0">
+        <row r="3">
             <c r="A3" s="1" t="s">
                 <v>
                     1
                 </v>
             </c>
         </row>
-        <row r="4" ht="17.25" customHeight="1" hidden="0">
+        <row r="4">
             <c r="A4" s="1" t="s">
                 <v>
                     2
                 </v>
             </c>
         </row>
-        <row r="5" ht="17.25" customHeight="1" hidden="0">
+        <row r="5">
             <c r="A5" s="1" t="s">
                 <v>
                     1
@@ -18221,7 +18221,7 @@ exports[`Test XLSX export multiple elements are exported in the correct order 1`
         <col min="26" max="26" width="13.73" customWidth="1" hidden="0"/>
     </cols>
     <sheetData>
-        <row r="1" ht="17.25" customHeight="1" hidden="0">
+        <row r="1">
             <c r="A1" s="1" t="s">
                 <v>
                     0

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -850,6 +850,19 @@ describe("Import xlsx data", () => {
       expect(testSheet.isVisible).toEqual(false);
     });
   });
+
+  test("Import header groups", () => {
+    const testSheet = getWorkbookSheet("jestSheet", convertedData)!;
+    expect(testSheet.headerGroups?.ROW).toMatchObject([
+      { start: 9, end: 17, isFolded: false },
+      { start: 11, end: 13, isFolded: true },
+    ]);
+
+    expect(testSheet.headerGroups?.COL).toMatchObject([
+      { start: 9, end: 17, isFolded: false },
+      { start: 11, end: 13, isFolded: true },
+    ]);
+  });
 });
 
 test.each([


### PR DESCRIPTION
## [IMP] xlsx export: don't export default row size:

The previous export of row sizes in the xlsx was inconsistent:
there was a comment saying that we always force our own row size in the
export, but 20 lines later we din't export the row if it was the default
size.

Now we only export the row size if the user has changed it manually.
We decided to do this rather than forcing our own row size in the xlsx,
because forcing a row/size would break the auto row size feature
when re-importing (since the row would be considered as manually sized).

## [IMP] xlsx: import and export header groups

Add the import and the export of the headers groups from/to xlsx.

Task: : [3637643](https://www.odoo.com/web#id=3637643&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo