### PR TITLE
[FIX] composer: remove commented test

### DIFF
--- a/tests/composer/composer_component.test.ts
+++ b/tests/composer/composer_component.test.ts
@@ -997,12 +997,11 @@ describe("composer highlights color", () => {
     expect(composerStore.highlights[0].zone).toEqual({ left: 0, right: 1, top: 0, bottom: 2 });
   });
 
-  // ADRM TODO: are cells outside the sheet really invalid ranges ? Should the Composer really cares about that ?
-  test.each([/*"=ZZ1", "=A101",*/ "=A1A"])("Do not highlight invalid ref", async (ref) => {
-    setCellContent(model, "A1", ref);
+  test("Do not highlight invalid ref", async () => {
+    setCellContent(model, "A1", "=A1A");
     composerEl = await startComposition();
     expect(composerStore.highlights.length).toBe(0);
-    expect(composerEl.textContent).toBe(ref);
+    expect(composerEl.textContent).toBe("=A1A");
   });
 
   test("highlight cross-sheet ranges", async () => {


### PR DESCRIPTION
In the refactoring of the highlights, the test that checked that the composer didn't highlight cells that were out of the sheet was commented, awaiting further discussion.

The discussions didn't happen, and the test was left commented (oops).

This commit deletes the commented test cases. It shouldn't be the responsibility of the composer to check if a cell is out of the sheet. In practice it makes no difference anyway, the highlight store will not draw highlight for cells that are out of the viewport/sheet.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo