### PR TITLE
[FIX] headers_overlay: unhide cols/rows icon position broken

### DIFF
--- a/src/components/headers_overlay/headers_overlay.ts
+++ b/src/components/headers_overlay/headers_overlay.ts
@@ -340,11 +340,6 @@ css/* scss */ `
       height: 10000px;
       background-color: ${SELECTION_BORDER_COLOR};
     }
-    .o-unhide-buttons {
-      width: fit-content;
-      gap: 5px;
-      transform: translate(-50%, 0);
-    }
     .o-unhide:hover {
       z-index: ${ComponentsImportance.Grid + 1};
       background-color: lightgrey;
@@ -536,10 +531,6 @@ css/* scss */ `
       width: 10000px;
       height: 1px;
       background-color: ${SELECTION_BORDER_COLOR};
-    }
-    .o-unhide-buttons {
-      height: fit-content;
-      transform: translate(0, -50%);
     }
     .o-unhide:hover {
       z-index: ${ComponentsImportance.Grid + 1};

--- a/src/components/headers_overlay/headers_overlay.xml
+++ b/src/components/headers_overlay/headers_overlay.xml
@@ -42,25 +42,22 @@
         t-as="hiddenItem"
         t-key="hiddenItem_index">
         <div
-          class="o-unhide-buttons position-relative float-end"
+          class="position-absolute end-0 translate-middle-y"
           t-att-style="getUnhideButtonStyle(hiddenItem[0])">
-          <t t-if="!hiddenItem.includes(0)">
-            <div
-              class="o-unhide rounded mb-1"
-              t-att-data-index="hiddenItem_index"
-              t-on-click="() => this.unhide(hiddenItem)">
-              <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>
-            </div>
-          </t>
-          <t
-            t-if="!hiddenItem.includes(env.model.getters.getNumberRows(env.model.getters.getActiveSheetId())-1)">
-            <div
-              class="o-unhide rounded"
-              t-att-data-index="hiddenItem_index"
-              t-on-click="() => this.unhide(hiddenItem)">
-              <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
-            </div>
-          </t>
+          <div
+            class="o-unhide rounded mb-1"
+            t-att-class="{'invisible': hiddenItem.includes(0)}"
+            t-att-data-index="hiddenItem_index"
+            t-on-click="() => this.unhide(hiddenItem)">
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_UP"/>
+          </div>
+          <div
+            class="o-unhide rounded"
+            t-att-class="{'invisible': hiddenItem.includes(env.model.getters.getNumberRows(env.model.getters.getActiveSheetId())-1)}"
+            t-att-data-index="hiddenItem_index"
+            t-on-click="() => this.unhide(hiddenItem)">
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_DOWN"/>
+          </div>
         </div>
       </t>
     </div>
@@ -101,25 +98,22 @@
         t-as="hiddenItem"
         t-key="hiddenItem_index">
         <div
-          class="o-unhide-buttons position-relative h-100 d-flex align-items-center"
+          class="position-absolute h-100 d-flex align-items-center translate-middle-x gap-2"
           t-att-style="getUnhideButtonStyle(hiddenItem[0])">
-          <t t-if="!hiddenItem.includes(0)">
-            <div
-              class="o-unhide rounded"
-              t-att-data-index="hiddenItem_index"
-              t-on-click="() => this.unhide(hiddenItem)">
-              <t t-call="o-spreadsheet-Icon.TRIANGLE_LEFT"/>
-            </div>
-          </t>
-          <t
-            t-if="!hiddenItem.includes(env.model.getters.getNumberCols(env.model.getters.getActiveSheetId())-1)">
-            <div
-              class="o-unhide rounded"
-              t-att-data-index="hiddenItem_index"
-              t-on-click="() => this.unhide(hiddenItem)">
-              <t t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
-            </div>
-          </t>
+          <div
+            class="o-unhide rounded"
+            t-att-class="{'invisible': hiddenItem.includes(0)}"
+            t-att-data-index="hiddenItem_index"
+            t-on-click="() => this.unhide(hiddenItem)">
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_LEFT"/>
+          </div>
+          <div
+            class="o-unhide rounded"
+            t-att-class="{'invisible': hiddenItem.includes(env.model.getters.getNumberCols(env.model.getters.getActiveSheetId())-1)}"
+            t-att-data-index="hiddenItem_index"
+            t-on-click="() => this.unhide(hiddenItem)">
+            <t t-call="o-spreadsheet-Icon.TRIANGLE_RIGHT"/>
+          </div>
         </div>
       </t>
     </div>


### PR DESCRIPTION
## Description:

- Previously, there was an issue with the position of the unhide cols/rows icon, which has now been rectified. This fix involves setting the icon's position to absolute, applying bootstrap classes, and removing CSS from the ts file for o-unhide-buttons.

- Furthermore, when the hiddenItems consist of the first or last column/row, bootstrap classes are now utilized to appropriately hide one of the icons.

Task: : [3696210](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo