### PR TITLE
[IMP] xlsx: slice long sheet names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,7 +183,7 @@ export {
   invalidateEvaluationCommands,
   readonlyAllowedCommands,
 } from "./types/commands";
-export { CellErrorType, EvaluationError } from "./types/errors";
+export { CellErrorType, EvaluationError, XlsxExportError } from "./types/errors";
 
 export const SPREADSHEET_DIMENSIONS = {
   MIN_ROW_HEIGHT,

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -12,6 +12,7 @@ import {
   toCartesian,
 } from "../../helpers/index";
 import { _t } from "../../translation";
+import { XlsxExportError } from "../../types/errors";
 import {
   Cell,
   CellPosition,
@@ -292,6 +293,18 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
 
   exportForExcel(data: ExcelWorkbookData) {
     this.exportSheets(data);
+
+    const tooLongSheetNames = data.sheets
+      .filter((sheet) => sheet.name.length > 31)
+      .map((sheet) => `"${sheet.name}"`);
+    if (tooLongSheetNames.length) {
+      throw new XlsxExportError(
+        _t(
+          "Cannot export because sheet names longer than 31 characters are not supported in Excel. Please rename the sheets: %s.",
+          tooLongSheetNames.join(", ")
+        )
+      );
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -45,3 +45,9 @@ export class UnknownFunctionError extends EvaluationError {
     super(message, CellErrorType.UnknownFunction);
   }
 }
+
+export class XlsxExportError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -1,3 +1,4 @@
+import { XlsxExportError } from "../../src";
 import { functionRegistry } from "../../src/functions";
 import { buildSheetLink, toXC } from "../../src/helpers";
 import { createEmptyExcelWorkbookData } from "../../src/migrations/data";
@@ -1453,6 +1454,12 @@ describe("Test XLSX export", () => {
       });
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
+  });
+
+  test("Cannot export xlsx with sheet name longer than 31 characters", () => {
+    const model = new Model();
+    createSheet(model, { name: "a".repeat(40) });
+    expect(() => getExportedExcelData(model)).toThrow(XlsxExportError);
   });
 });
 


### PR DESCRIPTION
## Description

Excel sheet names are maximum 31 characters. This commit slices the sheet names at xlsx export to avoid an error when opening the xlsx.

Task: : [3801848](https://www.odoo.com/web#id=3801848&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo