### PR TITLE
[FIX] range: Support ranges with no `Rangeparts`

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -429,9 +429,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    * Get a Xc string that represent a part of a range
    */
   private getRangePartString(range: RangeImpl, part: 0 | 1): string {
-    const colFixed = range.parts && range.parts[part].colFixed ? "$" : "";
+    const colFixed = range.parts && range.parts[part]?.colFixed ? "$" : "";
     const col = part === 0 ? numberToLetters(range.zone.left) : numberToLetters(range.zone.right);
-    const rowFixed = range.parts && range.parts[part].rowFixed ? "$" : "";
+    const rowFixed = range.parts && range.parts[part]?.rowFixed ? "$" : "";
     const row = part === 0 ? String(range.zone.top + 1) : String(range.zone.bottom + 1);
 
     let str = "";

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -535,6 +535,12 @@ describe("range plugin", () => {
       expect(m.getters.getRangeString(undefined, "not there")).toBe(INCORRECT_RANGE_STRING);
     });
 
+    test("requesting a range without parts", () => {
+      const r = m.getters.getRangeFromSheetXC("s1", "A1");
+      const rNoParts = r.clone({ parts: [] });
+      expect(m.getters.getRangeString(rNoParts, "forceSheetName")).toBe("s1!A1");
+    });
+
     test.each(["Sheet 0", "<Sheet1>", "&Sheet2", "Sheet4;", "Sheet5🐻"])(
       "sheet name with special character %s",
       (name) => {


### PR DESCRIPTION
The current typing of `RangeImpl.parts` is such that we have to support the presence of 0, 1 or 2 parts defined in the `Range` object. We only supported the last 2 cases.

Task: 3608941

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo