### PR TITLE
[IMP] formats: add custom formats to format menu

### DIFF
--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -22,11 +22,15 @@ import { ActionSpec } from "./action";
 import * as ACTIONS from "./menu_items_actions";
 import { setFormatter, setStyle } from "./menu_items_actions";
 
+export interface NumberFormatActionSpec extends ActionSpec {
+  format?: Format | ((env: SpreadsheetChildEnv) => Format);
+}
+
 /**
  * Create a format action specification for a given format.
  * The format can be dynamically computed from the environment.
  */
-function createFormatActionSpec({
+export function createFormatActionSpec({
   name,
   format,
   descriptionValue,
@@ -34,7 +38,7 @@ function createFormatActionSpec({
   name: string;
   descriptionValue: CellValue;
   format: Format | ((env: SpreadsheetChildEnv) => Format);
-}): ActionSpec {
+}): NumberFormatActionSpec {
   const formatCallback = typeof format === "function" ? format : () => format;
   return {
     name,
@@ -45,16 +49,17 @@ function createFormatActionSpec({
       }),
     execute: (env) => setFormatter(env, formatCallback(env)),
     isActive: (env) => isFormatSelected(env, formatCallback(env)),
+    format,
   };
 }
 
-export const formatNumberAutomatic: ActionSpec = {
+export const formatNumberAutomatic: NumberFormatActionSpec = {
   name: _t("Automatic"),
   execute: (env) => setFormatter(env, ""),
   isActive: (env) => isAutomaticFormatSelected(env),
 };
 
-export const formatNumberPlainText: ActionSpec = {
+export const formatNumberPlainText: NumberFormatActionSpec = {
   name: _t("Plain text"),
   execute: (env) => setFormatter(env, PLAIN_TEXT_FORMAT),
   isActive: (env) => isFormatSelected(env, PLAIN_TEXT_FORMAT),
@@ -84,7 +89,7 @@ export const formatNumberCurrency = createFormatActionSpec({
   format: (env) => env.model.config.defaultCurrencyFormat ?? DEFAULT_CURRENCY_FORMAT,
 });
 
-export const formatNumberCurrencyRounded: ActionSpec = {
+export const formatNumberCurrencyRounded: NumberFormatActionSpec = {
   ...createFormatActionSpec({
     name: _t("Currency rounded"),
     descriptionValue: 1000,
@@ -98,7 +103,7 @@ export const formatNumberCurrencyRounded: ActionSpec = {
 
 const DEFAULT_CURRENCY_FORMAT = "[$$]#,##0.00";
 
-const EXAMPLE_DATE = parseLiteral("2023/09/26 10:43:00 PM", DEFAULT_LOCALE);
+export const EXAMPLE_DATE = parseLiteral("2023/09/26 10:43:00 PM", DEFAULT_LOCALE);
 
 export const formatCustomCurrency: ActionSpec = {
   name: _t("Custom currency"),

--- a/src/registries/menus/number_format_menu_registry.ts
+++ b/src/registries/menus/number_format_menu_registry.ts
@@ -1,66 +1,134 @@
-import { ActionSpec } from "../../actions/action";
+import { SpreadsheetChildEnv } from "../..";
+import { ActionSpec, createActions } from "../../actions/action";
 import * as ACTION_FORMAT from "../../actions/format_actions";
+import { isDateTimeFormat, memoize } from "../../helpers";
 import { _t } from "../../translation";
-import { MenuItemRegistry } from "../menu_items_registry";
+import { Format } from "../../types";
+import { Registry } from "../registry";
 
-export const numberFormatMenuRegistry = new MenuItemRegistry();
+export const numberFormatMenuRegistry = new Registry<ACTION_FORMAT.NumberFormatActionSpec>();
 
 numberFormatMenuRegistry
   .add("format_number_automatic", {
     ...ACTION_FORMAT.formatNumberAutomatic,
+    id: "format_number_automatic",
     sequence: 10,
   })
   .add("format_number_plain_text", {
     ...ACTION_FORMAT.formatNumberPlainText,
+    id: "format_number_plain_text",
     sequence: 15,
     separator: true,
   })
   .add("format_number_number", {
     ...ACTION_FORMAT.formatNumberNumber,
+    id: "format_number_number",
     sequence: 20,
   })
   .add("format_number_percent", {
     ...ACTION_FORMAT.formatNumberPercent,
+    id: "format_number_percent",
     sequence: 30,
     separator: true,
   })
   .add("format_number_currency", {
     ...ACTION_FORMAT.formatNumberCurrency,
+    id: "format_number_currency",
     sequence: 40,
   })
   .add("format_number_currency_rounded", {
     ...ACTION_FORMAT.formatNumberCurrencyRounded,
+    id: "format_number_currency_rounded",
     sequence: 50,
   })
   .add("format_custom_currency", {
     ...ACTION_FORMAT.formatCustomCurrency,
+    id: "format_custom_currency",
     sequence: 60,
     separator: true,
   })
   .add("format_number_date", {
     ...ACTION_FORMAT.formatNumberDate,
+    id: "format_number_date",
     sequence: 70,
   })
   .add("format_number_time", {
     ...ACTION_FORMAT.formatNumberTime,
+    id: "format_number_time",
     sequence: 80,
   })
   .add("format_number_date_time", {
     ...ACTION_FORMAT.formatNumberDateTime,
+    id: "format_number_date_time",
     sequence: 90,
   })
   .add("format_number_duration", {
     ...ACTION_FORMAT.formatNumberDuration,
+    id: "format_number_duration",
     sequence: 100,
     separator: true,
   })
   .add("more_formats", {
     ...ACTION_FORMAT.moreFormats,
-    sequence: 110,
+    id: "more_formats",
+    sequence: 120,
   });
+
+export function getCustomNumberFormats(
+  env: SpreadsheetChildEnv
+): ACTION_FORMAT.NumberFormatActionSpec[] {
+  const defaultFormats = new Set(
+    numberFormatMenuRegistry
+      .getAll()
+      .map((f) => (typeof f.format === "function" ? f.format(env) : f.format))
+  );
+
+  const customFormats = new Map<Format, ACTION_FORMAT.NumberFormatActionSpec>();
+  for (const sheetId of env.model.getters.getSheetIds()) {
+    const cells = env.model.getters.getEvaluatedCells(sheetId);
+    for (const cellId in cells) {
+      const cell = cells[cellId];
+
+      if (cell.format && !customFormats.has(cell.format) && !defaultFormats.has(cell.format)) {
+        const formatType = getNumberFormatType(cell.format);
+        if (formatType === "date" || formatType === "currency") {
+          customFormats.set(
+            cell.format,
+            ACTION_FORMAT.createFormatActionSpec({
+              descriptionValue: formatType === "currency" ? 1000 : ACTION_FORMAT.EXAMPLE_DATE,
+              format: cell.format,
+              name: cell.format,
+            })
+          );
+        }
+      }
+    }
+  }
+  return [...customFormats.values()];
+}
+
+const getNumberFormatType = memoize((format: Format) => {
+  if (isDateTimeFormat(format)) {
+    return "date";
+  } else if (format.includes("[$")) {
+    return "currency";
+  }
+  return "number";
+});
 
 export const formatNumberMenuItemSpec: ActionSpec = {
   name: _t("More formats"),
   icon: "o-spreadsheet-Icon.NUMBER_FORMATS",
-  children: [() => numberFormatMenuRegistry.getAll()],
+  children: [
+    (env) => {
+      const customFormats = getCustomNumberFormats(env).map((action) => ({
+        ...action,
+        sequence: 110,
+      }));
+      if (customFormats.length > 0) {
+        customFormats[customFormats.length - 1].separator = true;
+      }
+      return createActions([...numberFormatMenuRegistry.getAll(), ...customFormats]);
+    },
+  ],
 };

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -24,6 +24,7 @@ import {
   selectRow,
   setAnchorCorner,
   setCellContent,
+  setFormat,
   setSelection,
   setStyle,
   updateLocale,
@@ -1154,6 +1155,34 @@ describe("Menu Item actions", () => {
       doAction(["format", "format_number", "format_number_percent"], env);
       expect(composerStore.editionMode).toBe("inactive");
       expect(getCellContent(model, "A1")).toBe("");
+    });
+
+    describe("Custom number formats", () => {
+      function getNumberFormatsInMenu() {
+        return getNode(["format", "format_number"], env)
+          .children(env)
+          .map((node) => node.name(env));
+      }
+
+      test("Custom date and currency formats are present in the number format item", () => {
+        expect(getNumberFormatsInMenu()).not.toContain("#.##0[$£]");
+        setFormat(model, "A1", "#.##0[$£]");
+        expect(getNumberFormatsInMenu()).toContain("#.##0[$£]");
+
+        expect(getNumberFormatsInMenu()).not.toContain("dd/mm/yyyy");
+        setFormat(model, "A1", "dd/mm/yyyy");
+        expect(getNumberFormatsInMenu()).toContain("dd/mm/yyyy");
+      });
+
+      test("Custom formats that are nether dates nor currencies are not present", () => {
+        setFormat(model, "A1", "#.####0");
+        expect(getNumberFormatsInMenu()).not.toContain("#.####0");
+      });
+
+      test("Default formats are not re-added in custom formats", () => {
+        setFormat(model, "A1", "m/d/yyyy");
+        expect(getNumberFormatsInMenu()).not.toContain("m/d/yyyy");
+      });
     });
   });
 


### PR DESCRIPTION
## Description

When a custom format was inserted in the spreadsheet (eg. custom currency), there was no indication for the user that the format was active on the cell, and no way to add it on another cell.

This commit adds the custom formats to the format menu, so the menu item has a "check" when it's used on the active cell, and can be applied to another cell easily.

Task: : [3799480](https://www.odoo.com/web#id=3799480&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo