### PR TITLE
[FIX] tests: fix props validation

### DIFF
--- a/src/components/side_panel/chart/building_blocks/label_range/label_range.ts
+++ b/src/components/side_panel/chart/building_blocks/label_range/label_range.ts
@@ -16,7 +16,7 @@ interface Props {
     name: string;
     label: string;
     value: boolean;
-    update: (value: boolean) => void;
+    onChange: (value: boolean) => void;
   }>;
 }
 

--- a/tests/side_panels/building_blocks/label_range.test.ts
+++ b/tests/side_panels/building_blocks/label_range.test.ts
@@ -42,7 +42,7 @@ describe("Label range", () => {
           name: "my_option",
           label: "My option",
           value: true,
-          update: () => {},
+          onChange: () => {},
         },
       ],
     });

--- a/tools/owl_templates/compile_templates.cjs
+++ b/tools/owl_templates/compile_templates.cjs
@@ -43,7 +43,7 @@ function slugify(str) {
 function compileTemplates() {
   const owl = importOwl();
   const parsedXMl = getParsedOwlTemplateBundle();
-  const app = new owl.App(owl.Component, {});
+  const app = new owl.App(owl.Component, { test: true });
   const compiledTemplates = {};
   for (const template of parsedXMl.querySelectorAll("[t-name]")) {
     const name = template.getAttribute("t-name");


### PR DESCRIPTION
The props validation wasn't working in tests since we pre-compiled the templates. This was because we used an owl.App that wasn't in test mode to compile the templates.

Also fixed the props type of the label_range component that was wrong.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo