### PR TITLE
[IMP] renderer: highlight array formula

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -33,6 +33,7 @@ import { ImageProvider } from "../../helpers/figures/images/image_provider";
 import { Model } from "../../model";
 import { Store, useStore, useStoreProvider } from "../../store_engine";
 import { ModelStore } from "../../stores";
+import { ArrayFormulaHighlight } from "../../stores/array_formula_highlight";
 import { NotificationStore } from "../../stores/notification_store";
 import { _t } from "../../translation";
 import { HeaderGroup, InformationNotification, Pixel, SpreadsheetChildEnv } from "../../types";
@@ -295,6 +296,7 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     this.notificationStore = useStore(NotificationStore);
     this.composerFocusStore = useStore(ComposerFocusStore);
     this.sidePanel = useStore(SidePanelStore);
+    useStore(ArrayFormulaHighlight);
     this.keyDownMapping = {
       "CTRL+H": () => this.sidePanel.toggle("FindAndReplace", {}),
       "CTRL+F": () => this.sidePanel.toggle("FindAndReplace", {}),

--- a/src/stores/array_formula_highlight.ts
+++ b/src/stores/array_formula_highlight.ts
@@ -1,0 +1,47 @@
+import { positionToZone, union } from "../helpers";
+import { Get } from "../store_engine";
+import { Highlight, Zone } from "../types";
+import { HighlightStore } from "./highlight_store";
+import { SpreadsheetStore } from "./spreadsheet_store";
+
+export class ArrayFormulaHighlight extends SpreadsheetStore {
+  protected highlightStore = this.get(HighlightStore);
+
+  constructor(get: Get) {
+    super(get);
+    this.highlightStore.register(this);
+  }
+
+  get highlights(): Highlight[] {
+    const zone = this.getHighlightZone();
+    if (!zone) {
+      return [];
+    }
+
+    const sheetId = this.model.getters.getActiveSheetId();
+    return [
+      {
+        sheetId,
+        zone,
+        color: "#17A2B8",
+        noFill: true,
+        thinLine: true,
+      },
+    ];
+  }
+
+  private getHighlightZone(): Zone | undefined {
+    const position = this.model.getters.getActivePosition();
+    const spreader = this.model.getters.getArrayFormulaSpreadingOn(position);
+    const spreadPositions = spreader
+      ? this.model.getters.getSpreadPositionsOf(spreader)
+      : this.model.getters.getSpreadPositionsOf(position);
+
+    if (spreadPositions.length) {
+      const zones = spreadPositions.map(positionToZone);
+      return union(...zones);
+    } else {
+      return undefined;
+    }
+  }
+}

--- a/tests/grid/array_formula_highlights_store.test.ts
+++ b/tests/grid/array_formula_highlights_store.test.ts
@@ -1,0 +1,31 @@
+import { toZone } from "../../src/helpers";
+import { ArrayFormulaHighlight } from "../../src/stores/array_formula_highlight";
+import { selectCell, setCellContent } from "../test_helpers/commands_helpers";
+import { getHighlightsFromStore } from "../test_helpers/helpers";
+import { makeStore } from "../test_helpers/stores";
+
+describe("array function highlights", () => {
+  test("Putting the selection inside an array formula highlights it", () => {
+    const { model, container } = makeStore(ArrayFormulaHighlight);
+    setCellContent(model, "A2", "=TRANSPOSE(A1:C1)");
+    expect(getHighlightsFromStore(container)).toEqual([]);
+    const highlight = {
+      sheetId: model.getters.getActiveSheetId(),
+      zone: toZone("A2:A4"),
+      color: "#17A2B8",
+      noFill: true,
+      thinLine: true,
+    };
+    selectCell(model, "A2"); // main cell
+    expect(getHighlightsFromStore(container)).toEqual([highlight]);
+    selectCell(model, "A3"); // array function cell
+    expect(getHighlightsFromStore(container)).toEqual([highlight]);
+  });
+
+  test("Non-array formula are not highlighted", () => {
+    const { model, container } = makeStore(ArrayFormulaHighlight);
+    setCellContent(model, "A2", "=A1");
+    selectCell(model, "A2");
+    expect(getHighlightsFromStore(container)).toEqual([]);
+  });
+});

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -854,8 +854,13 @@ export function drawGrid(model: Model, ctx: GridRenderingContext) {
   }
 }
 
-export function getHighlightsFromStore(env: SpreadsheetChildEnv): Highlight[] {
-  const rendererStore = env.getStore(RendererStore);
+export function getHighlightsFromStore(
+  storeGetter: SpreadsheetChildEnv | DependencyContainer
+): Highlight[] {
+  const rendererStore =
+    "getStore" in storeGetter
+      ? storeGetter.getStore(RendererStore)
+      : storeGetter.get(RendererStore);
   return (Object.values(rendererStore["renderers"]) as any)
     .flat()
     .filter((renderer) => renderer instanceof HighlightStore)


### PR DESCRIPTION
## [IMP] renderer: highlight array formula

When the selection in in an array formula, or a spreaded cell, we now highlight the zone on which the formula is spreaded.

Task: : [3797136](https://www.odoo.com/web#id=3797136&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo