### PR TITLE
[FIX] evaluation: allow empty error message

### DIFF
--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -12,36 +12,36 @@ export const CellErrorType = {
 export const errorTypes: Set<string> = new Set(Object.values(CellErrorType));
 
 export class EvaluationError extends Error {
-  constructor(message?: string, readonly value: string = CellErrorType.GenericError) {
-    super(message || _t("Error"));
+  constructor(message = _t("Error"), readonly value: string = CellErrorType.GenericError) {
+    super(message);
   }
 }
 
 export class BadExpressionError extends EvaluationError {
-  constructor(message?: string) {
-    super(message || _t("Invalid expression"), CellErrorType.BadExpression);
+  constructor(message = _t("Invalid expression")) {
+    super(message, CellErrorType.BadExpression);
   }
 }
 export class CircularDependencyError extends EvaluationError {
-  constructor(message?: string) {
-    super(message || _t("Circular reference"), CellErrorType.CircularDependency);
+  constructor(message = _t("Circular reference")) {
+    super(message, CellErrorType.CircularDependency);
   }
 }
 
 export class InvalidReferenceError extends EvaluationError {
-  constructor(message?: string) {
-    super(message || _t("Invalid reference"), CellErrorType.InvalidReference);
+  constructor(message = _t("Invalid reference")) {
+    super(message, CellErrorType.InvalidReference);
   }
 }
 
 export class NotAvailableError extends EvaluationError {
-  constructor(message?: string) {
-    super(message || _t("Data not available"), CellErrorType.NotAvailable);
+  constructor(message = _t("Data not available")) {
+    super(message, CellErrorType.NotAvailable);
   }
 }
 
 export class UnknownFunctionError extends EvaluationError {
-  constructor(message?: string) {
-    super(message || _t("Unknown function"), CellErrorType.UnknownFunction);
+  constructor(message = _t("Unknown function")) {
+    super(message, CellErrorType.UnknownFunction);
   }
 }


### PR DESCRIPTION
Currently, a function cannot throw an error with an empty error message. (e.g. `new EvaluationError("")`) because of the `||` fallback.

An error without message behaves just like an error but won't render the small red triangle on the top right corner of the cell and won't show the tooltip with the error message.

The "Loading..." error in Odoo is such an error.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo