### PR TITLE
[FIX] Find&Replace: Do not reset the search when iterating through se…

### DIFF
--- a/src/plugins/ui_feature/find_and_replace.ts
+++ b/src/plugins/ui_feature/find_and_replace.ts
@@ -289,6 +289,8 @@ export class FindAndReplacePlugin extends UIPlugin {
         sheetIdFrom: this.getters.getActiveSheetId(),
         sheetIdTo: selectedMatch.sheetId,
       });
+      // We do not want to reset the selection at finalize in this case
+      this.isSearchDirty = false;
     }
     // we want grid selection to capture the selection stream
     this.selection.getBackToDefault();

--- a/tests/find_and_replace/find_and_replace_plugin.test.ts
+++ b/tests/find_and_replace/find_and_replace_plugin.test.ts
@@ -480,6 +480,18 @@ describe("next/previous cycle", () => {
       match(sheetId1, "A3"),
     ]);
   });
+
+  test("Selecting previous match will select the last match of the previous sheet", () => {
+    createSheet(model, { sheetId: "s2" });
+    setCellContent(model, "A1", "1", "s2");
+    setCellContent(model, "Z26", "1", "s2");
+    updateSearch(model, "1");
+    expect(model.getters.getActiveSheetId()).toBe("s1");
+    expect(getActivePosition(model)).toBe("A1");
+    model.dispatch("SELECT_SEARCH_PREVIOUS_MATCH");
+    expect(model.getters.getActiveSheetId()).toBe("s2");
+    expect(getActivePosition(model)).toBe("Z26");
+  });
 });
 
 describe("next/previous with single match", () => {


### PR DESCRIPTION
…arch results

Since the introduction of Multi-sheet find & replace, going to the next/previous result could invalidate the search when the next result was on another sheet. As a side effect, iterating backwards did not work properly and the search index would jump to the first result of the previous sheet instead of the last one.

Task: 3743879

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo