### PR TITLE
[FIX] Grid: Context menu position was broken

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -100,6 +100,7 @@ export interface ComposerProps {
   focus: "inactive" | "cellFocus" | "contentFocus";
   onComposerContentFocused: () => void;
   onComposerCellFocused?: (content: String) => void;
+  onInputContextMenu?: (event: MouseEvent) => void;
   isDefaultFocus?: boolean;
 }
 
@@ -446,6 +447,12 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
 
   onCompleted(text: string | undefined) {
     text && this.autoComplete(text);
+  }
+
+  onContextMenu(ev: MouseEvent) {
+    if (this.env.model.getters.getEditionMode() === "inactive") {
+      this.props.onInputContextMenu?.(ev);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/components/composer/composer/composer.xml
+++ b/src/components/composer/composer/composer.xml
@@ -17,6 +17,7 @@
         t-on-paste="onPaste"
         t-on-compositionstart="onCompositionStart"
         t-on-compositionend="onCompositionEnd"
+        t-on-contextmenu="onContextMenu"
       />
 
       <div

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -27,6 +27,7 @@ interface Props {
   content: string;
   onComposerContentFocused: () => void;
   onComposerCellFocused: () => void;
+  onInputContextMenu: (event: MouseEvent) => void;
 }
 
 /**
@@ -77,6 +78,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
       isDefaultFocus: true,
       onComposerContentFocused: this.props.onComposerContentFocused,
       onComposerCellFocused: this.props.onComposerCellFocused,
+      onInputContextMenu: this.props.onInputContextMenu,
     };
   }
 

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -451,9 +451,8 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     } else if (this.env.model.getters.getActiveRows().has(row)) {
       type = "ROW";
     }
-    const { x, y, width, height } = this.env.model.getters.getVisibleRect(lastZone);
-
-    this.toggleContextMenu(type, x + width, y + height);
+    const { x, y, width } = this.env.model.getters.getVisibleRect(lastZone);
+    this.toggleContextMenu(type, this.canvasPosition.x + x + width, this.canvasPosition.y + y);
   }
 
   onCellRightClicked(col: HeaderIndex, row: HeaderIndex, { x, y }: DOMCoordinates) {

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -7,7 +7,6 @@
       t-on-click="focusDefaultElement"
       t-on-keydown="onKeydown"
       t-on-wheel="onMouseWheel"
-      t-on-contextmenu="onInputContextMenu"
       t-ref="grid">
       <GridOverlay
         onCellClicked.bind="onCellClicked"
@@ -25,6 +24,7 @@
         onComposerContentFocused="props.onComposerContentFocused"
         onComposerCellFocused="props.onGridComposerCellFocused"
         focus="props.focusComposer"
+        onInputContextMenu.bind="onInputContextMenu"
       />
       <canvas t-ref="canvas"/>
       <t

--- a/tests/components/context_menu.test.ts
+++ b/tests/components/context_menu.test.ts
@@ -1,6 +1,12 @@
 import { Component, useSubEnv, xml } from "@odoo/owl";
 import { Menu } from "../../src/components/menu/menu";
-import { MENU_ITEM_HEIGHT, MENU_WIDTH, TOPBAR_HEIGHT } from "../../src/constants";
+import {
+  DEFAULT_CELL_HEIGHT,
+  DEFAULT_CELL_WIDTH,
+  MENU_ITEM_HEIGHT,
+  MENU_WIDTH,
+  TOPBAR_HEIGHT,
+} from "../../src/constants";
 import { toXC } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { createFullMenuItem, FullMenuItem } from "../../src/registries";
@@ -15,6 +21,9 @@ import {
   nextTick,
   Touch,
 } from "../test_helpers/helpers";
+
+const COLUMN_D = { x: 340, y: 10 };
+const ROW_5 = { x: 30, y: 100 };
 
 let fixture: HTMLElement;
 let model: Model;
@@ -211,6 +220,35 @@ describe("Context Menu integration tests", () => {
     await rightClickCell(model, "C8");
     expect(getActiveXc(model)).toBe("C8");
     expect(fixture.querySelector(".o-menu")).toBeTruthy();
+  });
+
+  test("context menu opens at correct position upon right-clicking a cell", async () => {
+    expect(fixture.querySelector(".o-menu")).toBeFalsy();
+    await rightClickCell(model, "B2");
+    expect(getActiveXc(model)).toBe("B2");
+    expect(getPosition(".o-menu")).toMatchObject({
+      left: DEFAULT_CELL_WIDTH,
+      top: DEFAULT_CELL_HEIGHT,
+    });
+    expect(fixture.querySelector(".o-menu")).toBeTruthy();
+  });
+
+  test("context menu opens at the correct position upon right-clicking a row or column resizer", async () => {
+    triggerMouseEvent(".o-col-resizer", "contextmenu", COLUMN_D.x, COLUMN_D.y);
+    await nextTick();
+    const colMenuContainer = document.querySelector(".o-menu")! as HTMLElement;
+    const { top: colTop, left: colLeft } = window.getComputedStyle(colMenuContainer.parentElement!);
+
+    expect(colLeft).toBe(`${COLUMN_D.x}px`);
+    expect(colTop).toBe(`${COLUMN_D.y}px`);
+
+    triggerMouseEvent(".o-row-resizer", "contextmenu", ROW_5.x, ROW_5.y);
+    await nextTick();
+    const rowMenuContainer = document.querySelector(".o-menu")! as HTMLElement;
+    const { top: rowTop, left: rowLeft } = window.getComputedStyle(rowMenuContainer.parentElement!);
+
+    expect(rowLeft).toBe(`${ROW_5.x}px`);
+    expect(rowTop).toBe(`${ROW_5.y}px`);
   });
 
   test("right click on a cell, then left click elsewhere closes a context menu", async () => {


### PR DESCRIPTION
## Description:

Previously, the context menu didn't open in the right spot due to a misplacement of t-on-contextmenu in grid.xml. This caused the menu's position to be recalculated unnecessarily.

This PR relocates t-on-contextmenu to its correct position.

Task: : [3746771](https://www.odoo.com/web#id=3746771&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo