### PR TITLE
Master table autofill adrm

### DIFF
--- a/src/plugins/ui_feature/autofill.ts
+++ b/src/plugins/ui_feature/autofill.ts
@@ -16,6 +16,7 @@ import {
   Tooltip,
   Zone,
 } from "../../types/index";
+
 import { UIPlugin } from "../ui_plugin";
 
 /**
@@ -268,10 +269,24 @@ export class AutofillPlugin extends UIPlugin {
    * autofiller
    */
   private autofillAuto() {
+    const activePosition = this.getters.getActivePosition();
+
+    const table = this.getters.getTable(activePosition);
+    const row = table ? table.range.zone.bottom : this.getAutofillAutoLastRow();
+
+    const selection = this.getters.getSelectedZone();
+    if (row !== selection.bottom) {
+      this.select(activePosition.col, row);
+      this.autofill(true);
+    }
+  }
+
+  private getAutofillAutoLastRow() {
     const zone = this.getters.getSelectedZone();
     const sheetId = this.getters.getActiveSheetId();
     let col: HeaderIndex = zone.left;
     let row: HeaderIndex = zone.bottom;
+
     if (col > 0) {
       let leftPosition = { sheetId, col: col - 1, row };
       while (
@@ -295,10 +310,7 @@ export class AutofillPlugin extends UIPlugin {
         }
       }
     }
-    if (row !== zone.bottom) {
-      this.select(zone.left, row - 1);
-      this.autofill(true);
-    }
+    return row - 1;
   }
 
   /**

--- a/tests/autofill/autofill_plugin.test.ts
+++ b/tests/autofill/autofill_plugin.test.ts
@@ -627,6 +627,28 @@ describe("Autofill", () => {
     expect(getCell(model, "A4")?.content).toBe(undefined);
   });
 
+  test("Auto-autofill stops at non empty cell", () => {
+    // On standard range
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+    setCellContent(model, "A3", "3");
+    setCellContent(model, "B1", "=A1");
+    setCellContent(model, "B3", "Text not overwritten");
+    setSelection(model, ["B1"]);
+    model.dispatch("AUTOFILL_AUTO");
+    expect(getCell(model, "B2")?.content).toBe("=A2");
+    expect(getCell(model, "B3")?.content).toBe("Text not overwritten");
+
+    // On a table
+    createTable(model, "C1:C3");
+    setCellContent(model, "C1", "=D1");
+    setCellContent(model, "C3", "Text not overwritten");
+    setSelection(model, ["C1"]);
+    model.dispatch("AUTOFILL_AUTO");
+    expect(getCell(model, "C2")?.content).toBe("=D2");
+    expect(getCell(model, "C3")?.content).toBe("Text not overwritten");
+  });
+
   test("autofill with merge in selection", () => {
     merge(model, "A1:A2");
     setCellContent(model, "A1", "1");

--- a/tests/autofill/autofill_plugin.test.ts
+++ b/tests/autofill/autofill_plugin.test.ts
@@ -1,13 +1,12 @@
-import { Model } from "../../src";
-import { functionRegistry } from "../../src/functions";
+import "../test_helpers/helpers";
+
 import { buildSheetLink, toCartesian, toZone } from "../../src/helpers";
-import { AutofillPlugin } from "../../src/plugins/ui_feature/autofill";
 import { Border, ConditionalFormat, Style } from "../../src/types";
-import { DIRECTION } from "../../src/types/index";
 import {
   addDataValidation,
   createSheet,
   createSheetWithName,
+  createTable,
   deleteColumns,
   deleteRows,
   merge,
@@ -22,8 +21,7 @@ import {
   getCellText,
   getMerges,
   getStyle,
-} from "../test_helpers/getters_helpers"; // to have getcontext mocks
-import "../test_helpers/helpers";
+} from "../test_helpers/getters_helpers";
 import {
   XCToMergeCellMap,
   getDataValidationRules,
@@ -32,6 +30,11 @@ import {
   makeTestComposerStore,
   toRangesData,
 } from "../test_helpers/helpers";
+
+import { Model } from "../../src";
+import { functionRegistry } from "../../src/functions";
+import { AutofillPlugin } from "../../src/plugins/ui_feature/autofill";
+import { DIRECTION } from "../../src/types/index";
 
 let autoFill: AutofillPlugin;
 let model: Model;
@@ -613,6 +616,15 @@ describe("Autofill", () => {
     expect(getCellContent(model, "C2")).toBe("2");
     expect(getCellContent(model, "C3")).toBe("2");
     expect(getCell(model, "C4")).toBeUndefined();
+  });
+
+  test("Auto-autofill in a table fill until the end of the table", () => {
+    createTable(model, "A1:B3");
+    setCellContent(model, "A1", "=C1");
+    model.dispatch("AUTOFILL_AUTO");
+    expect(getCell(model, "A2")?.content).toBe("=C2");
+    expect(getCell(model, "A3")?.content).toBe("=C3");
+    expect(getCell(model, "A4")?.content).toBe(undefined);
   });
 
   test("autofill with merge in selection", () => {


### PR DESCRIPTION
## Description:

### [IMP] autofill: `AUTOFILL_AUTO` for tables

This commit improves the `AUTOFILL_AUTO` command for tables. Now when
auto filling a cell in a table, we will autofill until the end of the
table.

Task: : [3777825](https://www.odoo.com/web#id=3777825&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

### [FIX] autofill: `AUTOFILL_AUTO` overwrite cells

The autofill done in the `AUTOFILL_AUTO` command wasn't checking if
the cells already had a content, and thus could overwrite cells.

This commit add a check to stop the autofill at the first non-empty
cell encountered.

Task: : [3777825](https://www.odoo.com/web#id=3777825&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo