### PR TITLE
[FIX] Find and replace: draw search results

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -1,11 +1,13 @@
 import { debounce, getSearchRegex, isInside, positionToZone } from "../../../helpers";
+import { HighlightProvider, HighlightStore } from "../../../stores/highlight_store";
+import { CellPosition, Color, Command, Highlight } from "../../../types";
+
+import { toRaw } from "@odoo/owl";
 import { Get } from "../../../store_engine";
 import { SpreadsheetStore } from "../../../stores";
-import { CellPosition, Color, Command, GridRenderingContext } from "../../../types";
 import { SearchOptions } from "../../../types/find_and_replace";
 
-const BORDER_COLOR: Color = "#8B008B";
-const BACKGROUND_COLOR: Color = "#8B008B33";
+const FIND_AND_REPLACE_HIGHLIGHT_COLOR: Color = "#8B008B";
 
 enum Direction {
   previous = -1,
@@ -13,7 +15,7 @@ enum Direction {
   next = 1,
 }
 
-export class FindAndReplaceStore extends SpreadsheetStore {
+export class FindAndReplaceStore extends SpreadsheetStore implements HighlightProvider {
   private allSheetsMatches: CellPosition[] = [];
   private activeSheetMatches: CellPosition[] = [];
   private specificRangeMatches: CellPosition[] = [];
@@ -36,20 +38,18 @@ export class FindAndReplaceStore extends SpreadsheetStore {
   };
 
   updateSearchContent = debounce(this._updateSearchContent.bind(this), 200);
-
   constructor(get: Get) {
     super(get);
     this.initialShowFormulaState = this.model.getters.shouldShowFormulas();
     this.searchOptions.searchFormulas = this.initialShowFormulaState;
 
+    const highlightStore = get(HighlightStore);
+    highlightStore.register(toRaw(this));
     this.onDispose(() => {
       this.model.dispatch("SET_FORMULA_VISIBILITY", { show: this.initialShowFormulaState });
       this.updateSearchContent.stopDebounce();
+      highlightStore.unRegister(toRaw(this));
     });
-  }
-
-  get renderingLayers() {
-    return ["Search"] as const;
   }
 
   get searchMatches(): CellPosition[] {
@@ -306,8 +306,8 @@ export class FindAndReplaceStore extends SpreadsheetStore {
   // Grid rendering
   // ---------------------------------------------------------------------------
 
-  draw(renderingContext: GridRenderingContext) {
-    const { ctx } = renderingContext;
+  get highlights(): Highlight[] {
+    const highlights: Highlight[] = [];
     const sheetId = this.getters.getActiveSheetId();
 
     for (const [index, match] of this.searchMatches.entries()) {
@@ -318,26 +318,32 @@ export class FindAndReplaceStore extends SpreadsheetStore {
       const zone = positionToZone(match);
       const zoneWithMerge = this.getters.expandZone(sheetId, zone);
 
-      const { x, y, width, height } = this.getters.getVisibleRect(zoneWithMerge);
+      const { width, height } = this.getters.getVisibleRect(zoneWithMerge);
       if (width > 0 && height > 0) {
-        ctx.fillStyle = BACKGROUND_COLOR;
-        ctx.fillRect(x, y, width, height);
-        if (index === this.selectedMatchIndex) {
-          ctx.strokeStyle = BORDER_COLOR;
-          ctx.strokeRect(x, y, width, height);
-        }
+        highlights.push({
+          sheetId,
+          zone: zoneWithMerge,
+          color: FIND_AND_REPLACE_HIGHLIGHT_COLOR,
+          noBorder: index !== this.selectedMatchIndex,
+          thinLine: true,
+          fillAlpha: 0.2,
+        });
       }
     }
 
-    // TODO: use Highlights helpers/stores when the Highlight PR is merged
     if (this.searchOptions.searchScope === "specificRange") {
       const range = this.searchOptions.specificRange;
-      if (!range || range.sheetId !== sheetId) {
-        return;
+      if (range && range.sheetId === sheetId) {
+        highlights.push({
+          sheetId,
+          zone: range.zone,
+          color: FIND_AND_REPLACE_HIGHLIGHT_COLOR,
+          noFill: true,
+          thinLine: true,
+        });
       }
-      const { x, y, width, height } = this.getters.getVisibleRect(range.zone);
-      ctx.strokeStyle = BORDER_COLOR;
-      ctx.strokeRect(x, y, width, height);
     }
+
+    return highlights;
   }
 }

--- a/src/helpers/rendering.ts
+++ b/src/helpers/rendering.ts
@@ -1,5 +1,6 @@
-import { HIGHLIGHT_COLOR } from "../constants";
 import { GridRenderingContext, Highlight, Rect } from "../types";
+
+import { HIGHLIGHT_COLOR } from "../constants";
 import { setColorAlpha } from "./color";
 
 export function drawHighlight(
@@ -14,11 +15,17 @@ export function drawHighlight(
   const color = highlight.color || HIGHLIGHT_COLOR;
 
   const { ctx } = renderingContext;
-  ctx.lineWidth = 2;
-  ctx.strokeStyle = color;
-  /** + 0.5 offset to have sharp lines. See comment in {@link RendererPlugin#drawBorders} for more details */
-  ctx.strokeRect(x + 0.5, y + 0.5, width, height);
-  ctx.globalCompositeOperation = "source-over";
+  if (!highlight.noBorder) {
+    ctx.strokeStyle = color;
+    if (highlight.thinLine) {
+      ctx.lineWidth = 1;
+      ctx.strokeRect(x, y, width, height);
+    } else {
+      ctx.lineWidth = 2;
+      /** + 0.5 offset to have sharp lines. See comment in {@link RendererPlugin#drawBorder} for more details */
+      ctx.strokeRect(x + 0.5, y + 0.5, width, height);
+    }
+  }
   if (!highlight.noFill) {
     ctx.fillStyle = setColorAlpha(color, highlight.fillAlpha ?? 0.12);
     ctx.fillRect(x, y, width, height);

--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -15,7 +15,6 @@ import { UIPlugin } from "../ui_plugin";
  */
 
 export class FindAndReplacePlugin extends UIPlugin {
-  static layers = ["Search"] as const;
   static getters = [] as const;
 
   handle(cmd: Command) {

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -1,10 +1,11 @@
+import { Cell, CellValue, EvaluatedCell } from "./cells";
+
+import { CommandResult } from "./commands";
 // -----------------------------------------------------------------------------
 // MISC
 // -----------------------------------------------------------------------------
 import { ComponentConstructor } from "@odoo/owl";
 import { Token } from "../formulas";
-import { Cell, CellValue, EvaluatedCell } from "./cells";
-import { CommandResult } from "./commands";
 import { Format } from "./format";
 import { Range } from "./range";
 
@@ -226,9 +227,11 @@ export interface Highlight {
   sheetId: UID;
   color: Color;
   interactive?: boolean;
+  thinLine?: boolean;
   noFill?: boolean;
   /** transparency of the fill color (0-1) */
   fillAlpha?: number;
+  noBorder?: boolean;
 }
 
 export interface PaneDivision {

--- a/src/types/rendering.ts
+++ b/src/types/rendering.ts
@@ -85,7 +85,6 @@ const LAYERS = {
   Background: 0,
   Highlights: 1,
   Clipboard: 2,
-  Search: 3,
   Chart: 4,
   Autofill: 5,
   Selection: 6,

--- a/tests/__snapshots__/renderer_store.test.ts.snap
+++ b/tests/__snapshots__/renderer_store.test.ts.snap
@@ -1311,8 +1311,6 @@ exports[`renderer snapshot for a simple grid rendering 1`] = `
   "context.save()",
   "context.restore()",
   "context.save()",
-  "context.restore()",
-  "context.save()",
   "context.fillStyle="#f3f7fe";",
   "context.fillStyle="#f3f7fe";",
   "context.strokeStyle="#3266ca";",

--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -341,6 +341,21 @@ describe("basic search", () => {
     expect(store.specificRangeMatchesCount).toBe(0);
     expect(model.getters.getActiveMainViewport()).toMatchObject(toZone("Q58:Z100"));
   });
+
+  test("Search results and range are highlighted", () => {
+    setCellContent(model, "A2", "Hello");
+    setCellContent(model, "A3", "Hello");
+    updateSearch(model, "hello", {
+      searchScope: "specificRange",
+      specificRange: model.getters.getRangeFromSheetXC(sheetId1, "A1:A3"),
+    });
+
+    expect(store.highlights).toMatchObject([
+      { zone: toZone("A2") },
+      { zone: toZone("A3"), noBorder: true }, // Not selected, we don't show a border
+      { zone: toZone("A1:A3"), noFill: true }, // Searched range
+    ]);
+  });
 });
 
 test("simple search with array formula", () => {

--- a/tests/grid/highlight_store.test.ts
+++ b/tests/grid/highlight_store.test.ts
@@ -1,8 +1,9 @@
-import { Model } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH, HIGHLIGHT_COLOR } from "../../src/constants";
-import { toZone } from "../../src/helpers";
 import { HighlightProvider, HighlightStore } from "../../src/stores/highlight_store";
 import { Highlight, UID } from "../../src/types";
+
+import { Model } from "../../src";
+import { toZone } from "../../src/helpers";
 import { MockGridRenderingContext } from "../test_helpers/renderer_helpers";
 import { makeStoreWithModel } from "../test_helpers/stores";
 
@@ -82,6 +83,16 @@ describe("Highlight store", () => {
     expect(ctxInstructions).toContain('context.fillStyle="#FF00001F";');
   });
 
+  test("Can change highlight line width", () => {
+    const testHighlight = { zone: toZone("A1"), sheetId, color: "#FF0000" };
+    drawHighlight(testHighlight);
+    expect(ctxInstructions).toContain(`context.lineWidth=2;`);
+
+    ctxInstructions = [];
+    drawHighlight({ ...testHighlight, thinLine: true });
+    expect(ctxInstructions).toContain(`context.lineWidth=1;`);
+  });
+
   test("Can draw highlights without fill", () => {
     const testHighlight = { zone: toZone("A1"), sheetId, color: "#FF0000", noFill: true };
     drawHighlight(testHighlight);
@@ -89,6 +100,15 @@ describe("Highlight store", () => {
     expect(ctxInstructions).not.toContain('context.fillStyle="#FF00001F";');
     expect(ctxInstructions).not.toContain(
       `context.fillRect(0, 0, ${DEFAULT_CELL_WIDTH}, ${DEFAULT_CELL_HEIGHT})`
+    );
+  });
+
+  test("Can draw highlights without border", () => {
+    const testHighlight = { zone: toZone("A1"), sheetId, color: "#FF0000", noBorder: true };
+    drawHighlight(testHighlight);
+
+    expect(ctxInstructions).not.toContain(
+      `context.strokeRect(0.5, 0.5, ${DEFAULT_CELL_WIDTH}, ${DEFAULT_CELL_HEIGHT})`
     );
   });
 


### PR DESCRIPTION
The search results were not drawn since transforming the f&r plugin with a store (we defined a `draw` instead of a `drawLayer` method).

Took the opportunity to draw to use the `HighlightStore` to draw the search results instead of doing it manually.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3721321](https://www.odoo.com/web#id=3721321&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo