### PR TITLE
[FIX] SelectionInputsManagerPlugin: bad ranges break selection input

### DIFF
--- a/src/plugins/ui_feature/selection_inputs_manager.ts
+++ b/src/plugins/ui_feature/selection_inputs_manager.ts
@@ -108,15 +108,13 @@ export class SelectionInputsManagerPlugin extends UIPlugin {
         if (cmd.id !== this.focusedInputId) {
           const input = this.inputs[cmd.id];
           const range = input.ranges.find((range) => range.id === cmd.rangeId);
-          if (this.isRangeValid(range?.xc || "A1")) {
-            const sheetId = this.getters.getActiveSheetId();
-            const zone = this.getters.getRangeFromSheetXC(sheetId, range?.xc || "A1").zone;
-            this.selection.capture(
-              input,
-              { cell: { col: zone.left, row: zone.top }, zone },
-              { handleEvent: input.handleEvent.bind(input) }
-            );
-          }
+          const sheetId = this.getters.getActiveSheetId();
+          const zone = this.getters.getRangeFromSheetXC(sheetId, range?.xc || "A1").zone;
+          this.selection.capture(
+            input,
+            { cell: { col: zone.left, row: zone.top }, zone },
+            { handleEvent: input.handleEvent.bind(input) }
+          );
           this.focusedInputId = cmd.id;
         }
         break;

--- a/tests/components/selection_input.test.ts
+++ b/tests/components/selection_input.test.ts
@@ -523,4 +523,18 @@ describe("Selection Input", () => {
 
     expect(model.getters.isGridSelectionActive()).toBeTruthy();
   });
+
+  test("Ensure responsive behavior of selection input after entering an invalid range", async () => {
+    const { model, id } = await createSelectionInput({
+      hasSingleRange: true,
+      initialRanges: ["TEST"],
+    });
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("TEST");
+
+    await keyDown({ key: "Enter" });
+    await simulateClick("input");
+
+    selectCell(model, "B4");
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("B4");
+  });
 });


### PR DESCRIPTION
## Description:

In the past, entering invalid ranges (e.g., 'TEST') in the selection input, hitting enter, and subsequently attempting to select ranges from the grid would result in a malfunction.

This commit addresses the problem by eliminating the if statement responsible for validating ranges, as it was identified as the root cause of the issue.

Task: : [3626171](https://www.odoo.com/web#id=3626171&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo