### PR TITLE
[FIX] SelectionInput: Allow commands that target non focused input

### DIFF
--- a/src/plugins/ui/selection_input.ts
+++ b/src/plugins/ui/selection_input.ts
@@ -15,7 +15,6 @@ import {
   Color,
   Command,
   CommandDispatcher,
-  CommandResult,
   Getters,
   Highlight,
   LAYERS,
@@ -54,7 +53,7 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
     config: ModelConfig,
     selection: SelectionStreamProcessor,
     initialRanges: string[],
-    private readonly inputHasSingleRange: boolean
+    readonly inputHasSingleRange: boolean
   ) {
     if (inputHasSingleRange && initialRanges.length > 1) {
       throw new Error(
@@ -73,22 +72,6 @@ export class SelectionInputPlugin extends UIPlugin implements StreamCallbacks<Se
   // ---------------------------------------------------------------------------
   // Command Handling
   // ---------------------------------------------------------------------------
-
-  allowDispatch(cmd: Command): CommandResult {
-    switch (cmd.type) {
-      case "ADD_EMPTY_RANGE":
-        if (this.inputHasSingleRange && this.ranges.length === 1) {
-          return CommandResult.MaximumRangesReached;
-        }
-        break;
-      case "CHANGE_RANGE":
-        if (this.inputHasSingleRange && cmd.value.split(",").length > 1) {
-          return CommandResult.MaximumRangesReached;
-        }
-        break;
-    }
-    return CommandResult.Success;
-  }
 
   handleEvent(event: SelectionEvent) {
     const xc = zoneToXc(event.anchor.zone);

--- a/src/plugins/ui/selection_inputs_manager.ts
+++ b/src/plugins/ui/selection_inputs_manager.ts
@@ -53,15 +53,36 @@ export class SelectionInputsManagerPlugin extends UIPlugin {
   allowDispatch(cmd: Command): CommandResult {
     switch (cmd.type) {
       case "FOCUS_RANGE":
+      case "CHANGE_RANGE":
+      case "ADD_EMPTY_RANGE":
+      case "REMOVE_RANGE":
+        if (!this.inputs[cmd.id]) {
+          return CommandResult.InvalidInputId;
+        }
+    }
+
+    switch (cmd.type) {
+      case "FOCUS_RANGE":
         const index = this.currentInput?.getIndex(cmd.rangeId);
         if (this.focusedInputId === cmd.id && this.currentInput?.focusedRangeIndex === index) {
           return CommandResult.InputAlreadyFocused;
         }
         break;
+      case "ADD_EMPTY_RANGE":
+        const input = this.inputs[cmd.id];
+        if (input.inputHasSingleRange && input.ranges.length === 1) {
+          return CommandResult.MaximumRangesReached;
+        }
+        break;
+      case "CHANGE_RANGE": {
+        const input = this.inputs[cmd.id];
+        if (input.inputHasSingleRange && cmd.value.split(",").length > 1) {
+          return CommandResult.MaximumRangesReached;
+        }
+        break;
+      }
     }
-    if (this.currentInput) {
-      return this.currentInput.allowDispatch(cmd);
-    }
+
     return CommandResult.Success;
   }
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1056,6 +1056,7 @@ export const enum CommandResult {
   InvalidSheetId,
   InputAlreadyFocused,
   MaximumRangesReached,
+  InvalidInputId,
   InvalidChartDefinition,
   InvalidDataSet,
   InvalidLabelRange,

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -644,4 +644,38 @@ describe("selection input plugin", () => {
     moveAnchorCell(model, "down");
     expect(highlightedZones(model)).toEqual(["A3"]);
   });
+
+  test("Cannot update ranges of inexisting input", () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id });
+    const rangeId = idOfRange(model, id, 0);
+    let result = model.dispatch("FOCUS_RANGE", { id: "fakeId", rangeId });
+    expect(result).toBeCancelledBecause(CommandResult.InvalidInputId);
+    result = model.dispatch("CHANGE_RANGE", { id: "fakeId", rangeId, value: "A1" });
+    expect(result).toBeCancelledBecause(CommandResult.InvalidInputId);
+    result = model.dispatch("ADD_EMPTY_RANGE", { id: "fakeId" });
+    expect(result).toBeCancelledBecause(CommandResult.InvalidInputId);
+    result = model.dispatch("REMOVE_RANGE", { id: "fakeId", rangeId });
+    expect(result).toBeCancelledBecause(CommandResult.InvalidInputId);
+  });
+
+  test("Can add a empty range to a second input without pre-focusing", () => {
+    const id2 = "2";
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, hasSingleRange: true });
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id: id2 });
+    model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
+    model.dispatch("ADD_EMPTY_RANGE", { id: id2 });
+    expect(model.getters.getSelectionInput("2")).toHaveLength(2);
+  });
+
+  test("Can change the range of a second input without pre-focusing", () => {
+    const id2 = "2";
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, hasSingleRange: true });
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id: id2 });
+    model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
+    model.dispatch("CHANGE_RANGE", { id: id2, rangeId: idOfRange(model, id2, 0), value: "F1,F2" });
+    expect(model.getters.getSelectionInput(id2)).toHaveLength(2);
+    expect(model.getters.getSelectionInput(id2)[0].xc).toBe("F1");
+    expect(model.getters.getSelectionInput(id2)[1].xc).toBe("F2");
+    expect(model.getters.getSelectionInput(id2)[1].isFocused).toBe(true);
+  });
 });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -74,6 +74,10 @@ export function getChildFromComponent<T extends new (...args: any) => any>(
     ?.component as unknown as InstanceType<T>;
 }
 
+export function spyModelDispatch(model: Model): jest.SpyInstance {
+  return jest.spyOn(model, "dispatch");
+}
+
 export function makeTestFixture() {
   let fixture = document.createElement("div");
   document.body.appendChild(fixture);


### PR DESCRIPTION
Currently, dispatching a selectionInput related command can be rejected by the focused input even if the said command does not concern it.

Example:
- Set up 2 selection inputs, one of them with a single range (like for a line chart)
- Focus the single range input
- click on the "Add range" of the multi-range input -> nothing happens

The command are rejected as they pass through the currently focused input, which might not have the same properties (e.g. `hasSingleRange`) than the one targetted by the command.

Task: 3689504

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo