### PR TITLE
[REM] composer: remove CTRL+Space shortcut

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -183,7 +183,6 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     F2: () => console.warn("Not implemented"),
     F4: this.processF4Key,
     Tab: (ev: KeyboardEvent) => this.processTabKey(ev),
-    " ": (ev: KeyboardEvent) => this.processSpaceKey(ev),
   };
 
   keyCodeMapping: { [keyCode: string]: Function } = {
@@ -264,15 +263,6 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     const direction = ev.shiftKey ? "left" : "right";
     this.env.model.dispatch("STOP_EDITION");
     this.env.model.selection.moveAnchorCell(direction, 1);
-  }
-
-  processSpaceKey(ev: KeyboardEvent) {
-    if (ev.ctrlKey) {
-      ev.preventDefault();
-      ev.stopPropagation();
-      this.showAutocomplete("");
-      this.env.model.dispatch("STOP_COMPOSER_RANGE_SELECTION");
-    }
   }
 
   private processEnterKey(ev: KeyboardEvent) {

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -249,25 +249,6 @@ describe("Functions autocomplete", () => {
       expect(document.activeElement).toBe(composerEl);
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(2);
     });
-    test("= and CTRL+Space show autocomplete", async () => {
-      await typeInComposer("=");
-      await keyDown({ key: " ", ctrlKey: true });
-      //TODO Need a second nextTick to wait the re-render of SelectionInput (onMounted => uuid assignation). But why not before ?
-      await nextTick();
-      expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(3);
-      await keyDown({ key: "Tab" });
-      expect(composerEl.textContent).toBe("=IF(");
-      expect(cehMock.selectionState.isSelectingRange).toBeTruthy();
-      expect(cehMock.selectionState.position).toBe(4);
-    });
-    test("= and CTRL+Space & DOWN move to next autocomplete", async () => {
-      await typeInComposer("=");
-      await keyDown({ key: " ", ctrlKey: true });
-      await keyDown({ key: "ArrowDown" });
-      expect(
-        fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
-      ).toBe("SUM");
-    });
   });
 });
 


### PR DESCRIPTION
## Description:

The shortcut is broken, no one uses it.

Task: : [3504025](https://www.odoo.com/web#id=3504025&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo