### PR TITLE
[IMP] cssPropertiesToCss: don't use `Object.entries()`

### DIFF
--- a/src/components/helpers/css.ts
+++ b/src/components/helpers/css.ts
@@ -140,12 +140,15 @@ export function cellTextStyleToCss(style: Style | undefined): CSSProperties {
  * Transform CSS properties into a CSS string.
  */
 export function cssPropertiesToCss(attributes: CSSProperties): string {
-  const str = Object.entries(attributes)
-    .filter(([attName, attValue]) => attValue !== undefined)
-    .map(([attName, attValue]) => `${attName}:${attValue};`)
-    .join(" ");
+  let styleStr = "";
+  for (const attName in attributes) {
+    if (!attributes[attName]) {
+      continue;
+    }
+    styleStr += `${attName}:${attributes[attName]}; `;
+  }
 
-  return str;
+  return styleStr;
 }
 
 export function getElementMargins(el: Element) {

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -555,7 +555,7 @@ exports[`TopBar component can set cell format 1`] = `
         </div>
         <div
           class="o-topbar-composer bg-white user-select-text"
-          style="border-color:#E0E2E4; border-right:none;"
+          style="border-color:#E0E2E4; border-right:none; "
         >
           <div
             class="o-composer-container w-100 h-100"
@@ -564,7 +564,7 @@ exports[`TopBar component can set cell format 1`] = `
               class="o-composer w-100 text-start"
               contenteditable="true"
               spellcheck="false"
-              style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
+              style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
               tabindex="1"
             />
             
@@ -1448,7 +1448,7 @@ exports[`TopBar component simple rendering 1`] = `
     </div>
     <div
       class="o-topbar-composer bg-white user-select-text"
-      style="border-color:#E0E2E4; border-right:none;"
+      style="border-color:#E0E2E4; border-right:none; "
     >
       <div
         class="o-composer-container w-100 h-100"
@@ -1457,7 +1457,7 @@ exports[`TopBar component simple rendering 1`] = `
           class="o-composer w-100 text-start"
           contenteditable="true"
           spellcheck="false"
-          style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
+          style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
           tabindex="1"
         />
         

--- a/tests/autofill/autofill_component.test.ts
+++ b/tests/autofill/autofill_component.test.ts
@@ -85,7 +85,7 @@ describe("Autofill component", () => {
     expect(fixture.querySelector(".o-autofill-nextvalue")).toMatchInlineSnapshot(`
       <div
         class="o-autofill-nextvalue"
-        style="top:30px; left:375px;"
+        style="top:30px; left:375px; "
       >
         <div>
           test
@@ -111,7 +111,7 @@ describe("Autofill component", () => {
     expect(fixture.querySelector(".o-autofill-nextvalue")).toMatchInlineSnapshot(`
       <div
         class="o-autofill-nextvalue"
-        style="top:30px; left:375px;"
+        style="top:30px; left:375px; "
       >
         <div>
           test
@@ -140,7 +140,7 @@ describe("Autofill component", () => {
     expect(fixture.querySelector(".o-autofill-nextvalue")).toMatchInlineSnapshot(`
       <div
         class="o-autofill-nextvalue"
-        style="top:30px; left:375px;"
+        style="top:30px; left:375px; "
       >
         <div>
           test

--- a/tests/colors/__snapshots__/color_picker_component.test.ts.snap
+++ b/tests/colors/__snapshots__/color_picker_component.test.ts.snap
@@ -460,7 +460,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
   >
     <div
       class="o-gradient"
-      style="background:hsl(0 100% 50%);"
+      style="background:hsl(0 100% 50%); "
     >
       <div
         class="saturation w-100 h-100 position-absolute pe-none"
@@ -470,7 +470,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       />
       <div
         class="magnifier pe-none"
-        style="left:-8px; top:178px; background:#000000;"
+        style="left:-8px; top:178px; background:#000000; "
       />
     </div>
     <div
@@ -481,7 +481,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       />
       <div
         class="o-hue-slider pe-none"
-        style="margin-left:-8px;"
+        style="margin-left:-8px; "
       >
         <svg
           class="o-icon"
@@ -503,7 +503,7 @@ exports[`Color Picker buttons Full component rendering 1`] = `
       />
       <div
         class="o-color-preview"
-        style="background-color:#000000;"
+        style="background-color:#000000; "
       />
     </div>
     <div

--- a/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
+++ b/tests/composer/__snapshots__/autocomplete_dropdown_component.test.ts.snap
@@ -58,7 +58,7 @@ exports[`Functions autocomplete autocomplete simple snapshot with =S 1`] = `
 exports[`composer Assistant render above the cell when not enough place below 1`] = `
 <div
   class="o-composer-assistant shadow"
-  style="min-width:96px; width:300px; max-height:150px; top:-3px; transform:translate(0, -100%); right:0px;"
+  style="min-width:96px; width:300px; max-height:150px; top:-3px; transform:translate(0, -100%); right:0px; "
 >
   <div
     class="o-autocomplete-dropdown"
@@ -120,7 +120,7 @@ exports[`composer Assistant render above the cell when not enough place below 1`
 exports[`composer Assistant render below the cell by default 1`] = `
 <div
   class="o-composer-assistant shadow"
-  style="min-width:300px; width:300px;"
+  style="min-width:300px; width:300px; "
 >
   <div
     class="o-autocomplete-dropdown"

--- a/tests/composer/__snapshots__/composer_integration_component.test.ts.snap
+++ b/tests/composer/__snapshots__/composer_integration_component.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Grid composer grid composer basic style Grid composer snapshot 1`] = `
 <div
   class="o-grid-composer"
-  style="left:47px; top:26px; min-width:97px; min-height:24px; max-width:985px; max-height:985px; background:#ffffff; color:#000000; font-size:13px; font-style:normal; text-decoration:none; text-align:left;"
+  style="left:47px; top:26px; min-width:97px; min-height:24px; max-width:985px; max-height:985px; background:#ffffff; color:#000000; font-size:13px; font-style:normal; text-decoration:none; text-align:left; "
 >
   <div
     class="o-composer-container w-100 h-100"

--- a/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
+++ b/tests/conditional_formatting/__snapshots__/conditional_formatting_panel_component.test.ts.snap
@@ -51,7 +51,7 @@ exports[`UI of conditional formats Conditional format list simple snapshot 1`] =
           
           <div
             class="o-cf-preview-icon d-flex justify-content-around align-items-center me-2"
-            style="background:#FF0000;"
+            style="background:#FF0000; "
           >
              123 
           </div>

--- a/tests/figures/__snapshots__/figure_component.test.ts.snap
+++ b/tests/figures/__snapshots__/figure_component.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`figures selected figure snapshot 1`] = `
 <div
   class="o-figure-wrapper pe-auto"
-  style="left:1px; top:1px; width:100px; height:100px; z-index:11;"
+  style="left:1px; top:1px; width:100px; height:100px; z-index:11; "
 >
   <div
     class="o-figure w-100 h-100"
@@ -61,35 +61,35 @@ exports[`figures selected figure snapshot 1`] = `
   />
   <div
     class="o-fig-anchor o-top"
-    style="top:-3px; right:calc(50% - 3px);"
+    style="top:-3px; right:calc(50% - 3px); "
   />
   <div
     class="o-fig-anchor o-topRight"
-    style="top:-3px; right:-3px;"
+    style="top:-3px; right:-3px; "
   />
   <div
     class="o-fig-anchor o-right"
-    style="bottom:calc(50% - 3px); right:-3px;"
+    style="bottom:calc(50% - 3px); right:-3px; "
   />
   <div
     class="o-fig-anchor o-bottomRight"
-    style="bottom:-3px; right:-3px;"
+    style="bottom:-3px; right:-3px; "
   />
   <div
     class="o-fig-anchor o-bottom"
-    style="bottom:-3px; right:calc(50% - 3px);"
+    style="bottom:-3px; right:calc(50% - 3px); "
   />
   <div
     class="o-fig-anchor o-bottomLeft"
-    style="bottom:-3px; left:-3px;"
+    style="bottom:-3px; left:-3px; "
   />
   <div
     class="o-fig-anchor o-left"
-    style="bottom:calc(50% - 3px); left:-3px;"
+    style="bottom:calc(50% - 3px); left:-3px; "
   />
   <div
     class="o-fig-anchor o-topLeft"
-    style="top:-3px; left:-3px;"
+    style="top:-3px; left:-3px; "
   />
   
 </div>

--- a/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
@@ -7,11 +7,11 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
 >
   <div
     class="mx-auto h-100 position-relative"
-    style="max-width:2496px;"
+    style="max-width:2496px; "
   >
     <div
       class="o-grid-overlay overflow-hidden"
-      style="height:100%; width:100%;"
+      style="height:100%; width:100%; "
     >
       <div>
         
@@ -40,19 +40,19 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
   </div>
   <div
     class="o-scrollbar vertical"
-    style="top:0px; right:0px; width:15px; bottom:0px;"
+    style="top:0px; right:0px; width:15px; bottom:0px; "
   >
     <div
-      style="width:1px; height:2328px;"
+      style="width:1px; height:2328px; "
     />
   </div>
   
   <div
     class="o-scrollbar horizontal"
-    style="left:0px; bottom:0px; height:15px; right:0px;"
+    style="left:0px; bottom:0px; height:15px; right:0px; "
   >
     <div
-      style="width:2592px; height:1px;"
+      style="width:2592px; height:1px; "
     />
   </div>
   

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
 >
   <div
     class="o-grid-overlay overflow-hidden"
-    style="top:26px; left:48px; height:calc(100% - 41px); width:calc(100% - 63px);"
+    style="top:26px; left:48px; height:calc(100% - 41px); width:calc(100% - 63px); "
   >
     <div>
       
@@ -21,7 +21,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
     
     <div
       class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center"
-      style="top:2300px;"
+      style="top:2300px; "
     >
       <button
         class="o-button"
@@ -102,11 +102,11 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   <div
     class="o-autofill"
-    style="top:45px; left:140px; visibility:visible;"
+    style="top:45px; left:140px; visibility:visible; "
   />
   <div
     class="o-autofill-handler"
-    style="top:45px; left:140px;"
+    style="top:45px; left:140px; "
   />
   
   
@@ -117,19 +117,19 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   <div
     class="o-scrollbar vertical"
-    style="top:26px; right:0px; width:15px; bottom:0px;"
+    style="top:26px; right:0px; width:15px; bottom:0px; "
   >
     <div
-      style="width:1px; height:2374px;"
+      style="width:1px; height:2374px; "
     />
   </div>
   
   <div
     class="o-scrollbar horizontal"
-    style="left:48px; bottom:0px; height:15px; right:0px;"
+    style="left:48px; bottom:0px; height:15px; right:0px; "
   >
     <div
-      style="width:2592px; height:1px;"
+      style="width:2592px; height:1px; "
     />
   </div>
   

--- a/tests/header_group/__snapshots__/header_group_component.test.ts.snap
+++ b/tests/header_group/__snapshots__/header_group_component.test.ts.snap
@@ -11,20 +11,20 @@ exports[`Header group component test For column groups Snapshot 1`] = `
   >
     <div
       class="o-header-group-scroll-container position-relative"
-      style="left:0px;"
+      style="left:0px; "
     >
       <div
         class="o-header-group position-absolute"
         data-id="0-5"
-        style="top:0px; left:0px; width:624px; height:21px;"
+        style="top:0px; left:0px; width:624px; height:21px; "
       >
         <div
           class="o-header-group-header position-absolute d-flex align-items-center justify-content-center overflow-hidden"
-          style="width:48px; height:100%;"
+          style="width:48px; height:100%; "
         >
           <div
             class="o-group-fold-button user-select-none rounded d-flex align-items-center justify-content-center"
-            style="background-color:#fff; color:#333;"
+            style="background-color:#fff; color:#333; "
           >
             <svg
               class="o-icon minus"
@@ -39,7 +39,7 @@ exports[`Header group component test For column groups Snapshot 1`] = `
         </div>
         <div
           class="o-group-border position-absolute"
-          style="top:calc(50% - 1px); left:24px; width:calc(100% - 24px); height:30%; border-top:1px solid #999; border-right:1px solid #999;"
+          style="top:calc(50% - 1px); left:24px; width:calc(100% - 24px); height:30%; border-top:1px solid #999; border-right:1px solid #999; "
         />
         
       </div>
@@ -47,15 +47,15 @@ exports[`Header group component test For column groups Snapshot 1`] = `
       <div
         class="o-header-group position-absolute"
         data-id="2-5"
-        style="top:21px; left:144px; width:480px; height:21px;"
+        style="top:21px; left:144px; width:480px; height:21px; "
       >
         <div
           class="o-header-group-header position-absolute d-flex align-items-center justify-content-center overflow-hidden"
-          style="width:96px; height:100%;"
+          style="width:96px; height:100%; "
         >
           <div
             class="o-group-fold-button user-select-none rounded d-flex align-items-center justify-content-center"
-            style="background-color:#fff; color:#333;"
+            style="background-color:#fff; color:#333; "
           >
             <svg
               class="o-icon minus"
@@ -70,7 +70,7 @@ exports[`Header group component test For column groups Snapshot 1`] = `
         </div>
         <div
           class="o-group-border position-absolute"
-          style="top:calc(50% - 1px); left:48px; width:calc(100% - 48px); height:30%; border-top:1px solid #999; border-right:1px solid #999;"
+          style="top:calc(50% - 1px); left:48px; width:calc(100% - 48px); height:30%; border-top:1px solid #999; border-right:1px solid #999; "
         />
         
       </div>
@@ -93,20 +93,20 @@ exports[`Header group component test For row groups Snapshot 1`] = `
   >
     <div
       class="o-header-group-scroll-container position-relative"
-      style="top:0px;"
+      style="top:0px; "
     >
       <div
         class="o-header-group position-absolute"
         data-id="0-5"
-        style="top:0px; left:0px; width:21px; height:164px;"
+        style="top:0px; left:0px; width:21px; height:164px; "
       >
         <div
           class="o-header-group-header position-absolute d-flex align-items-center justify-content-center overflow-hidden"
-          style="width:100%; height:26px;"
+          style="width:100%; height:26px; "
         >
           <div
             class="o-group-fold-button user-select-none rounded d-flex align-items-center justify-content-center"
-            style="background-color:#fff; color:#333;"
+            style="background-color:#fff; color:#333; "
           >
             <svg
               class="o-icon minus"
@@ -121,7 +121,7 @@ exports[`Header group component test For row groups Snapshot 1`] = `
         </div>
         <div
           class="o-group-border position-absolute"
-          style="top:13px; left:calc(50% - 1px); width:30%; height:calc(100% - 13px); border-left:1px solid #999; border-bottom:1px solid #999;"
+          style="top:13px; left:calc(50% - 1px); width:30%; height:calc(100% - 13px); border-left:1px solid #999; border-bottom:1px solid #999; "
         />
         
       </div>
@@ -129,15 +129,15 @@ exports[`Header group component test For row groups Snapshot 1`] = `
       <div
         class="o-header-group position-absolute"
         data-id="2-5"
-        style="top:49px; left:21px; width:21px; height:115px;"
+        style="top:49px; left:21px; width:21px; height:115px; "
       >
         <div
           class="o-header-group-header position-absolute d-flex align-items-center justify-content-center overflow-hidden"
-          style="width:100%; height:23px;"
+          style="width:100%; height:23px; "
         >
           <div
             class="o-group-fold-button user-select-none rounded d-flex align-items-center justify-content-center"
-            style="background-color:#fff; color:#333;"
+            style="background-color:#fff; color:#333; "
           >
             <svg
               class="o-icon minus"
@@ -152,7 +152,7 @@ exports[`Header group component test For row groups Snapshot 1`] = `
         </div>
         <div
           class="o-group-border position-absolute"
-          style="top:11.5px; left:calc(50% - 1px); width:30%; height:calc(100% - 11.5px); border-left:1px solid #999; border-bottom:1px solid #999;"
+          style="top:11.5px; left:calc(50% - 1px); width:30%; height:calc(100% - 11.5px); border-left:1px solid #999; border-bottom:1px solid #999; "
         />
         
       </div>

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -556,7 +556,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       </div>
       <div
         class="o-topbar-composer bg-white user-select-text"
-        style="border-color:#E0E2E4; border-right:none;"
+        style="border-color:#E0E2E4; border-right:none; "
       >
         <div
           class="o-composer-container w-100 h-100"
@@ -565,7 +565,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
             class="o-composer w-100 text-start"
             contenteditable="true"
             spellcheck="false"
-            style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px;"
+            style="padding:5px 0px 5px 8px; max-height:100px; line-height:24px; height:34px; "
             tabindex="1"
           />
           
@@ -577,7 +577,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
   
   <div
     class="o-grid-container o-two-columns"
-    style="grid-template-columns:0px auto; grid-template-rows:0px auto;"
+    style="grid-template-columns:0px auto; grid-template-rows:0px auto; "
   >
     <div
       class="o-top-left"
@@ -601,7 +601,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
       >
         <div
           class="o-grid-overlay overflow-hidden"
-          style="top:26px; left:48px; height:calc(100% - 41px); width:calc(100% - 63px);"
+          style="top:26px; left:48px; height:calc(100% - 41px); width:calc(100% - 63px); "
         >
           <div>
             
@@ -615,7 +615,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           
           <div
             class="o-grid-add-rows mt-2 ms-2 w-100 d-flex position-relative align-items-center"
-            style="top:2300px;"
+            style="top:2300px; "
           >
             <button
               class="o-button"
@@ -696,11 +696,11 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
         <div
           class="o-autofill"
-          style="top:45px; left:140px; visibility:visible;"
+          style="top:45px; left:140px; visibility:visible; "
         />
         <div
           class="o-autofill-handler"
-          style="top:45px; left:140px;"
+          style="top:45px; left:140px; "
         />
         
         
@@ -711,19 +711,19 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
         <div
           class="o-scrollbar vertical"
-          style="top:26px; right:0px; width:15px; bottom:0px;"
+          style="top:26px; right:0px; width:15px; bottom:0px; "
         >
           <div
-            style="width:1px; height:2374px;"
+            style="width:1px; height:2374px; "
           />
         </div>
         
         <div
           class="o-scrollbar horizontal"
-          style="left:48px; bottom:0px; height:15px; right:0px;"
+          style="left:48px; bottom:0px; height:15px; right:0px; "
         >
           <div
-            style="width:2592px; height:1px;"
+            style="width:2592px; height:1px; "
           />
         </div>
         


### PR DESCRIPTION
`Object.entries()` allocate a new array, which will need to be garbage collected later. Not using that reduce the memory usage from `cssPropertiesToCss` from ~0.75% of total to ~0.25% of total.

There are other uses of `Object.entries()` in the code base, but their impact are too negligible to matter.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo