### PR TITLE
[FIX] spreadsheet: remove `beforeunload` handler

### DIFF
--- a/src/components/spreadsheet.ts
+++ b/src/components/spreadsheet.ts
@@ -165,7 +165,6 @@ export class Spreadsheet extends Component<Props, SpreadsheetEnv> {
     useExternalListener(document.body, "copy", this.copy.bind(this, false));
     useExternalListener(document.body, "paste", this.paste);
     useExternalListener(document.body, "keyup", this.onKeyup.bind(this));
-    useExternalListener(window, "beforeunload", this.leaveCollaborativeSession.bind(this));
     this.activateFirstSheet();
   }
 

--- a/tests/components/spreadsheet.test.ts
+++ b/tests/components/spreadsheet.test.ts
@@ -8,7 +8,7 @@ import { SelectionMode } from "../../src/plugins/ui/selection";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/registries";
 import { Client } from "../../src/types";
 import { StateUpdateMessage } from "../../src/types/collaborative/transport_service";
-import { createSheet, selectCell, setCellContent } from "../test_helpers/commands_helpers";
+import { selectCell, setCellContent } from "../test_helpers/commands_helpers";
 import { simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
 import {
   makeTestFixture,
@@ -360,15 +360,6 @@ describe("Composer interactions", () => {
     selectCell(parent.model, "B2");
     await nextTick();
     expect(spy).not.toHaveBeenCalled();
-  });
-
-  test("The spreadsheet does not render after onbeforeunload", async () => {
-    window.dispatchEvent(new Event("beforeunload", { bubbles: true }));
-    await nextTick();
-    createSheet(parent.model, {});
-    await nextTick();
-    const sheets = document.querySelectorAll(".o-all-sheets .o-sheet");
-    expect(sheets).toHaveLength(parent.model.getters.getVisibleSheets().length - 1);
   });
 
   test("The activate sheet is the sheet in first position, after replaying commands", async () => {


### PR DESCRIPTION
The event `beforeunload` was handled to remove the listeners on the browser in order to avoid memory leaks.
This was an overkill as `beforeunload` is called when:
- we unload the page resources[^1] ; This means killing the browser tab, after which the memory will be cleaned
- In some browsers (Chromium based), when the user is redirected to a third-party program (for instance the mail editor). The callback is applied (in our case, removes the update listeners, effectively breaking the canvas/component rendering)

Combined with the unreliability of the event firing[^1] , the added value seems null.

[^1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo