### PR TITLE
[FIX] Composer: weird behavior of autocomplete dropdown

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -208,6 +208,11 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
       if (!this.isKeyStillDown) {
         this.processContent();
       }
+
+      // Required because typing '=SUM' and double-clicking another cell leaves ShowProvider and ShowDescription true
+      if (this.env.model.getters.getEditionMode() === "inactive") {
+        this.processTokenAtCursor();
+      }
     });
   }
 

--- a/tests/components/autocomplete_dropdown.test.ts
+++ b/tests/components/autocomplete_dropdown.test.ts
@@ -8,6 +8,7 @@ import {
   mountSpreadsheet,
   nextTick,
   restoreDefaultFunctions,
+  startGridComposition,
   typeInComposerGrid as typeInComposerGridHelper,
 } from "../test_helpers/helpers";
 import { ContentEditableHelper } from "./__mocks__/content_editable_helper";
@@ -188,6 +189,19 @@ describe("Functions autocomplete", () => {
     });
   });
 
+  test("autocomplete should not appear when typing '=S', clicking outside, and edting back", async () => {
+    await typeInComposerGrid("=S");
+    expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(2);
+
+    model.dispatch("STOP_EDITION");
+    await nextTick();
+    expect(fixture.querySelector(".o-autocomplete-dropdown")).toBeFalsy();
+
+    await startGridComposition();
+    await nextTick();
+    expect(fixture.querySelector(".o-autocomplete-dropdown")).toBeFalsy();
+  });
+
   test.each(["Enter", "Tab"])(
     "=S(A1:A5) + %s complete the function --> =SUM(A1:A5)",
     async (buttonkey) => {
@@ -286,6 +300,18 @@ describe("Autocomplete parenthesis", () => {
     composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
     await nextTick();
     expect(getCellText(model, "A1")).toBe("=sum(1,2)");
+  });
+
+  test("=sum( + enter + edit does not show the formula assistant", async () => {
+    await typeInComposerGrid("=sum(");
+    expect(fixture.querySelector(".o-formula-assistant-container")).toBeTruthy();
+
+    composerEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    await nextTick();
+    expect(fixture.querySelector(".o-formula-assistant-container")).toBeFalsy();
+
+    await startGridComposition();
+    expect(fixture.querySelector(".o-formula-assistant-container")).toBeFalsy();
   });
 
   test("=sum(1,2) + enter + edit sum does not add parenthesis", async () => {


### PR DESCRIPTION
## Description:

Previously, when users typed "=S" in the composer, clicked outside, then started editing another cell, the autocomplete dropdown remained visible. Similarly, when they typed "=SUM(" and pressed enter, then edited another cell, the function assistant persisted.

This PR addresses the problem by ensuring that state values are set to false whenever the composer is not in edit mode.

Task: : [3789473](https://www.odoo.com/web#id=3789473&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo