### PR TITLE
[IMP] table: add table resizer component in grid

### DIFF
--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -23,6 +23,7 @@ import {
 } from "../../constants";
 import { isInside } from "../../helpers/index";
 import { openLink } from "../../helpers/links";
+import { isStaticTable } from "../../helpers/table_helpers";
 import { interactiveCut } from "../../helpers/ui/cut_interactive";
 import { interactivePaste, interactivePasteFromOS } from "../../helpers/ui/paste_interactive";
 import { cellMenuRegistry } from "../../registries/menus/cell_menu_registry";
@@ -52,6 +53,7 @@ import {
   Rect,
   Ref,
   SpreadsheetChildEnv,
+  Table,
 } from "../../types/index";
 import { Autofill } from "../autofill/autofill";
 import { ClientTag } from "../collaborative_client_tag/collaborative_client_tag";
@@ -74,6 +76,7 @@ import { CellPopoverStore } from "../popover";
 import { Popover } from "../popover/popover";
 import { HorizontalScrollBar, VerticalScrollBar } from "../scrollbar/";
 import { SidePanelStore } from "../side_panel/side_panel/side_panel_store";
+import { TableResizer } from "../tables/table_resizer/table_resizer";
 import { HoveredCellStore } from "./hovered_cell_store";
 
 /**
@@ -127,6 +130,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     Popover,
     VerticalScrollBar,
     HorizontalScrollBar,
+    TableResizer,
   };
   readonly HEADER_HEIGHT = HEADER_HEIGHT;
   readonly HEADER_WIDTH = HEADER_WIDTH;
@@ -780,5 +784,10 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
 
   onComposerContentFocused() {
     this.composerFocusStore.focusGridComposerContent();
+  }
+
+  get staticTables(): Table[] {
+    const sheetId = this.env.model.getters.getActiveSheetId();
+    return this.env.model.getters.getCoreTables(sheetId).filter(isStaticTable);
   }
 }

--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -56,6 +56,9 @@
         position="menuState.position"
         onClose="() => this.closeMenu()"
       />
+      <t t-foreach="staticTables" t-as="table" t-key="table.id">
+        <TableResizer table="table"/>
+      </t>
       <VerticalScrollBar topOffset="HEADER_HEIGHT"/>
       <HorizontalScrollBar leftOffset="HEADER_WIDTH"/>
       <div class="o-scrollbar corner"/>

--- a/src/components/side_panel/table_panel/table_panel.ts
+++ b/src/components/side_panel/table_panel/table_panel.ts
@@ -162,7 +162,13 @@ export class TablePanel extends Component<Props, SpreadsheetChildEnv> {
       const extendedZone = this.env.model.getters.getContiguousZone(sheetId, newRange.zone);
       newRange = this.env.model.getters.getRangeFromZone(sheetId, extendedZone);
     }
-    const result = this.env.model.dispatch("UPDATE_TABLE", {
+    const newTableZone = newRange.zone;
+    const oldTableZone = this.props.table.range.zone;
+    const cmdToCall =
+      newTableZone.top === oldTableZone.top && newTableZone.left === oldTableZone.left
+        ? "RESIZE_TABLE"
+        : "UPDATE_TABLE";
+    const result = this.env.model.dispatch(cmdToCall, {
       sheetId,
       zone: this.props.table.range.zone,
       newTableRange: newRange.rangeData,

--- a/src/components/tables/table_resizer/table_resizer.ts
+++ b/src/components/tables/table_resizer/table_resizer.ts
@@ -1,0 +1,92 @@
+import { Component, useState } from "@odoo/owl";
+import { HeaderIndex, Highlight, SpreadsheetChildEnv, Table, Zone } from "../../../types";
+import { css, cssPropertiesToCss } from "../../helpers";
+import { dragAndDropBeyondTheViewport } from "../../helpers/drag_and_drop";
+import { useHighlights } from "../../helpers/highlight_hook";
+
+const SIZE = 3;
+const COLOR = "#777";
+
+css/* scss */ `
+  .o-table-resizer {
+    width: ${SIZE}px;
+    height: ${SIZE}px;
+    border-bottom: ${SIZE}px solid ${COLOR};
+    border-right: ${SIZE}px solid ${COLOR};
+    cursor: nwse-resize;
+  }
+`;
+
+interface Props {
+  table: Table;
+}
+
+interface State {
+  highlightZone: Zone | undefined;
+}
+
+export class TableResizer extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-TableResizer";
+  static props = { table: Object };
+
+  state = useState<State>({ highlightZone: undefined });
+
+  setup(): void {
+    useHighlights(this);
+  }
+
+  get containerStyle(): string {
+    const tableZone = this.props.table.range.zone;
+    const bottomRight = { ...tableZone, left: tableZone.right, top: tableZone.bottom };
+    const rect = this.env.model.getters.getVisibleRect(bottomRight);
+    if (rect.height === 0 || rect.width === 0) {
+      return cssPropertiesToCss({ display: "none" });
+    }
+
+    return cssPropertiesToCss({
+      top: `${rect.y + rect.height - SIZE * 2}px`,
+      left: `${rect.x + rect.width - SIZE * 2}px`,
+    });
+  }
+
+  onMouseDown(ev: MouseEvent) {
+    const tableZone = this.props.table.range.zone;
+    const topLeft = { col: tableZone.left, row: tableZone.top };
+    document.body.style.cursor = "nwse-resize";
+
+    const onMouseUp = () => {
+      document.body.style.cursor = "";
+      const newTableZone = this.state.highlightZone;
+      if (!newTableZone) return;
+      const sheetId = this.props.table.range.sheetId;
+      this.env.model.dispatch("RESIZE_TABLE", {
+        sheetId,
+        zone: this.props.table.range.zone,
+        newTableRange: this.env.model.getters.getRangeDataFromZone(sheetId, newTableZone),
+      });
+      this.state.highlightZone = undefined;
+    };
+
+    const onMouseMove = (col: HeaderIndex, row: HeaderIndex, ev: MouseEvent) => {
+      this.state.highlightZone = {
+        left: topLeft.col,
+        top: topLeft.row,
+        right: Math.max(col, topLeft.col),
+        bottom: Math.max(row, topLeft.row),
+      };
+    };
+    dragAndDropBeyondTheViewport(this.env, onMouseMove, onMouseUp);
+  }
+
+  get highlights(): Highlight[] {
+    if (!this.state.highlightZone) return [];
+    return [
+      {
+        zone: this.state.highlightZone,
+        sheetId: this.props.table.range.sheetId,
+        color: COLOR,
+        noFill: true,
+      },
+    ];
+  }
+}

--- a/src/components/tables/table_resizer/table_resizer.xml
+++ b/src/components/tables/table_resizer/table_resizer.xml
@@ -1,0 +1,9 @@
+<templates>
+  <t t-name="o-spreadsheet-TableResizer">
+    <div
+      class="o-table-resizer position-absolute"
+      t-att-style="containerStyle"
+      t-on-pointerdown="onMouseDown"
+    />
+  </t>
+</templates>

--- a/src/helpers/table_helpers.ts
+++ b/src/helpers/table_helpers.ts
@@ -1,5 +1,5 @@
 import { Border, BorderDescr, CellPosition, Range, Style, UID, Zone } from "../types";
-import { CoreTable, Filter, Table, TableConfig, TableStyle } from "../types/table";
+import { CoreTable, Filter, StaticTable, Table, TableConfig, TableStyle } from "../types/table";
 
 import { generateMatrix } from "../functions/helpers";
 import { ComputedTableStyle } from "./../types/table";
@@ -48,6 +48,10 @@ export function createFilter(
     col: zone.left,
     filteredRange: filteredZone.top > filteredZone.bottom ? undefined : filteredRange,
   };
+}
+
+export function isStaticTable(table: CoreTable): table is StaticTable {
+  return table.type === "static" || table.type === "forceStatic";
 }
 
 export function getComputedTableStyle(

--- a/src/plugins/core/tables.ts
+++ b/src/plugins/core/tables.ts
@@ -46,7 +46,7 @@ interface TableState {
 }
 
 export class TablePlugin extends CorePlugin<TableState> implements TableState {
-  static getters = ["getCoreTable", "getCoreTables"] as const;
+  static getters = ["getCoreTable", "getCoreTables", "getCoreTableMatchingTopLeft"] as const;
 
   readonly tables: Record<UID, Record<TableId, CoreTable | undefined>> = {};
 
@@ -77,7 +77,7 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
           (cmd) => this.checkTableConfigUpdateIsValid(cmd.config)
         );
       case "UPDATE_TABLE":
-        const updatedTable = this.getTableFromZone(cmd.sheetId, cmd.zone);
+        const updatedTable = this.getCoreTableMatchingTopLeft(cmd.sheetId, cmd.zone);
         if (!updatedTable) {
           return CommandResult.TableNotFound;
         }
@@ -255,10 +255,9 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
     return direction;
   }
 
-  private getTableFromZone(sheetId: UID, zone: Zone): CoreTable | undefined {
+  getCoreTableMatchingTopLeft(sheetId: UID, zone: Zone): CoreTable | undefined {
     for (const table of this.getCoreTables(sheetId)) {
       const tableZone = table.range.zone;
-      // Only check top left to match dynamic tables
       if (tableZone.left === zone.left && tableZone.top === zone.top) {
         return table;
       }
@@ -275,7 +274,7 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
     if (zoneIsInSheet !== CommandResult.Success) {
       return zoneIsInSheet;
     }
-    const updatedTable = this.getTableFromZone(cmd.sheetId, cmd.zone);
+    const updatedTable = this.getCoreTableMatchingTopLeft(cmd.sheetId, cmd.zone);
     if (!updatedTable) {
       return CommandResult.TableNotFound;
     }
@@ -341,7 +340,7 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
   }
 
   private updateTable(cmd: UpdateTableCommand) {
-    const table = this.getTableFromZone(cmd.sheetId, cmd.zone);
+    const table = this.getCoreTableMatchingTopLeft(cmd.sheetId, cmd.zone);
     if (!table) {
       return;
     }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -41,6 +41,7 @@ import { CellComputedStylePlugin } from "./ui_feature/cell_computed_style";
 import { HistoryPlugin } from "./ui_feature/local_history";
 import { SplitToColumnsPlugin } from "./ui_feature/split_to_columns";
 import { TableAutofillPlugin } from "./ui_feature/table_autofill";
+import { TableResizeUI } from "./ui_feature/table_resize_ui";
 import { TableStylePlugin } from "./ui_feature/table_style";
 import { UIPluginConstructor } from "./ui_plugin";
 import {
@@ -80,7 +81,8 @@ export const featurePluginRegistry = new Registry<UIPluginConstructor>()
   .add("collaborative", CollaborativePlugin)
   .add("history", HistoryPlugin)
   .add("data_cleanup", DataCleanupPlugin)
-  .add("table_autofill", TableAutofillPlugin);
+  .add("table_autofill", TableAutofillPlugin)
+  .add("table_ui_resize", TableResizeUI);
 
 // Plugins which have a state, but which should not be shared in collaborative
 export const statefulUIPluginRegistry = new Registry<UIPluginConstructor>()

--- a/src/plugins/ui_feature/table_autofill.ts
+++ b/src/plugins/ui_feature/table_autofill.ts
@@ -16,7 +16,10 @@ export class TableAutofillPlugin extends UIPlugin {
         const { col, row } = cmd;
         const tableContentZone = getTableContentZone(table.range.zone, table.config);
         if (tableContentZone && isInside(col, row, tableContentZone)) {
-          this.autofillTableZone(cmd, tableContentZone);
+          const top = cmd.autofillRowStart ?? tableContentZone.top;
+          const bottom = cmd.autofillRowEnd ?? tableContentZone.bottom;
+          const autofillZone = { ...tableContentZone, top, bottom };
+          this.autofillTableZone(cmd, autofillZone);
         }
         break;
     }

--- a/src/plugins/ui_feature/table_resize_ui.ts
+++ b/src/plugins/ui_feature/table_resize_ui.ts
@@ -1,0 +1,50 @@
+import { Command, CommandResult } from "../../types";
+import { UIPlugin } from "../ui_plugin";
+
+export class TableResizeUI extends UIPlugin {
+  allowDispatch(cmd: Command): CommandResult | CommandResult[] {
+    switch (cmd.type) {
+      case "RESIZE_TABLE":
+        const table = this.getters.getCoreTableMatchingTopLeft(cmd.sheetId, cmd.zone);
+        if (!table) {
+          return CommandResult.TableNotFound;
+        }
+
+        const oldTableZone = table.range.zone;
+        const newTableZone = this.getters.getRangeFromRangeData(cmd.newTableRange).zone;
+        if (newTableZone.top !== oldTableZone.top || newTableZone.left !== oldTableZone.left) {
+          return CommandResult.InvalidTableResize;
+        }
+        return this.canDispatch("UPDATE_TABLE", { ...cmd }).reasons;
+    }
+    return CommandResult.Success;
+  }
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "RESIZE_TABLE": {
+        const table = this.getters.getCoreTableMatchingTopLeft(cmd.sheetId, cmd.zone);
+        this.dispatch("UPDATE_TABLE", { ...cmd });
+
+        if (!table || !table.config.automaticAutofill) return;
+
+        const oldTableZone = table.range.zone;
+        const newTableZone = this.getters.getRangeFromRangeData(cmd.newTableRange).zone;
+
+        if (newTableZone.bottom >= oldTableZone.bottom) {
+          for (let col = newTableZone.left; col <= newTableZone.right; col++) {
+            const autofillSource = { col, row: oldTableZone.bottom, sheetId: cmd.sheetId };
+            if (this.getters.getCell(autofillSource)?.content.startsWith("=")) {
+              this.dispatch("AUTOFILL_TABLE_COLUMN", {
+                ...autofillSource,
+                autofillRowStart: oldTableZone.bottom,
+                autofillRowEnd: newTableZone.bottom,
+              });
+            }
+          }
+          break;
+        }
+      }
+    }
+  }
+}

--- a/src/plugins/ui_feature/table_style.ts
+++ b/src/plugins/ui_feature/table_style.ts
@@ -192,6 +192,7 @@ const invalidateTableStyleCommands = [
   "UPDATE_TABLE",
   "UPDATE_FILTER",
   "REMOVE_TABLE",
+  "RESIZE_TABLE",
 ] as const;
 const invalidateTableStyleCommandsSet = new Set<CommandTypes>(invalidateTableStyleCommands);
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -501,8 +501,21 @@ export interface UpdateTableCommand {
   config?: Partial<TableConfig>;
 }
 
+export interface ResizeTableCommand {
+  type: "RESIZE_TABLE";
+  zone: Zone;
+  sheetId: UID;
+  newTableRange: RangeData;
+  tableType?: CoreTableType;
+}
+
 export interface AutofillTableCommand extends PositionDependentCommand {
   type: "AUTOFILL_TABLE_COLUMN";
+
+  /** The row to start the autofill in. If undefined, it will autofill from the top of the table column */
+  autofillRowStart?: number;
+  /** The row to end the autofill in. If undefined, it will autofill to the bottom of the table column */
+  autofillRowEnd?: number;
 }
 
 export interface UpdateFilterCommand extends PositionDependentCommand {
@@ -985,7 +998,8 @@ export type LocalCommand =
   | SplitTextIntoColumnsCommand
   | RemoveDuplicatesCommand
   | TrimWhitespaceCommand
-  | RenderCanvasCommand;
+  | RenderCanvasCommand
+  | ResizeTableCommand;
 
 export type Command = CoreCommand | LocalCommand;
 
@@ -1145,6 +1159,7 @@ export const enum CommandResult {
   NoChanges = "NoChanges",
   InvalidInputId = "InvalidInputId",
   SheetIsHidden = "SheetIsHidden",
+  InvalidTableResize = "InvalidTableResize",
 }
 
 export interface CommandHandler<T> {

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -117,6 +117,8 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   
   
+  
+  
   <div
     class="o-scrollbar vertical"
     style="top:26px; right:0px; width:15px; bottom:0px; "

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -767,6 +767,8 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
         
         
+        
+        
         <div
           class="o-scrollbar vertical"
           style="top:26px; right:0px; width:15px; bottom:0px; "

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -8,6 +8,7 @@ import {
   updateTableConfig,
 } from "../test_helpers/commands_helpers";
 import { click, setInputValueAndTrigger, simulateClick } from "../test_helpers/dom_helper";
+import { getCell } from "../test_helpers/getters_helpers";
 import { mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
 
 import { Model } from "../../src";
@@ -106,6 +107,14 @@ describe("Table side panel", () => {
     await click(fixture, ".o-selection .o-selection-ok");
     expect(zoneToXc(getTable(model, sheetId).range.zone)).toEqual("D4:D5");
     expect(model.getters.getSelectedZone()).toEqual(toZone("D4"));
+  });
+
+  test("Table is auto-filled if the new zone expands the table down", async () => {
+    setCellContent(model, "A4", "=A3+1");
+    await simulateClick(".o-selection input");
+    await setInputValueAndTrigger(".o-selection input", "A1:C5");
+    await click(fixture, ".o-selection .o-selection-ok");
+    expect(getCell(model, "A5")?.content).toEqual("=A4+1");
   });
 
   test("Side panel works with unbounded table zones", async () => {

--- a/tests/table/table_resize_ui_plugin.test.ts
+++ b/tests/table/table_resize_ui_plugin.test.ts
@@ -1,0 +1,61 @@
+import { CommandResult, Model, UID } from "../../src";
+import { toZone } from "../../src/helpers";
+import {
+  createDynamicTable,
+  createTable,
+  resizeTable,
+  setCellContent,
+} from "../test_helpers/commands_helpers";
+import { getCell } from "../test_helpers/getters_helpers";
+
+let model: Model;
+let sheetId: UID;
+
+describe("Table resize", () => {
+  beforeEach(() => {
+    model = new Model();
+    sheetId = model.getters.getActiveSheetId();
+  });
+
+  describe("dispatch result", () => {
+    test("Cannot resize a table zone to a wrong zone", () => {
+      createTable(model, "A1:A5");
+
+      expect(resizeTable(model, "A1", "A1:A600")).toBeCancelledBecause(
+        CommandResult.TargetOutOfSheet
+      );
+
+      createTable(model, "B1:B5");
+      expect(resizeTable(model, "A1", "A1:B5")).toBeCancelledBecause(CommandResult.TableOverlap);
+    });
+
+    test("Cannot resize a table while changing it's top-left", () => {
+      createTable(model, "A1:A5");
+      expect(resizeTable(model, "A1", "B1:B5")).toBeCancelledBecause(
+        CommandResult.InvalidTableResize
+      );
+    });
+  });
+
+  test("Can resize a table", () => {
+    createTable(model, "A1:A5");
+    resizeTable(model, "A1", "A1:B10");
+    expect(model.getters.getTables(sheetId)).toMatchObject([{ range: { zone: toZone("A1:B10") } }]);
+  });
+
+  test("Can resize a dynamic table", () => {
+    setCellContent(model, "A1", "=MUNIT(4)");
+    createDynamicTable(model, "A1");
+    resizeTable(model, "A1", "A1:B10", "static");
+    expect(model.getters.getCoreTables(sheetId)).toMatchObject([
+      { range: { zone: toZone("A1:B10") }, type: "static" },
+    ]);
+  });
+
+  test("Resize a table also autofills", () => {
+    createTable(model, "A1:A5");
+    setCellContent(model, "A5", "=B5");
+    resizeTable(model, "A1", "A1:A6");
+    expect(getCell(model, "A6")?.content).toBe("=B6");
+  });
+});

--- a/tests/table/table_resizer_component.test.ts
+++ b/tests/table/table_resizer_component.test.ts
@@ -1,0 +1,78 @@
+import { Model, SpreadsheetChildEnv, UID } from "../../src";
+import { Grid } from "../../src/components/grid/grid";
+import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
+import { toZone, zoneToXc } from "../../src/helpers";
+import { createDynamicTable, createTable, setCellContent } from "../test_helpers/commands_helpers";
+import { dragElement, triggerMouseEvent } from "../test_helpers/dom_helper";
+import { getCell } from "../test_helpers/getters_helpers";
+import { getHighlightsFromStore, mountComponent, nextTick } from "../test_helpers/helpers";
+
+describe("Table resizer component", () => {
+  let model: Model;
+  let sheetId: UID;
+  let fixture: HTMLElement;
+  let env: SpreadsheetChildEnv;
+
+  beforeEach(async () => {
+    ({ model, fixture, env } = await mountComponent(Grid, { props: { exposeFocus: () => {} } }));
+    sheetId = model.getters.getActiveSheetId();
+    fixture.style ? "ok" : "ko";
+  });
+
+  test("Can resize a table with drag & drop", async () => {
+    createTable(model, "A1:B2");
+    await nextTick();
+
+    let dragEndPosition = { x: DEFAULT_CELL_WIDTH * 4, y: DEFAULT_CELL_HEIGHT * 4 };
+    await dragElement(".o-table-resizer", dragEndPosition, undefined, true);
+    expect(zoneToXc(model.getters.getTables(sheetId)[0].range.zone)).toEqual("A1:E5");
+
+    dragEndPosition = { x: DEFAULT_CELL_WIDTH * 2, y: DEFAULT_CELL_HEIGHT * 2 };
+    await dragElement(".o-table-resizer", dragEndPosition, undefined, true);
+    expect(zoneToXc(model.getters.getTables(sheetId)[0].range.zone)).toEqual("A1:C3");
+  });
+
+  test("Highlight appear during the table drag & drop", async () => {
+    createTable(model, "A1:B2");
+    await nextTick();
+
+    const dragEndPosition = { x: DEFAULT_CELL_WIDTH * 4, y: DEFAULT_CELL_HEIGHT * 4 };
+    dragElement(".o-table-resizer", dragEndPosition, undefined, false);
+    expect(getHighlightsFromStore(env)[0]).toMatchObject({ zone: toZone("A1:E5"), noFill: true });
+
+    triggerMouseEvent(".o-table-resizer", "pointerup", 0, 0);
+    expect(getHighlightsFromStore(env)[0]).toEqual(undefined);
+  });
+
+  test("Cannot drag & drop to position above/left of the table", async () => {
+    createTable(model, "C3:D4");
+    await nextTick();
+
+    dragElement(".o-table-resizer", { x: 0, y: 0 }, undefined, false);
+    expect(getHighlightsFromStore(env)[0]).toMatchObject({ zone: toZone("C3") });
+    triggerMouseEvent(".o-table-resizer", "pointerup", 0, 0);
+    expect(zoneToXc(model.getters.getTables(sheetId)[0].range.zone)).toEqual("C3");
+  });
+
+  test("Table formula are auto-filled on resize table down", async () => {
+    createTable(model, "A1:B2");
+    setCellContent(model, "A2", "=A1+1");
+    setCellContent(model, "B2", "string content");
+    await nextTick();
+
+    const dragEndPosition = { x: DEFAULT_CELL_WIDTH, y: DEFAULT_CELL_HEIGHT * 2 };
+    await dragElement(".o-table-resizer", dragEndPosition, undefined, true);
+
+    expect(zoneToXc(model.getters.getTables(sheetId)[0].range.zone)).toEqual("A1:B3");
+    expect(getCell(model, "A3")?.content).toEqual("=A2+1");
+    expect(getCell(model, "B3")?.content).toBeUndefined();
+  });
+
+  test("Cannot resize a dynamic table", async () => {
+    setCellContent(model, "A1", "=MUNIT(5)");
+    createDynamicTable(model, "A1");
+    await nextTick();
+
+    expect(document.querySelector(".o-table-resizer")).toBeNull();
+  });
+});

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -1005,6 +1005,26 @@ export function updateTableZone(
   });
 }
 
+export function resizeTable(
+  model: Model,
+  range: string,
+  newZone: string,
+  tableType?: CoreTableType,
+  sheetId: UID = model.getters.getActiveSheetId()
+): DispatchResult {
+  const zone = toZone(range);
+  const table = model.getters.getTable({ sheetId, col: zone.left, row: zone.top });
+  if (!table) {
+    throw new Error(`No table found at ${range}`);
+  }
+  return model.dispatch("RESIZE_TABLE", {
+    sheetId,
+    zone: table.range.zone,
+    newTableRange: toRangeData(sheetId, newZone),
+    tableType,
+  });
+}
+
 export function updateFilter(
   model: Model,
   xc: string,


### PR DESCRIPTION
## Description

This commit adds the table resizer component in the grid. It is a small div at the bottom-right of tables that allow for resizing with drag & drop.

Task: : [3792914](https://www.odoo.com/web#id=3792914&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo