### PR TITLE
[REF] filter: move filters icons inside grid overlay

### DIFF
--- a/src/components/dashboard/dashboard.ts
+++ b/src/components/dashboard/dashboard.ts
@@ -12,7 +12,6 @@ import {
   SpreadsheetChildEnv,
   Zone,
 } from "../../types/index";
-import { FilterIconsOverlay } from "../filters/filter_icons_overlay/filter_icons_overlay";
 import { HoveredCellStore } from "../grid/hovered_cell_store";
 import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
@@ -51,7 +50,6 @@ export class SpreadsheetDashboard extends Component<Props, SpreadsheetChildEnv> 
     Popover,
     VerticalScrollBar,
     HorizontalScrollBar,
-    FilterIconsOverlay,
   };
 
   protected cellPopovers!: Store<CellPopoverStore>;

--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -4,7 +4,7 @@
       class="o-grid o-two-columns"
       tabindex="-1"
       t-on-wheel="onMouseWheel"
-      t-on-click="onClosePopover">
+      t-on-pointerdown="onClosePopover">
       <div class="mx-auto h-100 position-relative" t-ref="grid" t-att-style="gridContainer">
         <GridOverlay
           onCellHovered.bind="onCellHovered"
@@ -27,7 +27,6 @@
           t-on-contextmenu.prevent=""
           t-att-style="getCellClickableStyle(clickableCell.coordinates)"
         />
-        <FilterIconsOverlay/>
       </div>
       <VerticalScrollBar/>
       <HorizontalScrollBar/>

--- a/src/components/filters/filter_icon/filter_icon.xml
+++ b/src/components/filters/filter_icon/filter_icon.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-FilterIcon">
-    <div class="o-filter-icon" t-att-class="iconClass" t-on-click.stop="onClick">
+    <div class="o-filter-icon" t-att-class="iconClass" t-on-click="onClick">
       <t t-if="isFilterActive" t-call="o-spreadsheet-Icon.FILTER_ICON_ACTIVE"/>
       <t t-else="" t-call="o-spreadsheet-Icon.FILTER_ICON"/>
     </div>

--- a/src/components/filters/filter_icons_overlay/filter_icons_overlay.ts
+++ b/src/components/filters/filter_icons_overlay/filter_icons_overlay.ts
@@ -1,23 +1,20 @@
 import { Component } from "@odoo/owl";
-import { CellPosition, DOMCoordinates, SpreadsheetChildEnv } from "../../../types";
+import { CellPosition, SpreadsheetChildEnv } from "../../../types";
 import { GridCellIcon } from "../../grid_cell_icon/grid_cell_icon";
 import { FilterIcon } from "../filter_icon/filter_icon";
 
 interface Props {
-  gridPosition: DOMCoordinates;
+  onMouseDown: (ev: MouseEvent) => void;
 }
 
 export class FilterIconsOverlay extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterIconsOverlay";
   static props = {
-    gridPosition: { type: Object, optional: true },
+    onMouseDown: Function,
   };
   static components = {
     GridCellIcon,
     FilterIcon,
-  };
-  static defaultProps = {
-    gridPosition: { x: 0, y: 0 },
   };
 
   getFilterHeadersPositions(): CellPosition[] {

--- a/src/components/filters/filter_icons_overlay/filter_icons_overlay.xml
+++ b/src/components/filters/filter_icons_overlay/filter_icons_overlay.xml
@@ -1,12 +1,14 @@
 <templates>
   <t t-name="o-spreadsheet-FilterIconsOverlay">
-    <t
-      t-foreach="getFilterHeadersPositions()"
-      t-as="position"
-      t-key="'filter'+position.col + '_' + position.row">
-      <GridCellIcon cellPosition="position" offset="props.gridPosition" horizontalAlign="'right'">
-        <FilterIcon cellPosition="position"/>
-      </GridCellIcon>
-    </t>
+    <div t-on-pointerdown.stop="this.props.onMouseDown">
+      <t
+        t-foreach="getFilterHeadersPositions()"
+        t-as="position"
+        t-key="'filter'+position.col + '_' + position.row">
+        <GridCellIcon cellPosition="position" horizontalAlign="'right'">
+          <FilterIcon cellPosition="position"/>
+        </GridCellIcon>
+      </t>
+    </div>
   </t>
 </templates>

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -45,6 +45,7 @@ import {
   DOMDimension,
   Dimension,
   Direction,
+  GridClickModifiers,
   HeaderIndex,
   Pixel,
   Rect,
@@ -56,7 +57,6 @@ import { ClientTag } from "../collaborative_client_tag/collaborative_client_tag"
 import { ComposerSelection, ComposerStore } from "../composer/composer/composer_store";
 import { ComposerFocusStore } from "../composer/composer_focus_store";
 import { GridComposer } from "../composer/grid_composer/grid_composer";
-import { FilterIconsOverlay } from "../filters/filter_icons_overlay/filter_icons_overlay";
 import { GridOverlay } from "../grid_overlay/grid_overlay";
 import { GridPopover } from "../grid_popover/grid_popover";
 import { HeadersOverlay } from "../headers_overlay/headers_overlay";
@@ -126,7 +126,6 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     Popover,
     VerticalScrollBar,
     HorizontalScrollBar,
-    FilterIconsOverlay,
   };
   readonly HEADER_HEIGHT = HEADER_HEIGHT;
   readonly HEADER_WIDTH = HEADER_WIDTH;
@@ -464,20 +463,16 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   // Zone selection with mouse
   // ---------------------------------------------------------------------------
 
-  onCellClicked(
-    col: HeaderIndex,
-    row: HeaderIndex,
-    { addZone, expandZone }: { addZone: boolean; expandZone: boolean }
-  ) {
-    if (this.cellPopovers.isOpen) {
+  onCellClicked(col: HeaderIndex, row: HeaderIndex, modifiers: GridClickModifiers) {
+    if (modifiers.closePopover && this.cellPopovers.isOpen) {
       this.cellPopovers.close();
     }
     if (this.composerStore.editionMode === "editing") {
       this.composerStore.stopEdition();
     }
-    if (expandZone) {
+    if (modifiers.expandZone) {
       this.env.model.selection.setAnchorCorner(col, row);
-    } else if (addZone) {
+    } else if (modifiers.addZone) {
       this.env.model.selection.addCellToSelection(col, row);
     } else {
       this.env.model.selection.selectCell(col, row);

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -56,7 +56,6 @@
         position="menuState.position"
         onClose="() => this.closeMenu()"
       />
-      <FilterIconsOverlay gridPosition="{ x: HEADER_WIDTH, y : HEADER_HEIGHT }"/>
       <VerticalScrollBar topOffset="HEADER_HEIGHT"/>
       <HorizontalScrollBar leftOffset="HEADER_WIDTH"/>
       <div class="o-scrollbar corner"/>

--- a/src/components/grid_cell_icon/grid_cell_icon.ts
+++ b/src/components/grid_cell_icon/grid_cell_icon.ts
@@ -1,14 +1,7 @@
 import { Component } from "@odoo/owl";
 import { DEFAULT_VERTICAL_ALIGN, GRID_ICON_EDGE_LENGTH, GRID_ICON_MARGIN } from "../../constants";
 import { positionToZone } from "../../helpers";
-import {
-  Align,
-  CellPosition,
-  DOMCoordinates,
-  Rect,
-  SpreadsheetChildEnv,
-  VerticalAlign,
-} from "../../types";
+import { Align, CellPosition, Rect, SpreadsheetChildEnv, VerticalAlign } from "../../types";
 import { css, cssPropertiesToCss } from "../helpers";
 
 css/* scss */ `
@@ -22,7 +15,6 @@ export interface GridCellIconProps {
   cellPosition: CellPosition;
   horizontalAlign?: Align;
   verticalAlign?: VerticalAlign;
-  offset?: DOMCoordinates;
 }
 
 export class GridCellIcon extends Component<GridCellIconProps, SpreadsheetChildEnv> {
@@ -31,7 +23,6 @@ export class GridCellIcon extends Component<GridCellIconProps, SpreadsheetChildE
     cellPosition: Object,
     horizontalAlign: { type: String, optional: true },
     verticalAlign: { type: String, optional: true },
-    offset: { type: Object, optional: true },
     slots: Object,
   };
 
@@ -43,8 +34,8 @@ export class GridCellIcon extends Component<GridCellIconProps, SpreadsheetChildE
     const x = this.getIconHorizontalPosition(rect, cellPosition);
     const y = this.getIconVerticalPosition(rect, cellPosition);
     return cssPropertiesToCss({
-      top: `${y + (this.props.offset?.y || 0)}px`,
-      left: `${x + (this.props.offset?.x || 0)}px`,
+      top: `${y}px`,
+      left: `${x}px`,
     });
   }
 

--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -1,6 +1,7 @@
 import { Component, onMounted, onWillUnmount, useExternalListener, useRef } from "@odoo/owl";
 import {
   DOMCoordinates,
+  GridClickModifiers,
   HeaderIndex,
   Pixel,
   Position,
@@ -10,6 +11,7 @@ import {
 } from "../../types";
 import { DataValidationOverlay } from "../data_validation_overlay/data_validation_overlay";
 import { FiguresContainer } from "../figures/figure_container/figure_container";
+import { FilterIconsOverlay } from "../filters/filter_icons_overlay/filter_icons_overlay";
 import { GridAddRowsFooter } from "../grid_add_rows_footer/grid_add_rows_footer";
 import { css } from "../helpers";
 import { getBoundingRectAsPOJO, isCtrlKey } from "../helpers/dom_helpers";
@@ -156,11 +158,7 @@ function useTouchMove(
 interface Props {
   onCellHovered: (position: Partial<Position>) => void;
   onCellDoubleClicked: (col: HeaderIndex, row: HeaderIndex) => void;
-  onCellClicked: (
-    col: HeaderIndex,
-    row: HeaderIndex,
-    modifiers: { addZone: boolean; expandZone: boolean }
-  ) => void;
+  onCellClicked: (col: HeaderIndex, row: HeaderIndex, modifiers: GridClickModifiers) => void;
   onCellRightClicked: (col: HeaderIndex, row: HeaderIndex, coordinates: DOMCoordinates) => void;
   onGridResized: (dimension: Rect) => void;
   onGridMoved: (deltaX: Pixel, deltaY: Pixel) => void;
@@ -180,7 +178,12 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
     onGridMoved: Function,
     gridOverlayDimensions: String,
   };
-  static components = { FiguresContainer, DataValidationOverlay, GridAddRowsFooter };
+  static components = {
+    FiguresContainer,
+    DataValidationOverlay,
+    GridAddRowsFooter,
+    FilterIconsOverlay,
+  };
   static defaultProps = {
     onCellHovered: () => {},
     onCellDoubleClicked: () => {},
@@ -230,7 +233,7 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
     return this.env.model.getters.isPaintingFormat();
   }
 
-  onMouseDown(ev: MouseEvent) {
+  onMouseDown(ev: MouseEvent, modifiers?: { closePopover: boolean }) {
     if (ev.button > 0) {
       // not main button, probably a context menu
       return;
@@ -239,6 +242,7 @@ export class GridOverlay extends Component<Props, SpreadsheetChildEnv> {
     this.props.onCellClicked(col, row, {
       expandZone: ev.shiftKey,
       addZone: isCtrlKey(ev),
+      closePopover: modifiers?.closePopover ?? true,
     });
   }
 

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -10,6 +10,7 @@
       t-on-contextmenu.stop.prevent="onContextMenu">
       <FiguresContainer onFigureDeleted="props.onFigureDeleted"/>
       <DataValidationOverlay/>
+      <FilterIconsOverlay onMouseDown="(ev) => this.onMouseDown(ev, {closePopover: false})"/>
       <GridAddRowsFooter
         t-if="!env.model.getters.isReadonly()"
         t-key="env.model.getters.getActiveSheetId()"

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -372,3 +372,9 @@ export type DebouncedFunction<T> = T & {
   stopDebounce: () => void;
   isDebouncePending: () => boolean;
 };
+
+export interface GridClickModifiers {
+  addZone: boolean;
+  expandZone: boolean;
+  closePopover: boolean;
+}

--- a/tests/components/filter_icon_overlay.test.ts
+++ b/tests/components/filter_icon_overlay.test.ts
@@ -1,8 +1,11 @@
 import { Model } from "../../src";
+import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
+import { createTable } from "../test_helpers/commands_helpers";
+import { simulateClick } from "../test_helpers/dom_helper";
 import { mountSpreadsheet } from "../test_helpers/helpers";
 
 describe("Filter Icon Overlay component", () => {
-  test("Overlapping filters are overwritten bythe latest inserted", async () => {
+  test("Overlapping filters are overwritten by the latest inserted", async () => {
     const model = new Model({
       version: 12,
       sheets: [
@@ -15,5 +18,16 @@ describe("Filter Icon Overlay component", () => {
     });
     const { fixture } = await mountSpreadsheet({ model });
     expect(fixture.querySelectorAll(".o-filter-icon").length).toBe(3);
+  });
+
+  test("Click on filter icon bubble and select the underlying cell", async () => {
+    const model = new Model();
+    createTable(model, "B2:B3");
+    const sheetId = model.getters.getActiveSheetId();
+    const {} = await mountSpreadsheet({ model });
+    expect(model.getters.getActivePosition()).toEqual({ sheetId, col: 0, row: 0 });
+
+    await simulateClick(".o-filter-icon", DEFAULT_CELL_WIDTH, DEFAULT_CELL_HEIGHT);
+    expect(model.getters.getActivePosition()).toEqual({ sheetId, col: 1, row: 1 });
   });
 });

--- a/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
@@ -22,6 +22,10 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
       
       
       
+      <div>
+        
+      </div>
+      
       
       
     </div>
@@ -31,8 +35,6 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
       style="width:985px;height:985px;"
       width="985"
     />
-    
-    
     
     
     

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -18,6 +18,10 @@ exports[`Grid component simple rendering snapshot 1`] = `
     
     
     
+    <div>
+      
+    </div>
+    
     
     <div
       class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center"
@@ -108,8 +112,6 @@ exports[`Grid component simple rendering snapshot 1`] = `
     class="o-autofill-handler"
     style="top:45px; left:140px; "
   />
-  
-  
   
   
   

--- a/tests/grid/grid_cell_icon_component.test.ts
+++ b/tests/grid/grid_cell_icon_component.test.ts
@@ -9,8 +9,6 @@ import {
   DEFAULT_CELL_WIDTH,
   GRID_ICON_EDGE_LENGTH,
   GRID_ICON_MARGIN,
-  HEADER_HEIGHT,
-  HEADER_WIDTH,
 } from "../../src/constants";
 import { SpreadsheetChildEnv, UID } from "../../src/types";
 import { merge, resizeColumns, resizeRows, setStyle } from "../test_helpers/commands_helpers";
@@ -39,7 +37,6 @@ describe("Grid cell icon component", () => {
   async function mountGridIcon(partialProps: Partial<GridCellIconProps>) {
     const props: GridCellIconProps = {
       cellPosition: { sheetId, col: 1, row: 1 },
-      offset: { x: HEADER_WIDTH, y: HEADER_HEIGHT },
       ...partialProps,
     };
 
@@ -56,7 +53,7 @@ describe("Grid cell icon component", () => {
     resizeColumns(model, ["B"], 200);
     await mountGridIcon({ cellPosition: { sheetId, col: 1, row: 1 }, horizontalAlign: "left" });
     const colDims = model.getters.getColDimensionsInViewport(sheetId, 1);
-    const left = colDims.start + GRID_ICON_MARGIN + HEADER_WIDTH;
+    const left = colDims.start + GRID_ICON_MARGIN;
     expect(getStylePropertyInPx(icon, "left")).toEqual(left);
   });
 
@@ -65,7 +62,7 @@ describe("Grid cell icon component", () => {
     await mountGridIcon({ cellPosition: { sheetId, col: 1, row: 1 }, horizontalAlign: "center" });
     const colDims = model.getters.getColDimensionsInViewport(sheetId, 1);
     const centeringOffset = Math.floor((colDims.size - GRID_ICON_EDGE_LENGTH) / 2);
-    const center = colDims.end - GRID_ICON_EDGE_LENGTH - centeringOffset + HEADER_WIDTH;
+    const center = colDims.end - GRID_ICON_EDGE_LENGTH - centeringOffset;
     expect(getStylePropertyInPx(icon, "left")).toEqual(center);
   });
 
@@ -73,7 +70,7 @@ describe("Grid cell icon component", () => {
     resizeColumns(model, ["B"], 200);
     await mountGridIcon({ cellPosition: { sheetId, col: 1, row: 1 }, horizontalAlign: "right" });
     const colDims = model.getters.getColDimensionsInViewport(sheetId, 1);
-    const right = colDims.end - GRID_ICON_MARGIN - GRID_ICON_EDGE_LENGTH + HEADER_WIDTH;
+    const right = colDims.end - GRID_ICON_MARGIN - GRID_ICON_EDGE_LENGTH;
     expect(getStylePropertyInPx(icon, "left")).toEqual(right);
   });
 
@@ -81,7 +78,7 @@ describe("Grid cell icon component", () => {
     resizeRows(model, [1], 200);
     await mountGridIcon({ cellPosition: { sheetId, col: 1, row: 1 }, verticalAlign: "top" });
     const rowDims = model.getters.getRowDimensionsInViewport(sheetId, 1);
-    const top = rowDims.start + GRID_ICON_MARGIN + HEADER_HEIGHT;
+    const top = rowDims.start + GRID_ICON_MARGIN;
     expect(getStylePropertyInPx(icon, "top")).toEqual(top);
   });
 
@@ -90,7 +87,7 @@ describe("Grid cell icon component", () => {
     await mountGridIcon({ cellPosition: { sheetId, col: 1, row: 1 }, verticalAlign: "middle" });
     const rowDims = model.getters.getRowDimensionsInViewport(sheetId, 1);
     const centeringOffset = Math.floor((rowDims.size - GRID_ICON_EDGE_LENGTH) / 2);
-    const middle = rowDims.end - GRID_ICON_EDGE_LENGTH - centeringOffset + HEADER_HEIGHT;
+    const middle = rowDims.end - GRID_ICON_EDGE_LENGTH - centeringOffset;
     expect(getStylePropertyInPx(icon, "top")).toEqual(middle);
   });
 
@@ -98,7 +95,7 @@ describe("Grid cell icon component", () => {
     resizeRows(model, [1], 200);
     await mountGridIcon({ cellPosition: { sheetId, col: 1, row: 1 }, verticalAlign: "bottom" });
     const rowDims = model.getters.getRowDimensionsInViewport(sheetId, 1);
-    const bottom = rowDims.end - GRID_ICON_MARGIN - GRID_ICON_EDGE_LENGTH + HEADER_HEIGHT;
+    const bottom = rowDims.end - GRID_ICON_MARGIN - GRID_ICON_EDGE_LENGTH;
     expect(bottom).toEqual(getStylePropertyInPx(icon, "top"));
   });
 
@@ -115,8 +112,8 @@ describe("Grid cell icon component", () => {
       horizontalAlign: "left",
     });
 
-    const top = rowDims.start + GRID_ICON_MARGIN + HEADER_HEIGHT;
-    const left = colDims.start + GRID_ICON_MARGIN + HEADER_WIDTH;
+    const top = rowDims.start + GRID_ICON_MARGIN;
+    const left = colDims.start + GRID_ICON_MARGIN;
     expect(getStylePropertyInPx(icon, "top")).toEqual(top);
     expect(getStylePropertyInPx(icon, "left")).toEqual(left);
   });
@@ -129,10 +126,10 @@ describe("Grid cell icon component", () => {
       verticalAlign: "bottom",
     });
 
-    const top = 2 * DEFAULT_CELL_HEIGHT - GRID_ICON_EDGE_LENGTH - GRID_ICON_MARGIN + HEADER_HEIGHT;
+    const top = 2 * DEFAULT_CELL_HEIGHT - GRID_ICON_EDGE_LENGTH - GRID_ICON_MARGIN;
     expect(getStylePropertyInPx(icon, "top")).toEqual(top);
 
-    const left = 2 * DEFAULT_CELL_WIDTH - GRID_ICON_EDGE_LENGTH - GRID_ICON_MARGIN + HEADER_WIDTH;
+    const left = 2 * DEFAULT_CELL_WIDTH - GRID_ICON_EDGE_LENGTH - GRID_ICON_MARGIN;
     expect(getStylePropertyInPx(icon, "left")).toEqual(left);
   });
 });

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -739,15 +739,9 @@ describe("Grid component", () => {
 
       const icons = fixture.querySelectorAll(".o-grid-cell-icon");
       expect(icons).toHaveLength(2);
-      const top = `${
-        DEFAULT_CELL_HEIGHT * 2 - GRID_ICON_EDGE_LENGTH - GRID_ICON_MARGIN + HEADER_HEIGHT
-      }px`;
-      const leftA = `${
-        DEFAULT_CELL_WIDTH * 2 - GRID_ICON_EDGE_LENGTH + HEADER_WIDTH - GRID_ICON_MARGIN
-      }px`;
-      const leftB = `${
-        DEFAULT_CELL_WIDTH * 3 - GRID_ICON_EDGE_LENGTH + HEADER_WIDTH - GRID_ICON_MARGIN
-      }px`;
+      const top = `${DEFAULT_CELL_HEIGHT * 2 - GRID_ICON_EDGE_LENGTH - GRID_ICON_MARGIN}px`;
+      const leftA = `${DEFAULT_CELL_WIDTH * 2 - GRID_ICON_EDGE_LENGTH - GRID_ICON_MARGIN}px`;
+      const leftB = `${DEFAULT_CELL_WIDTH * 3 - GRID_ICON_EDGE_LENGTH - GRID_ICON_MARGIN}px`;
       expect((icons[0] as HTMLElement).style["_values"]).toEqual({ top, left: leftA });
       expect((icons[1] as HTMLElement).style["_values"]).toEqual({ top, left: leftB });
     });

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -668,6 +668,10 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           
           
           
+          <div>
+            
+          </div>
+          
           
           <div
             class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center"
@@ -758,8 +762,6 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           class="o-autofill-handler"
           style="top:45px; left:140px; "
         />
-        
-        
         
         
         


### PR DESCRIPTION
## Description

This commit moves the filters icon overlay from `grid.xml/dashboard.xml` to `grid_overlay.xml`. This has several benefits:

- since the icons are positioned inside the grid overlay, they don't have to worry about the grid/dashboard position offset. The GridOverlay handles that.
- we can call the onMouseDown of grid from the FilterIconOverlay, selecting the cell with all its side effect (eg. closing the current grid composer on left click, opening the context menu on the correct cell on right click, ...)

The annoying thing is that we need to prevent the mouseDown to close the filter menu when clicking on the filter icon. This is handled on the click of the filter icon. Otherwise, the menu toggle won't work.

Task: : [3754487](https://www.odoo.com/web#id=3754487&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo