### PR TITLE
[FIX] Composer: double click on composer gives traceback

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -470,6 +470,9 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
           token.start <= currentSelection.start &&
           token.end >= currentSelection.end
       )[0];
+      if (!token) {
+        return;
+      }
       if (token.type === "REFERENCE") {
         this.env.model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", {
           start: token.start,

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -1155,4 +1155,23 @@ describe("Double click selection in composer", () => {
       end: 14,
     });
   });
+
+  test("Double click on function parameters does not produce a traceback", async () => {
+    const composerEl = await typeInComposer("=A1+A2+A3");
+    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", {
+      start: 1,
+      end: 6,
+    });
+    await nextTick();
+    expect(model.getters.getComposerSelection()).toEqual({
+      start: 1,
+      end: 6,
+    });
+    triggerMouseEvent(composerEl, "dblclick");
+    await nextTick();
+    expect(model.getters.getComposerSelection()).toEqual({
+      start: 1,
+      end: 6,
+    });
+  });
 });


### PR DESCRIPTION
## Description:

Previously, a traceback occurred when double clicking on the Composer or selecting a range within it.

The problem has been resolved by adding a check during the command dispatch for composer cursor selection. Now, if the token is empty, the function will early return.

Task: : [3648496](https://www.odoo.com/web#id=3648496&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo