### PR TITLE
[IMP] xlsx: import/export scatter plot

### DIFF
--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -60,7 +60,7 @@ export interface ExcelChartDataset {
   readonly range: string;
 }
 
-export type ExcelChartType = "line" | "bar" | "pie" | "combo";
+export type ExcelChartType = "line" | "bar" | "pie" | "combo" | "scatter";
 
 export interface ExcelChartDefinition {
   readonly title?: string;

--- a/src/xlsx/conversion/conversion_maps.ts
+++ b/src/xlsx/conversion/conversion_maps.ts
@@ -194,7 +194,7 @@ export const CHART_TYPE_CONVERSION_MAP: Record<XLSXChartType, ExcelChartType | u
   line3DChart: undefined,
   stockChart: undefined,
   radarChart: undefined,
-  scatterChart: undefined,
+  scatterChart: "scatter",
   pieChart: "pie",
   pie3DChart: undefined,
   doughnutChart: "pie",

--- a/tests/__xlsx__/xlsx_demo_data/[Content_Types].xml
+++ b/tests/__xlsx__/xlsx_demo_data/[Content_Types].xml
@@ -43,6 +43,7 @@
   <Override PartName="/xl/charts/chart3.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/charts/chart4.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/charts/chart5.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
+  <Override PartName="/xl/charts/chart6.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/charts/chart7.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
   <Override PartName="/xl/calcChain.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.calcChain+xml"/>
   <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>

--- a/tests/__xlsx__/xlsx_demo_data/xl/charts/chart6.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/charts/chart6.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace
+  xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:c16r2="http://schemas.microsoft.com/office/drawing/2015/06/chart">
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr lvl="0">
+              <a:defRPr b="0">
+                <a:solidFill>
+                  <a:srgbClr val="000000"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+              </a:defRPr>
+            </a:pPr>
+            <a:r>
+              <a:rPr lang="en-US" sz="2200"/>
+              <a:t>scatter chart</a:t>
+            </a:r>
+          </a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:autoTitleDeleted val="0"/>
+    <c:plotArea>
+      <c:layout/>
+      <c:scatterChart>
+        <c:scatterStyle val="lineMarker"/>
+        <c:varyColors val="0"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:spPr>
+            <a:solidFill>
+              <a:srgbClr val="1F77B4"/>
+            </a:solidFill>
+            <a:ln w="19050">
+              <a:noFill/>
+            </a:ln>
+          </c:spPr>
+          <c:xVal>
+            <c:numRef>
+              <c:f>Sheet1!$B$27:$B$35</c:f>
+            </c:numRef>
+          </c:xVal>
+          <c:yVal>
+            <c:numRef>
+              <c:f>Sheet1!$C$27:$C$35</c:f>
+            </c:numRef>
+          </c:yVal>
+          <c:smooth val="0"/>
+          <c:extLst>
+            <c:ext xmlns:c16="http://schemas.microsoft.com/office/drawing/2014/chart" uri="{C3380CC4-5D6E-409C-BE32-E72D297353CC}">
+              <c16:uniqueId val="{00000000-1000-4695-A558-70E3A3698455}"/>
+            </c:ext>
+          </c:extLst>
+        </c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+        <c:axId val="17781237"/>
+        <c:axId val="88853993"/>
+      </c:scatterChart>
+      <c:valAx>
+        <c:axId val="17781237"/>
+        <c:scaling>
+          <c:orientation val="minMax"/>
+        </c:scaling>
+        <c:delete val="0"/>
+        <c:axPos val="b"/>
+        <c:majorGridlines>
+          <c:spPr>
+            <a:ln cmpd="sng">
+              <a:solidFill>
+                <a:srgbClr val="B7B7B7"/>
+              </a:solidFill>
+            </a:ln>
+          </c:spPr>
+        </c:majorGridlines>
+        <c:title>
+          <c:tx>
+            <c:rich>
+              <a:bodyPr/>
+              <a:lstStyle/>
+              <a:p>
+                <a:pPr lvl="0">
+                  <a:defRPr b="0">
+                    <a:solidFill>
+                      <a:srgbClr val="000000"/>
+                    </a:solidFill>
+                    <a:latin typeface="+mn-lt"/>
+                  </a:defRPr>
+                </a:pPr>
+                <a:endParaRPr lang="en-US"/>
+              </a:p>
+            </c:rich>
+          </c:tx>
+          <c:overlay val="1"/>
+        </c:title>
+        <c:numFmt formatCode="General" sourceLinked="1"/>
+        <c:majorTickMark val="out"/>
+        <c:minorTickMark val="none"/>
+        <c:tickLblPos val="nextTo"/>
+        <c:txPr>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr lvl="0">
+              <a:defRPr sz="1000" b="0" i="0">
+                <a:solidFill>
+                  <a:srgbClr val="000000"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+              </a:defRPr>
+            </a:pPr>
+            <a:endParaRPr lang="fr-FR"/>
+          </a:p>
+        </c:txPr>
+        <c:crossAx val="88853993"/>
+        <c:crosses val="autoZero"/>
+        <c:crossBetween val="midCat"/>
+      </c:valAx>
+      <c:valAx>
+        <c:axId val="88853993"/>
+        <c:scaling>
+          <c:orientation val="minMax"/>
+        </c:scaling>
+        <c:delete val="0"/>
+        <c:axPos val="l"/>
+        <c:majorGridlines>
+          <c:spPr>
+            <a:ln cmpd="sng">
+              <a:solidFill>
+                <a:srgbClr val="B7B7B7"/>
+              </a:solidFill>
+            </a:ln>
+          </c:spPr>
+        </c:majorGridlines>
+        <c:title>
+          <c:tx>
+            <c:rich>
+              <a:bodyPr/>
+              <a:lstStyle/>
+              <a:p>
+                <a:pPr lvl="0">
+                  <a:defRPr b="0">
+                    <a:solidFill>
+                      <a:srgbClr val="000000"/>
+                    </a:solidFill>
+                    <a:latin typeface="+mn-lt"/>
+                  </a:defRPr>
+                </a:pPr>
+                <a:endParaRPr lang="en-US"/>
+              </a:p>
+            </c:rich>
+          </c:tx>
+          <c:overlay val="1"/>
+        </c:title>
+        <c:numFmt formatCode="General" sourceLinked="1"/>
+        <c:majorTickMark val="out"/>
+        <c:minorTickMark val="none"/>
+        <c:tickLblPos val="nextTo"/>
+        <c:txPr>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr lvl="0">
+              <a:defRPr sz="1000" b="0" i="0">
+                <a:solidFill>
+                  <a:srgbClr val="000000"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+              </a:defRPr>
+            </a:pPr>
+            <a:endParaRPr lang="fr-FR"/>
+          </a:p>
+        </c:txPr>
+        <c:crossAx val="17781237"/>
+        <c:crosses val="autoZero"/>
+        <c:crossBetween val="midCat"/>
+      </c:valAx>
+      <c:spPr>
+        <a:solidFill>
+          <a:srgbClr val="FFFFFF"/>
+        </a:solidFill>
+      </c:spPr>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="t"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p>
+          <a:pPr lvl="0">
+            <a:defRPr sz="1000" b="0" i="0">
+              <a:solidFill>
+                <a:srgbClr val="000000"/>
+              </a:solidFill>
+              <a:latin typeface="+mn-lt"/>
+            </a:defRPr>
+          </a:pPr>
+          <a:endParaRPr lang="fr-FR"/>
+        </a:p>
+      </c:txPr>
+    </c:legend>
+    <c:plotVisOnly val="1"/>
+    <c:dispBlanksAs val="zero"/>
+    <c:showDLblsOverMax val="1"/>
+  </c:chart>
+  <c:spPr>
+    <a:solidFill>
+      <a:srgbClr val="FFFFFF"/>
+    </a:solidFill>
+    <a:ln cmpd="sng">
+      <a:solidFill>
+        <a:srgbClr val="000000"/>
+      </a:solidFill>
+    </a:ln>
+  </c:spPr>
+</c:chartSpace>

--- a/tests/__xlsx__/xlsx_demo_data/xl/drawings/_rels/drawing1.xml.rels
+++ b/tests/__xlsx__/xlsx_demo_data/xl/drawings/_rels/drawing1.xml.rels
@@ -4,5 +4,6 @@
   <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart2.xml"/>
   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/>
   <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart7.xml"/>
+  <Relationship Id="rId6" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart6.xml"/>
   <Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart4.xml"/>
 </Relationships>

--- a/tests/__xlsx__/xlsx_demo_data/xl/drawings/drawing1.xml
+++ b/tests/__xlsx__/xlsx_demo_data/xl/drawings/drawing1.xml
@@ -150,6 +150,44 @@
   </xdr:twoCellAnchor>
   <xdr:twoCellAnchor>
     <xdr:from>
+      <xdr:col>12</xdr:col>
+      <xdr:colOff>0</xdr:colOff>
+      <xdr:row>4</xdr:row>
+      <xdr:rowOff>0</xdr:rowOff>
+    </xdr:from>
+    <xdr:to>
+      <xdr:col>16</xdr:col>
+      <xdr:colOff>152400</xdr:colOff>
+      <xdr:row>17</xdr:row>
+      <xdr:rowOff>9525</xdr:rowOff>
+    </xdr:to>
+    <xdr:graphicFrame macro="">
+      <xdr:nvGraphicFramePr>
+        <xdr:cNvPr id="7" name="Chart 4" title="Chart">
+          <a:extLst>
+            <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+              <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{6CC27214-40A9-4FF9-BB37-40F876B2768B}"/>
+            </a:ext>
+          </a:extLst>
+        </xdr:cNvPr>
+        <xdr:cNvGraphicFramePr>
+          <a:graphicFrameLocks/>
+        </xdr:cNvGraphicFramePr>
+      </xdr:nvGraphicFramePr>
+      <xdr:xfrm>
+        <a:off x="0" y="0"/>
+        <a:ext cx="0" cy="0"/>
+      </xdr:xfrm>
+      <a:graphic>
+        <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+          <c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rId6"/>
+        </a:graphicData>
+      </a:graphic>
+    </xdr:graphicFrame>
+    <xdr:clientData fLocksWithSheet="0"/>
+  </xdr:twoCellAnchor>
+  <xdr:twoCellAnchor>
+    <xdr:from>
       <xdr:col>7</xdr:col>
       <xdr:colOff>0</xdr:colOff>
       <xdr:row>57</xdr:row>
@@ -163,7 +201,7 @@
     </xdr:to>
     <xdr:graphicFrame macro="">
       <xdr:nvGraphicFramePr>
-        <xdr:cNvPr id="8" name="Chart 2" title="Chart">
+        <xdr:cNvPr id="8" name="Chart 6" title="Chart">
           <a:extLst>
             <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
               <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{A5685A00-859E-4641-A529-E7042819F3BF}"/>

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -10174,6 +10174,1185 @@ exports[`Test XLSX export Charts simple pie chart with dataset [ 'Sheet1!B1:B4',
 }
 `;
 
+exports[`Test XLSX export Charts simple scatter chart with dataset [ 'Sheet1!B1:B4' ] 1`] = `
+{
+  "files": [
+    {
+      "content": "<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets>
+        <sheet state="visible" name="Sheet1" sheetId="1" r:id="rId1"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    {
+      "content": "<c:chartSpace xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+    <c:roundedCorners val="0"/>
+    <!-- <manualLayout/> to manually position the chart in the figure container -->
+    <c:spPr>
+        <a:solidFill>
+            <a:srgbClr val="FFFFFF"/>
+        </a:solidFill>
+        <a:ln cmpd="sng">
+            <a:solidFill>
+                <a:srgbClr val="000000"/>
+            </a:solidFill>
+        </a:ln>
+    </c:spPr>
+    <c:chart>
+        <c:title>
+            <c:tx>
+                <c:rich>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl="0">
+                            <a:defRPr b="0">
+                                <a:solidFill>
+                                    <a:srgbClr val="000000"/>
+                                </a:solidFill>
+                                <a:latin typeface="+mn-lt"/>
+                            </a:defRPr>
+                        </a:pPr>
+                        <a:r>
+                            <!-- Runs -->
+                            <a:rPr sz="2200"/>
+                            <a:t>
+                                test
+                            </a:t>
+                        </a:r>
+                    </a:p>
+                </c:rich>
+            </c:tx>
+            <c:overlay val="0"/>
+        </c:title>
+        <c:autoTitleDeleted val="0"/>
+        <c:plotArea>
+            <!-- how the chart element is placed on the chart -->
+            <c:layout/>
+            <c:scatterChart>
+                <!-- each data marker in the series does not have a different color -->
+                <c:varyColors val="0"/>
+                <c:scatterStyle val="lineMarker"/>
+                <c:ser>
+                    <c:idx val="0"/>
+                    <c:order val="0"/>
+                    <c:smooth val="0"/>
+                    <c:spPr>
+                        <a:ln w="19050" cap="rnd">
+                            <a:noFill/>
+                            <a:round/>
+                        </a:ln>
+                        <a:effectLst/>
+                    </c:spPr>
+                    <c:marker>
+                        <c:symbol val="circle"/>
+                        <c:size val="5"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val="1F77B4"/>
+                            </a:solidFill>
+                        </c:spPr>
+                    </c:marker>
+                    <c:xVal>
+                        <!-- x-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!A2:A4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:xVal>
+                    <c:yVal>
+                        <!-- y-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!B2:B4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:yVal>
+                </c:ser>
+                <c:axId val="17781237"/>
+                <c:axId val="88853993"/>
+            </c:scatterChart>
+            <c:valAx>
+                <c:axId val="17781237"/>
+                <c:crossAx val="88853993"/>
+                <!-- reference to the other axe of the chart -->
+                <c:delete val="0"/>
+                <!-- by default, axis are not displayed -->
+                <c:scaling>
+                    <c:orientation val="minMax"/>
+                </c:scaling>
+                <c:axPos val="b"/>
+                <c:majorGridlines>
+                    <c:spPr>
+                        <a:ln cmpd="sng">
+                            <a:solidFill>
+                                <a:srgbClr val="B7B7B7"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                </c:majorGridlines>
+                <c:majorTickMark val="out"/>
+                <c:minorTickMark val="none"/>
+                <c:numFmt formatCode="General" sourceLinked="1"/>
+                <c:title>
+                    <c:tx>
+                        <c:rich>
+                            <a:bodyPr/>
+                            <a:lstStyle/>
+                            <a:p>
+                                <a:pPr lvl="0">
+                                    <a:defRPr b="0">
+                                        <a:solidFill>
+                                            <a:srgbClr val="000000"/>
+                                        </a:solidFill>
+                                        <a:latin typeface="+mn-lt"/>
+                                    </a:defRPr>
+                                </a:pPr>
+                                <a:r>
+                                    <!-- Runs -->
+                                    <a:rPr sz="2200"/>
+                                    <a:t/>
+                                </a:r>
+                            </a:p>
+                        </c:rich>
+                    </c:tx>
+                </c:title>
+                <c:txPr>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl="0">
+                            <a:defRPr b="0" i="0" sz="1000">
+                                <a:solidFill>
+                                    <a:srgbClr val="000000"/>
+                                </a:solidFill>
+                                <a:latin typeface="+mn-lt"/>
+                            </a:defRPr>
+                        </a:pPr>
+                    </a:p>
+                </c:txPr>
+            </c:valAx>
+            <!-- <tickLblPos/> omitted -->
+            <c:valAx>
+                <c:axId val="88853993"/>
+                <c:crossAx val="17781237"/>
+                <!-- reference to the other axe of the chart -->
+                <c:delete val="0"/>
+                <!-- by default, axis are not displayed -->
+                <c:scaling>
+                    <c:orientation val="minMax"/>
+                </c:scaling>
+                <c:axPos val="l"/>
+                <c:majorGridlines>
+                    <c:spPr>
+                        <a:ln cmpd="sng">
+                            <a:solidFill>
+                                <a:srgbClr val="B7B7B7"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                </c:majorGridlines>
+                <c:majorTickMark val="out"/>
+                <c:minorTickMark val="none"/>
+                <c:numFmt formatCode="General" sourceLinked="1"/>
+                <c:title>
+                    <c:tx>
+                        <c:rich>
+                            <a:bodyPr/>
+                            <a:lstStyle/>
+                            <a:p>
+                                <a:pPr lvl="0">
+                                    <a:defRPr b="0">
+                                        <a:solidFill>
+                                            <a:srgbClr val="000000"/>
+                                        </a:solidFill>
+                                        <a:latin typeface="+mn-lt"/>
+                                    </a:defRPr>
+                                </a:pPr>
+                                <a:r>
+                                    <!-- Runs -->
+                                    <a:rPr sz="2200"/>
+                                    <a:t/>
+                                </a:r>
+                            </a:p>
+                        </c:rich>
+                    </c:tx>
+                </c:title>
+                <c:txPr>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl="0">
+                            <a:defRPr b="0" i="0" sz="1000">
+                                <a:solidFill>
+                                    <a:srgbClr val="000000"/>
+                                </a:solidFill>
+                                <a:latin typeface="+mn-lt"/>
+                            </a:defRPr>
+                        </a:pPr>
+                    </a:p>
+                </c:txPr>
+            </c:valAx>
+            <!-- <tickLblPos/> omitted -->
+            <c:spPr>
+                <a:solidFill>
+                    <a:srgbClr val="FFFFFF"/>
+                </a:solidFill>
+            </c:spPr>
+        </c:plotArea>
+        <c:legend>
+            <c:legendPos val="t"/>
+            <c:overlay val="0"/>
+            <c:txPr>
+                <a:bodyPr/>
+                <a:lstStyle/>
+                <a:p>
+                    <a:pPr lvl="0">
+                        <a:defRPr b="0" i="0" sz="1000">
+                            <a:solidFill>
+                                <a:srgbClr val="000000"/>
+                            </a:solidFill>
+                            <a:latin typeface="+mn-lt"/>
+                        </a:defRPr>
+                    </a:pPr>
+                </a:p>
+            </c:txPr>
+        </c:legend>
+    </c:chart>
+</c:chartSpace>",
+      "contentType": "chart",
+      "path": "xl/charts/chart1.xml",
+    },
+    {
+      "content": "<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+    <xdr:twoCellAnchor>
+        <xdr:from>
+            <xdr:col>
+                0
+            </xdr:col>
+            <xdr:colOff>
+                9525
+            </xdr:colOff>
+            <xdr:row>
+                0
+            </xdr:row>
+            <xdr:rowOff>
+                9525
+            </xdr:rowOff>
+        </xdr:from>
+        <xdr:to>
+            <xdr:col>
+                5
+            </xdr:col>
+            <xdr:colOff>
+                542925
+            </xdr:colOff>
+            <xdr:row>
+                14
+            </xdr:row>
+            <xdr:rowOff>
+                133350
+            </xdr:rowOff>
+        </xdr:to>
+        <xdr:graphicFrame>
+            <xdr:nvGraphicFramePr>
+                <xdr:cNvPr id="1" name="Chart 1" title="Chart"/>
+                <xdr:cNvGraphicFramePr/>
+            </xdr:nvGraphicFramePr>
+            <xdr:xfrm>
+                <a:off x="0" y="0"/>
+                <a:ext cx="0" cy="0"/>
+            </xdr:xfrm>
+            <a:graphic>
+                <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                    <c:chart r:id="rId1"/>
+                </a:graphicData>
+            </a:graphic>
+        </xdr:graphicFrame>
+        <xdr:clientData fLocksWithSheet="0"/>
+    </xdr:twoCellAnchor>
+</xdr:wsDr>",
+      "contentType": "drawing",
+      "path": "xl/drawings/drawing0.xml",
+    },
+    {
+      "content": "<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheetViews>
+        <sheetView showGridLines="1" workbookViewId="0">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight="17.25" defaultColWidth="13.73"/>
+    <cols>
+        <col min="1" max="1" width="13.73" customWidth="1" hidden="0"/>
+        <col min="2" max="2" width="13.73" customWidth="1" hidden="0"/>
+        <col min="3" max="3" width="13.73" customWidth="1" hidden="0"/>
+        <col min="4" max="4" width="13.73" customWidth="1" hidden="0"/>
+        <col min="5" max="5" width="13.73" customWidth="1" hidden="0"/>
+        <col min="6" max="6" width="13.73" customWidth="1" hidden="0"/>
+        <col min="7" max="7" width="13.73" customWidth="1" hidden="0"/>
+        <col min="8" max="8" width="13.73" customWidth="1" hidden="0"/>
+        <col min="9" max="9" width="13.73" customWidth="1" hidden="0"/>
+        <col min="10" max="10" width="13.73" customWidth="1" hidden="0"/>
+        <col min="11" max="11" width="13.73" customWidth="1" hidden="0"/>
+        <col min="12" max="12" width="13.73" customWidth="1" hidden="0"/>
+        <col min="13" max="13" width="13.73" customWidth="1" hidden="0"/>
+        <col min="14" max="14" width="13.73" customWidth="1" hidden="0"/>
+        <col min="15" max="15" width="13.73" customWidth="1" hidden="0"/>
+        <col min="16" max="16" width="13.73" customWidth="1" hidden="0"/>
+        <col min="17" max="17" width="13.73" customWidth="1" hidden="0"/>
+        <col min="18" max="18" width="13.73" customWidth="1" hidden="0"/>
+        <col min="19" max="19" width="13.73" customWidth="1" hidden="0"/>
+        <col min="20" max="20" width="13.73" customWidth="1" hidden="0"/>
+        <col min="21" max="21" width="13.73" customWidth="1" hidden="0"/>
+        <col min="22" max="22" width="13.73" customWidth="1" hidden="0"/>
+        <col min="23" max="23" width="13.73" customWidth="1" hidden="0"/>
+        <col min="24" max="24" width="13.73" customWidth="1" hidden="0"/>
+        <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
+    </cols>
+    <sheetData>
+        <row r="1">
+            <c r="B1" s="1" t="s">
+                <v>
+                    0
+                </v>
+            </c>
+            <c r="C1" s="1" t="s">
+                <v>
+                    1
+                </v>
+            </c>
+        </row>
+        <row r="2">
+            <c r="A2" s="1" t="s">
+                <v>
+                    2
+                </v>
+            </c>
+            <c r="B2" s="1">
+                <v>
+                    10
+                </v>
+            </c>
+            <c r="C2" s="1">
+                <v>
+                    20
+                </v>
+            </c>
+        </row>
+        <row r="3">
+            <c r="A3" s="1" t="s">
+                <v>
+                    3
+                </v>
+            </c>
+            <c r="B3" s="1">
+                <v>
+                    11
+                </v>
+            </c>
+            <c r="C3" s="1">
+                <v>
+                    19
+                </v>
+            </c>
+        </row>
+        <row r="4">
+            <c r="A4" s="1" t="s">
+                <v>
+                    4
+                </v>
+            </c>
+            <c r="B4" s="1">
+                <v>
+                    12
+                </v>
+            </c>
+            <c r="C4" s="1">
+                <v>
+                    18
+                </v>
+            </c>
+        </row>
+        <row r="5">
+            <c r="A5" s="1" t="s">
+                <v>
+                    5
+                </v>
+            </c>
+            <c r="B5" s="1">
+                <v>
+                    13
+                </v>
+            </c>
+            <c r="C5" s="1">
+                <v>
+                    17
+                </v>
+            </c>
+        </row>
+    </sheetData>
+    <drawing r:id="rId1"/>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <numFmts count="0">
+    </numFmts>
+    <fonts count="2">
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Calibri"/>
+        </font>
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Arial"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left>
+            </left>
+            <right>
+            </right>
+            <top>
+            </top>
+            <bottom>
+            </bottom>
+            <diagonal>
+            </diagonal>
+        </border>
+    </borders>
+    <cellXfs count="2">
+        <xf numFmtId="0" fillId="0" fontId="0" borderId="0" applyAlignment="1">
+            <alignment vertical="bottom"/>
+        </xf>
+        <xf numFmtId="0" fillId="0" fontId="1" borderId="0"/>
+    </cellXfs>
+    <dxfs count="0">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    {
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="6" uniqueCount="6">
+    <si>
+        <t>
+            first column dataset
+        </t>
+    </si>
+    <si>
+        <t>
+            second column dataset
+        </t>
+    </si>
+    <si>
+        <t>
+            P1
+        </t>
+    </si>
+    <si>
+        <t>
+            P2
+        </t>
+    </si>
+    <si>
+        <t>
+            P3
+        </t>
+    </si>
+    <si>
+        <t>
+            P4
+        </t>
+    </si>
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+    <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
+    <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="../charts/chart1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/drawings/_rels/drawing0.xml.rels",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="../drawings/drawing0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/worksheets/_rels/sheet0.xml.rels",
+    },
+    {
+      "content": "<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="avif" ContentType="image/avif"/>
+    <Default Extension="bmp" ContentType="image/bmp"/>
+    <Default Extension="gif" ContentType="image/gif"/>
+    <Default Extension="ico" ContentType="image/vnd.microsoft.icon"/>
+    <Default Extension="jpeg" ContentType="image/jpeg"/>
+    <Default Extension="png" ContentType="image/png"/>
+    <Default Extension="tiff" ContentType="image/tiff"/>
+    <Default Extension="webp" ContentType="image/webp"/>
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
+exports[`Test XLSX export Charts simple scatter chart with dataset [ 'Sheet1!B1:B4', 'Sheet1!C1:C4' ] 1`] = `
+{
+  "files": [
+    {
+      "content": "<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets>
+        <sheet state="visible" name="Sheet1" sheetId="1" r:id="rId1"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    {
+      "content": "<c:chartSpace xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+    <c:roundedCorners val="0"/>
+    <!-- <manualLayout/> to manually position the chart in the figure container -->
+    <c:spPr>
+        <a:solidFill>
+            <a:srgbClr val="FFFFFF"/>
+        </a:solidFill>
+        <a:ln cmpd="sng">
+            <a:solidFill>
+                <a:srgbClr val="000000"/>
+            </a:solidFill>
+        </a:ln>
+    </c:spPr>
+    <c:chart>
+        <c:title>
+            <c:tx>
+                <c:rich>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl="0">
+                            <a:defRPr b="0">
+                                <a:solidFill>
+                                    <a:srgbClr val="000000"/>
+                                </a:solidFill>
+                                <a:latin typeface="+mn-lt"/>
+                            </a:defRPr>
+                        </a:pPr>
+                        <a:r>
+                            <!-- Runs -->
+                            <a:rPr sz="2200"/>
+                            <a:t>
+                                test
+                            </a:t>
+                        </a:r>
+                    </a:p>
+                </c:rich>
+            </c:tx>
+            <c:overlay val="0"/>
+        </c:title>
+        <c:autoTitleDeleted val="0"/>
+        <c:plotArea>
+            <!-- how the chart element is placed on the chart -->
+            <c:layout/>
+            <c:scatterChart>
+                <!-- each data marker in the series does not have a different color -->
+                <c:varyColors val="0"/>
+                <c:scatterStyle val="lineMarker"/>
+                <c:ser>
+                    <c:idx val="0"/>
+                    <c:order val="0"/>
+                    <c:smooth val="0"/>
+                    <c:spPr>
+                        <a:ln w="19050" cap="rnd">
+                            <a:noFill/>
+                            <a:round/>
+                        </a:ln>
+                        <a:effectLst/>
+                    </c:spPr>
+                    <c:marker>
+                        <c:symbol val="circle"/>
+                        <c:size val="5"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val="1F77B4"/>
+                            </a:solidFill>
+                        </c:spPr>
+                    </c:marker>
+                    <c:xVal>
+                        <!-- x-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!A2:A4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:xVal>
+                    <c:yVal>
+                        <!-- y-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!B2:B4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:yVal>
+                </c:ser>
+                <c:ser>
+                    <c:idx val="1"/>
+                    <c:order val="1"/>
+                    <c:smooth val="0"/>
+                    <c:spPr>
+                        <a:ln w="19050" cap="rnd">
+                            <a:noFill/>
+                            <a:round/>
+                        </a:ln>
+                        <a:effectLst/>
+                    </c:spPr>
+                    <c:marker>
+                        <c:symbol val="circle"/>
+                        <c:size val="5"/>
+                        <c:spPr>
+                            <a:solidFill>
+                                <a:srgbClr val="FF7F0E"/>
+                            </a:solidFill>
+                        </c:spPr>
+                    </c:marker>
+                    <c:xVal>
+                        <!-- x-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!A2:A4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:xVal>
+                    <c:yVal>
+                        <!-- y-coordinate values -->
+                        <c:numRef>
+                            <c:f>
+                                Sheet1!C2:C4
+                            </c:f>
+                            <c:numCache/>
+                        </c:numRef>
+                    </c:yVal>
+                </c:ser>
+                <c:axId val="17781237"/>
+                <c:axId val="88853993"/>
+            </c:scatterChart>
+            <c:valAx>
+                <c:axId val="17781237"/>
+                <c:crossAx val="88853993"/>
+                <!-- reference to the other axe of the chart -->
+                <c:delete val="0"/>
+                <!-- by default, axis are not displayed -->
+                <c:scaling>
+                    <c:orientation val="minMax"/>
+                </c:scaling>
+                <c:axPos val="b"/>
+                <c:majorGridlines>
+                    <c:spPr>
+                        <a:ln cmpd="sng">
+                            <a:solidFill>
+                                <a:srgbClr val="B7B7B7"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                </c:majorGridlines>
+                <c:majorTickMark val="out"/>
+                <c:minorTickMark val="none"/>
+                <c:numFmt formatCode="General" sourceLinked="1"/>
+                <c:title>
+                    <c:tx>
+                        <c:rich>
+                            <a:bodyPr/>
+                            <a:lstStyle/>
+                            <a:p>
+                                <a:pPr lvl="0">
+                                    <a:defRPr b="0">
+                                        <a:solidFill>
+                                            <a:srgbClr val="000000"/>
+                                        </a:solidFill>
+                                        <a:latin typeface="+mn-lt"/>
+                                    </a:defRPr>
+                                </a:pPr>
+                                <a:r>
+                                    <!-- Runs -->
+                                    <a:rPr sz="2200"/>
+                                    <a:t/>
+                                </a:r>
+                            </a:p>
+                        </c:rich>
+                    </c:tx>
+                </c:title>
+                <c:txPr>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl="0">
+                            <a:defRPr b="0" i="0" sz="1000">
+                                <a:solidFill>
+                                    <a:srgbClr val="000000"/>
+                                </a:solidFill>
+                                <a:latin typeface="+mn-lt"/>
+                            </a:defRPr>
+                        </a:pPr>
+                    </a:p>
+                </c:txPr>
+            </c:valAx>
+            <!-- <tickLblPos/> omitted -->
+            <c:valAx>
+                <c:axId val="88853993"/>
+                <c:crossAx val="17781237"/>
+                <!-- reference to the other axe of the chart -->
+                <c:delete val="0"/>
+                <!-- by default, axis are not displayed -->
+                <c:scaling>
+                    <c:orientation val="minMax"/>
+                </c:scaling>
+                <c:axPos val="l"/>
+                <c:majorGridlines>
+                    <c:spPr>
+                        <a:ln cmpd="sng">
+                            <a:solidFill>
+                                <a:srgbClr val="B7B7B7"/>
+                            </a:solidFill>
+                        </a:ln>
+                    </c:spPr>
+                </c:majorGridlines>
+                <c:majorTickMark val="out"/>
+                <c:minorTickMark val="none"/>
+                <c:numFmt formatCode="General" sourceLinked="1"/>
+                <c:title>
+                    <c:tx>
+                        <c:rich>
+                            <a:bodyPr/>
+                            <a:lstStyle/>
+                            <a:p>
+                                <a:pPr lvl="0">
+                                    <a:defRPr b="0">
+                                        <a:solidFill>
+                                            <a:srgbClr val="000000"/>
+                                        </a:solidFill>
+                                        <a:latin typeface="+mn-lt"/>
+                                    </a:defRPr>
+                                </a:pPr>
+                                <a:r>
+                                    <!-- Runs -->
+                                    <a:rPr sz="2200"/>
+                                    <a:t/>
+                                </a:r>
+                            </a:p>
+                        </c:rich>
+                    </c:tx>
+                </c:title>
+                <c:txPr>
+                    <a:bodyPr/>
+                    <a:lstStyle/>
+                    <a:p>
+                        <a:pPr lvl="0">
+                            <a:defRPr b="0" i="0" sz="1000">
+                                <a:solidFill>
+                                    <a:srgbClr val="000000"/>
+                                </a:solidFill>
+                                <a:latin typeface="+mn-lt"/>
+                            </a:defRPr>
+                        </a:pPr>
+                    </a:p>
+                </c:txPr>
+            </c:valAx>
+            <!-- <tickLblPos/> omitted -->
+            <c:spPr>
+                <a:solidFill>
+                    <a:srgbClr val="FFFFFF"/>
+                </a:solidFill>
+            </c:spPr>
+        </c:plotArea>
+        <c:legend>
+            <c:legendPos val="t"/>
+            <c:overlay val="0"/>
+            <c:txPr>
+                <a:bodyPr/>
+                <a:lstStyle/>
+                <a:p>
+                    <a:pPr lvl="0">
+                        <a:defRPr b="0" i="0" sz="1000">
+                            <a:solidFill>
+                                <a:srgbClr val="000000"/>
+                            </a:solidFill>
+                            <a:latin typeface="+mn-lt"/>
+                        </a:defRPr>
+                    </a:pPr>
+                </a:p>
+            </c:txPr>
+        </c:legend>
+    </c:chart>
+</c:chartSpace>",
+      "contentType": "chart",
+      "path": "xl/charts/chart1.xml",
+    },
+    {
+      "content": "<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+    <xdr:twoCellAnchor>
+        <xdr:from>
+            <xdr:col>
+                0
+            </xdr:col>
+            <xdr:colOff>
+                9525
+            </xdr:colOff>
+            <xdr:row>
+                0
+            </xdr:row>
+            <xdr:rowOff>
+                9525
+            </xdr:rowOff>
+        </xdr:from>
+        <xdr:to>
+            <xdr:col>
+                5
+            </xdr:col>
+            <xdr:colOff>
+                542925
+            </xdr:colOff>
+            <xdr:row>
+                14
+            </xdr:row>
+            <xdr:rowOff>
+                133350
+            </xdr:rowOff>
+        </xdr:to>
+        <xdr:graphicFrame>
+            <xdr:nvGraphicFramePr>
+                <xdr:cNvPr id="1" name="Chart 1" title="Chart"/>
+                <xdr:cNvGraphicFramePr/>
+            </xdr:nvGraphicFramePr>
+            <xdr:xfrm>
+                <a:off x="0" y="0"/>
+                <a:ext cx="0" cy="0"/>
+            </xdr:xfrm>
+            <a:graphic>
+                <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                    <c:chart r:id="rId1"/>
+                </a:graphicData>
+            </a:graphic>
+        </xdr:graphicFrame>
+        <xdr:clientData fLocksWithSheet="0"/>
+    </xdr:twoCellAnchor>
+</xdr:wsDr>",
+      "contentType": "drawing",
+      "path": "xl/drawings/drawing0.xml",
+    },
+    {
+      "content": "<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheetViews>
+        <sheetView showGridLines="1" workbookViewId="0">
+        </sheetView>
+    </sheetViews>
+    <sheetFormatPr defaultRowHeight="17.25" defaultColWidth="13.73"/>
+    <cols>
+        <col min="1" max="1" width="13.73" customWidth="1" hidden="0"/>
+        <col min="2" max="2" width="13.73" customWidth="1" hidden="0"/>
+        <col min="3" max="3" width="13.73" customWidth="1" hidden="0"/>
+        <col min="4" max="4" width="13.73" customWidth="1" hidden="0"/>
+        <col min="5" max="5" width="13.73" customWidth="1" hidden="0"/>
+        <col min="6" max="6" width="13.73" customWidth="1" hidden="0"/>
+        <col min="7" max="7" width="13.73" customWidth="1" hidden="0"/>
+        <col min="8" max="8" width="13.73" customWidth="1" hidden="0"/>
+        <col min="9" max="9" width="13.73" customWidth="1" hidden="0"/>
+        <col min="10" max="10" width="13.73" customWidth="1" hidden="0"/>
+        <col min="11" max="11" width="13.73" customWidth="1" hidden="0"/>
+        <col min="12" max="12" width="13.73" customWidth="1" hidden="0"/>
+        <col min="13" max="13" width="13.73" customWidth="1" hidden="0"/>
+        <col min="14" max="14" width="13.73" customWidth="1" hidden="0"/>
+        <col min="15" max="15" width="13.73" customWidth="1" hidden="0"/>
+        <col min="16" max="16" width="13.73" customWidth="1" hidden="0"/>
+        <col min="17" max="17" width="13.73" customWidth="1" hidden="0"/>
+        <col min="18" max="18" width="13.73" customWidth="1" hidden="0"/>
+        <col min="19" max="19" width="13.73" customWidth="1" hidden="0"/>
+        <col min="20" max="20" width="13.73" customWidth="1" hidden="0"/>
+        <col min="21" max="21" width="13.73" customWidth="1" hidden="0"/>
+        <col min="22" max="22" width="13.73" customWidth="1" hidden="0"/>
+        <col min="23" max="23" width="13.73" customWidth="1" hidden="0"/>
+        <col min="24" max="24" width="13.73" customWidth="1" hidden="0"/>
+        <col min="25" max="25" width="13.73" customWidth="1" hidden="0"/>
+    </cols>
+    <sheetData>
+        <row r="1">
+            <c r="B1" s="1" t="s">
+                <v>
+                    0
+                </v>
+            </c>
+            <c r="C1" s="1" t="s">
+                <v>
+                    1
+                </v>
+            </c>
+        </row>
+        <row r="2">
+            <c r="A2" s="1" t="s">
+                <v>
+                    2
+                </v>
+            </c>
+            <c r="B2" s="1">
+                <v>
+                    10
+                </v>
+            </c>
+            <c r="C2" s="1">
+                <v>
+                    20
+                </v>
+            </c>
+        </row>
+        <row r="3">
+            <c r="A3" s="1" t="s">
+                <v>
+                    3
+                </v>
+            </c>
+            <c r="B3" s="1">
+                <v>
+                    11
+                </v>
+            </c>
+            <c r="C3" s="1">
+                <v>
+                    19
+                </v>
+            </c>
+        </row>
+        <row r="4">
+            <c r="A4" s="1" t="s">
+                <v>
+                    4
+                </v>
+            </c>
+            <c r="B4" s="1">
+                <v>
+                    12
+                </v>
+            </c>
+            <c r="C4" s="1">
+                <v>
+                    18
+                </v>
+            </c>
+        </row>
+        <row r="5">
+            <c r="A5" s="1" t="s">
+                <v>
+                    5
+                </v>
+            </c>
+            <c r="B5" s="1">
+                <v>
+                    13
+                </v>
+            </c>
+            <c r="C5" s="1">
+                <v>
+                    17
+                </v>
+            </c>
+        </row>
+    </sheetData>
+    <drawing r:id="rId1"/>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    {
+      "content": "<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <numFmts count="0">
+    </numFmts>
+    <fonts count="2">
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Calibri"/>
+        </font>
+        <font>
+            <sz val="10"/>
+            <color rgb="000000"/>
+            <name val="Arial"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left>
+            </left>
+            <right>
+            </right>
+            <top>
+            </top>
+            <bottom>
+            </bottom>
+            <diagonal>
+            </diagonal>
+        </border>
+    </borders>
+    <cellXfs count="2">
+        <xf numFmtId="0" fillId="0" fontId="0" borderId="0" applyAlignment="1">
+            <alignment vertical="bottom"/>
+        </xf>
+        <xf numFmtId="0" fillId="0" fontId="1" borderId="0"/>
+    </cellXfs>
+    <dxfs count="0">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    {
+      "content": "<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="6" uniqueCount="6">
+    <si>
+        <t>
+            first column dataset
+        </t>
+    </si>
+    <si>
+        <t>
+            second column dataset
+        </t>
+    </si>
+    <si>
+        <t>
+            P1
+        </t>
+    </si>
+    <si>
+        <t>
+            P2
+        </t>
+    </si>
+    <si>
+        <t>
+            P3
+        </t>
+    </si>
+    <si>
+        <t>
+            P4
+        </t>
+    </si>
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="worksheets/sheet0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+    <Relationship Id="rId2" Target="sharedStrings.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"/>
+    <Relationship Id="rId3" Target="styles.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="../charts/chart1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/drawings/_rels/drawing0.xml.rels",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Target="../drawings/drawing0.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/worksheets/_rels/sheet0.xml.rels",
+    },
+    {
+      "content": "<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="avif" ContentType="image/avif"/>
+    <Default Extension="bmp" ContentType="image/bmp"/>
+    <Default Extension="gif" ContentType="image/gif"/>
+    <Default Extension="ico" ContentType="image/vnd.microsoft.icon"/>
+    <Default Extension="jpeg" ContentType="image/jpeg"/>
+    <Default Extension="png" ContentType="image/png"/>
+    <Default Extension="tiff" ContentType="image/tiff"/>
+    <Default Extension="webp" ContentType="image/webp"/>
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml" PartName="/xl/workbook.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml" PartName="/xl/charts/chart1.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.drawing+xml" PartName="/xl/drawings/drawing0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" PartName="/xl/worksheets/sheet0.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml" PartName="/xl/styles.xml"/>
+    <Override ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml" PartName="/xl/sharedStrings.xml"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    {
+      "content": "<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
 exports[`Test XLSX export Charts stacked bar chart 1`] = `
 {
   "files": [

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -1,7 +1,7 @@
 import { functionRegistry } from "../../src/functions";
 import { buildSheetLink, toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
-import { Dimension, PLAIN_TEXT_FORMAT } from "../../src/types";
+import { Dimension, ExcelChartType, PLAIN_TEXT_FORMAT } from "../../src/types";
 import { XLSXExportXMLFile } from "../../src/types/xlsx";
 import { adaptFormulaToExcel } from "../../src/xlsx/functions/cells";
 import { escapeXml, parseXML } from "../../src/xlsx/helpers/xml_helpers";
@@ -874,10 +874,12 @@ describe("Test XLSX export", () => {
 
     test.each([
       ["line", ["Sheet1!B1:B4", "Sheet1!C1:C4"]],
+      ["scatter", ["Sheet1!B1:B4", "Sheet1!C1:C4"]],
       ["bar", ["Sheet1!B1:B4", "Sheet1!C1:C4"]],
       ["combo", ["Sheet1!B1:B4", "Sheet1!C1:C4"]],
       ["pie", ["Sheet1!B1:B4", "Sheet1!C1:C4"]],
       ["line", ["Sheet1!B1:B4"]],
+      ["scatter", ["Sheet1!B1:B4"]],
       ["bar", ["Sheet1!B1:B4"]],
       ["combo", ["Sheet1!B1:B4"]],
       ["pie", ["Sheet1!B1:B4"]],
@@ -942,9 +944,9 @@ describe("Test XLSX export", () => {
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
 
-    test.each(["bar", "line", "pie"] as const)(
+    test.each(["bar", "line", "pie", "scatter"] as const)(
       "%s chart that aggregate labels is exported as image",
-      async (type: "bar" | "line" | "pie") => {
+      async (type: ExcelChartType) => {
         const model = new Model({
           sheets: [
             {

--- a/tests/xlsx/xlsx_import.test.ts
+++ b/tests/xlsx/xlsx_import.test.ts
@@ -15,8 +15,10 @@ import {
   Style,
 } from "../../src/types";
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
+import { ComboChartDefinition } from "../../src/types/chart/combo_chart";
 import { LineChartDefinition } from "../../src/types/chart/line_chart";
 import { PieChartDefinition } from "../../src/types/chart/pie_chart";
+import { ScatterChartDefinition } from "../../src/types/chart/scatter_chart";
 import { Image } from "../../src/types/image";
 import { SheetData, WorkbookData } from "../../src/types/workbook_data";
 import { XLSXCfOperatorType, XLSXSharedFormula } from "../../src/types/xlsx";
@@ -729,6 +731,7 @@ describe("Import xlsx data", () => {
   test.each([
     ["line chart", "C5:G18"],
     ["bar chart", "H5:L18"],
+    ["scatter chart", "M5:Q18"],
     ["pie chart", "C38:L56"],
     ["combo chart", "H58:L71"],
     ["doughnut chart", "C19:L37"],
@@ -767,10 +770,7 @@ describe("Import xlsx data", () => {
     (chartTitle, chartType, chartColor, chartDatasets) => {
       const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
       const figure = testSheet.figures.find((figure) => figure.data.title === chartTitle)!;
-      const chartData = figure.data as
-        | LineChartDefinition
-        | PieChartDefinition
-        | BarChartDefinition;
+      const chartData = figure.data as BarChartDefinition | ComboChartDefinition;
       expect(chartData.title).toEqual(chartTitle);
       expect(chartData.type).toEqual(chartType);
       expect(standardizeColor(chartData.background!)).toEqual(standardizeColor(chartColor));
@@ -790,10 +790,7 @@ describe("Import xlsx data", () => {
     (chartTitle, chartType, chartColor, chartDatasets) => {
       const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
       const figure = testSheet.figures.find((figure) => figure.data.title === chartTitle)!;
-      const chartData = figure.data as
-        | LineChartDefinition
-        | PieChartDefinition
-        | BarChartDefinition;
+      const chartData = figure.data as LineChartDefinition | PieChartDefinition;
       expect(chartData.title).toEqual(chartTitle);
       expect(chartData.type).toEqual(chartType);
       expect(standardizeColor(chartData.background!)).toEqual(standardizeColor(chartColor));
@@ -803,6 +800,18 @@ describe("Import xlsx data", () => {
       expect(chartData.dataSetsHaveTitle).toBeTruthy();
     }
   );
+
+  test("Can import scatter plot", () => {
+    const testSheet = getWorkbookSheet("jestCharts", convertedData)!;
+    const figure = testSheet.figures.find((figure) => figure.data.title === "scatter chart")!;
+    const chartData = figure.data as ScatterChartDefinition;
+    expect(chartData.title).toEqual("scatter chart");
+    expect(chartData.type).toEqual("scatter");
+    expect(standardizeColor(chartData.background!)).toEqual(standardizeColor("#fff"));
+    expect(chartData.dataSets).toEqual(["Sheet1!C26:C35"]);
+    expect(chartData.labelRange).toEqual("Sheet1!B26:B35");
+    expect(chartData.dataSetsHaveTitle).toBeTruthy();
+  });
 
   test.each([
     ["chart", "A1:F19"],


### PR DESCRIPTION
## Description:

Following the add of scatter plot in o-spreadsheet, this PR aims to allow the user to import/export a scatter plot from/to an xlsx file.

## Related Task/PR :
- Task: : [3633445](https://www.odoo.com/web#id=3633445&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
- https://github.com/odoo/o-spreadsheet/pull/3316

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo