### PR TITLE
[FIX] components: use pointer events

### DIFF
--- a/src/components/autofill/autofill.xml
+++ b/src/components/autofill/autofill.xml
@@ -4,7 +4,7 @@
     <div
       class="o-autofill-handler"
       t-att-style="handlerStyle"
-      t-on-mousedown="onMouseDown"
+      t-on-pointerdown="onMouseDown"
       t-on-dblclick="onDblClick"
     />
     <t t-set="tooltip" t-value="getTooltip()"/>

--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.xml
@@ -3,7 +3,7 @@
     <Ripple>
       <div
         class="o-sheet d-flex align-items-center user-select-none text-nowrap "
-        t-on-mousedown="(ev) => this.onMouseDown(ev)"
+        t-on-pointerdown="(ev) => this.onMouseDown(ev)"
         t-on-contextmenu.prevent="(ev) => this.onContextMenu(ev)"
         t-ref="sheetDiv"
         t-att-style="props.style"

--- a/src/components/color_picker/color_picker.xml
+++ b/src/components/color_picker/color_picker.xml
@@ -52,13 +52,13 @@
           <div
             class="o-gradient"
             t-on-click.stop=""
-            t-on-mousedown="dragGradientPointer"
+            t-on-pointerdown="dragGradientPointer"
             t-att-style="gradientHueStyle">
             <div class="saturation w-100 h-100 position-absolute pe-none"/>
             <div class="lightness w-100 h-100 position-absolute pe-none"/>
             <div class="magnifier pe-none" t-att-style="pointerStyle"/>
           </div>
-          <div class="o-hue-container" t-on-mousedown="dragHuePointer">
+          <div class="o-hue-container" t-on-pointerdown="dragHuePointer">
             <div class="o-hue-picker" t-on-click.stop=""/>
             <div class="o-hue-slider pe-none" t-att-style="sliderStyle">
               <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>

--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown.xml
@@ -9,7 +9,7 @@
           class="d-flex flex-column text-start"
           t-att-class="{'o-autocomplete-value-focus': props.selectedIndex === v_index}"
           t-on-click="() => this.props.onValueSelected(v.text)"
-          t-on-mousemove="() => this.props.onValueHovered(v_index)">
+          t-on-pointermove="() => this.props.onValueHovered(v_index)">
           <div class="o-autocomplete-value text-truncate">
             <t t-set="htmlContent" t-value="props.getHtmlContent(v.text)"/>
             <span

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -12,7 +12,7 @@
         t-on-keydown="onKeydown"
         t-on-mousewheel.stop=""
         t-on-input="onInput"
-        t-on-mousedown="onMousedown"
+        t-on-pointerdown="onMousedown"
         t-on-click="onClick"
         t-on-keyup="onKeyup"
         t-on-paste="onPaste"
@@ -26,9 +26,9 @@
         class="o-composer-assistant shadow"
         t-att-style="assistantStyle"
         t-on-wheel.stop=""
-        t-on-mousedown.prevent.stop=""
+        t-on-pointerdown.prevent.stop=""
         t-on-click.prevent.stop=""
-        t-on-mouseup.prevent.stop="">
+        t-on-pointerup.prevent.stop="">
         <TextValueProvider
           t-if="autoCompleteState.showProvider"
           values="autoCompleteState.values"

--- a/src/components/composer/formula_assistant/formula_assistant.xml
+++ b/src/components/composer/formula_assistant/formula_assistant.xml
@@ -10,7 +10,7 @@
       <div
         class="o-formula-assistant bg-white"
         t-if="context.functionName"
-        t-on-mousemove="onMouseMove"
+        t-on-pointermove="onMouseMove"
         t-att-class="{'opacity-25': assistantState.allowCellSelectionBehind}">
         <div class="o-formula-assistant-head">
           <span t-esc="context.functionName"/>

--- a/src/components/figures/figure/figure.xml
+++ b/src/components/figures/figure/figure.xml
@@ -3,7 +3,7 @@
     <div class="o-figure-wrapper pe-auto" t-att-style="wrapperStyle">
       <div
         class="o-figure w-100 h-100"
-        t-on-mousedown.stop="(ev) => this.onMouseDown(ev)"
+        t-on-pointerdown.stop="(ev) => this.onMouseDown(ev)"
         t-on-contextmenu.prevent.stop="(ev) => !env.model.getters.isReadonly() and this.onContextMenu(ev)"
         t-ref="figure"
         t-att-style="props.style"
@@ -39,42 +39,42 @@
         <div
           class="o-fig-anchor o-top"
           t-att-style="this.getResizerPosition('top')"
-          t-on-mousedown="(ev) => this.clickAnchor(0,-1, ev)"
+          t-on-pointerdown="(ev) => this.clickAnchor(0,-1, ev)"
         />
         <div
           class="o-fig-anchor o-topRight"
           t-att-style="this.getResizerPosition('top right')"
-          t-on-mousedown="(ev) => this.clickAnchor(1,-1, ev)"
+          t-on-pointerdown="(ev) => this.clickAnchor(1,-1, ev)"
         />
         <div
           class="o-fig-anchor o-right"
           t-att-style="this.getResizerPosition('right')"
-          t-on-mousedown="(ev) => this.clickAnchor(1,0, ev)"
+          t-on-pointerdown="(ev) => this.clickAnchor(1,0, ev)"
         />
         <div
           class="o-fig-anchor o-bottomRight"
           t-att-style="this.getResizerPosition('bottom right')"
-          t-on-mousedown="(ev) => this.clickAnchor(1,1, ev)"
+          t-on-pointerdown="(ev) => this.clickAnchor(1,1, ev)"
         />
         <div
           class="o-fig-anchor o-bottom"
           t-att-style="this.getResizerPosition('bottom')"
-          t-on-mousedown="(ev) => this.clickAnchor(0,1, ev)"
+          t-on-pointerdown="(ev) => this.clickAnchor(0,1, ev)"
         />
         <div
           class="o-fig-anchor o-bottomLeft"
           t-att-style="this.getResizerPosition('bottom left')"
-          t-on-mousedown="(ev) => this.clickAnchor(-1,1, ev)"
+          t-on-pointerdown="(ev) => this.clickAnchor(-1,1, ev)"
         />
         <div
           class="o-fig-anchor o-left"
           t-att-style="this.getResizerPosition('left')"
-          t-on-mousedown="(ev) => this.clickAnchor(-1,0, ev)"
+          t-on-pointerdown="(ev) => this.clickAnchor(-1,0, ev)"
         />
         <div
           class="o-fig-anchor o-topLeft"
           t-att-style="this.getResizerPosition('top left')"
-          t-on-mousedown="(ev) => this.clickAnchor(-1,-1, ev)"
+          t-on-pointerdown="(ev) => this.clickAnchor(-1,-1, ev)"
         />
       </t>
     </div>

--- a/src/components/filters/filter_menu_item/filter_menu_value_item.xml
+++ b/src/components/filters/filter_menu_item/filter_menu_value_item.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-FilterMenuValueItem">
     <div
       t-on-click="this.props.onClick"
-      t-on-mousemove="this.props.onMouseMove"
+      t-on-pointermove="this.props.onMouseMove"
       class="o-filter-menu-item o-filter-menu-value"
       t-ref="menuValueItem"
       t-att-class="{'selected': this.props.isSelected}">

--- a/src/components/grid_add_rows_footer/grid_add_rows_footer.xml
+++ b/src/components/grid_add_rows_footer/grid_add_rows_footer.xml
@@ -3,7 +3,7 @@
     <div
       class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center"
       t-att-style="addRowsPosition"
-      t-on-mousedown.stop.prevent="">
+      t-on-pointerdown.stop.prevent="">
       <button t-on-click="onConfirm" t-att-disabled="state.errorFlag" class="o-button">Add</button>
       <input
         type="text"
@@ -12,7 +12,7 @@
         value="100"
         t-on-click.stop=""
         t-on-keydown.stop="onKeydown"
-        t-on-mousedown.stop=""
+        t-on-pointerdown.stop=""
         t-on-input.stop="onInput"
       />
       <span>more rows at the bottom</span>

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -89,10 +89,10 @@ function useCellHovered(
     }
   }
 
-  useRefListener(gridRef, "mousemove", updateMousePosition);
+  useRefListener(gridRef, "pointermove", updateMousePosition);
   useRefListener(gridRef, "mouseleave", onMouseLeave);
   useRefListener(gridRef, "mouseenter", resume);
-  useRefListener(gridRef, "mousedown", recompute);
+  useRefListener(gridRef, "pointerdown", recompute);
 
   useExternalListener(window, "click", handleGlobalClick);
   function handleGlobalClick(e: MouseEvent) {

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -5,7 +5,7 @@
       class="o-grid-overlay overflow-hidden"
       t-att-class="{'o-paint-format-cursor': isPaintingFormat}"
       t-att-style="style"
-      t-on-mousedown="onMouseDown"
+      t-on-pointerdown="onMouseDown"
       t-on-dblclick.self="onDoubleClick"
       t-on-contextmenu.stop.prevent="onContextMenu">
       <FiguresContainer onFigureDeleted="props.onFigureDeleted"/>

--- a/src/components/headers_overlay/headers_overlay.xml
+++ b/src/components/headers_overlay/headers_overlay.xml
@@ -3,18 +3,18 @@
     <div class="o-overlay">
       <ColResizer onOpenContextMenu="props.onOpenContextMenu"/>
       <RowResizer onOpenContextMenu="props.onOpenContextMenu"/>
-      <div class="all" t-on-mousedown.self="selectAll"/>
+      <div class="all" t-on-pointerdown.self="selectAll"/>
     </div>
   </t>
 
   <t t-name="o-spreadsheet-RowResizer">
     <div
       class="o-row-resizer"
-      t-on-mousemove.self="onMouseMove"
+      t-on-pointermove.self="onMouseMove"
       t-on-mouseleave="onMouseLeave"
-      t-on-mousedown.self.prevent="select"
+      t-on-pointerdown.self.prevent="select"
       t-ref="rowResizer"
-      t-on-mouseup.self="onMouseUp"
+      t-on-pointerup.self="onMouseUp"
       t-on-contextmenu.self="onContextMenu"
       t-att-class="{'o-grab': state.waitingForMove, 'o-dragging': state.isMoving}">
       <div
@@ -30,7 +30,7 @@
       <t t-if="state.resizerIsActive">
         <div
           class="o-handle"
-          t-on-mousedown="onMouseDown"
+          t-on-pointerdown="onMouseDown"
           t-on-dblclick="onDblClick"
           t-on-contextmenu.prevent=""
           t-attf-style="top:{{state.draggerLinePosition - 2}}px;">
@@ -69,11 +69,11 @@
   <t t-name="o-spreadsheet-ColResizer">
     <div
       class="o-col-resizer"
-      t-on-mousemove.self="onMouseMove"
+      t-on-pointermove.self="onMouseMove"
       t-on-mouseleave="onMouseLeave"
-      t-on-mousedown.self.prevent="select"
+      t-on-pointerdown.self.prevent="select"
       t-ref="colResizer"
-      t-on-mouseup.self="onMouseUp"
+      t-on-pointerup.self="onMouseUp"
       t-on-contextmenu.self="onContextMenu"
       t-att-class="{'o-grab': state.waitingForMove, 'o-dragging': state.isMoving, }">
       <div
@@ -89,7 +89,7 @@
       <t t-if="state.resizerIsActive">
         <div
           class="o-handle"
-          t-on-mousedown="onMouseDown"
+          t-on-pointerdown="onMouseDown"
           t-on-dblclick="onDblClick"
           t-on-contextmenu.prevent=""
           t-attf-style="left:{{state.draggerLinePosition - 2}}px;">

--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -12,19 +12,19 @@ export function startDnd(
   const _onMouseUp = (ev: MouseEvent) => {
     onMouseUp(ev);
 
-    window.removeEventListener("mousedown", onMouseDown);
-    window.removeEventListener("mouseup", _onMouseUp);
+    window.removeEventListener("pointerdown", onMouseDown);
+    window.removeEventListener("pointerup", _onMouseUp);
     window.removeEventListener("dragstart", _onDragStart);
-    window.removeEventListener("mousemove", onMouseMove);
+    window.removeEventListener("pointermove", onMouseMove);
     window.removeEventListener("wheel", onMouseMove);
   };
   function _onDragStart(ev: DragEvent) {
     ev.preventDefault();
   }
-  window.addEventListener("mousedown", onMouseDown);
-  window.addEventListener("mouseup", _onMouseUp);
+  window.addEventListener("pointerdown", onMouseDown);
+  window.addEventListener("pointerup", _onMouseUp);
   window.addEventListener("dragstart", _onDragStart);
-  window.addEventListener("mousemove", onMouseMove);
+  window.addEventListener("pointermove", onMouseMove);
   // mouse wheel on window is by default a passive event.
   // preventDefault() is not allowed in passive event handler.
   // https://chromestatus.com/feature/6662647093133312
@@ -32,13 +32,13 @@ export function startDnd(
 }
 
 /**
- * Function to be used during a mousedown event, this function allows to
- * perform actions related to the mousemove and mouseup events and adjusts the viewport
- * when the new position related to the mousemove event is outside of it.
+ * Function to be used during a pointerdown event, this function allows to
+ * perform actions related to the pointermove and pointerup events and adjusts the viewport
+ * when the new position related to the pointermove event is outside of it.
  * Among inputs are two callback functions. First intended for actions performed during
- * the mousemove event, it receives as parameters the current position of the mousemove
+ * the pointermove event, it receives as parameters the current position of the pointermove
  * (occurrence of the current column and the current row). Second intended for actions
- * performed during the mouseup event.
+ * performed during the pointerup event.
  */
 export function dragAndDropBeyondTheViewport(
   env: SpreadsheetChildEnv,

--- a/src/components/helpers/drag_and_drop_hook.ts
+++ b/src/components/helpers/drag_and_drop_hook.ts
@@ -127,7 +127,7 @@ class DOMDndHelper {
   private onDragEnd: (itemId: UID, indexAtEnd: number) => void;
 
   /**
-   * The dead zone is an area in which the mousemove events are ignored.
+   * The dead zone is an area in which the pointermove events are ignored.
    *
    * This is useful when swapping the dragged item with a larger item. After the swap,
    * the mouse is still hovering on the item  we just swapped with. In this case, we don't want
@@ -182,7 +182,7 @@ class DOMDndHelper {
   }
 
   onMouseMove(ev: MouseEvent) {
-    if (ev.button !== 0) {
+    if (ev.button !== -1) {
       this.onCancel();
       return;
     }

--- a/src/components/highlight/border/border.xml
+++ b/src/components/highlight/border/border.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-Border">
     <div
       class="o-border"
-      t-on-mousedown.prevent="onMouseDown"
+      t-on-pointerdown.prevent="onMouseDown"
       t-att-style="style"
       t-att-class="{
           'o-moving': props.isMoving,

--- a/src/components/highlight/corner/corner.xml
+++ b/src/components/highlight/corner/corner.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-Corner">
     <div
       class="o-corner"
-      t-on-mousedown.prevent="onMouseDown"
+      t-on-pointerdown.prevent="onMouseDown"
       t-att-style="style"
       t-att-class="{
           'o-resizing': props.isResizing,

--- a/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
+++ b/src/components/side_panel/conditional_formatting/cf_preview/cf_preview.xml
@@ -7,7 +7,7 @@
       t-att-class="props.class"
       t-att-data-id="cf.id"
       t-on-click="props.onPreviewClick"
-      t-on-mousedown="(ev) => this.onMouseDown(ev)">
+      t-on-pointerdown="(ev) => this.onMouseDown(ev)">
       <div class="position-relative h-100 w-100 d-flex align-items-center">
         <div class="o-cf-drag-handle h-100 position-absolute d-flex align-items-center text-muted">
           <t t-call="o-spreadsheet-Icon.THIN_DRAG_HANDLE"/>

--- a/src/components/side_panel/select_menu/select_menu.xml
+++ b/src/components/side_panel/select_menu/select_menu.xml
@@ -3,7 +3,7 @@
     <select
       t-att-class="props.class"
       t-ref="select"
-      t-on-mousedown.stop.prevent=""
+      t-on-pointerdown.stop.prevent=""
       t-on-click="onClick">
       <option selected="true" t-esc="props.selectedValue"/>
     </select>

--- a/tests/autofill/autofill_component.test.ts
+++ b/tests/autofill/autofill_component.test.ts
@@ -28,17 +28,17 @@ describe("Autofill component", () => {
   test("Can drag and drop autofill on columns", async () => {
     const dispatch = spyDispatch(parent);
     const autofill = fixture.querySelector(".o-autofill-handler");
-    triggerMouseEvent(autofill, "mousedown", 4, 4);
+    triggerMouseEvent(autofill, "pointerdown", 4, 4);
     await nextTick();
     triggerMouseEvent(
       autofill,
-      "mousemove",
+      "pointermove",
       model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start + 10,
       model.getters.getRowDimensions(model.getters.getActiveSheetId(), 1)!.end + 10
     );
     await nextTick();
     expect(dispatch).toHaveBeenCalledWith("AUTOFILL_SELECT", { col: 0, row: 2 });
-    triggerMouseEvent(autofill, "mouseup");
+    triggerMouseEvent(autofill, "pointerup");
     await nextTick();
     expect(dispatch).toHaveBeenCalledWith("AUTOFILL");
   });
@@ -46,17 +46,17 @@ describe("Autofill component", () => {
   test("Can drag and drop autofill on rows", async () => {
     const dispatch = spyDispatch(parent);
     const autofill = fixture.querySelector(".o-autofill-handler");
-    triggerMouseEvent(autofill, "mousedown", 4, 4);
+    triggerMouseEvent(autofill, "pointerdown", 4, 4);
     await nextTick();
     triggerMouseEvent(
       autofill,
-      "mousemove",
+      "pointermove",
       model.getters.getColDimensions(model.getters.getActiveSheetId(), 1)!.end + 10,
       model.getters.getRowDimensions(model.getters.getActiveSheetId(), 0)!.start + 10
     );
     await nextTick();
     expect(dispatch).toHaveBeenCalledWith("AUTOFILL_SELECT", { col: 2, row: 0 });
-    triggerMouseEvent(autofill, "mouseup");
+    triggerMouseEvent(autofill, "pointerup");
     await nextTick();
     expect(dispatch).toHaveBeenCalledWith("AUTOFILL");
   });
@@ -74,13 +74,13 @@ describe("Autofill component", () => {
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
     setCellContent(model, "A1", "test");
     await nextTick();
-    triggerMouseEvent(autofill, "mousedown", 40, 40);
+    triggerMouseEvent(autofill, "pointerdown", 40, 40);
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
     const sheetId = model.getters.getActiveSheetId();
     const x = HEADER_WIDTH + model.getters.getColDimensions(sheetId, 1)!.end + 20;
     const y = model.getters.getRowDimensions(sheetId, 0)!.start + 20;
-    triggerMouseEvent(autofill, "mousemove", x, y);
+    triggerMouseEvent(autofill, "pointermove", x, y);
     await nextTick();
     expect(fixture.querySelector(".o-autofill")).not.toBeNull();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toMatchInlineSnapshot(`
@@ -100,7 +100,7 @@ describe("Autofill component", () => {
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
     setCellContent(model, "A1", "test");
     await nextTick();
-    triggerMouseEvent(autofill, "mousedown", 40, 40);
+    triggerMouseEvent(autofill, "pointerdown", 40, 40);
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
     const sheetId = model.getters.getActiveSheetId();
@@ -129,13 +129,13 @@ describe("Autofill component", () => {
     await clickCell(model, "F22");
     await nextTick();
     expect(fixture.querySelector(".o-autofill")).not.toBeNull();
-    triggerMouseEvent(autofill, "mousedown", 40, 40);
+    triggerMouseEvent(autofill, "pointerdown", 40, 40);
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
     const sheetId = model.getters.getActiveSheetId();
     const x = HEADER_WIDTH + model.getters.getColDimensions(sheetId, 1)!.end + 20;
     const y = model.getters.getRowDimensions(sheetId, 0)!.start + 20;
-    triggerMouseEvent(autofill, "mousemove", x, y);
+    triggerMouseEvent(autofill, "pointermove", x, y);
     await nextTick();
     expect(fixture.querySelector(".o-autofill")).not.toBeNull();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toMatchInlineSnapshot(`
@@ -155,11 +155,11 @@ describe("Autofill component", () => {
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
     setCellContent(model, "A1", "test");
     await nextTick();
-    triggerMouseEvent(autofill, "mousedown", 4, 4);
+    triggerMouseEvent(autofill, "pointerdown", 4, 4);
     await nextTick();
     triggerMouseEvent(
       autofill,
-      "mousemove",
+      "pointermove",
       HEADER_WIDTH +
         model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start +
         10,
@@ -175,11 +175,11 @@ describe("Autofill component", () => {
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
     setCellContent(model, "A1", "test");
     await nextTick();
-    triggerMouseEvent(autofill, "mousedown", 4, 4);
+    triggerMouseEvent(autofill, "pointerdown", 4, 4);
     await nextTick();
     triggerMouseEvent(
       autofill,
-      "mousemove",
+      "pointermove",
       HEADER_WIDTH +
         model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start +
         10,
@@ -189,14 +189,14 @@ describe("Autofill component", () => {
     expect(fixture.querySelector(".o-autofill-nextvalue")).not.toBeNull();
     triggerMouseEvent(
       autofill,
-      "mousemove",
+      "pointermove",
       HEADER_WIDTH +
         model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start +
         10,
       model.getters.getRowDimensions(model.getters.getActiveSheetId(), 0)!.start + 10
     );
     await nextTick();
-    triggerMouseEvent(autofill, "mouseup");
+    triggerMouseEvent(autofill, "pointerup");
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
   });
@@ -217,11 +217,11 @@ describe("Autofill component", () => {
     });
     setCellContent(model, "A1", "test");
     await nextTick();
-    triggerMouseEvent(autofill, "mousedown", 4, 4);
+    triggerMouseEvent(autofill, "pointerdown", 4, 4);
     await nextTick();
     triggerMouseEvent(
       autofill,
-      "mousemove",
+      "pointermove",
       HEADER_WIDTH +
         model.getters.getColDimensions(model.getters.getActiveSheetId(), 0)!.start +
         10,
@@ -239,22 +239,22 @@ describe("Autofill component", () => {
     parent.model.dispatch("SET_VIEWPORT_OFFSET", { offsetX: 400, offsetY: 400 });
     const firstViewport = parent.model.getters.getActiveMainViewport();
     const autofill = fixture.querySelector(".o-autofill");
-    triggerMouseEvent(autofill, "mousedown", 4, 4);
+    triggerMouseEvent(autofill, "pointerdown", 4, 4);
     await nextTick();
     const newX =
       HEADER_WIDTH +
       parent.model.getters.getColDimensions(parent.model.getters.getActiveSheetId(), 0)!.start +
       2 * DEFAULT_CELL_WIDTH;
-    triggerMouseEvent(autofill, "mousemove", newX, HEADER_HEIGHT + 4);
+    triggerMouseEvent(autofill, "pointermove", newX, HEADER_HEIGHT + 4);
     await nextTick();
-    triggerMouseEvent(autofill, "mouseup", newX, HEADER_HEIGHT + 4);
+    triggerMouseEvent(autofill, "pointerup", newX, HEADER_HEIGHT + 4);
     await nextTick();
     expect(firstViewport).toMatchObject(parent.model.getters.getActiveMainViewport());
   });
 
   test("Autofill is not loaded when the grid selection does not have the focus", async () => {
     const autofill = fixture.querySelector(".o-autofill");
-    triggerMouseEvent(autofill, "mousedown", 4, 4);
+    triggerMouseEvent(autofill, "pointerdown", 4, 4);
     await nextTick();
     expect(fixture.querySelector(".o-autofill")).not.toBeNull();
     // force composer to capture the selection
@@ -277,12 +277,12 @@ describe("Autofill edge scrolling", () => {
     const { width, height } = model.getters.getSheetViewDimension();
     const y = height / 2;
     const autofill = fixture.querySelector(".o-autofill-handler");
-    triggerMouseEvent(autofill, "mousedown", width / 2, y);
-    triggerMouseEvent(autofill, "mousemove", 1.5 * width, y);
+    triggerMouseEvent(autofill, "pointerdown", width / 2, y);
+    triggerMouseEvent(autofill, "pointermove", 1.5 * width, y);
     const advanceTimer = edgeScrollDelay(0.5 * width, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(autofill, "mouseup", 1.5 * width, y);
+    triggerMouseEvent(autofill, "pointerup", 1.5 * width, y);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 6,
       right: 16,
@@ -290,12 +290,12 @@ describe("Autofill edge scrolling", () => {
       bottom: 42,
     });
 
-    triggerMouseEvent(autofill, "mousedown", width / 2, y);
-    triggerMouseEvent(autofill, "mousemove", -0.5 * width, y);
+    triggerMouseEvent(autofill, "pointerdown", width / 2, y);
+    triggerMouseEvent(autofill, "pointermove", -0.5 * width, y);
     const advanceTimer2 = edgeScrollDelay(0.5 * width, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(autofill, "mouseup", -0.5 * width, y);
+    triggerMouseEvent(autofill, "pointerup", -0.5 * width, y);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 3,
@@ -309,12 +309,12 @@ describe("Autofill edge scrolling", () => {
     const { width, height } = model.getters.getSheetViewDimensionWithHeaders();
     const x = width / 2;
     const autofill = fixture.querySelector(".o-autofill-handler");
-    triggerMouseEvent(autofill, "mousedown", x, height / 2);
-    triggerMouseEvent(autofill, "mousemove", x, 1.5 * height);
+    triggerMouseEvent(autofill, "pointerdown", x, height / 2);
+    triggerMouseEvent(autofill, "pointermove", x, 1.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * height, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(autofill, "mouseup", x, 1.5 * height);
+    triggerMouseEvent(autofill, "pointerup", x, 1.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,
@@ -323,12 +323,12 @@ describe("Autofill edge scrolling", () => {
       bottom: 48,
     });
 
-    triggerMouseEvent(autofill, "mousedown", x, height / 2);
-    triggerMouseEvent(autofill, "mousemove", x, -0.5 * height);
+    triggerMouseEvent(autofill, "pointerdown", x, height / 2);
+    triggerMouseEvent(autofill, "pointermove", x, -0.5 * height);
     const advanceTimer2 = edgeScrollDelay(0.5 * height, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(autofill, "mouseup", x, -0.5 * height);
+    triggerMouseEvent(autofill, "pointerup", x, -0.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,
@@ -344,8 +344,8 @@ describe("Autofill edge scrolling", () => {
     const { width } = model.getters.getSheetViewDimensionWithHeaders();
     const autofill = fixture.querySelector(".o-autofill-handler");
 
-    triggerMouseEvent(autofill, "mousedown", width / 2, 0);
-    triggerMouseEvent(autofill, "mousemove", width * 1.5, 0);
+    triggerMouseEvent(autofill, "pointerdown", width / 2, 0);
+    triggerMouseEvent(autofill, "pointermove", width * 1.5, 0);
     const advanceTimer = edgeScrollDelay(width / 2, 5);
     jest.advanceTimersByTime(advanceTimer);
     await nextTick(); // now the cursor is out of the sheet
@@ -354,13 +354,13 @@ describe("Autofill edge scrolling", () => {
     expect(tooltipElement.textContent).toBe("test");
     expect(isVisibleInViewport(tooltipElement, model)).toBeFalsy();
 
-    triggerMouseEvent(autofill, "mousemove", width / 2, 0);
+    triggerMouseEvent(autofill, "pointermove", width / 2, 0);
     const advanceTimer2 = edgeScrollDelay(width / 2, 5);
     jest.advanceTimersByTime(advanceTimer2);
     await nextTick();
     expect(isVisibleInViewport(tooltipElement, model)).toBeTruthy();
 
-    triggerMouseEvent(autofill, "mouseup", width / 2, 0);
+    triggerMouseEvent(autofill, "pointerup", width / 2, 0);
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
   });
@@ -371,8 +371,8 @@ describe("Autofill edge scrolling", () => {
     const { height } = model.getters.getSheetViewDimensionWithHeaders();
     const autofill = fixture.querySelector(".o-autofill-handler");
 
-    triggerMouseEvent(autofill, "mousedown", 0, height / 2);
-    triggerMouseEvent(autofill, "mousemove", 0, height * 1.5);
+    triggerMouseEvent(autofill, "pointerdown", 0, height / 2);
+    triggerMouseEvent(autofill, "pointermove", 0, height * 1.5);
     const advanceTimer = edgeScrollDelay(height / 2, 5);
     jest.advanceTimersByTime(advanceTimer);
     await nextTick(); // now the cursor is out of the viewport
@@ -382,7 +382,7 @@ describe("Autofill edge scrolling", () => {
     expect(tooltipElement.textContent).toBe("test");
     expect(isVisibleInViewport(tooltipElement, model)).toBeFalsy();
 
-    triggerMouseEvent(autofill, "mousemove", 0, height / 2);
+    triggerMouseEvent(autofill, "pointermove", 0, height / 2);
     /**
      * We have a time out when dragging
      * (see line 162 in `drag_and_drop.ts`)
@@ -393,7 +393,7 @@ describe("Autofill edge scrolling", () => {
     await nextTick();
     expect(isVisibleInViewport(tooltipElement, model)).toBeTruthy();
 
-    triggerMouseEvent(autofill, "mouseup", 0, height / 2);
+    triggerMouseEvent(autofill, "pointerup", 0, height / 2);
     await nextTick();
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
   });

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -110,7 +110,7 @@ describe("BottomBar component", () => {
     const model = new Model({ sheets: [{ id: "Sheet1" }, { id: "Sheet2" }] });
     await mountBottomBar(model);
     const dispatch = jest.spyOn(model, "dispatch");
-    triggerMouseEvent(`.o-sheet[data-id="Sheet2"]`, "mousedown");
+    triggerMouseEvent(`.o-sheet[data-id="Sheet2"]`, "pointerdown");
     expect(dispatch).toHaveBeenCalledWith("ACTIVATE_SHEET", {
       sheetIdFrom: "Sheet1",
       sheetIdTo: "Sheet2",
@@ -716,7 +716,7 @@ describe("BottomBar component", () => {
       sheetList.scrollLeft = 120;
       sheetList.dispatchEvent(new Event("scroll")); // JSDOm don't trigger scroll event when the scrollLeft is changed...
 
-      triggerMouseEvent(document, "mouseup");
+      triggerMouseEvent(document, "pointerup");
       const sheetIds = model.getters.getVisibleSheetIds();
       expect(sheetIds).toEqual(["Sheet2", "Sheet1", "Sheet3", "Sheet4"]);
     });
@@ -736,7 +736,7 @@ describe("BottomBar component", () => {
       const sheetList = fixture.querySelector(".o-sheet-list")!;
       sheetList.dispatchEvent(new Event("scroll")); // JSDOm don't trigger scroll event when the scrollLeft is changed...
 
-      triggerMouseEvent(document, "mouseup");
+      triggerMouseEvent(document, "pointerup");
       const sheetIds = model.getters.getVisibleSheetIds();
       expect(sheetIds[sheetIds.length - 1]).toEqual("Sheet1");
     });
@@ -756,7 +756,7 @@ describe("BottomBar component", () => {
       const sheetList = fixture.querySelector(".o-sheet-list")!;
       sheetList.dispatchEvent(new Event("scroll")); // JSDOm don't trigger scroll event when the scrollLeft is changed...
 
-      triggerMouseEvent(document, "mouseup");
+      triggerMouseEvent(document, "pointerup");
       expect(model.getters.getVisibleSheetIds()[0]).toEqual("Sheet10");
     });
 
@@ -770,18 +770,18 @@ describe("BottomBar component", () => {
         },
       });
 
-      triggerMouseEvent('.o-sheet[data-id="Sheet1"]', "mousedown");
-      triggerMouseEvent('.o-sheet[data-id="Sheet1"]', "mousemove", 0, 0);
+      triggerMouseEvent('.o-sheet[data-id="Sheet1"]', "pointerdown");
+      triggerMouseEvent('.o-sheet[data-id="Sheet1"]', "pointermove", 0, 0);
       await nextTick();
       expect(getElComputedStyle('.o-sheet[data-id="Sheet1"]', "left")).toBe("0px");
       expect(getElComputedStyle('.o-sheet[data-id="Sheet2"]', "left")).toBe("0px");
 
-      triggerMouseEvent('.o-sheet[data-id="Sheet1"]', "mousemove", 100, 0);
+      triggerMouseEvent('.o-sheet[data-id="Sheet1"]', "pointermove", 100, 0);
       await nextTick();
       expect(getElComputedStyle(".o-sheet[data-id=Sheet1]", "left")).toBe("100px");
       expect(getElComputedStyle(".o-sheet[data-id=Sheet2]", "left")).toBe("-99px"); // -99 because we do a -1 to take the negative margin into account
 
-      triggerMouseEvent('.o-sheet[data-id="Sheet1"]', "mousemove", 150, 0); // 150 is the position of the mouse not the move offset
+      triggerMouseEvent('.o-sheet[data-id="Sheet1"]', "pointermove", 150, 0); // 150 is the position of the mouse not the move offset
       await nextTick();
       expect(getElComputedStyle(".o-sheet[data-id=Sheet1]", "left")).toBe("150px");
       expect(getElComputedStyle(".o-sheet[data-id=Sheet2]", "left")).toBe("-99px");

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -246,12 +246,12 @@ describe("Functions autocomplete", () => {
       const entries = fixture.querySelectorAll(".o-autocomplete-value");
       const firstEntry = entries[0];
       const secondEntry = entries[1];
-      triggerMouseEvent(secondEntry, "mousemove");
+      triggerMouseEvent(secondEntry, "pointermove");
       await nextTick();
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent
       ).toBe("SZZ");
-      triggerMouseEvent(firstEntry, "mousemove");
+      triggerMouseEvent(firstEntry, "pointermove");
       await nextTick();
       expect(
         fixture.querySelector(".o-autocomplete-value-focus .o-autocomplete-value")!.textContent

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -215,9 +215,9 @@ describe("Composer interactions", () => {
 
   test("=+Click range, the range ref should be colored", async () => {
     const composerEl = await typeInComposerGrid("=");
-    gridMouseEvent(model, "mousedown", "C8");
-    gridMouseEvent(model, "mousemove", "B8");
-    gridMouseEvent(model, "mouseup", "B8");
+    gridMouseEvent(model, "pointerdown", "C8");
+    gridMouseEvent(model, "pointermove", "B8");
+    gridMouseEvent(model, "pointerup", "B8");
     await nextTick();
     expect(composerEl.textContent).toBe("=B8:C8");
     expect(cehMock.colors["B8:C8"]).toBe(colors[0]);

--- a/tests/data_filter/filter_menu_component.test.ts
+++ b/tests/data_filter/filter_menu_component.test.ts
@@ -138,7 +138,7 @@ describe("Filter menu component", () => {
       const listItems = fixture.querySelectorAll(".o-filter-menu-value");
       expect(listItems[0].classList.contains("selected")).toBeFalsy();
 
-      listItems[0].dispatchEvent(new Event("mousemove", { bubbles: true }));
+      listItems[0].dispatchEvent(new Event("pointermove", { bubbles: true }));
       await nextTick();
       expect(listItems[0].classList.contains("selected")).toBeTruthy();
     });

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -375,9 +375,9 @@ describe("figures", () => {
         await nextTick();
         const figureEl = fixture.querySelector(".o-figure")!;
 
-        triggerMouseEvent(figureEl, "mousedown");
+        triggerMouseEvent(figureEl, "pointerdown");
         triggerWheelEvent(figureEl, { deltaY: wheelY, deltaX: wheelX });
-        triggerMouseEvent(figureEl, "mouseup");
+        triggerMouseEvent(figureEl, "pointerup");
         await nextTick();
 
         expect(model.getters.getFigure(model.getters.getActiveSheetId(), "someuuid")).toMatchObject(
@@ -400,7 +400,7 @@ describe("figures", () => {
     expect(document.activeElement).not.toBe(figure);
     expect(fixture.querySelector(".o-fig-anchor")).toBeNull();
 
-    triggerMouseEvent(figure, "mousedown", 300, 200);
+    triggerMouseEvent(figure, "pointerdown", 300, 200);
     await nextTick();
     expect(figure.classList).not.toContain("o-dragging");
   });
@@ -628,7 +628,7 @@ describe("figures", () => {
   test("Clicking a figure does not mark it a 'dragging'", async () => {
     createFigure(model);
     await nextTick();
-    triggerMouseEvent(".o-figure", "mousedown", 0, 0);
+    triggerMouseEvent(".o-figure", "pointerdown", 0, 0);
     await nextTick();
     expect(fixture.querySelector(".o-figure")?.classList.contains("o-dragging")).toBeFalsy();
   });
@@ -846,7 +846,7 @@ describe("figures", () => {
         expect(fixture.querySelectorAll(".o-figure-snap-line")).toHaveLength(0);
         await dragElement(".o-figure[data-id=f1]", { x: 50, y: 50 }, undefined, false);
         expect(fixture.querySelectorAll(".o-figure-snap-line")).toHaveLength(2);
-        triggerMouseEvent(".o-figure[data-id=f1]", "mouseup");
+        triggerMouseEvent(".o-figure[data-id=f1]", "pointerup");
         await nextTick();
         expect(fixture.querySelectorAll(".o-figure-snap-line")).toHaveLength(0);
       });

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -826,14 +826,14 @@ describe("Grid component", () => {
       selectCell(model, "B2");
       setStyle(model, "B2", { bold: true });
       model.dispatch("ACTIVATE_PAINT_FORMAT", { persistent: false });
-      gridMouseEvent(model, "mousedown", "C8");
+      gridMouseEvent(model, "pointerdown", "C8");
       expect(getCell(model, "C8")).toBeUndefined();
-      gridMouseEvent(model, "mouseup", "C8");
+      gridMouseEvent(model, "pointerup", "C8");
       expect(getCell(model, "C8")!.style).toEqual({ bold: true });
 
-      gridMouseEvent(model, "mousedown", "D8");
+      gridMouseEvent(model, "pointerdown", "D8");
       expect(getCell(model, "D8")).toBeUndefined();
-      gridMouseEvent(model, "mouseup", "D8");
+      gridMouseEvent(model, "pointerup", "D8");
       expect(getCell(model, "D8")).toBeUndefined();
     });
 
@@ -842,14 +842,14 @@ describe("Grid component", () => {
       selectCell(model, "B2");
       setStyle(model, "B2", { bold: true });
       model.dispatch("ACTIVATE_PAINT_FORMAT", { persistent: true });
-      gridMouseEvent(model, "mousedown", "C8");
+      gridMouseEvent(model, "pointerdown", "C8");
       expect(getCell(model, "C8")).toBeUndefined();
-      gridMouseEvent(model, "mouseup", "C8");
+      gridMouseEvent(model, "pointerup", "C8");
       expect(getCell(model, "C8")!.style).toEqual({ bold: true });
 
-      gridMouseEvent(model, "mousedown", "D8");
+      gridMouseEvent(model, "pointerdown", "D8");
       expect(getCell(model, "D8")).toBeUndefined();
-      gridMouseEvent(model, "mouseup", "D8");
+      gridMouseEvent(model, "pointerup", "D8");
       expect(getCell(model, "D8")!.style).toEqual({ bold: true });
     });
 
@@ -869,9 +869,9 @@ describe("Grid component", () => {
       setStyle(model, "B2", { bold: true });
       model.dispatch("ACTIVATE_PAINT_FORMAT", { persistent: false });
       keyDown({ key: "Escape" });
-      gridMouseEvent(model, "mousedown", "C8");
+      gridMouseEvent(model, "pointerdown", "C8");
       expect(getCell(model, "C8")).toBeUndefined();
-      gridMouseEvent(model, "mouseup", "C8");
+      gridMouseEvent(model, "pointerup", "C8");
       expect(getCell(model, "C8")).toBeUndefined();
     });
 
@@ -882,9 +882,9 @@ describe("Grid component", () => {
       model.dispatch("ACTIVATE_PAINT_FORMAT", { persistent: true });
       setStyle(model, "B2", { bold: false });
 
-      gridMouseEvent(model, "mousedown", "D8");
+      gridMouseEvent(model, "pointerdown", "D8");
       expect(getCell(model, "D8")).toBeUndefined();
-      gridMouseEvent(model, "mouseup", "D8");
+      gridMouseEvent(model, "pointerup", "D8");
       expect(getCell(model, "D8")!.style).toEqual({ bold: true });
     });
   });
@@ -1266,12 +1266,12 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
   test("Can edge-scroll horizontally", async () => {
     const { width, height } = model.getters.getSheetViewDimension();
     const y = height / 2;
-    triggerMouseEvent(".o-grid-overlay", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-grid-overlay", "mousemove", 1.5 * width, y);
+    triggerMouseEvent(".o-grid-overlay", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-grid-overlay", "pointermove", 1.5 * width, y);
     const advanceTimer = edgeScrollDelay(0.5 * width, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-grid-overlay", "mouseup", 1.5 * width, y);
+    triggerMouseEvent(".o-grid-overlay", "pointerup", 1.5 * width, y);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 6,
@@ -1280,12 +1280,12 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
       bottom: 42,
     });
 
-    triggerMouseEvent(".o-grid-overlay", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-grid-overlay", "mousemove", -0.5 * width, y);
+    triggerMouseEvent(".o-grid-overlay", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-grid-overlay", "pointermove", -0.5 * width, y);
     const advanceTimer2 = edgeScrollDelay(0.5 * width, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(".o-grid-overlay", "mouseup", -0.5 * width, y);
+    triggerMouseEvent(".o-grid-overlay", "pointerup", -0.5 * width, y);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 3,
@@ -1298,12 +1298,12 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
   test("Can edge-scroll vertically", async () => {
     const { width, height } = model.getters.getSheetViewDimensionWithHeaders();
     const x = width / 2;
-    triggerMouseEvent(".o-grid-overlay", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-grid-overlay", "mousemove", x, 1.5 * height);
+    triggerMouseEvent(".o-grid-overlay", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-grid-overlay", "pointermove", x, 1.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * height, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-grid-overlay", "mouseup", x, 1.5 * height);
+    triggerMouseEvent(".o-grid-overlay", "pointerup", x, 1.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,
@@ -1312,12 +1312,12 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
       bottom: 48,
     });
 
-    triggerMouseEvent(".o-grid-overlay", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-grid-overlay", "mousemove", x, -0.5 * height);
+    triggerMouseEvent(".o-grid-overlay", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-grid-overlay", "pointermove", x, -0.5 * height);
     const advanceTimer2 = edgeScrollDelay(0.5 * height, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(".o-grid-overlay", "mouseup", x, -0.5 * height);
+    triggerMouseEvent(".o-grid-overlay", "pointerup", x, -0.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,

--- a/tests/grid/grid_drag_and_drop_component.test.ts
+++ b/tests/grid/grid_drag_and_drop_component.test.ts
@@ -29,7 +29,7 @@ let sheetId: UID;
 
 //Test Component required
 const TEMPLATE = xml/* xml */ `
-  <div class="o-fake-grid" t-on-mousedown="onMouseDown">
+  <div class="o-fake-grid" t-on-pointerdown="onMouseDown">
     <t t-esc='"coucou"'/>
   </div>
 `;
@@ -89,12 +89,12 @@ describe("Drag And Drop horizontal tests", () => {
     const { height } = model.getters.getSheetViewDimension();
     const { x: offsetCorrectionX } = model.getters.getMainViewportCoordinates();
     const x = offsetCorrectionX + DEFAULT_CELL_WIDTH;
-    triggerMouseEvent(".o-fake-grid", "mousedown", x, 0.5 * height);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 0.5 * offsetCorrectionX, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", x, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 0.5 * offsetCorrectionX, 0.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * offsetCorrectionX, 1);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 0.5 * offsetCorrectionX, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 0.5 * offsetCorrectionX, 0.5 * height);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 8,
       right: 14,
@@ -112,9 +112,9 @@ describe("Drag And Drop horizontal tests", () => {
     const { height } = model.getters.getSheetViewDimension();
     const { x: offsetCorrectionX } = model.getters.getMainViewportCoordinates();
     const x = offsetCorrectionX + DEFAULT_CELL_WIDTH;
-    triggerMouseEvent(".o-fake-grid", "mousedown", 0.5 * offsetCorrectionX, 0.5 * height);
-    triggerMouseEvent(".o-fake-grid", "mousemove", x, 0.5 * height);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 0.5 * offsetCorrectionX, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", 0.5 * offsetCorrectionX, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointermove", x, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 0.5 * offsetCorrectionX, 0.5 * height);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 4,
       right: 10,
@@ -129,12 +129,12 @@ describe("Drag And Drop horizontal tests", () => {
       right: 10,
     });
     const { width, height } = model.getters.getSheetViewDimension();
-    triggerMouseEvent(".o-fake-grid", "mousedown", width, 0.5 * height);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 1.5 * width, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", width, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 1.5 * width, 0.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * width, 4);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 1.5 * width, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 1.5 * width, 0.5 * height);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 9,
       right: 15,
@@ -150,12 +150,12 @@ describe("Drag And Drop horizontal tests", () => {
     });
     const { width, height } = model.getters.getSheetViewDimension();
     const { x: offsetCorrectionX } = model.getters.getMainViewportCoordinates();
-    triggerMouseEvent(".o-fake-grid", "mousedown", 0.5 * offsetCorrectionX, 0.5 * height);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 1.5 * width, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", 0.5 * offsetCorrectionX, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 1.5 * width, 0.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * width, 4);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 1.5 * width, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 1.5 * width, 0.5 * height);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 9,
       right: 15,
@@ -168,23 +168,23 @@ describe("Drag And Drop horizontal tests", () => {
     hideColumns(model, [numberToLetters(right + 1)]);
     const { width, height } = model.getters.getSheetViewDimension();
     const y = height / 2;
-    triggerMouseEvent(".o-fake-grid", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 1.5 * width, y);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 1.5 * width, y);
     const advanceTimer = edgeScrollDelay(0.5 * width, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 1.5 * width, y);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 1.5 * width, y);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 6,
       right: 17,
     });
     setViewportOffset(model, (right + 2) * DEFAULT_CELL_WIDTH, 0);
     await nextTick();
-    triggerMouseEvent(".o-fake-grid", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-fake-grid", "mousemove", -1.5 * width, y);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-fake-grid", "pointermove", -1.5 * width, y);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", -1.5 * width, y);
+    triggerMouseEvent(".o-fake-grid", "pointerup", -1.5 * width, y);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 6,
       right: 17,
@@ -197,12 +197,12 @@ describe("Drag And Drop horizontal tests", () => {
     await nextTick();
     const { x: offsetCorrectionX } = model.getters.getMainViewportCoordinates();
     const x = offsetCorrectionX + DEFAULT_CELL_WIDTH;
-    triggerMouseEvent(".o-fake-grid", "mousedown", x, 0);
-    triggerMouseEvent(".o-fake-grid", "mousemove", -50, 0);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", x, 0);
+    triggerMouseEvent(".o-fake-grid", "pointermove", -50, 0);
     const advanceTimer = edgeScrollDelay(offsetCorrectionX + 50, 6);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", -50, 0);
+    triggerMouseEvent(".o-fake-grid", "pointerup", -50, 0);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 4,
       right: 10,
@@ -223,12 +223,12 @@ describe("Drag And Drop vertical tests", () => {
     const { width } = model.getters.getSheetViewDimension();
     const { y: offsetCorrectionY } = model.getters.getMainViewportCoordinates();
     const y = offsetCorrectionY + DEFAULT_CELL_HEIGHT;
-    triggerMouseEvent(".o-fake-grid", "mousedown", 0.5 * width, y);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 0.5 * width, 0.5 * offsetCorrectionY);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", 0.5 * width, y);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 0.5 * width, 0.5 * offsetCorrectionY);
     const advanceTimer = edgeScrollDelay(0.5 * offsetCorrectionY, 1);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 0.5 * width, 0.5 * offsetCorrectionY);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 0.5 * width, 0.5 * offsetCorrectionY);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 8,
       bottom: 47,
@@ -246,10 +246,10 @@ describe("Drag And Drop vertical tests", () => {
     const { width } = model.getters.getSheetViewDimension();
     const { y: offsetCorrectionY } = model.getters.getMainViewportCoordinates();
     const y = offsetCorrectionY + DEFAULT_CELL_HEIGHT;
-    triggerMouseEvent(".o-fake-grid", "mousedown", 0.5 * width, 0.5 * offsetCorrectionY);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 0.5 * width, y);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", 0.5 * width, 0.5 * offsetCorrectionY);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 0.5 * width, y);
 
-    triggerMouseEvent(".o-fake-grid", "mouseup", 0.5 * width, 0.5 * offsetCorrectionY);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 0.5 * width, 0.5 * offsetCorrectionY);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 4,
       bottom: 43,
@@ -264,12 +264,12 @@ describe("Drag And Drop vertical tests", () => {
       bottom: 43,
     });
     const { width, height } = model.getters.getSheetViewDimension();
-    triggerMouseEvent(".o-fake-grid", "mousedown", 0.5 * width, height);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 0.5 * width, 1.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", 0.5 * width, height);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 0.5 * width, 1.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * height, 4);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 0.5 * width, 1.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 0.5 * width, 1.5 * height);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 9,
       bottom: 48,
@@ -285,12 +285,12 @@ describe("Drag And Drop vertical tests", () => {
     });
     const { width, height } = model.getters.getSheetViewDimension();
     const { y: offsetCorrectionY } = model.getters.getMainViewportCoordinates();
-    triggerMouseEvent(".o-fake-grid", "mousedown", 0.5 * width, 0.5 * offsetCorrectionY);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 0.5 * width, 1.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", 0.5 * width, 0.5 * offsetCorrectionY);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 0.5 * width, 1.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * height, 4);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 0.5 * width, 1.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 0.5 * width, 1.5 * height);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 9,
       bottom: 48,
@@ -303,12 +303,12 @@ describe("Drag And Drop vertical tests", () => {
     await nextTick();
     const { y: offsetCorrectionY } = model.getters.getMainViewportCoordinates();
     const y = offsetCorrectionY + DEFAULT_CELL_HEIGHT;
-    triggerMouseEvent(".o-fake-grid", "mousedown", 0, y);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 0, -50);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", 0, y);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 0, -50);
     const advanceTimer = edgeScrollDelay(offsetCorrectionY + 50, 6);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 0, -50);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 0, -50);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 4,
       bottom: 43,
@@ -325,12 +325,12 @@ describe("Drag And Drop vertical tests without frozen panes", () => {
       right: 16,
     });
     const { height } = model.getters.getSheetViewDimension();
-    triggerMouseEvent(".o-fake-grid", "mousedown", DEFAULT_CELL_WIDTH, 0.5 * height);
-    triggerMouseEvent(".o-fake-grid", "mousemove", -0.5 * DEFAULT_CELL_WIDTH, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", DEFAULT_CELL_WIDTH, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointermove", -0.5 * DEFAULT_CELL_WIDTH, 0.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * DEFAULT_CELL_WIDTH, 1);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", -0.5 * DEFAULT_CELL_WIDTH, 0.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerup", -0.5 * DEFAULT_CELL_WIDTH, 0.5 * height);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 4,
       right: 14,
@@ -343,11 +343,11 @@ describe("Drag And Drop vertical tests without frozen panes", () => {
       bottom: 49,
     });
     const { width } = model.getters.getSheetViewDimension();
-    triggerMouseEvent(".o-fake-grid", "mousedown", 0.5 * width, DEFAULT_CELL_HEIGHT);
-    triggerMouseEvent(".o-fake-grid", "mousemove", 0.5 * width, -0.5 * DEFAULT_CELL_HEIGHT);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", 0.5 * width, DEFAULT_CELL_HEIGHT);
+    triggerMouseEvent(".o-fake-grid", "pointermove", 0.5 * width, -0.5 * DEFAULT_CELL_HEIGHT);
     const advanceTimer = edgeScrollDelay(0.5 * DEFAULT_CELL_HEIGHT, 1);
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", 0.5 * width, -0.5 * DEFAULT_CELL_HEIGHT);
+    triggerMouseEvent(".o-fake-grid", "pointerup", 0.5 * width, -0.5 * DEFAULT_CELL_HEIGHT);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 4,
       bottom: 47,
@@ -360,23 +360,23 @@ describe("Drag And Drop vertical tests without frozen panes", () => {
     hideRows(model, [bottom + 1]);
     const { width, height } = model.getters.getSheetViewDimension();
     const x = width / 2;
-    triggerMouseEvent(".o-fake-grid", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-fake-grid", "mousemove", x, 1.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-fake-grid", "pointermove", x, 1.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * height, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", x, 1.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerup", x, 1.5 * height);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 6,
       bottom: 50,
     });
     setViewportOffset(model, 0, (bottom + 2) * DEFAULT_CELL_HEIGHT);
     await nextTick();
-    triggerMouseEvent(".o-fake-grid", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-fake-grid", "mousemove", x, -1.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-fake-grid", "pointermove", x, -1.5 * height);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-fake-grid", "mouseup", x, -1.5 * height);
+    triggerMouseEvent(".o-fake-grid", "pointerup", x, -1.5 * height);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       top: 39,
       bottom: 83,

--- a/tests/grid/grid_overlay_component.test.ts
+++ b/tests/grid/grid_overlay_component.test.ts
@@ -57,11 +57,11 @@ async function selectColumn(letter: string, extra: any = {}) {
 async function resizeColumn(letter: string, delta: number) {
   const index = lettersToNumber(letter);
   const x = model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
-  triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", x, 10);
+  triggerMouseEvent(".o-overlay .o-col-resizer", "pointermove", x, 10);
   await nextTick();
-  triggerMouseEvent(".o-overlay .o-col-resizer .o-handle", "mousedown", x, 10);
-  triggerMouseEvent(window, "mousemove", x + delta, 10);
-  triggerMouseEvent(window, "mouseup", x + delta, 10);
+  triggerMouseEvent(".o-overlay .o-col-resizer .o-handle", "pointerdown", x, 10);
+  triggerMouseEvent(window, "pointermove", x + delta, 10);
+  triggerMouseEvent(window, "pointerup", x + delta, 10);
   await nextTick();
 }
 /**
@@ -72,12 +72,12 @@ async function resizeColumn(letter: string, delta: number) {
 async function dragColumn(startLetter: string, endLetter: string) {
   let index = lettersToNumber(startLetter);
   let x = model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
-  triggerMouseEvent(".o-overlay .o-col-resizer", "mousedown", x, 10);
+  triggerMouseEvent(".o-overlay .o-col-resizer", "pointerdown", x, 10);
   index = lettersToNumber(endLetter);
   x = model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
-  triggerMouseEvent(window, "mousemove", x, 10, { buttons: 1 });
+  triggerMouseEvent(window, "pointermove", x, 10, { buttons: 1 });
   await nextTick();
-  triggerMouseEvent(window, "mouseup", x, 10);
+  triggerMouseEvent(window, "pointerup", x, 10);
 }
 /**
  * Trigger a double click on a column
@@ -86,7 +86,7 @@ async function dragColumn(startLetter: string, endLetter: string) {
 async function dblClickColumn(letter: string) {
   const index = lettersToNumber(letter);
   const x = model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.end;
-  triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", x, 10);
+  triggerMouseEvent(".o-overlay .o-col-resizer", "pointermove", x, 10);
   await nextTick();
   triggerMouseEvent(".o-overlay .o-col-resizer .o-handle", "dblclick", x, 10);
 }
@@ -97,10 +97,10 @@ async function dblClickColumn(letter: string) {
  */
 async function selectRow(index: number, extra: any = {}) {
   const y = model.getters.getRowDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
-  triggerMouseEvent(".o-overlay .o-row-resizer", "mousemove", 10, y);
+  triggerMouseEvent(".o-overlay .o-row-resizer", "pointermove", 10, y);
   await nextTick();
-  triggerMouseEvent(".o-overlay .o-row-resizer", "mousedown", 10, y, extra);
-  triggerMouseEvent(window, "mouseup", 10, y);
+  triggerMouseEvent(".o-overlay .o-row-resizer", "pointerdown", 10, y, extra);
+  triggerMouseEvent(window, "pointerup", 10, y);
 }
 /**
  * Resize a row
@@ -109,11 +109,11 @@ async function selectRow(index: number, extra: any = {}) {
  */
 async function resizeRow(index: number, delta: number) {
   const y = model.getters.getRowDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
-  triggerMouseEvent(".o-overlay .o-row-resizer", "mousemove", 10, y);
+  triggerMouseEvent(".o-overlay .o-row-resizer", "pointermove", 10, y);
   await nextTick();
-  triggerMouseEvent(".o-overlay .o-row-resizer .o-handle", "mousedown", 10, y);
-  triggerMouseEvent(window, "mousemove", 10, y + delta);
-  triggerMouseEvent(window, "mouseup", 10, y + delta);
+  triggerMouseEvent(".o-overlay .o-row-resizer .o-handle", "pointerdown", 10, y);
+  triggerMouseEvent(window, "pointermove", 10, y + delta);
+  triggerMouseEvent(window, "pointerup", 10, y + delta);
   await nextTick();
 }
 /**
@@ -123,11 +123,11 @@ async function resizeRow(index: number, delta: number) {
  */
 async function dragRow(startIndex: number, endIndex: number) {
   let y = model.getters.getRowDimensions(model.getters.getActiveSheetId(), startIndex)!.start + 1;
-  triggerMouseEvent(".o-overlay .o-row-resizer", "mousedown", 10, y);
+  triggerMouseEvent(".o-overlay .o-row-resizer", "pointerdown", 10, y);
   y = model.getters.getRowDimensions(model.getters.getActiveSheetId(), endIndex)!.start + 1;
-  triggerMouseEvent(window, "mousemove", 10, y, { buttons: 1 });
+  triggerMouseEvent(window, "pointermove", 10, y, { buttons: 1 });
   await nextTick();
-  triggerMouseEvent(window, "mouseup", 10, y);
+  triggerMouseEvent(window, "pointerup", 10, y);
 }
 /**
  * Trigger a double click on a row
@@ -135,7 +135,7 @@ async function dragRow(startIndex: number, endIndex: number) {
  */
 async function dblClickRow(index: number) {
   const y = model.getters.getRowDimensions(model.getters.getActiveSheetId(), index)!.end;
-  triggerMouseEvent(".o-overlay .o-row-resizer", "mousemove", 10, y);
+  triggerMouseEvent(".o-overlay .o-row-resizer", "pointermove", 10, y);
   await nextTick();
 
   triggerMouseEvent(".o-overlay .o-row-resizer .o-handle", "dblclick", 10, y);
@@ -174,14 +174,14 @@ describe("Resizer component", () => {
     const index = lettersToNumber("C");
     const x = model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
     expect(getSelectionAnchorCellXc(model)).toBe("A1");
-    triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", x, 10);
+    triggerMouseEvent(".o-overlay .o-col-resizer", "pointermove", x, 10);
     await nextTick();
     expect(getSelectionAnchorCellXc(model)).toBe("A1");
-    triggerMouseEvent(".o-overlay .o-col-resizer .o-handle", "mousedown", x, 10);
-    triggerMouseEvent(window, "mousemove", x + 50, 10);
+    triggerMouseEvent(".o-overlay .o-col-resizer .o-handle", "pointerdown", x, 10);
+    triggerMouseEvent(window, "pointermove", x + 50, 10);
     await nextTick();
     expect(getSelectionAnchorCellXc(model)).toBe("A1");
-    triggerMouseEvent(window, "mouseup", x + 50, 10);
+    triggerMouseEvent(window, "pointerup", x + 50, 10);
     await nextTick();
     expect(getSelectionAnchorCellXc(model)).toBe("A1");
   });
@@ -355,22 +355,22 @@ describe("Resizer component", () => {
     );
   });
   test("can select the entire sheet", async () => {
-    triggerMouseEvent(".o-overlay .all", "mousedown", 5, 5);
+    triggerMouseEvent(".o-overlay .all", "pointerdown", 5, 5);
     expect(model.getters.getSelectedZones()[0]).toEqual({ left: 0, top: 0, right: 9, bottom: 9 });
     expect(getSelectionAnchorCellXc(model)).toBe("A1");
   });
 
   test("Mousemove hover something else than a header", async () => {
-    triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", -10, 10);
+    triggerMouseEvent(".o-overlay .o-col-resizer", "pointermove", -10, 10);
     expect(fixture.querySelector("o-handle")).toBeNull();
 
-    triggerMouseEvent(".o-overlay .o-row-resizer", "mousemove", 10, -10);
+    triggerMouseEvent(".o-overlay .o-row-resizer", "pointermove", 10, -10);
     expect(fixture.querySelector("o-handle")).toBeNull();
 
-    triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", 20, 10);
+    triggerMouseEvent(".o-overlay .o-col-resizer", "pointermove", 20, 10);
     expect(fixture.querySelector("o-handle")).toBeNull();
 
-    triggerMouseEvent(".o-overlay .o-row-resizer", "mousemove", 10, 12);
+    triggerMouseEvent(".o-overlay .o-row-resizer", "pointermove", 10, 12);
     expect(fixture.querySelector("o-handle")).toBeNull();
   });
 
@@ -782,13 +782,13 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
     const { width } = model.getters.getSheetViewDimension();
     const y = DEFAULT_CELL_HEIGHT;
 
-    triggerMouseEvent(".o-col-resizer", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-col-resizer", "mousemove", 1.5 * width, y);
+    triggerMouseEvent(".o-col-resizer", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-col-resizer", "pointermove", 1.5 * width, y);
     // we want 5 ticks of setTimeout
     const advanceTimer = edgeScrollDelay(0.5 * width, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-col-resizer", "mouseup", 1.5 * width, y);
+    triggerMouseEvent(".o-col-resizer", "pointerup", 1.5 * width, y);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 6,
@@ -797,13 +797,13 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
       bottom: 42,
     });
 
-    triggerMouseEvent(".o-col-resizer", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-col-resizer", "mousemove", -0.5 * width, y);
+    triggerMouseEvent(".o-col-resizer", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-col-resizer", "pointermove", -0.5 * width, y);
     // we want 2 ticks of setTimeout
     const advanceTimer2 = edgeScrollDelay(0.5 * width, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(".o-col-resizer", "mouseup", -0.5 * width, y);
+    triggerMouseEvent(".o-col-resizer", "pointerup", -0.5 * width, y);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 3,
@@ -816,12 +816,12 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
   test("Can edge-scroll vertically", async () => {
     const { height } = model.getters.getSheetViewDimensionWithHeaders();
     const x = DEFAULT_CELL_WIDTH / 2;
-    triggerMouseEvent(".o-row-resizer", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-row-resizer", "mousemove", x, 1.5 * height);
+    triggerMouseEvent(".o-row-resizer", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-row-resizer", "pointermove", x, 1.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * height, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-row-resizer", "mouseup", x, 1.5 * height);
+    triggerMouseEvent(".o-row-resizer", "pointerup", x, 1.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,
@@ -830,12 +830,12 @@ describe("Edge-Scrolling on mouseMove in selection", () => {
       bottom: 48,
     });
 
-    triggerMouseEvent(".o-row-resizer", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-row-resizer", "mousemove", x, -0.5 * height);
+    triggerMouseEvent(".o-row-resizer", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-row-resizer", "pointermove", x, -0.5 * height);
     const advanceTimer2 = edgeScrollDelay(0.5 * height, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(".o-row-resizer", "mouseup", x, -0.5 * height);
+    triggerMouseEvent(".o-row-resizer", "pointerup", x, -0.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,

--- a/tests/grid/highlight_component.test.ts
+++ b/tests/grid/highlight_component.test.ts
@@ -47,55 +47,70 @@ function getRowEndPosition(row: number) {
 
 async function selectNWCellCorner(el: Element, xc: string) {
   const { top, left } = toZone(xc);
-  triggerMouseEvent(el, "mousedown", getColStartPosition(left), getRowStartPosition(top));
+  triggerMouseEvent(el, "pointerdown", getColStartPosition(left), getRowStartPosition(top));
   await nextTick();
 }
 
 async function selectNECellCorner(el: Element, xc: string) {
   const { top, left } = toZone(xc);
-  triggerMouseEvent(el, "mousedown", getColEndPosition(left), getRowStartPosition(top));
+  triggerMouseEvent(el, "pointerdown", getColEndPosition(left), getRowStartPosition(top));
   await nextTick();
 }
 
 async function selectSWCellCorner(el: Element, xc: string) {
   const { top, left } = toZone(xc);
-  triggerMouseEvent(el, "mousedown", getColStartPosition(left), getRowEndPosition(top));
+  triggerMouseEvent(el, "pointerdown", getColStartPosition(left), getRowEndPosition(top));
   await nextTick();
 }
 
 async function selectSECellCorner(el: Element, xc: string) {
   const { top, left } = toZone(xc);
-  triggerMouseEvent(el, "mousedown", getColEndPosition(left), getRowEndPosition(top));
+  triggerMouseEvent(el, "pointerdown", getColEndPosition(left), getRowEndPosition(top));
   await nextTick();
 }
 
 async function selectTopCellBorder(el: Element, xc: string) {
   const { top, left } = toZone(xc);
-  triggerMouseEvent(el, "mousedown", getColStartPosition(left) + 10, getRowStartPosition(top) + 2);
+  triggerMouseEvent(
+    el,
+    "pointerdown",
+    getColStartPosition(left) + 10,
+    getRowStartPosition(top) + 2
+  );
   await nextTick();
 }
 
 async function selectBottomCellBorder(el: Element, xc: string) {
   const { top, left } = toZone(xc);
-  triggerMouseEvent(el, "mousedown", getColStartPosition(left) + 10, getRowEndPosition(top) - 2);
+  triggerMouseEvent(el, "pointerdown", getColStartPosition(left) + 10, getRowEndPosition(top) - 2);
   await nextTick();
 }
 
 async function selectLeftCellBorder(el: Element, xc: string) {
   const { top, left } = toZone(xc);
-  triggerMouseEvent(el, "mousedown", getColStartPosition(left) + 2, getRowStartPosition(top) + 10);
+  triggerMouseEvent(
+    el,
+    "pointerdown",
+    getColStartPosition(left) + 2,
+    getRowStartPosition(top) + 10
+  );
   await nextTick();
 }
 
 async function selectRightCellBorder(el: Element, xc: string) {
   const { top, left } = toZone(xc);
-  triggerMouseEvent(el, "mousedown", getColEndPosition(left) - 2, getRowStartPosition(top) + 10);
+  triggerMouseEvent(el, "pointerdown", getColEndPosition(left) - 2, getRowStartPosition(top) + 10);
   await nextTick();
 }
 
 async function moveToCell(el: Element, xc: string) {
   const { top, left } = toZone(xc);
-  triggerMouseEvent(el, "mousemove", getColStartPosition(left) + 10, getRowStartPosition(top) + 10);
+  triggerMouseEvent(
+    el,
+    "pointermove",
+    getColStartPosition(left) + 10,
+    getRowStartPosition(top) + 10
+  );
   await nextTick();
 }
 
@@ -328,7 +343,7 @@ describe("Corner component", () => {
     // move outside the grid
     triggerMouseEvent(
       cornerEl,
-      "mousemove",
+      "pointermove",
       getColStartPosition(0) - 100,
       getRowStartPosition(0) - 100
     );
@@ -758,12 +773,12 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     const { width } = model.getters.getSheetViewDimensionWithHeaders();
     const y = DEFAULT_CELL_HEIGHT;
 
-    triggerMouseEvent(".o-border-n", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-border-n", "mousemove", 1.5 * width, y);
+    triggerMouseEvent(".o-border-n", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-border-n", "pointermove", 1.5 * width, y);
     const advanceTimer = edgeScrollDelay(0.5 * width, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-border-n", "mouseup", 1.5 * width, y);
+    triggerMouseEvent(".o-border-n", "pointerup", 1.5 * width, y);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 6,
       right: 16,
@@ -774,12 +789,12 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     // force a nextTick to update the props of Highlight as it is not using an internal state
     await nextTick();
 
-    triggerMouseEvent(".o-border-n", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-border-n", "mousemove", -0.5 * width, y);
+    triggerMouseEvent(".o-border-n", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-border-n", "pointermove", -0.5 * width, y);
     const advanceTimer2 = edgeScrollDelay(0.5 * width, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(".o-border-n", "mouseup", -0.5 * width, y);
+    triggerMouseEvent(".o-border-n", "pointerup", -0.5 * width, y);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 3,
@@ -792,12 +807,12 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
   test("Can edge-scroll border vertically", async () => {
     const { height } = model.getters.getSheetViewDimensionWithHeaders();
     const x = DEFAULT_CELL_WIDTH / 2;
-    triggerMouseEvent(".o-border-n", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-border-n", "mousemove", x, 1.5 * height);
+    triggerMouseEvent(".o-border-n", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-border-n", "pointermove", x, 1.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * height, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-border-n", "mouseup", x, 1.5 * height);
+    triggerMouseEvent(".o-border-n", "pointerup", x, 1.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,
@@ -809,12 +824,12 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     // force a nextTick to update the props of Highlight as it is not using an internal state
     await nextTick();
 
-    triggerMouseEvent(".o-border-n", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-border-n", "mousemove", x, -0.5 * height);
+    triggerMouseEvent(".o-border-n", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-border-n", "pointermove", x, -0.5 * height);
     const advanceTimer2 = edgeScrollDelay(0.5 * height, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(".o-border-n", "mouseup", x, -0.5 * height);
+    triggerMouseEvent(".o-border-n", "pointerup", x, -0.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,
@@ -828,12 +843,12 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     const { width } = model.getters.getSheetViewDimensionWithHeaders();
     const y = DEFAULT_CELL_HEIGHT;
 
-    triggerMouseEvent(".o-corner-nw", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-corner-nw", "mousemove", 1.5 * width, y);
+    triggerMouseEvent(".o-corner-nw", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-corner-nw", "pointermove", 1.5 * width, y);
     const advanceTimer = edgeScrollDelay(0.5 * width, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-corner-nw", "mouseup", 1.5 * width, y);
+    triggerMouseEvent(".o-corner-nw", "pointerup", 1.5 * width, y);
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 6,
       right: 16,
@@ -844,12 +859,12 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     // force a nextTick to update the props of Highlight as it is not using an internal state
     await nextTick();
 
-    triggerMouseEvent(".o-corner-nw", "mousedown", width / 2, y);
-    triggerMouseEvent(".o-corner-nw", "mousemove", -0.5 * width, y);
+    triggerMouseEvent(".o-corner-nw", "pointerdown", width / 2, y);
+    triggerMouseEvent(".o-corner-nw", "pointermove", -0.5 * width, y);
     const advanceTimer2 = edgeScrollDelay(0.5 * width, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(".o-corner-nw", "mouseup", -0.5 * width, y);
+    triggerMouseEvent(".o-corner-nw", "pointerup", -0.5 * width, y);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 3,
@@ -862,12 +877,12 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
   test("Can edge-scroll corner vertically", async () => {
     const { height } = model.getters.getSheetViewDimensionWithHeaders();
     const x = DEFAULT_CELL_WIDTH / 2;
-    triggerMouseEvent(".o-corner-nw", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-corner-nw", "mousemove", x, 1.5 * height);
+    triggerMouseEvent(".o-corner-nw", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-corner-nw", "pointermove", x, 1.5 * height);
     const advanceTimer = edgeScrollDelay(0.5 * height, 5);
 
     jest.advanceTimersByTime(advanceTimer);
-    triggerMouseEvent(".o-corner-nw", "mouseup", x, 1.5 * height);
+    triggerMouseEvent(".o-corner-nw", "pointerup", x, 1.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,
@@ -879,12 +894,12 @@ describe("Edge-Scrolling on mouseMove of hightlights", () => {
     // force a nextTick to update the props of Highlight as it is not using an internal state
     await nextTick();
 
-    triggerMouseEvent(".o-corner-nw", "mousedown", x, height / 2);
-    triggerMouseEvent(".o-corner-nw", "mousemove", x, -0.5 * height);
+    triggerMouseEvent(".o-corner-nw", "pointerdown", x, height / 2);
+    triggerMouseEvent(".o-corner-nw", "pointermove", x, -0.5 * height);
     const advanceTimer2 = edgeScrollDelay(0.5 * height, 2);
 
     jest.advanceTimersByTime(advanceTimer2);
-    triggerMouseEvent(".o-corner-nw", "mouseup", x, -0.5 * height);
+    triggerMouseEvent(".o-corner-nw", "pointerup", x, -0.5 * height);
 
     expect(model.getters.getActiveMainViewport()).toMatchObject({
       left: 0,

--- a/tests/popover/error_tooltip_component.test.ts
+++ b/tests/popover/error_tooltip_component.test.ts
@@ -96,7 +96,7 @@ describe("Grid integration", () => {
     Date.now = jest.fn(() => 0);
     setCellContent(model, "A1", "=NA()");
     await nextTick();
-    gridMouseEvent(model, "mousemove", "A1");
+    gridMouseEvent(model, "pointermove", "A1");
     Date.now = jest.fn(() => 500);
     jest.advanceTimersByTime(300);
     await nextTick();
@@ -107,7 +107,7 @@ describe("Grid integration", () => {
     Date.now = jest.fn(() => 0);
     setCellContent(model, "A1", "=VLOOKUP(6,A1:A2,B2:B4)");
     await nextTick();
-    gridMouseEvent(model, "mousemove", "A1");
+    gridMouseEvent(model, "pointermove", "A1");
     Date.now = jest.fn(() => 500);
     jest.advanceTimersByTime(300);
     await nextTick();
@@ -147,7 +147,7 @@ describe("Grid integration", () => {
     await nextTick();
     setCellContent(model, "C3", "[label](url.com)");
 
-    triggerMouseEvent(".o-figure", "mousemove", DEFAULT_CELL_WIDTH * 2, DEFAULT_CELL_HEIGHT * 2);
+    triggerMouseEvent(".o-figure", "pointermove", DEFAULT_CELL_WIDTH * 2, DEFAULT_CELL_HEIGHT * 2);
     jest.advanceTimersByTime(400);
     await nextTick();
 

--- a/tests/sheet/sheet_manipulation_component.test.ts
+++ b/tests/sheet/sheet_manipulation_component.test.ts
@@ -38,9 +38,9 @@ beforeEach(async () => {
 
 function simulateContextMenu(selector: string, coord: { x: number; y: number }) {
   const target = document.querySelector(selector)! as HTMLElement;
-  triggerMouseEvent(selector, "mousedown", coord.x, coord.y, { button: 1, bubbles: true });
+  triggerMouseEvent(selector, "pointerdown", coord.x, coord.y, { button: 1, bubbles: true });
   target.focus();
-  triggerMouseEvent(selector, "mouseup", coord.x, coord.y, { button: 1, bubbles: true });
+  triggerMouseEvent(selector, "pointerup", coord.x, coord.y, { button: 1, bubbles: true });
   triggerMouseEvent(selector, "contextmenu", coord.x, coord.y, { button: 1, bubbles: true });
 }
 describe("Context Menu add/remove row/col", () => {

--- a/tests/test_helpers/dom_helper.ts
+++ b/tests/test_helpers/dom_helper.ts
@@ -13,7 +13,7 @@ export async function simulateClick(
   extra: MouseEventInit = { bubbles: true }
 ) {
   const target = getTarget(selector);
-  triggerMouseEvent(selector, "mousedown", x, y, extra);
+  triggerMouseEvent(selector, "pointerdown", x, y, extra);
   if (target !== document.activeElement) {
     const oldActiveEl = document.activeElement;
     (document.activeElement as HTMLElement | null)?.dispatchEvent(
@@ -33,7 +33,7 @@ export async function simulateClick(
       target.dispatchEvent(new FocusEvent("focus", { relatedTarget: oldActiveEl }));
     }
   }
-  triggerMouseEvent(selector, "mouseup", x, y, extra);
+  triggerMouseEvent(selector, "pointerup", x, y, extra);
   triggerMouseEvent(selector, "click", x, y, extra);
   await nextTick();
 }
@@ -95,7 +95,7 @@ export async function hoverCell(model: Model, xc: string, delay: number) {
     x -= HEADER_WIDTH;
     y -= HEADER_HEIGHT;
   }
-  triggerMouseEvent(".o-grid-overlay", "mousemove", x, y);
+  triggerMouseEvent(".o-grid-overlay", "pointermove", x, y);
   jest.advanceTimersByTime(delay);
   await nextTick();
 }
@@ -149,6 +149,9 @@ export function triggerMouseEvent(
   offsetY?: number,
   extra: MouseEventInit = { bubbles: true }
 ) {
+  if (type === "pointermove") {
+    extra = { button: -1, ...extra };
+  }
   const ev = new MouseEvent(type, {
     // this is only correct if we assume the target is positioned
     // at the very top left corner of the screen
@@ -279,10 +282,10 @@ export function getElStyle(selector: string, style: string): string {
 export async function selectColumnByClicking(model: Model, letter: string, extra: any = {}) {
   const index = lettersToNumber(letter);
   const x = model.getters.getColDimensions(model.getters.getActiveSheetId(), index)!.start + 1;
-  triggerMouseEvent(".o-overlay .o-col-resizer", "mousemove", x, 10);
+  triggerMouseEvent(".o-overlay .o-col-resizer", "pointermove", x, 10);
   await nextTick();
-  triggerMouseEvent(".o-overlay .o-col-resizer", "mousedown", x, 10, extra);
-  triggerMouseEvent(window, "mouseup", x, 10);
+  triggerMouseEvent(".o-overlay .o-col-resizer", "pointerdown", x, 10, extra);
+  triggerMouseEvent(window, "pointerup", x, 10);
   await nextTick();
 }
 
@@ -294,10 +297,10 @@ export async function dragElement(
 ) {
   const { x: startX, y: startY } = startingPosition;
   const { x: offsetX, y: offsetY } = dragOffset;
-  triggerMouseEvent(element, "mousedown", startX, startY);
-  triggerMouseEvent(element, "mousemove", startX + offsetX, startY + offsetY);
+  triggerMouseEvent(element, "pointerdown", startX, startY);
+  triggerMouseEvent(element, "pointermove", startX + offsetX, startY + offsetY);
   if (mouseUp) {
-    triggerMouseEvent(element, "mouseup", startX + offsetX, startY + offsetY);
+    triggerMouseEvent(element, "pointerup", startX + offsetX, startY + offsetY);
   }
   await nextTick();
 }

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -456,7 +456,7 @@ describe("TopBar component", () => {
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(0);
   });
 
-  test("Can open a Topbar menu with mousemove", async () => {
+  test("Can open a Topbar menu with pointermove", async () => {
     const { parent } = await mountParent();
     await click(fixture, ".o-topbar-menu[data-id='edit']");
     const edit = getNode(["edit"], topbarMenuRegistry);


### PR DESCRIPTION
## Description:

Pointer events are hardware-agnostic events. They should be favored over their mouse events counter part.

Note that touch is currently (very) badly supported by o-spreadsheet (this commit may be a step in the right direction).

This commit is still usefull to be able to use DOM test helpers in odoo test suite. (namely, I want to use the `dragAndDrop` test helper)

Note that there's a difference for the `button` property between
`mousemove` and `pointermove`.
For `pointermove`: *"the button property has the value -1 when the button state has not changed from the previous pointermove event"*.
See https://github.com/w3c/pointerevents/issues/33



Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo