### PR TITLE
[IMP] build: add odoo-module ignore annotation

### DIFF
--- a/tools/bundle.cjs
+++ b/tools/bundle.cjs
@@ -13,6 +13,7 @@ __info__.hash = "${BUILD_INFOS.hash}";
 
 function jsBanner() {
   return `
+// @odoo-module ignore
 /**
 ${BANNER_MESSAGE.map((line) => ` * ${line}`).join("\n")}
  */


### PR DESCRIPTION


## Description:

In odoo's source code, javascript files are transpiled.

With this task, all files are now transpiled by default.

This library's build file (o_spreadsheet.js) however doesn't need to be transpiled. Other libs in odoo are located in `libs` folders, which are ignored by transpilation, but `o_spreadsheet.js` is located (on purpose) in `src` to extract translatable terms.

This commit adds an annotation on top of the build file to opt-out of transpilation. Even if it doesn't really makes sense when thinking of o-spreadsheet as a stand-alone lib, independent from odoo, it's the easiest.

Task: : [3439583](https://www.odoo.com/web#id=3439583&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo