### PR TITLE
[FIX] cell_menu_registry: link cell should display 'Edit Link' in context menu

### DIFF
--- a/src/registries/menus/cell_menu_registry.ts
+++ b/src/registries/menus/cell_menu_registry.ts
@@ -100,7 +100,7 @@ cellMenuRegistry
     action: ACTIONS.DELETE_CELL_SHIFT_LEFT,
   })
   .add("insert_link", {
-    name: _lt("Insert link"),
+    name: ACTIONS.INSERT_LINK_NAME,
     separator: true,
     sequence: 150,
     action: ACTIONS.INSERT_LINK,

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -715,6 +715,14 @@ export const INSERT_LINK = (env: SpreadsheetChildEnv) => {
   env.model.dispatch("OPEN_CELL_POPOVER", { col, row, popoverType: "LinkEditor" });
 };
 
+export const INSERT_LINK_NAME = (env: SpreadsheetChildEnv) => {
+  const sheetId = env.model.getters.getActiveSheetId();
+  const { col, row } = env.model.getters.getPosition();
+  const cell = env.model.getters.getCell(sheetId, col, row);
+
+  return cell && cell.isLink() ? _lt("Edit link") : _lt("Insert link");
+};
+
 //------------------------------------------------------------------------------
 // Filters action
 //------------------------------------------------------------------------------

--- a/tests/components/link/link_display.test.ts
+++ b/tests/components/link/link_display.test.ts
@@ -85,6 +85,20 @@ describe("link display component", () => {
     expect(fixture.querySelector(".o-link-tool")).toBeFalsy();
   });
 
+  test("right-click on a linked cell should show 'Edit Link' instead of 'Insert Link' in the context menu", async () => {
+    setCellContent(model, "A1", "HELLO");
+    await rightClickCell(model, "A1");
+    expect(
+      fixture.querySelector(".o-menu .o-menu-item[data-name='insert_link']")?.textContent
+    ).toBe("Insert link");
+
+    setCellContent(model, "A1", "[label](url.com)");
+    await rightClickCell(model, "A1");
+    expect(
+      fixture.querySelector(".o-menu .o-menu-item[data-name='insert_link']")?.textContent
+    ).toBe("Edit link");
+  });
+
   test("component is closed when cell is deleted", async () => {
     setCellContent(model, "A1", "[label](url.com)");
     await hoverCell(model, "A1", 400);


### PR DESCRIPTION
## Description:

Previously, if a link was inserted into a cell and right-clicked, the context menu incorrectly displayed 'Insert Link' instead of 'Edit Link'.

This PR addresses the problem by verifying whether the cell is a link cell and adjusts the menu item name accordingly.

Task: : [3698437](https://www.odoo.com/web#id=3698437&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo