### PR TITLE
[FIX] FigureComponent: Undo/Redo broken after pasting figure

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -1,4 +1,4 @@
-import { Component, useEffect, useRef } from "@odoo/owl";
+import { Component, onWillUnmount, useEffect, useRef } from "@odoo/owl";
 import {
   ComponentsImportance,
   FIGURE_BORDER_COLOR,
@@ -165,6 +165,10 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
       },
       () => [this.env.model.getters.getSelectedFigureId(), this.props.figure.id, this.figureRef.el]
     );
+
+    onWillUnmount(() => {
+      this.props.onFigureDeleted();
+    });
   }
 
   clickAnchor(dirX: ResizeDirection, dirY: ResizeDirection, ev: MouseEvent) {
@@ -186,6 +190,7 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
         });
         this.props.onFigureDeleted();
         ev.preventDefault();
+        ev.stopPropagation();
         break;
       case "ArrowDown":
       case "ArrowLeft":
@@ -205,6 +210,7 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
           y: figure.y + delta[1],
         });
         ev.preventDefault();
+        ev.stopPropagation();
         break;
     }
   }

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -7,7 +7,7 @@
         t-ref="figure"
         t-att-style="props.style"
         tabindex="0"
-        t-on-keydown.stop="(ev) => this.onKeyDown(ev)"
+        t-on-keydown="(ev) => this.onKeyDown(ev)"
         t-on-keyup.stop="">
         <t
           t-component="figureRegistry.get(props.figure.tag).Component"

--- a/src/plugins/ui/selection.ts
+++ b/src/plugins/ui/selection.ts
@@ -324,6 +324,7 @@ export class GridSelectionPlugin extends UIPlugin {
           this.gridSelection.anchor.zone
         );
         this.setSelectionMixin(this.gridSelection.anchor, this.gridSelection.zones);
+        this.selectedFigureId = null;
         break;
     }
     /** Any change to the selection has to be  reflected in the selection processor. */

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -5,16 +5,20 @@ import { toHex, toZone } from "../../src/helpers";
 import { ChartDefinition } from "../../src/types";
 import { BarChartDefinition } from "../../src/types/chart/bar_chart";
 import { LineChartDefinition } from "../../src/types/chart/line_chart";
+import { getCellContent } from "../test_helpers";
 import {
+  copy,
   createChart,
   createGaugeChart,
   createScorecardChart,
   createSheet,
   paste,
+  setCellContent,
   setStyle,
   updateChart,
 } from "../test_helpers/commands_helpers";
 import {
+  keyDown,
   setInputValueAndTrigger,
   simulateClick,
   triggerMouseEvent,
@@ -1306,6 +1310,32 @@ describe("figures", () => {
         "A1",
       ]);
     });
+  });
+
+  test("Can undo multiple times after pasting figure", async () => {
+    setCellContent(model, "D6", "HELLO");
+    createTestChart("gauge");
+    await nextTick();
+    parent.env.model.dispatch("SELECT_FIGURE", { id: chartId });
+    await nextTick();
+
+    copy(model);
+    await simulateClick(".o-grid-overlay", 0, 0);
+    paste(model, "A1");
+    await nextTick();
+
+    await keyDown("z", { ctrlKey: true });
+    expect(model.getters.getChartIds(sheetId)).toHaveLength(1);
+
+    await keyDown("y", { ctrlKey: true });
+    expect(model.getters.getChartIds(sheetId)).toHaveLength(2);
+
+    await keyDown("z", { ctrlKey: true });
+    await keyDown("z", { ctrlKey: true });
+    expect(model.getters.getChartIds(sheetId)).toHaveLength(0);
+
+    await keyDown("z", { ctrlKey: true });
+    expect(getCellContent(model, "D6")).toEqual("");
   });
 });
 

--- a/tests/plugins/selection.test.ts
+++ b/tests/plugins/selection.test.ts
@@ -533,6 +533,26 @@ describe("simple selection", () => {
     moveAnchorCell(model, "up");
     expect(model.getters.getSelectedZone()).toEqual(toZone("A1:B2"));
   });
+
+  test("Selecting figure and undo cleanup selectedFigureId in selection plugin", () => {
+    const model = new Model();
+    model.dispatch("CREATE_FIGURE", {
+      sheetId: model.getters.getActiveSheetId(),
+      figure: {
+        id: "someuuid",
+        x: 10,
+        y: 10,
+        tag: "hey",
+        width: 100,
+        height: 100,
+      },
+    });
+    expect(model.getters.getSelectedFigureId()).toBe(null);
+    model.dispatch("SELECT_FIGURE", { id: "someuuid" });
+    expect(model.getters.getSelectedFigureId()).toBe("someuuid");
+    undo(model);
+    expect(model.getters.getSelectedFigureId()).toBe(null);
+  });
 });
 
 describe("multiple selections", () => {


### PR DESCRIPTION
## Description:

Previously, the Undo/Redo functionality was broken after pasting a figure. This occurred because the focus remained on the pasted figure rather than on the grid or composer, where the key events for Undo/Redo are handled.

This commit resolves the issue by handling the key events directly on the figure component itself. With this change, Undo/Redo operations now work as expected even after pasting a figure.

Task: : [3659930](https://www.odoo.com/web#id=3659930&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo