### PR TITLE
[FIX] format: support additional date formats

### DIFF
--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -1,4 +1,5 @@
 import { DATETIME_FORMAT } from "../constants";
+import { _lt } from "../translation";
 import { CellValue, Format, FormattedValue } from "../types";
 import { DateTime, INITIAL_1900_DAY, numberToJsDate } from "./dates";
 
@@ -39,6 +40,33 @@ type InternalFormat = (
   | { type: "STRING"; format: string }
   | { type: "DATE"; format: string }
 )[];
+
+// TODO in the future : remove these constants MONTHS/DAYS, and use a library such as luxon to handle it
+// + possibly handle automatic translation of day/month
+const MONTHS: Readonly<Record<number, string>> = {
+  0: _lt("January"),
+  1: _lt("February"),
+  2: _lt("March"),
+  3: _lt("April"),
+  4: _lt("May"),
+  5: _lt("June"),
+  6: _lt("July"),
+  7: _lt("August"),
+  8: _lt("September"),
+  9: _lt("October"),
+  10: _lt("November"),
+  11: _lt("December"),
+};
+
+const DAYS: Readonly<Record<number, string>> = {
+  0: _lt("Sunday"),
+  1: _lt("Monday"),
+  2: _lt("Tuesday"),
+  3: _lt("Wednesday"),
+  4: _lt("Thursday"),
+  5: _lt("Friday"),
+  6: _lt("Saturday"),
+};
 
 interface InternalNumberFormat {
   readonly integerPart: string;
@@ -338,8 +366,8 @@ export function applyDateTimeFormat(value: number, format: Format): FormattedVal
 }
 
 function formatJSDate(jsDate: DateTime, format: Format): FormattedValue {
-  const sep = format.match(/\/|-|\s/)![0];
-  const parts = format.split(sep);
+  const sep = format.match(/\/|-|\s/)?.[0];
+  const parts = sep ? format.split(sep) : [format];
   return parts
     .map((p) => {
       switch (p) {
@@ -347,10 +375,23 @@ function formatJSDate(jsDate: DateTime, format: Format): FormattedValue {
           return jsDate.getDate();
         case "dd":
           return jsDate.getDate().toString().padStart(2, "0");
+        case "ddd":
+          return DAYS[jsDate.getDay()].slice(0, 3);
+        case "dddd":
+          return DAYS[jsDate.getDay()];
         case "m":
           return jsDate.getMonth() + 1;
         case "mm":
           return String(jsDate.getMonth() + 1).padStart(2, "0");
+        case "mmm":
+          return MONTHS[jsDate.getMonth()].slice(0, 3);
+        case "mmmm":
+          return MONTHS[jsDate.getMonth()];
+        case "mmmmm":
+          return MONTHS[jsDate.getMonth()].slice(0, 1);
+        case "yy":
+          const fullYear = String(jsDate.getFullYear()).replace("-", "").padStart(2, "0");
+          return fullYear.slice(fullYear.length - 2);
         case "yyyy":
           return jsDate.getFullYear();
         default:

--- a/tests/helpers/format.test.ts
+++ b/tests/helpers/format.test.ts
@@ -363,6 +363,12 @@ describe("formatValue on date and time", () => {
     "m d",
     "m-d",
     "m/d",
+    "yy-mm",
+    "ddd-mm",
+    "dddd-mm",
+    "mmm-yy",
+    "mmmm-yy",
+    "mmmmm-yy",
   ])("detect date time format %s", (format) => {
     expect(isDateTimeFormat(format)).toBe(true);
   });
@@ -614,6 +620,109 @@ describe("formatValue on date and time", () => {
       ["yyyy mm dd", "1954 01 02"],
     ])("year month day, with ' ' as separator", (format, result) => {
       expect(formatValue(value, format)).toBe(result);
+    });
+
+    test.each([
+      ["01/01/2023", "Sun-01-2023"],
+      ["01/02/2023", "Mon-01-2023"],
+      ["01/03/2023", "Tue-01-2023"],
+      ["01/04/2023", "Wed-01-2023"],
+      ["01/05/2023", "Thu-01-2023"],
+      ["01/06/2023", "Fri-01-2023"],
+      ["01/07/2023", "Sat-01-2023"],
+    ])("three letter day of the week (ddd) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "ddd-mm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      ["2023/01/01", "Sunday-01-2023"],
+      ["2023/01/02", "Monday-01-2023"],
+      ["2023/01/03", "Tuesday-01-2023"],
+      ["2023/01/04", "Wednesday-01-2023"],
+      ["2023/01/05", "Thursday-01-2023"],
+      ["2023/01/06", "Friday-01-2023"],
+      ["2023/01/07", "Saturday-01-2023"],
+    ])("Full letter day of the week (dddd) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "dddd-mm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      ["2023/01/01", "Jan-2023"],
+      ["2023/02/01", "Feb-2023"],
+      ["2023/03/01", "Mar-2023"],
+      ["2023/04/01", "Apr-2023"],
+      ["2023/05/01", "May-2023"],
+      ["2023/06/01", "Jun-2023"],
+      ["2023/07/01", "Jul-2023"],
+      ["2023/08/01", "Aug-2023"],
+      ["2023/09/01", "Sep-2023"],
+      ["2023/10/01", "Oct-2023"],
+      ["2023/11/01", "Nov-2023"],
+      ["2023/12/01", "Dec-2023"],
+    ])("Three letter day of month (mmm) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "mmm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      ["2023/01/01", "January-2023"],
+      ["2023/02/01", "February-2023"],
+      ["2023/03/01", "March-2023"],
+      ["2023/04/01", "April-2023"],
+      ["2023/05/01", "May-2023"],
+      ["2023/06/01", "June-2023"],
+      ["2023/07/01", "July-2023"],
+      ["2023/08/01", "August-2023"],
+      ["2023/09/01", "September-2023"],
+      ["2023/10/01", "October-2023"],
+      ["2023/11/01", "November-2023"],
+      ["2023/12/01", "December-2023"],
+    ])("Full letter day of month (mmmm) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "mmmm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      ["2023/01/01", "J-2023"],
+      ["2023/02/01", "F-2023"],
+      ["2023/03/01", "M-2023"],
+      ["2023/04/01", "A-2023"],
+      ["2023/05/01", "M-2023"],
+      ["2023/06/01", "J-2023"],
+      ["2023/07/01", "J-2023"],
+      ["2023/08/01", "A-2023"],
+      ["2023/09/01", "S-2023"],
+      ["2023/10/01", "O-2023"],
+      ["2023/11/01", "N-2023"],
+      ["2023/12/01", "D-2023"],
+    ])("One letter day of month (mmmmm) %s", (value, result) => {
+      expect(formatValue(parseDateTime(value)!.value, "mmmmm-yyyy")).toBe(result);
+    });
+
+    test.each([
+      [44927 /* 01/01/2023 */, "01-23"],
+      [45292 /* 01/01/2024 */, "01-24"],
+      [24838 /* 01/01/1968 */, "01-68"],
+      [38718 /* 01/01/2006 */, "01-06"],
+      [-691767 /* 01/01/0006 */, "01-06"],
+      [-715508 /* 01/01/-0059 */, "01-59"],
+      [-737422 /* 01/01/-0119 */, "01-19"],
+    ])("2 last digits of year (yy) %s", (value, result) => {
+      expect(formatValue(value, "mm-yy")).toBe(result);
+    });
+
+    test.each([
+      ["d", "1"],
+      ["dd", "01"],
+      ["ddd", "Sun"],
+      ["dddd", "Sunday"],
+      ["m", "1"],
+      ["mm", "01"],
+      ["mmm", "Jan"],
+      ["mmmm", "January"],
+      ["mmmmm", "J"],
+      ["yy", "23"],
+      ["yyyy", "2023"],
+    ])("Format without separators %s", (format, result) => {
+      expect(formatValue(parseDateTime("01/01/2023")!.value, format)).toBe(result);
     });
   });
 


### PR DESCRIPTION
Some date formats weren't supported in o_spreadsheet, and thus the xlsx import failed for these formats.

Added basic support for formats :
- yy
- mmm
- mmmm
- mmmmm
- ddd
- dddd

Also fixed a bug that prevented date formats without separators (eg. "yyyy") from working.

Follow up with more feature will be done in 3035270. The goal here was mainly to improve the xlsx import.

Odoo task 3006028

closes odoo/o-spreadsheet#1747

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo