### PR TITLE
[FIX] evaluation: accept 1x1 result array in sub-formula

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -87,7 +87,6 @@ function addInputHandling(
     this: EvalContext,
     ...args: Arg[]
   ): FPayload | Matrix<FPayload> | CellValue | Matrix<CellValue> {
-    const checkedArgs: Arg[] = [];
     for (let i = 0; i < args.length; i++) {
       const argDefinition = descr.args[descr.getArgToFocus(i + 1) - 1];
       const acceptMatrix = argDefinition.type.some((t) => t.startsWith("RANGE"));
@@ -101,14 +100,10 @@ function addInputHandling(
             )
           );
         }
-        checkedArgs.push(arg[0][0]);
-      } else {
-        checkedArgs.push(arg);
+        args[i] = arg[0][0];
       }
     }
-
-    const compute = descr.compute.bind(this);
-    return compute(...checkedArgs);
+    return descr.compute.apply(this, args);
   };
 }
 

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -172,13 +172,17 @@ export class Evaluator {
       this.getters.getRangeFromSheetXC(sheetId, xc)
     );
     this.updateCompilationParameters();
-    const result = updateEvalContextAndExecute(
+    let result = updateEvalContextAndExecute(
+      // todo: check if 'toScalar' should be called here
       { ...compiledFormula, dependencies: ranges },
       this.compilationParams,
       sheetId
     );
     if (isMatrix(result)) {
-      return matrixMap(result, (cell) => cell.value);
+      if (result.length !== 1 || result[0].length !== 1) {
+        return matrixMap(result, (cell) => cell.value);
+      }
+      result = result[0][0];
     }
     if (result.value === null) {
       return 0;
@@ -564,14 +568,14 @@ export function updateEvalContextAndExecute(
   sheetId: UID,
   cellId?: UID
 ) {
-  compilationParams[2].__originCellXC = lazy(() => {
+  compilationParams[1].__originCellXC = lazy(() => {
     if (!cellId) {
       return undefined;
     }
     // compute the value lazily for performance reasons
-    const position = compilationParams[2].getters.getCellPosition(cellId);
+    const position = compilationParams[1].getters.getCellPosition(cellId);
     return toXC(position.col, position.row);
   });
-  compilationParams[2].__originSheetId = sheetId;
+  compilationParams[1].__originSheetId = sheetId;
   return compiledFormula.execute(compiledFormula.dependencies, ...compilationParams);
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -152,18 +152,10 @@ export interface Border {
   right?: BorderDescr;
 }
 
-export type ReferenceDenormalizer = (
-  range: Range,
-  isMeta: boolean,
-  functionName: string,
-  paramNumber: number
-) => FPayload;
-
-export type EnsureRange = (range: Range) => Matrix<FPayload>;
+export type EnsureRange = (range: Range, isMeta: boolean) => Matrix<FPayload>;
 
 export type _CompiledFormula = (
   deps: Range[],
-  refFn: ReferenceDenormalizer,
   range: EnsureRange,
   ctx: {}
 ) => Matrix<FPayload> | FPayload;

--- a/tests/evaluation/__snapshots__/compiler.test.ts.snap
+++ b/tests/evaluation/__snapshots__/compiler.test.ts.snap
@@ -1,76 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`compile functions with meta arguments function call requesting meta parameter 1`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =USEMETAARG(|0|)
-const _1 = ref(deps[0], true, "USEMETAARG",  1);
+const _1 = range(deps[0], true);
 return ctx['USEMETAARG'](_1);
 }"
 `;
 
 exports[`compile functions with meta arguments function call requesting meta parameter 2`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =USEMETAARG(|0|)
-const _1 = ref(deps[0], true, "USEMETAARG",  1);
+const _1 = range(deps[0], true);
 return ctx['USEMETAARG'](_1);
 }"
 `;
 
 exports[`expression compiler cells are converted to ranges if function require a range 1`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =sum(|0|)
-const _1 = range(deps[0]);
+const _1 = range(deps[0], false);
 return ctx['SUM'](_1);
 }"
 `;
 
 exports[`expression compiler expression with $ref 1`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|0|+|1|+|2|
-const _1 = ref(deps[0], false, "ADD",  undefined);
-const _2 = ref(deps[1], false, "ADD",  undefined);
+const _1 = range(deps[0], false);
+const _2 = range(deps[1], false);
 const _3 = ctx['ADD'](_1, _2);
-const _4 = ref(deps[2], false, "ADD",  undefined);
+const _4 = range(deps[2], false);
 return ctx['ADD'](_3, _4);
 }"
 `;
 
 exports[`expression compiler expression with references with a sheet 1`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|0|
-return ref(deps[0], false, "EQ",  undefined);
+return range(deps[0], false);
 }"
 `;
 
 exports[`expression compiler expressions with a debugger 1`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =?|0|/|N0|
 debugger;
-const _1 = ref(deps[0], false, "DIVIDE",  undefined);
+const _1 = range(deps[0], false);
 const _2 = { value: this.constantValues.numbers[0] };
 return ctx['DIVIDE'](_1, _2);
 }"
 `;
 
 exports[`expression compiler read some values and functions 1`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|0|+sum(|1|)
-const _1 = ref(deps[0], false, "ADD",  undefined);
-const _2 = range(deps[1]);
+const _1 = range(deps[0], false);
+const _2 = range(deps[1], false);
 const _3 = ctx['SUM'](_2);
 return ctx['ADD'](_1, _3);
 }"
 `;
 
 exports[`expression compiler some arithmetic expressions 1`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|N0|
 return { value: this.constantValues.numbers[0] };
@@ -78,7 +78,7 @@ return { value: this.constantValues.numbers[0] };
 `;
 
 exports[`expression compiler some arithmetic expressions 2`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =true
 return { value: true };
@@ -86,7 +86,7 @@ return { value: true };
 `;
 
 exports[`expression compiler some arithmetic expressions 3`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|S0|
 return { value: this.constantValues.strings[0] };
@@ -94,7 +94,7 @@ return { value: this.constantValues.strings[0] };
 `;
 
 exports[`expression compiler some arithmetic expressions 4`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|N0|+|N1|
 const _1 = { value: this.constantValues.numbers[0] };
@@ -104,7 +104,7 @@ return ctx['ADD'](_1, _2);
 `;
 
 exports[`expression compiler some arithmetic expressions 5`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|N0|*|N1|
 const _1 = { value: this.constantValues.numbers[0] };
@@ -114,7 +114,7 @@ return ctx['MULTIPLY'](_1, _2);
 `;
 
 exports[`expression compiler some arithmetic expressions 6`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|N0|-|N1|
 const _1 = { value: this.constantValues.numbers[0] };
@@ -124,7 +124,7 @@ return ctx['MINUS'](_1, _2);
 `;
 
 exports[`expression compiler some arithmetic expressions 7`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|N0|/|N1|
 const _1 = { value: this.constantValues.numbers[0] };
@@ -134,7 +134,7 @@ return ctx['DIVIDE'](_1, _2);
 `;
 
 exports[`expression compiler some arithmetic expressions 8`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =-|N0|
 const _1 = { value: this.constantValues.numbers[0] };
@@ -143,7 +143,7 @@ return ctx['UMINUS'](_1);
 `;
 
 exports[`expression compiler some arithmetic expressions 9`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =(|N0|+|N1|)*(-|N1|+|N2|)
 const _1 = { value: this.constantValues.numbers[0] };
@@ -158,7 +158,7 @@ return ctx['MULTIPLY'](_3, _7);
 `;
 
 exports[`expression compiler some arithmetic expressions 10`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =sum(|N0|,|N1|)
 const _1 = { value: this.constantValues.numbers[0] };
@@ -168,7 +168,7 @@ return ctx['SUM'](_1,_2);
 `;
 
 exports[`expression compiler some arithmetic expressions 11`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =sum(true,|S0|)
 const _1 = { value: true };
@@ -178,7 +178,7 @@ return ctx['SUM'](_1,_2);
 `;
 
 exports[`expression compiler some arithmetic expressions 12`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =sum(|N0|,,|N1|)
 const _1 = { value: this.constantValues.numbers[0] };
@@ -189,7 +189,7 @@ return ctx['SUM'](_1,_2,_3);
 `;
 
 exports[`expression compiler some arithmetic expressions 13`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|N0|%
 const _1 = { value: this.constantValues.numbers[0] };
@@ -198,7 +198,7 @@ return ctx['UNARY.PERCENT'](_1);
 `;
 
 exports[`expression compiler some arithmetic expressions 14`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =(|N0|+|N1|)%
 const _1 = { value: this.constantValues.numbers[0] };
@@ -209,21 +209,21 @@ return ctx['UNARY.PERCENT'](_3);
 `;
 
 exports[`expression compiler some arithmetic expressions 15`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =|0|%
-const _1 = ref(deps[0], false, "UNARY.PERCENT",  undefined);
+const _1 = range(deps[0], false);
 return ctx['UNARY.PERCENT'](_1);
 }"
 `;
 
 exports[`expression compiler with the same reference multiple times 1`] = `
-"function anonymous(deps,ref,range,ctx
+"function anonymous(deps,range,ctx
 ) {
 // =SUM(|0|,|0|,|2|)
-const _1 = range(deps[0]);
-const _2 = range(deps[0]);
-const _3 = range(deps[2]);
+const _1 = range(deps[0], false);
+const _2 = range(deps[0], false);
+const _3 = range(deps[2], false);
 return ctx['SUM'](_1,_2,_3);
 }"
 `;

--- a/tests/evaluation/compiler.test.ts
+++ b/tests/evaluation/compiler.test.ts
@@ -292,7 +292,7 @@ describe("compile functions", () => {
     test("reject range when expecting only non-range argument", () => {
       for (let typeExpected of ["ANY", "BOOLEAN", "DATE", "NUMBER", "STRING"] as ArgType[]) {
         functionRegistry.add(typeExpected + "EXPECTED", {
-          description: "function expect number in 1st arg",
+          description: "function expect " + typeExpected + " in 1st arg",
           compute: () => {
             return true;
           },
@@ -310,7 +310,6 @@ describe("compile functions", () => {
       setCellContent(m, "B5", "=STRINGEXPECTED(A1:A2)");
       setCellContent(m, "B6", "=ANYEXPECTED(A1:A$2)");
       setCellContent(m, "B7", "=ANYEXPECTED(sheet1!A1:A$2)");
-      setCellContent(m, "B8", "=A2:A3");
       setCellContent(m, "B9", "=+A2:A3");
       setCellContent(m, "B10", "=A1+A2:A3");
       setCellContent(m, "B11", "=-A2:A3");
@@ -319,43 +318,40 @@ describe("compile functions", () => {
       setCellContent(m, "B14", "=ANYEXPECTED(A1:A1)");
 
       expect(getCellError(m, "B1")).toBe(
-        "Function ANYEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
+        "Function ANYEXPECTED expects the parameter 'arg1' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B2")).toBe(
-        "Function BOOLEANEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
+        "Function BOOLEANEXPECTED expects the parameter 'arg1' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B3")).toBe(
-        "Function DATEEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
+        "Function DATEEXPECTED expects the parameter 'arg1' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B4")).toBe(
-        "Function NUMBEREXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
+        "Function NUMBEREXPECTED expects the parameter 'arg1' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B5")).toBe(
-        "Function STRINGEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
+        "Function STRINGEXPECTED expects the parameter 'arg1' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B6")).toBe(
-        "Function ANYEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
+        "Function ANYEXPECTED expects the parameter 'arg1' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B7")).toBe(
-        "Function ANYEXPECTED expects the parameter 1 to be a single value or a single cell reference, not a range."
-      );
-      expect(getCellError(m, "B8")).toBe(
-        "Function EQ expects its parameters to be single values or single cell references, not ranges."
+        "Function ANYEXPECTED expects the parameter 'arg1' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B9")).toBe(
-        "Function UPLUS expects its parameters to be single values or single cell references, not ranges."
+        "Function UPLUS expects the parameter 'value' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B10")).toBe(
-        "Function ADD expects its parameters to be single values or single cell references, not ranges."
+        "Function ADD expects the parameter 'value2' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B11")).toBe(
-        "Function UMINUS expects its parameters to be single values or single cell references, not ranges."
+        "Function UMINUS expects the parameter 'value' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B12")).toBe(
-        "Function MINUS expects its parameters to be single values or single cell references, not ranges."
+        "Function MINUS expects the parameter 'value2' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B13")).toBe(
-        "Function MULTIPLY expects its parameters to be single values or single cell references, not ranges."
+        "Function MULTIPLY expects the parameter 'factor2' to be a single value or a single cell reference, not a range."
       );
       expect(getCellError(m, "B14")).toBeUndefined();
     });
@@ -410,7 +406,6 @@ describe("compile functions", () => {
 
       const m = new Model();
 
-      let refFn = jest.fn();
       let ensureRange = jest.fn();
 
       const ctx = { USEMETAARG: () => {}, NOTUSEMETAARG: () => {} };
@@ -418,25 +413,21 @@ describe("compile functions", () => {
       const rangeA1 = createRange(m.getters, "ABC", "A1")!;
       const rangeA1ToB2 = createRange(m.getters, "ABC", "A1:B2")!;
 
-      compiledFormula1.execute([rangeA1], refFn, ensureRange, ctx);
-      expect(refFn).toHaveBeenCalledWith(rangeA1, true, "USEMETAARG", 1);
-      expect(ensureRange).toHaveBeenCalledTimes(0);
-      refFn.mockReset();
+      compiledFormula1.execute([rangeA1], ensureRange, ctx);
+      expect(ensureRange).toHaveBeenCalledWith(rangeA1, true);
+      ensureRange.mockReset();
 
-      compiledFormula2.execute([rangeA1ToB2], refFn, ensureRange, ctx);
-      expect(refFn).toHaveBeenCalledWith(rangeA1ToB2, true, "USEMETAARG", 1);
-      expect(ensureRange).toHaveBeenCalledTimes(0);
-      refFn.mockReset();
+      compiledFormula2.execute([rangeA1ToB2], ensureRange, ctx);
+      expect(ensureRange).toHaveBeenCalledWith(rangeA1ToB2, true);
+      ensureRange.mockReset();
 
-      compiledFormula3.execute([rangeA1], refFn, ensureRange, ctx);
-      expect(refFn).toHaveBeenCalledWith(rangeA1, false, "NOTUSEMETAARG", 1);
-      expect(ensureRange).toHaveBeenCalledTimes(0);
-      refFn.mockReset();
+      compiledFormula3.execute([rangeA1], ensureRange, ctx);
+      expect(ensureRange).toHaveBeenCalledWith(rangeA1, false);
+      ensureRange.mockReset();
 
-      compiledFormula4.execute([rangeA1ToB2], refFn, ensureRange, ctx);
-      expect(refFn).toHaveBeenCalledWith(rangeA1ToB2, false, "NOTUSEMETAARG", 1);
-      expect(ensureRange).toHaveBeenCalledTimes(0);
-      refFn.mockReset();
+      compiledFormula4.execute([rangeA1ToB2], ensureRange, ctx);
+      expect(ensureRange).toHaveBeenCalledWith(rangeA1ToB2, false);
+      ensureRange.mockReset();
     });
   });
 

--- a/tests/evaluation/evaluation.test.ts
+++ b/tests/evaluation/evaluation.test.ts
@@ -319,12 +319,6 @@ describe("evaluateCells", () => {
     expect(getEvaluatedCell(model, "A1").value).toBe(0);
   });
 
-  test("=Range", () => {
-    const model = new Model();
-    setCellContent(model, "A1", "=A2:A3");
-    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
-  });
-
   test("misc math formulas", () => {
     const model = new Model();
     setCellContent(model, "A1", "42");

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -55,6 +55,24 @@ describe("evaluate formulas that return an array", () => {
     expect(getEvaluatedCell(model, "B2").value).toBe(42);
   });
 
+  test("can use result array in formula that accept array", () => {
+    setCellContent(model, "A1", "=SUM(MFILL(2, 2, 42))");
+    expect(getEvaluatedCell(model, "A1").value).toBe(168);
+  });
+
+  test("can't use result array in formula that accept scalar only", () => {
+    setCellContent(model, "A1", "=ABS(MFILL(2, 2, -42))");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+    expect(getCellError(model, "A1")).toBe(
+      "Function ABS expects the parameter 'value' to be a single value or a single cell reference, not a range."
+    );
+  });
+
+  test("can use 1x1 result array in formula that accept scalar", () => {
+    setCellContent(model, "A1", "=ABS(MFILL(1, 1, -42))");
+    expect(getEvaluatedCell(model, "A1").value).toBe(42);
+  });
+
   test("reference to a formula result array is possible", () => {
     setCellContent(model, "E5", "=B2");
     setCellContent(model, "A1", "=MFILL(3,3,42)");

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -42,9 +42,12 @@ describe("evaluate formulas that return an array", () => {
     restoreDefaultFunctions();
   });
 
-  test("a simple reference to a range cannot return an array", () => {
-    setCellContent(model, "A1", "=A2:A3");
-    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+  test("a simple reference to a range can return an array", () => {
+    setCellContent(model, "A1", "a1");
+    setCellContent(model, "A2", "a2");
+    setCellContent(model, "B1", "=A1:A2");
+    expect(getEvaluatedCell(model, "B1").value).toBe("a1");
+    expect(getEvaluatedCell(model, "B2").value).toBe("a2");
   });
 
   test("can spread array", () => {

--- a/tests/functions/module_math.test.ts
+++ b/tests/functions/module_math.test.ts
@@ -14,7 +14,7 @@ import {
 describe("ABS formula", () => {
   test("take 1 argument", () => {
     expect(evaluateCell("A1", { A1: "=ABS()" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
-    expect(evaluateCell("A1", { A1: "=ABS(-42)" })).toBe(42);
+    expect(evaluateCell("A1", { A1: "=?ABS(-42)" })).toBe(42);
     expect(evaluateCell("A1", { A1: "=ABS(-42, 24)" })).toBe("#BAD_EXPR"); // @compatibility: on google sheets, return #N/A
   });
 

--- a/tests/sheet/sheet_manipulation_plugin.test.ts
+++ b/tests/sheet/sheet_manipulation_plugin.test.ts
@@ -540,7 +540,7 @@ describe("Columns", () => {
           },
           {
             id: "sheet2",
-            colNumber: 1,
+            colNumber: 2,
             rowNumber: 3,
             cells: {
               A1: { content: "=B1" },
@@ -1179,7 +1179,7 @@ describe("Rows", () => {
           {
             id: "sheet2",
             colNumber: 3,
-            rowNumber: 1,
+            rowNumber: 4,
             cells: {
               A1: { content: "=A2" },
               B1: { content: "=Sheet1!A2" },


### PR DESCRIPTION
## Description:

Before this commit, when a formula function
expected a simple argument, and it received
an array, we transformed the array into a
simple argument if the array was of size 1x1

However, this process was only done when
reading the references to the ranges.

This commit extends the process when the result
array comes from a sub-formula and no longer
range references.

Task : [3756474](https://www.odoo.com/web#id=3756474&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo