### PR TITLE
[IMP] link: link to hidden sheet warning

### DIFF
--- a/src/helpers/links.ts
+++ b/src/helpers/links.ts
@@ -1,6 +1,6 @@
 import { Registry } from "../registries/registry";
 import { _t } from "../translation";
-import { CellValue, Getters, Link, SpreadsheetChildEnv } from "../types";
+import { CellValue, CommandResult, Getters, Link, SpreadsheetChildEnv } from "../types";
 import { isMarkdownLink, isSheetUrl, isWebLink, parseMarkdownLink, parseSheetUrl } from "./misc";
 
 /**
@@ -56,10 +56,17 @@ urlRegistry.add("sheet_URL", {
   },
   open(url, env) {
     const sheetId = parseSheetUrl(url);
-    env.model.dispatch("ACTIVATE_SHEET", {
+    const result = env.model.dispatch("ACTIVATE_SHEET", {
       sheetIdFrom: env.model.getters.getActiveSheetId(),
       sheetIdTo: sheetId,
     });
+    if (result.isCancelledBecause(CommandResult.SheetIsHidden)) {
+      env.notifyUser({
+        type: "warning",
+        sticky: false,
+        text: _t("Cannot open the link because the linked sheet is hidden."),
+      });
+    }
   },
   sequence: 0,
 });


### PR DESCRIPTION
Since 3dd8c4259 `ACTIVATE_SHEET` does not activate hidden sheets, and thus a link to a hidden sheet will not work. This behaviour is intended, but this commit adds a warning to the user when trying to open a link to a hidden sheet.

Task: : [3814127](https://www.odoo.com/web#id=3814127&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo