### PR TITLE
[IMP] plugins: remove unused getters

### DIFF
--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -47,7 +47,6 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     "isInSameMerge",
     "isMergeHidden",
     "getMainCellPosition",
-    "getBottomLeftCell",
     "expandZone",
     "doesIntersectMerge",
     "doesColumnsHaveCommonMerges",
@@ -260,14 +259,6 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     }
     const mergeTopLeftPos = this.getMerge(position)!.topLeft;
     return { sheetId: position.sheetId, col: mergeTopLeftPos.col, row: mergeTopLeftPos.row };
-  }
-
-  getBottomLeftCell(position: CellPosition): CellPosition {
-    if (!this.isInMerge(position)) {
-      return position;
-    }
-    const { bottom, left } = this.getMerge(position)!;
-    return { sheetId: position.sheetId, col: left, row: bottom };
   }
 
   isMergeHidden(sheetId: UID, merge: Merge): boolean {

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -55,7 +55,6 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     "getSheetIds",
     "getVisibleSheetIds",
     "isSheetVisible",
-    "getEvaluationSheets",
     "doesHeaderExist",
     "doesHeadersExist",
     "getCell",
@@ -352,10 +351,6 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
     return this.orderedSheetIds.filter(this.isSheetVisible.bind(this));
   }
 
-  getEvaluationSheets(): Record<UID, Sheet | undefined> {
-    return this.sheets;
-  }
-
   doesHeaderExist(sheetId: UID, dimension: Dimension, index: number) {
     return dimension === "COL"
       ? index >= 0 && index < this.getNumberCols(sheetId)
@@ -364,14 +359,6 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
 
   doesHeadersExist(sheetId: UID, dimension: Dimension, headerIndexes: HeaderIndex[]): boolean {
     return headerIndexes.every((index) => this.doesHeaderExist(sheetId, dimension, index));
-  }
-
-  getRow(sheetId: UID, index: HeaderIndex): Row {
-    const row = this.getSheet(sheetId).rows[index];
-    if (!row) {
-      throw new Error(`Row ${row} not found.`);
-    }
-    return row;
   }
 
   getCell({ sheetId, col, row }: CellPosition): Cell | undefined {

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -6,7 +6,6 @@ import { getClipboardDataPositions } from "../../helpers/clipboard/clipboard_hel
 import {
   clip,
   deepCopy,
-  formatValue,
   isEqual,
   positionToZone,
   positions,
@@ -99,7 +98,6 @@ export class GridSelectionPlugin extends UIPlugin {
     "getSelectedZone",
     "getSelectedCells",
     "getStatisticFnResults",
-    "getAggregate",
     "getSelectedFigureId",
     "getSelection",
     "getActivePosition",
@@ -452,22 +450,6 @@ export class GridSelectionPlugin extends UIPlugin {
       statisticFnResults[fn.name] = fnResult;
     }
     return statisticFnResults;
-  }
-
-  getAggregate(): string | null {
-    let aggregate = 0;
-    let n = 0;
-    const sheetId = this.getters.getActiveSheetId();
-    const cellPositions = this.gridSelection.zones.map(positions).flat();
-    for (const { col, row } of cellPositions) {
-      const cell = this.getters.getEvaluatedCell({ sheetId, col, row });
-      if (cell.type === CellValueType.number) {
-        n++;
-        aggregate += cell.value;
-      }
-    }
-    const locale = this.getters.getLocale();
-    return n < 2 ? null : formatValue(aggregate, { locale });
   }
 
   isSelected(zone: Zone): boolean {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -17,7 +17,6 @@ import {
   Border,
   BorderData,
   CellPosition,
-  Color,
   Dimension,
   HeaderIndex,
   Pixel,
@@ -686,15 +685,6 @@ export interface ActivateSheetCommand {
   sheetIdTo: UID;
 }
 
-/**
- * Set a color to be used for the next selection to highlight.
- * The color is only used when selection highlight is enabled.
- */
-export interface SetColorCommand {
-  type: "SET_HIGHLIGHT_COLOR";
-  color: Color;
-}
-
 export interface EvaluateCellsCommand {
   type: "EVALUATE_CELLS";
 }
@@ -962,7 +952,6 @@ export type LocalCommand =
   | ActivateSheetCommand
   | EvaluateCellsCommand
   | StartChangeHighlightCommand
-  | SetColorCommand
   | StartCommand
   | AutofillCommand
   | AutofillSelectCommand


### PR DESCRIPTION
As the library evolved, some getters that were created for specific purpose became completely obsolete (sometimes the features evolved and theyr were replaces by better alternatives, sometimes, due to a conceptual evolution, like a finer split between plugins responsibilities). Some of those getters were not removed at the time and can be safely removed.

Task: 3825311

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo