### PR TITLE
[PERF] functions: lookup function return error

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -8,6 +8,7 @@ import {
   assertNumberGreaterThanOrEqualToOne,
   dichotomicSearch,
   expectNumberRangeError,
+  isEvaluationError,
   linearSearch,
   strictToInteger,
   toBoolean,
@@ -177,6 +178,9 @@ export const HLOOKUP = {
       () => 1 <= _index && _index <= range[0].length,
       _t("[[FUNCTION_NAME]] evaluates to an out of bounds range.")
     );
+    if (searchKey && isEvaluationError(searchKey.value)) {
+      return searchKey;
+    }
 
     const getValueFromRange = (range: Matrix<FPayload>, index: number) => range[index][0].value;
 
@@ -458,6 +462,9 @@ export const VLOOKUP = {
       () => 1 <= _index && _index <= range.length,
       _t("[[FUNCTION_NAME]] evaluates to an out of bounds range.")
     );
+    if (searchKey && isEvaluationError(searchKey.value)) {
+      return searchKey;
+    }
 
     const getValueFromRange = (range: Matrix<FPayload>, index: number) => range[0][index].value;
 
@@ -539,6 +546,10 @@ export const XLOOKUP = {
           : returnRange.length === lookupRange.length,
       _t("return_range should have the same dimensions as lookup_range.")
     );
+
+    if (searchKey && isEvaluationError(searchKey.value)) {
+      return [[searchKey]];
+    }
 
     const getElement =
       lookupDirection === "col"


### PR DESCRIPTION

## Description:

Since 78e377f, functions can return errors instead of throwing them. It's significantly faster.

While loading spreadsheet 3721226 on odoo.com, `linearSearch` total time goes from ~2s to ~125ms

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo