### PR TITLE
[FIX] side_panel: dynamic props

### DIFF
--- a/src/components/figures/figure_chart/figure_chart.ts
+++ b/src/components/figures/figure_chart/figure_chart.ts
@@ -30,10 +30,8 @@ export class ChartFigure extends Component<Props, SpreadsheetChildEnv> {
   static components = {};
 
   onDoubleClick() {
-    const result = this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
-    if (result.isSuccessful) {
-      this.env.openSidePanel("ChartPanel");
-    }
+    this.env.model.dispatch("SELECT_FIGURE", { id: this.props.figure.id });
+    this.env.openSidePanel("ChartPanel");
   }
 
   get chartType(): ChartType {

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -38,21 +38,22 @@ css/* scss */ `
 
 interface Props {
   onCloseSidePanel: () => void;
+  figureId: UID;
 }
 
 export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartPanel";
   static components = { Section };
-  static props = { onCloseSidePanel: Function };
+  static props = { onCloseSidePanel: Function, figureId: String };
 
-  private store!: Store<MainChartPanelStore>;
+  store!: Store<MainChartPanelStore>;
 
   get figureId() {
-    return this.store.figureId;
+    return this.props.figureId;
   }
 
   setup(): void {
-    this.store = useLocalStore(MainChartPanelStore, this.env.model.getters.getSelectedFigureId());
+    this.store = useLocalStore(MainChartPanelStore);
   }
 
   updateChart<T extends ChartDefinition>(figureId: UID, updateDefinition: Partial<T>) {

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
@@ -1,34 +1,7 @@
-import { Get } from "../../../../store_engine";
 import { SpreadsheetStore } from "../../../../stores";
-import { Command, UID } from "../../../../types";
-import { SidePanelStore } from "../../side_panel/side_panel_store";
 
 export class MainChartPanelStore extends SpreadsheetStore {
-  private sidePanel = this.get(SidePanelStore);
-
-  figureId: UID | null;
   panel: "configuration" | "design" = "configuration";
-
-  constructor(get: Get, figureId: UID | null) {
-    super(get);
-    this.figureId = figureId;
-  }
-
-  protected handle(cmd: Command): void {
-    switch (cmd.type) {
-      case "DELETE_FIGURE":
-        if (this.sidePanel.componentTag === "ChartPanel" && this.figureId === cmd.id) {
-          this.sidePanel.close();
-        }
-        break;
-      case "SELECT_FIGURE":
-        if (cmd.id) {
-          this.figureId = cmd.id;
-        } else if (this.sidePanel.componentTag === "ChartPanel") {
-          this.sidePanel.close();
-        }
-    }
-  }
 
   activatePanel(panel: "configuration" | "design") {
     this.panel = panel;

--- a/src/registries/index.ts
+++ b/src/registries/index.ts
@@ -7,4 +7,5 @@ export * from "./figure_registry";
 export * from "./inverse_command_registry";
 export * from "./menus/index";
 export * from "./ot_registry";
+export * from "./side_panel_registry_entries";
 export * from "./topbar_component_registry";

--- a/src/registries/side_panel_registry.ts
+++ b/src/registries/side_panel_registry.ts
@@ -1,74 +1,20 @@
-import { ChartPanel } from "../components/side_panel/chart/main_chart_panel/main_chart_panel";
-import { ConditionalFormattingPanel } from "../components/side_panel/conditional_formatting/conditional_formatting";
-import { CustomCurrencyPanel } from "../components/side_panel/custom_currency/custom_currency";
-import { DataValidationEditor } from "../components/side_panel/data_validation/dv_editor/dv_editor";
-import { FindAndReplacePanel } from "../components/side_panel/find_and_replace/find_and_replace";
-import { MoreFormatsPanel } from "../components/side_panel/more_formats/more_formats";
-import { RemoveDuplicatesPanel } from "../components/side_panel/remove_duplicates/remove_duplicates";
-import { SettingsPanel } from "../components/side_panel/settings/settings_panel";
-import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns_panel/split_to_columns_panel";
-import { _t } from "../translation";
-import { SpreadsheetChildEnv } from "../types";
-import { DataValidationPanel } from "./../components/side_panel/data_validation/data_validation_panel";
+import { SidePanelState } from "../components/side_panel/side_panel/side_panel_store";
+import { Getters, SpreadsheetChildEnv } from "../types";
 import { Registry } from "./registry";
 
 //------------------------------------------------------------------------------
 // Side Panel Registry
 //------------------------------------------------------------------------------
+
 export interface SidePanelContent {
   title: string | ((env: SpreadsheetChildEnv) => string);
   Body: any;
   Footer?: any;
+  /**
+   * A callback used to validate the props or generate new props
+   * based on the current state of the spreadsheet model, using the getters.
+   */
+  computeState?: (getters: Getters, initialProps: object) => SidePanelState;
 }
 
 export const sidePanelRegistry = new Registry<SidePanelContent>();
-
-sidePanelRegistry.add("ConditionalFormatting", {
-  title: _t("Conditional formatting"),
-  Body: ConditionalFormattingPanel,
-});
-
-sidePanelRegistry.add("ChartPanel", {
-  title: _t("Chart"),
-  Body: ChartPanel,
-});
-
-sidePanelRegistry.add("FindAndReplace", {
-  title: _t("Find and Replace"),
-  Body: FindAndReplacePanel,
-});
-
-sidePanelRegistry.add("CustomCurrency", {
-  title: _t("Custom currency format"),
-  Body: CustomCurrencyPanel,
-});
-
-sidePanelRegistry.add("SplitToColumns", {
-  title: _t("Split text into columns"),
-  Body: SplitIntoColumnsPanel,
-});
-
-sidePanelRegistry.add("Settings", {
-  title: _t("Spreadsheet settings"),
-  Body: SettingsPanel,
-});
-
-sidePanelRegistry.add("RemoveDuplicates", {
-  title: _t("Remove duplicates"),
-  Body: RemoveDuplicatesPanel,
-});
-
-sidePanelRegistry.add("DataValidation", {
-  title: _t("Data validation"),
-  Body: DataValidationPanel,
-});
-
-sidePanelRegistry.add("DataValidationEditor", {
-  title: _t("Data validation"),
-  Body: DataValidationEditor,
-});
-
-sidePanelRegistry.add("MoreFormats", {
-  title: _t("More date formats"),
-  Body: MoreFormatsPanel,
-});

--- a/src/registries/side_panel_registry_entries.ts
+++ b/src/registries/side_panel_registry_entries.ts
@@ -1,0 +1,74 @@
+import { ChartPanel } from "../components/side_panel/chart/main_chart_panel/main_chart_panel";
+import { ConditionalFormattingPanel } from "../components/side_panel/conditional_formatting/conditional_formatting";
+import { CustomCurrencyPanel } from "../components/side_panel/custom_currency/custom_currency";
+import { DataValidationPanel } from "../components/side_panel/data_validation/data_validation_panel";
+import { DataValidationEditor } from "../components/side_panel/data_validation/dv_editor/dv_editor";
+import { FindAndReplacePanel } from "../components/side_panel/find_and_replace/find_and_replace";
+import { MoreFormatsPanel } from "../components/side_panel/more_formats/more_formats";
+import { RemoveDuplicatesPanel } from "../components/side_panel/remove_duplicates/remove_duplicates";
+import { SettingsPanel } from "../components/side_panel/settings/settings_panel";
+import { SplitIntoColumnsPanel } from "../components/side_panel/split_to_columns_panel/split_to_columns_panel";
+import { _t } from "../translation";
+import { Getters, UID } from "../types";
+import { sidePanelRegistry } from "./side_panel_registry";
+
+//------------------------------------------------------------------------------
+// Side Panel Registry
+//------------------------------------------------------------------------------
+
+sidePanelRegistry.add("ConditionalFormatting", {
+  title: _t("Conditional formatting"),
+  Body: ConditionalFormattingPanel,
+});
+
+sidePanelRegistry.add("ChartPanel", {
+  title: _t("Chart"),
+  Body: ChartPanel,
+  computeState: (getters: Getters, initialProps: { figureId: UID }) => {
+    const figureId = getters.getSelectedFigureId() ?? initialProps.figureId;
+    if (!getters.isChartDefined(figureId)) {
+      return { isOpen: false };
+    }
+    return { isOpen: true, props: { figureId } };
+  },
+});
+
+sidePanelRegistry.add("FindAndReplace", {
+  title: _t("Find and Replace"),
+  Body: FindAndReplacePanel,
+});
+
+sidePanelRegistry.add("CustomCurrency", {
+  title: _t("Custom currency format"),
+  Body: CustomCurrencyPanel,
+});
+
+sidePanelRegistry.add("SplitToColumns", {
+  title: _t("Split text into columns"),
+  Body: SplitIntoColumnsPanel,
+});
+
+sidePanelRegistry.add("Settings", {
+  title: _t("Spreadsheet settings"),
+  Body: SettingsPanel,
+});
+
+sidePanelRegistry.add("RemoveDuplicates", {
+  title: _t("Remove duplicates"),
+  Body: RemoveDuplicatesPanel,
+});
+
+sidePanelRegistry.add("DataValidation", {
+  title: _t("Data validation"),
+  Body: DataValidationPanel,
+});
+
+sidePanelRegistry.add("DataValidationEditor", {
+  title: _t("Data validation"),
+  Body: DataValidationEditor,
+});
+
+sidePanelRegistry.add("MoreFormats", {
+  title: _t("More date formats"),
+  Body: MoreFormatsPanel,
+});

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -13,6 +13,7 @@ import {
   createSheet,
   setFormat,
   setStyle,
+  undo,
   updateChart,
 } from "../../test_helpers/commands_helpers";
 import { TEST_CHART_DATA } from "../../test_helpers/constants";
@@ -513,6 +514,14 @@ describe("charts", () => {
     await simulateClick(".o-figure");
     await keyDown({ key: "Delete" });
     expect(fixture.querySelector(".o-figure")).toBeFalsy();
+  });
+
+  test("Undo a chart insertion will close the chart side panel", async () => {
+    createTestChart("basicChart");
+    await openChartConfigSidePanel();
+    undo(model);
+    await nextTick();
+    expect(fixture.querySelector(".o-sidePanel")).toBeFalsy();
   });
 
   test("double click a chart in readonly mode does not open the side panel", async () => {


### PR DESCRIPTION

## Description:

There are several problems in the current way side panels "props" are designed.

If the side panel receives an id as a prop (e.g. `figureId`, `pivotId`), we have to check that the underlying figure exists when the side panel is open. We also have to check at every render that it has not been deleted.

It's currently done with `onWillUpdateProps` which closes the side panel if the id is no longer valid.
Closing the side panel at this point (while rendering) breaks the mental model of `UI = f(data)`. It's also error prone as the state is changed in the middle of a render. It means `sidePanel.isOpen` might be `true` at the begining of the template but the side panel might actually be closed later in the template.

`onWillUpdateProps` should be avoided as much as possible.

This commit adds the ability to declare a function in the side panel registry entry to:
1) validate the props
2) generate props based on the model (e.g. the selected figure/pivot/...)

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo