### PR TITLE
[IMP] chart: improve pie chart

### DIFF
--- a/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
+++ b/src/components/side_panel/chart/line_bar_pie_panel/config_panel.ts
@@ -91,7 +91,7 @@ export class LineBarPieConfigPanel extends Component<Props, SpreadsheetChildEnv>
       {
         name: "aggregated",
         label: _t("Aggregate"),
-        value: this.props.definition.aggregated,
+        value: this.props.definition.aggregated ?? false,
         onChange: this.onUpdateAggregated.bind(this),
       },
     ];

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -98,7 +98,7 @@ export class BarChart extends AbstractChart {
       dataSets: context.range ? context.range : [],
       dataSetsHaveTitle: false,
       stacked: false,
-      aggregated: false,
+      aggregated: context.aggregated ?? false,
       legendPosition: "top",
       title: context.title || "",
       type: "bar",
@@ -117,6 +117,7 @@ export class BarChart extends AbstractChart {
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
+      aggregated: this.aggregated,
     };
   }
 

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -1,6 +1,7 @@
 import type { BasePlatform, ChartConfiguration, ChartOptions, ChartType } from "chart.js";
 import { ChartTerms } from "../../../components/translations_terms";
 import { MAX_CHAR_LABEL } from "../../../constants";
+import { isEvaluationError } from "../../../functions/helpers";
 import { _t } from "../../../translation";
 import { Color, Figure, Format, Getters, LocaleFormat, Range } from "../../../types";
 import { GaugeChartRuntime, ScorecardChartRuntime } from "../../../types/chart";
@@ -231,9 +232,15 @@ export function getChartDatasetValues(getters: Getters, dataSets: DataSet[]): Da
           ? truncateLabel(cell.formattedValue)
           : (label = `${ChartTerms.Series} ${parseInt(dsIndex) + 1}`);
     } else {
-      label = label = `${ChartTerms.Series} ${parseInt(dsIndex) + 1}`;
+      label = `${ChartTerms.Series} ${parseInt(dsIndex) + 1}`;
     }
     let data = ds.dataRange ? getData(getters, ds) : [];
+    if (data.every((e) => typeof e === "string" && !isEvaluationError(e))) {
+      // In this case, we want a chart based on the string occurrences count
+      // This will be done by associating each string with a value of 1 and
+      // the using the classical aggregation method to sum the values.
+      data.fill(1);
+    }
     datasetValues.push({ data, label });
   }
   return datasetValues;

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -96,7 +96,7 @@ export class LineChart extends AbstractChart {
       verticalAxisPosition: "left",
       labelRange: context.auxiliaryRange || undefined,
       stacked: false,
-      aggregated: false,
+      aggregated: context.aggregated ?? false,
       cumulative: false,
     };
   }
@@ -140,6 +140,7 @@ export class LineChart extends AbstractChart {
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
+      aggregated: this.aggregated,
     };
   }
 

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -104,7 +104,7 @@ export class PieChart extends AbstractChart {
       title: context.title || "",
       type: "pie",
       labelRange: context.auxiliaryRange || undefined,
-      aggregated: false,
+      aggregated: context.aggregated ?? false,
     };
   }
 
@@ -122,6 +122,7 @@ export class PieChart extends AbstractChart {
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
+      aggregated: this.aggregated,
     };
   }
 

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -83,7 +83,7 @@ export class ScatterChart extends AbstractChart {
       type: "scatter",
       verticalAxisPosition: "left",
       labelRange: context.auxiliaryRange || undefined,
-      aggregated: false,
+      aggregated: context.aggregated ?? false,
     };
   }
 
@@ -124,6 +124,7 @@ export class ScatterChart extends AbstractChart {
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
+      aggregated: this.aggregated,
     };
   }
 

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -68,4 +68,5 @@ export interface ChartCreationContext {
   readonly title?: string;
   readonly background?: string;
   readonly auxiliaryRange?: string;
+  readonly aggregated?: boolean;
 }

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -11,6 +11,7 @@ import {
   createGaugeChart,
   createScorecardChart,
   createSheet,
+  setCellContent,
   setFormat,
   setStyle,
   undo,
@@ -1122,6 +1123,51 @@ describe("charts", () => {
         "A1:A2",
         "A1",
       ]);
+    });
+  });
+
+  describe("aggregate", () => {
+    beforeEach(async () => {
+      ({ parent, fixture, model } = await mountSpreadsheet({ model: new Model() }));
+    });
+    test.each(["bar", "pie", "line", "scatter"] as const)(
+      "aggregate checkbox is checked for string-count charts",
+      async (type: "bar" | "pie" | "line" | "scatter") => {
+        setCellContent(model, "A1", "London");
+        setCellContent(model, "A2", "Berlin");
+        setCellContent(model, "A3", "Paris");
+        setCellContent(model, "A4", "Paris");
+        createChart(
+          model,
+          {
+            dataSets: ["K1:K6"],
+            labelRange: "K1:K6",
+            aggregated: true,
+            legendPosition: "top",
+            type,
+            dataSetsHaveTitle: false,
+            title: "",
+          },
+          chartId,
+          sheetId
+        );
+        await openChartConfigSidePanel();
+
+        const checkbox = document.querySelector("input[name='aggregated']") as HTMLInputElement;
+        expect(checkbox.checked).toBe(true);
+      }
+    );
+
+    test("aggregate value is kept when changing chart type", async () => {
+      createTestChart("basicChart");
+      updateChart(model, chartId, { aggregated: true, type: "pie" });
+      await openChartConfigSidePanel();
+
+      for (const chartType of ["bar", "line", "scatter", "pie"] as const) {
+        await setInputValueAndTrigger(".o-type-selector", chartType);
+        const checkbox = document.querySelector("input[name='aggregated']") as HTMLInputElement;
+        expect(checkbox.checked).toBe(true);
+      }
     });
   });
 });

--- a/tests/figures/chart/menu_item_insert_chart.test.ts
+++ b/tests/figures/chart/menu_item_insert_chart.test.ts
@@ -508,4 +508,29 @@ describe("Insert chart menu item", () => {
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
     expect(zoneToXc(model.getters.getSelectedZone())).toBe("K1:L3");
   });
+
+  test("Chart with only one column of text cells is a count pie chart", () => {
+    setCellContent(model, "K1", "London");
+    setCellContent(model, "K2", "Berlin");
+    setCellContent(model, "K3", "Paris");
+    setCellContent(model, "K4", "Paris");
+    setCellContent(model, "K5", "Paris");
+    setCellContent(model, "K6", "London");
+
+    setSelection(model, ["K1:K6"]);
+    insertChart();
+    const payload = {
+      ...defaultPayload,
+      definition: {
+        dataSets: ["K1:K6"],
+        labelRange: "K1:K6",
+        aggregated: true,
+        legendPosition: "top",
+        type: "pie",
+        dataSetsHaveTitle: false,
+        title: "",
+      },
+    };
+    expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
+  });
 });


### PR DESCRIPTION
## Task Description

The aims of this task is to improve the user experience when creating a pie chart :
1. User can now plot a chart only based on the count of string occurrences
2. When hovering a pie part, the corresponding dataset are highlighted
3. When hovering a legend item, the corresponding pie part are highlighted

## Related Task:
- Task: : [3370683](https://www.odoo.com/web#id=3370683&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo