### PR TITLE
[IMP] index: export chart and side panels building blocks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,14 @@ import {
   ScorecardChartDesignPanel,
   chartSidePanelComponentRegistry,
 } from "./components/side_panel/chart";
+import { ChartColor } from "./components/side_panel/chart/building_blocks/color/color";
+import { ChartDataSeries } from "./components/side_panel/chart/building_blocks/data_series/data_series";
+import { ChartErrorSection } from "./components/side_panel/chart/building_blocks/error_section/error_section";
+import { ChartLabelRange } from "./components/side_panel/chart/building_blocks/label_range/label_range";
+import { ChartTitle } from "./components/side_panel/chart/building_blocks/title/title";
 import { ChartPanel } from "./components/side_panel/chart/main_chart_panel/main_chart_panel";
+import { Checkbox } from "./components/side_panel/components/checkbox/checkbox";
+import { Section } from "./components/side_panel/components/section/section";
 import { ValidationMessages } from "./components/validation_messages/validation_messages";
 import {
   BOTTOMBAR_HEIGHT,
@@ -235,6 +242,13 @@ export const links = {
   urlRepresentation,
 };
 export const components = {
+  Checkbox,
+  Section,
+  ChartColor,
+  ChartDataSeries,
+  ChartErrorSection,
+  ChartLabelRange,
+  ChartTitle,
   ChartPanel,
   ChartFigure,
   ChartJsComponent,


### PR DESCRIPTION
This commit exports the chart and side panels building blocks to be able to use them outside of o-spreadsheet (i.e. Odoo)

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo