### PR TITLE
[FIX] formatting: do not show escape character

### DIFF
--- a/src/helpers/cells/cell_helpers.ts
+++ b/src/helpers/cells/cell_helpers.ts
@@ -10,6 +10,9 @@ import { formatNumber, formatStandardNumber } from "../numbers";
 export function formatValue(value: CellValue, format?: string): string {
   switch (typeof value) {
     case "string":
+      if (value.includes('\\"')) {
+        return value.replace(/\\"/g, '"');
+      }
       return value;
     case "boolean":
       return value ? "TRUE" : "FALSE";

--- a/tests/plugins/cell.test.ts
+++ b/tests/plugins/cell.test.ts
@@ -62,6 +62,12 @@ describe("getCellText", () => {
     });
     expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
   });
+
+  test("escape character is not display when formatting string", () => {
+    const model = new Model();
+    setCellContent(model, "A1", '="hello \\"world\\""');
+    expect(getCell(model, "A1")?.formattedValue).toBe('hello "world"');
+  });
 });
 
 describe("link cell", () => {


### PR DESCRIPTION
## Description:

If you want to use double quotes in a string which is part of a formula, you have to escape it using a backslash (="hello \"world\"") However, the backslash is shown when displaying the cell content.

Task: : [3698283](https://www.odoo.com/web#id=3698283&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo