### PR TITLE
[FIX] selection_inputs_manager: arrow keys when broken ranges

### DIFF
--- a/src/plugins/ui_feature/selection_inputs_manager.ts
+++ b/src/plugins/ui_feature/selection_inputs_manager.ts
@@ -98,9 +98,9 @@ export class SelectionInputsManagerPlugin extends UIPlugin {
         break;
       case "FOCUS_RANGE":
       case "CHANGE_RANGE":
-        if (cmd.id !== this.focusedInputId) {
-          const input = this.inputs[cmd.id];
-          const range = input.ranges.find((range) => range.id === cmd.rangeId);
+        const input = this.inputs[cmd.id];
+        const range = input.ranges.find((range) => range.id === cmd.rangeId);
+        if (range) {
           const sheetId = this.getters.getActiveSheetId();
           const zone = this.getters.getRangeFromSheetXC(sheetId, range?.xc || "A1").zone;
           this.selection.capture(

--- a/tests/plugins/selection_input.test.ts
+++ b/tests/plugins/selection_input.test.ts
@@ -700,4 +700,19 @@ describe("selection input plugin", () => {
     expect(model.getters.getSelectionInput(id2)[1].xc).toBe("F2");
     expect(model.getters.getSelectionInput(id2)[1].isFocused).toBe(true);
   });
+
+  test("Selection anchor updates when focusing on a new range within the same SelectionInput component", async () => {
+    model.dispatch("ENABLE_NEW_SELECTION_INPUT", { id, initialRanges: ["TEST", "B2"] });
+    model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 0) });
+
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("TEST");
+    model.selection.moveAnchorCell("down");
+    expect(model.getters.getSelectionInput(id)[0].xc).toBe("TEST");
+
+    model.dispatch("FOCUS_RANGE", { id, rangeId: idOfRange(model, id, 1) });
+
+    expect(model.getters.getSelectionInput(id)[1].xc).toBe("B2");
+    model.selection.moveAnchorCell("down");
+    expect(model.getters.getSelectionInput(id)[1].xc).toBe("B3");
+  });
 });


### PR DESCRIPTION
## Description:

Previously, the arrow keys failed to function as expected when broken ranges were present in the selection input.

### Steps to reproduce:

From the side panel of a chart with a SelectionInput containing two ranges:
- Enter a valid range in the second input.
- Corrupt the first input by entering "A11wwwz".
- Press Enter to confirm.
- Reselect the first range.
- Attempt to use the keyboard arrows to change the zone; however, this does not work.
- Select the second input.
- Attempt to use the keyboard arrows to change the zone; again, this does not work.

To address this issue, the if statement in command handling from the plugin was removed to ensure it allows capturing the range.


Task: : [3626171](https://www.odoo.com/web#id=3626171&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo