### PR TITLE
[REF] UiSheet: clear unused getter

### DIFF
--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -8,7 +8,7 @@ import {
   splitTextToWidth,
 } from "../../helpers/index";
 import { localizeFormula } from "../../helpers/locale";
-import { CellValueType, Command, CommandResult, LocalCommand, UID } from "../../types";
+import { Command, CommandResult, LocalCommand, UID } from "../../types";
 import { CellPosition, HeaderIndex, Pixel, Style, Zone } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
@@ -20,7 +20,6 @@ export class SheetUIPlugin extends UIPlugin {
     "getCellText",
     "getCellMultiLineText",
     "getContiguousZone",
-    "isEvaluatedCellEmpty",
   ] as const;
 
   private ctx = document.createElement("canvas").getContext("2d")!;
@@ -168,19 +167,6 @@ export class SheetUIPlugin extends UIPlugin {
     } while (hasExpanded);
 
     return zone;
-  }
-
-  /**
-   * Checks if a cell evaluated value is empty. If the cell is part of a merge,
-   * the check applies to the main cell of the merge.
-   */
-  //TODORAR this does not fit the new scheme where a cell with an empty string is not empty anymore
-  // this means the navigation was acually altered with the recent change
-  // remove the getter and put it back in selection processor as nobody uses it
-  isEvaluatedCellEmpty(position: CellPosition): boolean {
-    const mainPosition = this.getters.getMainCellPosition(position);
-    const cell = this.getters.getEvaluatedCell(mainPosition);
-    return cell.type === CellValueType.empty;
   }
 
   /**


### PR DESCRIPTION
The getter 'isEvaluatedCellEmpty' became obsolete with PR https://github.com/odoo/o-spreadsheet/pull/3668 but it was not cleean up, as were the dev comments.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo