### PR TITLE
[FIX] evaluation: accept 1x1 result array in sub-formula

### DIFF
--- a/src/functions/arguments.ts
+++ b/src/functions/arguments.ts
@@ -71,6 +71,9 @@ function makeArg(str: string, description: string): ArgDefinition {
     result.default = true;
     result.defaultValue = defaultValue;
   }
+  if (types.some((t) => t.startsWith("RANGE"))) {
+    result.acceptMatrix = true;
+  }
   return result;
 }
 

--- a/src/types/functions.ts
+++ b/src/types/functions.ts
@@ -18,6 +18,7 @@ export type ArgType =
   | "META";
 
 export interface ArgDefinition {
+  acceptMatrix?: boolean;
   repeating?: boolean;
   optional?: boolean;
   lazy?: boolean;

--- a/tests/evaluation/evaluation.test.ts
+++ b/tests/evaluation/evaluation.test.ts
@@ -305,7 +305,7 @@ describe("evaluateCells", () => {
         ArgValue,
         CellValue
       >,
-      args: [{ name: "range", description: "", type: ["RANGE"] }],
+      args: [{ name: "range", description: "", type: ["RANGE"], acceptMatrix: true }],
       returns: ["NUMBER"],
     });
     const model = new Model();

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -80,6 +80,21 @@ describe("evaluate formulas that return an array", () => {
     expect(getEvaluatedCell(model, "B2").value).toBe(42);
   });
 
+  test("can use result array in formula that accept array", () => {
+    setCellContent(model, "A1", "=SUM(MFILL(2, 2, 42))");
+    expect(getEvaluatedCell(model, "A1").value).toBe(168);
+  });
+
+  test("can't use result array in formula that accept scalar only", () => {
+    setCellContent(model, "A1", "=ABS(MFILL(2, 2, -42))");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+  });
+
+  test("can use 1x1 result array in formula that accept scalar", () => {
+    setCellContent(model, "A1", "=ABS(MFILL(1, 1, -42))");
+    expect(getEvaluatedCell(model, "A1").value).toBe(42);
+  });
+
   test("reference to a formula result array is possible", () => {
     setCellContent(model, "E5", "=B2");
     setCellContent(model, "A1", "=MFILL(3,3,42)");


### PR DESCRIPTION
## Description:

Before this commit, when a formula function
expected a simple argument, and it received
an array, we transformed the array into a
simple argument if the array was of size 1x1

However, this process was only done when
reading the references to the ranges.

This commit extends the process when the result
array comes from a sub-formula and no longer
range references.


Task: : [3756474](https://www.odoo.com/web#id=3756474&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo