### PR TITLE
[FIX] header_positions: perfs of update style

### DIFF
--- a/src/plugins/ui_stateful/header_positions.ts
+++ b/src/plugins/ui_stateful/header_positions.ts
@@ -23,12 +23,8 @@ export class HeaderPositionsUIPlugin extends UIPlugin {
         }
         break;
       case "UPDATE_CELL":
-        if ("content" in cmd || "format" in cmd) {
-          this.headerPositions = {};
-          this.isDirty = true;
-        } else {
-          this.headerPositions[cmd.sheetId] = this.computeHeaderPositionsOfSheet(cmd.sheetId);
-        }
+        this.headerPositions = {};
+        this.isDirty = true;
         break;
       case "UPDATE_FILTER":
       case "REMOVE_FILTER_TABLE":


### PR DESCRIPTION
## Description

The plugin `HeaderPositions` was re-computing the positions of the headers at each update of the style. That means that if we change the style of 1000 cells, we will re-compute the positions of the headers 1000 times. That's very slow on big spreadsheets.

Task: : [3797400](https://www.odoo.com/web#id=3797400&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo