### PR TITLE
[FIX] *: Compute max/min on huge arrays

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -274,3 +274,35 @@ export function deepEquals(o1: any, o2: any): boolean {
 
   return true;
 }
+
+/**
+ * Alternative to Math.max that works with large arrays.
+ * Typically useful for arrays bigger than 100k elements.
+ */
+export function largeMax(array: number[]) {
+  let len = array.length;
+
+  if (len < 100_000) return Math.max(...array);
+
+  let max: number = -Infinity;
+  while (len--) {
+    max = array[len] > max ? array[len] : max;
+  }
+  return max;
+}
+
+/**
+ * Alternative to Math.min that works with large arrays.
+ * Typically useful for arrays bigger than 100k elements.
+ */
+export function largeMin(array: number[]) {
+  let len = array.length;
+
+  if (len < 100_000) return Math.min(...array);
+
+  let min: number = +Infinity;
+  while (len--) {
+    min = array[len] < min ? array[len] : min;
+  }
+  return min;
+}

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -4,6 +4,8 @@ import {
   getComposerSheetName,
   groupConsecutive,
   isZoneValid,
+  largeMax,
+  largeMin,
   numberToLetters,
   rangeReference,
   splitReference,
@@ -59,8 +61,8 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
           let newRange = range;
           let changeType: ChangeType = "NONE";
           for (let group of groups) {
-            const min = Math.min(...group);
-            const max = Math.max(...group);
+            const min = largeMin(group);
+            const max = largeMax(group);
             if (range.zone[start] <= min && min <= range.zone[end]) {
               const toRemove = Math.min(range.zone[end], max) - min + 1;
               changeType = "RESIZE";

--- a/src/plugins/core/sheet.ts
+++ b/src/plugins/core/sheet.ts
@@ -11,6 +11,7 @@ import {
   isDefined,
   isZoneInside,
   isZoneValid,
+  largeMax,
   mapCellsInZone,
   numberToLetters,
   toCartesian,
@@ -950,8 +951,8 @@ export class SheetPlugin extends CorePlugin<SheetState> implements SheetState {
   private getImportedSheetSize(data: SheetData): { rowNumber: number; colNumber: number } {
     const positions = Object.keys(data.cells).map(toCartesian);
     return {
-      rowNumber: Math.max(data.rowNumber, ...new Set(positions.map(([col, row]) => row + 1))),
-      colNumber: Math.max(data.colNumber, ...new Set(positions.map(([col, row]) => col + 1))),
+      rowNumber: Math.max(data.rowNumber, largeMax(positions.map(([col, row]) => row + 1))),
+      colNumber: Math.max(data.colNumber, largeMax(positions.map(([col, row]) => col + 1))),
     };
   }
 

--- a/src/plugins/ui/automatic_sum.ts
+++ b/src/plugins/ui/automatic_sum.ts
@@ -3,6 +3,8 @@ import {
   groupConsecutive,
   isInside,
   isOneDimensional,
+  largeMax,
+  largeMin,
   mapCellsInZone,
   positions,
   range,
@@ -175,15 +177,15 @@ export class AutomaticSumPlugin extends UIPlugin {
     const invalidCells = cellPositions.filter(
       (position) => cells[position] && !cells[position]?.isAutoSummable
     );
-    const maxValidPosition = Math.max(...invalidCells);
+    const maxValidPosition = largeMax(invalidCells);
     const numberSequences = groupConsecutive(
       cellPositions.filter((position) => this.isNumber(cells[position]))
     );
     const firstSequence = numberSequences[0] || [];
-    if (Math.max(...firstSequence) < maxValidPosition) {
+    if (largeMax(firstSequence) < maxValidPosition) {
       return Infinity;
     }
-    return Math.min(...firstSequence);
+    return largeMin(firstSequence);
   }
 
   private shouldFindData(sheetId: UID, zone: Zone): boolean {

--- a/src/plugins/ui/ui_sheet.ts
+++ b/src/plugins/ui/ui_sheet.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_FONT_SIZE, PADDING_AUTORESIZE } from "../../constants";
 import { fontSizeMap } from "../../fonts";
-import { computeIconWidth, computeTextWidth } from "../../helpers/index";
+import { computeIconWidth, computeTextWidth, largeMax } from "../../helpers/index";
 import { _lt } from "../../translation";
 import { Cell, CellValueType, Command, CommandResult, UID, Zone } from "../../types";
 import { UIPlugin } from "../ui_plugin";
@@ -113,14 +113,14 @@ export class SheetUIPlugin extends UIPlugin {
   private getColMaxWidth(sheetId: UID, index: number): number {
     const cells = this.getters.getColCells(sheetId, index);
     const sizes = cells.map((cell: Cell) => this.getCellWidth(cell));
-    return Math.max(0, ...sizes);
+    return Math.max(0, largeMax(sizes));
   }
 
   private getRowMaxHeight(sheetId: UID, index: number): number {
     const sheet = this.getters.getSheet(sheetId);
     const cells = Object.values(sheet.rows[index].cells);
     const sizes = cells.map((cell: Cell) => this.getCellHeight(cell));
-    return Math.max(0, ...sizes);
+    return Math.max(0, largeMax(sizes));
   }
 
   private interactiveRenameSheet(sheetId: UID, title: string) {

--- a/src/registries/menus/menu_items_actions.ts
+++ b/src/registries/menus/menu_items_actions.ts
@@ -1,5 +1,5 @@
 import { BACKGROUND_CHART_COLOR } from "../../constants";
-import { numberToLetters, zoneToXc } from "../../helpers/index";
+import { largeMax, largeMin, numberToLetters, zoneToXc } from "../../helpers/index";
 import { _lt } from "../../translation";
 import { CellValueType, SpreadsheetEnv, Style } from "../../types/index";
 
@@ -114,8 +114,8 @@ export const DELETE_CONTENT_ROWS_NAME = (env: SpreadsheetEnv) => {
   let last: number;
   const activesRows = env.getters.getActiveRows();
   if (activesRows.size !== 0) {
-    first = Math.min(...activesRows);
-    last = Math.max(...activesRows);
+    first = largeMin([...activesRows]);
+    last = largeMax([...activesRows]);
   } else {
     const zone = env.getters.getSelectedZones()[0];
     first = zone.top;
@@ -143,8 +143,8 @@ export const DELETE_CONTENT_COLUMNS_NAME = (env: SpreadsheetEnv) => {
   let last: number;
   const activeCols = env.getters.getActiveCols();
   if (activeCols.size !== 0) {
-    first = Math.min(...activeCols);
-    last = Math.max(...activeCols);
+    first = largeMin([...activeCols]);
+    last = largeMax([...activeCols]);
   } else {
     const zone = env.getters.getSelectedZones()[0];
     first = zone.left;
@@ -172,8 +172,8 @@ export const REMOVE_ROWS_NAME = (env: SpreadsheetEnv) => {
   let last: number;
   const activesRows = env.getters.getActiveRows();
   if (activesRows.size !== 0) {
-    first = Math.min(...activesRows);
-    last = Math.max(...activesRows);
+    first = largeMin([...activesRows]);
+    last = largeMax([...activesRows]);
   } else {
     const zone = env.getters.getSelectedZones()[0];
     first = zone.top;
@@ -205,8 +205,8 @@ export const REMOVE_COLUMNS_NAME = (env: SpreadsheetEnv) => {
   let last: number;
   const activeCols = env.getters.getActiveCols();
   if (activeCols.size !== 0) {
-    first = Math.min(...activeCols);
-    last = Math.max(...activeCols);
+    first = largeMin([...activeCols]);
+    last = largeMax([...activeCols]);
   } else {
     const zone = env.getters.getSelectedZones()[0];
     first = zone.left;
@@ -279,7 +279,7 @@ export const INSERT_ROWS_BEFORE_ACTION = (env: SpreadsheetEnv) => {
   let row: number;
   let quantity: number;
   if (activeRows.size) {
-    row = Math.min(...activeRows);
+    row = largeMin([...activeRows]);
     quantity = activeRows.size;
   } else {
     const zone = env.getters.getSelectedZones()[0];
@@ -313,7 +313,7 @@ export const INSERT_ROWS_AFTER_ACTION = (env: SpreadsheetEnv) => {
   let row: number;
   let quantity: number;
   if (activeRows.size) {
-    row = Math.max(...activeRows);
+    row = largeMax([...activeRows]);
     quantity = activeRows.size;
   } else {
     const zone = env.getters.getSelectedZones()[0];
@@ -357,7 +357,7 @@ export const INSERT_COLUMNS_BEFORE_ACTION = (env: SpreadsheetEnv) => {
   let column: number;
   let quantity: number;
   if (activeCols.size) {
-    column = Math.min(...activeCols);
+    column = largeMin([...activeCols]);
     quantity = activeCols.size;
   } else {
     const zone = env.getters.getSelectedZones()[0];
@@ -393,7 +393,7 @@ export const INSERT_COLUMNS_AFTER_ACTION = (env: SpreadsheetEnv) => {
   let column: number;
   let quantity: number;
   if (activeCols.size) {
-    column = Math.max(...activeCols);
+    column = largeMax([...activeCols]);
     quantity = activeCols.size;
   } else {
     const zone = env.getters.getSelectedZones()[0];


### PR DESCRIPTION
This is an extension of PR #1217. Navigators (or rather javascript engines) have a limit to the number of function arguments [1].

We sometimes have to use Math.max and Math.min functions (which are subject to this limitation) on every cell/column/row which means that we are functionally limited.

E.g. If we take the limitation of Chrome, we could only process 117k rows, which is not such a huge number if we consider the situation of a user importing their data.

This revision introduces wrappers `largeMax` and `largeMin` which take an  1-D array (a single argument) and find the maximum (resp. minimum) present in that list. For arrays with les than a 100K cells, the wrapper will still call Math.max as its implementation is most of the time faster.

[1]: Experimentally, that limit is 117k on Google Chrome and 501k on Firefox.

Task: 3802691

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo