### PR TITLE
[REF] SidePanel: allow to open from external code

### DIFF
--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -30,8 +30,10 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   static components = {};
 
   onDoubleClick() {
-    this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
-    this.env.openSidePanel("ChartPanel");
+    const result = this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
+    if (result.isSuccessful) {
+      this.env.openSidePanel("ChartPanel");
+    }
   }
 
   get chartType(): ChartType {

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -2,6 +2,7 @@ import {
   Component,
   onMounted,
   useChildSubEnv,
+  useEffect,
   useExternalListener,
   useRef,
   useState,
@@ -71,6 +72,7 @@ import { Menu, MenuState } from "../menu/menu";
 import { CellPopoverStore } from "../popover";
 import { Popover } from "../popover/popover";
 import { HorizontalScrollBar, VerticalScrollBar } from "../scrollbar/";
+import { SidePanelStore } from "../side_panel/side_panel/side_panel_store";
 import { HoveredCellStore } from "./hovered_cell_store";
 
 /**
@@ -101,7 +103,6 @@ const registries = {
 };
 
 interface Props {
-  sidePanelIsOpen: boolean;
   exposeFocus: (focus: () => void) => void;
 }
 
@@ -111,7 +112,6 @@ interface Props {
 export class Grid extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-Grid";
   static props = {
-    sidePanelIsOpen: Boolean,
     exposeFocus: Function,
   };
   static components = {
@@ -141,6 +141,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   onMouseWheel!: (ev: WheelEvent) => void;
   canvasPosition!: DOMCoordinates;
   hoveredCell!: Store<HoveredCellStore>;
+  sidePanel!: Store<SidePanelStore>;
 
   setup() {
     this.highlightStore = useStore(HighlightStore);
@@ -155,6 +156,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     this.composerStore = useStore(ComposerStore);
     this.composerFocusStore = useStore(ComposerFocusStore);
     this.DOMFocusableElementStore = useStore(DOMFocusableElementStore);
+    this.sidePanel = useStore(SidePanelStore);
 
     useChildSubEnv({ getPopoverContainerRect: () => this.getGridRect() });
     useExternalListener(document.body, "cut", this.copy.bind(this, true));
@@ -170,6 +172,15 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
       this.hoveredCell.clear();
     });
     this.cellPopovers = useStore(CellPopoverStore);
+
+    useEffect(
+      () => {
+        if (!this.sidePanel.isOpen) {
+          this.DOMFocusableElementStore.focus();
+        }
+      },
+      () => [this.sidePanel.isOpen]
+    );
   }
 
   onCellHovered({ col, row }) {

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.xml
@@ -1,25 +1,25 @@
 <templates>
   <t t-name="o-spreadsheet-ChartPanel">
-    <div class="o-chart">
+    <div class="o-chart" t-if="figureId">
       <div class="o-panel">
         <div
           class="o-panel-element o-panel-configuration"
-          t-att-class="state.panel !== 'configuration' ? 'inactive' : ''"
-          t-on-click="() => this.activatePanel('configuration')">
+          t-att-class="store.panel !== 'configuration' ? 'inactive' : ''"
+          t-on-click="() => this.store.activatePanel('configuration')">
           <i class="fa fa-sliders"/>
           Configuration
         </div>
         <div
           class="o-panel-element o-panel-design"
-          t-att-class="state.panel !== 'design' ? 'inactive' : ''"
-          t-on-click="() => this.activatePanel('design')">
+          t-att-class="store.panel !== 'design' ? 'inactive' : ''"
+          t-on-click="() => this.store.activatePanel('design')">
           <i class="fa fa-paint-brush"/>
           Design
         </div>
       </div>
 
-      <t t-set="definition" t-value="getChartDefinition()"/>
-      <t t-if="state.panel === 'configuration'">
+      <t t-set="definition" t-value="getChartDefinition(this.figureId)"/>
+      <t t-if="store.panel === 'configuration'">
         <Section>
           <t t-set-slot="title">Chart type</t>
           <t t-set="types" t-value="chartTypes"/>

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
@@ -1,0 +1,36 @@
+import { Get } from "../../../../store_engine";
+import { SpreadsheetStore } from "../../../../stores";
+import { Command, UID } from "../../../../types";
+import { SidePanelStore } from "../../side_panel/side_panel_store";
+
+export class MainChartPanelStore extends SpreadsheetStore {
+  private sidePanel = this.get(SidePanelStore);
+
+  figureId: UID | null;
+  panel: "configuration" | "design" = "configuration";
+
+  constructor(get: Get, figureId: UID | null) {
+    super(get);
+    this.figureId = figureId;
+  }
+
+  protected handle(cmd: Command): void {
+    switch (cmd.type) {
+      case "DELETE_FIGURE":
+        if (this.sidePanel.componentTag === "ChartPanel" && this.figureId === cmd.id) {
+          this.sidePanel.close();
+        }
+        break;
+      case "SELECT_FIGURE":
+        if (cmd.id) {
+          this.figureId = cmd.id;
+        } else if (this.sidePanel.componentTag === "ChartPanel") {
+          this.sidePanel.close();
+        }
+    }
+  }
+
+  activatePanel(panel: "configuration" | "design") {
+    this.panel = panel;
+  }
+}

--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -1,8 +1,10 @@
-import { Component, onWillUpdateProps, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { BACKGROUND_HEADER_COLOR, FILTERS_COLOR } from "../../../constants";
-import { SidePanelContent, sidePanelRegistry } from "../../../registries/side_panel_registry";
+import { sidePanelRegistry } from "../../../registries/side_panel_registry";
+import { Store, useStore } from "../../../store_engine";
 import { SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
+import { SidePanelStore } from "./side_panel_store";
 
 css/* scss */ `
   .o-sidePanel {
@@ -152,37 +154,25 @@ css/* scss */ `
   }
 `;
 
-interface Props {
-  component: string;
-  panelProps: any;
-  onCloseSidePanel: () => void;
-}
-
-interface State {
-  panel: SidePanelContent;
-}
-
-export class SidePanel extends Component<Props, SpreadsheetChildEnv> {
+export class SidePanel extends Component<never, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-SidePanel";
-  static props = {
-    component: String,
-    panelProps: { type: Object, optional: true },
-    onCloseSidePanel: Function,
-  };
-  state!: State;
+  static props = {};
+  sidePanelStore!: Store<SidePanelStore>;
 
   setup() {
-    this.state = useState({
-      panel: sidePanelRegistry.get(this.props.component),
-    });
-    onWillUpdateProps(
-      (nextProps: Props) => (this.state.panel = sidePanelRegistry.get(nextProps.component))
-    );
+    this.sidePanelStore = useStore(SidePanelStore);
+  }
+
+  get panel() {
+    return sidePanelRegistry.get(this.sidePanelStore.componentTag);
+  }
+
+  close() {
+    this.sidePanelStore.close();
   }
 
   getTitle() {
-    return typeof this.state.panel.title === "function"
-      ? this.state.panel.title(this.env)
-      : this.state.panel.title;
+    const panel = this.panel;
+    return typeof panel.title === "function" ? panel.title(this.env) : panel.title;
   }
 }

--- a/src/components/side_panel/side_panel/side_panel.xml
+++ b/src/components/side_panel/side_panel/side_panel.xml
@@ -1,23 +1,23 @@
 <templates>
   <t t-name="o-spreadsheet-SidePanel">
-    <div class="o-sidePanel">
+    <div class="o-sidePanel" t-if="sidePanelStore.isOpen">
       <div class="o-sidePanelHeader">
         <div class="o-sidePanelTitle" t-esc="getTitle()"/>
-        <div class="o-sidePanelClose" t-on-click="() => this.props.onCloseSidePanel()">✕</div>
+        <div class="o-sidePanelClose" t-on-click="close">✕</div>
       </div>
       <div class="o-sidePanelBody">
         <t
-          t-component="state.panel.Body"
-          t-props="props.panelProps"
-          onCloseSidePanel="props.onCloseSidePanel"
-          t-key="'Body_' + props.component"
+          t-component="panel.Body"
+          t-props="sidePanelStore.panelProps"
+          onCloseSidePanel.bind="close"
+          t-key="'Body_' + sidePanelStore.componentTag"
         />
       </div>
-      <div class="o-sidePanelFooter" t-if="state.panel.Footer">
+      <div class="o-sidePanelFooter" t-if="panel?.Footer">
         <t
-          t-component="state.panel.Footer"
-          t-props="props.panelProps"
-          t-key="'Footer_' + props.component"
+          t-component="panel.Footer"
+          t-props="sidePanelStore.panelProps"
+          t-key="'Footer_' + sidePanelStore.componentTag"
         />
       </div>
     </div>

--- a/src/components/side_panel/side_panel/side_panel_store.ts
+++ b/src/components/side_panel/side_panel/side_panel_store.ts
@@ -1,0 +1,36 @@
+import { SpreadsheetStore } from "../../../stores";
+
+interface SidePanelProps {
+  onCloseSidePanel?: () => void;
+  [key: string]: unknown;
+}
+
+export class SidePanelStore extends SpreadsheetStore {
+  isOpen: boolean = false;
+  panelProps: SidePanelProps = {};
+  componentTag: string = "";
+
+  open(componentTag: string, panelProps: SidePanelProps = {}) {
+    if (this.isOpen && componentTag !== this.componentTag) {
+      this.panelProps?.onCloseSidePanel?.();
+    }
+    this.componentTag = componentTag;
+    this.panelProps = panelProps;
+    this.isOpen = true;
+  }
+
+  toggle(componentTag: string, panelProps: SidePanelProps) {
+    if (this.isOpen && componentTag === this.componentTag) {
+      this.close();
+    } else {
+      this.open(componentTag, panelProps);
+    }
+  }
+
+  close() {
+    this.panelProps.onCloseSidePanel?.();
+    this.isOpen = false;
+    this.panelProps = {};
+    this.componentTag = "";
+  }
+}

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -23,18 +23,10 @@
             <HeaderGroupContainer layers="rowLayers" dimension="'ROW'"/>
           </div>
           <div class="o-group-grid overflow-hidden">
-            <Grid
-              sidePanelIsOpen="sidePanel.isOpen"
-              exposeFocus="(focus) => this._focusGrid = focus"
-            />
+            <Grid exposeFocus="(focus) => this._focusGrid = focus"/>
           </div>
         </div>
-        <SidePanel
-          t-if="sidePanel.isOpen"
-          onCloseSidePanel="() => this.closeSidePanel()"
-          component="sidePanel.component"
-          panelProps="sidePanel.panelProps"
-        />
+        <SidePanel t-if="sidePanel.isOpen"/>
         <BottomBar onClick="() => this.focusGrid()"/>
       </t>
     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import { ChartPanel } from "./components/side_panel/chart/main_chart_panel/main_
 import { Checkbox } from "./components/side_panel/components/checkbox/checkbox";
 import { Section } from "./components/side_panel/components/section/section";
 import { FindAndReplaceStore } from "./components/side_panel/find_and_replace/find_and_replace_store";
+import { SidePanelStore } from "./components/side_panel/side_panel/side_panel_store";
 import { ValidationMessages } from "./components/validation_messages/validation_messages";
 import {
   BOTTOMBAR_HEIGHT,
@@ -116,7 +117,7 @@ import {
   repeatLocalCommandTransformRegistry,
 } from "./registries/repeat_commands_registry";
 import { sidePanelRegistry } from "./registries/side_panel_registry";
-import { useStoreProvider } from "./store_engine";
+import { useLocalStore, useStore, useStoreProvider } from "./store_engine";
 import { DependencyContainer } from "./store_engine/dependency_container";
 import { SpreadsheetStore } from "./stores";
 import { HighlightStore } from "./stores/highlight_store";
@@ -312,6 +313,9 @@ export const stores = {
   RendererStore,
   SelectionInputStore,
   SpreadsheetStore,
+  useStore,
+  useLocalStore,
+  SidePanelStore,
 };
 
 export function addFunction(functionName: string, functionDescription: AddFunctionDescription) {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -41,22 +41,22 @@ mockGetBoundingClientRect({
 });
 type AllChartType = ChartType | "basicChart";
 
-function createTestChart(type: AllChartType) {
+function createTestChart(type: AllChartType, newChartId = chartId) {
   switch (type) {
     case "scorecard":
-      createScorecardChart(model, TEST_CHART_DATA.scorecard, chartId);
+      createScorecardChart(model, TEST_CHART_DATA.scorecard, newChartId);
       break;
     case "gauge":
-      createGaugeChart(model, TEST_CHART_DATA.gauge, chartId);
+      createGaugeChart(model, TEST_CHART_DATA.gauge, newChartId);
       break;
     case "basicChart":
-      createChart(model, TEST_CHART_DATA.basicChart, chartId);
+      createChart(model, TEST_CHART_DATA.basicChart, newChartId);
       break;
     case "line":
     case "bar":
     case "pie":
     case "scatter":
-      createChart(model, { ...TEST_CHART_DATA.basicChart, type }, chartId);
+      createChart(model, { ...TEST_CHART_DATA.basicChart, type }, newChartId);
       break;
   }
 }
@@ -489,6 +489,19 @@ describe("charts", () => {
     }
   );
 
+  test("deleting another chart does not close the side panel", async () => {
+    const figureId1 = "figureId1";
+    const figureId2 = "figureId2";
+    createTestChart("basicChart", figureId1);
+    createTestChart("basicChart", figureId2);
+    const sheetId = model.getters.getActiveSheetId();
+    await openChartConfigSidePanel(figureId1);
+    expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeTruthy();
+    model.dispatch("DELETE_FIGURE", { id: figureId2, sheetId }); // could be deleted by another user
+    await nextTick();
+    expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeTruthy();
+  });
+
   test("Deleting a chart with active selection input does not produce a traceback", async () => {
     createTestChart("basicChart");
     await openChartConfigSidePanel();
@@ -511,6 +524,7 @@ describe("charts", () => {
     expect(model.getters.getSelectedFigureId()).toBeNull();
     await nextTick();
     await doubleClick(fixture, ".o-chart-container");
+    expect(fixture.querySelector(".o-sidePanel")).toBeFalsy();
     expect(fixture.querySelector(".o-sidePanel .o-sidePanelBody .o-chart")).toBeFalsy();
   });
 


### PR DESCRIPTION
## Description:

This commit moves the side panel state from the `Spreadsheet` component to a dedicated store.

It simplifies the `Spreadsheet` component, but more importantly, it allows to
open the side panel from outside the `Spreadsheet` component
(=from a parent component).

We've done it once [^1] in a monstrous way, with the tools we had at the time. Let's get rid of that!

[^1]: 🙈 https://github.com/odoo/enterprise/blob/c7090769173bdc1940485365178c7738ff2a6518/spreadsheet_edition/static/src/bundle/actions/version_history/version_history_action.js#L75

Task: : [/](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo