### PR TITLE
[IMP] bottom_bar: prevent selection of hidden sheets

### DIFF
--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -141,10 +141,14 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
         name: sheet.name,
         sequence: i,
         isReadonlyAllowed: true,
-        textColor: sheet.isVisible ? undefined : "grey",
+        textColor: sheet.isVisible ? undefined : "#808080",
         execute: (env) => {
+          if (!this.env.model.getters.isSheetVisible(sheetId)) {
+            this.env.model.dispatch("SHOW_SHEET", { sheetId });
+          }
           env.model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: from, sheetIdTo: sheetId });
         },
+        isEnabled: (env) => (env.model.getters.isReadonly() ? sheet.isVisible : true),
       });
       i++;
     }

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -143,7 +143,10 @@ export class GridSelectionPlugin extends UIPlugin {
     switch (cmd.type) {
       case "ACTIVATE_SHEET":
         try {
-          this.getters.getSheet(cmd.sheetIdTo);
+          const sheet = this.getters.getSheet(cmd.sheetIdTo);
+          if (!sheet.isVisible) {
+            return CommandResult.SheetIsHidden;
+          }
           break;
         } catch (error) {
           return CommandResult.InvalidSheetId;
@@ -518,9 +521,6 @@ export class GridSelectionPlugin extends UIPlugin {
   // ---------------------------------------------------------------------------
 
   private activateSheet(sheetIdFrom: UID, sheetIdTo: UID) {
-    if (!this.getters.isSheetVisible(sheetIdTo)) {
-      this.dispatch("SHOW_SHEET", { sheetId: sheetIdTo });
-    }
     this.setActiveSheet(sheetIdTo);
     this.sheetsData[sheetIdFrom] = {
       gridSelection: deepCopy(this.gridSelection),

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1146,6 +1146,7 @@ export const enum CommandResult {
   InvalidCopyPasteSelection = "InvalidCopyPasteSelection",
   NoChanges = "NoChanges",
   InvalidInputId = "InvalidInputId",
+  SheetIsHidden = "SheetIsHidden",
 }
 
 export interface CommandHandler<T> {

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -1,5 +1,6 @@
 import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
 import { BottomBar } from "../../src/components/bottom_bar/bottom_bar";
+import { toHex } from "../../src/helpers";
 import { interactiveRenameSheet } from "../../src/helpers/ui/sheet_interactive";
 import { Model } from "../../src/model";
 import { Pixel, SpreadsheetChildEnv, UID } from "../../src/types";
@@ -420,6 +421,26 @@ describe("BottomBar component", () => {
       sheetIdFrom: sheet,
       sheetIdTo: "42",
     });
+  });
+
+  test("Clicking on an hidden sheet in the list of sheets unhide and activate it", async () => {
+    const { model } = await mountBottomBar();
+    createSheet(model, { sheetId: "42", hidden: true });
+    await click(fixture, ".o-list-sheets");
+    const menuItem = fixture.querySelector<HTMLElement>(".o-menu-item[data-name='42'")!;
+    expect(toHex(menuItem.style.color)).toEqual("#808080");
+    await click(menuItem);
+    expect(model.getters.getActiveSheetId()).toBe("42");
+    expect(model.getters.getActiveSheet().isVisible).toBe(true);
+  });
+
+  test("Hidden sheets menu items are disabled in readonly in the list of sheets", async () => {
+    const { model } = await mountBottomBar();
+    createSheet(model, { sheetId: "42", hidden: true });
+    model.updateMode("readonly");
+    await click(fixture, ".o-list-sheets");
+    const menuItem = fixture.querySelector<HTMLElement>(".o-menu-item[data-name='42'");
+    expect(menuItem!.classList).toContain("disabled");
   });
 
   describe("Scroll on the list of sheets", () => {

--- a/tests/sheet/sheets_plugin.test.ts
+++ b/tests/sheet/sheets_plugin.test.ts
@@ -266,6 +266,12 @@ describe("sheets", () => {
     expect(activateSheet(model, "INVALID_ID")).toBeCancelledBecause(CommandResult.InvalidSheetId);
   });
 
+  test("cannot activate an hidden sheet", () => {
+    const model = new Model();
+    createSheet(model, { sheetId: "42", hidden: true });
+    expect(activateSheet(model, "42")).toBeCancelledBecause(CommandResult.SheetIsHidden);
+  });
+
   test("evaluating multiple sheets", () => {
     const model = new Model({
       sheets: [

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -59,7 +59,7 @@ export function activateSheet(
  */
 export function createSheet(
   model: Model,
-  data: Partial<CreateSheetCommand & { activate: boolean }>
+  data: Partial<CreateSheetCommand & { activate: boolean; hidden: boolean }>
 ) {
   const sheetId = data.sheetId || model.uuidGenerator.uuidv4();
   const result = model.dispatch("CREATE_SHEET", {
@@ -69,6 +69,9 @@ export function createSheet(
     rows: data.rows,
     name: data.name,
   });
+  if (data.hidden) {
+    hideSheet(model, sheetId);
+  }
   if (data.activate) {
     activateSheet(model, sheetId);
   }


### PR DESCRIPTION
## Description

Before activating an hidden sheet had the side effect of making the
sheet visible. But it made possible to activate a hidden sheet in
readonly mode, since the command to un-hide the sheet was prevented.

Now the allowDispatch of `ACTIVATE_SHEET` prevents activating an hidden
sheet. In the bottom bar, we also now disable the menu item that
unhides & activates an hidden sheet in readonly.

Task: 3801883
Task: : [3801883](https://www.odoo.com/web#id=3801883&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo