### PR TITLE
[FIX] composer: limit autocomplete height

### DIFF
--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.ts
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, useEffect, useRef } from "@odoo/owl";
 import { css } from "../../helpers/css";
 import { AutocompleteValue } from "../composer/composer";
 
@@ -33,6 +33,21 @@ interface Props {
 
 export class TextValueProvider extends Component<Props> {
   static template = "o-spreadsheet-TextValueProvider";
+  private autoCompleteListRef = useRef("autoCompleteList");
+
+  setup() {
+    useEffect(
+      () => {
+        const selectedIndex = this.props.selectedIndex;
+        if (selectedIndex === undefined) {
+          return;
+        }
+        const selectedElement = this.autoCompleteListRef.el?.children[selectedIndex];
+        selectedElement?.scrollIntoView?.({ block: "nearest" });
+      },
+      () => [this.props.selectedIndex, this.autoCompleteListRef.el]
+    );
+  }
 }
 
 TextValueProvider.props = {

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -1,6 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-TextValueProvider">
     <div
+      t-ref="autoCompleteList"
       t-att-class="{
           'o-autocomplete-dropdown':props.values.length,
           'shadow':props.values.length}">

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -3,8 +3,7 @@
     <div
       t-ref="autoCompleteList"
       t-att-class="{
-          'o-autocomplete-dropdown':props.values.length,
-          'shadow':props.values.length}">
+          'o-autocomplete-dropdown':props.values.length }">
       <t t-foreach="props.values" t-as="v" t-key="v.text">
         <div
           class="d-flex flex-column text-start"

--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -86,6 +86,7 @@ css/* scss */ `
       position: absolute;
       margin: 1px 4px;
       pointer-events: none;
+      overflow: auto;
 
       .o-semi-bold {
         /** FIXME: to remove in favor of Bootstrap
@@ -174,7 +175,10 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     if (this.props.delimitation && this.props.rect) {
       const { x: cellX, y: cellY, height: cellHeight } = this.props.rect;
       const remainingHeight = this.props.delimitation.height - (cellY + cellHeight);
+      assistantStyle["max-height"] = `${remainingHeight}px`;
       if (cellY > remainingHeight) {
+        const availableSpaceAbove = cellY;
+        assistantStyle["max-height"] = `${availableSpaceAbove}px`;
         // render top
         // We compensate 2 px of margin on the assistant style + 1px for design reasons
         assistantStyle.top = `-3px`;

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -25,6 +25,7 @@
         t-if="props.focus !== 'inactive' and (autoCompleteState.showProvider or functionDescriptionState.showDescription)"
         class="o-composer-assistant"
         t-att-style="assistantStyle"
+        t-on-wheel.stop=""
         t-on-mousedown.prevent.stop=""
         t-on-click.prevent.stop=""
         t-on-mouseup.prevent.stop="">

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -23,7 +23,7 @@
 
       <div
         t-if="props.focus !== 'inactive' and (autoCompleteState.showProvider or functionDescriptionState.showDescription)"
-        class="o-composer-assistant"
+        class="o-composer-assistant shadow"
         t-att-style="assistantStyle"
         t-on-wheel.stop=""
         t-on-mousedown.prevent.stop=""

--- a/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
+++ b/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
@@ -58,7 +58,7 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
 exports[`composer Assistant render above the cell when not enough place below 1`] = `
 <div
   class="o-composer-assistant"
-  style="min-width:96px; width:300px; top:-3px; transform:translate(0, -100%); right:0px;"
+  style="min-width:96px; width:300px; max-height:150px; top:-3px; transform:translate(0, -100%); right:0px;"
 >
   <div
     class="o-autocomplete-dropdown shadow"

--- a/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
+++ b/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
 <div
-  class="o-autocomplete-dropdown shadow"
+  class="o-autocomplete-dropdown"
 >
   <div
     class="d-flex flex-column text-start o-autocomplete-value-focus"
@@ -57,11 +57,11 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
 
 exports[`composer Assistant render above the cell when not enough place below 1`] = `
 <div
-  class="o-composer-assistant"
+  class="o-composer-assistant shadow"
   style="min-width:96px; width:300px; max-height:150px; top:-3px; transform:translate(0, -100%); right:0px;"
 >
   <div
-    class="o-autocomplete-dropdown shadow"
+    class="o-autocomplete-dropdown"
   >
     <div
       class="d-flex flex-column text-start o-autocomplete-value-focus"
@@ -119,11 +119,11 @@ exports[`composer Assistant render above the cell when not enough place below 1`
 
 exports[`composer Assistant render below the cell by default 1`] = `
 <div
-  class="o-composer-assistant"
+  class="o-composer-assistant shadow"
   style="min-width:300px; width:300px;"
 >
   <div
-    class="o-autocomplete-dropdown shadow"
+    class="o-autocomplete-dropdown"
   >
     <div
       class="d-flex flex-column text-start o-autocomplete-value-focus"


### PR DESCRIPTION
## Description:

Steps to reproduce:
- Insert a data validation rule with the "Value in range" criteria
- Add a range with many many values
- Click on the arrow next to the cell to open the autocomplete list => you can't select values that are outside of the grid

Task: : [3675171](https://www.odoo.com/web#id=3675171&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo