### PR TITLE
[FIX] automatic_sum: wrong behaviour with spreaded values

### DIFF
--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -8,7 +8,6 @@ import {
   isDefined,
   isZoneInside,
   isZoneValid,
-  positions,
   range,
   toCartesian,
 } from "../../helpers/index";
@@ -68,7 +67,6 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "getNumberHeaders",
     "getGridLinesVisibility",
     "getNextSheetName",
-    "isEmpty",
     "getSheetSize",
     "getSheetZone",
     "getPaneDivisions",
@@ -507,15 +505,6 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   // ---------------------------------------------------------------------------
   // Row/Col manipulation
   // ---------------------------------------------------------------------------
-
-  /**
-   * Check if a zone only contains empty cells
-   */
-  isEmpty(sheetId: UID, zone: Zone): boolean {
-    return positions(zone)
-      .map(({ col, row }) => this.getCell({ sheetId, col, row }))
-      .every((cell) => !cell || cell.content === "");
-  }
 
   getCommandZones(cmd: Command): Zone[] {
     const zones: Zone[] = [];

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -4,6 +4,7 @@ import { CellErrorType, EvaluationError } from "../../../types/errors";
 import {
   CellPosition,
   CellValue,
+  CellValueType,
   Command,
   EvaluatedCell,
   ExcelCellData,
@@ -146,6 +147,7 @@ export class EvaluationPlugin extends UIPlugin {
     "getEvaluatedCell",
     "getEvaluatedCells",
     "getEvaluatedCellsInZone",
+    "isEmpty",
   ] as const;
 
   private shouldRebuildDependenciesGraph = true;
@@ -256,6 +258,15 @@ export class EvaluationPlugin extends UIPlugin {
     return positions(zone).map(({ col, row }) =>
       this.getters.getEvaluatedCell({ sheetId, col, row })
     );
+  }
+
+  /**
+   * Check if a zone only contains empty cells
+   */
+  isEmpty(sheetId: UID, zone: Zone): boolean {
+    return positions(zone)
+      .map(({ col, row }) => this.getEvaluatedCell({ sheetId, col, row }))
+      .every((cell) => cell.type === CellValueType.empty);
   }
 
   // ---------------------------------------------------------------------------

--- a/tests/plugins/automatic_sum.test.ts
+++ b/tests/plugins/automatic_sum.test.ts
@@ -118,6 +118,12 @@ describe("automatic sum", () => {
     expect(getCellText(model, "B4")).toBe("=SUM(B2:B3)");
   });
 
+  test("with spreaded values", () => {
+    setCellContent(model, "A1", "=MUNIT(2)");
+    automaticSum(model, "B1:B2");
+    expect(getCellText(model, "B3")).toBe("=SUM(B1:B2)");
+  });
+
   test("on a number", () => {
     setCellContent(model, "B2", "4");
     setCellContent(model, "B3", "4");


### PR DESCRIPTION
## Description

The automatic sum wasn't working properly when it was used on a range with spreaded values, because it was using the `isEmpty` getter that was core and didn't take into account the spreaded values.

Task: : [3782971](https://www.odoo.com/web#id=3782971&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo