### PR TITLE
[IMP] stores: add `resetStores` method

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -189,6 +189,12 @@ class Demo extends Component {
             inputFiles[images[i]] = { imageSrc };
           }
           await this.initiateConnection(inputFiles);
+          stores.resetStores();
+          stores.inject(NotificationStore, {
+            notifyUser: this.notifyUser,
+            raiseError: this.raiseError,
+            askConfirmation: this.askConfirmation,
+          });
           this.state.key = this.state.key + 1;
 
           // note : the onchange won't be called if we cancel the dialog w/o selecting a file, so this won't be called.

--- a/src/store_engine/dependency_container.ts
+++ b/src/store_engine/dependency_container.ts
@@ -32,6 +32,10 @@ export class DependencyContainer {
   instantiate<T>(Store: StoreConstructor<T>, ...args: StoreParams<StoreConstructor<T>>): T {
     return this.factory.build(Store, ...args);
   }
+
+  resetStores() {
+    this.dependencies.clear();
+  }
 }
 
 class StoreFactory {


### PR DESCRIPTION
## Description

Once the `DependencyContainer` was created and stores were injected, there was no way to remove them. It was a problem for the import of xlsx in Demo, because we created a new model and we'd want to inject a new ModelStore and re-create all the stores that had a reference to the old model.

This commit creates a `resetStores` method in the `DependencyContainer` that removes all the stores. Note that references to the old stores are not removed, so we need to destroy all the components that may use store to not end up in an incorrect state.


## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo