### PR TITLE
[IMP] tables: store `getCellComputedStyle`

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -37,6 +37,7 @@ import {
   SortPlugin,
   UIOptionsPlugin,
 } from "./ui_feature";
+import { CellComputedStylePlugin } from "./ui_feature/cell_computed_style";
 import { HistoryPlugin } from "./ui_feature/local_history";
 import { SplitToColumnsPlugin } from "./ui_feature/split_to_columns";
 import { TableAutofillPlugin } from "./ui_feature/table_autofill";
@@ -87,6 +88,7 @@ export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()
   .add("evaluation_filter", FilterEvaluationPlugin)
   .add("header_visibility_ui", HeaderVisibilityUIPlugin)
   .add("table_style", TableStylePlugin)
+  .add("cell_computed_style", CellComputedStylePlugin)
   .add("header_positions", HeaderPositionsUIPlugin)
   .add("viewport", SheetViewPlugin)
   .add("clipboard", ClipboardPlugin);

--- a/src/plugins/ui_feature/cell_computed_style.ts
+++ b/src/plugins/ui_feature/cell_computed_style.ts
@@ -1,0 +1,100 @@
+import { LINK_COLOR } from "../../constants";
+import { isObjectEmptyRecursive, removeFalsyAttributes } from "../../helpers/index";
+import { Command, invalidateCFEvaluationCommands, invalidateEvaluationCommands } from "../../types";
+import { Border, CellPosition, Style, UID } from "../../types/misc";
+import { UIPlugin } from "../ui_plugin";
+import { doesCommandInvalidatesTableStyle } from "./table_style";
+
+export class CellComputedStylePlugin extends UIPlugin {
+  static getters = ["getCellComputedBorder", "getCellComputedStyle"] as const;
+
+  private styles: Record<UID, Record<number, Record<number, Style>>> = {};
+  private borders: Record<UID, Record<number, Record<number, Border | null>>> = {};
+
+  handle(cmd: Command) {
+    if (
+      invalidateEvaluationCommands.has(cmd.type) ||
+      cmd.type === "UPDATE_CELL" ||
+      cmd.type === "EVALUATE_CELLS"
+    ) {
+      this.styles = {};
+      this.borders = {};
+      return;
+    }
+
+    if (doesCommandInvalidatesTableStyle(cmd)) {
+      delete this.styles[cmd.sheetId];
+      delete this.borders[cmd.sheetId];
+      return;
+    }
+
+    if (invalidateCFEvaluationCommands.has(cmd.type)) {
+      this.styles = {};
+      return;
+    }
+  }
+
+  getCellComputedBorder(position: CellPosition): Border | null {
+    const { sheetId, row, col } = position;
+    if (this.borders[sheetId]?.[row]?.[col] !== undefined) {
+      return this.borders[sheetId][row][col];
+    }
+    if (!this.borders[sheetId]) {
+      this.borders[sheetId] = {};
+    }
+    if (!this.borders[sheetId][row]) {
+      this.borders[sheetId][row] = {};
+    }
+    if (!this.borders[sheetId][row][col]) {
+      this.borders[sheetId][row][col] = this.computeCellBorder(position);
+    }
+    return this.borders[sheetId][row][col];
+  }
+
+  getCellComputedStyle(position: CellPosition): Style {
+    const { sheetId, row, col } = position;
+    if (this.styles[sheetId]?.[row]?.[col] !== undefined) {
+      return this.styles[sheetId][row][col];
+    }
+    if (!this.styles[sheetId]) {
+      this.styles[sheetId] = {};
+    }
+    if (!this.styles[sheetId][row]) {
+      this.styles[sheetId][row] = {};
+    }
+    if (!this.styles[sheetId][row][col]) {
+      this.styles[sheetId][row][col] = this.computeCellStyle(position);
+    }
+    return this.styles[sheetId][row][col];
+  }
+
+  private computeCellBorder(position: CellPosition): Border | null {
+    const cellBorder = this.getters.getCellBorder(position) || {};
+    const cellTableBorder = this.getters.getCellTableBorder(position) || {};
+
+    // Use removeFalsyAttributes to avoid overwriting borders with undefined values
+    const border = {
+      ...removeFalsyAttributes(cellTableBorder),
+      ...removeFalsyAttributes(cellBorder),
+    };
+
+    return isObjectEmptyRecursive(border) ? null : border;
+  }
+
+  private computeCellStyle(position: CellPosition): Style {
+    const cell = this.getters.getCell(position);
+    const cfStyle = this.getters.getCellConditionalFormatStyle(position);
+    const tableStyle = this.getters.getCellTableStyle(position);
+    const computedStyle = {
+      ...removeFalsyAttributes(tableStyle),
+      ...removeFalsyAttributes(cell?.style),
+      ...removeFalsyAttributes(cfStyle),
+    };
+    const evaluatedCell = this.getters.getEvaluatedCell(position);
+    if (evaluatedCell.link && !computedStyle.textColor) {
+      computedStyle.textColor = LINK_COLOR;
+    }
+
+    return computedStyle;
+  }
+}

--- a/src/plugins/ui_feature/table_style.ts
+++ b/src/plugins/ui_feature/table_style.ts
@@ -4,6 +4,7 @@ import {
   Border,
   CellPosition,
   Command,
+  CommandTypes,
   Lazy,
   Style,
   Table,
@@ -39,17 +40,10 @@ export class TableStylePlugin extends UIPlugin {
       this.tableStyles = {};
       return;
     }
-    switch (cmd.type) {
-      case "HIDE_COLUMNS_ROWS":
-      case "UNHIDE_COLUMNS_ROWS":
-      case "UNFOLD_HEADER_GROUP":
-      case "FOLD_HEADER_GROUP":
-      case "FOLD_ALL_HEADER_GROUPS":
-      case "UNFOLD_ALL_HEADER_GROUPS":
-      case "UPDATE_TABLE":
-      case "UPDATE_FILTER":
-        delete this.tableStyles[cmd.sheetId];
-        break;
+
+    if (doesCommandInvalidatesTableStyle(cmd)) {
+      delete this.tableStyles[cmd.sheetId];
+      return;
     }
   }
 
@@ -185,4 +179,23 @@ export class TableStylePlugin extends UIPlugin {
       rowMapping,
     };
   }
+}
+
+const invalidateTableStyleCommands = [
+  "HIDE_COLUMNS_ROWS",
+  "UNHIDE_COLUMNS_ROWS",
+  "UNFOLD_HEADER_GROUP",
+  "FOLD_HEADER_GROUP",
+  "FOLD_ALL_HEADER_GROUPS",
+  "UNFOLD_ALL_HEADER_GROUPS",
+  "CREATE_TABLE",
+  "UPDATE_TABLE",
+  "UPDATE_FILTER",
+] as const;
+const invalidateTableStyleCommandsSet = new Set<CommandTypes>(invalidateTableStyleCommands);
+
+export function doesCommandInvalidatesTableStyle(
+  cmd: Command
+): cmd is { type: (typeof invalidateTableStyleCommands)[number] } & Command {
+  return invalidateTableStyleCommandsSet.has(cmd.type);
 }

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -1,30 +1,21 @@
-import {
-  GRID_ICON_MARGIN,
-  ICON_EDGE_LENGTH,
-  LINK_COLOR,
-  PADDING_AUTORESIZE_HORIZONTAL,
-} from "../../constants";
+import { GRID_ICON_MARGIN, ICON_EDGE_LENGTH, PADDING_AUTORESIZE_HORIZONTAL } from "../../constants";
 import {
   computeIconWidth,
   computeTextWidth,
   isEqual,
-  isObjectEmptyRecursive,
   positions,
   range,
-  removeFalsyAttributes,
   splitTextToWidth,
 } from "../../helpers/index";
 import { localizeFormula } from "../../helpers/locale";
 import { Command, CommandResult, LocalCommand, UID } from "../../types";
-import { Border, CellPosition, HeaderIndex, Pixel, Style, Zone } from "../../types/misc";
+import { CellPosition, HeaderIndex, Pixel, Style, Zone } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
 export class SheetUIPlugin extends UIPlugin {
   static getters = [
     "doesCellHaveGridIcon",
     "getCellWidth",
-    "getCellComputedBorder",
-    "getCellComputedStyle",
     "getTextWidth",
     "getCellText",
     "getCellMultiLineText",
@@ -74,7 +65,7 @@ export class SheetUIPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
 
   getCellWidth(position: CellPosition): number {
-    const style = this.getCellComputedStyle(position);
+    const style = this.getters.getCellComputedStyle(position);
 
     let contentWidth = 0;
 
@@ -188,33 +179,6 @@ export class SheetUIPlugin extends UIPlugin {
       this.getters.getCorrespondingFormulaCell(mainPosition) ||
       this.getters.getCell(mainPosition)?.content
     );
-  }
-
-  getCellComputedBorder(position: CellPosition): Border | null {
-    const cellBorder = this.getters.getCellBorder(position) || {};
-    const cellTableBorder = this.getters.getCellTableBorder(position) || {};
-
-    // Use removeFalsyAttributes to avoid overwriting borders with undefined values
-    const border = { ...cellTableBorder, ...removeFalsyAttributes(cellBorder) };
-
-    return isObjectEmptyRecursive(border) ? null : border;
-  }
-
-  getCellComputedStyle(position: CellPosition): Style {
-    const cell = this.getters.getCell(position);
-    const cfStyle = this.getters.getCellConditionalFormatStyle(position);
-    const tableStyle = this.getters.getCellTableStyle(position);
-    const computedStyle = {
-      ...removeFalsyAttributes(tableStyle),
-      ...removeFalsyAttributes(cell?.style),
-      ...removeFalsyAttributes(cfStyle),
-    };
-    const evaluatedCell = this.getters.getEvaluatedCell(position);
-    if (evaluatedCell.link && !computedStyle.textColor) {
-      computedStyle.textColor = LINK_COLOR;
-    }
-
-    return computedStyle;
   }
 
   private getColMaxWidth(sheetId: UID, index: HeaderIndex): number {

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -22,6 +22,7 @@ import { EvaluationConditionalFormatPlugin } from "../plugins/ui_core_views/eval
 import { HeaderSizeUIPlugin } from "../plugins/ui_core_views/header_sizes_ui";
 import { AutofillPlugin } from "../plugins/ui_feature/autofill";
 import { AutomaticSumPlugin } from "../plugins/ui_feature/automatic_sum";
+import { CellComputedStylePlugin } from "../plugins/ui_feature/cell_computed_style";
 import { CollaborativePlugin } from "../plugins/ui_feature/collaborative";
 import { FindAndReplacePlugin } from "../plugins/ui_feature/find_and_replace";
 import { HeaderVisibilityUIPlugin } from "../plugins/ui_feature/header_visibility_ui";
@@ -136,4 +137,5 @@ export type Getters = {
   PluginGetters<typeof EvaluationDataValidationPlugin> &
   PluginGetters<typeof HeaderPositionsUIPlugin> &
   PluginGetters<typeof TableStylePlugin> &
+  PluginGetters<typeof CellComputedStylePlugin> &
   PluginGetters<typeof DynamicTablesPlugin>;


### PR DESCRIPTION
The actual style/borders of the cell is a combination of of the user defined style, the CF style, and the table style.

Before this commit, at each call to getCellComputedStyle we combined the three the get the actual style of the cell.

Now there is a new plugin `CellComputedStylePlugin` that caches this computed style.

Benchmark:
Tested by scrolling around on a sheet with 10000 rows and 100 cols,
and a bunch of tables/CFs.

`getCellComputedStyle` + `getCellComputedBorder` went from 5\~10% of
an animation frame (of 6ms) to almost nothing (<0.5%). The Garbage
Collection is also lighter, the two functions accounted for 15\~20% of
all the memory allocated when scrolling.

The tradeoff is that the memory usage is higher, since the style is now
stored in the `CellComputedStylePlugin` and not GC'd. We go up to 15%
of the heap occupied by the computed styles when scrolling all the way
down (about the same size as the CellPlugin).

Task: : [3768596](https://www.odoo.com/web#id=3768596&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo