### PR TITLE
[REL] 16.3.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.3.19",
+  "version": "16.3.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.3.19",
+      "version": "16.3.20",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.3.19",
+  "version": "16.3.20",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/ce84f520f [FIX] evaluation: `evaluateFormula` no longer throws Task: 3576149
https://github.com/odoo/o-spreadsheet/commit/a60d7cc48 [FIX] Components: rename private method arguments
https://github.com/odoo/o-spreadsheet/commit/007abc626 [FIX] *: Support metaKey modifier in event handlers Task: 3606161
