### PR TITLE
[FIX] highlight: fix highlight line width

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.ts
@@ -1,5 +1,5 @@
 import { Component, useRef } from "@odoo/owl";
-import { SECONDARY_COLOR } from "../../../../constants";
+import { HIGHLIGHT_COLOR } from "../../../../constants";
 import { colorNumberString } from "../../../../helpers";
 import { _t } from "../../../../translation";
 import { ConditionalFormat, Highlight, SpreadsheetChildEnv } from "../../../../types";
@@ -138,8 +138,8 @@ export class ConditionalFormatPreview extends Component<Props, SpreadsheetChildE
     return this.props.conditionalFormat.ranges.map((range) => ({
       sheetId,
       zone: this.env.model.getters.getRangeFromSheetXC(sheetId, range).zone,
-      color: SECONDARY_COLOR,
-      noFill: true,
+      color: HIGHLIGHT_COLOR,
+      fillAlpha: 0.06,
     }));
   }
 }

--- a/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
+++ b/src/components/side_panel/data_validation/dv_preview/dv_preview.ts
@@ -1,5 +1,5 @@
 import { Component, useRef } from "@odoo/owl";
-import { FIGURE_BORDER_COLOR, SECONDARY_COLOR } from "../../../../constants";
+import { FIGURE_BORDER_COLOR, HIGHLIGHT_COLOR } from "../../../../constants";
 import { dataValidationEvaluatorRegistry } from "../../../../registries/data_validation_registry";
 import { DataValidationRule, Highlight, SpreadsheetChildEnv } from "../../../../types";
 import { css } from "../../../helpers";
@@ -58,8 +58,8 @@ export class DataValidationPreview extends Component<Props, SpreadsheetChildEnv>
     return this.props.rule.ranges.map((range) => ({
       sheetId: this.env.model.getters.getActiveSheetId(),
       zone: range.zone,
-      color: SECONDARY_COLOR,
-      noFill: true,
+      color: HIGHLIGHT_COLOR,
+      fillAlpha: 0.06,
     }));
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import { BorderDescr, Color, Style } from "./types";
 export const CANVAS_SHIFT = 0.5;
 
 // Colors
-export const SECONDARY_COLOR = "#017E84";
+export const HIGHLIGHT_COLOR = "#37A850";
 export const BACKGROUND_GRAY_COLOR = "#f5f5f5";
 export const BACKGROUND_HEADER_COLOR = "#F8F9FA";
 export const BACKGROUND_HEADER_SELECTED_COLOR = "#E8EAED";
@@ -17,7 +17,7 @@ export const BACKGROUND_CHART_COLOR = "#FFFFFF";
 export const BG_HOVER_COLOR = "#EBEBEB";
 export const DISABLED_TEXT_COLOR = "#CACACA";
 export const DEFAULT_COLOR_SCALE_MIDPOINT_COLOR = 0xb6d7a8;
-export const LINK_COLOR = SECONDARY_COLOR;
+export const LINK_COLOR = "#017E84";
 export const FILTERS_COLOR = "#188038";
 export const BACKGROUND_HEADER_FILTER_COLOR = "#E6F4EA";
 export const BACKGROUND_HEADER_SELECTED_FILTER_COLOR = "#CEEAD6";

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -319,3 +319,7 @@ export function isSameColor(color1: Color, color2: Color, tolerance: number = 0)
   );
   return diff <= tolerance;
 }
+
+export function setColorAlpha(color: Color, alpha: number): string {
+  return alpha === 1 ? toHex(color).slice(0, 7) : rgbaToHex({ ...colorToRGBA(color), a: alpha });
+}

--- a/src/helpers/rendering.ts
+++ b/src/helpers/rendering.ts
@@ -1,4 +1,6 @@
+import { HIGHLIGHT_COLOR } from "../constants";
 import { GridRenderingContext, Highlight, Rect } from "../types";
+import { setColorAlpha } from "./color";
 
 export function drawHighlight(
   renderingContext: GridRenderingContext,
@@ -9,14 +11,16 @@ export function drawHighlight(
   if (width < 0 || height < 0) {
     return;
   }
+  const color = highlight.color || HIGHLIGHT_COLOR;
 
   const { ctx } = renderingContext;
-  ctx.strokeStyle = highlight.color;
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = color;
   /** + 0.5 offset to have sharp lines. See comment in {@link RendererPlugin#drawBorders} for more details */
   ctx.strokeRect(x + 0.5, y + 0.5, width, height);
   ctx.globalCompositeOperation = "source-over";
   if (!highlight.noFill) {
-    ctx.fillStyle = highlight.color! + "20";
+    ctx.fillStyle = setColorAlpha(color, highlight.fillAlpha ?? 0.12);
     ctx.fillRect(x, y, width, height);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,10 +37,10 @@ import {
   DEFAULT_CELL_WIDTH,
   HEADER_HEIGHT,
   HEADER_WIDTH,
+  HIGHLIGHT_COLOR,
   MIN_COL_WIDTH,
   MIN_ROW_HEIGHT,
   SCROLLBAR_WIDTH,
-  SECONDARY_COLOR,
   TOPBAR_HEIGHT,
 } from "./constants";
 import { isEvaluationError, toBoolean, toJsDate, toNumber, toString } from "./functions/helpers";
@@ -302,7 +302,7 @@ export function addFunction(functionName: string, functionDescription: AddFuncti
 
 export const constants = {
   DEFAULT_LOCALE,
-  SECONDARY_COLOR,
+  HIGHLIGHT_COLOR,
 };
 
 export type { EnrichedToken } from "./formulas/composer_tokenizer";

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -227,6 +227,8 @@ export interface Highlight {
   color: Color;
   interactive?: boolean;
   noFill?: boolean;
+  /** transparency of the fill color (0-1) */
+  fillAlpha?: number;
 }
 
 export interface PaneDivision {

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -1,7 +1,6 @@
 import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { ConditionalFormattingPanel } from "../../src/components/side_panel/conditional_formatting/conditional_formatting";
-import { SECONDARY_COLOR } from "../../src/constants";
 import { toZone } from "../../src/helpers";
 import { ConditionalFormatPlugin } from "../../src/plugins/core/conditional_format";
 import { CellIsRule, CommandResult, SpreadsheetChildEnv, UID } from "../../src/types";
@@ -207,9 +206,7 @@ describe("UI of conditional formats", () => {
     test("Ranges of hovered previews are highlighted", async () => {
       expect(getHighlightsFromStore(env)).toEqual([]);
       triggerMouseEvent(selectors.listPreview, "mouseenter");
-      expect(getHighlightsFromStore(env)).toMatchObject([
-        { zone: toZone("A1:A2"), color: SECONDARY_COLOR },
-      ]);
+      expect(getHighlightsFromStore(env)).toMatchObject([{ zone: toZone("A1:A2") }]);
       triggerMouseEvent(selectors.listPreview, "mouseleave");
       expect(getHighlightsFromStore(env)).toEqual([]);
     });

--- a/tests/data_validation/data_validation_preview_component.test.ts
+++ b/tests/data_validation/data_validation_preview_component.test.ts
@@ -1,7 +1,6 @@
 import { Component } from "@odoo/owl";
 import { Model } from "../../src";
 import { DataValidationPreview } from "../../src/components/side_panel/data_validation/dv_preview/dv_preview";
-import { SECONDARY_COLOR } from "../../src/constants";
 import { toZone } from "../../src/helpers";
 import { dataValidationEvaluatorRegistry } from "../../src/registries/data_validation_registry";
 import { DataValidationRuleData, DEFAULT_LOCALE, SpreadsheetChildEnv } from "../../src/types";
@@ -75,8 +74,8 @@ describe("Data validation preview", () => {
     expect(getHighlightsFromStore(env)).toEqual([]);
     triggerMouseEvent(".o-dv-preview", "mouseenter");
     expect(getHighlightsFromStore(env)).toMatchObject([
-      { zone: toZone("A1"), color: SECONDARY_COLOR },
-      { zone: toZone("A3"), color: SECONDARY_COLOR },
+      { zone: toZone("A1") },
+      { zone: toZone("A3") },
     ]);
     triggerMouseEvent(".o-dv-preview", "mouseleave");
     expect(getHighlightsFromStore(env)).toEqual([]);

--- a/tests/grid/highlight_store.test.ts
+++ b/tests/grid/highlight_store.test.ts
@@ -1,0 +1,101 @@
+import { Model } from "../../src";
+import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH, HIGHLIGHT_COLOR } from "../../src/constants";
+import { toZone } from "../../src/helpers";
+import { HighlightProvider, HighlightStore } from "../../src/stores/highlight_store";
+import { Highlight, UID } from "../../src/types";
+import { MockGridRenderingContext } from "../test_helpers/renderer_helpers";
+import { makeStoreWithModel } from "../test_helpers/stores";
+
+let highlightStore: HighlightStore;
+let ctx: MockGridRenderingContext;
+let ctxInstructions: string[];
+let model: Model;
+let sheetId: UID;
+
+function drawHighlight(highlight: Highlight) {
+  const provider: HighlightProvider = { highlights: [highlight] };
+  highlightStore.register(provider);
+  highlightStore.drawLayer(ctx, "Highlights");
+}
+
+describe("Highlight store", () => {
+  beforeEach(() => {
+    model = new Model();
+    sheetId = model.getters.getActiveSheetId();
+    ({ store: highlightStore } = makeStoreWithModel(model, HighlightStore));
+
+    ctxInstructions = [];
+    ctx = new MockGridRenderingContext(model, 1000, 1000, {
+      onSet: (key, value) => {
+        ctxInstructions.push(`context.${key}=${JSON.stringify(value)};`);
+      },
+      onFunctionCall: (key, args) => {
+        ctxInstructions.push(`context.${key}(${args.map((a) => JSON.stringify(a)).join(", ")})`);
+      },
+    });
+  });
+
+  test("Can add a highlight provider", () => {
+    const testHighlight = { zone: toZone("A1"), sheetId, color: "#FF0000" };
+    const provider: HighlightProvider = { highlights: [testHighlight] };
+    highlightStore.register(provider);
+
+    highlightStore.drawLayer(ctx, "Highlights");
+    expect(ctxInstructions).not.toHaveLength(0);
+  });
+
+  test("Can remove a highlight provider", () => {
+    const testHighlight = { zone: toZone("A1"), sheetId, color: "#FF0000" };
+    const provider: HighlightProvider = { highlights: [testHighlight] };
+    highlightStore.register(provider);
+
+    highlightStore.drawLayer(ctx, "Highlights");
+    expect(ctxInstructions).not.toHaveLength(0);
+    const length = ctxInstructions.length;
+
+    highlightStore.unRegister(provider);
+    highlightStore.drawLayer(ctx, "Highlights");
+    expect(ctxInstructions).toHaveLength(length);
+  });
+
+  test("Highlights are correctly drawn", () => {
+    const testHighlight = { zone: toZone("A1"), sheetId, color: HIGHLIGHT_COLOR };
+    drawHighlight(testHighlight);
+
+    expect(ctxInstructions).toContain(`context.strokeStyle="${HIGHLIGHT_COLOR}";`);
+    expect(ctxInstructions).toContain("context.lineWidth=2;");
+    // 0.5 offset for sharp lines (compensate 0.5 global offset of drawGridHook )
+    expect(ctxInstructions).toContain(
+      `context.strokeRect(0.5, 0.5, ${DEFAULT_CELL_WIDTH}, ${DEFAULT_CELL_HEIGHT})`
+    );
+    expect(ctxInstructions).toContain(`context.fillStyle="${HIGHLIGHT_COLOR}1F";`);
+    expect(ctxInstructions).toContain(
+      `context.fillRect(0, 0, ${DEFAULT_CELL_WIDTH}, ${DEFAULT_CELL_HEIGHT})`
+    );
+  });
+
+  test("Can change highlight color", () => {
+    const testHighlight = { zone: toZone("A1"), sheetId, color: "#FF0000" };
+    drawHighlight(testHighlight);
+
+    expect(ctxInstructions).toContain(`context.strokeStyle="#FF0000";`);
+    expect(ctxInstructions).toContain('context.fillStyle="#FF00001F";');
+  });
+
+  test("Can draw highlights without fill", () => {
+    const testHighlight = { zone: toZone("A1"), sheetId, color: "#FF0000", noFill: true };
+    drawHighlight(testHighlight);
+
+    expect(ctxInstructions).not.toContain('context.fillStyle="#FF00001F";');
+    expect(ctxInstructions).not.toContain(
+      `context.fillRect(0, 0, ${DEFAULT_CELL_WIDTH}, ${DEFAULT_CELL_HEIGHT})`
+    );
+  });
+
+  test("Can change highlights fill color transparency", () => {
+    const testHighlight = { zone: toZone("A1"), sheetId, color: "#FF0000", fillAlpha: 0.5 };
+    drawHighlight(testHighlight);
+
+    expect(ctxInstructions).toContain('context.fillStyle="#FF000080";');
+  });
+});


### PR DESCRIPTION
## Description

The highlight line width was not correctly set when drawing highlights on the canvas. This caused highlights to not be blurry and not aligned to the borders, since we were drawing with the wrong offset.

Also took the occasion to add tests for the rendering of highlights.

Task: : [3731988](https://www.odoo.com/web#id=3731988&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo