### PR TITLE
[FIX] dv_editor: make props validation work

### DIFF
--- a/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
+++ b/src/components/side_panel/data_validation/dv_editor/dv_editor.ts
@@ -30,6 +30,7 @@ css/* scss */ `
 interface Props {
   rule: DataValidationRule | undefined;
   onExit: () => void;
+  onCloseSidePanel?: () => void;
 }
 
 interface State {
@@ -42,6 +43,7 @@ export class DataValidationEditor extends Component<Props, SpreadsheetChildEnv> 
   static props = {
     rule: { type: Object, optional: true },
     onExit: Function,
+    onCloseSidePanel: { type: Function, optional: true },
   };
 
   state = useState<State>({ rule: this.defaultDataValidationRule });


### PR DESCRIPTION
DataValidationEditor is a side panel and therefore should have `onCloseSidePanel` as props. Currently, with owl in debug mode, trying to insert a dropdown from the menu will cause a traceback

Task: 3771048

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo