### PR TITLE
[FIX] functions: name MID args

### DIFF
--- a/src/functions/arguments.ts
+++ b/src/functions/arguments.ts
@@ -27,6 +27,9 @@ export function arg(definition: string, description: string = ""): ArgDefinition
 function makeArg(str: string): ArgDefinition {
   let parts = str.match(ARG_REGEXP)!;
   let name = parts[1].trim();
+  if (!name) {
+    throw new Error(`Function argument definition is missing a name: '${str}'.`);
+  }
   let types: ArgType[] = [];
   let isOptional = false;
   let isRepeating = false;

--- a/src/functions/module_engineering.ts
+++ b/src/functions/module_engineering.ts
@@ -11,8 +11,8 @@ const DEFAULT_DELTA_ARG = 0;
 export const DELTA: AddFunctionDescription = {
   description: _lt("Compare two numeric values, returning 1 if they're equal."),
   args: [
-    arg(" (number)", _lt("The first number to compare.")),
-    arg(` (number, default=${DEFAULT_DELTA_ARG})`, _lt("The second number to compare.")),
+    arg("number1 (number)", _lt("The first number to compare.")),
+    arg(`number2 (number, default=${DEFAULT_DELTA_ARG})`, _lt("The second number to compare.")),
   ],
   returns: ["NUMBER"],
   compute: function (

--- a/src/functions/module_financial.ts
+++ b/src/functions/module_financial.ts
@@ -182,7 +182,10 @@ export const AMORLINC: AddFunctionDescription = {
       _lt("The single period within life for which to calculate depreciation.")
     ),
     arg("rate (number)", _lt("The deprecation rate.")),
-    arg(" (number, optional)", _lt("An indicator of what day count method to use.")),
+    arg(
+      "day_count_convention (number, optional)",
+      _lt("An indicator of what day count method to use.")
+    ),
   ],
   returns: ["NUMBER"],
   compute: function (

--- a/src/functions/module_text.ts
+++ b/src/functions/module_text.ts
@@ -218,12 +218,12 @@ export const MID: AddFunctionDescription = {
   args: [
     arg("text (string)", _lt("The string to extract a segment from.")),
     arg(
-      " (number)",
+      "starting_at (number)",
       _lt(
         "The index from the left of string from which to begin extracting. The first character in string has the index 1."
       )
     ),
-    arg(" (number)", _lt("The length of the segment to extract.")),
+    arg("extract_length (number)", _lt("The length of the segment to extract.")),
   ],
   returns: ["STRING"],
   compute: function (


### PR DESCRIPTION
The names of the second and third arguments of MID are missing.

It makes the composer autocomplete crash if you write "=MID(" because the t-foreach key is duplicated (an empty string)

Mistake from a815a16

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo