### PR TITLE
[FIX] bottom_bar: disable sheet drag & drop in readonly

### DIFF
--- a/src/components/bottom_bar/bottom_bar.ts
+++ b/src/components/bottom_bar/bottom_bar.ts
@@ -240,7 +240,7 @@ export class BottomBar extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onSheetMouseDown(sheetId: UID, event: MouseEvent) {
-    if (event.button !== 0) return;
+    if (event.button !== 0 || this.env.model.getters.isReadonly()) return;
     this.closeMenu();
 
     const mouseX = event.clientX;

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -825,5 +825,12 @@ describe("BottomBar component", () => {
       await dragSheet("Sheet1", { mouseMoveX: 10, mouseUp: false });
       expect(fixture.querySelector(".o-menu")).toBeFalsy();
     });
+
+    test("Cannot drag & drop sheets in readonly mode", async () => {
+      model.updateMode("readonly");
+      await dragSheet("Sheet1", { mouseMoveX: 10, mouseUp: false });
+      expect(getElComputedStyle('.o-sheet[data-id="Sheet1"]', "position")).toBe("");
+      expect(getElComputedStyle('.o-sheet[data-id="Sheet1"]', "left")).toBe("");
+    });
   });
 });


### PR DESCRIPTION
## Description

When the sheet is readonly, the bottom bar should not allow the user to drag and drop the sheet. Before this commit, dragging a sheet was possible, but the sheet was not moved when dropping. Now we prevent dragging the sheet when it is readonly.

Task: : [3820888](https://www.odoo.com/web#id=3820888&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo