### PR TITLE
[IMP] Find&Replace: support inverse iteration on search results

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -101,7 +101,7 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     if (ev.key === "Enter") {
       ev.preventDefault();
       ev.stopPropagation();
-      this.store.selectNextMatch();
+      ev.shiftKey ? this.store.selectPreviousMatch() : this.store.selectNextMatch();
     }
   }
 

--- a/tests/find_and_replace/find_replace_side_panel_component.test.ts
+++ b/tests/find_and_replace/find_replace_side_panel_component.test.ts
@@ -132,12 +132,24 @@ describe("find and replace sidePanel component", () => {
       expect(getSelectedMatchIndex()).toBe(2);
     });
 
-    test("Going to next with Enter key", async () => {
+    test("Going to the next match with Enter key", async () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "A2", "1");
       await inputSearchValue("1");
       expect(getSelectedMatchIndex()).toBe(1);
       await focusAndKeyDown(selectors.inputSearch, { key: "Enter" });
+      expect(getSelectedMatchIndex()).toBe(2);
+    });
+
+    test("Going to the previous match with Shift+Enter key", async () => {
+      setCellContent(model, "A1", "1");
+      setCellContent(model, "A2", "1");
+      setCellContent(model, "A3", "1");
+      await inputSearchValue("1");
+      expect(getSelectedMatchIndex()).toBe(1);
+      await focusAndKeyDown(selectors.inputSearch, { key: "Enter", shiftKey: true });
+      expect(getSelectedMatchIndex()).toBe(3);
+      await focusAndKeyDown(selectors.inputSearch, { key: "Enter", shiftKey: true });
       expect(getSelectedMatchIndex()).toBe(2);
     });
 


### PR DESCRIPTION
At the moment, the user can press `Enter` in the search input to iterate through results. In most serach related features, pressing shift inverts the iteration order.

We already support this behaviour with the `Enter` and `Tab` shortcuts when navigating through the grid.

This commit applies the same logid to the find&replace search input.

Task: 3736442

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo