### PR TITLE
[FIX] xlsx: slice long sheet names at export

### DIFF
--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -71,6 +71,7 @@ import {
 import { Image } from "../../src/types/image";
 import { XLSXExport } from "../../src/types/xlsx";
 import { isXLSXExportXMLFile } from "../../src/xlsx/helpers/xlsx_helper";
+import { fixLengthySheetNames } from "../../src/xlsx/xlsx_writer";
 import { FileStore } from "../__mocks__/mock_file_store";
 import { registerCleanup } from "../setup/jest.setup";
 import { MockClipboard } from "./clipboard";
@@ -642,7 +643,7 @@ export function getExportedExcelData(model: Model): ExcelWorkbookData {
       handler.exportForExcel(data);
     }
   }
-  return data;
+  return fixLengthySheetNames(data);
 }
 
 export function mockUuidV4To(model: Model, value: number | string) {

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -1446,6 +1446,51 @@ describe("Test XLSX export", () => {
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
   });
+
+  test("Sheet names longer than 31 characters are sliced in the Excel Export", () => {
+    const model = new Model();
+    const longSheetName = "a".repeat(40);
+    const longSheetNameWithSpaces = "Hey " + "a".repeat(40);
+    createSheet(model, { name: longSheetNameWithSpaces });
+    createSheet(model, { name: longSheetName });
+    setCellContent(model, "A1", `='${longSheetNameWithSpaces}'!A1`);
+    createChart(model, {
+      dataSets: [`${longSheetName}!A1:A4`],
+      labelRange: `${longSheetName}!A1:A4`,
+    });
+
+    const fixedSheetName = "a".repeat(31);
+    const fixedSheetNameWithSpaces = "Hey " + "a".repeat(27);
+    const exportedData = getExportedExcelData(model);
+    expect(exportedData.sheets[1].name).toBe(fixedSheetName);
+    expect(exportedData.sheets[0].cells["A1"]?.content).toBe(`='${fixedSheetNameWithSpaces}'!A1`);
+    expect(exportedData.sheets[0].charts[0].data.labelRange).toBe(`${fixedSheetName}!A2:A4`);
+    expect(exportedData.sheets[0].charts[0].data.dataSets[0]).toEqual({
+      label: `${fixedSheetName}!A1`,
+      range: `${fixedSheetName}!A2:A4`,
+    });
+  });
+
+  test("Avoid duplicated sheet names in excel export if multiple sliced names are the same", () => {
+    const model = new Model();
+    createSheet(model, { name: "a".repeat(40) });
+    createSheet(model, { name: "a".repeat(41) });
+    createSheet(model, { name: "a".repeat(42) });
+    const exportedExcelData = getExportedExcelData(model);
+    expect(exportedExcelData.sheets[1].name).toBe("a".repeat(31));
+    expect(exportedExcelData.sheets[2].name).toBe("a".repeat(30) + "1");
+    expect(exportedExcelData.sheets[3].name).toBe("a".repeat(30) + "2");
+  });
+
+  test("Cells whose content are the same as a too long sheet name are not changed", () => {
+    const model = new Model();
+    const longFormula = "=A1+A2+A3+A4+A5+A6+A7+A8+A9+A10+A11+A12+A13+A14+A15+A16";
+    createSheet(model, { name: longFormula });
+    setCellContent(model, "A1", longFormula);
+    const exportedExcelData = getExportedExcelData(model);
+    expect(exportedExcelData.sheets[1].name).toBe(longFormula.slice(0, 31));
+    expect(exportedExcelData.sheets[0].cells["A1"]?.content).toBe(longFormula);
+  });
 });
 
 describe("XML parser", () => {


### PR DESCRIPTION
## Description

Excel has a limit of 31 characters for sheet names. This commit slices the sheet names at export time to ensure that the sheet names are not too long.

We also try to rename all the references that contain the old sheet name to the new sheet name. This does not work for dynamically constructed references (e.g. =INDIRECT(CONCAT("sheet", "name!A1"))).

We do a very simple approach to renaming the references, with a simple regex on the stringified exported data. This might break the content of some cells if the cell's content is the same as the old sheet name. This should be a good enough solution for now, as we don't want to spend resources and bloat the codebase for an edge case of an edge case.

Task: : [3801848](https://www.odoo.com/web#id=3801848&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo