### PR TITLE
Convert the compilationParameter to an object

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -2,7 +2,7 @@ import { Token } from ".";
 import { functionRegistry } from "../functions/index";
 import { concat, parseNumber, removeStringQuotes } from "../helpers";
 import { _t } from "../translation";
-import { CompiledFormula, DEFAULT_LOCALE } from "../types";
+import { CompiledFormula, DEFAULT_LOCALE, FormulaToExecute } from "../types";
 import { BadExpressionError, UnknownFunctionError } from "../types/errors";
 import { FunctionCode, FunctionCodeBuilder, Scope } from "./code_builder";
 import { AST, ASTFuncall, parseTokens } from "./parser";
@@ -44,8 +44,7 @@ type InternalCompiledFormula = CompiledFormula & {
 // example, "=2*sum(A1:A4)" and "=2*sum(B1:B4)" are compiled into the same
 // structural function.
 // It is only exported for testing purposes
-export const functionCache: { [key: string]: Omit<CompiledFormula, "dependencies" | "tokens"> } =
-  {};
+export const functionCache: { [key: string]: FormulaToExecute } = {};
 
 // -----------------------------------------------------------------------------
 // COMPILER
@@ -82,10 +81,9 @@ export function compileTokens(tokens: Token[]): CompiledFormula {
       code.toString()
     );
 
-    functionCache[cacheKey] = {
-      // @ts-ignore
-      execute: baseFunction,
-    };
+    // @ts-ignore
+    functionCache[cacheKey] = baseFunction;
+
     /**
      * This function compile the function arguments. It is mostly straightforward,
      * except that there is a non trivial transformation in one situation:
@@ -228,7 +226,7 @@ export function compileTokens(tokens: Token[]): CompiledFormula {
     }
   }
   const compiledFormula: InternalCompiledFormula = {
-    execute: functionCache[cacheKey].execute,
+    execute: functionCache[cacheKey],
     dependencies,
     constantValues,
     tokens,

--- a/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
@@ -15,7 +15,11 @@ import {
 } from "../../../types";
 import { EvaluationError, InvalidReferenceError } from "../../../types/errors";
 
-export type CompilationParameters = [ReferenceDenormalizer, EnsureRange, EvalContext];
+export type CompilationParameters = {
+  referenceDenormalizer: ReferenceDenormalizer;
+  ensureRange: EnsureRange;
+  evalContext: EvalContext;
+};
 const functionMap = functionRegistry.mapping;
 
 /**
@@ -50,7 +54,11 @@ class CompilationParametersBuilder {
   }
 
   getParameters(): CompilationParameters {
-    return [this.refFn.bind(this), this.range.bind(this), this.evalContext];
+    return {
+      referenceDenormalizer: this.refFn.bind(this),
+      ensureRange: this.range.bind(this),
+      evalContext: this.evalContext,
+    };
   }
 
   /**

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -35,7 +35,6 @@ export type PositionId = bigint;
 const MAX_ITERATION = 30;
 const ERROR_CYCLE_CELL = createEvaluatedCell(new CircularDependencyError());
 const EMPTY_CELL = createEvaluatedCell({ value: null });
-const EVAL_CONTEXT_INDEX = 2;
 
 export class Evaluator {
   private readonly getters: Getters;
@@ -109,9 +108,8 @@ export class Evaluator {
       this.getters,
       this.computeAndSave.bind(this)
     );
-    this.compilationParams[EVAL_CONTEXT_INDEX].updateDependencies =
-      this.updateDependencies.bind(this);
-    this.compilationParams[EVAL_CONTEXT_INDEX].addDependencies = this.addDependencies.bind(this);
+    this.compilationParams.evalContext.updateDependencies = this.updateDependencies.bind(this);
+    this.compilationParams.evalContext.addDependencies = this.addDependencies.bind(this);
   }
 
   evaluateCells(positions: CellPosition[]) {
@@ -569,14 +567,19 @@ export function updateEvalContextAndExecute(
   sheetId: UID,
   cellId?: UID
 ) {
-  compilationParams[EVAL_CONTEXT_INDEX].__originCellXC = lazy(() => {
+  compilationParams.evalContext.__originCellXC = lazy(() => {
     if (!cellId) {
       return undefined;
     }
     // compute the value lazily for performance reasons
-    const position = compilationParams[EVAL_CONTEXT_INDEX].getters.getCellPosition(cellId);
+    const position = compilationParams.evalContext.getters.getCellPosition(cellId);
     return toXC(position.col, position.row);
   });
-  compilationParams[EVAL_CONTEXT_INDEX].__originSheetId = sheetId;
-  return compiledFormula.execute(compiledFormula.dependencies, ...compilationParams);
+  compilationParams.evalContext.__originSheetId = sheetId;
+  return compiledFormula.execute(
+    compiledFormula.dependencies,
+    compilationParams.referenceDenormalizer,
+    compilationParams.ensureRange,
+    compilationParams.evalContext
+  );
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -161,7 +161,7 @@ export type ReferenceDenormalizer = (
 
 export type EnsureRange = (range: Range) => Matrix<FPayload>;
 
-type _CompiledFormula = (
+export type FormulaToExecute = (
   deps: Range[],
   refFn: ReferenceDenormalizer,
   range: EnsureRange,
@@ -169,7 +169,7 @@ type _CompiledFormula = (
 ) => Matrix<FPayload> | FPayload;
 
 export interface CompiledFormula {
-  execute: _CompiledFormula;
+  execute: FormulaToExecute;
   tokens: Token[];
   dependencies: string[];
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -161,7 +161,7 @@ export type ReferenceDenormalizer = (
 
 export type EnsureRange = (range: Range) => Matrix<FPayload>;
 
-export type _CompiledFormula = (
+type _CompiledFormula = (
   deps: Range[],
   refFn: ReferenceDenormalizer,
   range: EnsureRange,


### PR DESCRIPTION
## Description:

Convert the compilationParameter to an object

Task: [3725622](https://www.odoo.com/web#id=3725622&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo