### PR TITLE
[IMP] index: export ClipboardHandlers Classes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -339,3 +339,6 @@ export type {
   FPayload,
 } from "./types";
 export type { FunctionRegistry };
+
+export { AbstractCellClipboardHandler } from "./clipboard_handlers/abstract_cell_clipboard_handler";
+export { AbstractFigureClipboardHandler } from "./clipboard_handlers/abstract_figure_clipboard_handler";


### PR DESCRIPTION
## Description

With the new clipboard refactoring, we are now able to implement clipboard handlers to extend the o-spreadsheet clipboard behavior. Then, if one's wants to implement a new handler, it should be better to use the abstract classes as a base class for the handler, so this commit aims to export them.

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo