### PR TITLE
[REL] 16.3.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.3.27",
+  "version": "16.3.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.3.27",
+      "version": "16.3.28",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.3.27",
+  "version": "16.3.28",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/316571144 [FIX] sheet_interactive: rename sheet in readonly mode
https://github.com/odoo/o-spreadsheet/commit/1f0d71277 [FIX] GridComposer: Reset the cell reference visibility on stop edition Task: 3736211
https://github.com/odoo/o-spreadsheet/commit/65ee3525a [FIX] autofill: allow to autofill a mix of number values and formulas Task: 3700733
