### PR TITLE
[REV][FIX] side_panel: cf rule range bugs

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -103,7 +103,7 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
       : [];
     return ranges.map((range) => ({
       ...range,
-      isValidRange: range.xc !== "" && this.env.model.getters.isRangeValid(range.xc),
+      isValidRange: range.xc === "" || this.env.model.getters.isRangeValid(range.xc),
     }));
   }
 

--- a/src/components/side_panel/conditional_formatting/conditional_formatting.xml
+++ b/src/components/side_panel/conditional_formatting/conditional_formatting.xml
@@ -37,6 +37,7 @@
               <SelectionInput
                 ranges="state.currentCF.ranges"
                 class="'o-range'"
+                isInvalid="isRangeValid"
                 onSelectionChanged="(ranges) => this.onRangesChanged(ranges)"
                 required="true"
               />

--- a/tests/components/conditional_formatting.test.ts
+++ b/tests/components/conditional_formatting.test.ts
@@ -9,11 +9,7 @@ import {
   paste,
   setSelection,
 } from "../test_helpers/commands_helpers";
-import {
-  setInputValueAndTrigger,
-  simulateClick,
-  triggerMouseEvent,
-} from "../test_helpers/dom_helper";
+import { setInputValueAndTrigger, triggerMouseEvent } from "../test_helpers/dom_helper";
 import {
   createColorScale,
   createEqualCF,
@@ -354,47 +350,20 @@ describe("UI of conditional formats", () => {
     });
 
     test("cannot create a new CF with invalid range", async () => {
-      await simulateClick(selectors.buttonAdd);
+      triggerMouseEvent(selectors.buttonAdd, "click");
+      await nextTick();
       await nextTick();
 
       setInputValueAndTrigger(selectors.ruleEditor.range, "hello", "change");
 
       const dispatch = spyDispatch(parent);
       //  click save
-      await simulateClick(selectors.buttonSave);
+      triggerMouseEvent(selectors.buttonSave, "click");
+      await nextTick();
       expect(dispatch).not.toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT");
       const errorString = document.querySelector(selectors.error);
       expect(errorString!.textContent).toBe("The range is invalid");
-
-      setInputValueAndTrigger(selectors.ruleEditor.range, "s!A1", "change");
-      await simulateClick(selectors.buttonSave);
-      expect(dispatch).not.toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT");
-      const errorString2 = document.querySelector(selectors.error);
-      expect(errorString2!.textContent).toBe("The range is invalid");
     });
-
-    test("display error message if and only if invalid range", async () => {
-      await simulateClick(selectors.buttonAdd);
-      await nextTick();
-      const dispatch = spyDispatch(parent);
-
-      setInputValueAndTrigger(selectors.ruleEditor.range, "", "change");
-      await simulateClick(selectors.buttonSave);
-      expect(dispatch).not.toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT");
-      const errorString = document.querySelector(selectors.error);
-      expect(errorString!.textContent).toBe("A range needs to be defined");
-
-      setInputValueAndTrigger(selectors.ruleEditor.range, "A1", "change");
-      await nextTick();
-      expect(document.querySelector(selectors.error)).toBe(null);
-
-      setInputValueAndTrigger(selectors.ruleEditor.range, "s!A1", "change");
-      await simulateClick(selectors.buttonSave);
-      expect(dispatch).not.toHaveBeenCalledWith("ADD_CONDITIONAL_FORMAT");
-      const errorString1 = document.querySelector(selectors.error);
-      expect(errorString1!.textContent).toBe("The range is invalid");
-    });
-
     test("displayed range is updated if range changes", async () => {
       const previews = document.querySelectorAll(selectors.listPreview);
       expect(previews[0].querySelector(selectors.description.range)!.textContent).toBe("A1:A2");
@@ -774,6 +743,8 @@ describe("UI of conditional formats", () => {
     await nextTick();
     await nextTick();
     setInputValueAndTrigger(selectors.ruleEditor.range, "", "change");
+    await nextTick();
+    triggerMouseEvent(selectors.buttonSave, "click");
     await nextTick();
     expect(errorMessages()).toEqual(["A range needs to be defined"]);
     expect(fixture.querySelector(selectors.ruleEditor.range)?.className).toContain("o-invalid");

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -343,14 +343,10 @@ describe("Selection Input", () => {
     expect(fixture.querySelectorAll("input")[0].value).toBe("B1");
     expect(fixture.querySelectorAll("input")[0].getAttribute("style")).not.toBe("color: #000;");
     expect(fixture.querySelectorAll("input")[0].classList).not.toContain("o-invalid");
-    await writeInput(0, "");
-    expect(fixture.querySelectorAll("input")[0].value).toBe("");
-    expect(fixture.querySelectorAll("input")[0].getAttribute("style")).toBe("color: #000;");
-    expect(fixture.querySelectorAll("input")[0].classList).toContain("o-invalid");
-    await writeInput(0, "s!A1");
-    expect(fixture.querySelectorAll("input")[0].value).toBe("s!A1");
-    expect(fixture.querySelectorAll("input")[0].getAttribute("style")).toBe("color: #000;");
-    expect(fixture.querySelectorAll("input")[0].classList).toContain("o-invalid");
+  });
+  test("don't show red border initially", async () => {
+    await createSelectionInput();
+    expect(fixture.querySelectorAll("input")[0].classList).not.toContain("o-invalid");
   });
 
   test("pressing and releasing control has no effect on future clicks", async () => {


### PR DESCRIPTION
This reverts commit 4a956f3eafe299badcc9479dc1eecd7f55248b25.

the task was not fixing bugs (in the sens of tracebacks or corrupted
behaviour) but rather seemingly backporting a feture introduced in
later versions. Since the implementation was not accounting for every
case and that it' not fixing any behaviour, just improving the user
experience, it's better to  cancel it.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo