### PR TITLE
[FIX] locale: accept thousands separator

### DIFF
--- a/src/helpers/locale.ts
+++ b/src/helpers/locale.ts
@@ -157,7 +157,7 @@ export function canonicalizeNumberLiteral(content: string, locale: Locale): stri
   if (locale.decimalSeparator === "." || !isNumber(content, locale)) {
     return content;
   }
-  return content.replace(locale.decimalSeparator, ".");
+  return content.replace(locale.thousandsSeparator, "").replace(locale.decimalSeparator, ".");
 }
 
 /**

--- a/src/helpers/locale.ts
+++ b/src/helpers/locale.ts
@@ -36,6 +36,9 @@ export function isValidLocale(locale: any): locale is Locale {
   if (locale.formulaArgSeparator === locale.decimalSeparator) {
     return false;
   }
+  if (locale.thousandsSeparator === locale.decimalSeparator) {
+    return false;
+  }
 
   try {
     formatValue(1, { locale, format: "#,##0.00" });

--- a/tests/components/link/link_editor.test.ts
+++ b/tests/components/link/link_editor.test.ts
@@ -161,7 +161,12 @@ describe("link editor component", () => {
   });
 
   test("label is changed to canonical form in model", async () => {
-    updateLocale(model, { ...DEFAULT_LOCALE, formulaArgSeparator: ";", decimalSeparator: "," });
+    updateLocale(model, {
+      ...DEFAULT_LOCALE,
+      formulaArgSeparator: ";",
+      decimalSeparator: ",",
+      thousandsSeparator: " ",
+    });
     await openLinkEditor(model, "A1");
     setInputValueAndTrigger(labelInput(), "3,15", "input");
     setInputValueAndTrigger(urlInput(), "https://url.com", "input");

--- a/tests/functions/helper.test.ts
+++ b/tests/functions/helper.test.ts
@@ -345,4 +345,10 @@ describe("Locale helpers", () => {
       false
     );
   });
+
+  test("isValidLocale with identical thousands and decimal separators", () => {
+    const locale = { ...DEFAULT_LOCALE, thousandsSeparator: ".", decimalSeparator: "." };
+
+    expect(isValidLocale(locale)).toBe(false);
+  });
 });

--- a/tests/helpers/locale.test.ts
+++ b/tests/helpers/locale.test.ts
@@ -17,6 +17,10 @@ describe("Locale helpers", () => {
     test("Can canonicalize literal", () => {
       expect(canonicalizeContent("1", FR_LOCALE)).toBe("1");
       expect(canonicalizeContent("1,1", FR_LOCALE)).toBe("1.1");
+      expect(canonicalizeContent("1 000,1", FR_LOCALE)).toBe("1000.1");
+      expect(canonicalizeContent("1.000,1", { ...FR_LOCALE, thousandsSeparator: "." })).toBe(
+        "1000.1"
+      );
       expect(canonicalizeContent(",1", FR_LOCALE)).toBe(".1");
       expect(canonicalizeContent("1,", FR_LOCALE)).toBe("1.");
       expect(canonicalizeContent("1,1%", FR_LOCALE)).toBe("1.1%");

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -1921,7 +1921,12 @@ describe("clipboard: pasting outside of sheet", () => {
 
   test("Can paste localized formula from the OS", () => {
     const model = new Model();
-    updateLocale(model, { ...DEFAULT_LOCALE, decimalSeparator: ",", formulaArgSeparator: ";" });
+    updateLocale(model, {
+      ...DEFAULT_LOCALE,
+      decimalSeparator: ",",
+      formulaArgSeparator: ";",
+      thousandsSeparator: " ",
+    });
     pasteFromOSClipboard(model, "A1", "=SUM(5 ; 3,14)");
     expect(getCell(model, "A1")?.content).toBe("=SUM(5 , 3.14)");
     expect(getEvaluatedCell(model, "A1").value).toBe(8.14);

--- a/tests/plugins/edition.test.ts
+++ b/tests/plugins/edition.test.ts
@@ -1131,7 +1131,12 @@ describe("edition", () => {
         editCell(model, "A1", "=SUM(B2;5)");
         expect(getEvaluatedCell(model, "A1").type).toBe(CellValueType.error);
 
-        updateLocale(model, { ...DEFAULT_LOCALE, formulaArgSeparator: ";", decimalSeparator: "," });
+        updateLocale(model, {
+          ...DEFAULT_LOCALE,
+          formulaArgSeparator: ";",
+          decimalSeparator: ",",
+          thousandsSeparator: " ",
+        });
         editCell(model, "A1", "=SUM(B2,5)");
         expect(getEvaluatedCell(model, "A1").type).toBe(CellValueType.error);
         editCell(model, "A1", "=SUM(B2;5)");
@@ -1141,6 +1146,7 @@ describe("edition", () => {
       test("Decimal numbers as function argument", () => {
         updateLocale(model, {
           ...DEFAULT_LOCALE,
+          thousandsSeparator: " ",
           decimalSeparator: ",",
           formulaArgSeparator: ";",
         });

--- a/tests/plugins/find_and_replace.test.ts
+++ b/tests/plugins/find_and_replace.test.ts
@@ -653,7 +653,12 @@ describe("replace", () => {
 
   test("Replaced value is changed to canonical form in model", () => {
     searchOptions.searchFormulas = true;
-    updateLocale(model, { ...DEFAULT_LOCALE, decimalSeparator: ",", formulaArgSeparator: ";" });
+    updateLocale(model, {
+      ...DEFAULT_LOCALE,
+      decimalSeparator: ",",
+      formulaArgSeparator: ";",
+      thousandsSeparator: " ",
+    });
     model.dispatch("UPDATE_SEARCH", { toSearch: "2", searchOptions });
     model.dispatch("REPLACE_SEARCH", { replaceWith: "4,5" });
     const matches = model.getters.getSearchMatches();

--- a/tests/plugins/split_to_column.test.ts
+++ b/tests/plugins/split_to_column.test.ts
@@ -107,7 +107,12 @@ describe("Split text into columns", () => {
   });
 
   test("Localized split values are handled", () => {
-    updateLocale(model, { ...DEFAULT_LOCALE, decimalSeparator: ",", formulaArgSeparator: ";" });
+    updateLocale(model, {
+      ...DEFAULT_LOCALE,
+      decimalSeparator: ",",
+      formulaArgSeparator: ";",
+      thousandsSeparator: " ",
+    });
     setGrid(model, { A1: "5,6||=SUM(5; 1,6)" });
     splitTextToColumns(model, "||", "A1");
     expect(getGrid(model)).toEqual({ A1: 5.6, B1: 6.6 });


### PR DESCRIPTION
Set your locale to FR,type in a cell "1 000,45"
=> the cell is not recognized as a number.

(In odoo), set your locale to Français (BE), type in a cell "1.000,45" => the content is transformed to 1.000.45

opw 3720586
Task: 3720586

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3720586](https://www.odoo.com/web#id=3720586&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo