### PR TITLE
[FIX] export: unbound formula stays unbound in snapshots

### DIFF
--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -232,10 +232,6 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
           format: cell.format ? getItemId<Format>(cell.format, formats) : undefined,
           content: cell.content || undefined,
         };
-
-        if (cell.isFormula()) {
-          cells[xc].content = this.buildFormulaContent(_sheet.id, cell, cell.dependencies, true);
-        }
       }
       _sheet.cells = cells;
     }
@@ -265,6 +261,15 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
         const exportedCellData = sheet.cells[xc]!;
         exportedCellData.value = cell.evaluated.value;
         exportedCellData.isFormula = cell.isFormula();
+
+        if (cell.isFormula()) {
+          exportedCellData.content = this.buildFormulaContent(
+            sheet.id,
+            cell,
+            cell.dependencies,
+            true
+          );
+        }
         if (cell.format !== cell.evaluated.format) {
           exportedCellData.computedFormat = cell.evaluated.format;
         }

--- a/tests/__snapshots__/model.test.ts.snap
+++ b/tests/__snapshots__/model.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Model export formula with unbound zone stays unbound 1`] = `
+Object {
+  "borders": Object {},
+  "entities": Object {},
+  "formats": Object {},
+  "revisionId": "START_REVISION",
+  "sheets": Array [
+    Object {
+      "areGridLinesVisible": true,
+      "cells": Object {
+        "A1": Object {
+          "content": "=SUM(A3:3)",
+          "format": undefined,
+          "style": undefined,
+        },
+        "A2": Object {
+          "content": "=SUM(A3:A)",
+          "format": undefined,
+          "style": undefined,
+        },
+      },
+      "colNumber": 26,
+      "cols": Object {},
+      "conditionalFormats": Array [],
+      "figures": Array [],
+      "filterTables": Array [],
+      "id": "Sheet1",
+      "isVisible": true,
+      "merges": Array [],
+      "name": "Sheet1",
+      "rowNumber": 100,
+      "rows": Object {},
+    },
+  ],
+  "styles": Object {},
+  "uniqueFigureIds": true,
+  "version": 12,
+}
+`;

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -197,4 +197,19 @@ describe("Model", () => {
     uiPluginRegistry.remove("myUIPlugin");
     corePluginRegistry.remove("myCorePlugin");
   });
+
+  test("export formula with unbound zone stays unbound", () => {
+    const modelData = {
+      sheets: [
+        {
+          cells: {
+            A1: { content: "=SUM(A3:3)" },
+            A2: { content: "=SUM(A3:A)" },
+          },
+        },
+      ],
+    };
+    const model = new Model(modelData);
+    expect(model.exportData()).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
In the PR https://github.com/odoo/o-spreadsheet/issues/3364 I try to fix the export to excel of unbound zones by fixing them. However I have not taken into account the normal expor in spreadsheet that is done when generating snapshot.

This fix keeps the unbound zones in snapshots, while convert them into bound zones in excel export.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo