### PR TITLE
[FIX] migration: Fix migration steps

### DIFF
--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -334,7 +334,7 @@ const MIGRATIONS: Migration[] = [
   },
   {
     description: "Change Border description structure",
-    from: 12,
+    from: 12.5,
     to: 13,
     applyMigration(data: any): any {
       for (const borderId in data.borders) {

--- a/tests/plugins/import_export.test.ts
+++ b/tests/plugins/import_export.test.ts
@@ -373,9 +373,23 @@ describe("Migrations", () => {
     expect(data.sheets[1].cells["A2"]?.format).toEqual(2);
   });
 
-  test("migrate version 12: update border description structure", () => {
+  test("migrate version 12: Fix Overlapping datafilters", () => {
     const model = new Model({
       version: 12,
+      sheets: [
+        {
+          id: "1",
+          filterTables: [{ range: "A1:B2" }, { range: "A1:C2" }],
+        },
+      ],
+    });
+    const data = model.exportData();
+    expect(data.sheets[0].filterTables).toEqual([{ range: "A1:C2" }]);
+  });
+
+  test("migrate version 12.5: update border description structure", () => {
+    const model = new Model({
+      version: 12.5,
       sheets: [
         {
           id: "1",
@@ -401,20 +415,6 @@ describe("Migrations", () => {
         },
       },
     });
-  });
-
-  test("migrate version 12.5: Fix Overlapping datafilters", () => {
-    const model = new Model({
-      version: 12,
-      sheets: [
-        {
-          id: "1",
-          filterTables: [{ range: "A1:B2" }, { range: "A1:C2" }],
-        },
-      ],
-    });
-    const data = model.exportData();
-    expect(data.sheets[0].filterTables).toEqual([{ range: "A1:C2" }]);
   });
 });
 


### PR DESCRIPTION
The forward-port fix in https://github.com/odoo/o-spreadsheet/pull/3632 was incorrect as it did not adapted the (already present) following migration step to be exectued after step 12.5 and not step 12. In the current state, a user coming from version 16.2  and below will not be able to migrate their data as their current version (12.5) does not match any 'from' of the migration steps.

OPW 3757136

Task: 3771209

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo