### PR TITLE
[FIX] components: useless static components

### DIFF
--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -5,7 +5,6 @@ import { openLink, urlRepresentation } from "../../../helpers/links";
 import { EvaluatedCell, Link, Position, SpreadsheetChildEnv } from "../../../types";
 import { CellPopoverComponent, PopoverBuilders } from "../../../types/cell_popovers";
 import { css } from "../../helpers/css";
-import { Menu } from "../../menu/menu";
 
 const LINK_TOOLTIP_HEIGHT = 32;
 const LINK_TOOLTIP_WIDTH = 220;
@@ -69,7 +68,6 @@ export class LinkDisplay extends Component<LinkDisplayProps, SpreadsheetChildEnv
     cellPosition: Object,
     onClosed: { type: Function, optional: true },
   };
-  static components = { Menu };
 
   get cell(): EvaluatedCell {
     const { col, row } = this.props.cellPosition;

--- a/src/components/side_panel/chart/building_blocks/title/title.ts
+++ b/src/components/side_panel/chart/building_blocks/title/title.ts
@@ -1,6 +1,5 @@
 import { Component } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../../../types";
-import { ColorPickerWidget } from "../../../../color_picker/color_picker_widget";
 import { Section } from "../../../components/section/section";
 
 interface Props {
@@ -10,7 +9,7 @@ interface Props {
 
 export class ChartTitle extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartTitle";
-  static components = { ColorPickerWidget, Section };
+  static components = { Section };
   static props = { title: String, update: Function };
 
   updateTitle(ev: InputEvent) {

--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_config_panel.ts
@@ -1,7 +1,6 @@
 import { Component, useState } from "@odoo/owl";
 import { GaugeChartDefinition } from "../../../../types/chart/gauge_chart";
 import { CommandResult, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
-import { SelectionInput } from "../../../selection_input/selection_input";
 import { ChartTerms } from "../../../translations_terms";
 import { ChartDataSeries } from "../building_blocks/data_series/data_series";
 import { ChartErrorSection } from "../building_blocks/error_section/error_section";
@@ -19,7 +18,7 @@ interface PanelState {
 
 export class GaugeChartConfigPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-GaugeChartConfigPanel";
-  static components = { SelectionInput, ChartErrorSection, ChartDataSeries };
+  static components = { ChartErrorSection, ChartDataSeries };
   static props = {
     figureId: String,
     definition: Object,

--- a/src/components/side_panel/chart/line_bar_pie_panel/design_panel.ts
+++ b/src/components/side_panel/chart/line_bar_pie_panel/design_panel.ts
@@ -4,7 +4,6 @@ import { BarChartDefinition } from "../../../../types/chart/bar_chart";
 import { LineChartDefinition } from "../../../../types/chart/line_chart";
 import { PieChartDefinition } from "../../../../types/chart/pie_chart";
 import { Color, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
-import { ColorPickerWidget } from "../../../color_picker/color_picker_widget";
 import { Section } from "../../components/section/section";
 import { ChartColor } from "../building_blocks/color/color";
 import { ChartTitle } from "../building_blocks/title/title";
@@ -23,7 +22,7 @@ interface Props {
 
 export class LineBarPieDesignPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-LineBarPieDesignPanel";
-  static components = { ChartColor, ColorPickerWidget, ChartTitle, Section };
+  static components = { ChartColor, ChartTitle, Section };
   static props = {
     figureId: String,
     definition: Object,

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_config_panel.ts
@@ -3,7 +3,6 @@ import { ScorecardChartDefinition } from "../../../../types/chart/scorecard_char
 import { CommandResult, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
 import { SelectionInput } from "../../../selection_input/selection_input";
 import { ChartTerms } from "../../../translations_terms";
-import { ValidationMessages } from "../../../validation_messages/validation_messages";
 import { Section } from "../../components/section/section";
 import { ChartErrorSection } from "../building_blocks/error_section/error_section";
 
@@ -21,7 +20,7 @@ interface PanelState {
 
 export class ScorecardChartConfigPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ScorecardChartConfigPanel";
-  static components = { SelectionInput, ValidationMessages, ChartErrorSection, Section };
+  static components = { SelectionInput, ChartErrorSection, Section };
   static props = {
     figureId: String,
     definition: Object,


### PR DESCRIPTION
Some components (particularly after the chart panel refactoring) had static components that were not used. This commit removes them.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo