### PR TITLE
[FIX] demo: wrong App.mount arguments

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -263,8 +263,8 @@ async function setup() {
   const templates = await (await fetch("../build/o_spreadsheet.xml")).text();
   start = Date.now();
 
-  const rootApp = new owl.App(Demo);
+  const rootApp = new owl.App(Demo, { dev: true });
   rootApp.addTemplates(templates);
-  rootApp.mount(document.body, { dev: true });
+  rootApp.mount(document.body);
 }
 whenReady(setup);


### PR DESCRIPTION
We gave the wrong arguments to App.mount in the demo. The dev mode should be set in the App constructor, not in App.mount (thanks for nothing JS).

This enable props validation in the demo for versions 16.1+.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo