### PR TITLE
[FIX] Grid: Support Mac shortcuts in `Grid`

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -98,6 +98,8 @@ const registries = {
   UNGROUP_HEADERS: unGroupHeadersMenuRegistry,
 };
 
+const MODIFIER_KEYS = ["Shift", "Control", "Alt", "Meta"];
+
 interface Props {
   sidePanelIsOpen: boolean;
   exposeFocus: (focus: () => void) => void;
@@ -521,12 +523,12 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onKeydown(ev: KeyboardEvent) {
-    const eventKey = ev.key.toUpperCase();
     let keyDownString = "";
-    if (isCtrlKey(ev) && eventKey !== "CTRL") keyDownString += "CTRL+";
-    if (ev.metaKey) keyDownString += "CTRL+";
-    if (ev.altKey && eventKey !== "ALT") keyDownString += "ALT+";
-    if (ev.shiftKey && eventKey !== "SHIFT") keyDownString += "SHIFT+";
+    if (!MODIFIER_KEYS.includes(ev.key)) {
+      if (isCtrlKey(ev)) keyDownString += "CTRL+";
+      if (ev.altKey) keyDownString += "ALT+";
+      if (ev.shiftKey) keyDownString += "SHIFT+";
+    }
     keyDownString += ev.key.toUpperCase();
 
     let handler = this.keyDownMapping[keyDownString];

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -976,6 +976,19 @@ describe("Grid component", () => {
     await nextTick();
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
+
+  test("Mac user use metaKey, not CtrlKey", async () => {
+    const mockUserAgent = jest.spyOn(navigator, "userAgent", "get");
+    mockUserAgent.mockImplementation(
+      () => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0"
+    );
+    await keyDown({ key: "A", ctrlKey: true, bubbles: true });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1"));
+    await nextTick();
+    await keyDown({ key: "A", metaKey: true, bubbles: true });
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1:Z100"));
+    jest.restoreAllMocks();
+  });
 });
 
 describe("Multi User selection", () => {


### PR DESCRIPTION
the forward-port #3338 was not properly adapted and a test was missing for the shortcuts in the component `Grid`.

This revision also fixes the sanity check added in commit e7d85184 as the key event key `Ctrl`does not exist; it is `Control`.

Task: 3707416

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo