### PR TITLE
[FIX] chart: fix scatter chart props in template

### DIFF
--- a/src/components/side_panel/chart/scatter_chart/scatter_chart_config_panel.xml
+++ b/src/components/side_panel/chart/scatter_chart/scatter_chart_config_panel.xml
@@ -2,12 +2,12 @@
   <t t-name="o-spreadsheet-ScatterConfigPanel">
     <div>
       <ChartDataSeries
-        ranges="() => this.getDataSeriesRanges()"
+        ranges="this.getDataSeriesRanges()"
         onSelectionChanged="(ranges) => this.onDataSeriesRangesChanged(ranges)"
         onSelectionConfirmed="() => this.onDataSeriesConfirmed()"
       />
       <ChartLabelRange
-        range="() => this.getLabelRange()"
+        range="this.getLabelRange()"
         isInvalid="isLabelInvalid"
         onSelectionChanged="(ranges) => this.onLabelRangeChanged(ranges)"
         onSelectionConfirmed="() => this.onLabelRangeConfirmed()"

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -8,7 +8,8 @@ import { PieChartDefinition, PieChartRuntime } from "./pie_chart";
 import { ScatterChartDefinition, ScatterChartRuntime } from "./scatter_chart";
 import { ScorecardChartDefinition, ScorecardChartRuntime } from "./scorecard_chart";
 
-export type ChartType = "line" | "bar" | "pie" | "scorecard" | "gauge" | "scatter";
+export const CHART_TYPES = ["line", "bar", "pie", "scorecard", "gauge", "scatter"] as const;
+export type ChartType = (typeof CHART_TYPES)[number];
 
 export type ChartDefinition =
   | LineChartDefinition


### PR DESCRIPTION
## Task Description

When switching a chart type to/from scatter plot, we currently get an error due to the fact we pass a lambda instead of an array to the props of the ChartDataSeries in the scatter chart config panel.

## Related Task

- Task: [3741540](https://www.odoo.com/web#id=3741540&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo