### PR TITLE
[FIX] GridComposer: Reset the cell reference visibility on stop edition

### DIFF
--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -184,7 +184,11 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private updateCellReferenceVisibility() {
-    if (this.isCellReferenceVisible || this.env.model.getters.getEditionMode() === "inactive") {
+    if (this.env.model.getters.getEditionMode() === "inactive") {
+      this.isCellReferenceVisible = false;
+      return;
+    }
+    if (this.isCellReferenceVisible) {
       return;
     }
     const sheetId = this.env.model.getters.getActiveSheetId();

--- a/tests/components/composer_integration.test.ts
+++ b/tests/components/composer_integration.test.ts
@@ -274,6 +274,23 @@ describe("Composer interactions", () => {
     expect(reference!.textContent).toBe("'My beautiful name'!A1");
   });
 
+  test("Stopping the edition resets the cell reference visibility", async () => {
+    await startComposition();
+    model.dispatch("SET_VIEWPORT_OFFSET", {
+      offsetX: 0,
+      offsetY: DEFAULT_CELL_HEIGHT * 5,
+    });
+    await nextTick();
+    const referenceSelector = ".o-grid div.o-cell-reference";
+    const reference = fixture.querySelector(referenceSelector);
+    expect(reference).not.toBeNull();
+    expect(reference!.textContent).toBe("A1");
+    await keyDown("Escape");
+    expect(fixture.querySelector(referenceSelector)).toBeNull();
+    await startComposition();
+    expect(fixture.querySelector(referenceSelector)).toBeNull();
+  });
+
   test("starting the edition with a key stroke =, the composer should have the focus after the key input", async () => {
     const composerEl = await startComposition("=");
     expect(composerEl.textContent).toBe("=");


### PR DESCRIPTION
Following the fix in PR #3456, the `GridComposer` is now a persistent component and one of its properties `isCellReferenceVisibility` did not account for this.

How to reproduce the bug:
- start editing a cell in the grid
- scroll the viewport such that the celle refecerence is visible above the composer
- stop the edition
- start editing another cell

-> the cell reference is already visible even though it should only appear when the composer box is  no longer aligned with the cell position in the viewport.

Task: 3736211

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo