### PR TITLE
[IMP] tables: introduce dynamic tables

### DIFF
--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -11,7 +11,6 @@ import {
   isConsecutive,
   isEqual,
   numberToLetters,
-  positionToZone,
 } from "../helpers/index";
 import { DEFAULT_TABLE_CONFIG } from "../helpers/table_presets";
 import { interactivePaste, interactivePasteFromOS } from "../helpers/ui/paste_interactive";
@@ -521,9 +520,13 @@ export const INSERT_TABLE = (env: SpreadsheetChildEnv) => {
 
 export const DELETE_SELECTED_TABLE = (env: SpreadsheetChildEnv) => {
   const position = env.model.getters.getActivePosition();
+  const table = env.model.getters.getTable(position);
+  if (!table) {
+    return;
+  }
   env.model.dispatch("REMOVE_TABLE", {
     sheetId: position.sheetId,
-    target: [positionToZone(position)],
+    target: [table.range.zone],
   });
 };
 

--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -1,6 +1,6 @@
 import { CommandResult } from "..";
 import { canonicalizeNumberValue } from "../formulas/formula_locale";
-import { formatValue } from "../helpers";
+import { deepEquals, formatValue } from "../helpers";
 import { getPasteZones } from "../helpers/clipboard/clipboard_helpers";
 import {
   CellPosition,
@@ -55,7 +55,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
         const spreader = this.getters.getArrayFormulaSpreadingOn(position);
         let cell = this.getters.getCell(position);
         const evaluatedCell = this.getters.getEvaluatedCell(position);
-        if (spreader) {
+        if (spreader && !deepEquals(spreader, position)) {
           const isSpreaderCopied =
             rowsIndexes.includes(spreader.row) && columnsIndexes.includes(spreader.col);
           const content = isSpreaderCopied

--- a/src/components/filters/filter_icons_overlay/filter_icons_overlay.ts
+++ b/src/components/filters/filter_icons_overlay/filter_icons_overlay.ts
@@ -22,7 +22,6 @@ export class FilterIconsOverlay extends Component<Props, SpreadsheetChildEnv> {
 
   getFilterHeadersPositions(): CellPosition[] {
     const sheetId = this.env.model.getters.getActiveSheetId();
-    const headerPositions = this.env.model.getters.getFilterHeaders(sheetId);
-    return headerPositions.map((position) => ({ sheetId, ...position }));
+    return this.env.model.getters.getFilterHeaders(sheetId);
   }
 }

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -948,4 +948,12 @@ https://fontawesome.com/license -->
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.CIRCLE_INFO">
+    <svg class="o-icon" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fill="currentColor"
+        d="M9 .55a8.4 8.4 0 1 0 8.4 8.4A8.4 8.4 0 0 0 9 .55M7.6 4.155a1.4 1.4 0 1 1 1.4 1.4 1.4 1.4 0 0 1-1.4-1.4m4.9 8.995a.7.7 0 0 1-.7.7H6.9a.7.7 0 1 1 0-1.4h1.4v-4.2h-.7a.7.7 0 0 1 0-1.4h2.8v5.6h1.4a.7.7 0 0 1 .7.7"
+      />
+    </svg>
+  </t>
 </templates>

--- a/src/components/side_panel/table_panel/table_panel.xml
+++ b/src/components/side_panel/table_panel/table_panel.xml
@@ -69,7 +69,7 @@
       <Section>
         <t t-set-slot="title">Data range</t>
         <SelectionInput
-          t-key="props.table.id"
+          t-key="props.table.type"
           ranges="[this.state.tableXc]"
           hasSingleRange="true"
           onSelectionChanged="(ranges) => this.onRangeChanged(ranges)"
@@ -82,6 +82,20 @@
           value="tableConfig.automaticAutofill"
           onChange="(val) => this.updateTableConfig('automaticAutofill', val)"
         />
+        <div class="d-flex flex-row align-items-center">
+          <Checkbox
+            label="getCheckboxLabel('isDynamic')"
+            name="'isDynamic'"
+            value="props.table.type === 'dynamic'"
+            onChange.bind="this.updateTableIsDynamic"
+            disabled="!this.canBeDynamic"
+          />
+          <div
+            class="o-info-icon d-flex flex-row align-items-center text-muted ps-1"
+            t-att-title="dynamicTableTooltip">
+            <t t-call="o-spreadsheet-Icon.CIRCLE_INFO"/>
+          </div>
+        </div>
       </Section>
       <div class="o-sidePanelButtons">
         <button t-on-click="deleteTable" class="o-table-delete o-button">Delete table</button>

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -151,8 +151,10 @@ export const TableTerms = {
     bandedColumns: _t("Banded columns"),
     automaticAutofill: _t("Automatically autofill formulas"),
     totalRow: _t("Total row"),
+    isDynamic: _t("Auto-adjust to formula result"),
   },
   Tooltips: {
     filterWithoutHeader: _t("Cannot have filters without a header row"),
+    isDynamic: _t("For tables based on array formulas only"),
   },
 };

--- a/src/helpers/table_helpers.ts
+++ b/src/helpers/table_helpers.ts
@@ -1,6 +1,7 @@
+import { Border, BorderDescr, CellPosition, Range, Style, UID, Zone } from "../types";
+import { CoreTable, Filter, Table, TableConfig, TableStyle } from "../types/table";
+
 import { generateMatrix } from "../functions/helpers";
-import { Border, BorderDescr, Style, Zone } from "../types";
-import { TableConfig, TableStyle } from "../types/table";
 import { ComputedTableStyle } from "./../types/table";
 import { TABLE_PRESETS } from "./table_presets";
 
@@ -22,6 +23,31 @@ export function getTableContentZone(tableZone: Zone, tableConfig: TableConfig): 
   const numberOfHeaders = tableConfig.numberOfHeaders;
   const contentZone = { ...tableZone, top: tableZone.top + numberOfHeaders };
   return contentZone.top <= contentZone.bottom ? contentZone : undefined;
+}
+
+export function getTableTopLeft(table: Table | CoreTable): CellPosition {
+  const range = table.range;
+  return { row: range.zone.top, col: range.zone.left, sheetId: range.sheetId };
+}
+
+export function createFilter(
+  id: UID,
+  range: Range,
+  config: TableConfig,
+  createRange: (sheetId: UID, zone: Zone) => Range
+): Filter {
+  const zone = range.zone;
+  if (zone.left !== zone.right) {
+    throw new Error("Can only define a filter on a single column");
+  }
+  const filteredZone = { ...zone, top: zone.top + config.numberOfHeaders };
+  const filteredRange = createRange(range.sheetId, filteredZone);
+  return {
+    id,
+    rangeWithHeaders: range,
+    col: zone.left,
+    filteredRange: filteredZone.top > filteredZone.bottom ? undefined : filteredRange,
+  };
 }
 
 export function getComputedTableStyle(

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -672,6 +672,11 @@ export function positionToZone(position: Position) {
   return { left: position.col, right: position.col, top: position.row, bottom: position.row };
 }
 
+/** Transform a zone into a zone with only its top-left position */
+export function zoneToTopLeft(zone: Zone): Zone {
+  return { ...zone, right: zone.left, bottom: zone.top };
+}
+
 export function isFullRow(zone: UnboundedZone): boolean {
   return zone.right === undefined;
 }
@@ -714,4 +719,15 @@ export function getZonesRows(zones: Zone[]): Set<number> {
     }
   }
   return set;
+}
+
+export function unionPositionsToZone(positions: Position[]): Zone {
+  const zone = { top: Infinity, left: Infinity, bottom: -Infinity, right: -Infinity };
+  for (const { col, row } of positions) {
+    zone.top = Math.min(zone.top, row);
+    zone.left = Math.min(zone.left, col);
+    zone.bottom = Math.max(zone.bottom, row);
+    zone.right = Math.max(zone.right, col);
+  }
+  return zone;
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -23,6 +23,7 @@ import {
   EvaluationDataValidationPlugin,
   EvaluationPlugin,
 } from "./ui_core_views";
+import { DynamicTablesPlugin } from "./ui_core_views/dynamic_tables";
 import { HeaderSizeUIPlugin } from "./ui_core_views/header_sizes_ui";
 import {
   AutofillPlugin,
@@ -96,5 +97,6 @@ export const coreViewsPluginRegistry = new Registry<UIPluginConstructor>()
   .add("evaluation_chart", EvaluationChartPlugin)
   .add("evaluation_cf", EvaluationConditionalFormatPlugin)
   .add("row_size", HeaderSizeUIPlugin)
-  .add("custom_colors", CustomColorsPlugin)
-  .add("data_validation_ui", EvaluationDataValidationPlugin);
+  .add("data_validation_ui", EvaluationDataValidationPlugin)
+  .add("dynamic_tables", DynamicTablesPlugin)
+  .add("custom_colors", CustomColorsPlugin);

--- a/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/src/plugins/ui_core_views/dynamic_tables.ts
@@ -1,0 +1,235 @@
+import {
+  areZonesContinuous,
+  deepEquals,
+  getZoneArea,
+  isInside,
+  overlap,
+  toZone,
+  union,
+  unionPositionsToZone,
+  zoneToXc,
+} from "../../helpers";
+import { createFilter } from "../../helpers/table_helpers";
+import {
+  CellPosition,
+  Command,
+  CoreTable,
+  DynamicTable,
+  ExcelWorkbookData,
+  Filter,
+  FilterId,
+  Table,
+  TableId,
+  UID,
+  Zone,
+  invalidateEvaluationCommands,
+} from "../../types/index";
+
+import { UIPlugin } from "../ui_plugin";
+
+export class DynamicTablesPlugin extends UIPlugin {
+  static getters = [
+    "canCreateDynamicTableOnZones",
+    "doesZonesContainFilter",
+    "getFilter",
+    "getFilters",
+    "getTable",
+    "getTables",
+    "getTablesOverlappingZones",
+    "getFilterId",
+    "getFilterHeaders",
+    "isFilterHeader",
+  ] as const;
+
+  tables: Record<UID, Table[]> = {};
+
+  handle(cmd: Command) {
+    if (
+      invalidateEvaluationCommands.has(cmd.type) ||
+      (cmd.type === "UPDATE_CELL" && "content" in cmd) ||
+      cmd.type === "EVALUATE_CELLS"
+    ) {
+      this.tables = {};
+      return;
+    }
+    switch (cmd.type) {
+      case "CREATE_TABLE":
+      case "REMOVE_TABLE":
+      case "UPDATE_TABLE":
+      case "DELETE_CONTENT":
+        this.tables = {};
+        break;
+    }
+  }
+
+  finalize() {
+    for (const sheetId of this.getters.getSheetIds()) {
+      if (!this.tables[sheetId]) {
+        this.tables[sheetId] = this.computeTables(sheetId);
+      }
+    }
+  }
+
+  private computeTables(sheetId: UID): Table[] {
+    const tables: Table[] = [];
+    const coreTables = this.getters.getCoreTables(sheetId);
+
+    // First we create the static tables, so we can use them to compute collision with dynamic tables
+    for (const table of coreTables) {
+      if (table.type === "dynamic") continue;
+      tables.push(table);
+    }
+    const staticTables = [...tables];
+
+    // Then we create the dynamic tables
+    for (const coreTable of coreTables) {
+      if (coreTable.type !== "dynamic") continue;
+      const table = this.coreTableToTable(sheetId, coreTable);
+      let tableZone = table.range.zone;
+      // Reduce the zone to avoid collision with static tables. Per design, dynamic tables can't overlap with other
+      // dynamic tables, because formulas cannot spread on the same area, so we don't need to check for that.
+      for (const staticTable of staticTables) {
+        if (overlap(tableZone, staticTable.range.zone)) {
+          tableZone = { ...tableZone, right: staticTable.range.zone.left - 1 };
+        }
+      }
+      tables.push({ ...table, range: this.getters.getRangeFromZone(sheetId, tableZone) });
+    }
+
+    return tables;
+  }
+
+  getFilters(sheetId: UID): Filter[] {
+    return this.getTables(sheetId)
+      .filter((table) => table.config.hasFilters)
+      .map((table) => table.filters)
+      .flat();
+  }
+
+  getTables(sheetId: UID): Table[] {
+    return this.tables[sheetId] || [];
+  }
+
+  getFilter(position: CellPosition): Filter | undefined {
+    const table = this.getTable(position);
+    if (!table || !table.config.hasFilters) {
+      return undefined;
+    }
+    return table.filters.find((filter) => filter.col === position.col);
+  }
+
+  getFilterId(position: CellPosition): FilterId | undefined {
+    return this.getFilter(position)?.id;
+  }
+
+  getTable({ sheetId, col, row }: CellPosition): Table | undefined {
+    return this.getTables(sheetId).find((table) => isInside(col, row, table.range.zone));
+  }
+
+  getTablesOverlappingZones(sheetId: UID, zones: Zone[]): Table[] {
+    return this.getTables(sheetId).filter((table) =>
+      zones.some((zone) => overlap(table.range.zone, zone))
+    );
+  }
+
+  doesZonesContainFilter(sheetId: UID, zones: Zone[]): boolean {
+    return this.getTablesOverlappingZones(sheetId, zones).some((table) => table.config.hasFilters);
+  }
+
+  getFilterHeaders(sheetId: UID): CellPosition[] {
+    const headers: CellPosition[] = [];
+    for (const table of this.getTables(sheetId)) {
+      if (!table.config.hasFilters) {
+        continue;
+      }
+      const zone = table.range.zone;
+      const row = zone.top;
+      for (let col = zone.left; col <= zone.right; col++) {
+        headers.push({ sheetId, col, row });
+      }
+    }
+    return headers;
+  }
+
+  isFilterHeader({ sheetId, col, row }: CellPosition): boolean {
+    const headers = this.getFilterHeaders(sheetId);
+    return headers.some((header) => header.col === col && header.row === row);
+  }
+
+  /**
+   * Check if we can create a dynamic table on the given zones.
+   * - The zones must be continuous
+   * - The union of the zones must be either:
+   *    - A single cell that contains an array formula
+   *    - All the spread cells of a single array formula
+   */
+  canCreateDynamicTableOnZones(sheetId: UID, zones: Zone[]): boolean {
+    if (!areZonesContinuous(zones)) {
+      return false;
+    }
+    const unionZone = union(...zones);
+    const topLeft = { col: unionZone.left, row: unionZone.top, sheetId };
+
+    const parentSpreadingCell = this.getters.getArrayFormulaSpreadingOn(topLeft);
+    if (!parentSpreadingCell) {
+      return false;
+    } else if (deepEquals(parentSpreadingCell, topLeft) && getZoneArea(unionZone) === 1) {
+      return true;
+    }
+
+    const spreadPositions = this.getters.getSpreadPositionsOf(parentSpreadingCell);
+
+    return deepEquals(unionZone, unionPositionsToZone(spreadPositions));
+  }
+
+  private coreTableToTable(sheetId: UID, table: CoreTable): Table {
+    if (table.type !== "dynamic") {
+      return table;
+    }
+
+    const tableZone = table.range.zone;
+    const tablePosition = { sheetId, col: tableZone.left, row: tableZone.top };
+    const spreadPositions = this.getters.getSpreadPositionsOf(tablePosition);
+    const zone = spreadPositions.length ? unionPositionsToZone(spreadPositions) : table.range.zone;
+    const range = this.getters.getRangeFromZone(sheetId, zone);
+    const filters = this.getDynamicTableFilters(sheetId, table, zone);
+    return { id: table.id, range, filters, config: table.config };
+  }
+
+  private getDynamicTableFilters(sheetId: UID, table: DynamicTable, tableZone: Zone): Filter[] {
+    const filters: Filter[] = [];
+    const { top, bottom, left, right } = tableZone;
+    for (let col = left; col <= right; col++) {
+      const tableColIndex = col - left;
+      const zone = { left: col, right: col, top, bottom };
+      const filter = createFilter(
+        this.getDynamicTableFilterId(table.id, tableColIndex),
+        this.getters.getRangeFromZone(sheetId, zone),
+        table.config,
+        this.getters.getRangeFromZone
+      );
+      filters.push(filter);
+    }
+    return filters;
+  }
+
+  private getDynamicTableFilterId(tableId: TableId, tableCol: number): string {
+    return tableId + "_" + tableCol;
+  }
+
+  exportForExcel(data: ExcelWorkbookData) {
+    for (const sheet of data.sheets) {
+      for (const tableData of sheet.tables) {
+        const zone = toZone(tableData.range);
+        const topLeft = { sheetId: sheet.id, col: zone.left, row: zone.top };
+        const coreTable = this.getters.getCoreTable(topLeft);
+        const table = this.getTable(topLeft);
+
+        if (coreTable?.type !== "dynamic" || !table) {
+          continue;
+        }
+        tableData.range = zoneToXc(table.range.zone);
+      }
+    }
+  }
+}

--- a/src/plugins/ui_feature/table_autofill.ts
+++ b/src/plugins/ui_feature/table_autofill.ts
@@ -7,9 +7,11 @@ export class TableAutofillPlugin extends UIPlugin {
   handle(cmd: Command) {
     switch (cmd.type) {
       case "AUTOFILL_TABLE_COLUMN":
-        const table = this.getters.getTable(cmd);
+        const table = this.getters.getCoreTable(cmd);
         const cell = this.getters.getCell(cmd);
-        if (!table || !table.config.automaticAutofill || !cell?.isFormula) return;
+        if (!table?.config.automaticAutofill || table.type === "dynamic" || !cell?.isFormula) {
+          return;
+        }
 
         const { col, row } = cmd;
         const tableContentZone = getTableContentZone(table.range.zone, table.config);

--- a/src/plugins/ui_stateful/filter_evaluation.ts
+++ b/src/plugins/ui_stateful/filter_evaluation.ts
@@ -1,4 +1,12 @@
-import { positions, range, toLowerCase, toXC, toZone, zoneToDimension } from "../../helpers";
+import {
+  deepCopy,
+  positions,
+  range,
+  toLowerCase,
+  toXC,
+  toZone,
+  zoneToDimension,
+} from "../../helpers";
 import {
   CellPosition,
   Command,
@@ -52,9 +60,6 @@ export class FilterEvaluationPlugin extends UIPlugin {
       case "START":
         for (const sheetId of this.getters.getSheetIds()) {
           this.filterValues[sheetId] = {};
-          for (const filter of this.getters.getFilters(sheetId)) {
-            this.filterValues[sheetId][filter.id] = [];
-          }
         }
         break;
       case "CREATE_SHEET":
@@ -75,16 +80,7 @@ export class FilterEvaluationPlugin extends UIPlugin {
         this.updateHiddenRows();
         break;
       case "DUPLICATE_SHEET":
-        const filterValues: Record<FilterId, string[]> = {};
-        for (const newFilter of this.getters.getFilters(cmd.sheetIdTo)) {
-          const zone = newFilter.rangeWithHeaders.zone;
-          filterValues[newFilter.id] = this.getFilterHiddenValues({
-            sheetId: cmd.sheetId,
-            col: zone.left,
-            row: zone.top,
-          });
-        }
-        this.filterValues[cmd.sheetIdTo] = filterValues;
+        this.filterValues[cmd.sheetIdTo] = deepCopy(this.filterValues[cmd.sheetId]);
         break;
       // If we don't handle DELETE_SHEET, on one hand we will have some residual data, on the other hand we keep the data
       // on DELETE_SHEET followed by undo

--- a/src/registries/side_panel_registry_entries.ts
+++ b/src/registries/side_panel_registry_entries.ts
@@ -9,6 +9,7 @@ import { RemoveDuplicatesPanel } from "../components/side_panel/remove_duplicate
 import { SettingsPanel } from "../components/side_panel/settings/settings_panel";
 import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns_panel/split_to_columns_panel";
 import { TablePanel } from "../components/side_panel/table_panel/table_panel";
+import { getTableTopLeft } from "../helpers/table_helpers";
 import { _t } from "../translation";
 import { Getters, UID } from "../types";
 import { sidePanelRegistry } from "./side_panel_registry";
@@ -81,10 +82,8 @@ sidePanelRegistry.add("TableSidePanel", {
     if (!table) {
       return { isOpen: false };
     }
-    return {
-      isOpen: true,
-      props: { table },
-      key: table.id,
-    };
+
+    const coreTable = getters.getCoreTable(getTableTopLeft(table));
+    return { isOpen: true, props: { table: coreTable }, key: table.id };
   },
 });

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,12 +1,7 @@
-import { ChartDefinition } from "./chart/chart";
-import { ClipboardPasteOptions } from "./clipboard";
-import { FigureSize } from "./figure";
-import { SearchOptions } from "./find_and_replace";
-import { Image } from "./image";
 import {
   ConditionalFormat,
-  DataValidationRule,
   DOMCoordinates,
+  DataValidationRule,
   Figure,
   Format,
   Locale,
@@ -25,8 +20,14 @@ import {
   SortOptions,
   UID,
 } from "./misc";
+
+import { ChartDefinition } from "./chart/chart";
+import { ClipboardPasteOptions } from "./clipboard";
+import { FigureSize } from "./figure";
+import { SearchOptions } from "./find_and_replace";
+import { Image } from "./image";
 import { RangeData } from "./range";
-import { TableConfig } from "./table";
+import { CoreTableType, TableConfig } from "./table";
 
 // -----------------------------------------------------------------------------
 // Grid commands
@@ -479,6 +480,7 @@ export interface CreateTableCommand extends RangesDependentCommand {
   type: "CREATE_TABLE";
   sheetId: UID;
   config?: TableConfig;
+  tableType: CoreTableType;
 }
 
 export interface RemoveTableCommand extends TargetDependentCommand {
@@ -490,6 +492,7 @@ export interface UpdateTableCommand {
   zone: Zone;
   sheetId: UID;
   newTableRange?: RangeData;
+  tableType?: CoreTableType;
   config?: Partial<TableConfig>;
 }
 

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -16,6 +16,7 @@ import { TablePlugin } from "../plugins/core/tables";
 import { EvaluationDataValidationPlugin } from "../plugins/ui_core_views";
 import { EvaluationPlugin } from "../plugins/ui_core_views/cell_evaluation";
 import { CustomColorsPlugin } from "../plugins/ui_core_views/custom_colors";
+import { DynamicTablesPlugin } from "../plugins/ui_core_views/dynamic_tables";
 import { EvaluationChartPlugin } from "../plugins/ui_core_views/evaluation_chart";
 import { EvaluationConditionalFormatPlugin } from "../plugins/ui_core_views/evaluation_conditional_format";
 import { HeaderSizeUIPlugin } from "../plugins/ui_core_views/header_sizes_ui";
@@ -134,4 +135,5 @@ export type Getters = {
   PluginGetters<typeof HeaderSizeUIPlugin> &
   PluginGetters<typeof EvaluationDataValidationPlugin> &
   PluginGetters<typeof HeaderPositionsUIPlugin> &
-  PluginGetters<typeof TableStylePlugin>;
+  PluginGetters<typeof TableStylePlugin> &
+  PluginGetters<typeof DynamicTablesPlugin>;

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -8,6 +8,17 @@ export interface Table {
   readonly config: TableConfig;
 }
 
+export interface StaticTable extends Table {
+  readonly type: "static" | "forceStatic";
+}
+
+export interface DynamicTable extends Omit<Table, "filters"> {
+  readonly type: "dynamic";
+}
+
+export type CoreTable = StaticTable | DynamicTable;
+export type CoreTableType = Extract<CoreTable, { type: string }>["type"];
+
 export interface Filter {
   readonly id: UID;
   readonly rangeWithHeaders: Range;

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -3,7 +3,7 @@ import { ExcelChartDefinition } from "./chart/chart";
 import { ConditionalFormat } from "./conditional_formatting";
 import { Image } from "./image";
 import { Border, Dimension, HeaderGroup, PaneDivision, Pixel, Style, UID } from "./misc";
-import { TableConfig } from "./table";
+import { CoreTableType, TableConfig } from "./table";
 
 export interface Dependencies {
   references: string[];
@@ -93,6 +93,7 @@ export interface ExcelHeaderData extends HeaderData {
 export interface TableData {
   range: string;
   config?: TableConfig;
+  type?: CoreTableType;
 }
 
 export interface DataValidationRuleData extends Omit<DataValidationRule, "ranges"> {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -744,7 +744,7 @@ describe("Multi users synchronisation", () => {
         sheetId: "Sheet1",
         sheetIdTo: "sheet2",
       });
-      createTable(charlie, "A1:B4", undefined, firstSheetId);
+      createTable(charlie, "A1:B4", undefined, undefined, firstSheetId);
     });
     expect([alice, bob, charlie]).toHaveSynchronizedValue(
       (user) => user.getters.getTables("sheet2"),

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -389,7 +389,7 @@ describe("Migrations", () => {
       ],
     });
     const data = model.exportData();
-    expect(data.sheets[0].tables).toEqual([{ range: "A1:C2" }]);
+    expect(data.sheets[0].tables).toEqual([{ range: "A1:C2", type: "static" }]);
   });
 
   test("migrate version 12.5: update border description structure", () => {
@@ -439,7 +439,7 @@ describe("Migrations", () => {
       ],
     });
     const data = model.exportData();
-    expect(data.sheets[0].tables).toEqual([{ range: "A1:C2" }]);
+    expect(data.sheets[0].tables).toEqual([{ range: "A1:C2", type: "static" }]);
   });
 
   test("migrate version 15: filterTables are renamed into tables", () => {
@@ -455,7 +455,7 @@ describe("Migrations", () => {
     expect(model.getters.getTables("1")).toMatchObject([{ range: { zone: toZone("A1:B2") } }]);
     let data = model.exportData();
     expect(data.version).toBe(CURRENT_VERSION);
-    expect(data.sheets[0].tables).toEqual([{ range: "A1:B2" }]);
+    expect(data.sheets[0].tables).toEqual([{ range: "A1:B2", type: "static" }]);
   });
 });
 

--- a/tests/table/dynamic_table_plugin.test.ts
+++ b/tests/table/dynamic_table_plugin.test.ts
@@ -1,0 +1,234 @@
+import { Model } from "../../src";
+import { toZone, zoneToXc } from "../../src/helpers";
+import { TABLE_PRESETS } from "../../src/helpers/table_presets";
+import { UID } from "../../src/types";
+import {
+  copy,
+  createDynamicTable,
+  createTable,
+  cut,
+  deleteTable,
+  duplicateSheet,
+  paste,
+  setCellContent,
+  updateFilter,
+  updateTableConfig,
+  updateTableZone,
+} from "../test_helpers/commands_helpers";
+import { TABLE_STYLE_ALL_RED } from "../test_helpers/constants";
+import { getCell } from "../test_helpers/getters_helpers";
+import {
+  getExportedExcelData,
+  getFilterHiddenValues,
+  toCellPosition,
+} from "../test_helpers/helpers";
+
+let model: Model;
+let sheetId: UID;
+
+const oldTablePresets = { ...TABLE_PRESETS };
+
+beforeEach(() => {
+  model = new Model();
+  sheetId = model.getters.getActiveSheetId();
+  TABLE_PRESETS.TestStyleAllRed = TABLE_STYLE_ALL_RED;
+});
+
+afterEach(() => {
+  Object.keys(TABLE_PRESETS).forEach((key) => delete TABLE_PRESETS[key]);
+  Object.assign(TABLE_PRESETS, oldTablePresets);
+});
+
+function getTables(model: Model, sheetId: UID) {
+  return model.getters
+    .getTables(sheetId)
+    .map((table) => ({ ...table, zone: zoneToXc(table.range.zone) }));
+}
+
+describe("Dynamic tables", () => {
+  test("Can create a dynamic table", () => {
+    setCellContent(model, "A1", "=MUNIT(3)");
+    createDynamicTable(model, "A1");
+
+    expect(model.getters.getCoreTables(sheetId)[0]).toMatchObject({
+      range: { zone: toZone("A1") },
+      type: "dynamic",
+    });
+    expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A1:C3" });
+  });
+
+  test("Can update a dynamic table", () => {
+    setCellContent(model, "A1", "=MUNIT(3)");
+    createDynamicTable(model, "A1");
+    updateTableConfig(model, "A1", { styleId: "TableStyleMedium12" });
+    expect(getTables(model, sheetId)[0]).toMatchObject({
+      config: { styleId: "TableStyleMedium12" },
+    });
+  });
+
+  test("Can duplicate a sheet with a dynamic table", () => {
+    setCellContent(model, "A1", "=MUNIT(3)");
+    createDynamicTable(model, "A1");
+    duplicateSheet(model, sheetId, "Sheet2Id");
+
+    expect(model.getters.getCoreTables("Sheet2Id")).toMatchObject([
+      { range: { zone: toZone("A1") }, type: "dynamic" },
+    ]);
+    expect(getTables(model, "Sheet2Id")[0]).toMatchObject({ zone: "A1:C3" });
+  });
+
+  test("Can change a static table to a dynamic one", () => {
+    setCellContent(model, "C1", "=MUNIT(2)");
+    createTable(model, "A1:A3");
+
+    const table = model.getters.getCoreTables(sheetId)[0];
+    expect(table).toMatchObject({ range: { zone: toZone("A1:A3") }, type: "static" });
+
+    updateTableZone(model, "A1:A3", "C1", "dynamic");
+    expect(model.getters.getCoreTables(sheetId)).toHaveLength(1);
+    expect(model.getters.getCoreTables(sheetId)[0]).toMatchObject({
+      id: table.id,
+      range: { zone: toZone("C1") },
+      type: "dynamic",
+    });
+    expect(getTables(model, sheetId)).toHaveLength(1);
+    expect(getTables(model, sheetId)[0]).toMatchObject({
+      id: table.id,
+      zone: "C1:D2",
+    });
+  });
+
+  test("Can change a dynamic table to a static one", () => {
+    setCellContent(model, "A1", "=MUNIT(2)");
+    createDynamicTable(model, "A1");
+
+    const table = model.getters.getCoreTables(sheetId)[0];
+    expect(table).toMatchObject({ range: { zone: toZone("A1") }, type: "dynamic" });
+
+    updateTableZone(model, "A1:B2", "C1:C3", "static");
+    expect(model.getters.getCoreTables(sheetId)).toHaveLength(1);
+    expect(model.getters.getCoreTables(sheetId)[0]).toMatchObject({
+      id: table.id,
+      range: { zone: toZone("C1:C3") },
+      type: "static",
+    });
+    expect(getTables(model, sheetId)).toHaveLength(1);
+    expect(getTables(model, sheetId)[0]).toMatchObject({
+      id: table.id,
+      zone: "C1:C3",
+    });
+  });
+
+  test("Dynamic tables cannot overlap with static tables", () => {
+    setCellContent(model, "A1", "=MUNIT(3)");
+    createDynamicTable(model, "A1");
+    createTable(model, "C2:C3");
+    expect(getTables(model, sheetId)).toMatchObject([{ zone: "C2:C3" }, { zone: "A1:B3" }]);
+  });
+
+  test("Can delete a dynamic table", () => {
+    setCellContent(model, "A1", "=MUNIT(3)");
+    createDynamicTable(model, "A1");
+    expect(getTables(model, sheetId)).toHaveLength(1);
+    deleteTable(model, "A1");
+    expect(getTables(model, sheetId)).toHaveLength(0);
+  });
+
+  test("Can update the filter of a dynamic table", () => {
+    setCellContent(model, "A1", "=MUNIT(2)");
+    createDynamicTable(model, "A1");
+    updateFilter(model, "A1", ["0"]);
+    updateFilter(model, "B1", ["1"]);
+    expect(getFilterHiddenValues(model)).toMatchObject([
+      { value: ["0"], zone: "A1:A2" },
+      { value: ["1"], zone: "B1:B2" },
+    ]);
+    expect(model.getters.isRowHidden(sheetId, 1)).toBe(true);
+  });
+
+  test("Dynamic table is updated when formula result changes", () => {
+    setCellContent(model, "C10", "2");
+    setCellContent(model, "A1", "=MUNIT(C10)");
+    createDynamicTable(model, "A1");
+
+    expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A1:B2" });
+    expect(model.getters.getCellTableStyle(toCellPosition(sheetId, "C3"))).toBeUndefined();
+
+    setCellContent(model, "C10", "3");
+    expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A1:C3" });
+    expect(model.getters.getCellTableStyle(toCellPosition(sheetId, "C3"))).not.toBeUndefined();
+  });
+
+  test("Dynamic table is updated when cell is in error", () => {
+    setCellContent(model, "C10", "2");
+    setCellContent(model, "A1", "=MUNIT(C10)");
+    createDynamicTable(model, "A1");
+
+    expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A1:B2" });
+
+    setCellContent(model, "A2", "this will prevent the array formula to be spread");
+    expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A1" });
+
+    setCellContent(model, "A2", "");
+    expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A1:B2" });
+
+    setCellContent(model, "C10", "=0/0");
+    expect(getTables(model, sheetId)[0]).toMatchObject({ zone: "A1" });
+  });
+
+  test("Can copy/paste a dynamic table", () => {
+    setCellContent(model, "A1", "=MUNIT(2)");
+    createDynamicTable(model, "A1");
+
+    copy(model, "A1");
+    paste(model, "D1");
+
+    expect(getTables(model, sheetId)).toMatchObject([{ zone: "A1:B2" }, { zone: "D1:E2" }]);
+  });
+
+  test("Can cut/paste a dynamic table", () => {
+    setCellContent(model, "A1", "=MUNIT(2)");
+    createDynamicTable(model, "A1");
+
+    cut(model, "A1");
+    paste(model, "D1");
+
+    expect(getTables(model, sheetId)).toMatchObject([{ zone: "D1:E2" }]);
+  });
+
+  test("Can copy/paste a cell of a dynamic table", () => {
+    setCellContent(model, "A1", "=MUNIT(2)");
+    createDynamicTable(model, "A1");
+    updateTableConfig(model, "A1", { styleId: "TestStyleAllRed" });
+
+    copy(model, "B1");
+    paste(model, "D1");
+
+    expect(model.getters.getTable({ sheetId, col: 3, row: 0 })).toBeUndefined();
+    expect(getCell(model, "D1")?.style).toMatchObject({ fillColor: "#FF0000" });
+  });
+
+  describe("Import/export", () => {
+    test("Can export and import dynamic tables", () => {
+      setCellContent(model, "A1", "=MUNIT(2)");
+      createDynamicTable(model, "A1");
+
+      const exported = model.exportData();
+      expect(exported.sheets[0].tables).toMatchObject([{ range: "A1", type: "dynamic" }]);
+
+      const newModel = new Model(exported);
+      expect(newModel.getters.getCoreTables(sheetId)).toMatchObject([
+        { range: { zone: toZone("A1") }, type: "dynamic" },
+      ]);
+      expect(getTables(model, sheetId)).toMatchObject([{ zone: "A1:B2" }]);
+    });
+
+    test("Dynamic tables are transformed into static tables when exporting for excel", () => {
+      setCellContent(model, "A1", "=MUNIT(3)");
+      createDynamicTable(model, "A1");
+
+      const exported = getExportedExcelData(model);
+      expect(exported.sheets[0].tables).toMatchObject([{ range: "A1:C3" }]);
+    });
+  });
+});

--- a/tests/table/tables_plugin.test.ts
+++ b/tests/table/tables_plugin.test.ts
@@ -1,7 +1,5 @@
 import { CommandResult, Model } from "../../src";
-import { DEFAULT_BORDER_DESC } from "../../src/constants";
 import { toUnboundedZone, toZone, zoneToXc } from "../../src/helpers";
-import { TABLE_PRESETS } from "../../src/helpers/table_presets";
 import { ClipboardPasteOptions, UID } from "../../src/types";
 import {
   addColumns,
@@ -33,15 +31,15 @@ import {
   getTable,
 } from "../test_helpers/getters_helpers";
 import { getFilterHiddenValues, toRangeData } from "../test_helpers/helpers";
+
+import { DEFAULT_BORDER_DESC } from "../../src/constants";
+import { TABLE_PRESETS } from "../../src/helpers/table_presets";
+import { TABLE_STYLE_ALL_RED } from "../test_helpers/constants";
 import { DEFAULT_TABLE_CONFIG } from "./../../src/helpers/table_presets";
 
 const oldTablePresets = { ...TABLE_PRESETS };
 beforeEach(() => {
-  TABLE_PRESETS.TestStyleAllRed = {
-    category: "dark",
-    colorName: "Red",
-    wholeTable: { style: { fillColor: "#FF0000" }, border: { top: DEFAULT_BORDER_DESC } },
-  };
+  TABLE_PRESETS.TestStyleAllRed = TABLE_STYLE_ALL_RED;
 });
 
 afterEach(() => {
@@ -64,6 +62,7 @@ describe("Table plugin", () => {
         model.dispatch("CREATE_TABLE", {
           sheetId: model.getters.getActiveSheetId(),
           ranges: [{ _sheetId: sheetId, _zone: { top: -1, bottom: 0, right: 5, left: 9 } }],
+          tableType: "static",
         })
       ).toBeCancelledBecause(CommandResult.InvalidRange);
     });
@@ -668,9 +667,9 @@ describe("Table plugin", () => {
 
   describe("Copy/Cut/Paste tables", () => {
     test("Can copy and paste a whole table", () => {
+      // Note: copying filter values is not possible since the introduction of dynamic tables
       createTable(model, "A1:B4");
       updateTableConfig(model, "A1", { bandedColumns: true, styleId: "TableStyleDark2" });
-      updateFilter(model, "A1", ["thisIsAValue"]);
 
       copy(model, "A1:B4");
       paste(model, "A5");
@@ -682,13 +681,6 @@ describe("Table plugin", () => {
         bandedColumns: true,
         styleId: "TableStyleDark2",
       });
-      expect(
-        model.getters.getFilterHiddenValues({
-          sheetId,
-          col: copiedTable!.range.zone.left,
-          row: copiedTable!.range.zone.top,
-        })
-      ).toEqual(["thisIsAValue"]);
     });
 
     test("Can cut and paste a whole table", () => {

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -20,6 +20,8 @@ import {
   Style,
   UID,
 } from "../../src/types";
+import { target, toRangeData, toRangesData } from "./helpers";
+
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
 import { GaugeChartDefinition } from "../../src/types/chart/gauge_chart";
 import { LineChartDefinition } from "../../src/types/chart/line_chart";
@@ -27,9 +29,8 @@ import { PieChartDefinition } from "../../src/types/chart/pie_chart";
 import { ScatterChartDefinition } from "../../src/types/chart/scatter_chart";
 import { ScorecardChartDefinition } from "../../src/types/chart/scorecard_chart";
 import { Image } from "../../src/types/image";
-import { TableConfig } from "../../src/types/table";
+import { CoreTableType, TableConfig } from "../../src/types/table";
 import { FigureSize } from "./../../src/types/figure";
-import { target, toRangeData, toRangesData } from "./helpers";
 
 /**
  * Dispatch an UNDO to the model
@@ -892,6 +893,7 @@ export function createTable(
   model: Model,
   range: string,
   config?: Partial<TableConfig>,
+  tableType: CoreTableType = "static",
   sheetId: UID = model.getters.getActiveSheetId()
 ): DispatchResult {
   model.selection.selectTableAroundSelection();
@@ -899,13 +901,24 @@ export function createTable(
     sheetId,
     ranges: toRangesData(sheetId, range),
     config: { ...DEFAULT_TABLE_CONFIG, ...config },
+    tableType,
   });
+}
+
+export function createDynamicTable(
+  model: Model,
+  range: string,
+  config?: Partial<TableConfig>,
+  sheetId: UID = model.getters.getActiveSheetId()
+): DispatchResult {
+  return createTable(model, range, config, "dynamic", sheetId);
 }
 
 export function updateTableConfig(
   model: Model,
   range: string,
   config: Partial<TableConfig>,
+  tableType?: CoreTableType,
   sheetId: UID = model.getters.getActiveSheetId()
 ): DispatchResult {
   const zone = toZone(range);
@@ -917,6 +930,7 @@ export function updateTableConfig(
     sheetId,
     zone: table.range.zone,
     config,
+    tableType,
   });
 }
 
@@ -924,6 +938,7 @@ export function updateTableZone(
   model: Model,
   range: string,
   newZone: string,
+  tableType?: CoreTableType,
   sheetId: UID = model.getters.getActiveSheetId()
 ): DispatchResult {
   const zone = toZone(range);
@@ -935,6 +950,7 @@ export function updateTableZone(
     sheetId,
     zone: table.range.zone,
     newTableRange: toRangeData(sheetId, newZone),
+    tableType,
   });
 }
 

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -1,5 +1,5 @@
 import { BACKGROUND_CHART_COLOR, DEFAULT_BORDER_DESC } from "../../src/constants";
-import { CoreCommand, CoreCommandTypes, DEFAULT_LOCALE, Locale } from "../../src/types";
+import { CoreCommand, CoreCommandTypes, DEFAULT_LOCALE, Locale, TableStyle } from "../../src/types";
 import { target, toRangesData } from "./helpers";
 
 export const TEST_CHART_DATA = {
@@ -108,6 +108,7 @@ export const TEST_COMMANDS: CommandMapping = {
     type: "CREATE_TABLE",
     ranges: toRangesData("sheetId", "A1"),
     sheetId: "sheetId",
+    tableType: "static",
   },
   REMOVE_TABLE: {
     type: "REMOVE_TABLE",
@@ -421,4 +422,10 @@ export const CUSTOM_LOCALE: Locale = {
   dateFormat: "dd/mm/yyyy",
   timeFormat: "hh:mm:ss a",
   formulaArgSeparator: ";",
+};
+
+export const TABLE_STYLE_ALL_RED: TableStyle = {
+  category: "dark",
+  colorName: "Red",
+  wholeTable: { style: { fillColor: "#FF0000" }, border: { top: DEFAULT_BORDER_DESC } },
 };

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -29,7 +29,9 @@ import {
   toZone,
   zoneToXc,
 } from "../../src/helpers/index";
+import { createEmptyExcelWorkbookData } from "../../src/migrations/data";
 import { Model } from "../../src/model";
+import { BasePlugin } from "../../src/plugins/base_plugin";
 import { MergePlugin } from "../../src/plugins/core/merge";
 import { CorePluginConstructor } from "../../src/plugins/core_plugin";
 import { UIPluginConstructor } from "../../src/plugins/ui_plugin";
@@ -53,6 +55,7 @@ import {
   Currency,
   DEFAULT_LOCALES,
   EvaluatedCell,
+  ExcelWorkbookData,
   Format,
   GridRenderingContext,
   Highlight,
@@ -629,6 +632,17 @@ export async function exportPrettifiedXlsx(model: Model): Promise<XLSXExport> {
       return { ...file };
     }),
   };
+}
+
+export function getExportedExcelData(model: Model): ExcelWorkbookData {
+  model.dispatch("EVALUATE_CELLS");
+  let data = createEmptyExcelWorkbookData();
+  for (let handler of model["handlers"]) {
+    if (handler instanceof BasePlugin) {
+      handler.exportForExcel(data);
+    }
+  }
+  return data;
 }
 
 export function mockUuidV4To(model: Model, value: number | string) {

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -1,9 +1,7 @@
 import { functionRegistry } from "../../src/functions";
 import { buildSheetLink, toXC } from "../../src/helpers";
-import { createEmptyExcelWorkbookData } from "../../src/migrations/data";
 import { Model } from "../../src/model";
-import { BasePlugin } from "../../src/plugins/base_plugin";
-import { Dimension, ExcelWorkbookData, PLAIN_TEXT_FORMAT } from "../../src/types";
+import { Dimension, PLAIN_TEXT_FORMAT } from "../../src/types";
 import { XLSXExportXMLFile } from "../../src/types/xlsx";
 import { adaptFormulaToExcel } from "../../src/xlsx/functions/cells";
 import { escapeXml, parseXML } from "../../src/xlsx/helpers/xml_helpers";
@@ -23,18 +21,12 @@ import {
 } from "../test_helpers/commands_helpers";
 import { TEST_CHART_DATA } from "../test_helpers/constants";
 import { getCellContent } from "../test_helpers/getters_helpers";
-import { exportPrettifiedXlsx, mockChart, toRangesData } from "../test_helpers/helpers";
-
-function getExportedExcelData(model: Model): ExcelWorkbookData {
-  model.dispatch("EVALUATE_CELLS");
-  let data = createEmptyExcelWorkbookData();
-  for (let handler of model["handlers"]) {
-    if (handler instanceof BasePlugin) {
-      handler.exportForExcel(data);
-    }
-  }
-  return data;
-}
+import {
+  exportPrettifiedXlsx,
+  getExportedExcelData,
+  mockChart,
+  toRangesData,
+} from "../test_helpers/helpers";
 
 mockChart();
 


### PR DESCRIPTION
## [IMP] tables: introduce dynamic tables

This commit introduces the concept of dynamic table. A dynamic table
is a table that is bound to a array formula, instead of a static range.
The table will grow and shrink along the results of the array formula.

The notion is transparent to the user: if the users defines a table on
a single cell that contains an array formula, or all the cells of the
array formula, the table will be dynamic.

This means that the table zones are now an UI concept. The core plugin
now manages `InternalTable` objects, that can be either static or
dynamic (in which case they don't have a zone, but a single cell position).
The UI plugin `DynamicTablesPlugin` transform those `InternalTable` into
`Table` objects that every other plugin and component can easily use.

As the core plugin doesn't have access to the evaluation results, and
can't know if a cell contains an array formula, it's the responsability
of the components that create a table to determine if it's dynamic or not.

## [IMP] array formula: `getSpreadPositionsOf` now returns root position

Before this the getter `getSpreadPositionsOf` only returned the
position of the cells an array formula was spread to, minus the
cell the array formula was in. This made it impossible to differentiate
between a cell with a normal formula, and a cell with an array formula
returning a 1x1 matrix.

Now the getter returns the root position of the array formula as well.

There was also a bug where the spread relation weren't properly cleaned.


Task:  [3707037](https://www.odoo.com/web#id=3707037&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo