### PR TITLE
[IMP] colors: configure custom colors

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -33,6 +33,7 @@ import {
   canExecuteInReadonly,
   Client,
   ClientPosition,
+  Color,
   Command,
   CommandDispatcher,
   CommandHandler,
@@ -106,6 +107,7 @@ export interface ModelConfig {
   readonly snapshotRequested: boolean;
   readonly notifyUI: (payload: InformationNotification) => void;
   readonly raiseBlockingErrorUI: (text: string) => void;
+  readonly customColors: Color[];
 }
 
 export interface ModelExternalConfig {
@@ -401,6 +403,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       snapshotRequested: false,
       notifyUI: (payload) => this.trigger("notify-ui", payload),
       raiseBlockingErrorUI: (text) => this.trigger("raise-error-ui", { text }),
+      customColors: config.customColors || [],
     };
   }
 
@@ -435,6 +438,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       uiActions: this.config,
       session: this.session,
       defaultCurrencyFormat: this.config.defaultCurrencyFormat,
+      customColors: this.config.customColors || [],
     };
   }
 

--- a/src/plugins/ui_core_views/custom_colors.ts
+++ b/src/plugins/ui_core_views/custom_colors.ts
@@ -11,7 +11,7 @@ import {
 } from "../../helpers";
 import { GaugeChart, ScorecardChart } from "../../helpers/figures/charts";
 import { Color, CoreViewCommand, Immutable, RGBA, UID } from "../../types";
-import { UIPlugin } from "../ui_plugin";
+import { UIPlugin, UIPluginConfig } from "../ui_plugin";
 
 /**
  * https://tomekdev.com/posts/sorting-colors-in-js
@@ -71,8 +71,14 @@ interface CustomColorState {
  */
 export class CustomColorsPlugin extends UIPlugin<CustomColorState> {
   private readonly customColors: Immutable<Record<Color, true>> = {};
+  private readonly configCustomColors: Color[];
   private readonly shouldUpdateColors = false;
   static getters = ["getCustomColors"] as const;
+
+  constructor(config: UIPluginConfig) {
+    super(config);
+    this.configCustomColors = config.customColors;
+  }
 
   handle(cmd: CoreViewCommand) {
     switch (cmd.type) {
@@ -97,7 +103,7 @@ export class CustomColorsPlugin extends UIPlugin<CustomColorState> {
   }
 
   getCustomColors(): Color[] {
-    let usedColors: Color[] = [];
+    let usedColors: Color[] = this.configCustomColors;
     for (const sheetId of this.getters.getSheetIds()) {
       usedColors = usedColors.concat(
         this.getColorsFromCells(sheetId),

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -4,6 +4,7 @@ import { SelectionStreamProcessor } from "../selection_stream/selection_stream_p
 import { StateObserver } from "../state_observer";
 import {
   ClientPosition,
+  Color,
   Command,
   CommandDispatcher,
   Format,
@@ -25,6 +26,7 @@ export interface UIPluginConfig {
   readonly custom: ModelConfig["custom"];
   readonly session: Session;
   readonly defaultCurrencyFormat?: Format;
+  readonly customColors: Color[];
 }
 
 export interface UIPluginConstructor {

--- a/tests/colors/custom_colors_plugin.test.ts
+++ b/tests/colors/custom_colors_plugin.test.ts
@@ -185,3 +185,9 @@ describe("custom colors are correctly handled when editing charts", () => {
     expect(model.getters.getCustomColors()).toEqual(["#123456"]);
   });
 });
+
+test("custom colors from config", () => {
+  const data = {};
+  const model = new Model(data, { customColors: ["#875A7B", "not a valid color"] });
+  expect(model.getters.getCustomColors()).toEqual(["#875A7B"]);
+});


### PR DESCRIPTION

## Description:

This commit allows to specify custom colors to add in the color picker.

It allows to easily create spreadsheets with a brand/company identity.

Task: [3707769](https://www.odoo.com/web#id=3707769&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo