### PR TITLE
[FIX] package: saas-17.1 is no longer the latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           tag: ${{ fromJSON(steps.parse.outputs.data).version }}
           body: ${{ fromJSON(steps.parse.outputs.data).body }}
           artifacts: "./dist/*.*"
-          makeLatest: true
+          makeLatest: false
           prerelease: ${{ fromJSON(steps.parse.outputs.data).prerelease }}
       - name: Publish
         run: npm publish

--- a/package.json
+++ b/package.json
@@ -139,6 +139,6 @@
     "*": "prettier --write"
   },
   "publishConfig": {
-    "tag": "latest"
+    "tag": "17-1"
   }
 }


### PR DESCRIPTION
Following the freeze of saas-17.2, the latter version takes the 'latest version' spot.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo