### PR TITLE
[IMP] data validation: performance of icons

### DIFF
--- a/src/components/data_validation_overlay/data_validation_overlay.ts
+++ b/src/components/data_validation_overlay/data_validation_overlay.ts
@@ -9,13 +9,18 @@ export class DataValidationOverlay extends Component<{}, SpreadsheetChildEnv> {
   static components = { GridCellIcon, DataValidationCheckbox, DataValidationListIcon };
 
   get checkBoxCellPositions(): CellPosition[] {
-    return this.env.model.getters.getDataValidationCheckBoxCellPositions();
+    return this.env.model.getters
+      .getVisibleCellPositions()
+      .filter(this.env.model.getters.isCellValidCheckbox);
   }
 
   get listIconsCellPositions(): CellPosition[] {
-    return this.env.model.getters.isReadonly()
-      ? []
-      : this.env.model.getters.getDataValidationListCellsPositions();
+    if (this.env.model.getters.isReadonly()) {
+      return [];
+    }
+    return this.env.model.getters
+      .getVisibleCellPositions()
+      .filter(this.env.model.getters.cellHasListDataValidationIcon);
   }
 }
 

--- a/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
+++ b/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
@@ -36,7 +36,7 @@ export class DataValidationCheckbox extends Component<Props, SpreadsheetChildEnv
 
   get isDisabled(): boolean {
     const cell = this.env.model.getters.getCell(this.props.cellPosition);
-    return !!cell?.isFormula;
+    return this.env.model.getters.isReadonly() || !!cell?.isFormula;
   }
 }
 

--- a/src/components/grid_cell_icon/grid_cell_icon.ts
+++ b/src/components/grid_cell_icon/grid_cell_icon.ts
@@ -5,6 +5,7 @@ import {
   Align,
   CellPosition,
   DOMCoordinates,
+  Rect,
   SpreadsheetChildEnv,
   VerticalAlign,
 } from "../../types";
@@ -28,25 +29,24 @@ export class GridCellIcon extends Component<GridCellIconProps, SpreadsheetChildE
   static style = CSS;
   static template = "o-spreadsheet-GridCellIcon";
 
-  get iconStyle() {
-    const x = this.getIconHorizontalPosition();
-    const y = this.getIconVerticalPosition();
+  get iconStyle(): string {
+    const cellPosition = this.props.cellPosition;
+    const merge = this.env.model.getters.getMerge(cellPosition);
+    const zone = merge || positionToZone(cellPosition);
+    const rect = this.env.model.getters.getVisibleRectWithoutHeaders(zone);
+    const x = this.getIconHorizontalPosition(rect, cellPosition);
+    const y = this.getIconVerticalPosition(rect, cellPosition);
     return cssPropertiesToCss({
       top: `${y + (this.props.offset?.y || 0)}px`,
       left: `${x + (this.props.offset?.x || 0)}px`,
     });
   }
 
-  private getIconVerticalPosition(): number {
-    const { sheetId, row } = this.props.cellPosition;
-    const merge = this.env.model.getters.getMerge(this.props.cellPosition);
-    const start = this.env.model.getters.getRowDimensionsInViewport(sheetId, row).start;
-    const end = this.env.model.getters.getRowDimensionsInViewport(
-      sheetId,
-      merge ? merge.bottom : row
-    ).end;
+  private getIconVerticalPosition(rect: Rect, cellPosition: CellPosition): number {
+    const start = rect.y;
+    const end = rect.y + rect.height;
 
-    const cell = this.env.model.getters.getCell(this.props.cellPosition);
+    const cell = this.env.model.getters.getCell(cellPosition);
     const align = this.props.verticalAlign || cell?.style?.verticalAlign || DEFAULT_VERTICAL_ALIGN;
 
     switch (align) {
@@ -60,17 +60,12 @@ export class GridCellIcon extends Component<GridCellIconProps, SpreadsheetChildE
     }
   }
 
-  private getIconHorizontalPosition(): number {
-    const { sheetId, col } = this.props.cellPosition;
-    const merge = this.env.model.getters.getMerge(this.props.cellPosition);
-    const start = this.env.model.getters.getColDimensionsInViewport(sheetId, col).start;
-    const end = this.env.model.getters.getColDimensionsInViewport(
-      sheetId,
-      merge ? merge.right : col
-    ).end;
+  private getIconHorizontalPosition(rect: Rect, cellPosition: CellPosition): number {
+    const start = rect.x;
+    const end = rect.x + rect.width;
 
-    const cell = this.env.model.getters.getCell(this.props.cellPosition);
-    const evaluatedCell = this.env.model.getters.getEvaluatedCell(this.props.cellPosition);
+    const cell = this.env.model.getters.getCell(cellPosition);
+    const evaluatedCell = this.env.model.getters.getEvaluatedCell(cellPosition);
     const align = this.props.horizontalAlign || cell?.style?.align || evaluatedCell.defaultAlign;
 
     switch (align) {

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -38,8 +38,6 @@ type SheetValidationResult = { [col: HeaderIndex]: Array<Lazy<ValidationResult>>
 export class EvaluationDataValidationPlugin extends UIPlugin {
   static getters = [
     "getDataValidationInvalidCriterionValueMessage",
-    "getDataValidationCheckBoxCellPositions",
-    "getDataValidationListCellsPositions",
     "getInvalidDataValidationMessage",
     "getValidationResultForCellValue",
     "isCellValidCheckbox",
@@ -120,26 +118,6 @@ export class EvaluationDataValidationPlugin extends UIPlugin {
     const error = this.getRuleErrorForCellValue(cellValue, cellPosition, rule);
 
     return error ? { error, rule, isValid: false } : VALID_RESULT;
-  }
-
-  getDataValidationCheckBoxCellPositions(): CellPosition[] {
-    const rules = this.getters
-      .getDataValidationRules(this.getters.getActiveSheetId())
-      .filter((rule) => rule.criterion.type === "isBoolean");
-    return getCellPositionsInRanges(rules.map((rule) => rule.ranges).flat()).filter((position) =>
-      this.isCellValidCheckbox(position)
-    );
-  }
-
-  getDataValidationListCellsPositions(): CellPosition[] {
-    const rules = this.getters
-      .getDataValidationRules(this.getters.getActiveSheetId())
-      .filter(
-        (rule) =>
-          (rule.criterion.type === "isValueInList" || rule.criterion.type === "isValueInRange") &&
-          rule.criterion.displayStyle === "arrow"
-      );
-    return getCellPositionsInRanges(rules.map((rule) => rule.ranges).flat());
   }
 
   private getValidationResultForCell(cellPosition: CellPosition): ValidationResult {

--- a/tests/data_validation/data_validation_checkbox_component.test.ts
+++ b/tests/data_validation/data_validation_checkbox_component.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src";
 import { addDataValidation, setCellContent, setStyle } from "../test_helpers/commands_helpers";
 import { getStyle } from "../test_helpers/getters_helpers";
+import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 import { MockGridRenderingContext } from "../test_helpers/renderer_helpers";
 
 describe("Checkbox in model", () => {
@@ -56,5 +57,28 @@ describe("Checkbox in model", () => {
       model.drawGrid(ctx);
       expect(renderedTexts).toContain("hello");
     });
+  });
+});
+
+describe("Checkbox component", () => {
+  test("Data validation checkbox on formula is disabled", async () => {
+    const model = new Model();
+    addDataValidation(model, "A1", "id", { type: "isBoolean", values: [] });
+    const { fixture } = await mountSpreadsheet({ model });
+    await nextTick();
+
+    expect(fixture.querySelector(".o-dv-checkbox")?.classList).not.toContain("pe-none");
+    setCellContent(model, "A1", "=TRUE");
+    await nextTick();
+    expect(fixture.querySelector(".o-dv-checkbox")?.classList).toContain("pe-none");
+  });
+
+  test("Data validation checkbox is disabled in readonly mode", async () => {
+    const model = new Model();
+    addDataValidation(model, "A1", "id", { type: "isBoolean", values: [] });
+    model.updateMode("readonly");
+    const { fixture } = await mountSpreadsheet({ model });
+
+    expect(fixture.querySelector(".o-dv-checkbox")?.classList).toContain("pe-none");
   });
 });


### PR DESCRIPTION
## Description

A sheet with a lot of data validation icons was slow to render, because:

- we loop on all the cells of the data validation, and not only the visible cells
- we created components even for non-visible cells
- we use `getColDimensionsInViewport` which is slow

This commit fixes all of the above. We go from ~10fps to ~45fps when scrolling the sheet.

We could be even faster by not using components and only t-call to templates, but the world isn't ready yet.

Task: : [3773923](https://www.odoo.com/web#id=3773923&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo