### PR TITLE
[IMP] components: add optional title on checkboxes

### DIFF
--- a/src/components/side_panel/components/checkbox/checkbox.ts
+++ b/src/components/side_panel/components/checkbox/checkbox.ts
@@ -7,6 +7,7 @@ interface Props {
   value: boolean;
   className?: string;
   name?: string;
+  title?: string;
   onChange: (value: boolean) => void;
 }
 
@@ -27,6 +28,7 @@ export class Checkbox extends Component<Props, SpreadsheetChildEnv> {
     value: { type: Boolean, optional: true },
     className: { type: String, optional: true },
     name: { type: String, optional: true },
+    title: { type: String, optional: true },
     onChange: Function,
   };
   static defaultProps = { value: false };

--- a/src/components/side_panel/components/checkbox/checkbox.xml
+++ b/src/components/side_panel/components/checkbox/checkbox.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet.Checkbox">
-    <label class="o-checkbox">
+    <label class="o-checkbox" t-att-title="props.title">
       <input
         type="checkbox"
         t-att-name="props.name"

--- a/tests/side_panels/components/checkbox.test.ts
+++ b/tests/side_panels/components/checkbox.test.ts
@@ -43,6 +43,11 @@ describe("Checkbox", () => {
 
   test("Can render a checkbox with a name", async () => {
     await mountCheckbox({ value: true, onChange: () => {}, name: "My name" });
-    expect(fixture.querySelector("input")!.getAttribute("name")).toEqual("My name");
+    expect(fixture.querySelector("input")?.getAttribute("name")).toEqual("My name");
+  });
+
+  test("Can render a checkbox with a title", async () => {
+    await mountCheckbox({ value: true, onChange: () => {}, title: "my title" });
+    expect(fixture.querySelector("label")?.getAttribute("title")).toEqual("my title");
   });
 });


### PR DESCRIPTION

## Description:

In odoo, we'll have a checkbox ("Defer updates" of pivot, which might use a title to explain why the checkbox exists)

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo