### PR TITLE
[IMP] table: automatic autofill formula in table

### DIFF
--- a/src/clipboard_handlers/tables_clipboard.ts
+++ b/src/clipboard_handlers/tables_clipboard.ts
@@ -153,6 +153,12 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
         this.pasteTableCell(sheetId, tableCell, position, clipboardOptions);
       }
     }
+
+    if (tableCells.length === 1) {
+      for (let c = 0; c < tableCells[0].length; c++) {
+        this.dispatch("AUTOFILL_TABLE_COLUMN", { col: col + c, row, sheetId });
+      }
+    }
   }
 
   private pasteTableCell(

--- a/src/components/composer/composer/composer_store.ts
+++ b/src/components/composer/composer/composer_store.ts
@@ -453,6 +453,7 @@ export class ComposerStore extends SpreadsheetStore {
           row,
         });
       }
+      this.model.dispatch("AUTOFILL_TABLE_COLUMN", { col, row, sheetId: this.sheetId });
       this.setContent("");
     }
   }

--- a/src/components/side_panel/table_panel/table_panel.xml
+++ b/src/components/side_panel/table_panel/table_panel.xml
@@ -76,6 +76,12 @@
           onSelectionConfirmed.bind="this.onRangeConfirmed"
         />
         <ValidationMessages messages="errorMessages" msgType="'error'"/>
+        <Checkbox
+          label="getCheckboxLabel('automaticAutofill')"
+          name="'automaticAutofill'"
+          value="tableConfig.automaticAutofill"
+          onChange="(val) => this.updateTableConfig('automaticAutofill', val)"
+        />
       </Section>
       <div class="o-sidePanelButtons">
         <button t-on-click="deleteTable" class="o-table-delete o-button">Delete table</button>

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -149,6 +149,7 @@ export const TableTerms = {
     firstColumn: _t("First column"),
     lastColumn: _t("Last column"),
     bandedColumns: _t("Banded columns"),
+    automaticAutofill: _t("Automatically autofill formulas"),
     totalRow: _t("Total row"),
   },
   Tooltips: {

--- a/src/helpers/table_helpers.ts
+++ b/src/helpers/table_helpers.ts
@@ -17,6 +17,13 @@ const TABLE_ELEMENTS_BY_PRIORITY: TableElement[] = [
   "totalRow",
 ];
 
+/** Return the content zone of the table, ie. the table zone without the headers */
+export function getTableContentZone(tableZone: Zone, tableConfig: TableConfig): Zone | undefined {
+  const numberOfHeaders = tableConfig.numberOfHeaders;
+  const contentZone = { ...tableZone, top: tableZone.top + numberOfHeaders };
+  return contentZone.top <= contentZone.bottom ? contentZone : undefined;
+}
+
 export function getComputedTableStyle(
   tableConfig: TableConfig,
   numberOfCols: number,

--- a/src/helpers/table_presets.ts
+++ b/src/helpers/table_presets.ts
@@ -20,6 +20,9 @@ export const DEFAULT_TABLE_CONFIG: TableConfig = {
 
   bandedRows: true,
   bandedColumns: false,
+
+  automaticAutofill: true,
+
   styleId: "TableStyleMedium2",
 };
 

--- a/src/plugins/core/tables.ts
+++ b/src/plugins/core/tables.ts
@@ -12,6 +12,7 @@ import {
   zoneToDimension,
   zoneToXc,
 } from "../../helpers";
+import { getTableContentZone } from "../../helpers/table_helpers";
 import { DEFAULT_TABLE_CONFIG, TABLE_PRESETS } from "../../helpers/table_presets";
 import {
   ApplyRangeChange,
@@ -428,13 +429,15 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
     if (zone.left !== zone.right) {
       throw new Error("Can only define a filter on a single column");
     }
-    const filteredZone = { ...zone, top: zone.top + config.numberOfHeaders };
-    const filteredRange = this.getters.getRangeFromZone(range.sheetId, filteredZone);
+    const contentZone = getTableContentZone(zone, config);
+    const filteredRange = contentZone
+      ? this.getters.getRangeFromZone(range.sheetId, contentZone)
+      : undefined;
     return {
       id,
       rangeWithHeaders: range,
       col: zone.left,
-      filteredRange: filteredZone.top > filteredZone.bottom ? undefined : filteredRange,
+      filteredRange,
     };
   }
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -38,6 +38,7 @@ import {
 } from "./ui_feature";
 import { HistoryPlugin } from "./ui_feature/local_history";
 import { SplitToColumnsPlugin } from "./ui_feature/split_to_columns";
+import { TableAutofillPlugin } from "./ui_feature/table_autofill";
 import { TableStylePlugin } from "./ui_feature/table_style";
 import { UIPluginConstructor } from "./ui_plugin";
 import {
@@ -76,7 +77,8 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("split_to_columns", SplitToColumnsPlugin)
   .add("collaborative", CollaborativePlugin)
   .add("history", HistoryPlugin)
-  .add("data_cleanup", DataCleanupPlugin);
+  .add("data_cleanup", DataCleanupPlugin)
+  .add("table_autofill", TableAutofillPlugin);
 
 // Plugins which have a state, but which should not be shared in collaborative
 export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()

--- a/src/plugins/ui_feature/table_autofill.ts
+++ b/src/plugins/ui_feature/table_autofill.ts
@@ -1,0 +1,55 @@
+import { isInside } from "../../helpers";
+import { getTableContentZone } from "../../helpers/table_helpers";
+import { CellPosition, CellValueType, Command, Zone } from "../../types";
+import { UIPlugin } from "../ui_plugin";
+
+export class TableAutofillPlugin extends UIPlugin {
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "AUTOFILL_TABLE_COLUMN":
+        const table = this.getters.getTable(cmd);
+        const cell = this.getters.getCell(cmd);
+        if (!table || !table.config.automaticAutofill || !cell?.isFormula) return;
+
+        const { col, row } = cmd;
+        const tableContentZone = getTableContentZone(table.range.zone, table.config);
+        if (tableContentZone && isInside(col, row, tableContentZone)) {
+          this.autofillTableZone(cmd, tableContentZone);
+        }
+        break;
+    }
+  }
+
+  private autofillTableZone(autofillSource: CellPosition, zone: Zone) {
+    if (zone.top === zone.bottom) {
+      return;
+    }
+    const { col, row, sheetId } = autofillSource;
+
+    for (let r = zone.top; r <= zone.bottom; r++) {
+      if (r === row) {
+        continue;
+      }
+      if (this.getters.getEvaluatedCell({ col, row: r, sheetId }).type !== CellValueType.empty) {
+        return;
+      }
+    }
+
+    // TODO: seems odd that autofill a table column have side effects on the selection. Autofill commands should be
+    // refactored to take the selection as a parameter
+    const oldSelection = {
+      zone: this.getters.getSelectedZone(),
+      cell: this.getters.getActivePosition(),
+    };
+
+    this.selection.selectCell(col, row);
+    this.dispatch("AUTOFILL_SELECT", { col, row: zone.bottom });
+    this.dispatch("AUTOFILL");
+
+    this.selection.selectCell(col, row);
+    this.dispatch("AUTOFILL_SELECT", { col, row: zone.top });
+    this.dispatch("AUTOFILL");
+
+    this.selection.selectZone(oldSelection);
+  }
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -493,6 +493,10 @@ export interface UpdateTableCommand {
   config?: Partial<TableConfig>;
 }
 
+export interface AutofillTableCommand extends PositionDependentCommand {
+  type: "AUTOFILL_TABLE_COLUMN";
+}
+
 export interface UpdateFilterCommand extends PositionDependentCommand {
   type: "UPDATE_FILTER";
   hiddenValues: string[];
@@ -962,6 +966,7 @@ export type LocalCommand =
   | StartCommand
   | AutofillCommand
   | AutofillSelectCommand
+  | AutofillTableCommand
   | ShowFormulaCommand
   | AutofillAutoCommand
   | SelectFigureCommand

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -27,6 +27,8 @@ export interface TableConfig {
   bandedRows: boolean;
   bandedColumns: boolean;
 
+  automaticAutofill?: boolean;
+
   styleId: string;
 }
 

--- a/tests/table/table_autofill_plugin.test.ts
+++ b/tests/table/table_autofill_plugin.test.ts
@@ -1,0 +1,206 @@
+import { Model, UID } from "../../src";
+import { ComposerStore } from "../../src/components/composer/composer/composer_store";
+import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
+import {
+  copy,
+  createTable,
+  cut,
+  paste,
+  redo,
+  selectCell,
+  setCellContent,
+  undo,
+} from "../test_helpers/commands_helpers";
+import { getCell } from "../test_helpers/getters_helpers";
+import { makeStore } from "../test_helpers/stores";
+
+const TABLE_CONFIG_NO_HEADERS = { ...DEFAULT_TABLE_CONFIG, numberOfHeaders: 0, hasFilters: false };
+
+let model: Model;
+let sheetId: UID;
+
+describe("Table formula autofill ", () => {
+  beforeEach(() => {
+    model = new Model();
+    sheetId = model.getters.getActiveSheetId();
+  });
+
+  test("Can autofill a formula on a table column", () => {
+    createTable(model, "C3:D5", TABLE_CONFIG_NO_HEADERS);
+    setCellContent(model, "C3", "=A1");
+    model.dispatch("AUTOFILL_TABLE_COLUMN", { col: 2, row: 2, sheetId });
+    expect(getCell(model, "C3")?.content).toEqual("=A1");
+    expect(getCell(model, "C4")?.content).toEqual("=A2");
+    expect(getCell(model, "C5")?.content).toEqual("=A3");
+  });
+
+  test("Autofill is not active with the automaticAutofill table option set to false", () => {
+    createTable(model, "A1:B3", { ...TABLE_CONFIG_NO_HEADERS, automaticAutofill: false });
+    setCellContent(model, "A1", "=C1");
+    model.dispatch("AUTOFILL_TABLE_COLUMN", { col: 0, row: 0, sheetId });
+    expect(getCell(model, "A1")?.content).toEqual("=C1");
+    expect(getCell(model, "A2")?.content).toEqual(undefined);
+  });
+
+  test("Table headers are not auto-filled ", () => {
+    createTable(model, "A1:B3", { ...DEFAULT_TABLE_CONFIG, numberOfHeaders: 1 });
+    setCellContent(model, "A1", "=C1");
+    model.dispatch("AUTOFILL_TABLE_COLUMN", { col: 0, row: 0, sheetId });
+    expect(getCell(model, "A1")?.content).toEqual("=C1");
+    expect(getCell(model, "A2")?.content).toEqual(undefined);
+    expect(getCell(model, "A3")?.content).toEqual(undefined);
+
+    setCellContent(model, "B2", "=C2");
+    model.dispatch("AUTOFILL_TABLE_COLUMN", { col: 1, row: 1, sheetId });
+    expect(getCell(model, "B1")?.content).toEqual(undefined);
+    expect(getCell(model, "B2")?.content).toEqual("=C2");
+    expect(getCell(model, "B3")?.content).toEqual("=C3");
+  });
+
+  test("Autofill on something else than a formula does not autofill the column", () => {
+    createTable(model, "A1:B3", TABLE_CONFIG_NO_HEADERS);
+    setCellContent(model, "A1", "hello");
+    model.dispatch("AUTOFILL_TABLE_COLUMN", { col: 0, row: 0, sheetId });
+    expect(getCell(model, "A1")?.content).toEqual("hello");
+    expect(getCell(model, "A2")?.content).toEqual(undefined);
+  });
+
+  test("Autofill works both above and below the inputted formula", () => {
+    createTable(model, "A1:B3", TABLE_CONFIG_NO_HEADERS);
+    setCellContent(model, "A2", "=C2");
+    model.dispatch("AUTOFILL_TABLE_COLUMN", { col: 0, row: 1, sheetId });
+    expect(getCell(model, "A1")?.content).toEqual("=C1");
+    expect(getCell(model, "A2")?.content).toEqual("=C2");
+    expect(getCell(model, "A3")?.content).toEqual("=C3");
+  });
+
+  test("Do not autofill non-empty columns", () => {
+    createTable(model, "A1:B3", TABLE_CONFIG_NO_HEADERS);
+    setCellContent(model, "A3", "hello");
+    setCellContent(model, "A1", "=C1");
+    model.dispatch("AUTOFILL_TABLE_COLUMN", { col: 0, row: 0, sheetId });
+    expect(getCell(model, "A1")?.content).toEqual("=C1");
+    expect(getCell(model, "A2")?.content).toEqual(undefined);
+    expect(getCell(model, "A3")?.content).toEqual("hello");
+  });
+});
+
+describe("Table autofill with composer", () => {
+  let composerStore: ComposerStore;
+
+  function editCell(model: Model, xc: string, content: string) {
+    selectCell(model, xc);
+    composerStore.startEdition(content);
+    composerStore.stopEdition();
+  }
+
+  beforeEach(() => {
+    ({ model, store: composerStore } = makeStore(ComposerStore));
+  });
+
+  test("Editing a cell autofill the table column", () => {
+    createTable(model, "A1:B3", TABLE_CONFIG_NO_HEADERS);
+    editCell(model, "A1", "=C1");
+    expect(getCell(model, "A1")?.content).toEqual("=C1");
+    expect(getCell(model, "A2")?.content).toEqual("=C2");
+    expect(getCell(model, "A3")?.content).toEqual("=C3");
+  });
+
+  test("Undo/redo table formula autofill with composer", () => {
+    createTable(model, "A1:B3", TABLE_CONFIG_NO_HEADERS);
+    editCell(model, "A1", "=C1");
+    expect(getCell(model, "A1")?.content).toEqual("=C1");
+    expect(getCell(model, "A2")?.content).toEqual("=C2");
+
+    // Unfortunately, we cannot do the editCell + the autofill in a single history step
+    undo(model);
+    expect(getCell(model, "A1")?.content).toEqual("=C1");
+    expect(getCell(model, "A2")?.content).toEqual(undefined);
+
+    undo(model);
+    expect(getCell(model, "A1")?.content).toEqual(undefined);
+    expect(getCell(model, "A2")?.content).toEqual(undefined);
+
+    redo(model);
+    expect(getCell(model, "A1")?.content).toEqual("=C1");
+    expect(getCell(model, "A2")?.content).toEqual(undefined);
+
+    redo(model);
+    expect(getCell(model, "A1")?.content).toEqual("=C1");
+    expect(getCell(model, "A2")?.content).toEqual("=C2");
+  });
+});
+
+describe("Table autofill with copy/paste", () => {
+  beforeEach(() => {
+    model = new Model();
+  });
+
+  test("Copy paste a formula autofill the table column", () => {
+    createTable(model, "C3:C5", TABLE_CONFIG_NO_HEADERS);
+    setCellContent(model, "A1", "=B1");
+    copy(model, "A1");
+    paste(model, "C3");
+
+    expect(getCell(model, "C3")?.content).toEqual("=D3");
+    expect(getCell(model, "C4")?.content).toEqual("=D4");
+    expect(getCell(model, "C5")?.content).toEqual("=D5");
+  });
+
+  test("Cut/paste a formula autofill the table column", () => {
+    createTable(model, "C3:C5", TABLE_CONFIG_NO_HEADERS);
+    setCellContent(model, "A1", "=B1");
+    cut(model, "A1");
+    paste(model, "C3");
+
+    expect(getCell(model, "A1")).toEqual(undefined);
+    expect(getCell(model, "C3")?.content).toEqual("=B1");
+    expect(getCell(model, "C4")?.content).toEqual("=B2");
+    expect(getCell(model, "C5")?.content).toEqual("=B3");
+  });
+
+  test("Copy/paste multiple columns autofill each column", () => {
+    createTable(model, "C3:D4", TABLE_CONFIG_NO_HEADERS);
+    setCellContent(model, "C1", "=D1");
+    setCellContent(model, "D1", "=E1");
+
+    copy(model, "C1:D1");
+    paste(model, "C3");
+
+    expect(getCell(model, "C3")?.content).toEqual("=D3");
+    expect(getCell(model, "C4")?.content).toEqual("=D4");
+    expect(getCell(model, "D3")?.content).toEqual("=E3");
+    expect(getCell(model, "D4")?.content).toEqual("=E4");
+  });
+
+  test("Copy/paste multiple rows does not autofill the table column", () => {
+    createTable(model, "A1:A3", TABLE_CONFIG_NO_HEADERS);
+    setCellContent(model, "B1", "=C1");
+    setCellContent(model, "B2", "=C2");
+
+    copy(model, "B1:B2");
+    paste(model, "A1");
+
+    expect(getCell(model, "A1")?.content).toEqual("=B1");
+    expect(getCell(model, "A2")?.content).toEqual("=B2");
+    expect(getCell(model, "A3")?.content).toEqual(undefined);
+  });
+
+  test("Can undo/redo table autofill on paste", () => {
+    createTable(model, "A1:A2", TABLE_CONFIG_NO_HEADERS);
+    setCellContent(model, "B1", "=C1");
+
+    copy(model, "B1");
+    paste(model, "A1");
+    expect(getCell(model, "A1")?.content).toEqual("=B1");
+    expect(getCell(model, "A2")?.content).toEqual("=B2");
+
+    undo(model);
+    expect(getCell(model, "A1")?.content).toEqual(undefined);
+    expect(getCell(model, "A2")?.content).toEqual(undefined);
+
+    redo(model);
+    expect(getCell(model, "A1")?.content).toEqual("=B1");
+    expect(getCell(model, "A2")?.content).toEqual("=B2");
+  });
+});

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -46,16 +46,21 @@ describe("Table side panel", () => {
     await nextTick();
   });
 
-  test.each(["hasFilters", "totalRow", "firstColumn", "lastColumn", "bandedRows", "bandedColumns"])(
-    "Can change table config boolean option %s",
-    (configOption) => {
-      const value = getTable(model, sheetId).config[configOption];
-      const checkbox = fixture.querySelector(`input[name="${configOption}"]`) as HTMLInputElement;
-      expect(checkbox.checked).toBe(value);
-      click(checkbox);
-      expect(getTable(model, sheetId).config[configOption]).toBe(!value);
-    }
-  );
+  test.each([
+    "hasFilters",
+    "totalRow",
+    "firstColumn",
+    "lastColumn",
+    "bandedRows",
+    "bandedColumns",
+    "automaticAutofill",
+  ])("Can change table config boolean option %s", (configOption) => {
+    const value = getTable(model, sheetId).config[configOption];
+    const checkbox = fixture.querySelector(`input[name="${configOption}"]`) as HTMLInputElement;
+    expect(checkbox.checked).toBe(value);
+    click(checkbox);
+    expect(getTable(model, sheetId).config[configOption]).toBe(!value);
+  });
 
   test("Cannot add filters to a table without headers", async () => {
     updateTableConfig(model, "A1:C4", { numberOfHeaders: 0 });


### PR DESCRIPTION
## Description

When the user inputs a formula in a table, it should be automatically autofilled in the table column.

That is handled in the new `TableAutofillPlugin` that handles the command `AUTOFILL_TABLE_COLUMN` that is fired but the composerStore after editing a cell, and by the clipboard on paste.

Task: : [3777873](https://www.odoo.com/web#id=3777873&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo