### PR TITLE
[FIX] autofill: allow to autofill a mix of number values and formulas

### DIFF
--- a/src/registries/autofill_rules.ts
+++ b/src/registries/autofill_rules.ts
@@ -29,8 +29,8 @@ function getGroup(cell: Cell, cells: (Cell | undefined)[]): number[] {
     if (x === cell) {
       found = true;
     }
-    const cellValue = evaluateLiteral(x?.content);
-    if (cellValue.type === CellValueType.number) {
+    const cellValue = x?.isFormula ? undefined : evaluateLiteral(x?.content);
+    if (cellValue?.type === CellValueType.number) {
       group.push(cellValue.value);
     } else {
       if (found) {

--- a/tests/plugins/autofill.test.ts
+++ b/tests/plugins/autofill.test.ts
@@ -331,6 +331,19 @@ describe("Autofill", () => {
       expect(getCellContent(model, "A4")).toBe("test");
     });
 
+    test("Autofill number and formulas", () => {
+      setCellContent(model, "A1", "1");
+      setCellContent(model, "A2", "2");
+      setCellContent(model, "A3", "=A1 + 10");
+      autofill("A1:A3", "A9");
+      expect(getCellContent(model, "A4")).toBe("3");
+      expect(getCellContent(model, "A5")).toBe("4");
+      expect(getCellContent(model, "A6")).toBe("13");
+      expect(getCellContent(model, "A7")).toBe("5");
+      expect(getCellContent(model, "A8")).toBe("6");
+      expect(getCellContent(model, "A9")).toBe("15");
+    });
+
     test.each([
       ["=A1", "=#REF"],
       ["=SUM(A1:B1)", "=SUM(#REF)"],


### PR DESCRIPTION
## Description:

The previous code did not allow autofilling a selection with numbers coming from both simple inputs and formulas.

This commit fix that

Task: : [3700733](https://www.odoo.com/web#id=3700733&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo