### PR TITLE
[IMP] model: expose canDispatch to all plugins

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -423,6 +423,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       stateObserver: this.state,
       range: this.range,
       dispatch: this.dispatchFromCorePlugin,
+      canDispatch: this.canDispatch,
       uuidGenerator: this.uuidGenerator,
       custom: this.config.custom,
       external: this.config.external,
@@ -434,6 +435,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
       getters: this.getters,
       stateObserver: this.state,
       dispatch: this.dispatch,
+      canDispatch: this.canDispatch,
       selection: this.selection,
       moveClient: this.session.move.bind(this.session),
       custom: this.config.custom,
@@ -485,7 +487,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
    * Check if a command can be dispatched, and returns a DispatchResult object with the possible
    * reasons the dispatch failed.
    */
-  canDispatch: CommandDispatcher["canDispatch"] = (type: string, payload?: any) => {
+  canDispatch: CommandDispatcher["dispatch"] = (type: string, payload?: any) => {
     return this.checkDispatchAllowed(createCommand(type, payload));
   };
 

--- a/src/plugins/base_plugin.ts
+++ b/src/plugins/base_plugin.ts
@@ -26,13 +26,19 @@ export class BasePlugin<State = any, C = any> implements CommandHandler<C>, Vali
 
   protected history: WorkbookHistory<State>;
   protected dispatch: CommandDispatcher["dispatch"];
+  protected canDispatch: CommandDispatcher["dispatch"];
 
-  constructor(stateObserver: StateObserver, dispatch: CommandDispatcher["dispatch"]) {
+  constructor(
+    stateObserver: StateObserver,
+    dispatch: CommandDispatcher["dispatch"],
+    canDispatch: CommandDispatcher["dispatch"]
+  ) {
     this.history = Object.assign(Object.create(stateObserver), {
       update: stateObserver.addChange.bind(stateObserver, this),
       selectCell: () => {},
     });
     this.dispatch = dispatch;
+    this.canDispatch = canDispatch;
   }
 
   /**

--- a/src/plugins/core_plugin.ts
+++ b/src/plugins/core_plugin.ts
@@ -18,6 +18,7 @@ export interface CorePluginConfig {
   readonly stateObserver: StateObserver;
   readonly range: RangeAdapter;
   readonly dispatch: CoreCommandDispatcher["dispatch"];
+  readonly canDispatch: CoreCommandDispatcher["dispatch"];
   readonly uuidGenerator: UuidGenerator;
   readonly custom: ModelConfig["custom"];
   readonly external: ModelConfig["external"];
@@ -41,8 +42,15 @@ export class CorePlugin<State = any>
   protected getters: CoreGetters;
   protected uuidGenerator: UuidGenerator;
 
-  constructor({ getters, stateObserver, range, dispatch, uuidGenerator }: CorePluginConfig) {
-    super(stateObserver, dispatch);
+  constructor({
+    getters,
+    stateObserver,
+    range,
+    dispatch,
+    canDispatch,
+    uuidGenerator,
+  }: CorePluginConfig) {
+    super(stateObserver, dispatch, canDispatch);
     range.addRangeProvider(this.adaptRanges.bind(this));
     this.getters = getters;
     this.uuidGenerator = uuidGenerator;

--- a/src/plugins/ui_plugin.ts
+++ b/src/plugins/ui_plugin.ts
@@ -20,6 +20,7 @@ export interface UIPluginConfig {
   readonly getters: Getters;
   readonly stateObserver: StateObserver;
   readonly dispatch: CommandDispatcher["dispatch"];
+  readonly canDispatch: CommandDispatcher["dispatch"];
   readonly selection: SelectionStreamProcessor;
   readonly moveClient: (position: ClientPosition) => void;
   readonly uiActions: UIActions;
@@ -45,8 +46,15 @@ export class UIPlugin<State = any> extends BasePlugin<State, Command> {
   protected getters: Getters;
   protected ui: UIActions;
   protected selection: SelectionStreamProcessor;
-  constructor({ getters, stateObserver, dispatch, uiActions, selection }: UIPluginConfig) {
-    super(stateObserver, dispatch);
+  constructor({
+    getters,
+    stateObserver,
+    dispatch,
+    canDispatch,
+    uiActions,
+    selection,
+  }: UIPluginConfig) {
+    super(stateObserver, dispatch, canDispatch);
     this.getters = getters;
     this.ui = uiActions;
     this.selection = selection;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1158,10 +1158,6 @@ export interface CommandDispatcher {
     type: T,
     r: Omit<C, "type">
   ): DispatchResult;
-  canDispatch<T extends CommandTypes, C extends Extract<Command, { type: T }>>(
-    type: T,
-    r: Omit<C, "type">
-  ): DispatchResult;
 }
 
 export interface CoreCommandDispatcher {
@@ -1169,10 +1165,6 @@ export interface CoreCommandDispatcher {
     type: {} extends Omit<C, "type"> ? T : never
   ): DispatchResult;
   dispatch<T extends CoreCommandTypes, C extends Extract<CoreCommand, { type: T }>>(
-    type: T,
-    r: Omit<C, "type">
-  ): DispatchResult;
-  canDispatch<T extends CoreCommandTypes, C extends Extract<CoreCommand, { type: T }>>(
     type: T,
     r: Omit<C, "type">
   ): DispatchResult;


### PR DESCRIPTION
## Description:

Core commands don't go through allowDispatch if they are dispatched
from a core plugin, because we assume the core plugins know what
they are doing. But sometimes it'd be useful to get the result of
canDispatch for a core command, so we don't dispatch invalid commands.

It can also sometime be useful for a command to call `canDispatch`
on a known sub-command in its allowDispatch method.

Task: : [3709540](https://www.odoo.com/web#id=3709540&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo