### PR TITLE
[IMP] LinkDisplay: update grid selection before opening the editor 

### DIFF
--- a/src/components/link/link_display/link_display.ts
+++ b/src/components/link/link_display/link_display.ts
@@ -103,6 +103,7 @@ export class LinkDisplay extends Component<LinkDisplayProps, SpreadsheetChildEnv
 
   edit() {
     const { col, row } = this.props.cellPosition;
+    this.env.model.selection.selectCell(col, row);
     this.cellPopovers.open({ col, row }, "LinkEditor");
   }
 

--- a/tests/link/link_display_component.test.ts
+++ b/tests/link/link_display_component.test.ts
@@ -1,6 +1,12 @@
 import { Model, Spreadsheet } from "../../src";
 import { buildSheetLink } from "../../src/helpers";
-import { clearCell, createSheet, merge, setCellContent } from "../test_helpers/commands_helpers";
+import {
+  clearCell,
+  createSheet,
+  merge,
+  selectCell,
+  setCellContent,
+} from "../test_helpers/commands_helpers";
 import { clickCell, hoverCell, rightClickCell, simulateClick } from "../test_helpers/dom_helper";
 import { getCell, getEvaluatedCell } from "../test_helpers/getters_helpers";
 import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
@@ -179,7 +185,21 @@ describe("link display component", () => {
     });
   });
 
-  test("open link editor", async () => {
+  test("open link editor selects the related cell in the grid", async () => {
+    selectCell(model, "A10");
+    setCellContent(model, "A1", "[label](url.com)");
+    await hoverCell(model, "A1", 400);
+    await simulateClick(".o-edit-link");
+    expect(fixture.querySelector(".o-link-tool")).toBeFalsy();
+    expect(model.getters.getActivePosition()).toMatchObject({ col: 0, row: 0 });
+    const editor = fixture.querySelector(".o-link-editor");
+    expect(editor).toBeTruthy();
+    const inputs = editor?.querySelectorAll("input")!;
+    expect(inputs[0].value).toBe("label");
+    expect(inputs[1].value).toBe("https://url.com");
+  });
+
+  test("open link editor ", async () => {
     setCellContent(model, "A1", "[label](url.com)");
     await hoverCell(model, "A1", 400);
     await simulateClick(".o-edit-link");


### PR DESCRIPTION
Currently, a user can open the link editor of a cell while hovering it but not selectd. This behaviour is counterintuitive as once the link editor is opened, we will close it if we change the selection.

This revision ensures that the link editor target and the selection are synchronized upon the initialization of the the former.

Task: 3793859

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo