### PR TITLE
[FIX] TopBar: Remove hidden functions from the `insert` menu

### DIFF
--- a/src/actions/insert_actions.ts
+++ b/src/actions/insert_actions.ts
@@ -154,19 +154,24 @@ export const categorieFunctionAll: ActionSpec = {
 };
 
 function allFunctionListMenuBuilder(): ActionSpec[] {
-  const fnNames = functionRegistry.getKeys();
+  const fnNames = functionRegistry.getKeys().filter((key) => !functionRegistry.get(key).hidden);
   return createFormulaFunctions(fnNames);
 }
 
 export const categoriesFunctionListMenuBuilder: ActionBuilder = () => {
   const functions = functionRegistry.content;
-  const categories = [...new Set(functionRegistry.getAll().map((fn) => fn.category))].filter(
-    isDefined
-  );
+  const categories = [
+    ...new Set(
+      functionRegistry
+        .getAll()
+        .filter((fn) => !fn.hidden)
+        .map((fn) => fn.category)
+    ),
+  ].filter(isDefined);
 
   return categories.sort().map((category, i) => {
     const functionsInCategory = Object.keys(functions).filter(
-      (key) => functions[key].category === category
+      (key) => functions[key].category === category && !functions[key].hidden
     );
     return {
       name: category,

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./test_helpers/commands_helpers";
 import { getCell, getCellContent, getEvaluatedCell } from "./test_helpers/getters_helpers";
 import {
+  clearFunctions,
   doAction,
   getName,
   getNode,
@@ -856,6 +857,26 @@ describe("Menu Item actions", () => {
       env
     );
     expect(allFunctions.map((f) => f.name(env))).toContain("TEST.FUNC");
+    restoreDefaultFunctions();
+  });
+
+  test("Insert -> Function -> hidden formulas are filtered out", () => {
+    clearFunctions();
+    functionRegistry.add("HIDDEN.FUNC", {
+      args: [],
+      compute: () => 42,
+      description: "Test function",
+      returns: ["NUMBER"],
+      hidden: true,
+      category: "hidden",
+    });
+    const env = makeTestEnv();
+    const functionCategories = getNode(["insert", "insert_function"]).children(env);
+    expect(functionCategories.map((f) => f.name(env))).not.toContain("hidden");
+    const allFunctions = getNode(["insert", "insert_function", "categorie_function_all"]).children(
+      env
+    );
+    expect(allFunctions.map((f) => f.name(env))).not.toContain("HIDDEN.FUNC");
     restoreDefaultFunctions();
   });
 


### PR DESCRIPTION
The introduction of the `hidden` tag of functions in pr #1928 did not account for the `insert function` menu of the top bar that was developped at the same time.

This revision ensures that the functions marked as `hidden` do not appear in the top bar menu, similarly to their behaviour in the composer formula autocomplete assistant.

Task: 3810284

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo