### PR TITLE
[IMP] formula: add INDIRECT function

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -1388,6 +1388,10 @@ export const demoData = {
         B223: { content: '=ADDRESS(27, 53, 1, TRUE, "sheet!")' },
         C223: { content: "'sheet!'!$BA$27" },
         D223: { content: "=IF(B223=C223, 1, 0)" },
+        A224: { content: "INDIRECT" },
+        B224: { content: '=INDIRECT("A1")' },
+        C224: { content: "=A1" },
+        D224: { content: "=IF(B224=C224, 1, 0)" },
 
         // DATA
         G1: { content: "Name", style: 8 },

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -96,6 +96,11 @@ export class Evaluator {
     this.formulaDependencies().addDependencies(positionId, dependencies);
   }
 
+  addDependencies(position: CellPosition, dependencies: Range[]) {
+    const positionId = this.encoder.encode(position);
+    this.formulaDependencies().addDependencies(positionId, dependencies);
+  }
+
   private updateCompilationParameters() {
     // rebuild the compilation parameters (with a clean cache)
     this.compilationParams = buildCompilationParameters(
@@ -103,6 +108,8 @@ export class Evaluator {
       this.getters,
       this.computeAndSave.bind(this)
     );
+    this.compilationParams[2].updateDependencies = this.updateDependencies.bind(this);
+    this.compilationParams[2].addDependencies = this.addDependencies.bind(this);
   }
 
   evaluateCells(positions: CellPosition[]) {

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -35,6 +35,7 @@ export type PositionId = bigint;
 const MAX_ITERATION = 30;
 const ERROR_CYCLE_CELL = createEvaluatedCell(new CircularDependencyError());
 const EMPTY_CELL = createEvaluatedCell({ value: null });
+const EVAL_CONTEXT_INDEX = 2;
 
 export class Evaluator {
   private readonly getters: Getters;
@@ -108,8 +109,9 @@ export class Evaluator {
       this.getters,
       this.computeAndSave.bind(this)
     );
-    this.compilationParams[2].updateDependencies = this.updateDependencies.bind(this);
-    this.compilationParams[2].addDependencies = this.addDependencies.bind(this);
+    this.compilationParams[EVAL_CONTEXT_INDEX].updateDependencies =
+      this.updateDependencies.bind(this);
+    this.compilationParams[EVAL_CONTEXT_INDEX].addDependencies = this.addDependencies.bind(this);
   }
 
   evaluateCells(positions: CellPosition[]) {
@@ -567,14 +569,14 @@ export function updateEvalContextAndExecute(
   sheetId: UID,
   cellId?: UID
 ) {
-  compilationParams[2].__originCellXC = lazy(() => {
+  compilationParams[EVAL_CONTEXT_INDEX].__originCellXC = lazy(() => {
     if (!cellId) {
       return undefined;
     }
     // compute the value lazily for performance reasons
-    const position = compilationParams[2].getters.getCellPosition(cellId);
+    const position = compilationParams[EVAL_CONTEXT_INDEX].getters.getCellPosition(cellId);
     return toXC(position.col, position.row);
   });
-  compilationParams[2].__originSheetId = sheetId;
+  compilationParams[EVAL_CONTEXT_INDEX].__originSheetId = sheetId;
   return compiledFormula.execute(compiledFormula.dependencies, ...compilationParams);
 }

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -1,7 +1,8 @@
 import { CellValue } from "./cells";
 import { Getters } from "./getters";
 import { Locale } from "./locale";
-import { Arg, FPayload, Matrix, UID } from "./misc";
+import { Arg, CellPosition, FPayload, Matrix, UID } from "./misc";
+import { Range } from "./range";
 
 export type ArgType =
   | "ANY"
@@ -52,4 +53,6 @@ export type EvalContext = {
   locale: Locale;
   getters: Getters;
   [key: string]: any;
+  updateDependencies?: (position: CellPosition) => void;
+  addDependencies?: (position: CellPosition, ranges: Range[]) => void;
 };


### PR DESCRIPTION
## Task Description

This task aims to add the INDIRECT function in o-spreadsheet. This has been implemented by returning the value of the referenced cell which means that we are still not able to do something like `=SUM(INDIRECT("A1"):INDIRECT("B3"))`, but other uses of this methods should be available.

## Related Task

- Task: [3203719](https://www.odoo.com/web#id=3203719&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo