### PR TITLE
[FIX] export: export non-Excel formulas as value

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -314,7 +314,7 @@ export class EvaluationPlugin extends UIPlugin {
         ? getItemId<Format>(newFormat, data.formats)
         : exportedCellData.format;
       let content;
-      if (formulaCell instanceof FormulaCellWithDependencies) {
+      if (isFormula && formulaCell instanceof FormulaCellWithDependencies) {
         content = this.getters.getFormulaCellContent(
           exportedSheetData.id,
           formulaCell.compiledFormula,

--- a/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
+++ b/tests/xlsx/__snapshots__/xlsx_export.test.ts.snap
@@ -15145,6 +15145,13 @@ exports[`Test XLSX export formulas All non-exportable formulas 1`] = `
                 </f>
             </c>
         </row>
+        <row r="24" ht="17.25" customHeight="1" hidden="0">
+            <c r="A24" s="1">
+                <v>
+                    2
+                </v>
+            </c>
+        </row>
     </sheetData>
 </worksheet>",
       "contentType": "sheet",

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -384,7 +384,7 @@ const allNonExportableFormulasData = {
     {
       cells: {
         A1: { content: "=WAIT(100)" },
-        A2: { content: "=COUNTUNIQUE(1,2,3,2,4)" },
+        A2: { content: "=COUNTUNIQUE(1,A24,3,2,4)" },
         A3: { content: "=sum(A1,wait(100))" },
         A4: { content: "=ADD(42,24)" },
         A5: { content: "=DIVIDE(84,42)" },
@@ -406,6 +406,7 @@ const allNonExportableFormulasData = {
         A21: { content: '=FORMAT.LARGE.NUMBER(1000, "k")' },
         A22: { content: "=SUM(A3:3)" }, // should be adapted to SUM(A3:Z3)
         A23: { content: "=SUM(A3:A)" }, // should be adapted to SUM(A3:A100)
+        A24: { content: "2" },
       },
     },
   ],


### PR DESCRIPTION
__Current behavior before commit:__
Since the commit [`201aea7`][1], when `formulaCell` is a `FormulaCellWithDependencies`, `content` might be set to raw formula even if it is not readable by Excel.

__Description of the fix:__
Prevent `content` to be set to the raw formula if `isFormula === false`.

__Example of steps to reproduce the issue:__
- Write a number in **A1**
- Write `=FORMAT.LARGE.NUMBER(A1)` in **A2**
- Save as XLSX and open in Excel -> **A2** is not evaluated by Excel

opw-3782676

[1]: https://github.com/odoo/o-spreadsheet/commit/201aea7

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo