### PR TITLE
[FIX] formula assistant: localize argument separator

### DIFF
--- a/src/components/composer/formula_assistant/formula_assistant.ts
+++ b/src/components/composer/formula_assistant/formula_assistant.ts
@@ -1,5 +1,5 @@
 import { Component, onWillUnmount, useState } from "@odoo/owl";
-import { FunctionDescription } from "../../../types";
+import { FunctionDescription, SpreadsheetChildEnv } from "../../../types";
 import { css } from "../../helpers/css";
 
 // -----------------------------------------------------------------------------
@@ -44,7 +44,7 @@ interface AssistantState {
   allowCellSelectionBehind: boolean;
 }
 
-export class FunctionDescriptionProvider extends Component<Props> {
+export class FunctionDescriptionProvider extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FunctionDescriptionProvider";
   assistantState: AssistantState = useState({
     allowCellSelectionBehind: false,
@@ -72,6 +72,10 @@ export class FunctionDescriptionProvider extends Component<Props> {
     this.timeOutId = setTimeout(() => {
       this.assistantState.allowCellSelectionBehind = false;
     }, 2000) as unknown as number;
+  }
+
+  get formulaArgSeparator() {
+    return this.env.model.getters.getLocale().formulaArgSeparator + " ";
   }
 }
 

--- a/src/components/composer/formula_assistant/formula_assistant.xml
+++ b/src/components/composer/formula_assistant/formula_assistant.xml
@@ -16,7 +16,7 @@
           <span t-esc="context.functionName"/>
           (
           <t t-foreach="context.functionDescription.args" t-as="arg" t-key="arg.name">
-            <span t-if="arg_index > '0'">,&#xA0;</span>
+            <span t-if="arg_index > '0'" t-esc="formulaArgSeparator"/>
             <span t-att-class="{ 'o-formula-assistant-focus': context.argToFocus === arg_index }">
               <span>
                 <span t-if="arg.optional || arg.repeating || arg.default">[</span>

--- a/tests/components/formula_assistant.test.ts
+++ b/tests/components/formula_assistant.test.ts
@@ -2,7 +2,9 @@ import { setTranslationMethod } from "../../src";
 import { arg, functionRegistry } from "../../src/functions/index";
 import { Model } from "../../src/model";
 import { _lt } from "../../src/translation";
+import { DEFAULT_LOCALE } from "../../src/types";
 import { registerCleanup } from "../setup/jest.setup";
+import { updateLocale } from "../test_helpers/commands_helpers";
 import { keyDown, keyUp } from "../test_helpers/dom_helper";
 import {
   clearFunctions,
@@ -246,6 +248,14 @@ describe("formula assistant", () => {
         await typeInComposer("=FUNC3(");
         expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
           "FUNC3 ( f3Arg1, [f3Arg2, ...] ) "
+        );
+      });
+
+      test("arguments separator is localized", async () => {
+        updateLocale(model, { ...DEFAULT_LOCALE, formulaArgSeparator: ";" });
+        await typeInComposer("=FUNC1(");
+        expect(fixture.querySelectorAll(".o-formula-assistant-head")[0].textContent).toBe(
+          "FUNC1 ( f1Arg1; f1Arg2 ) "
         );
       });
     });


### PR DESCRIPTION
## Description

The argument separator in the formula assistant was not localized, it was always a comma no matter the locale. This commit fixes it.

Task: : [3789860](https://www.odoo.com/web#id=3789860&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo