### PR TITLE
[IMP] cell: avoid useless UPDATE_CELL

### DIFF
--- a/tests/plugins/cell.test.ts
+++ b/tests/plugins/cell.test.ts
@@ -58,6 +58,90 @@ describe("getCellText", () => {
     expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
   });
 
+  test("update cell outside of sheet (without any modification)", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const result = model.dispatch("UPDATE_CELL", {
+      sheetId,
+      col: 9999,
+      row: 9999,
+    });
+    expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet, CommandResult.NoChanges);
+  });
+
+  test("update cell without any modification", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    const result = model.dispatch("UPDATE_CELL", {
+      sheetId,
+      col: 0,
+      row: 0,
+    });
+    expect(result).toBeCancelledBecause(CommandResult.NoChanges);
+  });
+
+  test("update cell with only the same content as before", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "hello");
+    setCellFormat(model, "A1", "#,##0.0");
+    setStyle(model, "A1", { bold: true });
+    const result = model.dispatch("UPDATE_CELL", {
+      sheetId,
+      col: 0,
+      row: 0,
+      content: "hello",
+    });
+    expect(result).toBeCancelledBecause(CommandResult.NoChanges);
+  });
+
+  test("update cell with only the same format as before", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "0");
+    setCellFormat(model, "A1", "#,##0.0");
+    setStyle(model, "A1", { bold: true });
+    const result = model.dispatch("UPDATE_CELL", {
+      sheetId,
+      col: 0,
+      row: 0,
+      format: "#,##0.0",
+    });
+    expect(result).toBeCancelledBecause(CommandResult.NoChanges);
+  });
+
+  test("update cell with only the same style as before", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "0");
+    setCellFormat(model, "A1", "#,##0.0");
+    setStyle(model, "A1", { bold: true });
+    const result = model.dispatch("UPDATE_CELL", {
+      sheetId,
+      col: 0,
+      row: 0,
+      style: { bold: true },
+    });
+    expect(result).toBeCancelledBecause(CommandResult.NoChanges);
+  });
+
+  test("update cell with the same style, content and format as before", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    setCellContent(model, "A1", "hello");
+    setCellFormat(model, "A1", "#,##0.0");
+    setStyle(model, "A1", { bold: true });
+    const result = model.dispatch("UPDATE_CELL", {
+      sheetId,
+      col: 0,
+      row: 0,
+      content: "hello",
+      format: "#,##0.0",
+      style: { bold: true },
+    });
+    expect(result).toBeCancelledBecause(CommandResult.NoChanges);
+  });
+
   test("clear content", () => {
     const model = new Model();
     setCellContent(model, "A1", "hello");
@@ -91,7 +175,7 @@ describe("getCellText", () => {
   test("clear cell outside of sheet", () => {
     const model = new Model();
     const result = clearCell(model, "AAA999");
-    expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet);
+    expect(result).toBeCancelledBecause(CommandResult.TargetOutOfSheet, CommandResult.NoChanges);
   });
 
   test("clear cell is cancelled if there is nothing on the cell", () => {


### PR DESCRIPTION
## Task Description

This task aims to avoid the dispatch of an UPDATE_CELL command when the cell to update is already in the same state that the one we want to get with that UPDATE_CELL command. This is done by adding an allowDispatch to make sure there is a difference between the cell state and the command payload.

## Related Task

- Task [3716689](https://www.odoo.com/web#id=3716689&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo