### PR TITLE
[PERF] evaluation: use custom data structures instead of Map and Set

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -461,22 +461,6 @@ export function isConsecutive(iterable: Iterable<number>): boolean {
   return true;
 }
 
-export class JetSet<T> extends Set<T> {
-  addMany(iterable: Iterable<T>): this {
-    for (const element of iterable) {
-      super.add(element);
-    }
-    return this;
-  }
-  deleteMany(iterable: Iterable<T>): boolean {
-    let wasDeleted = false;
-    for (const element of iterable) {
-      wasDeleted ||= super.delete(element);
-    }
-    return wasDeleted;
-  }
-}
-
 /**
  * Creates a version of the function that's memoized on the value of its first
  * argument, if any.

--- a/src/plugins/ui_core_views/cell_evaluation/binary_grid.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/binary_grid.ts
@@ -1,0 +1,98 @@
+import { CellPosition } from "../../../types";
+
+type Bit = 0 | 1;
+
+/**
+ * Implements a fixed-sized grid or 2D matrix of bits.
+ * based on https://github.com/zandaqo/structurae
+ *
+ * The grid is implemented as a 1D array of 32-bit integers, where each bit represents a cell in the grid.
+ * It follows row-major order, with each row stored consecutively in 32-bit blocks.
+ * Pads the number of columns to the next power of 2 to allow quick lookups with bitwise operations.
+ *
+ * Key terminology:
+ * - bucket: Index of an item in the Uint32Array, a 32-bit integer.
+ * - bitPosition: The position of a bit within the bucket 32-bit integer.
+ */
+export class BinaryGrid extends Uint32Array {
+  private columnOffset = 0;
+  cols = 0;
+  rows = 0;
+
+  /**
+   * Creates a binary grid of specified dimensions.
+   */
+  static create(rows: number, columns: number): BinaryGrid {
+    const columnOffset = log2Ceil(columns);
+    const length = (rows << columnOffset) >> 5;
+    const grid = new this(length + 1);
+    grid.columnOffset = columnOffset;
+    grid.cols = columns;
+    grid.rows = rows;
+    return grid;
+  }
+
+  /**
+   * Returns the bit at given coordinates.
+   */
+  getValue(position: CellPosition): Bit {
+    const [bucket, bitPosition] = this.getCoordinates(position);
+    return ((this[bucket] >> bitPosition) & 1) as Bit;
+  }
+
+  /**
+   * Sets the bit at given coordinates.
+   */
+  setValue(position: CellPosition, value: Bit) {
+    const [bucket, bitPosition] = this.getCoordinates(position);
+    const currentValue = (this[bucket] >> bitPosition) & 1;
+    const hasBeenInserted = currentValue === 0 && value === 1;
+    this[bucket] = (this[bucket] & ~(1 << bitPosition)) | (value << bitPosition);
+    return hasBeenInserted;
+    // Let's breakdown of the above line:
+    // with an example with a 4-bit integer (instead of 32-bit).
+    //
+    // Let's say we want to set the bit at position 2 to 1 and the existing
+    // bit sequence this[bucket] is 1001. The final bit sequence should be 1101.
+    //
+    // First, we clear the bit at position 2 by AND-ing this[bucket] with a
+    // mask having all 1s except a 0 at the bit position (~ (1 << bitPosition)).
+    // 1 << bitPosition is 0100 (shifting 0001 to the left by 2)
+    // Inverting the bits with ~ gives the final mask ~(1 << bitPosition): 1011
+    //
+    // Then, we shift the value by the bit position (value << bitPosition: 0100)
+    // and OR the result with the previous step's result:
+    // (1001 & 1011) | 0100 = 1101
+  }
+
+  isEmpty() {
+    return !this.some((bucket) => bucket !== 0);
+  }
+
+  fillAllPositions() {
+    const thirtyTwoOnes = -1 >>> 0; // same as 2 ** 32 - 1, a 32-bit number with all bits set to 1
+    this.fill(thirtyTwoOnes);
+  }
+
+  clear() {
+    this.fill(0);
+  }
+
+  private getCoordinates(position: CellPosition): [bucket: number, position: number] {
+    const { row, col } = position;
+    const index = (row << this.columnOffset) + col;
+    const bucket = index >> 5;
+    return [bucket, index - (bucket << 5)];
+  }
+}
+
+function log2Ceil(value: number) {
+  // A faster version of Math.ceil(Math.log2(value)).
+  if (value === 0) {
+    return -Infinity;
+  } else if (value < 0) {
+    return NaN;
+  }
+  // --value handles the case where value is a power of 2
+  return 32 - Math.clz32(--value);
+}

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -1,5 +1,5 @@
 import { compileTokens } from "../../../formulas/compiler";
-import { Token, isExportableToExcel } from "../../../formulas/index";
+import { isExportableToExcel, Token } from "../../../formulas/index";
 import { getItemId, positions, toXC } from "../../../helpers/index";
 import { CellErrorType } from "../../../types/errors";
 import {
@@ -13,11 +13,11 @@ import {
   Format,
   FormattedValue,
   FormulaCell,
+  invalidateDependenciesCommands,
   Matrix,
   Range,
   UID,
   Zone,
-  invalidateDependenciesCommands,
 } from "../../../types/index";
 import { FormulaCellWithDependencies } from "../../core";
 import { UIPlugin, UIPluginConfig } from "../../ui_plugin";
@@ -188,6 +188,10 @@ export class EvaluationPlugin extends UIPlugin {
         if ("content" in cmd) {
           this.evaluator.updateDependencies(cmd);
         }
+        break;
+      case "DUPLICATE_SHEET":
+      case "CREATE_SHEET":
+        this.shouldRebuildDependenciesGraph = true;
         break;
       case "EVALUATE_CELLS":
         this.evaluator.evaluateAllCells();

--- a/src/plugins/ui_core_views/cell_evaluation/position_map.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/position_map.ts
@@ -1,0 +1,41 @@
+import { CellPosition, UID } from "../../../types";
+
+export class PositionMap<T> {
+  private map: Record<UID, Record<number, Record<number, T>>> = {};
+
+  set({ sheetId, col, row }: CellPosition, value: T) {
+    const map = this.map;
+    if (!map[sheetId]) {
+      map[sheetId] = {};
+    }
+    if (!map[sheetId][col]) {
+      map[sheetId][col] = {};
+    }
+    map[sheetId][col][row] = value;
+  }
+
+  get({ sheetId, col, row }: CellPosition): T | undefined {
+    return this.map[sheetId]?.[col]?.[row];
+  }
+
+  has({ sheetId, col, row }: CellPosition): boolean {
+    return this.map[sheetId]?.[col]?.[row] !== undefined;
+  }
+
+  delete({ sheetId, col, row }: CellPosition) {
+    delete this.map[sheetId]?.[col]?.[row];
+  }
+
+  keys() {
+    const map = this.map;
+    const keys: CellPosition[] = [];
+    for (const sheetId in map) {
+      for (const col in map[sheetId]) {
+        for (const row in map[sheetId][col]) {
+          keys.push({ sheetId, col: parseInt(col), row: parseInt(row) });
+        }
+      }
+    }
+    return keys;
+  }
+}

--- a/src/plugins/ui_core_views/cell_evaluation/position_set.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/position_set.ts
@@ -1,0 +1,97 @@
+import { CellPosition, UID } from "../../../types";
+import { BinaryGrid } from "./binary_grid";
+
+export type SheetSizes = Record<UID, { rows: number; cols: number }>;
+
+export class PositionSet {
+  private sheets: Record<UID, BinaryGrid> = {};
+  /**
+   * List of positions in the order they were inserted.
+   */
+  private insertions: CellPosition[] = [];
+  private maxSize: number = 0;
+
+  constructor(sheetSizes: SheetSizes) {
+    for (const sheetId in sheetSizes) {
+      const cols = sheetSizes[sheetId].cols;
+      const rows = sheetSizes[sheetId].rows;
+      this.maxSize += cols * rows;
+      this.sheets[sheetId] = BinaryGrid.create(rows, cols);
+    }
+  }
+
+  add(position: CellPosition) {
+    const hasBeenInserted = this.sheets[position.sheetId].setValue(position, 1);
+    if (hasBeenInserted) {
+      this.insertions.push(position);
+    }
+  }
+
+  addMany(positions: Iterable<CellPosition>) {
+    for (const position of positions) {
+      this.add(position);
+    }
+  }
+
+  delete(position: CellPosition) {
+    this.sheets[position.sheetId].setValue(position, 0);
+  }
+
+  deleteMany(positions: Iterable<CellPosition>) {
+    for (const position of positions) {
+      this.delete(position);
+    }
+  }
+
+  has(position: CellPosition) {
+    return this.sheets[position.sheetId].getValue(position) === 1;
+  }
+
+  clear(): CellPosition[] {
+    const insertions = this.insertions;
+    this.insertions = [];
+    for (const sheetId in this.sheets) {
+      this.sheets[sheetId].clear();
+    }
+    return insertions;
+  }
+
+  isEmpty() {
+    if (this.insertions.length === 0) {
+      return true;
+    }
+    for (const sheetId in this.sheets) {
+      if (!this.sheets[sheetId].isEmpty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  fillAllPositions() {
+    this.insertions = new Array<CellPosition>(this.maxSize);
+    let index = 0;
+    for (const sheetId in this.sheets) {
+      const grid = this.sheets[sheetId];
+      grid.fillAllPositions();
+      for (let i = 0; i < grid.rows; i++) {
+        for (let j = 0; j < grid.cols; j++) {
+          this.insertions[index++] = { sheetId, row: i, col: j };
+        }
+      }
+    }
+  }
+
+  /**
+   * Iterate over the positions in the order of insertion.
+   * Note that the same position may be yielded multiple times if the value was added
+   * to the set then removed and then added again.
+   */
+  *[Symbol.iterator](): Generator<CellPosition> {
+    for (const position of this.insertions) {
+      if (this.sheets[position.sheetId].getValue(position) === 1) {
+        yield position;
+      }
+    }
+  }
+}

--- a/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
@@ -1,4 +1,6 @@
-import { PositionId } from "./evaluator";
+import { CellPosition } from "../../../types";
+import { PositionMap } from "./position_map";
+import { PositionSet } from "./position_set";
 
 /**
  * Contains, for each cell, the array
@@ -41,51 +43,53 @@ export class SpreadingRelation {
    * - (B1) --> (B2, B3, B4)  meaning B1 spreads on B2, B3 and B4
    *
    */
-  private readonly resultsToArrayFormulas: Map<PositionId, Set<PositionId>> = new Map();
-  private readonly arrayFormulasToResults: Map<PositionId, Set<PositionId>> = new Map();
+  private readonly resultsToArrayFormulas: PositionMap<PositionSet> = new PositionMap();
+  private readonly arrayFormulasToResults: PositionMap<PositionSet> = new PositionMap();
 
-  getFormulaPositionsSpreadingOn(resultPositionId: PositionId): Iterable<PositionId> {
-    return this.resultsToArrayFormulas.get(resultPositionId) || EMPTY_ARRAY;
+  constructor(private readonly createEmptyPositionSet: () => PositionSet) {}
+
+  getFormulaPositionsSpreadingOn(resultPosition: CellPosition): Iterable<CellPosition> {
+    return this.resultsToArrayFormulas.get(resultPosition) || EMPTY_ARRAY;
   }
 
-  getArrayResultPositionIds(formulasPositionId: PositionId): Iterable<PositionId> {
-    return this.arrayFormulasToResults.get(formulasPositionId) || EMPTY_ARRAY;
+  getArrayResultPositions(formulasPosition: CellPosition): Iterable<CellPosition> {
+    return this.arrayFormulasToResults.get(formulasPosition) || EMPTY_ARRAY;
   }
 
   /**
    * Remove a node, also remove it from other nodes adjacency list
    */
-  removeNode(positionId: PositionId) {
-    this.resultsToArrayFormulas.delete(positionId);
-    this.arrayFormulasToResults.delete(positionId);
+  removeNode(position: CellPosition) {
+    this.resultsToArrayFormulas.delete(position);
+    this.arrayFormulasToResults.delete(position);
   }
 
   /**
    * Create a spreading relation between two cells
    */
   addRelation({
-    arrayFormulaPositionId,
-    resultPositionId,
+    arrayFormulaPosition,
+    resultPosition,
   }: {
-    arrayFormulaPositionId: PositionId;
-    resultPositionId: PositionId;
+    arrayFormulaPosition: CellPosition;
+    resultPosition: CellPosition;
   }): void {
-    if (!this.resultsToArrayFormulas.has(resultPositionId)) {
-      this.resultsToArrayFormulas.set(resultPositionId, new Set<PositionId>());
+    if (!this.resultsToArrayFormulas.has(resultPosition)) {
+      this.resultsToArrayFormulas.set(resultPosition, this.createEmptyPositionSet());
     }
-    this.resultsToArrayFormulas.get(resultPositionId)?.add(arrayFormulaPositionId);
-    if (!this.arrayFormulasToResults.has(arrayFormulaPositionId)) {
-      this.arrayFormulasToResults.set(arrayFormulaPositionId, new Set<PositionId>());
+    this.resultsToArrayFormulas.get(resultPosition)?.add(arrayFormulaPosition);
+    if (!this.arrayFormulasToResults.has(arrayFormulaPosition)) {
+      this.arrayFormulasToResults.set(arrayFormulaPosition, this.createEmptyPositionSet());
     }
-    this.arrayFormulasToResults.get(arrayFormulaPositionId)?.add(resultPositionId);
+    this.arrayFormulasToResults.get(arrayFormulaPosition)?.add(resultPosition);
   }
 
-  hasArrayFormulaResult(positionId: PositionId): boolean {
-    return this.resultsToArrayFormulas.has(positionId);
+  hasArrayFormulaResult(position: CellPosition): boolean {
+    return this.resultsToArrayFormulas.has(position);
   }
 
-  isArrayFormula(positionId: PositionId): boolean {
-    return this.arrayFormulasToResults.has(positionId);
+  isArrayFormula(position: CellPosition): boolean {
+    return this.arrayFormulasToResults.has(position);
   }
 }
 

--- a/tests/helpers/positions_map.test.ts
+++ b/tests/helpers/positions_map.test.ts
@@ -1,0 +1,39 @@
+import { PositionMap } from "../../src/plugins/ui_core_views/cell_evaluation/position_map";
+
+describe("PositionMap", () => {
+  test("set an element", () => {
+    const map = new PositionMap<number>();
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    map.set(A1, 1);
+    expect(map.get(A1)).toBe(1);
+    expect(map.has(A1)).toBe(true);
+  });
+
+  test("remove an element", () => {
+    const map = new PositionMap<number>();
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    map.set(A1, 1);
+    map.delete(A1);
+    expect(map.get(A1)).toBeUndefined();
+    expect(map.has(A1)).toBe(false);
+  });
+
+  test("empty map has no element", () => {
+    const map = new PositionMap<number>();
+    expect(map.has({ sheetId: "1", row: 0, col: 0 })).toBe(false);
+  });
+
+  test("iterate over empty map keys", () => {
+    const map = new PositionMap<number>();
+    expect([...map.keys()]).toEqual([]);
+  });
+
+  test("iterate over keys", () => {
+    const map = new PositionMap<number>();
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    const A2 = { sheetId: "1", row: 0, col: 1 };
+    map.set(A1, 1);
+    map.set(A2, 2);
+    expect([...map.keys()]).toEqual([A1, A2]);
+  });
+});

--- a/tests/helpers/positions_set.test.ts
+++ b/tests/helpers/positions_set.test.ts
@@ -1,0 +1,142 @@
+import { PositionSet } from "../../src/plugins/ui_core_views/cell_evaluation/position_set";
+
+describe("PositionSet", () => {
+  test("add and delete position in the edge corners", () => {
+    for (const cols of [1, 2, 5, 31, 32, 33]) {
+      for (const rows of [1, 2, 5, 31, 32, 33]) {
+        const set = new PositionSet({ "1": { rows: rows, cols: cols } });
+        const upperLeft = { sheetId: "1", row: 0, col: 0 };
+        const upperRight = { sheetId: "1", row: 0, col: cols - 1 };
+        const lowerLeft = { sheetId: "1", row: rows - 1, col: 0 };
+        const lowerRight = { sheetId: "1", row: rows - 1, col: cols - 1 };
+        set.add(upperLeft);
+        set.add(upperRight);
+        set.add(lowerLeft);
+        set.add(lowerRight);
+        expect(set.has(upperLeft)).toBe(true);
+        expect(set.has(upperRight)).toBe(true);
+        expect(set.has(lowerLeft)).toBe(true);
+        expect(set.has(lowerRight)).toBe(true);
+        expect(set.isEmpty()).toBe(false);
+        set.delete(upperLeft);
+        set.delete(upperRight);
+        set.delete(lowerLeft);
+        set.delete(lowerRight);
+        expect(set.has(upperLeft)).toBe(false);
+        expect(set.has(upperRight)).toBe(false);
+        expect(set.has(lowerLeft)).toBe(false);
+        expect(set.has(lowerRight)).toBe(false);
+        expect(set.isEmpty()).toBe(true);
+      }
+    }
+  });
+
+  test("add same position twice", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    set.add({ sheetId: "1", row: 1, col: 1 });
+    set.add({ sheetId: "1", row: 1, col: 1 });
+    expect(set.has({ sheetId: "1", row: 1, col: 1 })).toBe(true);
+  });
+
+  test("add/delete two positions in batch", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    const A2 = { sheetId: "1", row: 0, col: 1 };
+    set.addMany([A1, A2]);
+    expect([...set]).toEqual([A1, A2]);
+    set.deleteMany([A1, A2]);
+    expect([...set]).toEqual([]);
+    expect(set.isEmpty()).toBe(true);
+  });
+
+  test("add the same position twice in batch", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    set.addMany([A1, A1]);
+    expect([...set]).toEqual([A1]);
+  });
+
+  test("has with position which has never been inserted", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    expect(set.has({ sheetId: "1", row: 1, col: 1 })).toBe(false);
+  });
+
+  test("clear a set with elements", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    set.add(A1);
+    expect(set.clear()).toEqual([A1]);
+    expect(set.isEmpty()).toBe(true);
+    expect(set.has(A1)).toBe(false);
+  });
+
+  test("iterate on empty set", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    expect([...set]).toEqual([]);
+  });
+
+  test("iterate on a set with multiple elements", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    const A2 = { sheetId: "1", row: 0, col: 1 };
+    set.add(A1);
+    expect([...set]).toEqual([A1]);
+    set.add(A2);
+    expect([...set]).toEqual([A1, A2]);
+  });
+
+  test("iterate only once on element inserted twice", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    set.add(A1);
+    set.add(A1);
+    expect([...set]).toEqual([A1]);
+  });
+
+  test("do not iterate on removed elements", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    set.add(A1);
+    set.delete(A1);
+    expect([...set]).toEqual([]);
+  });
+
+  test("iterate element added, removed, then added again", () => {
+    const set = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    set.add(A1);
+    set.delete(A1);
+    set.add(A1);
+    // this test shows an implementation limitation, that the same position
+    // may be yielded multiple times
+    expect([...set]).toEqual([A1, A1]);
+  });
+
+  test("insertion order is preserved when iterating", () => {
+    const set1 = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    const set2 = new PositionSet({ "1": { rows: 10, cols: 10 } });
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    const A2 = { sheetId: "1", row: 0, col: 1 };
+    set1.add(A1);
+    set1.add(A2);
+    // insert in reverse order
+    set2.add(A2);
+    set2.add(A1);
+    expect([...set1]).toEqual([A1, A2]);
+    expect([...set2]).toEqual([A2, A1]);
+  });
+
+  test("fill all positions", () => {
+    const set = new PositionSet({ "1": { rows: 2, cols: 2 } });
+    const A1 = { sheetId: "1", row: 0, col: 0 };
+    const A2 = { sheetId: "1", row: 0, col: 1 };
+    const B1 = { sheetId: "1", row: 1, col: 0 };
+    const B2 = { sheetId: "1", row: 1, col: 1 };
+    set.fillAllPositions();
+    expect([...set]).toEqual([A1, A2, B1, B2]);
+    expect(set.has(A1)).toBe(true);
+    expect(set.has(A2)).toBe(true);
+    expect(set.has(B1)).toBe(true);
+    expect(set.has(B2)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description:

This commit drastically improves the evaluation execution time (~43% faster with the large formula demo dataset)

`Map` and `Set` data structures are slow compared to objects and arrays (especially with `BigInt`, more on that later). Why use `Map` and `Set` then ?

We needed a set data structure to hold which positions should be evaluated. We obviously don't want duplicates (hence the set). However, we can't blindly add a position object `{ sheetId, col, row }` in a `Set` though because the same position could be added twice by adding the same position as two different objects that are not referentially equal.
That's why we came up with a way to encode the position object to a single value that can be added safely to the set without worrying about object references being equal. This encoded value is a `BigInt` (see `PositionBitsEncoder`). That's why we used `Set<BigInt>`. Since we had the position encoded as a single value, we naturally used that value as a key in a `Map` (regular `object` can only have `string` or `number` keys, not `BigInt`). Using this `BigInt` key also avoid having to decode the encoded value, then have a nested `[sheetId][col][row]` objects.

In the evaluation process, there's a lot going on. To the point were lookup in the map is a bottleneck.

This commit replaces the `Set` and `Map` in the evaluation by custom data structure `PositionSet` and `PositionMap<T>` with faster addition and lookup.

In addition to being faster, this makes the evaluation code simpler as we no longer need encoding/decoding everywhere. Those data structures are also easier to debug. With the `BigInt` encoding, it was hard to find back which position is the number `28416511n`.

Some measures
----------------------
*(all measures are averages over 8 runs)*

```js
console.time("eval");
o_spreadsheet.__DEBUG__.model.dispatch("EVALUATE_CELLS")
console.timeEnd("eval");
```
On the large formula demo data set (260k cells): -43%

|        	| Time  	| Allocated memory 	|
|--------	|-------	|------------------	|
| Before 	| 512ms 	| 190MB            	|
| After  	| 291ms 	| 122MB            	|

I also tried implementing `PositionSet` with a `PositionMap<boolean>` instead of `BinaryGrid`. It's ~10% slower and allocates ~20MB more (but it's 120 LoC less).

On RNG's Timesheet spreadsheet: -23%

|        	| Time  	| Allocated memory 	|
|--------	|-------	|------------------	|
| Before 	| 1894ms 	| 580MB            	|
| After  	| 1469ms 	| 460MB            	|


Basic tests on the raw data structures with 1M positions (10k rows and 100 columns)

|   	|                	| add   	| has   	|
|---	|----------------	|-------	|-------	|
| 1 	| `Set<BigInt>`    	| 314ms 	| 262ms 	|
| 2 	| `Set` + encoding 	| 440ms 	|       	|
| 3 	| `PositionSet`    	| 43ms  	| 46ms  	|

|   	|                     	| set   	| get   	|
|---	|---------------------	|-------	|-------	|
| 4 	| `Map<BigInt, number>` 	| 365ms 	| 304ms 	|
| 5 	| `PositionMap<number>` 	| 47ms  	| 51ms  	|

Setup code shared by all benchmarks:
```js
const sheetId = "1";
const postions = [];
for (let i = 0; i < 10000; i++) {
  for (let j = 0; j < 100; j++) {
    postions.push({ sheetId, row: i, col: j });
  }
}
```
1. `Set<BigInt>` 314ms	262ms
```js
const set = new Set();
const length = BigInt(postions.length);
performance.mark("add");
for (let i = 0n; i < length; i++) {
  set.add(i);
}
performance.measure("add", "add").duration);

performance.mark("has");
for (let i = 0n; i < length; i++) {
  set.has(i);
}
performance.measure("has", "has").duration;
```

2. `Set<BigInt> + encoding` 440ms
```js
const encoder = new PositionBitsEncoder();
const set = new Set();
performance.mark("add");
for (const position of postions) {
  set.add(encoder.encode(position));
}
performance.measure("add", "add").duration;
```

3. `PositionSet` 43ms	46ms
```js
const set = new PositionSet({
    [sheetId]: { rows: 10000, cols: 100 },
});
performance.mark("add");
for (const position of postions) {
  set.add(position);
}
performance.measure("add", "add").duration;

performance.mark("has");
let r;
for (const position of postions) {
  r = set.has(position);
}
performance.measure("has", "has").duration;
```

4. `Map<BigInt, number>` 365ms	304ms

```js
const map = new Map();
const length = BigInt(postions.length);
performance.mark("set");
for (let i = 0n; i < length; i++) {
  map.set(i, 4);
}
performance.measure("set", "set").duration;

performance.mark("get");
let r;
for (let i = 0n; i < length; i++) {
  r = map.get(i);
}
performance.measure("get", "get").duration;
```

5. `PositionMap` 47ms	51ms

```js
performance.mark("add");
for (const position of postions) {
  map.set(position, 4);
}
performance.measure("add", "add").duration;

performance.mark("get");
let r;
for (const position of postions) {
  r = map.get(position);
}
performance.measure("get", "get").duration;
```


Task: : [3802246](https://www.odoo.com/web#id=3802246&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo