### PR TITLE
[REL] 16.0.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.0.26",
+  "version": "16.0.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.0.26",
+      "version": "16.0.27",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.0.26",
+  "version": "16.0.27",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/ba682a95c [FIX] evaluation: `evaluateFormula` no longer throws Task: 3576149
https://github.com/odoo/o-spreadsheet/commit/7d54be7d5 [FIX] Components: rename private method arguments
https://github.com/odoo/o-spreadsheet/commit/8e3419fca [FIX] *: Support metaKey modifier in event handlers Task: 3606161
