### PR TITLE
[IMP] BottomBarStatistic: cache the statistics results 

### DIFF
--- a/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
+++ b/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
@@ -1,0 +1,140 @@
+import { sum } from "../../functions/helper_math";
+import { average, countAny, countNumbers, max, min } from "../../functions/helper_statistical";
+import { Get } from "../../store_engine";
+import { SpreadsheetStore } from "../../stores";
+import { _t } from "../../translation";
+import {
+  CellValueType,
+  Command,
+  EvaluatedCell,
+  Locale,
+  invalidateEvaluationCommands,
+} from "../../types";
+
+export interface StatisticFnResults {
+  [name: string]: number | undefined;
+}
+
+interface SelectionStatisticFunction {
+  name: string;
+  compute: (data: EvaluatedCell[], locale: Locale) => number;
+  types: CellValueType[];
+}
+
+const selectionStatisticFunctions: SelectionStatisticFunction[] = [
+  {
+    name: _t("Sum"),
+    types: [CellValueType.number],
+    compute: (values, locale) => sum([[values]], locale),
+  },
+  {
+    name: _t("Avg"),
+    types: [CellValueType.number],
+    compute: (values, locale) => average([[values]], locale),
+  },
+  {
+    name: _t("Min"),
+    types: [CellValueType.number],
+    compute: (values, locale) => min([[values]], locale),
+  },
+  {
+    name: _t("Max"),
+    types: [CellValueType.number],
+    compute: (values, locale) => max([[values]], locale),
+  },
+  {
+    name: _t("Count"),
+    types: [CellValueType.number, CellValueType.text, CellValueType.boolean, CellValueType.error],
+    compute: (values) => countAny([[values]]),
+  },
+  {
+    name: _t("Count Numbers"),
+    types: [CellValueType.number, CellValueType.text, CellValueType.boolean, CellValueType.error],
+    compute: (values, locale) => countNumbers([[values]], locale),
+  },
+];
+
+export class AggregateStatisticsStore extends SpreadsheetStore {
+  statisticFnResults: StatisticFnResults = this._computeStatisticFnResults();
+  private isDirty = false;
+
+  constructor(get: Get) {
+    super(get);
+    this.model.selection.observe(this, {
+      handleEvent: this.handleEvent.bind(this),
+    });
+  }
+
+  handle(cmd: Command) {
+    if (
+      invalidateEvaluationCommands.has(cmd.type) ||
+      (cmd.type === "UPDATE_CELL" && "content" in cmd)
+    ) {
+      this.isDirty = true;
+    }
+    switch (cmd.type) {
+      case "HIDE_COLUMNS_ROWS":
+      case "UNHIDE_COLUMNS_ROWS":
+      case "GROUP_HEADERS":
+      case "UNGROUP_HEADERS":
+      case "ACTIVATE_SHEET":
+      case "ACTIVATE_NEXT_SHEET":
+      case "ACTIVATE_PREVIOUS_SHEET":
+      case "EVALUATE_CELLS":
+      case "UNDO":
+      case "REDO":
+        this.isDirty = true;
+    }
+  }
+
+  finalize() {
+    if (this.isDirty) {
+      this.isDirty = false;
+      this.statisticFnResults = this._computeStatisticFnResults();
+    }
+  }
+
+  handleEvent() {
+    if (this.getters.isGridSelectionActive()) {
+      this.statisticFnResults = this._computeStatisticFnResults();
+    }
+  }
+
+  private _computeStatisticFnResults(): StatisticFnResults {
+    const getters = this.getters;
+    const sheetId = getters.getActiveSheetId();
+    const cells = new Set<EvaluatedCell>();
+
+    const zones = getters.getSelectedZones();
+    for (const zone of zones) {
+      for (let col = zone.left; col <= zone.right; col++) {
+        for (let row = zone.top; row <= zone.bottom; row++) {
+          if (getters.isRowHidden(sheetId, row) || getters.isColHidden(sheetId, col)) {
+            continue; // Skip hidden cells
+          }
+
+          const evaluatedCell = getters.getEvaluatedCell({ sheetId, col, row });
+          if (evaluatedCell.type !== CellValueType.empty) {
+            cells.add(evaluatedCell);
+          }
+        }
+      }
+    }
+    const locale = getters.getLocale();
+    let statisticFnResults: StatisticFnResults = {};
+    for (let fn of selectionStatisticFunctions) {
+      // We don't want to display statistical information when there is no interest:
+      // We set the statistical result to undefined if the data handled by the selection
+      // does not match the data handled by the function.
+      // Ex: if there are only texts in the selection, we prefer that the SUM result
+      // be displayed as undefined rather than 0.
+      let fnResult: number | undefined = undefined;
+      const evaluatedCells = [...cells].filter((c) => fn.types.includes(c.type));
+      if (evaluatedCells.length) {
+        fnResult = fn.compute(evaluatedCells, locale);
+      }
+      statisticFnResults[fn.name] = fnResult;
+    }
+    return statisticFnResults;
+  }
+}

--- a/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
+++ b/src/components/bottom_bar_statistic/aggregate_statistics_store.ts
@@ -122,6 +122,7 @@ export class AggregateStatisticsStore extends SpreadsheetStore {
     }
     const locale = getters.getLocale();
     let statisticFnResults: StatisticFnResults = {};
+    const cellsArray = [...cells];
     for (let fn of selectionStatisticFunctions) {
       // We don't want to display statistical information when there is no interest:
       // We set the statistical result to undefined if the data handled by the selection
@@ -129,7 +130,7 @@ export class AggregateStatisticsStore extends SpreadsheetStore {
       // Ex: if there are only texts in the selection, we prefer that the SUM result
       // be displayed as undefined rather than 0.
       let fnResult: number | undefined = undefined;
-      const evaluatedCells = [...cells].filter((c) => fn.types.includes(c.type));
+      const evaluatedCells = cellsArray.filter((c) => fn.types.includes(c.type));
       if (evaluatedCells.length) {
         fnResult = fn.compute(evaluatedCells, locale);
       }

--- a/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -1,12 +1,11 @@
 import { Component, onWillUpdateProps } from "@odoo/owl";
-import { deepEquals } from "../../helpers";
 import { formatValue } from "../../helpers/format";
 import { MenuItemRegistry } from "../../registries/menu_items_registry";
 import { Store, useStore } from "../../store_engine";
 import { SpreadsheetChildEnv } from "../../types";
 import { Ripple } from "../animation/ripple";
 import { css } from "../helpers/css";
-import { AggregateStatisticsStore, StatisticFnResults } from "./aggregate_statistics_store";
+import { AggregateStatisticsStore } from "./aggregate_statistics_store";
 
 // -----------------------------------------------------------------------------
 // SpreadSheet
@@ -38,41 +37,34 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
   static components = { Ripple };
 
   selectedStatisticFn: string = "";
-  private statisticFnResults: StatisticFnResults = {};
   private store!: Store<AggregateStatisticsStore>;
 
   setup() {
     this.store = useStore(AggregateStatisticsStore);
-
     onWillUpdateProps(() => {
-      const newStatisticFnResults = this.store.statisticFnResults;
-      if (!deepEquals(newStatisticFnResults, this.statisticFnResults)) {
+      if (Object.values(this.store.statisticFnResults).every((result) => result === undefined)) {
         this.props.closeContextMenu();
       }
-      this.statisticFnResults = newStatisticFnResults;
     });
   }
 
   getSelectedStatistic() {
     // don't display button if no function has a result
-    if (Object.values(this.statisticFnResults).every((result) => result === undefined)) {
+    if (Object.values(this.store.statisticFnResults).every((result) => result === undefined)) {
       return undefined;
     }
     if (this.selectedStatisticFn === "") {
-      this.selectedStatisticFn = Object.keys(this.statisticFnResults)[0];
+      this.selectedStatisticFn = Object.keys(this.store.statisticFnResults)[0];
     }
-    return this.getComposedFnName(
-      this.selectedStatisticFn,
-      this.statisticFnResults[this.selectedStatisticFn]
-    );
+    return this.getComposedFnName(this.selectedStatisticFn);
   }
 
   listSelectionStatistics(ev: MouseEvent) {
     const registry = new MenuItemRegistry();
     let i = 0;
-    for (let [fnName, fnValue] of Object.entries(this.statisticFnResults)) {
+    for (let [fnName] of Object.entries(this.store.statisticFnResults)) {
       registry.add(fnName, {
-        name: this.getComposedFnName(fnName, fnValue),
+        name: () => this.getComposedFnName(fnName),
         sequence: i,
         isReadonlyAllowed: true,
         execute: () => {
@@ -86,8 +78,9 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
     this.props.openContextMenu(left + width, top, registry);
   }
 
-  private getComposedFnName(fnName: string, fnValue: number | undefined): string {
+  private getComposedFnName(fnName: string): string {
     const locale = this.env.model.getters.getLocale();
+    const fnValue = this.store.statisticFnResults[fnName];
     return fnName + ": " + (fnValue !== undefined ? formatValue(fnValue, { locale }) : "__");
   }
 }

--- a/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -2,9 +2,11 @@ import { Component, onWillUpdateProps } from "@odoo/owl";
 import { deepEquals } from "../../helpers";
 import { formatValue } from "../../helpers/format";
 import { MenuItemRegistry } from "../../registries/menu_items_registry";
+import { Store, useStore } from "../../store_engine";
 import { SpreadsheetChildEnv } from "../../types";
 import { Ripple } from "../animation/ripple";
 import { css } from "../helpers/css";
+import { AggregateStatisticsStore, StatisticFnResults } from "./aggregate_statistics_store";
 
 // -----------------------------------------------------------------------------
 // SpreadSheet
@@ -36,18 +38,17 @@ export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
   static components = { Ripple };
 
   selectedStatisticFn: string = "";
-  private statisticFnResults: { [name: string]: number | undefined } = {};
+  private statisticFnResults: StatisticFnResults = {};
+  private store!: Store<AggregateStatisticsStore>;
 
   setup() {
-    this.statisticFnResults = this.env.model.getters.getStatisticFnResults();
+    this.store = useStore(AggregateStatisticsStore);
 
     onWillUpdateProps(() => {
-      const newStatisticFnResults = this.env.model.getters.getStatisticFnResults();
-
+      const newStatisticFnResults = this.store.statisticFnResults;
       if (!deepEquals(newStatisticFnResults, this.statisticFnResults)) {
         this.props.closeContextMenu();
       }
-
       this.statisticFnResults = newStatisticFnResults;
     });
   }

--- a/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
+++ b/src/components/bottom_bar_statistic/bottom_bar_statistic.ts
@@ -28,7 +28,7 @@ interface Props {
 }
 
 export class BottomBarStatistic extends Component<Props, SpreadsheetChildEnv> {
-  static template = "o-spreadsheet-BottomBarStatisic";
+  static template = "o-spreadsheet-BottomBarStatistic";
   static props = {
     openContextMenu: Function,
     closeContextMenu: Function,

--- a/src/components/bottom_bar_statistic/bottom_bar_statistic.xml
+++ b/src/components/bottom_bar_statistic/bottom_bar_statistic.xml
@@ -1,5 +1,5 @@
 <templates>
-  <t t-name="o-spreadsheet-BottomBarStatisic">
+  <t t-name="o-spreadsheet-BottomBarStatistic">
     <t t-set="selectedStatistic" t-value="getSelectedStatistic()"/>
     <Ripple class="'ms-auto'" t-if="selectedStatistic !== undefined">
       <div

--- a/tests/bottom_bar/aggregate_statistics_store.test.ts
+++ b/tests/bottom_bar/aggregate_statistics_store.test.ts
@@ -1,0 +1,197 @@
+import { Model } from "../../src";
+import { AggregateStatisticsStore } from "../../src/components/bottom_bar_statistic/aggregate_statistics_store";
+import { functionRegistry } from "../../src/functions";
+import {
+  activateSheet,
+  addCellToSelection,
+  createSheet,
+  hideRows,
+  selectAll,
+  selectCell,
+  setAnchorCorner,
+  setCellContent,
+  setSelection,
+} from "../test_helpers/commands_helpers";
+import { getCellError, getEvaluatedCell } from "../test_helpers/getters_helpers";
+import { makeStore } from "../test_helpers/stores";
+
+describe("Aggregate statistic functions", () => {
+  test("functions are applied on deduplicated cells in zones", () => {
+    const { store, model } = makeStore(AggregateStatisticsStore);
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+    setCellContent(model, "A3", "3");
+
+    setSelection(model, ["A1:A2"]);
+    let statisticFnResults = store.statisticFnResults;
+    expect(statisticFnResults["Count"]).toBe(2);
+
+    // expand selection with the range A3:A2
+    addCellToSelection(model, "A3");
+    setAnchorCorner(model, "A2");
+
+    // A2 is now present in two selection
+    statisticFnResults = store.statisticFnResults;
+    expect(statisticFnResults["Count"]).toBe(3);
+  });
+
+  test("statistic function should not include hidden rows/columns in calculations", () => {
+    const { store, model } = makeStore(AggregateStatisticsStore);
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+    setCellContent(model, "A3", "3");
+
+    setSelection(model, ["A1:A4"]);
+    let statisticFnResults = store.statisticFnResults;
+    expect(statisticFnResults["Sum"]).toBe(6);
+
+    hideRows(model, [1, 2]);
+    statisticFnResults = store.statisticFnResults;
+    expect(statisticFnResults["Sum"]).toBe(1);
+  });
+
+  describe("return undefined if the types handled by the function are not present among the types of the selected cells", () => {
+    let model: Model;
+    let store: AggregateStatisticsStore;
+    beforeEach(() => {
+      ({ store, model } = makeStore(AggregateStatisticsStore));
+      setCellContent(model, "A1", "24");
+      setCellContent(model, "A2", "=42");
+      setCellContent(model, "A3", "107% of people don't get statistics");
+      setCellContent(model, "A4", "TRUE");
+      setCellContent(model, "A5", "=A5");
+      setCellContent(model, "A6", "=A7");
+    });
+
+    test('return the "SUM" value only on cells interpreted as number', () => {
+      // select the range A1:A7
+      selectCell(model, "A1");
+      setAnchorCorner(model, "A7");
+      let statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Sum"]).toBe(66);
+
+      selectCell(model, "A7");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Sum"]).toBe(undefined);
+    });
+
+    test('return the "Avg" result only on cells interpreted as number', () => {
+      // select the range A1:A7
+      selectCell(model, "A1");
+      setAnchorCorner(model, "A7");
+      let statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Avg"]).toBe(22);
+
+      selectCell(model, "A7");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Avg"]).toBe(undefined);
+    });
+
+    test('return "Min" value only on cells interpreted as number', () => {
+      // select the range A1:A7
+      selectCell(model, "A1");
+      setAnchorCorner(model, "A7");
+      let statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Min"]).toBe(0);
+
+      selectCell(model, "A7");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Min"]).toBe(undefined);
+    });
+
+    test('return the "Max" value only on cells interpreted as number', () => {
+      // select the range A1:A7
+      selectCell(model, "A1");
+      setAnchorCorner(model, "A7");
+      let statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Max"]).toBe(42);
+
+      selectCell(model, "A7");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Max"]).toBe(undefined);
+    });
+
+    test('return the "Count" value on all types of interpreted cells except on cells interpreted as empty', () => {
+      // select the range A1:A7
+      selectCell(model, "A1");
+      setAnchorCorner(model, "A7");
+      let statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Count"]).toBe(6);
+
+      selectCell(model, "A7");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Count"]).toBe(undefined);
+    });
+
+    test('return the "Count numbers" value on all types of interpreted cells except on cells interpreted as empty', () => {
+      selectCell(model, "A1");
+      let statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Count Numbers"]).toBe(1);
+
+      selectCell(model, "A2");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Count Numbers"]).toBe(1);
+
+      selectCell(model, "A3");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Count Numbers"]).toBe(0);
+
+      selectCell(model, "A4");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Count Numbers"]).toBe(0);
+
+      selectCell(model, "A5");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Count Numbers"]).toBe(0);
+
+      // select the range A6:A7
+      selectCell(model, "A6");
+      setAnchorCorner(model, "A7");
+      statisticFnResults = store.statisticFnResults;
+      expect(statisticFnResults["Count"]).toBe(1);
+    });
+  });
+
+  test("raise error from compilation with specific error message", () => {
+    functionRegistry.add("TWOARGSNEEDED", {
+      description: "any function",
+      compute: () => {
+        return true;
+      },
+      args: [
+        { name: "arg1", description: "", type: ["ANY"] },
+        { name: "arg2", description: "", type: ["ANY"] },
+      ],
+      returns: ["ANY"],
+    });
+
+    const model = new Model();
+    setCellContent(model, "A1", "=TWOARGSNEEDED(42)");
+
+    expect(getEvaluatedCell(model, "A1").value).toBe("#BAD_EXPR");
+    expect(getCellError(model, "A1")).toBe(
+      `Invalid number of arguments for the TWOARGSNEEDED function. Expected 2 minimum, but got 1 instead.`
+    );
+    functionRegistry.remove("TWOARGSNEEDED");
+  });
+
+  test("Statistics are recomputed when switching sheets", () => {
+    const { store, model } = makeStore(AggregateStatisticsStore);
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+    setCellContent(model, "A3", "3");
+    selectAll(model);
+    const sId1 = model.getters.getActiveSheetId();
+    const sId2 = "sh2";
+    createSheet(model, { sheetId: sId2 });
+    setCellContent(model, "A2", "4", sId2);
+    setCellContent(model, "A3", "4", sId2);
+    expect(store.statisticFnResults["Count"]).toBe(3);
+    activateSheet(model, sId2);
+    selectAll(model);
+    expect(store.statisticFnResults["Count"]).toBe(2);
+    activateSheet(model, sId1);
+    selectAll(model);
+    expect(store.statisticFnResults["Count"]).toBe(3);
+  });
+});

--- a/tests/bottom_bar/bottom_bar_component.test.ts
+++ b/tests/bottom_bar/bottom_bar_component.test.ts
@@ -657,7 +657,27 @@ describe("BottomBar component", () => {
     expect(fixture.querySelector(".o-selection-statistic")?.textContent).toBe("Count Numbers: 1");
   });
 
-  test("The list of statistics menu closes if the selection or the cell value change", async () => {
+  test("The list of statistics is updated with the selection", async () => {
+    const { model } = await mountBottomBar();
+    // Change value of cell
+    setCellContent(model, "A1", "24");
+    setCellContent(model, "A2", "23");
+    await nextTick();
+    triggerMouseEvent(".o-selection-statistic", "click");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu")).toBeTruthy();
+    expect(fixture.querySelector(".o-menu .o-menu-item")?.textContent).toBe("Sum: 24");
+
+    setCellContent(model, "A1", "42");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu .o-menu-item")?.textContent).toBe("Sum: 42");
+
+    selectCell(model, "A2");
+    await nextTick();
+    expect(fixture.querySelector(".o-menu .o-menu-item")?.textContent).toBe("Sum: 23");
+  });
+
+  test("Hide the statistics component when the statistics are empty", async () => {
     const { model } = await mountBottomBar();
     // Change value of cell
     setCellContent(model, "A1", "24");
@@ -665,18 +685,15 @@ describe("BottomBar component", () => {
     triggerMouseEvent(".o-selection-statistic", "click");
     await nextTick();
     expect(fixture.querySelector(".o-menu")).toBeTruthy();
+    expect(fixture.querySelector(".o-menu .o-menu-item")?.textContent).toBe("Sum: 24");
 
     setCellContent(model, "A1", "42");
     await nextTick();
-    expect(fixture.querySelector(".o-menu")).toBeFalsy();
-
-    // Change selection
-    triggerMouseEvent(".o-selection-statistic", "click");
-    await nextTick();
-    expect(fixture.querySelector(".o-menu")).toBeTruthy();
+    expect(fixture.querySelector(".o-menu .o-menu-item")?.textContent).toBe("Sum: 42");
 
     selectCell(model, "A2");
     await nextTick();
+    expect(fixture.querySelector(".o-selection-statistic")).toBeFalsy();
     expect(fixture.querySelector(".o-menu")).toBeFalsy();
   });
 


### PR DESCRIPTION
## Description:
Currently, the statistics results for the bottom bar are recomputed at
each call, which occurs everytime we force a full rendering (i.e. when
we dispatch a command). This computaion can be very costy depending on
the size of the current selection.
This commit moves the concerned code into a dedicated store (no need to
be part of the selection plugin) and caches the results, only
invalidating them whenever the selection is updated or if a command
susceptible to affect the statistics.


description of this task, what is implemented and why it is implemented that way.

Task: : [3820568](https://www.odoo.com/web#id=3820568&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo