### PR TITLE
[REL] 16.1.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.1.29",
+  "version": "16.1.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.1.29",
+      "version": "16.1.30",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.1.29",
+  "version": "16.1.30",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/5ade86312 [FIX] evaluation: `evaluateFormula` no longer throws Task: 3576149
https://github.com/odoo/o-spreadsheet/commit/50846e3f1 [FIX] Components: rename private method arguments
https://github.com/odoo/o-spreadsheet/commit/a689b1920 [FIX] *: Support metaKey modifier in event handlers Task: 3606161
