### PR TITLE
[FIX] side_panel: always call onCloseSidePanel callback

### DIFF
--- a/src/components/side_panel/side_panel/side_panel.ts
+++ b/src/components/side_panel/side_panel/side_panel.ts
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, useEffect } from "@odoo/owl";
 import { BACKGROUND_HEADER_COLOR, FILTERS_COLOR } from "../../../constants";
 import { sidePanelRegistry } from "../../../registries/side_panel_registry";
 import { Store, useStore } from "../../../store_engine";
@@ -161,6 +161,14 @@ export class SidePanel extends Component<never, SpreadsheetChildEnv> {
 
   setup() {
     this.sidePanelStore = useStore(SidePanelStore);
+    useEffect(
+      (isOpen) => {
+        if (!isOpen) {
+          this.sidePanelStore.close();
+        }
+      },
+      () => [this.sidePanelStore.isOpen]
+    );
   }
 
   get panel() {

--- a/src/components/spreadsheet/spreadsheet.xml
+++ b/src/components/spreadsheet/spreadsheet.xml
@@ -26,7 +26,7 @@
             <Grid exposeFocus="(focus) => this._focusGrid = focus"/>
           </div>
         </div>
-        <SidePanel t-if="sidePanel.isOpen"/>
+        <SidePanel/>
         <BottomBar onClick="() => this.focusGrid()"/>
       </t>
     </div>


### PR DESCRIPTION
The onCloseSidePanel callback was not being called when the side panel closed because of the computeState function. The state of the side panel store also wasn't being updated.

A bug that could happen was for example when the user deleted the chart being edited the side panel was closed, but clicking on another random chart would re-open the side panel.

This commit creates a useEffect in the side panel, that will make sure that the store is updated and the onCloseSidePanel callback is called when the side panel is closed.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo