### PR TITLE
[REF] model: preserve default currency format

### DIFF
--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -74,20 +74,22 @@ export const formatNumberPercent = createFormatActionSpec({
 export const formatNumberCurrency = createFormatActionSpec({
   name: _t("Currency"),
   descriptionValue: 1000.12,
-  format: (env) => env.model.config.defaultCurrencyFormat,
+  format: (env) => env.model.config.defaultCurrencyFormat ?? DEFAULT_CURRENCY_FORMAT,
 });
 
 export const formatNumberCurrencyRounded: ActionSpec = {
   ...createFormatActionSpec({
     name: _t("Currency rounded"),
     descriptionValue: 1000,
-    format: (env) => roundFormat(env.model.config.defaultCurrencyFormat),
+    format: (env) => roundFormat(env.model.config.defaultCurrencyFormat ?? DEFAULT_CURRENCY_FORMAT),
   }),
   isVisible: (env) => {
     const currencyFormat = env.model.config.defaultCurrencyFormat;
-    return currencyFormat !== roundFormat(currencyFormat);
+    return currencyFormat !== roundFormat(currencyFormat ?? DEFAULT_CURRENCY_FORMAT);
   },
 };
+
+const DEFAULT_CURRENCY_FORMAT = "[$$]#,##0.00";
 
 const EXAMPLE_DATE = parseLiteral("2023/09/26 10:43:00 PM", DEFAULT_LOCALE);
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -94,7 +94,7 @@ export interface ModelConfig {
   readonly custom: Readonly<{
     [key: string]: any;
   }>;
-  readonly defaultCurrencyFormat: Format;
+  readonly defaultCurrencyFormat?: Format;
   /**
    * External dependencies required to enable some features
    * such as uploading images.
@@ -390,7 +390,6 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       ...config,
       mode: config.mode || "normal",
       custom: config.custom || {},
-      defaultCurrencyFormat: config.defaultCurrencyFormat || "[$$]#,##0.00",
       external: this.setupExternalConfig(config.external || {}),
       transportService,
       client,
@@ -431,6 +430,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       custom: this.config.custom,
       uiActions: this.config,
       session: this.session,
+      defaultCurrencyFormat: this.config.defaultCurrencyFormat,
     };
   }
 

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -6,6 +6,7 @@ import {
   ClientPosition,
   Command,
   CommandDispatcher,
+  Format,
   Getters,
   GridRenderingContext,
   LAYERS,
@@ -23,6 +24,7 @@ export interface UIPluginConfig {
   readonly uiActions: UIActions;
   readonly custom: ModelConfig["custom"];
   readonly session: Session;
+  readonly defaultCurrencyFormat?: Format;
 }
 
 export interface UIPluginConstructor {


### PR DESCRIPTION


## Description:

Before this commit, plugins could not know the default currency format (and if it was defined).

It's usefull for the currency plugin in odoo to reused the format. It's also useful to know if it's manually defined or not to load the currency if it's not defined.

See https://github.com/odoo/odoo/pull/151725

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo