### PR TITLE
[FIX] menu: non-aligned menu items

### DIFF
--- a/src/components/menu/menu.xml
+++ b/src/components/menu/menu.xml
@@ -22,7 +22,7 @@
               t-att-class="{ 'o-menu-root': isMenuRoot, 'disabled': !isMenuEnabled, 'o-menu-item-active': isParentMenu(subMenu, menuItem)}"
               t-att-style="getColor(menuItem)">
               <div class="d-flex w-100">
-                <div t-if="childrenHaveIcon" class="o-menu-item-icon align-middle">
+                <div t-if="childrenHaveIcon" class="o-menu-item-icon align-middle flex-shrink-0">
                   <t t-if="getIconName(menuItem)" t-call="{{getIconName(menuItem)}}"/>
                 </div>
                 <div class="o-menu-item-name align-middle text-truncate" t-esc="getName(menuItem)"/>

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -591,7 +591,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             >
               <svg
                 class="o-icon"
@@ -627,7 +627,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div
@@ -654,7 +654,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div
@@ -685,7 +685,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div
@@ -712,7 +712,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div
@@ -739,7 +739,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div
@@ -765,7 +765,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div
@@ -792,7 +792,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div
@@ -819,7 +819,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div
@@ -846,7 +846,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div
@@ -877,7 +877,7 @@ exports[`TopBar component can set cell format 1`] = `
             class="d-flex w-100"
           >
             <div
-              class="o-menu-item-icon align-middle"
+              class="o-menu-item-icon align-middle flex-shrink-0"
             />
             
             <div

--- a/tests/menus/__snapshots__/context_menu_component.test.ts.snap
+++ b/tests/menus/__snapshots__/context_menu_component.test.ts.snap
@@ -14,7 +14,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -50,7 +50,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -86,7 +86,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -122,7 +122,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -170,7 +170,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -201,7 +201,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -232,7 +232,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -280,7 +280,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -311,7 +311,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -342,7 +342,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"
@@ -390,7 +390,7 @@ exports[`Context Menu integration tests context menu simple rendering 1`] = `
       class="d-flex w-100"
     >
       <div
-        class="o-menu-item-icon align-middle"
+        class="o-menu-item-icon align-middle flex-shrink-0"
       >
         <svg
           class="o-icon"


### PR DESCRIPTION
## Description

If the menu items were too long, and that the menu item had a blank space in place of an icon, the menu texts were not aligned properly because of a flex shrink.

Task: : [3814222](https://www.odoo.com/web#id=3814222&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo