### PR TITLE
reduce compute time in `getStatisticFnResults`

### DIFF
--- a/src/clipboard_handlers/conditional_format_clipboard.ts
+++ b/src/clipboard_handlers/conditional_format_clipboard.ts
@@ -93,15 +93,15 @@ export class ConditionalFormatClipboardHandler extends AbstractCellClipboardHand
             this.getters.getRangeFromSheetXC(origin.sheetId, range).zone
           )
         ) {
-          const toRemoveZone: Zone[] = [];
+          const toRemoveZones: Zone[] = [];
           if (isCutOperation) {
             //remove from current rule
-            toRemoveZone.push(positionToZone(origin));
+            toRemoveZones.push(positionToZone(origin));
           }
           if (origin.sheetId === target.sheetId) {
-            this.adaptCFRules(origin.sheetId, rule, [zone], toRemoveZone);
+            this.adaptCFRules(origin.sheetId, rule, [zone], toRemoveZones);
           } else {
-            this.adaptCFRules(origin.sheetId, rule, [], toRemoveZone);
+            this.adaptCFRules(origin.sheetId, rule, [], toRemoveZones);
             const cfToCopyTo = this.getCFToCopyTo(target.sheetId, rule);
             this.adaptCFRules(target.sheetId, cfToCopyTo, [zone], []);
           }

--- a/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
+++ b/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
@@ -1,5 +1,6 @@
 import { sum } from "../../functions/helper_math";
 import { average, countAny, countNumbers, max, min } from "../../functions/helper_statistical";
+import { memoize } from "../../helpers";
 import { Get } from "../../store_engine";
 import { SpreadsheetStore } from "../../stores";
 import { _t } from "../../translation";
@@ -123,6 +124,11 @@ export class AggregateStatisticsStore extends SpreadsheetStore {
     const locale = getters.getLocale();
     let statisticFnResults: StatisticFnResults = {};
     const cellsArray = [...cells];
+
+    const getCells = memoize((typeStr: string) => {
+      const types = typeStr.split(",");
+      return cellsArray.filter((c) => types.includes(c.type));
+    });
     for (let fn of selectionStatisticFunctions) {
       // We don't want to display statistical information when there is no interest:
       // We set the statistical result to undefined if the data handled by the selection
@@ -130,7 +136,7 @@ export class AggregateStatisticsStore extends SpreadsheetStore {
       // Ex: if there are only texts in the selection, we prefer that the SUM result
       // be displayed as undefined rather than 0.
       let fnResult: number | undefined = undefined;
-      const evaluatedCells = cellsArray.filter((c) => fn.types.includes(c.type));
+      const evaluatedCells = getCells(fn.types.join(","));
       if (evaluatedCells.length) {
         fnResult = fn.compute(evaluatedCells, locale);
       }

--- a/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
+++ b/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
@@ -1,6 +1,6 @@
 import { sum } from "../../functions/helper_math";
 import { average, countAny, countNumbers, max, min } from "../../functions/helper_statistical";
-import { memoize } from "../../helpers";
+import { lazy, memoize } from "../../helpers";
 import { Get } from "../../store_engine";
 import { SpreadsheetStore } from "../../stores";
 import { _t } from "../../translation";
@@ -8,12 +8,13 @@ import {
   CellValueType,
   Command,
   EvaluatedCell,
+  Lazy,
   Locale,
   invalidateEvaluationCommands,
 } from "../../types";
 
 export interface StatisticFnResults {
-  [name: string]: number | undefined;
+  [name: string]: Lazy<number> | undefined;
 }
 
 interface SelectionStatisticFunction {
@@ -135,10 +136,10 @@ export class AggregateStatisticsStore extends SpreadsheetStore {
       // does not match the data handled by the function.
       // Ex: if there are only texts in the selection, we prefer that the SUM result
       // be displayed as undefined rather than 0.
-      let fnResult: number | undefined = undefined;
+      let fnResult: Lazy<number> | undefined = undefined;
       const evaluatedCells = getCells(fn.types.join(","));
       if (evaluatedCells.length) {
-        fnResult = fn.compute(evaluatedCells, locale);
+        fnResult = lazy(() => fn.compute(evaluatedCells, locale));
       }
       statisticFnResults[fn.name] = fnResult;
     }

--- a/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
+++ b/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
@@ -1,6 +1,6 @@
 import { sum } from "../../functions/helper_math";
 import { average, countAny, countNumbers, max, min } from "../../functions/helper_statistical";
-import { lazy, memoize, recomputeZones, zoneToXc } from "../../helpers";
+import { lazy, memoize, recomputeZones } from "../../helpers";
 import { Get } from "../../store_engine";
 import { SpreadsheetStore } from "../../stores";
 import { _t } from "../../translation";
@@ -107,14 +107,13 @@ export class AggregateStatisticsStore extends SpreadsheetStore {
     const sheetId = getters.getActiveSheetId();
     const cells: EvaluatedCell[] = [];
 
-    const recomputedXC = recomputeZones(getters.getSelectedZones().map(zoneToXc), []);
-    const zonesCleanedFromOverlapping = recomputedXC.map(
-      (xc) => this.getters.getRangeFromSheetXC(sheetId, xc).zone
-    );
+    const recomputedZones = recomputeZones(getters.getSelectedZones(), []);
+    const heightMax = this.getters.getSheetSize(sheetId).numberOfRows - 1;
+    const widthMax = this.getters.getSheetSize(sheetId).numberOfCols - 1;
 
-    for (const zone of zonesCleanedFromOverlapping) {
-      for (let col = zone.left; col <= zone.right; col++) {
-        for (let row = zone.top; row <= zone.bottom; row++) {
+    for (const zone of recomputedZones) {
+      for (let col = zone.left; col <= (zone.right ?? widthMax); col++) {
+        for (let row = zone.top; row <= (zone.bottom ?? heightMax); row++) {
           if (getters.isRowHidden(sheetId, row) || getters.isColHidden(sheetId, col)) {
             continue; // Skip hidden cells
           }

--- a/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -81,6 +81,6 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
   private getComposedFnName(fnName: string): string {
     const locale = this.env.model.getters.getLocale();
     const fnValue = this.store.statisticFnResults[fnName];
-    return fnName + ": " + (fnValue !== undefined ? formatValue(fnValue, { locale }) : "__");
+    return fnName + ": " + (fnValue !== undefined ? formatValue(fnValue(), { locale }) : "__");
   }
 }

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -8,7 +8,7 @@ import { GaugeChartRuntime, ScorecardChartRuntime } from "../../../types/chart";
 import { ChartRuntime, DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
 import { formatValue, isDateTimeFormat } from "../../format";
 import { range } from "../../misc";
-import { recomputeZones, zoneToXc } from "../../zones";
+import { recomputeZones } from "../../zones";
 import { AbstractChart } from "./abstract_chart";
 import { drawGaugeChart } from "./gauge_chart_rendering";
 import { drawScoreChart } from "./scorecard_chart";
@@ -23,12 +23,12 @@ import { getScorecardConfiguration } from "./scorecard_chart_config_builder";
  */
 export function getData(getters: Getters, ds: DataSet): any[] {
   if (ds.dataRange) {
-    const labelCellZone = ds.labelCell ? [zoneToXc(ds.labelCell.zone)] : [];
-    const dataXC = recomputeZones([zoneToXc(ds.dataRange.zone)], labelCellZone)[0];
-    if (dataXC === undefined) {
+    const labelCellZone = ds.labelCell ? [ds.labelCell.zone] : [];
+    const dataZone = recomputeZones([ds.dataRange.zone], labelCellZone)[0];
+    if (dataZone === undefined) {
       return [];
     }
-    const dataRange = getters.getRangeFromSheetXC(ds.dataRange.sheetId, dataXC);
+    const dataRange = getters.getRangeFromZone(ds.dataRange.sheetId, dataZone);
     return getters.getRangeValues(dataRange).map((value) => (value === "" ? undefined : value));
   }
   return [];

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -8,7 +8,7 @@ import { GaugeChartRuntime, ScorecardChartRuntime } from "../../../types/chart";
 import { ChartRuntime, DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
 import { formatValue, isDateTimeFormat } from "../../format";
 import { range } from "../../misc";
-import { recomputeZones } from "../../zones";
+import { recomputeZones } from "../../recompute_zones";
 import { AbstractChart } from "./abstract_chart";
 import { drawGaugeChart } from "./gauge_chart_rendering";
 import { drawScoreChart } from "./scorecard_chart";

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -7,6 +7,7 @@ export * from "./format";
 export * from "./misc";
 export * from "./numbers";
 export * from "./range";
+export * from "./recompute_zones";
 export * from "./references";
 export * from "./search";
 export * from "./sheet";

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -392,6 +392,23 @@ export function deepEquals(o1: any, o2: any): boolean {
   return true;
 }
 
+/**
+ * Compares two arrays.
+ * For performance reasons, this function is to be preferred
+ * to 'deepEquals' in the case we know that the inputs are arrays.
+ */
+export function deepEqualsArray(arr1: unknown[], arr2: unknown[]): boolean {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+  for (let i = 0; i < arr1.length; i++) {
+    if (!deepEquals(arr1[i], arr2[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /** Check if the given array contains all the values of the other array. */
 export function includesAll<T>(arr: T[], values: T[]): boolean {
   return values.every((value) => arr.includes(value));

--- a/src/helpers/recompute_zones.ts
+++ b/src/helpers/recompute_zones.ts
@@ -1,0 +1,393 @@
+import { deepEqualsArray } from "../helpers";
+import { UnboundedZone } from "../types";
+
+/**
+ * ####################################################
+ * # INTRODUCTION
+ * ####################################################
+ *
+ * This file contain the function recomputeZones.
+ * This function try to recompute in a performant way
+ * an ensemble of zones possibly overlapping to avoid
+ * overlapping and to reduce the number of zones.
+ *
+ * It also allows to remove some zones from the ensemble.
+ *
+ * In the following example, 2 zones are overlapping.
+ * Applying recomputeZones will return zones without
+ * overlapping:
+ *
+ * ["B3:D4", "D2:E3"]         ["B3:C4", "D2:D4", "E2:E3"]
+ *
+ *      A B C D E                    A B C D E
+ *    1       ___                  1       ___
+ *    2   ___|_  |                 2   ___| | |
+ *    3  |   |_|_|      --->       3  |   | |_|
+ *    4  |_____|                   4  |___|_|
+ *    6                            6
+ *    7                            7
+ *
+ *
+ * In the following example, 2 zones are contiguous.
+ * Applying recomputeZones will return only one zone:
+ *
+ *  ["B2:B3", "C2:D3"]               ["B2:D3"]
+ *
+ *       A B C D E                   A B C D E
+ *     1   _ ___                   1   _____
+ *     2  | |   |        --->      2  |     |
+ *     3  |_|___|                  3  |_____|
+ *     4                           4
+ *
+ *
+ * In the following example, we want to remove a zone
+ * from the ensemble. Applying recomputeZones will
+ * return the ensemble without the zone to remove:
+ *
+ *    remove ["C3:D3"]           ["B2:B4", "C2:D2",
+ *                                "C4:D4", "E2:E4"]
+ *
+ *       A B C D E F                 A B C D E F
+ *     1   _______                 1   _______
+ *     2  |       |       --->     2  | |___| |
+ *     3  |  xxx  |                3  | |___| |
+ *     4  |_______|                4  |_|___|_|
+ *     5                           5
+ *
+ *
+ * The exercise seems simple when we have only 2 zones.
+ * But with n zones and in a performant way, we want to
+ * avoid comparing each zone with all the others.
+ *
+ *
+ * ####################################################
+ * # Methodological approach
+ * ####################################################
+ *
+ * The methodological approach to avoid comparing each
+ * zone with all the others is to use a data structure
+ * that allow to quickly find which zones are
+ * overlapping with any other given zone.
+ *
+ * Here the idea is to profile the zones at the columns level.
+ *
+ * To do that, we propose to use a data structure
+ * composed of 2 parts:
+ * - profilesStartingPosition: a sorted number array
+ * indicating on which columns a new profile begins.
+ * - profiles: a map where the key is a column
+ * position (from profilesStartingPosition) and the
+ * value is a sorted number array representing a
+ * profile.
+ *
+ *
+ * See the following example:    here profileStartingPosition
+ *                               corresponds to [A,C,E,G,K]
+ *    A B C D E F G H I J K      so with number [0,2,4,6,10]
+ *  1    '   '   '       '
+ *  2    '   '   '_______'       here profile correspond
+ *  3    '___'   |_______|       for A to []
+ *  4    |   |                   for C to [3, 5]
+ *  5    |___|                   for E to []
+ *  6                            for G to [2, 3]
+ *  7                            for K to []
+ *
+ *
+ * Now we can easily find which zones are overlapping
+ * with a given zone. Suppose we want to add a new zone
+ * D5:H6 to the ensemble:
+ *
+ *                              With a binary search of left and right
+ *    A B C D E F G H I J K     on profilesStartingPosition, we can
+ *  1    '   '   '       '      find the indexes of the profiles on which
+ *  2    '   '   '_______'      to apply a modification.
+ *  3    '___'   |_______|
+ *  4    |  _|_______           Here we will:
+ *  5    |_|_|       |          - add a new profile in D   --> become [3, 6]
+ *  6      |_________|          - modify the profile in E  --> become [4, 6]
+ *  7                           - modify the profile in G  --> become [2, 3, 4, 6]
+ *                              - add a new profile in I   --> become [8, 10]
+ *
+ *  See below the result:
+ *
+ *                              Note the particularity of the profile
+ *    A B C D E F G H I J K     for G: it will correspond to [2, 3, 4, 6]
+ *  1    ' ' '   '   '   '
+ *  2    ' ' '   '___'___'      To know how to modify the profile (add a
+ *  3    '_'_'   |___|___|      zone or remove it) we do a binary
+ *  4    | | |___ ___           search of the top and bottom value on the
+ *  5    |_| |   |   |          profile array. Depending on the result index
+ *  6      |_|___|___|          parity (odd or even), because zone boundaries
+ *  7                           go by pairs, we know if we are in a zone or
+ *                              not and how operate.
+ */
+
+/**
+ * Recompute the zone without the cells in toRemoveZones and avoid overlapping.
+ * This compute is particularly useful because after this function:
+ * - you will find coordinate of a cell only once among all the zones
+ * - the number of zones will be reduced to the minimum
+ */
+export function recomputeZones(
+  zones: UnboundedZone[],
+  zonesToRemove: UnboundedZone[]
+): UnboundedZone[] {
+  const profilesStartingPosition: number[] = [0];
+  const profiles = new Map<number, number[]>([[0, []]]);
+
+  modifyProfiles(profilesStartingPosition, profiles, zones, false);
+  modifyProfiles(profilesStartingPosition, profiles, zonesToRemove, true);
+  return constructZonesFromProfiles(profilesStartingPosition, profiles);
+}
+
+export function modifyProfiles( // export for testing only
+  profilesStartingPosition: number[],
+  profiles: Map<number, number[]>,
+  zones: UnboundedZone[],
+  toRemove: boolean = false
+) {
+  for (const zone of zones) {
+    const leftValue = zone.left;
+    const rightValue = zone.right === undefined ? undefined : zone.right + 1;
+
+    const leftIndex = findIndexAndCreateProfile(
+      profilesStartingPosition,
+      profiles,
+      leftValue,
+      true,
+      0
+    );
+    const rightIndex = findIndexAndCreateProfile(
+      profilesStartingPosition,
+      profiles,
+      rightValue,
+      false,
+      leftIndex
+    );
+
+    for (let i = leftIndex; i <= rightIndex; i++) {
+      const profile = profiles.get(profilesStartingPosition[i])!;
+      modifyProfile(profile, zone, toRemove);
+    }
+
+    // maybe this part cost in performance, and maybe it's not necessary (depending on the use case). To be checked
+    removeContiguousProfiles(profilesStartingPosition, profiles, leftIndex, rightIndex);
+  }
+}
+
+function findIndexAndCreateProfile(
+  profilesStartingPosition: number[],
+  profiles: Map<number, number[]>,
+  value: number | undefined,
+  searchLeft: boolean,
+  startIndex: number
+) {
+  if (value === undefined) {
+    // this is only the case when the value correspond to a bottom value that could be undefined
+    return profilesStartingPosition.length - 1;
+  }
+  const predecessorIndex = binaryPredecessorSearch(profilesStartingPosition, value, startIndex);
+  if (value != profilesStartingPosition[predecessorIndex]) {
+    // mean that the value is not ending/starting at the same position as the previous/next profile
+    // --> it's a new profile
+    // --> we need to add it
+    profilesStartingPosition.splice(predecessorIndex + 1, 0, value);
+    // suppose the               we want to add the       for the left value
+    // following profile         following zone:          'C', the predecessor index
+    //   for B: [1, 3]                "C3:D4"             correspond to 'B'.
+    //                                                    The next line code will
+    //       A B C D                A B C D               copy the profile of 'B'
+    //     1  '___'               1  '___'                to 'C'. In the rest of the
+    //     2  |   |       --->    2  |  _|_               process the 'modifyProfile'
+    //     3  |___|               3  |_|_| |              function will adapt the waiting
+    //     4                      4    |___|              'C' profile [1, 3] to the
+    //                                                    correct 'C' profile [1, 4]
+    profiles.set(value, [...profiles.get(profilesStartingPosition[predecessorIndex])!]);
+    return searchLeft ? predecessorIndex + 1 : predecessorIndex;
+  }
+  return searchLeft ? predecessorIndex : predecessorIndex - 1;
+}
+
+/**
+ *  Suppose the following        Suppose we want to add          We want to have the
+ *  profile:                     the following zone:             following profile:
+ *
+ *       A B C D E F                  A B C D E F                     A B C D E F
+ *     1    '___'                   1    '   '                      1    '___'
+ *     2    |___|                   2    '___'                      2    |   |
+ *     3    '   '                   3    |   |                      3    |   |
+ *     4    '___'          -->      4    |   |            -->       4    |   |
+ *     6    |   |                   6    |___|                      6    |   |
+ *     7    |___|                   7                               7    |___|
+ *     8                            8                               8
+ *
+ *  the profile for 'C'          the top zone correspond        Here [2, 3, 5, 8] with [3, 7]
+ *  corresponds to:              to 3 and the bottom zone       would be merged into [2, 8]
+ *   ____  ____                  correspond to 6
+ *  [2, 3, 5, 8]                 would be the profile:          The difficulty of modify profile
+ *                                ____                          is to know what must be deleted
+ *  Note that the 'filled        [3, 7]                         and what must be added to the
+ *  zone' are always between                                    existing profile.
+ *  an even index and its
+ *  next index
+ *
+ */
+
+function modifyProfile(
+  profile: number[],
+  zone: UnboundedZone,
+  toRemove: boolean = false
+): undefined {
+  const topValue = zone.top;
+  const bottomValue = zone.bottom === undefined ? undefined : zone.bottom + 1;
+  const newPoints: number[] = [];
+  // Case we want to add a zone to the profile:
+  // - If the top predecessor index `topPredIndex` is even, it means the top of the zone is already positioned on a filled zone
+  // so we don't need to add it to the profile. we can keep in reference the index of the predecessor.
+  // - If it is odd, it means the top of the zone must be the beginning of a filled zone.
+  // so we can keep the index of the top position
+  // Case we want to remove a zone from the profile: it's the opposite of the previous case
+  const topPredIndex = binaryPredecessorSearch(profile, topValue, 0, false);
+  if ((topPredIndex % 2 !== 0 && !toRemove) || (topPredIndex % 2 === 0 && toRemove)) {
+    newPoints.push(topValue);
+  }
+
+  if (bottomValue === undefined) {
+    // The following two code lines will not impact the final result,
+    // but they will impact the intermediate profile.
+    // We keep them for performance reason
+    profile.splice(topPredIndex + 1);
+    profile.push(...newPoints);
+    return;
+  }
+
+  // Case we want to add a zone to the profile:
+  // - If the bottom successor index `bottomSuccIndex` is even, it means the bottom of the zone must be the ending of a filled zone
+  // so we can keep the index of the bottom position.
+  // - If it is odd, it means the bottom of the zone is already positioned on a filled zone
+  // so we don't need to add it to the profile. we can keep in reference the index of the successor
+  // Case we want to remove a zone from the profile: it's the opposite of the previous case
+  const bottomSuccIndex = binarySuccessorSearch(profile, bottomValue, 0, false);
+  if ((bottomSuccIndex % 2 === 0 && !toRemove) || (bottomSuccIndex % 2 !== 0 && toRemove)) {
+    newPoints.push(bottomValue);
+  }
+
+  // add the top and bottom value to the profile and
+  // remove all information between the top and bottom index
+  profile.splice(topPredIndex + 1, bottomSuccIndex - topPredIndex - 1, ...newPoints);
+}
+
+function removeContiguousProfiles(
+  profilesStartingPosition: number[],
+  profiles: Map<number, number[]>,
+  leftIndex: number,
+  rightIndex: number
+) {
+  const start = leftIndex - 1 === -1 ? 0 : leftIndex - 1;
+  const end = rightIndex === profilesStartingPosition.length - 1 ? rightIndex : rightIndex + 1;
+  for (let i = end; i > start; i--) {
+    if (
+      deepEqualsArray(
+        profiles.get(profilesStartingPosition[i])!,
+        profiles.get(profilesStartingPosition[i - 1])!
+      )
+    ) {
+      profiles.delete(profilesStartingPosition[i]);
+      profilesStartingPosition.splice(i, 1);
+    }
+  }
+}
+
+function constructZonesFromProfiles(
+  profilesStartingPosition: number[],
+  profiles: Map<number, number[]>
+): UnboundedZone[] {
+  const mergedZone: UnboundedZone[] = [];
+  let pendingZones: UnboundedZone[] = [];
+  for (let colIndex = 0; colIndex < profilesStartingPosition.length; colIndex++) {
+    const left = profilesStartingPosition[colIndex];
+    const profile = profiles.get(left);
+    if (!profile || profile.length === 0) {
+      mergedZone.push(...pendingZones);
+      pendingZones = [];
+      continue;
+    }
+
+    let right = profilesStartingPosition[colIndex + 1];
+    if (right !== undefined) {
+      right--;
+    }
+
+    const nextPendingZones: UnboundedZone[] = [];
+    for (let i = 0; i < profile.length; i += 2) {
+      const top = profile[i];
+      let bottom = profile[i + 1];
+      if (bottom !== undefined) {
+        bottom--;
+      }
+      const profileZone: UnboundedZone = {
+        top,
+        left,
+        bottom,
+        right,
+        hasHeader: (bottom === undefined && top !== 0) || (right === undefined && left !== 0),
+      };
+
+      let findCorrespondingZone = false;
+      for (let j = pendingZones.length - 1; j >= 0; j--) {
+        const pendingZone = pendingZones[j];
+        if (pendingZone.top === profileZone.top && pendingZone.bottom === profileZone.bottom) {
+          pendingZone.right = profileZone.right;
+          pendingZones.splice(j, 1);
+          nextPendingZones.push(pendingZone);
+          findCorrespondingZone = true;
+          break;
+        }
+      }
+      if (!findCorrespondingZone) {
+        nextPendingZones.push(profileZone);
+      }
+    }
+
+    mergedZone.push(...pendingZones);
+    pendingZones = nextPendingZones;
+  }
+  mergedZone.push(...pendingZones);
+  return mergedZone;
+}
+
+function binaryPredecessorSearch(arr: number[], val: number, start = 0, matchEqual = true) {
+  let end = arr.length - 1;
+  let result = -1;
+
+  while (start <= end) {
+    const mid = Math.floor((start + end) / 2);
+    if (arr[mid] === val && matchEqual) {
+      return mid;
+    } else if (arr[mid] < val) {
+      result = mid;
+      start = mid + 1;
+    } else {
+      end = mid - 1;
+    }
+  }
+
+  return result;
+}
+
+function binarySuccessorSearch(arr: number[], val: number, start = 0, matchEqual = true) {
+  let end = arr.length - 1;
+  let result = arr.length;
+  while (start <= end) {
+    const mid = Math.floor((start + end) / 2);
+    if (arr[mid] === val && matchEqual) {
+      return mid;
+    } else if (arr[mid] > val) {
+      result = mid;
+      end = mid - 1;
+    } else {
+      start = mid + 1;
+    }
+  }
+  return result;
+}

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -386,9 +386,10 @@ export function isZoneInside(smallZone: Zone, biggerZone: Zone): boolean {
  * Recompute the ranges of the zone to contain all the cells in zones, without the cells in toRemoveZones
  * Also regroup zones together to shorten the string
  */
-export function recomputeZones(zonesXc: string[], toRemoveZonesXc: string[]): string[] {
-  const zones = zonesXc.map(toUnboundedZone);
-  const zonesToRemove = toRemoveZonesXc.map(toUnboundedZone);
+export function recomputeZones(
+  zones: UnboundedZone[],
+  zonesToRemove: UnboundedZone[]
+): UnboundedZone[] {
   // Compute the max to replace the bottom of full columns and right of full rows by something
   // bigger than any other col/row to be able to apply the algorithm while keeping tracks of what
   // zones are full cols/rows
@@ -410,13 +411,11 @@ export function recomputeZones(zonesXc: string[], toRemoveZonesXc: string[]): st
   const positionToKeep = positionsDifference(zonePositions, positionsToRemove);
   const columns = mergePositionsIntoColumns(positionToKeep);
 
-  return mergeAlignedColumns(columns)
-    .map((zone) => ({
-      ...zone,
-      bottom: zone.bottom === maxBottom + 1 ? undefined : zone.bottom,
-      right: zone.right === maxRight + 1 ? undefined : zone.right,
-    }))
-    .map(zoneToXc);
+  return mergeAlignedColumns(columns).map((zone) => ({
+    ...zone,
+    bottom: zone.bottom === maxBottom + 1 ? undefined : zone.bottom,
+    right: zone.right === maxRight + 1 ? undefined : zone.right,
+  }));
 }
 
 /**
@@ -659,7 +658,7 @@ export function organizeZone(zone: Zone): Zone {
   };
 }
 
-export function positionToZone(position: Position) {
+export function positionToZone(position: Position): Zone {
   return { left: position.col, right: position.col, top: position.row, bottom: position.row };
 }
 
@@ -687,7 +686,7 @@ export function getZoneArea(zone: Zone): number {
  * */
 export function areZonesContinuous(zones: Zone[]): boolean {
   if (zones.length < 2) return true;
-  return recomputeZones(zones.map(zoneToXc), []).length === 1;
+  return recomputeZones(zones, []).length === 1;
 }
 
 /** Return all the columns in the given list of zones */

--- a/src/model.ts
+++ b/src/model.ts
@@ -217,6 +217,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.coreGetters.getRangeDataFromZone = this.range.getRangeDataFromZone.bind(this.range);
     this.coreGetters.getRangeFromRangeData = this.range.getRangeFromRangeData.bind(this.range);
     this.coreGetters.getRangeFromZone = this.range.getRangeFromZone.bind(this.range);
+    this.coreGetters.recomputeRanges = this.range.recomputeRanges.bind(this.range);
     this.coreGetters.isRangeValid = this.range.isRangeValid.bind(this.range);
     this.coreGetters.extendRange = this.range.extendRange.bind(this.range);
     this.coreGetters.getRangesUnion = this.range.getRangesUnion.bind(this.range);

--- a/src/plugins/core/data_validation.ts
+++ b/src/plugins/core/data_validation.ts
@@ -3,7 +3,6 @@ import {
   deepCopy,
   getCellPositionsInRanges,
   isInside,
-  recomputeZones,
   toXC,
 } from "../../helpers";
 import { dataValidationEvaluatorRegistry } from "../../registries/data_validation_registry";
@@ -204,12 +203,8 @@ export class DataValidationPlugin
 
   private removeRangesFromRules(sheetId: UID, ranges: Range[], rules: DataValidationRule[]) {
     rules = deepCopy(rules);
-    const rangesXcs = ranges.map((range) => this.getters.getRangeString(range, sheetId));
     for (const rule of rules) {
-      const ruleRanges = rule.ranges.map((range) => this.getters.getRangeString(range, sheetId));
-      rule.ranges = recomputeZones(ruleRanges, rangesXcs).map((xc) =>
-        this.getters.getRangeFromSheetXC(sheetId, xc)
-      );
+      rule.ranges = this.getters.recomputeRanges(rule.ranges, ranges);
     }
     return rules.filter((rule) => rule.ranges.length > 0);
   }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -9,6 +9,7 @@ import {
   numberToLetters,
   RangeImpl,
   rangeReference,
+  recomputeZones,
   splitReference,
   toUnboundedZone,
   unionUnboundedZones,
@@ -49,6 +50,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     "getRangeFromRangeData",
     "getRangeFromZone",
     "getRangesUnion",
+    "recomputeRanges",
     "isRangeValid",
   ] as const;
 
@@ -421,6 +423,19 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
         prefixSheet: false,
       },
       this.getters.getSheetSize
+    );
+  }
+
+  /**
+   * Allows you to recompute ranges from the same sheet
+   */
+  recomputeRanges(ranges: Range[], rangesToRemove: Range[]): Range[] {
+    const zones = ranges.map((range) => RangeImpl.fromRange(range, this.getters).unboundedZone);
+    const zonesToRemove = rangesToRemove.map(
+      (range) => RangeImpl.fromRange(range, this.getters).unboundedZone
+    );
+    return recomputeZones(zones, zonesToRemove).map((zone) =>
+      this.getRangeFromZone(ranges[0].sheetId, zone)
     );
   }
 

--- a/tests/bottom_bar/aggregate_statistics_store.test.ts
+++ b/tests/bottom_bar/aggregate_statistics_store.test.ts
@@ -24,7 +24,7 @@ describe("Aggregate statistic functions", () => {
 
     setSelection(model, ["A1:A2"]);
     let statisticFnResults = store.statisticFnResults;
-    expect(statisticFnResults["Count"]).toBe(2);
+    expect(statisticFnResults["Count"]?.()).toBe(2);
 
     // expand selection with the range A3:A2
     addCellToSelection(model, "A3");
@@ -32,7 +32,7 @@ describe("Aggregate statistic functions", () => {
 
     // A2 is now present in two selection
     statisticFnResults = store.statisticFnResults;
-    expect(statisticFnResults["Count"]).toBe(3);
+    expect(statisticFnResults["Count"]?.()).toBe(3);
   });
 
   test("statistic function should not include hidden rows/columns in calculations", () => {
@@ -43,11 +43,11 @@ describe("Aggregate statistic functions", () => {
 
     setSelection(model, ["A1:A4"]);
     let statisticFnResults = store.statisticFnResults;
-    expect(statisticFnResults["Sum"]).toBe(6);
+    expect(statisticFnResults["Sum"]?.()).toBe(6);
 
     hideRows(model, [1, 2]);
     statisticFnResults = store.statisticFnResults;
-    expect(statisticFnResults["Sum"]).toBe(1);
+    expect(statisticFnResults["Sum"]?.()).toBe(1);
   });
 
   describe("return undefined if the types handled by the function are not present among the types of the selected cells", () => {
@@ -68,7 +68,7 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Sum"]).toBe(66);
+      expect(statisticFnResults["Sum"]?.()).toBe(66);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
@@ -80,7 +80,7 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Avg"]).toBe(22);
+      expect(statisticFnResults["Avg"]?.()).toBe(22);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
@@ -92,7 +92,7 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Min"]).toBe(0);
+      expect(statisticFnResults["Min"]?.()).toBe(0);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
@@ -104,7 +104,7 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Max"]).toBe(42);
+      expect(statisticFnResults["Max"]?.()).toBe(42);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
@@ -116,7 +116,7 @@ describe("Aggregate statistic functions", () => {
       selectCell(model, "A1");
       setAnchorCorner(model, "A7");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count"]).toBe(6);
+      expect(statisticFnResults["Count"]?.()).toBe(6);
 
       selectCell(model, "A7");
       statisticFnResults = store.statisticFnResults;
@@ -126,29 +126,29 @@ describe("Aggregate statistic functions", () => {
     test('return the "Count numbers" value on all types of interpreted cells except on cells interpreted as empty', () => {
       selectCell(model, "A1");
       let statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]).toBe(1);
+      expect(statisticFnResults["Count Numbers"]?.()).toBe(1);
 
       selectCell(model, "A2");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]).toBe(1);
+      expect(statisticFnResults["Count Numbers"]?.()).toBe(1);
 
       selectCell(model, "A3");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]).toBe(0);
+      expect(statisticFnResults["Count Numbers"]?.()).toBe(0);
 
       selectCell(model, "A4");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]).toBe(0);
+      expect(statisticFnResults["Count Numbers"]?.()).toBe(0);
 
       selectCell(model, "A5");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count Numbers"]).toBe(0);
+      expect(statisticFnResults["Count Numbers"]?.()).toBe(0);
 
       // select the range A6:A7
       selectCell(model, "A6");
       setAnchorCorner(model, "A7");
       statisticFnResults = store.statisticFnResults;
-      expect(statisticFnResults["Count"]).toBe(1);
+      expect(statisticFnResults["Count"]?.()).toBe(1);
     });
   });
 
@@ -186,12 +186,12 @@ describe("Aggregate statistic functions", () => {
     createSheet(model, { sheetId: sId2 });
     setCellContent(model, "A2", "4", sId2);
     setCellContent(model, "A3", "4", sId2);
-    expect(store.statisticFnResults["Count"]).toBe(3);
+    expect(store.statisticFnResults["Count"]?.()).toBe(3);
     activateSheet(model, sId2);
     selectAll(model);
-    expect(store.statisticFnResults["Count"]).toBe(2);
+    expect(store.statisticFnResults["Count"]?.()).toBe(2);
     activateSheet(model, sId1);
     selectAll(model);
-    expect(store.statisticFnResults["Count"]).toBe(3);
+    expect(store.statisticFnResults["Count"]?.()).toBe(3);
   });
 });

--- a/tests/helpers/recompute_zones_helpers.test.ts
+++ b/tests/helpers/recompute_zones_helpers.test.ts
@@ -1,0 +1,1007 @@
+import { modifyProfiles, recomputeZones, toUnboundedZone, zoneToXc } from "../../src/helpers";
+
+const recomputeZonesFromXC = function (xcs: string[], xcsToRemove: string[]): string[] {
+  return recomputeZones(xcs.map(toUnboundedZone), xcsToRemove.map(toUnboundedZone)).map(zoneToXc);
+};
+
+// Only to test result after modifyProfiles
+function computeProfiles(xcs: string[], xcsToRemove: string[]): Map<number, number[]> {
+  const zones = xcs.map(toUnboundedZone);
+  const zonesToRemove = xcsToRemove.map(toUnboundedZone);
+
+  const profilesStartingPosition: number[] = [0];
+  const profiles = new Map<number, number[]>([[0, []]]);
+
+  modifyProfiles(profilesStartingPosition, profiles, zones, false);
+  modifyProfiles(profilesStartingPosition, profiles, zonesToRemove, true);
+  return profiles;
+}
+
+// This 'describe' is here to test the modifyProfile function that is an intermediate step in the recomputeZones process.
+// We test the intermediate step and not the final result because this step is both complex and fundamental in the recompute.
+// You can find more information in the "recompute_zone" file.
+describe("modifyProfiles", () => {
+  test("modifProfiles with one range", () => {
+    const conf1 = ["C3:E5"];
+    const result = new Map<number, number[]>([
+      [0, []],
+      [2, [2, 5]],
+      [5, []],
+    ]);
+    expect(computeProfiles(conf1, [])).toEqual(result);
+  });
+
+  test("modifyProfiles with unbounded range", () => {
+    const conf1 = ["C3:E5", "C4:E"];
+    const result = new Map<number, number[]>([
+      [0, []],
+      [2, [2]],
+      [5, []],
+    ]);
+    expect(computeProfiles(conf1, [])).toEqual(result);
+  });
+
+  describe("translation of 2x1 on row 0 with C3:E5", () => {
+    test("A1:B1", () => {
+      const conf1 = ["A1:B1", "C3:E5"];
+      const conf2 = ["C3:E5", "A1:B1"];
+      const result = new Map<number, number[]>([
+        [0, [0, 1]],
+        [2, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("B1:C1", () => {
+      const conf1 = ["B1:C1", "C3:E5"];
+      const conf2 = ["C3:E5", "B1:C1"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [1, [0, 1]],
+        [2, [0, 1, 2, 5]],
+        [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("C1:D1", () => {
+      const conf1 = ["C1:D1", "C3:E5"];
+      const conf2 = ["C3:E5", "C1:D1"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [0, 1, 2, 5]],
+        [4, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("D1:E1", () => {
+      const conf1 = ["D1:E1", "C3:E5"];
+      const conf2 = ["C3:E5", "D1:E1"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [3, [0, 1, 2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("E1:F1", () => {
+      const conf1 = ["E1:F1", "C3:E5"];
+      const conf2 = ["C3:E5", "E1:F1"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [4, [0, 1, 2, 5]],
+        [5, [0, 1]],
+        [6, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("F1:G1", () => {
+      const conf1 = ["F1:G1", "C3:E5"];
+      const conf2 = ["C3:E5", "F1:G1"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, [0, 1]],
+        [7, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("G1:H1", () => {
+      const conf1 = ["G1:H1", "C3:E5"];
+      const conf2 = ["C3:E5", "G1:H1"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, []],
+        [6, [0, 1]],
+        [8, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+  });
+
+  describe("translation of 2x2 on row 0 with C3:E5", () => {
+    test("A1:B2", () => {
+      const conf1 = ["A1:B2", "C3:E5"];
+      const conf2 = ["C3:E5", "A1:B2"];
+      const result = new Map<number, number[]>([
+        [0, [0, 2]],
+        [2, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("B1:C2", () => {
+      const conf1 = ["B1:C2", "C3:E5"];
+      const conf2 = ["C3:E5", "B1:C2"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [1, [0, 2]],
+        [2, [0, 5]],
+        [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("C1:D2", () => {
+      const conf1 = ["C1:D2", "C3:E5"];
+      const conf2 = ["C3:E5", "C1:D2"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [0, 5]],
+        [4, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("D1:E2", () => {
+      const conf1 = ["D1:E2", "C3:E5"];
+      const conf2 = ["C3:E5", "D1:E2"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [3, [0, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("E1:F2", () => {
+      const conf1 = ["E1:F2", "C3:E5"];
+      const conf2 = ["C3:E5", "E1:F2"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [4, [0, 5]],
+        [5, [0, 2]],
+        [6, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("F1:G2", () => {
+      const conf1 = ["F1:G2", "C3:E5"];
+      const conf2 = ["C3:E5", "F1:G2"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, [0, 2]],
+        [7, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("G1:H2", () => {
+      const conf1 = ["G1:H2", "C3:E5"];
+      const conf2 = ["C3:E5", "G1:H2"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, []],
+        [6, [0, 2]],
+        [8, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+  });
+
+  describe("translation of 2x2 on row 1 with C3:E5", () => {
+    test("A2:B3", () => {
+      const conf1 = ["A2:B3", "C3:E5"];
+      const conf2 = ["C3:E5", "A2:B3"];
+      const result = new Map<number, number[]>([
+        [0, [1, 3]],
+        [2, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("B2:C3", () => {
+      const conf1 = ["B2:C3", "C3:E5"];
+      const conf2 = ["C3:E5", "B2:C3"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [1, [1, 3]],
+        [2, [1, 5]],
+        [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("C2:D3", () => {
+      const conf1 = ["C2:D3", "C3:E5"];
+      const conf2 = ["C3:E5", "C2:D3"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [1, 5]],
+        [4, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("D2:E3", () => {
+      const conf1 = ["D2:E3", "C3:E5"];
+      const conf2 = ["C3:E5", "D2:E3"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [3, [1, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("E2:F3", () => {
+      const conf1 = ["E2:F3", "C3:E5"];
+      const conf2 = ["C3:E5", "E2:F3"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [4, [1, 5]],
+        [5, [1, 3]],
+        [6, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("F2:G3", () => {
+      const conf1 = ["F2:G3", "C3:E5"];
+      const conf2 = ["C3:E5", "F2:G3"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, [1, 3]],
+        [7, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("G2:H3", () => {
+      const conf1 = ["G2:H3", "C3:E5"];
+      const conf2 = ["C3:E5", "G2:H3"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, []],
+        [6, [1, 3]],
+        [8, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+  });
+
+  describe("translation of 2x2 on row 2 with C3:E5", () => {
+    test("A3:B4", () => {
+      const conf1 = ["A3:B4", "C3:E5"];
+      const conf2 = ["C3:E5", "A3:B4"];
+      const result = new Map<number, number[]>([
+        [0, [2, 4]],
+        [2, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("B3:C4", () => {
+      const conf1 = ["B3:C4", "C3:E5"];
+      const conf2 = ["C3:E5", "B3:C4"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [1, [2, 4]],
+        [2, [2, 5]],
+        // WITHOUT REMOVE SAME CONTIGUOUS PROFILES [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("C3:D4", () => {
+      const conf1 = ["C3:D4", "C3:E5"];
+      const conf2 = ["C3:E5", "C3:D4"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        // WITHOUT REMOVE SAME CONTIGUOUS PROFILES [4, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("D3:E4", () => {
+      const conf1 = ["D3:E4", "C3:E5"];
+      const conf2 = ["C3:E5", "D3:E4"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        // WITHOUT REMOVE SAME CONTIGUOUS PROFILES [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("E3:F4", () => {
+      const conf1 = ["E3:F4", "C3:E5"];
+      const conf2 = ["C3:E5", "E3:F4"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        // WITHOUT REMOVE SAME CONTIGUOUS PROFILES [4, [2, 5]],
+        [5, [2, 4]],
+        [6, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("F3:G4", () => {
+      const conf1 = ["F3:G4", "C3:E5"];
+      const conf2 = ["C3:E5", "F3:G4"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, [2, 4]],
+        [7, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("G3:H4", () => {
+      const conf1 = ["G3:H4", "C3:E5"];
+      const conf2 = ["C3:E5", "G3:H4"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, []],
+        [6, [2, 4]],
+        [8, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+  });
+
+  describe("translation of 2x2 on row 3 with C3:E5", () => {
+    test("A4:B5", () => {
+      const conf1 = ["A4:B5", "C3:E5"];
+      const conf2 = ["C3:E5", "A4:B5"];
+      const result = new Map<number, number[]>([
+        [0, [3, 5]],
+        [2, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("B4:C5", () => {
+      const conf1 = ["B4:C5", "C3:E5"];
+      const conf2 = ["C3:E5", "B4:C5"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [1, [3, 5]],
+        [2, [2, 5]],
+        // WITHOUT REMOVE SAME CONTIGUOUS PROFILES [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("C4:D5", () => {
+      const conf1 = ["C4:D5", "C3:E5"];
+      const conf2 = ["C3:E5", "C4:D5"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        // WITHOUT REMOVE SAME CONTIGUOUS PROFILES [4, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("D4:E5", () => {
+      const conf1 = ["D4:E5", "C3:E5"];
+      const conf2 = ["C3:E5", "D4:E5"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        // WITHOUT REMOVE SAME CONTIGUOUS PROFILES [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("E4:F5", () => {
+      const conf1 = ["E4:F5", "C3:E5"];
+      const conf2 = ["C3:E5", "E4:F5"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        // WITHOUT REMOVE SAME CONTIGUOUS PROFILES [4, [2, 5]],
+        [5, [3, 5]],
+        [6, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("F4:G5", () => {
+      const conf1 = ["F4:G5", "C3:E5"];
+      const conf2 = ["C3:E5", "F4:G5"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, [3, 5]],
+        [7, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("G4:H5", () => {
+      const conf1 = ["G4:H5", "C3:E5"];
+      const conf2 = ["C3:E5", "G4:H5"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, []],
+        [6, [3, 5]],
+        [8, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+  });
+
+  describe("translation of 2x2 on row 4 with C3:E5", () => {
+    test("A5:B6", () => {
+      const conf1 = ["A5:B6", "C3:E5"];
+      const conf2 = ["C3:E5", "A5:B6"];
+      const result = new Map<number, number[]>([
+        [0, [4, 6]],
+        [2, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("B5:C6", () => {
+      const conf1 = ["B5:C6", "C3:E5"];
+      const conf2 = ["C3:E5", "B5:C6"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [1, [4, 6]],
+        [2, [2, 6]],
+        [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("C5:D6", () => {
+      const conf1 = ["C5:D6", "C3:E5"];
+      const conf2 = ["C3:E5", "C5:D6"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 6]],
+        [4, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("D5:E6", () => {
+      const conf1 = ["D5:E6", "C3:E5"];
+      const conf2 = ["C3:E5", "D5:E6"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [3, [2, 6]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("E5:F6", () => {
+      const conf1 = ["E5:F6", "C3:E5"];
+      const conf2 = ["C3:E5", "E5:F6"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [4, [2, 6]],
+        [5, [4, 6]],
+        [6, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("F5:G6", () => {
+      const conf1 = ["F5:G6", "C3:E5"];
+      const conf2 = ["C3:E5", "F5:G6"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, [4, 6]],
+        [7, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("G5:H6", () => {
+      const conf1 = ["G5:H6", "C3:E5"];
+      const conf2 = ["C3:E5", "G5:H6"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, []],
+        [6, [4, 6]],
+        [8, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+  });
+
+  describe("translation of 2x2 on row 5 with C3:E5", () => {
+    test("A6:B7", () => {
+      const conf1 = ["A6:B7", "C3:E5"];
+      const conf2 = ["C3:E5", "A6:B7"];
+      const result = new Map<number, number[]>([
+        [0, [5, 7]],
+        [2, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("B6:C7", () => {
+      const conf1 = ["B6:C7", "C3:E5"];
+      const conf2 = ["C3:E5", "B6:C7"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [1, [5, 7]],
+        [2, [2, 7]],
+        [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("C6:D7", () => {
+      const conf1 = ["C6:D7", "C3:E5"];
+      const conf2 = ["C3:E5", "C6:D7"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 7]],
+        [4, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("D6:E7", () => {
+      const conf1 = ["D6:E7", "C3:E5"];
+      const conf2 = ["C3:E5", "D6:E7"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [3, [2, 7]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("E6:F7", () => {
+      const conf1 = ["E6:F7", "C3:E5"];
+      const conf2 = ["C3:E5", "E6:F7"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [4, [2, 7]],
+        [5, [5, 7]],
+        [6, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("F6:G7", () => {
+      const conf1 = ["F6:G7", "C3:E5"];
+      const conf2 = ["C3:E5", "F6:G7"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, [5, 7]],
+        [7, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("G6:H7", () => {
+      const conf1 = ["G6:H7", "C3:E5"];
+      const conf2 = ["C3:E5", "G6:H7"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, []],
+        [6, [5, 7]],
+        [8, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+  });
+
+  describe("translation of 2x2 on row 6 with C3:E5", () => {
+    test("A7:B8", () => {
+      const conf1 = ["A7:B8", "C3:E5"];
+      const conf2 = ["C3:E5", "A7:B8"];
+      const result = new Map<number, number[]>([
+        [0, [6, 8]],
+        [2, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("B7:C8", () => {
+      const conf1 = ["B7:C8", "C3:E5"];
+      const conf2 = ["C3:E5", "B7:C8"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [1, [6, 8]],
+        [2, [2, 5, 6, 8]],
+        [3, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("C7:D8", () => {
+      const conf1 = ["C7:D8", "C3:E5"];
+      const conf2 = ["C3:E5", "C7:D8"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5, 6, 8]],
+        [4, [2, 5]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("D7:E8", () => {
+      const conf1 = ["D7:E8", "C3:E5"];
+      const conf2 = ["C3:E5", "D7:E8"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [3, [2, 5, 6, 8]],
+        [5, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("E7:F8", () => {
+      const conf1 = ["E7:F8", "C3:E5"];
+      const conf2 = ["C3:E5", "E7:F8"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [4, [2, 5, 6, 8]],
+        [5, [6, 8]],
+        [6, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("F7:G8", () => {
+      const conf1 = ["F7:G8", "C3:E5"];
+      const conf2 = ["C3:E5", "F7:G8"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, [6, 8]],
+        [7, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+
+    test("G7:H8", () => {
+      const conf1 = ["G7:H8", "C3:E5"];
+      const conf2 = ["C3:E5", "G7:H8"];
+      const result = new Map<number, number[]>([
+        [0, []],
+        [2, [2, 5]],
+        [5, []],
+        [6, [6, 8]],
+        [8, []],
+      ]);
+      expect(computeProfiles(conf1, [])).toEqual(result);
+      expect(computeProfiles(conf2, [])).toEqual(result);
+    });
+  });
+});
+
+describe("recomputeZones", () => {
+  test("on a simple zone", () => {
+    const conf1 = ["A1:B1"];
+    expect(recomputeZonesFromXC(conf1, [])).toEqual(conf1);
+  });
+
+  test.each([
+    ["A1:B1", ["A1:B1", "C3:E5"]],
+    ["B1:C1", ["B1:C1", "C3:E5"]],
+    ["C1:D1", ["C1:D1", "C3:E5"]],
+    ["D1:E1", ["D1:E1", "C3:E5"]],
+    ["E1:F1", ["C3:E5", "E1:F1"]],
+    ["F1:G1", ["C3:E5", "F1:G1"]],
+    ["G1:H1", ["C3:E5", "G1:H1"]],
+  ])("translation of 2x1 zone (%s) on rowIndex 0 with C3:E5", (zone, result) => {
+    expect(recomputeZonesFromXC(["C3:E5", zone], [])).toEqual(result);
+    expect(recomputeZonesFromXC([zone, "C3:E5"], [])).toEqual(result);
+  });
+
+  test.each([
+    ["A1:B2", ["A1:B2", "C3:E5"]],
+    ["B1:C2", ["B1:B2", "C1:C5", "D3:E5"]],
+    ["C1:D2", ["C1:D5", "E3:E5"]],
+    ["D1:E2", ["C3:C5", "D1:E5"]],
+    ["E1:F2", ["C3:D5", "E1:E5", "F1:F2"]],
+    ["F1:G2", ["C3:E5", "F1:G2"]],
+    ["G1:H2", ["C3:E5", "G1:H2"]],
+  ])("translation of 2x2 zone (%s) on rowIndex 0 with C3:E5", (zone, result) => {
+    expect(recomputeZonesFromXC(["C3:E5", zone], [])).toEqual(result);
+    expect(recomputeZonesFromXC([zone, "C3:E5"], [])).toEqual(result);
+  });
+
+  test("contiguous cells on the same column", () => {
+    const toMerge = [
+      "D6",
+      "D21",
+      "D8",
+      "D15",
+      "D16",
+      "D13",
+      "D12",
+      "D11",
+      "D14",
+      "D18",
+      "D10",
+      "D7",
+      "D9",
+      "D2",
+      "D20",
+      "D17",
+      "D1",
+      "D19",
+      "D4",
+      "D3",
+      "D5",
+    ];
+    expect(recomputeZonesFromXC(toMerge, [])).toEqual(["D1:D21"]);
+  });
+
+  test("contiguous cells on the same row", () => {
+    const toMerge = [
+      "F1",
+      "U1",
+      "H1",
+      "O1",
+      "P1",
+      "M1",
+      "L1",
+      "K1",
+      "N1",
+      "R1",
+      "J1",
+      "G1",
+      "I1",
+      "B1",
+      "S1",
+      "Q1",
+      "A1",
+      "T1",
+      "D1",
+      "C1",
+      "E1",
+    ];
+    expect(recomputeZonesFromXC(toMerge, [])).toEqual(["A1:U1"]);
+  });
+
+  test("add a cell to zone(1)", () => {
+    const toKeep = ["A1:C3", "A4"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A1:A4", "B1:C3"]);
+  });
+
+  test("add a cell to zone(2)", () => {
+    const toKeep = ["A1:C3", "D1"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A1:C3", "D1"]);
+  });
+
+  test("add a cell to a full column zone", () => {
+    const toKeep = ["A:B", "A4"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A:B"]);
+  });
+
+  test("add a cell to a full column zone (2)", () => {
+    const toKeep = ["A2:A", "A1"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A:A"]);
+  });
+
+  test("add a cell to a full row zone", () => {
+    const toKeep = ["1:2", "A1"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["1:2"]);
+  });
+
+  test("add a cell to a full row zone (2)", () => {
+    const toKeep = ["C1:1", "B1"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["B1:1"]);
+  });
+
+  test("add a row to a zone", () => {
+    const toKeep = ["A1:C3", "A4:C4"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A1:C4"]);
+  });
+
+  test("add a row to a full row range", () => {
+    const toKeep = ["1:1", "2:2"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["1:2"]);
+  });
+
+  test("add a col to a zone", () => {
+    const toKeep = ["A1:C3", "D1:D3"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A1:D3"]);
+  });
+
+  test("add a col to a full column range", () => {
+    const toKeep = ["A2:A", "B2:B"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A2:B"]);
+  });
+
+  test("merge zones", () => {
+    const toKeep = ["A1:B3", "B2:C5", "C1:C5"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A1:A3", "B1:C5"]);
+  });
+  test("zones included", () => {
+    const toKeep = ["A1:D6", "A2:C3"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A1:D6"]);
+  });
+  test("remove a cell (1)", () => {
+    const toKeep = ["A1:D6"];
+    const toRemove = ["A1"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["A2:A6", "B1:D6"]);
+  });
+  test("remove a cell (2)", () => {
+    const toKeep = ["A1:D6"];
+    const toRemove = ["D6"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["A1:C6", "D1:D5"]);
+  });
+  test("remove a cell (3)", () => {
+    const toKeep = ["A1:D6"];
+    const toRemove = ["B3"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["A1:A6", "B1:B2", "B4:B6", "C1:D6"]);
+  });
+  test("remove a cell inside a full column range", () => {
+    const toKeep = ["A:A"];
+    const toRemove = ["A4"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["A1:A3", "A5:A"]);
+  });
+  test("remove a cell at the top of a full column range", () => {
+    const toKeep = ["A:A"];
+    const toRemove = ["A1"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["A2:A"]);
+  });
+  test("remove a cell inside a full row range", () => {
+    const toKeep = ["1:1"];
+    const toRemove = ["C1"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["A1:B1", "D1:1"]);
+  });
+  test("remove a cell at the left of a full row range", () => {
+    const toKeep = ["1:1"];
+    const toRemove = ["A1"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["B1:1"]);
+  });
+
+  test("remove a zone", () => {
+    const toKeep = ["A1:D6"];
+    const toRemove = ["B1:C6"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["A1:A6", "D1:D6"]);
+  });
+
+  test("remove an unbounded zone", () => {
+    const toKeep = ["A1:D6"];
+    const toRemove = ["2:3"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["A1:D1", "A4:D6"]);
+  });
+
+  test("remove an unbounded zone with header", () => {
+    const toKeep = ["A1:D6"];
+    const toRemove = ["B2:3"];
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(["A1:A6", "B1:D1", "B4:D6"]);
+  });
+
+  test("merge 4 zones in both directions", () => {
+    const toKeep = ["A1", "A2", "B1", "B2"];
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(["A1:B2"]);
+  });
+});

--- a/tests/helpers/zones_helpers.test.ts
+++ b/tests/helpers/zones_helpers.test.ts
@@ -5,18 +5,12 @@ import {
   mergePositionsIntoColumns,
   overlap,
   positions,
-  recomputeZones,
   toCartesian,
   toUnboundedZone,
   toZone,
-  zoneToXc,
 } from "../../src/helpers/index";
 import { Position, Zone } from "../../src/types";
 import { target } from "../test_helpers/helpers";
-
-const recomputeZonesFromXC = function (xcs: string[], xcsToRemove: string[]): string[] {
-  return recomputeZones(xcs.map(toUnboundedZone), xcsToRemove.map(toUnboundedZone)).map(zoneToXc);
-};
 
 describe("overlap", () => {
   test("one zone above the other", () => {
@@ -188,135 +182,6 @@ describe("mergeAlignedColumns", () => {
     expect(mergeAlignedColumns(target("A1:A2, A3:A4, B1:B2, B3:B4"))).toEqual(
       target("A1:B2, A3:B4")
     );
-  });
-});
-
-describe("recomputeZones", () => {
-  test("add a cell to zone(1)", () => {
-    const toKeep = ["A1:C3", "A4"];
-    const expectedZone = ["A1:A4", "B1:C3"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("add a cell to zone(2)", () => {
-    const toKeep = ["A1:C3", "D1"];
-    const expectedZone = ["A1:C3", "D1"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("add a cell to a full column zone", () => {
-    const toKeep = ["A:B", "A4"];
-    const expectedZone = ["A:B"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("add a cell to a full column zone (2)", () => {
-    const toKeep = ["A2:A", "A1"];
-    const expectedZone = ["A:A"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("add a cell to a full row zone", () => {
-    const toKeep = ["1:2", "A1"];
-    const expectedZone = ["1:2"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("add a cell to a full row zone (2)", () => {
-    const toKeep = ["C1:1", "B1"];
-    const expectedZone = ["B1:1"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("add a row to a zone", () => {
-    const toKeep = ["A1:C3", "A4:C4"];
-    const expectedZone = ["A1:C4"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("add a row to a full row range", () => {
-    const toKeep = ["1:1", "2:2"];
-    const expectedZone = ["1:2"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("add a col to a zone", () => {
-    const toKeep = ["A1:C3", "D1:D3"];
-    const expectedZone = ["A1:D3"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("add a col to a full column range", () => {
-    const toKeep = ["A2:A", "B2:B"];
-    const expectedZone = ["A2:B"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-
-  test("merge zones", () => {
-    const toKeep = ["A1:B3", "B2:C5", "C1:C5"];
-    const expectedZone = ["A1:A3", "B1:C5"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-  test("zones included", () => {
-    const toKeep = ["A1:D6", "A2:C3"];
-    const expectedZone = ["A1:D6"];
-    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
-  });
-  test("remove a cell (1)", () => {
-    const toKeep = ["A1:D6"];
-    const toRemove = ["A1"];
-    const expectedZone = ["A2:A6", "B1:D6"];
-    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
-  });
-  test("remove a cell (2)", () => {
-    const toKeep = ["A1:D6"];
-    const toRemove = ["D6"];
-    const expectedZone = ["A1:C6", "D1:D5"];
-    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
-  });
-  test("remove a cell (3)", () => {
-    const toKeep = ["A1:D6"];
-    const toRemove = ["B3"];
-    const expectedZone = ["A1:A6", "B1:B2", "B4:B6", "C1:D6"];
-    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
-  });
-  test("remove a cell inside a full column range", () => {
-    const toKeep = ["A:A"];
-    const toRemove = ["A4"];
-    const expectedZone = ["A1:A3", "A5:A"];
-    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
-  });
-  test("remove a cell at the top of a full column range", () => {
-    const toKeep = ["A:A"];
-    const toRemove = ["A1"];
-    const expectedZone = ["A2:A"];
-    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
-  });
-  test("remove a cell inside a full row range", () => {
-    const toKeep = ["1:1"];
-    const toRemove = ["C1"];
-    const expectedZone = ["A1:B1", "D1:1"];
-    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
-  });
-  test("remove a cell at the left of a full row range", () => {
-    const toKeep = ["1:1"];
-    const toRemove = ["A1"];
-    const expectedZone = ["B1:1"];
-    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
-  });
-
-  test("remove a zone", () => {
-    const toKeep = ["A1:D6"];
-    const toRemove = ["B1:C6"];
-    const expectedZone = ["A1:A6", "D1:D6"];
-    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
-  });
-
-  test("remove an unbounded zone", () => {
-    const toKeep = ["A1:D6"];
-    const toRemove = ["2:3"];
-    const expectedZone = ["A1:D1", "A4:D6"];
-    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
 });
 

--- a/tests/helpers/zones_helpers.test.ts
+++ b/tests/helpers/zones_helpers.test.ts
@@ -9,9 +9,14 @@ import {
   toCartesian,
   toUnboundedZone,
   toZone,
+  zoneToXc,
 } from "../../src/helpers/index";
 import { Position, Zone } from "../../src/types";
 import { target } from "../test_helpers/helpers";
+
+const recomputeZonesFromXC = function (xcs: string[], xcsToRemove: string[]): string[] {
+  return recomputeZones(xcs.map(toUnboundedZone), xcsToRemove.map(toUnboundedZone)).map(zoneToXc);
+};
 
 describe("overlap", () => {
   test("one zone above the other", () => {
@@ -190,128 +195,128 @@ describe("recomputeZones", () => {
   test("add a cell to zone(1)", () => {
     const toKeep = ["A1:C3", "A4"];
     const expectedZone = ["A1:A4", "B1:C3"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("add a cell to zone(2)", () => {
     const toKeep = ["A1:C3", "D1"];
     const expectedZone = ["A1:C3", "D1"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("add a cell to a full column zone", () => {
     const toKeep = ["A:B", "A4"];
     const expectedZone = ["A:B"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("add a cell to a full column zone (2)", () => {
     const toKeep = ["A2:A", "A1"];
     const expectedZone = ["A:A"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("add a cell to a full row zone", () => {
     const toKeep = ["1:2", "A1"];
     const expectedZone = ["1:2"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("add a cell to a full row zone (2)", () => {
     const toKeep = ["C1:1", "B1"];
     const expectedZone = ["B1:1"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("add a row to a zone", () => {
     const toKeep = ["A1:C3", "A4:C4"];
     const expectedZone = ["A1:C4"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("add a row to a full row range", () => {
     const toKeep = ["1:1", "2:2"];
     const expectedZone = ["1:2"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("add a col to a zone", () => {
     const toKeep = ["A1:C3", "D1:D3"];
     const expectedZone = ["A1:D3"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("add a col to a full column range", () => {
     const toKeep = ["A2:A", "B2:B"];
     const expectedZone = ["A2:B"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
 
   test("merge zones", () => {
     const toKeep = ["A1:B3", "B2:C5", "C1:C5"];
     const expectedZone = ["A1:A3", "B1:C5"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
   test("zones included", () => {
     const toKeep = ["A1:D6", "A2:C3"];
     const expectedZone = ["A1:D6"];
-    expect(recomputeZones(toKeep, [])).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, [])).toEqual(expectedZone);
   });
   test("remove a cell (1)", () => {
     const toKeep = ["A1:D6"];
     const toRemove = ["A1"];
     const expectedZone = ["A2:A6", "B1:D6"];
-    expect(recomputeZones(toKeep, toRemove)).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
   test("remove a cell (2)", () => {
     const toKeep = ["A1:D6"];
     const toRemove = ["D6"];
     const expectedZone = ["A1:C6", "D1:D5"];
-    expect(recomputeZones(toKeep, toRemove)).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
   test("remove a cell (3)", () => {
     const toKeep = ["A1:D6"];
     const toRemove = ["B3"];
     const expectedZone = ["A1:A6", "B1:B2", "B4:B6", "C1:D6"];
-    expect(recomputeZones(toKeep, toRemove)).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
   test("remove a cell inside a full column range", () => {
     const toKeep = ["A:A"];
     const toRemove = ["A4"];
     const expectedZone = ["A1:A3", "A5:A"];
-    expect(recomputeZones(toKeep, toRemove)).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
   test("remove a cell at the top of a full column range", () => {
     const toKeep = ["A:A"];
     const toRemove = ["A1"];
     const expectedZone = ["A2:A"];
-    expect(recomputeZones(toKeep, toRemove)).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
   test("remove a cell inside a full row range", () => {
     const toKeep = ["1:1"];
     const toRemove = ["C1"];
     const expectedZone = ["A1:B1", "D1:1"];
-    expect(recomputeZones(toKeep, toRemove)).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
   test("remove a cell at the left of a full row range", () => {
     const toKeep = ["1:1"];
     const toRemove = ["A1"];
     const expectedZone = ["B1:1"];
-    expect(recomputeZones(toKeep, toRemove)).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
 
   test("remove a zone", () => {
     const toKeep = ["A1:D6"];
     const toRemove = ["B1:C6"];
     const expectedZone = ["A1:A6", "D1:D6"];
-    expect(recomputeZones(toKeep, toRemove)).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
 
   test("remove an unbounded zone", () => {
     const toKeep = ["A1:D6"];
     const toRemove = ["2:3"];
     const expectedZone = ["A1:D1", "A4:D6"];
-    expect(recomputeZones(toKeep, toRemove)).toEqual(expectedZone);
+    expect(recomputeZonesFromXC(toKeep, toRemove)).toEqual(expectedZone);
   });
 });
 


### PR DESCRIPTION
## Description:

When we select something in spreadsheet (a cell or
several cells) 80% of the execution time takes place
in the `getStatisticFnResults` function.

This PR aims to reduce compute time in `getStatisticFnResults`

The change potentially involves using the "recomputeZone" function.
So, not directly related to this task, but you can find changes that refactor the
“recomputeZones” function

Task: : [3276456](https://www.odoo.com/web#id=3276456&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo