### PR TITLE
[FIX] evaluation: ensure value to evaluated cell

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -93,7 +93,7 @@ function addErrorHandling(
   };
 }
 
-const implementationErrorMessage = _t(
+export const implementationErrorMessage = _t(
   "An unexpected error occurred. Submit a support ticket at odoo.com/help."
 );
 

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -1,4 +1,5 @@
 import { compile } from "../../../formulas";
+import { implementationErrorMessage } from "../../../functions";
 import { matrixMap } from "../../../functions/helpers";
 import { forEachPositionsInZone, JetSet, lazy, toXC } from "../../../helpers";
 import { createEvaluatedCell, evaluateLiteral } from "../../../helpers/cells";
@@ -20,7 +21,7 @@ import {
   RangeCompiledFormula,
   UID,
 } from "../../../types";
-import { CircularDependencyError, EvaluationError } from "../../../types/errors";
+import { CellErrorType, CircularDependencyError, EvaluationError } from "../../../types/errors";
 import { buildCompilationParameters, CompilationParameters } from "./compilation_parameters";
 import { FormulaDependencyGraph } from "./formula_dependency_graph";
 import { RTreeBoundingBox } from "./r_tree";
@@ -261,7 +262,11 @@ export class Evaluator {
         ? this.computeFormulaCell(cellPosition.sheetId, cell)
         : evaluateLiteral(cell.content, localeFormat);
     } catch (e) {
-      return createEvaluatedCell(e.value, localeFormat, e.message);
+      return createEvaluatedCell(
+        e?.value || CellErrorType.GenericError,
+        localeFormat,
+        e?.message || implementationErrorMessage
+      );
     } finally {
       this.cellsBeingComputed.delete(cellId);
     }


### PR DESCRIPTION
When the evaluation process fails, we catch the error and assume it is an `EvaluationError` but it's not always the case (i.e., `evaluateLiteral` can also fail in some situations [^1]) and the error.value can be undefined, which breaks the typing of `createEvaluatedFormula`. THis revision adds a default value to avoid this situation.

[^1]: Currently, this can happen if we try to define a link cell in which the label starts with an "=". That issue will be sorted out in another commit.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo