### PR TITLE
[FIX] DataValidationCheckbox: Fix input positioning in FF

### DIFF
--- a/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
+++ b/src/components/data_validation_overlay/dv_checkbox/dv_checkbox.ts
@@ -13,6 +13,8 @@ css/* scss */ `
     height: ${CHECKBOX_WIDTH}px;
     accent-color: #808080;
     margin: ${MARGIN}px;
+    /** required to prevent the checkbox position to be sensible to the font-size (affects Firefox) */
+    position: absolute;
   }
 `;
 


### PR DESCRIPTION
It turns out that an input[checkbox] box position is affected by the current font-size of its containing node in Firefox.

Task: 3774645

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo