### PR TITLE
[ADD] pivots: add pivot plumbing

### DIFF
--- a/src/collaborative/ot/ot_specific.ts
+++ b/src/collaborative/ot/ot_specific.ts
@@ -14,18 +14,23 @@ import {
   CreateSheetCommand,
   DeleteFigureCommand,
   DeleteSheetCommand,
+  DuplicatePivotCommand,
   FoldHeaderGroupCommand,
   FreezeColumnsCommand,
   FreezeRowsCommand,
   GroupHeadersCommand,
   HeaderIndex,
+  InsertPivotCommand,
   MoveRangeCommand,
   RemoveColumnsRowsCommand,
   RemoveMergeCommand,
+  RemovePivotCommand,
+  RenamePivotCommand,
   UnGroupHeadersCommand,
   UnfoldHeaderGroupCommand,
   UpdateChartCommand,
   UpdateFigureCommand,
+  UpdatePivotCommand,
   UpdateTableCommand,
   Zone,
 } from "../../types";
@@ -74,6 +79,22 @@ otRegistry.addTransformation(
   ["GROUP_HEADERS", "UNGROUP_HEADERS", "FOLD_HEADER_GROUP", "UNFOLD_HEADER_GROUP"],
   groupHeadersTransformation
 );
+
+otRegistry.addTransformation(
+  "REMOVE_PIVOT",
+  ["RENAME_PIVOT", "DUPLICATE_PIVOT", "INSERT_PIVOT", "UPDATE_PIVOT"],
+  pivotTransformation
+);
+
+function pivotTransformation(
+  toTransform: RenamePivotCommand | DuplicatePivotCommand | InsertPivotCommand | UpdatePivotCommand,
+  executed: RemovePivotCommand
+) {
+  if (toTransform.pivotId === executed.pivotId) {
+    return undefined;
+  }
+  return toTransform;
+}
 
 function transformTargetSheetId(
   toTransform: MoveRangeCommand,

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -956,4 +956,17 @@ https://fontawesome.com/license -->
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.PIVOT">
+    <svg class="o-icon" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fill="currentColor"
+        d="M17 2v14H1V6h4V2h12m-1 1H6v3h10M2 7v2h3V7m-3 3v2h3v-2m-3 3v2h3v-2m1-6v2h6V7m-6 3v2h6v-2m-6 3v2h6v-2m1-6v2h3V7m-3 3v2h3v-2m-3 3v2h3v-2"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.UNUSED_PIVOT_WARNING">
+    <div class="o-unused-pivot-icon text-warning" title="This pivot is not used">
+      <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
+    </div>
+  </t>
 </templates>

--- a/src/components/side_panel/pivot/all_pivots_side_panel.ts
+++ b/src/components/side_panel/pivot/all_pivots_side_panel.ts
@@ -1,0 +1,26 @@
+import { Component, useRef } from "@odoo/owl";
+import { getPivotHighlights } from "../../../helpers/pivot/pivot_highlight";
+import { useHighlightsOnHover } from "../../helpers/highlight_hook";
+
+class PivotPreview extends Component {
+  static template = "o-spreadsheet-PivotPreview";
+  static props = { pivotId: String };
+  setup() {
+    const previewRef = useRef("pivotPreview");
+    useHighlightsOnHover(previewRef, this);
+  }
+
+  selectPivot() {
+    this.env.openSidePanel("PIVOT_PROPERTIES_PANEL", { pivotId: this.props.pivotId });
+  }
+
+  get highlights() {
+    return getPivotHighlights(this.env.model.getters, this.props.pivotId);
+  }
+}
+
+export class AllPivotsSidePanel extends Component {
+  static template = "o-spreadsheet-AllPivotsSidePanel";
+  static components = { PivotPreview };
+  static props = { onCloseSidePanel: Function };
+}

--- a/src/components/side_panel/pivot/all_pivots_side_panel.xml
+++ b/src/components/side_panel/pivot/all_pivots_side_panel.xml
@@ -1,0 +1,13 @@
+<templates>
+  <div t-name="o-spreadsheet-AllPivotsSidePanel" class="o_spreadsheet_pivot_side_panel">
+    <t t-foreach="env.model.getters.getPivotIds()" t-as="pivotId" t-key="pivotId">
+      <PivotPreview pivotId="pivotId"/>
+    </t>
+  </div>
+
+  <t t-name="o-spreadsheet-PivotPreview">
+    <div class="o_side_panel_select" t-ref="pivotPreview" t-on-click="this.selectPivot">
+      <span t-esc="env.model.getters.getPivotDisplayName(props.pivotId)"/>
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/pivot/editable_name/editable_name.ts
+++ b/src/components/side_panel/pivot/editable_name/editable_name.ts
@@ -1,0 +1,37 @@
+/** @odoo-module */
+
+import { Component, useState } from "@odoo/owl";
+import { SpreadsheetChildEnv } from "../../../..";
+
+interface Props {
+  name: string;
+  displayName: string;
+  onChanged: (name: string) => void;
+}
+
+export class EditableName extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-EditableName";
+  static props = {
+    name: String,
+    displayName: String,
+    onChanged: Function,
+  };
+  private state!: { isEditing: boolean; name: string };
+
+  setup() {
+    this.state = useState({
+      isEditing: false,
+      name: "",
+    });
+  }
+
+  rename() {
+    this.state.isEditing = true;
+    this.state.name = this.props.name;
+  }
+
+  save() {
+    this.props.onChanged(this.state.name.trim());
+    this.state.isEditing = false;
+  }
+}

--- a/src/components/side_panel/pivot/editable_name/editable_name.xml
+++ b/src/components/side_panel/pivot/editable_name/editable_name.xml
@@ -1,0 +1,19 @@
+<templates>
+  <t t-name="o-spreadsheet-EditableName">
+    <t t-if="state.isEditing">
+      <div>
+        <input type="text" class="o_input o_sp_en_name" t-model="state.name"/>
+      </div>
+      <div class="btn btn-link o_sp_en_save" t-on-click="save">Save</div>
+      <br/>
+    </t>
+    <t t-else="">
+      <div class="o_sp_en_display_name" t-esc="props.displayName"/>
+      <div class="btn btn-link o_sp_en_rename" t-on-click="rename">
+        <i class="fa fa-pencil me-1"/>
+        Rename
+      </div>
+      <br/>
+    </t>
+  </t>
+</templates>

--- a/src/components/side_panel/pivot/pivot_dimensions/add_dimension_button/add_dimension_button.ts
+++ b/src/components/side_panel/pivot/pivot_dimensions/add_dimension_button/add_dimension_button.ts
@@ -1,0 +1,84 @@
+import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { SpreadsheetChildEnv } from "../../../../..";
+import { fuzzyLookup } from "../../../../../helpers";
+import { PivotField } from "../../../../../types/pivot";
+import { css } from "../../../../helpers";
+import { Popover } from "../../../../popover";
+
+interface Props {
+  onFieldPicked: (field: string) => void;
+  fields: PivotField[];
+}
+
+css/* scss */ `
+  input.pivot-dimension-search-field:focus {
+    outline: none;
+  }
+  .pivot-dimension-search-field-icon svg {
+    width: 13px;
+    height: 13px;
+  }
+  .pivot-dimension-search {
+    background-color: white;
+  }
+  .pivot-dimension-field {
+    background-color: white;
+
+    &:hover {
+      background-color: #f0f0f0;
+    }
+  }
+`;
+
+export class AddDimensionButton extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-AddDimensionButton";
+  static components = { Popover };
+  static props = {
+    onFieldPicked: Function,
+    fields: Array,
+  };
+
+  private buttonRef = useRef("button");
+  private popover = useState({ isOpen: false });
+  private search = useState({ input: "" });
+
+  // TODO navigation keys. (this looks a lot like auto-complete list. Could maybe be factorized)
+  setup() {
+    useExternalListener(window, "click", (ev) => {
+      if (ev.target !== this.buttonRef.el) {
+        this.popover.isOpen = false;
+      }
+    });
+  }
+
+  get filteredFields() {
+    if (this.search.input) {
+      return fuzzyLookup(this.search.input, this.props.fields, (field) => field.string);
+    }
+    return this.props.fields;
+  }
+
+  get popoverProps() {
+    return {
+      anchorRect: this.buttonRef.el!.getBoundingClientRect(),
+      positioning: "BottomLeft",
+    };
+  }
+
+  pickField(field: PivotField) {
+    this.props.onFieldPicked(field.name);
+    this.popover.isOpen = false;
+    this.search.input = "";
+  }
+
+  togglePopover() {
+    this.popover.isOpen = !this.popover.isOpen;
+    this.search.input = "";
+  }
+
+  onKeyDown(ev: KeyboardEvent) {
+    if (this.filteredFields.length === 1 && ev.key === "Enter") {
+      this.pickField(this.filteredFields[0]);
+    }
+  }
+}

--- a/src/components/side_panel/pivot/pivot_dimensions/add_dimension_button/add_dimension_button.xml
+++ b/src/components/side_panel/pivot/pivot_dimensions/add_dimension_button/add_dimension_button.xml
@@ -1,0 +1,30 @@
+<templates>
+  <t t-name="o-spreadsheet-AddDimensionButton">
+    <span class="btn btn-sm btn-link add-dimension" t-on-click="togglePopover" t-ref="button">
+      Add
+    </span>
+    <Popover t-if="popover.isOpen" t-props="popoverProps">
+      <div class="p-2 bg-white border-bottom d-flex align-items-baseline pivot-dimension-search">
+        <i class="pe-1 pivot-dimension-search-field-icon">
+          <t t-call="o-spreadsheet-Icon.SEARCH"/>
+        </i>
+        <input
+          t-model="search.input"
+          t-on-keydown="onKeyDown"
+          class="border-0 w-100 pivot-dimension-search-field"
+          autofocus="1"
+        />
+      </div>
+      <div
+        t-foreach="filteredFields"
+        t-as="field"
+        t-key="field.name"
+        t-esc="field.string"
+        t-att-title="field.help"
+        t-on-click="() => this.pickField(field)"
+        class="p-1 px-2 pivot-dimension-field"
+        role="button"
+      />
+    </Popover>
+  </t>
+</templates>

--- a/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension/pivot_dimension.ts
+++ b/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension/pivot_dimension.ts
@@ -1,0 +1,28 @@
+import { Component } from "@odoo/owl";
+import { SpreadsheetChildEnv } from "../../../../..";
+import { css } from "../../../../helpers";
+
+interface Props {
+  dimension: PivotDimension;
+  onRemoved: (dimension: PivotDimension) => void;
+}
+
+// don't use bg-white since it's flipped to dark in dark mode and we don't support dark mode
+css/* scss */ `
+  .pivot-dimension {
+    background-color: white;
+
+    select > option {
+      background-color: white;
+    }
+  }
+`;
+
+export class PivotDimension extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-PivotDimension";
+  static props = {
+    dimension: Object,
+    onRemoved: { type: Function, optional: true },
+    slots: { type: Object, optional: true },
+  };
+}

--- a/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension/pivot_dimension.xml
+++ b/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension/pivot_dimension.xml
@@ -1,0 +1,15 @@
+<templates>
+  <t t-name="o-spreadsheet-PivotDimension">
+    <div class="border py-1 px-2 d-flex flex-column shadow-sm pivot-dimension">
+      <div class="d-flex flex-row justify-content-between align-items-center">
+        <span class="fw-bold" t-esc="props.dimension.displayName"/>
+        <i
+          class="btn fa fa-times pe-0"
+          t-if="props.onRemoved"
+          t-on-click="() => props.onRemoved(props.dimension)"
+        />
+      </div>
+      <t t-slot="default"/>
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension_granularity/pivot_dimension_granularity.ts
+++ b/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension_granularity/pivot_dimension_granularity.ts
@@ -1,0 +1,21 @@
+import { Component } from "@odoo/owl";
+import { SpreadsheetChildEnv } from "../../../../..";
+import { PERIODS } from "../../../../../helpers/pivot/pivot_helpers";
+import { PivotDimension } from "../../../../../types/pivot";
+
+interface Props {
+  dimension: PivotDimension;
+  onUpdated: (dimension: PivotDimension, ev: InputEvent) => void;
+  availableGranularities: Set<string>;
+}
+
+export class PivotDimensionGranularity extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-PivotDimensionGranularity";
+  static props = {
+    dimension: Object,
+    onUpdated: Function,
+    availableGranularities: Set,
+  };
+  periods = PERIODS;
+  allGranularities = Object.keys(PERIODS);
+}

--- a/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension_granularity/pivot_dimension_granularity.xml
+++ b/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension_granularity/pivot_dimension_granularity.xml
@@ -1,0 +1,23 @@
+<templates>
+  <t t-name="o-spreadsheet-PivotDimensionGranularity">
+    <div class="d-flex flex-row">
+      <div class="d-flex flex-row py-1 px-2 w-100 small">
+        <t t-set="granularity" t-value="props.dimension.granularity"/>
+        <div class="flex-basis-50">Granularity</div>
+        <select
+          class="o_input flex-basis-50"
+          t-on-change="(ev) => props.onUpdated(props.dimension, ev.target.value)">
+          <option
+            t-foreach="allGranularities"
+            t-as="granularity"
+            t-key="granularity"
+            t-if="props.availableGranularities.has(granularity) || granularity === props.dimension.granularity"
+            t-att-value="granularity"
+            t-esc="periods[granularity]"
+            t-att-selected="granularity === props.dimension.granularity or (granularity === 'month' and !props.dimension.granularity)"
+          />
+        </select>
+      </div>
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension_order/pivot_dimension_order.ts
+++ b/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension_order/pivot_dimension_order.ts
@@ -1,0 +1,16 @@
+import { Component } from "@odoo/owl";
+import { SpreadsheetChildEnv } from "../../../../..";
+import { PivotDimension } from "../../../../../types/pivot";
+
+interface Props {
+  dimension: PivotDimension;
+  onUpdated: (dimension: PivotDimension, ev: InputEvent) => void;
+}
+
+export class PivotDimensionOrder extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-PivotDimensionOrder";
+  static props = {
+    dimension: Object,
+    onUpdated: Function,
+  };
+}

--- a/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension_order/pivot_dimension_order.xml
+++ b/src/components/side_panel/pivot/pivot_dimensions/pivot_dimension_order/pivot_dimension_order.xml
@@ -1,0 +1,16 @@
+<templates>
+  <t t-name="o-spreadsheet-PivotDimensionOrder">
+    <div class="d-flex">
+      <div class="d-flex py-1 px-2 w-100 small">
+        <div class="flex-basis-50">Order by</div>
+        <select
+          class="o_input flex-basis-50"
+          t-on-change="(ev) => props.onUpdated(props.dimension, ev.target.value)">
+          <option value="" t-att-selected="props.dimension.order === undefined">Automatic</option>
+          <option value="asc" t-att-selected="props.dimension.order === 'asc'">Ascending</option>
+          <option value="desc" t-att-selected="props.dimension.order === 'desc'">Descending</option>
+        </select>
+      </div>
+    </div>
+  </t>
+</templates>

--- a/src/components/side_panel/pivot/pivot_dimensions/pivot_dimensions.ts
+++ b/src/components/side_panel/pivot/pivot_dimensions/pivot_dimensions.ts
@@ -1,0 +1,226 @@
+import { Component, useRef } from "@odoo/owl";
+import { SpreadsheetChildEnv } from "../../../..";
+import { isDefined } from "../../../../helpers";
+import { AGGREGATORS, isDateField, parseDimension } from "../../../../helpers/pivot/pivot_helpers";
+import { PivotRuntimeDefinition } from "../../../../helpers/pivot/pivot_runtime_definition";
+import {
+  Granularity,
+  PivotCoreDefinition,
+  PivotCoreDimension,
+  PivotCoreMeasure,
+  PivotDimension as PivotDimensionType,
+  PivotField,
+  PivotMeasure,
+} from "../../../../types/pivot";
+import { useDragAndDropListItems } from "../../../helpers/drag_and_drop_hook";
+import { AddDimensionButton } from "./add_dimension_button/add_dimension_button";
+import { PivotDimension } from "./pivot_dimension/pivot_dimension";
+import { PivotDimensionGranularity } from "./pivot_dimension_granularity/pivot_dimension_granularity";
+import { PivotDimensionOrder } from "./pivot_dimension_order/pivot_dimension_order";
+
+interface Props {
+  definition: PivotRuntimeDefinition;
+  onDimensionsUpdated: (definition: Partial<PivotCoreDefinition>) => void;
+  unusedGroupableFields: PivotField[];
+  unusedMeasureFields: PivotField[];
+  unusedDateTimeGranularities: Record<string, Set<string>>;
+}
+
+export class PivotDimensions extends Component<Props, SpreadsheetChildEnv> {
+  static template = "o-spreadsheet-PivotDimensions";
+  static components = {
+    AddDimensionButton,
+    PivotDimension,
+    PivotDimensionOrder,
+    PivotDimensionGranularity,
+  };
+  static props = {
+    definition: Object,
+    onDimensionsUpdated: Function,
+    unusedGroupableFields: Array,
+    unusedMeasureFields: Array,
+    unusedDateTimeGranularities: Object,
+  };
+
+  private dimensionsRef = useRef("pivot-dimensions");
+  private dragAndDrop = useDragAndDropListItems();
+  AGGREGATORS = AGGREGATORS;
+  isDateField = isDateField;
+
+  startDragAndDrop(dimension: PivotDimensionType, event: MouseEvent) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    const rects = this.getDimensionElementsRects();
+    const definition = this.props.definition;
+    const { columns, rows } = definition;
+    const draggableIds = [
+      ...columns.map((col) => col.nameWithGranularity),
+      "__rows_title__",
+      ...rows.map((row) => row.nameWithGranularity),
+    ];
+    const offset = 1; // column title
+    const draggableItems = draggableIds.map((id, index) => ({
+      id,
+      size: rects[index + offset].height,
+      position: rects[index + offset].y,
+    }));
+    this.dragAndDrop.start("vertical", {
+      draggedItemId: dimension.nameWithGranularity,
+      initialMousePosition: event.clientY,
+      items: draggableItems,
+      containerEl: this.dimensionsRef.el!,
+      onDragEnd: (dimensionName, finalIndex) => {
+        const originalIndex = draggableIds.findIndex((id) => id === dimensionName);
+        if (originalIndex === finalIndex) {
+          return;
+        }
+        const draggedItems = [...draggableIds];
+        draggedItems.splice(originalIndex, 1);
+        draggedItems.splice(finalIndex, 0, dimensionName);
+        const columns = draggedItems.slice(0, draggedItems.indexOf("__rows_title__"));
+        const rows = draggedItems.slice(draggedItems.indexOf("__rows_title__") + 1);
+        this.props.onDimensionsUpdated({
+          columns: columns.map(parseDimension),
+          rows: rows.map(parseDimension),
+        });
+      },
+    });
+  }
+
+  startDragAndDropMeasures(measure: PivotMeasure, event: MouseEvent) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    const rects = this.getDimensionElementsRects();
+    const definition = this.props.definition;
+    const { measures, columns, rows } = definition;
+    const draggableIds = measures.map((m) => m.name);
+    const offset = 3 + columns.length + rows.length; // column title, row title, measure title
+    const draggableItems = draggableIds.map((id, index) => ({
+      id,
+      size: rects[index + offset].height,
+      position: rects[index + offset].y,
+    }));
+    this.dragAndDrop.start("vertical", {
+      draggedItemId: measure.name,
+      initialMousePosition: event.clientY,
+      items: draggableItems,
+      containerEl: this.dimensionsRef.el!,
+      onDragEnd: (measureName, finalIndex) => {
+        const originalIndex = draggableIds.findIndex((id) => id === measureName);
+        if (originalIndex === finalIndex) {
+          return;
+        }
+        const draggedItems = [...draggableIds];
+        draggedItems.splice(originalIndex, 1);
+        draggedItems.splice(finalIndex, 0, measureName);
+        this.props.onDimensionsUpdated({
+          measures: draggedItems
+            .map((m) => measures.find((measure) => measure.name === m))
+            .filter(isDefined),
+        });
+      },
+    });
+  }
+
+  getDimensionElementsRects() {
+    return Array.from(this.dimensionsRef.el!.children).map((el) => {
+      const style = getComputedStyle(el)!;
+      const rect = el.getBoundingClientRect();
+      return {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width + parseInt(style.marginLeft || "0") + parseInt(style.marginRight || "0"),
+        height:
+          rect.height + parseInt(style.marginTop || "0") + parseInt(style.marginBottom || "0"),
+      };
+    });
+  }
+
+  removeDimension(dimension: PivotDimensionType) {
+    const { columns, rows } = this.props.definition;
+    this.props.onDimensionsUpdated({
+      columns: columns.filter((col) => col.nameWithGranularity !== dimension.nameWithGranularity),
+      rows: rows.filter((row) => row.nameWithGranularity !== dimension.nameWithGranularity),
+    });
+  }
+
+  removeMeasureDimension(measure: PivotMeasure) {
+    const { measures } = this.props.definition;
+    this.props.onDimensionsUpdated({
+      measures: measures.filter((m) => m.name !== measure.name),
+    });
+  }
+
+  addColumnDimension(fieldName: string) {
+    const { columns }: { columns: PivotCoreDimension[] } = this.props.definition;
+    this.props.onDimensionsUpdated({
+      columns: columns.concat([{ name: fieldName }]),
+    });
+  }
+
+  addRowDimension(fieldName: string) {
+    const { rows }: { rows: PivotCoreDimension[] } = this.props.definition;
+    this.props.onDimensionsUpdated({
+      rows: rows.concat([{ name: fieldName }]),
+    });
+  }
+
+  addMeasureDimension(fieldName: string) {
+    const { measures }: { measures: PivotCoreMeasure[] } = this.props.definition;
+    this.props.onDimensionsUpdated({
+      measures: measures.concat([{ name: fieldName }]),
+    });
+  }
+
+  updateAggregator(updatedMeasure: PivotMeasure, aggregator: string) {
+    const { measures } = this.props.definition;
+    this.props.onDimensionsUpdated({
+      measures: measures.map((measure) => {
+        if (measure === updatedMeasure) {
+          return { ...measure, aggregator };
+        }
+        return measure;
+      }),
+    });
+  }
+
+  updateOrder(updateDimension: PivotDimensionType, order?: "asc" | "desc") {
+    const { rows, columns } = this.props.definition;
+    this.props.onDimensionsUpdated({
+      rows: rows.map((row) => {
+        if (row.nameWithGranularity === updateDimension.nameWithGranularity) {
+          return { ...row, order: order || undefined };
+        }
+        return row;
+      }),
+      columns: columns.map((col) => {
+        if (col.nameWithGranularity === updateDimension.nameWithGranularity) {
+          return { ...col, order: order || undefined };
+        }
+        return col;
+      }),
+    });
+  }
+
+  updateGranularity(dimension: PivotDimensionType, granularity: Granularity) {
+    const { rows, columns } = this.props.definition;
+    this.props.onDimensionsUpdated({
+      rows: rows.map((row) => {
+        if (row.nameWithGranularity === dimension.nameWithGranularity) {
+          return { ...row, granularity };
+        }
+        return row;
+      }),
+      columns: columns.map((col) => {
+        if (col.nameWithGranularity === dimension.nameWithGranularity) {
+          return { ...col, granularity };
+        }
+        return col;
+      }),
+    });
+  }
+}

--- a/src/components/side_panel/pivot/pivot_dimensions/pivot_dimensions.xml
+++ b/src/components/side_panel/pivot/pivot_dimensions/pivot_dimensions.xml
@@ -1,0 +1,87 @@
+<templates>
+  <t t-name="o-spreadsheet-PivotDimensions">
+    <div class="o_side_panel_section pivot-dimensions" t-ref="pivot-dimensions">
+      <div class="fw-bold py-1 d-flex flex-row justify-content-between align-items-center">
+        Columns
+        <AddDimensionButton
+          onFieldPicked.bind="addColumnDimension"
+          fields="props.unusedGroupableFields"
+        />
+      </div>
+      <t t-foreach="props.definition.columns" t-as="col" t-key="col.nameWithGranularity">
+        <div
+          t-on-pointerdown="(ev) => this.startDragAndDrop(col, ev)"
+          t-att-style="dragAndDrop.itemsStyle[col.nameWithGranularity]"
+          class="pt-1">
+          <PivotDimension dimension="col" onRemoved.bind="removeDimension">
+            <PivotDimensionGranularity
+              t-if="isDateField(col)"
+              dimension="col"
+              onUpdated.bind="this.updateGranularity"
+              availableGranularities="props.unusedDateTimeGranularities[col.name]"
+            />
+            <PivotDimensionOrder dimension="col" onUpdated.bind="this.updateOrder"/>
+          </PivotDimension>
+        </div>
+      </t>
+      <div
+        class="fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center"
+        t-att-style="dragAndDrop.itemsStyle['__rows_title__']">
+        Rows
+        <AddDimensionButton
+          onFieldPicked.bind="addRowDimension"
+          fields="props.unusedGroupableFields"
+        />
+      </div>
+      <t t-foreach="props.definition.rows" t-as="row" t-key="row.nameWithGranularity">
+        <div
+          t-on-pointerdown="(ev) => this.startDragAndDrop(row, ev)"
+          t-att-style="dragAndDrop.itemsStyle[row.nameWithGranularity]"
+          class="pt-1">
+          <PivotDimension dimension="row" onRemoved.bind="removeDimension">
+            <PivotDimensionGranularity
+              t-if="isDateField(row)"
+              dimension="row"
+              onUpdated.bind="this.updateGranularity"
+              availableGranularities="props.unusedDateTimeGranularities[row.name]"
+            />
+            <PivotDimensionOrder dimension="row" onUpdated.bind="this.updateOrder"/>
+          </PivotDimension>
+        </div>
+      </t>
+      <div class="fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center">
+        Measures
+        <AddDimensionButton
+          onFieldPicked.bind="addMeasureDimension"
+          fields="props.unusedMeasureFields"
+        />
+      </div>
+      <t t-foreach="props.definition.measures" t-as="measure" t-key="measure.nameWithAggregator">
+        <div
+          t-on-pointerdown="(ev) => this.startDragAndDropMeasures(measure, ev)"
+          t-att-style="dragAndDrop.itemsStyle[measure.name]"
+          class="pt-1 pivot-measure">
+          <PivotDimension dimension="measure" onRemoved.bind="removeMeasureDimension">
+            <div class="d-flex flex-row small">
+              <div class="d-flex flex-row py-1 px-2 w-100">
+                <div class="flex-basis-50">Aggregated by</div>
+                <select
+                  class="o_input flex-basis-50"
+                  t-on-change="(ev) => this.updateAggregator(measure, ev.target.value)">
+                  <option
+                    t-foreach="Object.keys(AGGREGATORS[measure.type])"
+                    t-as="agg"
+                    t-key="agg"
+                    t-att-value="agg"
+                    t-att-selected="agg === measure.aggregator"
+                    t-esc="AGGREGATORS[measure.type][agg]"
+                  />
+                </select>
+              </div>
+            </div>
+          </PivotDimension>
+        </div>
+      </t>
+    </div>
+  </t>
+</templates>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -249,3 +249,15 @@ export const MAXIMAL_FREEZABLE_RATIO = 0.85;
 
 export const NEWLINE = "\n";
 export const FONT_SIZES: number[] = [6, 7, 8, 9, 10, 11, 12, 14, 18, 24, 36];
+
+// Pivot
+export const PIVOT_TABLE_CONFIG = {
+  hasFilters: false,
+  totalRow: false,
+  firstColumn: true,
+  lastColumn: false,
+  numberOfHeaders: 1,
+  bandedRows: true,
+  bandedColumns: false,
+  styleId: "TableStyleMedium5",
+};

--- a/src/formulas/helpers.ts
+++ b/src/formulas/helpers.ts
@@ -1,5 +1,5 @@
 import { functionRegistry } from "../functions";
-import { iterateAstNodes, parseTokens } from "./parser";
+import { AST, ASTFuncall, iterateAstNodes, parseTokens } from "./parser";
 import { Token } from "./tokenizer";
 
 const functions = functionRegistry.content;
@@ -13,4 +13,28 @@ export function isExportableToExcel(tokens: Token[]): boolean {
   } catch (error) {
     return false;
   }
+}
+
+export function getFunctionsFromTokens(tokens: Token[], functionNames: string[]) {
+  // Parsing is an expensive operation, so we first check if the
+  // formula contains one of the function names
+  if (!tokens.some((t) => t.type === "SYMBOL" && functionNames.includes(t.value.toUpperCase()))) {
+    return [];
+  }
+  let ast: AST | undefined;
+  try {
+    ast = parseTokens(tokens);
+  } catch {
+    return [];
+  }
+  return getFunctionsFromAST(ast, functionNames);
+}
+
+function getFunctionsFromAST(ast: AST, functionNames: string[]) {
+  return iterateAstNodes(ast)
+    .filter((node) => node.type === "FUNCALL" && functionNames.includes(node.value.toUpperCase()))
+    .map((node: ASTFuncall) => ({
+      functionName: node.value.toUpperCase(),
+      args: node.args,
+    }));
 }

--- a/src/functions/helper_lookup.ts
+++ b/src/functions/helper_lookup.ts
@@ -1,0 +1,51 @@
+import { _t } from "../translation";
+import { AddFunctionDescription, Arg, EvalContext, FPayload, Getters, UID } from "../types";
+import { EvaluationError } from "../types/errors";
+import { SPTableCell } from "../types/pivot";
+
+/**
+ * Get the pivot ID from the formula pivot ID.
+ */
+export function getPivotId(pivotFormulaId: string, getters: Getters) {
+  const pivotId = getters.getPivotId(pivotFormulaId);
+  if (!pivotId) {
+    throw new EvaluationError(_t('There is no pivot with id "%s"', pivotFormulaId));
+  }
+  return pivotId;
+}
+
+export function assertMeasureExist(pivotId: UID, measure: string, getters: Getters) {
+  const { measures } = getters.getPivotCoreDefinition(pivotId);
+  if (!measures.find((m) => m.name === measure)) {
+    const validMeasures = `(${measures.map((m) => m.name).join(", ")})`;
+    throw new EvaluationError(
+      _t(
+        "The argument %s is not a valid measure. Here are the measures: %s",
+        measure,
+        validMeasures
+      )
+    );
+  }
+}
+
+export function assertDomainLength(domain: string[]) {
+  if (domain.length % 2 !== 0) {
+    throw new EvaluationError(_t("Function PIVOT takes an even number of arguments."));
+  }
+}
+
+export function getPivotCellValueAndFormat(
+  this: EvalContext,
+  pivotId: UID,
+  pivotCell: SPTableCell,
+  fn: AddFunctionDescription
+): FPayload {
+  if (!pivotCell.domain) {
+    return { value: "", format: undefined };
+  } else {
+    const domain = pivotCell.domain;
+    const measure = pivotCell.measure;
+    const args = pivotCell.isHeader ? [pivotId, ...domain] : [pivotId, measure, ...domain];
+    return fn.compute.call(this, ...(args as Arg[])) as FPayload;
+  }
+}

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -1,0 +1,185 @@
+import { tokenColors } from "../../components/composer/composer/composer";
+import { ComposerStore } from "../../components/composer/composer/composer_store";
+import { Token, getFunctionsFromTokens } from "../../formulas";
+import { EnrichedToken } from "../../formulas/composer_tokenizer";
+import { _t } from "../../translation";
+import { PivotCoreDimension, PivotField } from "../../types/pivot";
+
+const PIVOT_FUNCTIONS = ["PIVOT.VALUE", "PIVOT.HEADER", "PIVOT"];
+
+const AGGREGATOR_NAMES = {
+  count: _t("Count"),
+  count_distinct: _t("Count Distinct"),
+  bool_and: _t("Boolean And"),
+  bool_or: _t("Boolean Or"),
+  max: _t("Maximum"),
+  min: _t("Minimum"),
+  avg: _t("Average"),
+  sum: _t("Sum"),
+};
+
+const NUMBER_AGGREGATORS = ["max", "min", "avg", "sum", "count_distinct", "count"];
+const DATE_AGGREGATORS = ["max", "min", "count_distinct", "count"];
+
+const AGGREGATORS_BY_FIELD_TYPE = {
+  integer: NUMBER_AGGREGATORS,
+  float: NUMBER_AGGREGATORS,
+  monetary: NUMBER_AGGREGATORS,
+  date: DATE_AGGREGATORS,
+  datetime: DATE_AGGREGATORS,
+  boolean: ["count_distinct", "count", "bool_and", "bool_or"],
+  char: ["count_distinct", "count"],
+  many2one: ["count_distinct", "count"],
+};
+
+export const AGGREGATORS = {};
+
+for (const type in AGGREGATORS_BY_FIELD_TYPE) {
+  AGGREGATORS[type] = {};
+  for (const aggregator of AGGREGATORS_BY_FIELD_TYPE[type]) {
+    AGGREGATORS[type][aggregator] = AGGREGATOR_NAMES[aggregator];
+  }
+}
+
+/**
+ * Build a pivot formula expression
+ */
+export function makePivotFormula(
+  formula: "PIVOT.VALUE" | "PIVOT.HEADER",
+  args: (string | boolean | number)[]
+) {
+  return `=${formula}(${args
+    .map((arg) => {
+      const stringIsNumber =
+        typeof arg == "string" && !isNaN(Number(arg)) && Number(arg).toString() === arg;
+      const convertToNumber = typeof arg == "number" || stringIsNumber;
+      return convertToNumber ? `${arg}` : `"${arg.toString().replace(/"/g, '\\"')}"`;
+    })
+    .join(",")})`;
+}
+
+/**
+ * Given an object of form {"1": {...}, "2": {...}, ...} get the maximum ID used
+ * in this object
+ * If the object has no keys, return 0
+ *
+ */
+export function getMaxObjectId(o: object) {
+  const keys = Object.keys(o);
+  if (!keys.length) {
+    return 0;
+  }
+  const nums = keys.map((id) => parseInt(id, 10));
+  const max = Math.max(...nums);
+  return max;
+}
+
+/**
+ * Get the first Pivot function description of the given formula.
+ */
+export function getFirstPivotFunction(tokens: Token[]) {
+  return getFunctionsFromTokens(tokens, PIVOT_FUNCTIONS)[0];
+}
+
+/**
+ * Parse a spreadsheet formula and detect the number of PIVOT functions that are
+ * present in the given formula.
+ */
+export function getNumberOfPivotFunctions(tokens: Token[]) {
+  return getFunctionsFromTokens(tokens, PIVOT_FUNCTIONS).length;
+}
+
+export const PERIODS = {
+  year: _t("Year"),
+  quarter: _t("Quarter"),
+  month: _t("Month"),
+  week: _t("Week"),
+  day: _t("Day"),
+};
+
+const DATE_FIELDS = ["date", "datetime"];
+export const MEASURES_TYPES = ["integer", "float", "monetary"];
+
+/**
+ * Parse a dimension string into a pivot dimension definition.
+ * e.g "create_date:month" => { name: "create_date", granularity: "month" }
+ */
+export function parseDimension(dimension: string): PivotCoreDimension {
+  const [name, granularity] = dimension.split(":");
+  if (granularity) {
+    return { name, granularity };
+  }
+  return { name };
+}
+
+export function isDateField(field: PivotField) {
+  return DATE_FIELDS.includes(field.type);
+}
+
+/**
+ * Create a proposal entry for the compose autocomplete
+ * to insert a field name string in a formula.
+ */
+export function makeFieldProposal(field: PivotField) {
+  const quotedFieldName = `"${field.name}"`;
+  return {
+    text: quotedFieldName,
+    description: field.string + (field.help ? ` (${field.help})` : ""),
+    htmlContent: [{ value: quotedFieldName, color: tokenColors.STRING }],
+    fuzzySearchKey: field.string + quotedFieldName, // search on translated name and on technical name
+  };
+}
+
+/**
+ * Perform the autocomplete of the composer by inserting the value
+ * at the cursor position, replacing the current token if necessary.
+ * Must be bound to the autocomplete provider.
+ */
+export function insertTokenAfterArgSeparator(
+  this: { composer: ComposerStore },
+  tokenAtCursor: EnrichedToken,
+  value: string
+) {
+  let start = tokenAtCursor.end;
+  const end = tokenAtCursor.end;
+  if (tokenAtCursor.type !== "ARG_SEPARATOR") {
+    // replace the whole token
+    start = tokenAtCursor.start;
+  }
+  this.composer.changeComposerCursorSelection(start, end);
+  this.composer.replaceComposerCursorSelection(value);
+}
+
+/**
+ * Perform the autocomplete of the composer by inserting the value
+ * at the cursor position, replacing the current token if necessary.
+ * Must be bound to the autocomplete provider.
+ * @param {EnrichedToken} tokenAtCursor
+ * @param {string} value
+ */
+export function insertTokenAfterLeftParenthesis(
+  this: { composer: ComposerStore },
+  tokenAtCursor: EnrichedToken,
+  value: string
+) {
+  let start = tokenAtCursor.end;
+  const end = tokenAtCursor.end;
+  if (tokenAtCursor.type !== "LEFT_PAREN") {
+    // replace the whole token
+    start = tokenAtCursor.start;
+  }
+  this.composer.changeComposerCursorSelection(start, end);
+  this.composer.replaceComposerCursorSelection(value);
+}
+
+/**
+ * Extract the pivot id (always the first argument) from the function
+ * context of the given token.
+ */
+export function extractFormulaIdFromToken(tokenAtCursor: EnrichedToken) {
+  const idAst = tokenAtCursor.functionContext?.args[0];
+  if (!idAst || !["STRING", "NUMBER"].includes(idAst.type)) {
+    return;
+  }
+  return idAst.value;
+}

--- a/src/helpers/pivot/pivot_highlight.ts
+++ b/src/helpers/pivot/pivot_highlight.ts
@@ -1,0 +1,25 @@
+import { HIGHLIGHT_COLOR } from "../../constants";
+import { CellPosition, Getters, Highlight, UID } from "../../types";
+import { mergeContiguousZones, positionToZone } from "../zones";
+
+export function getPivotHighlights(getters: Getters, pivotId: UID): Highlight[] {
+  const sheetId = getters.getActiveSheetId();
+  const pivotCellPositions = getVisiblePivotCellPositions(getters, pivotId);
+  const mergedZones = mergeContiguousZones(pivotCellPositions.map(positionToZone));
+  return mergedZones.map((zone) => ({ sheetId, zone, noFill: true, color: HIGHLIGHT_COLOR }));
+}
+
+function getVisiblePivotCellPositions(getters: Getters, pivotId: UID) {
+  const positions: CellPosition[] = [];
+  const sheetId = getters.getActiveSheetId();
+  for (const col of getters.getSheetViewVisibleCols()) {
+    for (const row of getters.getSheetViewVisibleRows()) {
+      const position = { sheetId, col, row };
+      const cellPivotId = getters.getPivotIdFromPosition(position);
+      if (pivotId === cellPivotId) {
+        positions.push(position);
+      }
+    }
+  }
+  return positions;
+}

--- a/src/helpers/pivot/pivot_registry.ts
+++ b/src/helpers/pivot/pivot_registry.ts
@@ -1,0 +1,25 @@
+import { ModelConfig } from "../../model";
+import { Registry } from "../../registries/registry";
+import { Getters } from "../../types";
+import { PivotCoreDefinition, PivotFields } from "../../types/pivot";
+import { Pivot } from "./pivot_runtime";
+import { PivotRuntimeDefinition } from "./pivot_runtime_definition";
+
+interface PivotParams {
+  definition: PivotCoreDefinition;
+  getters: Getters;
+}
+
+type PivotConstructor = new (custom: ModelConfig["custom"], params: PivotParams) => Pivot;
+
+type PivotDefinitionConstructor = new (
+  definition: PivotCoreDefinition,
+  fields: PivotFields
+) => PivotRuntimeDefinition;
+
+export interface PivotRegistryItem {
+  cls: PivotConstructor;
+  definition: PivotDefinitionConstructor;
+}
+
+export const pivotRegistry = new Registry<PivotRegistryItem>();

--- a/src/helpers/pivot/pivot_runtime.ts
+++ b/src/helpers/pivot/pivot_runtime.ts
@@ -1,0 +1,20 @@
+import { FPayload } from "../../types/misc";
+import { PivotFields, PivotMeasure } from "../../types/pivot";
+import { PivotRuntimeDefinition } from "./pivot_runtime_definition";
+import { SpreadsheetPivotTable } from "./spreadsheet_pivot_table";
+
+export interface Pivot<T = PivotRuntimeDefinition> {
+  definition: T;
+  getMeasure: (name: string) => PivotMeasure;
+  computePivotHeaderValue(domain: Array<string | number>): string | boolean | number;
+  getLastPivotGroupValue(domain: Array<string | number>): string | boolean | number;
+  getTableStructure(): SpreadsheetPivotTable;
+  getPivotCellValue(measure: string, domain: Array<string | number>): string | boolean | number;
+  getPivotFieldFormat(name: string): string;
+  getPivotMeasureFormat(name: string): string | undefined;
+  assertIsValid({ throwOnError }: { throwOnError: boolean }): FPayload | undefined;
+  load(params: unknown): Promise<void>;
+  getFields(): PivotFields | undefined;
+  isLoadedAndValid(): boolean;
+  getPossibleFieldValues(groupBy: string): { value: string | boolean | number; label: string }[];
+}

--- a/src/helpers/pivot/pivot_runtime_definition.ts
+++ b/src/helpers/pivot/pivot_runtime_definition.ts
@@ -1,0 +1,98 @@
+import { _t } from "../../translation";
+import {
+  CommonPivotCoreDefinition,
+  PivotCoreDimension,
+  PivotCoreMeasure,
+  PivotDimension,
+  PivotFields,
+  PivotMeasure,
+} from "../../types/pivot";
+
+/**
+ * Represent a pivot runtime definition. A pivot runtime definition is a pivot
+ * definition that has been enriched to include the display name of its attributes
+ * (measures, columns, rows).
+ */
+export class PivotRuntimeDefinition {
+  readonly measures: PivotMeasure[];
+  readonly columns: PivotDimension[];
+  readonly rows: PivotDimension[];
+
+  constructor(definition: CommonPivotCoreDefinition, fields: PivotFields) {
+    this.measures = definition.measures.map((measure) => createMeasure(fields, measure));
+    this.columns = definition.columns.map((dimension) => createPivotDimension(fields, dimension));
+    this.rows = definition.rows.map((dimension) => createPivotDimension(fields, dimension));
+  }
+}
+
+function createMeasure(fields: PivotFields, measure: PivotCoreMeasure): PivotMeasure {
+  const name = measure.name;
+  const aggregator = measure.aggregator || fields[name]?.aggregator;
+  const field =
+    name === "__count" ? { name: "__count", string: _t("Count"), type: "integer" } : fields[name];
+  if (!field) {
+    throw new Error(`Field ${name} not found in fields`);
+  }
+  return {
+    nameWithAggregator: name + (aggregator ? `:${aggregator}` : ""),
+    /**
+     * Display name of the measure
+     * e.g. "__count" -> "Count", "amount_total" -> "Total Amount"
+     */
+    displayName: field.string,
+    /**
+     * Get the name of the measure, as it is stored in the pivot formula
+     */
+    name,
+    /**
+     * Get the aggregator of the measure
+     */
+    aggregator,
+    /**
+     * Get the type of the measure field
+     * e.g. "stage_id" -> "many2one", "create_date:month" -> "date"
+     */
+    type: name === "__count" ? "integer" : field.type,
+  };
+}
+
+function createPivotDimension(fields: PivotFields, dimension: PivotCoreDimension): PivotDimension {
+  const field = fields[dimension.name];
+  if (!field) {
+    throw new Error(`Field ${name} not found in fields`);
+  }
+  return {
+    /**
+     * Get the display name of the dimension
+     * e.g. "stage_id" -> "Stage", "create_date:month" -> "Create Date"
+     */
+    displayName: field.string,
+
+    /**
+     * Get the name of the dimension, as it is stored in the pivot formula
+     * e.g. "stage_id", "create_date:month"
+     */
+    nameWithGranularity:
+      dimension.name + (dimension.granularity ? `:${dimension.granularity}` : ""),
+
+    /**
+     * Get the name of the field of the dimension
+     * e.g. "stage_id" -> "stage_id", "create_date:month" -> "create_date"
+     */
+    name: dimension.name,
+
+    /**
+     * Get the aggregate operator of the dimension
+     * e.g. "stage_id" -> undefined, "create_date:month" -> "month"
+     */
+    granularity: dimension.granularity,
+
+    /**
+     * Get the type of the field of the dimension
+     * e.g. "stage_id" -> "many2one", "create_date:month" -> "date"
+     */
+    type: field.type,
+
+    order: dimension.order,
+  };
+}

--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -1,0 +1,143 @@
+import { toNumber } from "../../functions/helpers";
+import { Registry } from "../../registries/registry";
+import { _t } from "../../translation";
+import { DEFAULT_LOCALE } from "../../types";
+import { Granularity, PivotTimeAdapter } from "../../types/pivot";
+import { formatValue } from "../format";
+
+export const pivotTimeAdapterRegistry = new Registry<PivotTimeAdapter<string | number | false>>();
+
+export function pivotTimeAdapter(
+  granularity: Granularity
+): PivotTimeAdapter<string | number | false> {
+  return pivotTimeAdapterRegistry.get(granularity);
+}
+
+/**
+ * The Time Adapter: Managing Time Periods for Pivot Functions
+ *
+ * Overview:
+ * A time adapter is responsible for managing time periods associated with pivot functions.
+ * Each type of period (day, week, month, quarter, etc.) has its own dedicated adapter.
+ * The adapter's primary role is to normalize period values between spreadsheet functions,
+ * and the pivot.
+ * By normalizing the period value, it can be stored consistently in the pivot.
+ *
+ * Normalization Process:
+ * When working with functions in the spreadsheet, the time adapter normalizes
+ * the provided period to facilitate accurate lookup of values in the pivot.
+ * For instance, if the spreadsheet function represents a day period as a number generated
+ * by the DATE function (DATE(2023, 12, 25)), the time adapter will normalize it accordingly.
+ *
+ */
+
+/**
+ * Normalized value: "12/25/2023"
+ *
+ * Note: Those two format are equivalent:
+ * - "MM/dd/yyyy" (luxon format)
+ * - "mm/dd/yyyy" (spreadsheet format)
+ **/
+const dayAdapter: PivotTimeAdapter<string> = {
+  normalizeFunctionValue(value) {
+    const date = toNumber(value, DEFAULT_LOCALE);
+    return formatValue(date, { locale: DEFAULT_LOCALE, format: "mm/dd/yyyy" });
+  },
+  getFormat(locale) {
+    return (locale ?? DEFAULT_LOCALE).dateFormat;
+  },
+  formatValue(normalizedValue, locale) {
+    locale = locale ?? DEFAULT_LOCALE;
+    const value = toNumber(normalizedValue, DEFAULT_LOCALE);
+    return formatValue(value, { locale, format: this.getFormat(locale) });
+  },
+  toCellValue(normalizedValue) {
+    return toNumber(normalizedValue, DEFAULT_LOCALE);
+  },
+};
+
+/**
+ * Normalized value: "2/2023" for week 2 of 2023
+ */
+const weekAdapter: PivotTimeAdapter<string> = {
+  normalizeFunctionValue(value) {
+    const [week, year] = value.split("/");
+    return `${Number(week)}/${Number(year)}`;
+  },
+  getFormat() {
+    return undefined;
+  },
+  formatValue(normalizedValue) {
+    const [week, year] = normalizedValue.split("/");
+    return _t("W%(week)s %(year)s", { week, year });
+  },
+  toCellValue(normalizedValue) {
+    return this.formatValue(normalizedValue);
+  },
+};
+
+/**
+ * normalized month value is a string formatted as "MM/yyyy" (luxon format)
+ * e.g. "01/2020" for January 2020
+ */
+const monthAdapter: PivotTimeAdapter<string> = {
+  normalizeFunctionValue(value) {
+    const date = toNumber(value, DEFAULT_LOCALE);
+    return formatValue(date, { locale: DEFAULT_LOCALE, format: "mm/yyyy" });
+  },
+  getFormat() {
+    return "mmmm yyyy";
+  },
+  formatValue(normalizedValue, locale) {
+    locale = locale ?? DEFAULT_LOCALE;
+    const value = toNumber(normalizedValue, DEFAULT_LOCALE);
+    return formatValue(value, { locale, format: this.getFormat(locale) });
+  },
+  toCellValue(normalizedValue) {
+    return toNumber(normalizedValue, DEFAULT_LOCALE);
+  },
+};
+
+/**
+ * normalized quarter value is "quarter/year"
+ * e.g. "1/2020" for Q1 2020
+ */
+const quarterAdapter: PivotTimeAdapter<string> = {
+  normalizeFunctionValue(value) {
+    const [quarter, year] = value.split("/");
+    return `${quarter}/${year}`;
+  },
+  getFormat() {
+    return undefined;
+  },
+  formatValue(normalizedValue) {
+    const [quarter, year] = normalizedValue.split("/");
+    return _t("Q%(quarter)s %(year)s", { quarter, year });
+  },
+  toCellValue(normalizedValue) {
+    return this.formatValue(normalizedValue);
+  },
+};
+
+const yearAdapter: PivotTimeAdapter<number> = {
+  normalizeFunctionValue(value) {
+    return toNumber(value, DEFAULT_LOCALE);
+  },
+  getFormat() {
+    return "0";
+  },
+  formatValue(normalizedValue, locale) {
+    locale = locale ?? DEFAULT_LOCALE;
+    return formatValue(normalizedValue, { locale, format: "0" });
+  },
+  toCellValue(normalizedValue) {
+    return normalizedValue;
+  },
+};
+
+pivotTimeAdapterRegistry
+  .add("day", dayAdapter)
+  .add("week", weekAdapter)
+  .add("month", monthAdapter)
+  .add("quarter", quarterAdapter)
+  .add("year", yearAdapter);

--- a/src/helpers/pivot/spreadsheet_pivot_table.ts
+++ b/src/helpers/pivot/spreadsheet_pivot_table.ts
@@ -1,0 +1,180 @@
+import { SPTableCell, SPTableColumn, SPTableRow } from "../../types/pivot";
+
+/**
+ * Class used to ease the construction of a pivot table.
+ * Let's consider the following example, with:
+ * - columns groupBy: [sales_team, create_date]
+ * - rows groupBy: [continent, city]
+ * - measures: [revenues]
+ * _____________________________________________________________________________________|   ----|
+ * |                |   Sale Team 1             |  Sale Team 2            |             |       |
+ * |                |___________________________|_________________________|_____________|       |
+ * |                |   May 2020   | June 2020  |  May 2020  | June 2020  |   Total     |       |<---- `cols`
+ * |                |______________|____________|____________|____________|_____________|       |   ----|
+ * |                |   Revenues   |  Revenues  |  Revenues  |  Revenues  |   Revenues  |       |       |<--- `measureRow`
+ * |________________|______________|____________|____________|____________|_____________|   ----|   ----|
+ * |Europe          |     25       |     35     |     40     |     30     |     65      |   ----|
+ * |    Brussels    |      0       |     15     |     30     |     30     |     30      |       |
+ * |    Paris       |     25       |     20     |     10     |     0      |     35      |       |
+ * |North America   |     60       |     75     |            |            |     60      |       |<---- `body`
+ * |    Washington  |     60       |     75     |            |            |     60      |       |
+ * |Total           |     85       |     110    |     40     |     30     |     125     |       |
+ * |________________|______________|____________|____________|____________|_____________|   ----|
+ *
+ * |                |
+ * |----------------|
+ *         |
+ *         |
+ *       `rows`
+ *
+ * `rows` is an array of cells, each cells contains the indent level, the fields used for the group by and the values for theses fields.
+ * For example:
+ *   `Europe`: { indent: 1, fields: ["continent"], values: ["id_of_Europe"]}
+ *   `Brussels`: { indent: 2, fields: ["continent", "city"], values: ["id_of_Europe", "id_of_Brussels"]}
+ *   `Total`: { indent: 0, fields: [], values: []}
+ *
+ * `columns` is an double array, first by row and then by cell. So, in this example, it looks like:
+ *   [[row1], [row2], [measureRow]]
+ *   Each cell of a column's row contains the width (span) of the cells, the fields used for the group by and the values for theses fields.
+ * For example:
+ *   `Sale Team 1`: { width: 2, fields: ["sales_team"], values: ["id_of_SaleTeam1"]}
+ *   `May 2020` (the one under Sale Team 2): { width: 1, fields: ["sales_team", "create_date"], values: ["id_of_SaleTeam2", "May 2020"]}
+ *   `Revenues` (the one under Total): { width: 1, fields: ["measure"], values: ["revenues"]}
+ *
+ */
+export class SpreadsheetPivotTable {
+  readonly columns: SPTableColumn[][];
+  readonly rows: SPTableRow[];
+  readonly measures: string[];
+  readonly rowTitle?: string;
+  readonly maxIndent: number;
+  readonly pivotCells: { [key: string]: SPTableCell[][] } = {};
+
+  constructor(
+    columns: SPTableColumn[][],
+    rows: SPTableRow[],
+    measures: string[],
+    rowTitle: string = ""
+  ) {
+    this.columns = columns.map((row) => {
+      // offset in the pivot table
+      // starts at 1 because the first column is the row title
+      let offset = 1;
+      return row.map((col) => {
+        col = { ...col, offset };
+        offset += col.width;
+        return col;
+      });
+    });
+    this.rows = rows;
+    this.measures = measures;
+    this.rowTitle = rowTitle;
+    this.maxIndent = Math.max(...this.rows.map((row) => row.indent));
+  }
+
+  /**
+   * Get the number of columns leafs (i.e. the number of the last row of columns)
+   */
+  getNumberOfDataColumns() {
+    return this.columns.at(-1)?.length || 0;
+  }
+
+  getPivotCells(includeTotal = true, includeColumnHeaders = true): SPTableCell[][] {
+    const key = JSON.stringify({ includeTotal, includeColumnHeaders });
+    if (!this.pivotCells[key]) {
+      const numberOfDataRows = this.rows.length;
+      const numberOfDataColumns = this.getNumberOfDataColumns();
+      let pivotHeight = this.columns.length + numberOfDataRows;
+      let pivotWidth = 1 /*(row headers)*/ + numberOfDataColumns;
+      if (!includeTotal && numberOfDataRows !== 1) {
+        pivotHeight -= 1;
+      }
+      if (!includeTotal && numberOfDataColumns !== this.measures.length) {
+        pivotWidth -= this.measures.length;
+      }
+      const domainArray: SPTableCell[][] = [];
+      const startRow = includeColumnHeaders ? 0 : this.columns.length;
+      for (let col = 0; col < pivotWidth; col++) {
+        domainArray.push([]);
+        for (let row = startRow; row < pivotHeight; row++) {
+          if (!includeTotal && row === pivotHeight) {
+            continue;
+          }
+          domainArray[col].push(this.getPivotCell(col, row, includeTotal));
+        }
+      }
+      this.pivotCells[key] = domainArray;
+    }
+    return this.pivotCells[key];
+  }
+
+  private isTotalRow(index: number) {
+    return this.rows[index].indent !== this.maxIndent;
+  }
+
+  private getPivotCell(col: number, row: number, includeTotal = true): SPTableCell {
+    const colHeadersHeight = this.columns.length;
+    if (col === 0 && row === colHeadersHeight - 1) {
+      return { content: this.rowTitle, isHeader: true };
+    } else if (row <= colHeadersHeight - 1) {
+      const domain = this.getColHeaderDomain(col, row);
+      return { domain, isHeader: true };
+    } else if (col === 0) {
+      const rowIndex = row - colHeadersHeight;
+      const domain = this.getRowDomain(rowIndex);
+      return { domain, isHeader: true };
+    } else {
+      const rowIndex = row - colHeadersHeight;
+      if (!includeTotal && this.isTotalRow(rowIndex)) {
+        return { isHeader: false };
+      }
+      const domain = [...this.getRowDomain(rowIndex), ...this.getColDomain(col)];
+      const measure = this.getColMeasure(col);
+      return { domain, isHeader: false, measure };
+    }
+  }
+
+  private getColHeaderDomain(col: number, row: number) {
+    if (col === 0) {
+      return undefined;
+    }
+    const domain: string[] = [];
+    const pivotCol = this.columns[row].find((pivotCol) => pivotCol.offset === col);
+    if (!pivotCol) {
+      return undefined;
+    }
+    for (let i = 0; i < pivotCol.fields.length; i++) {
+      domain.push(pivotCol.fields[i]);
+      domain.push(pivotCol.values[i]);
+    }
+    return domain;
+  }
+
+  private getColDomain(col: number) {
+    const domain = this.getColHeaderDomain(col, this.columns.length - 1);
+    return domain ? domain.slice(0, -2) : []; // slice: remove measure and value
+  }
+
+  private getColMeasure(col: number) {
+    const domain = this.getColHeaderDomain(col, this.columns.length - 1);
+    return domain?.at(-1);
+  }
+
+  private getRowDomain(row: number) {
+    const domain: string[] = [];
+    for (let i = 0; i < this.rows[row].fields.length; i++) {
+      domain.push(this.rows[row].fields[i]);
+      domain.push(this.rows[row].values[i]);
+    }
+    return domain;
+  }
+
+  export() {
+    return {
+      cols: this.columns,
+      rows: this.rows,
+      measures: this.measures,
+      rowTitle: this.rowTitle,
+    };
+  }
+}

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -678,3 +678,49 @@ export function unionPositionsToZone(positions: Position[]): Zone {
   }
   return zone;
 }
+
+/**
+ * Check if two zones are contiguous, ie. that they share a border
+ */
+function areZoneContiguous(zone1: Zone, zone2: Zone) {
+  const u = union(zone1, zone2);
+  if (zone1.right + 1 === zone2.left || zone1.left === zone2.right + 1) {
+    return getZoneHeight(u) <= getZoneHeight(zone1) + getZoneHeight(zone2);
+  }
+  if (zone1.bottom + 1 === zone2.top || zone1.top === zone2.bottom + 1) {
+    return getZoneWidth(u) <= getZoneWidth(zone1) + getZoneWidth(zone2);
+  }
+  return false;
+}
+
+function getZoneHeight(zone: Zone) {
+  return zone.bottom - zone.top + 1;
+}
+
+function getZoneWidth(zone: Zone) {
+  return zone.right - zone.left + 1;
+}
+
+/**
+ * Merge contiguous and overlapping zones that are in the array into bigger zones
+ */
+export function mergeContiguousZones(zones: Zone[]) {
+  const mergedZones = [...zones];
+  let hasMerged = true;
+  while (hasMerged) {
+    hasMerged = false;
+    for (let i = 0; i < mergedZones.length; i++) {
+      const zone = mergedZones[i];
+      const mergeableZoneIndex = mergedZones.findIndex(
+        (z, j) => i !== j && (areZoneContiguous(z, zone) || overlap(z, zone))
+      );
+      if (mergeableZoneIndex !== -1) {
+        mergedZones[i] = union(mergedZones[mergeableZoneIndex], zone);
+        mergedZones.splice(mergeableZoneIndex, 1);
+        hasMerged = true;
+        break;
+      }
+    }
+  }
+  return mergedZones;
+}

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -26,7 +26,7 @@ import { normalizeV9 } from "./legacy_tools";
  * a breaking change is made in the way the state is handled, and an upgrade
  * function should be defined
  */
-export const CURRENT_VERSION = 15;
+export const CURRENT_VERSION = 16;
 const INITIAL_SHEET_ID = "Sheet1";
 
 /**
@@ -368,6 +368,20 @@ const MIGRATIONS: Migration[] = [
       return data;
     },
   },
+  {
+    description: "Add pivots",
+    from: 15,
+    to: 16,
+    applyMigration(data: any): any {
+      if (!data.pivots) {
+        data.pivots = {};
+      }
+      if (!data.pivotNextId) {
+        data.pivotNextId = 1;
+      }
+      return data;
+    },
+  },
 ];
 
 /**
@@ -594,6 +608,8 @@ export function createEmptyWorkbookData(sheetName = "Sheet1"): WorkbookData {
     revisionId: DEFAULT_REVISION_ID,
     uniqueFigureIds: true,
     settings: { locale: DEFAULT_LOCALE },
+    pivots: {},
+    pivotNextId: 1,
   };
   return data;
 }

--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -1,0 +1,280 @@
+import { PIVOT_TABLE_CONFIG } from "../../constants";
+import { deepCopy, deepEquals, isDefined } from "../../helpers";
+import { getMaxObjectId, makePivotFormula } from "../../helpers/pivot/pivot_helpers";
+import { SpreadsheetPivotTable } from "../../helpers/pivot/spreadsheet_pivot_table";
+import { _t } from "../../translation";
+import {
+  CellPosition,
+  CommandResult,
+  CoreCommand,
+  CreateTableCommand,
+  Position,
+  UID,
+  WorkbookData,
+} from "../../types";
+import { PivotCoreDefinition, SPTableCell } from "../../types/pivot";
+import { CorePlugin } from "../core_plugin";
+
+interface LocalPivot extends PivotCoreDefinition {
+  /**
+   * The formula id is the id that is used in the formula to identify the pivot.
+   * It's different from the pivot id, which is the id of the pivot in the state.
+   * The formula id is a readable id, auto-incremented. The pivotId is a UID.
+   * We need this distinction to be assured that the pivotId is unique in a
+   * context of collaboration.
+   */
+  formulaId: string;
+}
+
+interface CoreState {
+  nextFormulaId: number;
+  pivots: Record<UID, LocalPivot | undefined>;
+  formulaIds: Record<UID, string | undefined>;
+}
+
+export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState {
+  static getters = [
+    "getPivotCoreDefinition",
+    "getPivotDisplayName",
+    "getPivotId",
+    "getPivotFormulaId",
+    "getPivotIds",
+    "getPivotName",
+    "isExistingPivot",
+  ] as const;
+
+  readonly nextFormulaId: number = 1;
+  public readonly pivots: { [key: UID]: LocalPivot } = {};
+  public readonly formulaIds: { [key: UID]: string } = {};
+
+  allowDispatch(cmd: CoreCommand) {
+    switch (cmd.type) {
+      case "UPDATE_PIVOT": {
+        if (deepEquals(cmd.pivot, this.pivots[cmd.pivotId])) {
+          return CommandResult.NoChanges;
+        }
+        break;
+      }
+      case "RENAME_PIVOT":
+        if (!(cmd.pivotId in this.pivots)) {
+          return CommandResult.PivotIdNotFound;
+        }
+        if (cmd.name === "") {
+          return CommandResult.EmptyName;
+        }
+        break;
+      case "INSERT_PIVOT": {
+        if (!(cmd.pivotId in this.pivots)) {
+          return CommandResult.PivotIdNotFound;
+        }
+        break;
+      }
+      case "DUPLICATE_PIVOT":
+        if (!(cmd.pivotId in this.pivots)) {
+          return CommandResult.PivotIdNotFound;
+        }
+    }
+    return CommandResult.Success;
+  }
+
+  handle(cmd: CoreCommand) {
+    switch (cmd.type) {
+      case "ADD_PIVOT": {
+        const { pivotId, pivot } = cmd;
+        this.addPivot(pivotId, pivot);
+        break;
+      }
+      case "INSERT_PIVOT": {
+        const { sheetId, col, row, pivotId, table } = cmd;
+        const position = { sheetId, col, row };
+        const { cols, rows, measures, rowTitle } = table;
+        const spTable = new SpreadsheetPivotTable(cols, rows, measures, rowTitle);
+        const formulaId = this.getPivotFormulaId(pivotId);
+        this.insertPivot(position, formulaId, spTable);
+        break;
+      }
+      case "RENAME_PIVOT": {
+        this.history.update("pivots", cmd.pivotId, "name", cmd.name);
+        break;
+      }
+      case "REMOVE_PIVOT": {
+        const pivots = { ...this.pivots };
+        delete pivots[cmd.pivotId];
+        const formulaId = this.getPivotFormulaId(cmd.pivotId);
+        this.history.update("formulaIds", formulaId, undefined);
+        this.history.update("pivots", pivots);
+        break;
+      }
+      case "DUPLICATE_PIVOT": {
+        const { pivotId, newPivotId } = cmd;
+        const pivot = deepCopy(this.pivots[pivotId]);
+        this.addPivot(newPivotId, pivot);
+        break;
+      }
+      case "UPDATE_PIVOT": {
+        this.history.update("pivots", cmd.pivotId, {
+          ...cmd.pivot,
+          formulaId: this.pivots[cmd.pivotId].formulaId,
+        });
+        break;
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Getters
+  // -------------------------------------------------------------------------
+
+  getPivotDisplayName(pivotId: UID) {
+    const formulaId = this.getPivotFormulaId(pivotId);
+    return `(#${formulaId}) ${this.getPivotName(pivotId)}`;
+  }
+
+  getPivotName(pivotId: UID) {
+    return _t(this.pivots[pivotId].name);
+  }
+
+  /**
+   * Returns the pivot core definition of the pivot with the given id.
+   * Be careful, this is the core definition, this should be used only in a
+   * context where the pivot is not loaded yet.
+   */
+  getPivotCoreDefinition(pivotId: UID): PivotCoreDefinition {
+    return this.pivots[pivotId];
+  }
+
+  /**
+   * Get the pivot ID (UID) from the formula ID (the one used in the formula)
+   */
+  getPivotId(formulaId: string) {
+    return this.formulaIds[formulaId];
+  }
+
+  getPivotFormulaId(pivotId: UID) {
+    return this.pivots[pivotId]?.formulaId;
+  }
+
+  getPivotIds(): UID[] {
+    return Object.keys(this.pivots);
+  }
+
+  isExistingPivot(pivotId: UID) {
+    return pivotId in this.pivots;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private
+  // -------------------------------------------------------------------------
+
+  private addPivot(
+    pivotId: UID,
+    pivot: PivotCoreDefinition,
+    formulaId = this.nextFormulaId.toString()
+  ) {
+    const pivots = { ...this.pivots };
+    pivots[pivotId] = {
+      ...pivot,
+      formulaId,
+    };
+    this.history.update("pivots", pivots);
+    this.history.update("formulaIds", formulaId, pivotId);
+    this.history.update("nextFormulaId", this.nextFormulaId + 1);
+  }
+
+  private insertPivot(position: CellPosition, formulaId: UID, table: SpreadsheetPivotTable) {
+    this.resizeSheet(position.sheetId, position, table);
+    const pivotCells = table.getPivotCells();
+    for (let col = 0; col < pivotCells.length; col++) {
+      for (let row = 0; row < pivotCells[col].length; row++) {
+        const pivotCell = pivotCells[col][row];
+        const cellPosition = {
+          sheetId: position.sheetId,
+          col: position.col + col,
+          row: position.row + row,
+        };
+        this.addPivotFormula(cellPosition, formulaId, pivotCell);
+      }
+    }
+    const pivotZone = {
+      top: position.row,
+      bottom: position.row + pivotCells[0].length - 1,
+      left: position.col,
+      right: position.col + pivotCells.length - 1,
+    };
+    const numberOfHeaders = table.columns.length - 1;
+    const cmdContent: Omit<CreateTableCommand, "type"> = {
+      sheetId: position.sheetId,
+      ranges: [this.getters.getRangeDataFromZone(position.sheetId, pivotZone)],
+      config: { ...PIVOT_TABLE_CONFIG, numberOfHeaders },
+      tableType: "static",
+    };
+    if (this.canDispatch("CREATE_TABLE", cmdContent).isSuccessful) {
+      this.dispatch("CREATE_TABLE", cmdContent);
+    }
+  }
+
+  private resizeSheet(sheetId: UID, { col, row }: Position, table: SpreadsheetPivotTable) {
+    const colLimit = table.getNumberOfDataColumns() + 1; // +1 for the Top-Left
+    const numberCols = this.getters.getNumberCols(sheetId);
+    const deltaCol = numberCols - col;
+    if (deltaCol < colLimit) {
+      this.dispatch("ADD_COLUMNS_ROWS", {
+        dimension: "COL",
+        base: numberCols - 1,
+        sheetId: sheetId,
+        quantity: colLimit - deltaCol,
+        position: "after",
+      });
+    }
+    const rowLimit = table.columns.length + table.rows.length;
+    const numberRows = this.getters.getNumberRows(sheetId);
+    const deltaRow = numberRows - row;
+    if (deltaRow < rowLimit) {
+      this.dispatch("ADD_COLUMNS_ROWS", {
+        dimension: "ROW",
+        base: numberRows - 1,
+        sheetId: sheetId,
+        quantity: rowLimit - deltaRow,
+        position: "after",
+      });
+    }
+  }
+
+  private addPivotFormula(position: CellPosition, formulaId: UID, pivotCell: SPTableCell) {
+    const formula = pivotCell.isHeader ? "PIVOT.HEADER" : "PIVOT.VALUE";
+    const args = pivotCell.domain
+      ? [formulaId, pivotCell.measure, ...pivotCell.domain].filter(isDefined)
+      : undefined;
+
+    this.dispatch("UPDATE_CELL", {
+      ...position,
+      content: pivotCell.content || (args ? makePivotFormula(formula, args) : undefined),
+    });
+  }
+
+  // ---------------------------------------------------------------------
+  // Import/Export
+  // ---------------------------------------------------------------------
+
+  /**
+   * Import the pivots
+   */
+  import(data: WorkbookData) {
+    if (data.pivots) {
+      for (const [id, pivot] of Object.entries(data.pivots)) {
+        this.addPivot(id, deepCopy(pivot), pivot.formulaId);
+      }
+    }
+    this.history.update("nextFormulaId", data.pivotNextId || getMaxObjectId(this.pivots) + 1);
+  }
+  /**
+   * Export the pivots
+   */
+  export(data: WorkbookData) {
+    data.pivots = {};
+    for (const pivotId in this.pivots) {
+      data.pivots[pivotId] = deepCopy(this.pivots[pivotId]);
+    }
+    data.pivotNextId = this.nextFormulaId;
+  }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -14,6 +14,7 @@ import {
   TablePlugin,
 } from "./core";
 import { HeaderGroupingPlugin } from "./core/header_grouping";
+import { PivotCorePlugin } from "./core/pivot";
 import { SettingsPlugin } from "./core/settings";
 import { CorePluginConstructor } from "./core_plugin";
 import {
@@ -25,6 +26,7 @@ import {
 } from "./ui_core_views";
 import { DynamicTablesPlugin } from "./ui_core_views/dynamic_tables";
 import { HeaderSizeUIPlugin } from "./ui_core_views/header_sizes_ui";
+import { PivotUIPlugin } from "./ui_core_views/pivot_ui";
 import {
   AutofillPlugin,
   AutomaticSumPlugin,
@@ -66,7 +68,8 @@ export const corePluginRegistry = new Registry<CorePluginConstructor>()
   .add("conditional formatting", ConditionalFormatPlugin)
   .add("figures", FigurePlugin)
   .add("chart", ChartPlugin)
-  .add("image", ImagePlugin);
+  .add("image", ImagePlugin)
+  .add("pivot_core", PivotCorePlugin);
 
 // Plugins which handle a specific feature, without handling any core commands
 export const featurePluginRegistry = new Registry<UIPluginConstructor>()
@@ -103,4 +106,5 @@ export const coreViewsPluginRegistry = new Registry<UIPluginConstructor>()
   .add("row_size", HeaderSizeUIPlugin)
   .add("data_validation_ui", EvaluationDataValidationPlugin)
   .add("dynamic_tables", DynamicTablesPlugin)
-  .add("custom_colors", CustomColorsPlugin);
+  .add("custom_colors", CustomColorsPlugin)
+  .add("pivot_ui", PivotUIPlugin);

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -1,0 +1,272 @@
+import { Token } from "../../formulas";
+import { astToFormula } from "../../formulas/parser";
+import {
+  getFirstPivotFunction,
+  getNumberOfPivotFunctions,
+} from "../../helpers/pivot/pivot_helpers";
+import { pivotRegistry } from "../../helpers/pivot/pivot_registry";
+import { Pivot } from "../../helpers/pivot/pivot_runtime";
+import {
+  AddPivotCommand,
+  CellPosition,
+  Command,
+  CoreCommand,
+  UID,
+  UpdatePivotCommand,
+} from "../../types";
+import { UIPlugin, UIPluginConfig } from "../ui_plugin";
+
+export const UNDO_REDO_PIVOT_COMMANDS = ["ADD_PIVOT", "UPDATE_PIVOT"];
+
+function isPivotCommand(cmd: CoreCommand): cmd is AddPivotCommand | UpdatePivotCommand {
+  return UNDO_REDO_PIVOT_COMMANDS.includes(cmd.type);
+}
+
+export class PivotUIPlugin extends UIPlugin {
+  static getters = [
+    "getPivot",
+    "getFirstPivotFunction",
+    "getPivotIdFromPosition",
+    "getPivotDomainArgsFromPosition",
+    "isPivotUnused",
+    "areDomainArgsFieldsValid",
+  ] as const;
+
+  private pivots: Record<UID, Pivot> = {};
+  private unusedPivots?: UID[];
+  private custom: UIPluginConfig["custom"];
+
+  constructor(config: UIPluginConfig) {
+    super(config);
+    this.custom = config.custom;
+  }
+
+  beforeHandle(cmd: Command) {
+    switch (cmd.type) {
+      case "START":
+        for (const pivotId of this.getters.getPivotIds()) {
+          this.setupPivot(pivotId);
+        }
+    }
+  }
+
+  handle(cmd: Command) {
+    switch (cmd.type) {
+      case "REFRESH_PIVOT":
+        this.refreshPivot(cmd.id);
+        break;
+      case "ADD_PIVOT": {
+        this.setupPivot(cmd.pivotId);
+        break;
+      }
+      case "DUPLICATE_PIVOT": {
+        this.setupPivot(cmd.newPivotId);
+        break;
+      }
+      case "UPDATE_PIVOT": {
+        this.setupPivot(cmd.pivotId, { recreate: true });
+        break;
+      }
+      case "DELETE_SHEET":
+      case "UPDATE_CELL": {
+        this.unusedPivots = undefined;
+        break;
+      }
+      case "UNDO":
+      case "REDO": {
+        this.unusedPivots = undefined;
+
+        const pivotCommands = cmd.commands.filter(isPivotCommand);
+
+        for (const cmd of pivotCommands) {
+          const pivotId = cmd.pivotId;
+          if (!this.getters.isExistingPivot(pivotId)) {
+            continue;
+          }
+          this.setupPivot(pivotId, { recreate: true });
+        }
+        break;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Getters
+  // ---------------------------------------------------------------------
+
+  /**
+   * Get the id of the pivot at the given position. Returns undefined if there
+   * is no pivot at this position
+   */
+  getPivotIdFromPosition(position: CellPosition) {
+    const cell = this.getters.getCorrespondingFormulaCell(position);
+    if (cell && cell.isFormula) {
+      const pivotFunction = this.getFirstPivotFunction(cell.compiledFormula.tokens);
+      if (pivotFunction) {
+        const pivotId = pivotFunction.args[0]?.toString();
+        return pivotId && this.getters.getPivotId(pivotId);
+      }
+    }
+    return undefined;
+  }
+
+  getFirstPivotFunction(tokens: Token[]) {
+    const pivotFunction = getFirstPivotFunction(tokens);
+    if (!pivotFunction) {
+      return undefined;
+    }
+    const { functionName, args } = pivotFunction;
+    const evaluatedArgs = args.map((argAst) => {
+      if (argAst.type == "EMPTY") {
+        return undefined;
+      } else if (
+        argAst.type === "STRING" ||
+        argAst.type === "BOOLEAN" ||
+        argAst.type === "NUMBER"
+      ) {
+        return argAst.value;
+      }
+      const argsString = astToFormula(argAst);
+      return this.getters.evaluateFormula(this.getters.getActiveSheetId(), argsString);
+    });
+    return { functionName, args: evaluatedArgs };
+  }
+
+  /**
+   * Returns the domain args of a pivot formula from a position.
+   * For all those formulas:
+   *
+   * =PIVOT.VALUE(1,"expected_revenue","stage_id",2,"city","Brussels")
+   * =PIVOT.HEADER(1,"stage_id",2,"city","Brussels")
+   * =PIVOT.HEADER(1,"stage_id",2,"city","Brussels","measure","expected_revenue")
+   *
+   * the result is the same: ["stage_id", 2, "city", "Brussels"]
+   *
+   * If the cell is the result of PIVOT, the result is the domain of the cell
+   * as if it was the individual pivot formula
+   */
+  getPivotDomainArgsFromPosition(position: CellPosition) {
+    const cell = this.getters.getCorrespondingFormulaCell(position);
+    if (!cell || !cell.isFormula || getNumberOfPivotFunctions(cell.compiledFormula.tokens) === 0) {
+      return undefined;
+    }
+    const mainPosition = this.getters.getCellPosition(cell.id);
+    const result = this.getters.getFirstPivotFunction(cell.compiledFormula.tokens);
+    if (!result) {
+      return undefined;
+    }
+    const { functionName, args } = result;
+    if (functionName === "PIVOT") {
+      const formulaId = args[0];
+      if (!formulaId) {
+        return undefined;
+      }
+      const pivotId = this.getters.getPivotId(formulaId.toString());
+      const pivot = this.getPivot(pivotId);
+      if (!pivotId || !pivot.isLoadedAndValid()) {
+        return undefined;
+      }
+      const includeTotal = args[2] === false ? false : undefined;
+      const includeColumnHeaders = args[3] === false ? false : undefined;
+      const pivotCells = pivot
+        .getTableStructure()
+        .getPivotCells(includeTotal, includeColumnHeaders);
+      const pivotCol = position.col - mainPosition.col;
+      const pivotRow = position.row - mainPosition.row;
+      const pivotCell = pivotCells[pivotCol][pivotRow];
+      const domain = pivotCell.domain;
+      if (domain?.at(-2) === "measure") {
+        return domain.slice(0, -2);
+      }
+      return domain;
+    }
+    const domain = args.slice(functionName === "PIVOT.VALUE" ? 2 : 1);
+    if (domain.at(-2) === "measure") {
+      return domain.slice(0, -2);
+    }
+    return domain;
+  }
+
+  getPivot(pivotId: UID) {
+    const dataSourceId = this.getPivotDataSourceId(pivotId);
+    return this.pivots[dataSourceId];
+  }
+
+  getPivotDataSourceId(pivotId: UID) {
+    return `pivot-${pivotId}`;
+  }
+
+  isPivotUnused(pivotId: UID) {
+    return this._getUnusedPivots().includes(pivotId);
+  }
+
+  /**
+   * Check if the fields in the domain part of
+   * a pivot function are valid according to the pivot definition.
+   * e.g. =PIVOT.VALUE(1,"revenue","country_id",...,"create_date:month",...,"source_id",...)
+   */
+  areDomainArgsFieldsValid(pivotId: UID, domainArgs: string[]) {
+    const dimensions = domainArgs
+      .filter((arg, index) => index % 2 === 0)
+      .map((name) => (name.startsWith("#") ? name.slice(1) : name));
+    let argIndex = 0;
+    let definitionIndex = 0;
+    const pivot = this.getPivot(pivotId);
+    const definition = pivot.definition;
+    const cols = definition.columns.map((col) => col.nameWithGranularity);
+    const rows = definition.rows.map((row) => row.nameWithGranularity);
+    while (dimensions[argIndex] !== undefined && dimensions[argIndex] === rows[definitionIndex]) {
+      argIndex++;
+      definitionIndex++;
+    }
+    definitionIndex = 0;
+    while (dimensions[argIndex] !== undefined && dimensions[argIndex] === cols[definitionIndex]) {
+      argIndex++;
+      definitionIndex++;
+    }
+    return dimensions.length === argIndex;
+  }
+
+  // ---------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------
+
+  /**
+   * Refresh the cache of a pivot
+   */
+  private refreshPivot(pivotId: UID) {
+    const pivot = this.getters.getPivot(pivotId);
+    pivot.load({ reload: true });
+  }
+
+  setupPivot(pivotId: UID, { recreate } = { recreate: false }) {
+    const dataSourceId = this.getPivotDataSourceId(pivotId);
+    const definition = this.getters.getPivotCoreDefinition(pivotId);
+    if (recreate || !(dataSourceId in this.pivots)) {
+      const cls = pivotRegistry.get(definition.type).cls;
+      this.pivots[dataSourceId] = new cls(this.custom, { definition, getters: this.getters });
+    }
+  }
+
+  _getUnusedPivots() {
+    if (this.unusedPivots !== undefined) {
+      return this.unusedPivots;
+    }
+    const unusedPivots = new Set(this.getters.getPivotIds());
+    for (const sheetId of this.getters.getSheetIds()) {
+      for (const cellId in this.getters.getCells(sheetId)) {
+        const position = this.getters.getCellPosition(cellId);
+        const pivotId = this.getPivotIdFromPosition(position);
+        if (pivotId) {
+          unusedPivots.delete(pivotId);
+          if (!unusedPivots.size) {
+            this.unusedPivots = [];
+            return [];
+          }
+        }
+      }
+    }
+    this.unusedPivots = [...unusedPivots];
+    return this.unusedPivots;
+  }
+}

--- a/src/registries/auto_completes/index.ts
+++ b/src/registries/auto_completes/index.ts
@@ -1,4 +1,5 @@
 export * from "./auto_complete_registry";
 export * from "./data_validation_auto_complete";
 export * from "./function_auto_complete";
+export * from "./pivot_auto_complete";
 export * from "./sheet_name_auto_complete";

--- a/src/registries/auto_completes/pivot_auto_complete.ts
+++ b/src/registries/auto_completes/pivot_auto_complete.ts
@@ -1,0 +1,243 @@
+import { tokenColors } from "../../components/composer/composer/composer";
+import { EnrichedToken } from "../../formulas/composer_tokenizer";
+import { isDefined } from "../../helpers";
+import {
+  extractFormulaIdFromToken,
+  insertTokenAfterArgSeparator,
+  insertTokenAfterLeftParenthesis,
+  makeFieldProposal,
+} from "../../helpers/pivot/pivot_helpers";
+import { _t } from "../../translation";
+import { autoCompleteProviders } from "./auto_complete_registry";
+
+autoCompleteProviders.add("pivot_ids", {
+  sequence: 50,
+  autoSelectFirstProposal: true,
+  getProposals(tokenAtCursor) {
+    const functionContext = tokenAtCursor.functionContext;
+    const pivotFunction = ["PIVOT.VALUE", "PIVOT.HEADER", "PIVOT"];
+    if (
+      !functionContext ||
+      !pivotFunction.includes(functionContext.parent.toUpperCase()) ||
+      functionContext.argPosition !== 0
+    ) {
+      return;
+    }
+    const pivotIds = this.getters.getPivotIds();
+    if (pivotIds.includes(tokenAtCursor.value)) {
+      return;
+    }
+    return pivotIds.map((pivotId) => {
+      const definition = this.getters.getPivotCoreDefinition(pivotId);
+      const formulaId = this.getters.getPivotFormulaId(pivotId);
+      const str = `${formulaId}`;
+      return {
+        text: str,
+        description: definition.name,
+        htmlContent: [{ value: str, color: tokenColors.NUMBER }],
+        fuzzySearchKey: str + definition.name,
+      };
+    });
+  },
+  selectProposal: insertTokenAfterLeftParenthesis,
+});
+
+autoCompleteProviders.add("pivot_measures", {
+  sequence: 50,
+  autoSelectFirstProposal: true,
+  getProposals(tokenAtCursor) {
+    const functionContext = tokenAtCursor.functionContext;
+    if (
+      functionContext?.parent.toUpperCase() !== "PIVOT.VALUE" ||
+      functionContext.argPosition !== 1
+    ) {
+      return [];
+    }
+    const pivotFormulaId = extractFormulaIdFromToken(tokenAtCursor);
+    const pivotId = this.getters.getPivotId(pivotFormulaId);
+    if (!this.getters.isExistingPivot(pivotId)) {
+      return [];
+    }
+    const dataSource = this.getters.getPivot(pivotId);
+    const fields = dataSource.getFields();
+    if (!fields) {
+      return [];
+    }
+    const definition = this.getters.getPivotCoreDefinition(pivotId);
+    return definition.measures
+      .map((measure) => {
+        if (measure.name === "__count") {
+          const text = '"__count"';
+          return {
+            text,
+            description: _t("Count"),
+            htmlContent: [{ value: text, color: tokenColors.STRING }],
+            fuzzySearchKey: _t("Count") + text,
+          };
+        }
+        const field = fields[measure.name];
+        if (!field) {
+          return;
+        }
+        return makeFieldProposal(field);
+      })
+      .filter(isDefined);
+  },
+  selectProposal: insertTokenAfterArgSeparator,
+});
+
+autoCompleteProviders.add("pivot_group_fields", {
+  sequence: 50,
+  autoSelectFirstProposal: true,
+  getProposals(tokenAtCursor) {
+    const functionContext = tokenAtCursor.functionContext;
+    if (
+      !functionContext ||
+      (!canAutoCompletePivotField(tokenAtCursor) && !canAutoCompletePivotHeaderField(tokenAtCursor))
+    ) {
+      return;
+    }
+    const pivotFormulaId = extractFormulaIdFromToken(tokenAtCursor);
+    const pivotId = this.getters.getPivotId(pivotFormulaId);
+    if (!this.getters.isExistingPivot(pivotId)) {
+      return;
+    }
+    const dataSource = this.getters.getPivot(pivotId);
+    const fields = dataSource.getFields();
+    if (!fields) {
+      return;
+    }
+    let args = functionContext.args;
+    if (functionContext?.parent.toUpperCase() === "PIVOT.VALUE") {
+      args = args.filter((ast, index) => index % 2 === 0); // keep only the field names
+      args = args.slice(1, functionContext.argPosition); // remove the first even argument (the pivot id)
+    } else {
+      args = args.filter((ast, index) => index % 2 === 1); // keep only the field names
+    }
+    const argGroupBys = args.map((ast) => ast?.value).filter(isDefined);
+    const { columns, rows } = this.getters.getPivotCoreDefinition(pivotId);
+    const colFields = columns.map((groupBy) => groupBy.name);
+    const rowFields = rows.map((groupBy) => groupBy.name);
+
+    const proposals: string[] = [];
+    const previousGroupBy = ["ARG_SEPARATOR", "SPACE"].includes(tokenAtCursor.type)
+      ? argGroupBys.at(-1)
+      : argGroupBys.at(-2);
+    if (previousGroupBy === undefined) {
+      proposals.push(colFields[0]);
+      proposals.push(rowFields[0]);
+    }
+    if (rowFields.includes(previousGroupBy)) {
+      const nextRowGroupBy = rowFields[rowFields.indexOf(previousGroupBy) + 1];
+      proposals.push(nextRowGroupBy);
+      proposals.push(colFields[0]);
+    }
+    if (colFields.includes(previousGroupBy)) {
+      const nextGroupBy = colFields[colFields.indexOf(previousGroupBy) + 1];
+      proposals.push(nextGroupBy);
+    }
+    const groupBys = proposals.filter(isDefined);
+    return groupBys
+      .map((groupBy) => {
+        const field = fields[groupBy];
+        return field ? makeFieldProposal(field) : undefined;
+      })
+      .concat(
+        groupBys.map((groupBy) => {
+          const field = fields[groupBy];
+          if (!field) {
+            return undefined;
+          }
+          const positionalFieldArg = `"#${field.name}"`;
+          const positionalProposal = {
+            text: positionalFieldArg,
+            description:
+              _t("%s (positional)", field.string) + (field.help ? ` (${field.help})` : ""),
+            htmlContent: [{ value: positionalFieldArg, color: tokenColors.STRING }],
+            fuzzySearchKey: field.string + positionalFieldArg, // search on translated name and on technical name
+          };
+          return positionalProposal;
+        })
+      )
+      .filter(isDefined);
+  },
+  selectProposal: insertTokenAfterArgSeparator,
+});
+
+function canAutoCompletePivotField(tokenAtCursor) {
+  const functionContext = tokenAtCursor.functionContext;
+  return (
+    functionContext?.parent.toUpperCase() === "PIVOT.VALUE" &&
+    functionContext.argPosition >= 2 && // the first two arguments are the pivot id and the measure
+    functionContext.argPosition % 2 === 0 // only the even arguments are the group bys
+  );
+}
+
+function canAutoCompletePivotHeaderField(tokenAtCursor) {
+  const functionContext = tokenAtCursor.functionContext;
+  return (
+    functionContext?.parent.toUpperCase() === "PIVOT.HEADER" &&
+    functionContext.argPosition >= 1 && // the first argument is the pivot id
+    functionContext.argPosition % 2 === 1 // only the odd arguments are the group bys
+  );
+}
+
+autoCompleteProviders.add("pivot_group_values", {
+  sequence: 50,
+  autoSelectFirstProposal: true,
+  getProposals(tokenAtCursor) {
+    const functionContext = tokenAtCursor.functionContext;
+    if (
+      !functionContext ||
+      !tokenAtCursor ||
+      (!canAutoCompletePivotGroupValue(tokenAtCursor) &&
+        !canAutoCompletePivotHeaderGroupValue(tokenAtCursor))
+    ) {
+      return;
+    }
+    const pivotFormulaId = extractFormulaIdFromToken(tokenAtCursor);
+    const pivotId = this.getters.getPivotId(pivotFormulaId);
+    if (!this.getters.isExistingPivot(pivotId)) {
+      return;
+    }
+    const dataSource = this.getters.getPivot(pivotId);
+    if (!dataSource.isLoadedAndValid()) {
+      return;
+    }
+    const argPosition = functionContext.argPosition;
+    const groupByField = tokenAtCursor.functionContext?.args[argPosition - 1]?.value;
+    if (!groupByField) {
+      return;
+    }
+    return dataSource.getPossibleFieldValues(groupByField).map(({ value, label }) => {
+      const isString = typeof value === "string";
+      const text = isString ? `"${value}"` : value.toString();
+      const color = isString ? tokenColors.STRING : tokenColors.NUMBER;
+      return {
+        text,
+        description: label,
+        htmlContent: [{ value: text, color }],
+        fuzzySearchKey: value + label,
+      };
+    });
+  },
+  selectProposal: insertTokenAfterArgSeparator,
+});
+
+function canAutoCompletePivotGroupValue(tokenAtCursor: EnrichedToken) {
+  const functionContext = tokenAtCursor.functionContext;
+  return (
+    functionContext?.parent.toUpperCase() === "PIVOT.VALUE" &&
+    functionContext.argPosition >= 2 && // the first two arguments are the pivot id and the measure
+    functionContext.argPosition % 2 === 1 // only the odd arguments are the group by values
+  );
+}
+
+function canAutoCompletePivotHeaderGroupValue(tokenAtCursor: EnrichedToken) {
+  const functionContext = tokenAtCursor.functionContext;
+  return (
+    functionContext?.parent.toUpperCase() === "PIVOT.HEADER" &&
+    functionContext.argPosition >= 1 && // the first argument is the pivot id
+    functionContext.argPosition % 2 === 0 // only the even arguments are the group by values
+  );
+}

--- a/src/stores/pivot_side_panel_store.ts
+++ b/src/stores/pivot_side_panel_store.ts
@@ -1,0 +1,216 @@
+import { deepCopy, deepEquals } from "../helpers";
+import { MEASURES_TYPES } from "../helpers/pivot/pivot_helpers";
+import { pivotRegistry } from "../helpers/pivot/pivot_registry";
+import { Get } from "../store_engine";
+import { _t } from "../translation";
+import { UID } from "../types";
+import {
+  PivotCoreDefinition,
+  PivotDimension,
+  PivotField,
+  PivotFields,
+  PivotMeasure,
+} from "../types/pivot";
+import { SpreadsheetStore } from "./spreadsheet_store";
+
+export class PivotSidePanelStore extends SpreadsheetStore {
+  private updatesAreDeferred: boolean = true;
+  private draft: PivotCoreDefinition | null = null;
+  constructor(get: Get, private pivotId: UID) {
+    super(get);
+  }
+
+  get fields() {
+    const fields = this.pivot.getFields();
+    if (!fields) {
+      throw new Error("Fields not found");
+    }
+    return fields;
+  }
+
+  get pivot() {
+    return this.getters.getPivot(this.pivotId);
+  }
+
+  get definition() {
+    const type = this.getters.getPivotCoreDefinition(this.pivotId).type;
+    const cls = pivotRegistry.get(type).definition;
+    return this.draft ? new cls(this.draft, this.fields) : this.pivot.definition;
+  }
+
+  get isDirty() {
+    return !!this.draft;
+  }
+
+  get unusedMeasureFields() {
+    const measureFields: PivotField[] = [
+      {
+        name: "__count",
+        string: _t("Count"),
+        type: "integer",
+        aggregator: "sum",
+      },
+    ];
+    const fields = this.fields;
+    for (const fieldName in fields) {
+      const field = fields[fieldName];
+      if (!field) {
+        continue;
+      }
+      if (
+        ((MEASURES_TYPES.includes(field.type) && field.aggregator) || field.type === "many2one") &&
+        field.name !== "id" &&
+        field.store
+      ) {
+        measureFields.push(field);
+      }
+    }
+    const { rows, columns, measures } = this.definition;
+    const currentlyUsed = (measures as (PivotMeasure | PivotDimension)[])
+      .concat(rows)
+      .concat(columns)
+      .map((field) => field.name);
+    return measureFields
+      .filter((field) => !currentlyUsed.includes(field.name))
+      .sort((a, b) => a.string.localeCompare(b.string));
+  }
+
+  get unusedGroupableFields() {
+    const groupableFields: PivotField[] = [];
+    const fields = this.fields;
+    for (const fieldName in fields) {
+      const field = fields[fieldName];
+      if (!field) {
+        continue;
+      }
+      if (field.groupable) {
+        groupableFields.push(field);
+      }
+    }
+    const { columns, rows, measures } = this.definition;
+    const currentlyUsed = (measures as (PivotMeasure | PivotDimension)[])
+      .concat(rows)
+      .concat(columns)
+      .map((field) => field.name);
+    const unusedDateTimeGranularities = this.unusedDateTimeGranularities;
+    return groupableFields
+      .filter((field) => {
+        if (field.type === "date" || field.type === "datetime") {
+          return (
+            !currentlyUsed.includes(field.name) || unusedDateTimeGranularities[field.name].size > 0
+          );
+        }
+        return !currentlyUsed.includes(field.name);
+      })
+      .sort((a, b) => a.string.localeCompare(b.string));
+  }
+
+  get unusedDateTimeGranularities() {
+    return this.getUnusedDateTimeGranularities(
+      this.fields,
+      this.draft ?? this.getters.getPivotCoreDefinition(this.pivotId)
+    );
+  }
+
+  reset(pivotId: UID) {
+    this.pivotId = pivotId;
+    this.updatesAreDeferred = true;
+    this.draft = null;
+  }
+
+  deferUpdates(shouldDefer: boolean) {
+    this.updatesAreDeferred = shouldDefer;
+    if (shouldDefer === false && this.draft) {
+      this.applyUpdate();
+    }
+  }
+
+  applyUpdate() {
+    if (this.draft) {
+      this.model.dispatch("UPDATE_PIVOT", {
+        pivotId: this.pivotId,
+        pivot: this.draft,
+      });
+      this.draft = null;
+    }
+  }
+
+  discardPendingUpdate() {
+    this.draft = null;
+  }
+
+  update(definitionUpdate: Partial<PivotCoreDefinition>) {
+    const coreDefinition = this.getters.getPivotCoreDefinition(this.pivotId);
+    const definition = { ...coreDefinition, ...this.draft, ...definitionUpdate };
+    // clean to make sure we only keep the core properties
+    const cleanedDefinition = {
+      ...definition,
+      columns: definition.columns.map((col) => ({
+        name: col.name,
+        order: col.order,
+        granularity: col.granularity,
+      })),
+      rows: definition.rows.map((row) => ({
+        name: row.name,
+        order: row.order,
+        granularity: row.granularity,
+      })),
+      measures: definition.measures.map((measure) => ({
+        name: measure.name,
+        aggregator: measure.aggregator,
+      })),
+    };
+    if (!this.draft && deepEquals(coreDefinition, cleanedDefinition)) {
+      return;
+    }
+    const cleanedWithGranularity = this.addDefaultDateTimeGranularity(
+      this.fields,
+      cleanedDefinition
+    );
+    if (this.updatesAreDeferred) {
+      this.draft = cleanedWithGranularity;
+    } else {
+      this.model.dispatch("UPDATE_PIVOT", {
+        pivotId: this.pivotId,
+        pivot: cleanedWithGranularity,
+      });
+    }
+  }
+
+  private addDefaultDateTimeGranularity(fields: PivotFields, definition: PivotCoreDefinition) {
+    const { columns, rows } = definition;
+    const columnsWithGranularity = deepCopy(columns);
+    const rowsWithGranularity = deepCopy(rows);
+    const unusedGranularities = this.getUnusedDateTimeGranularities(fields, definition);
+    for (const dimension of columnsWithGranularity.concat(rowsWithGranularity)) {
+      const fieldType = fields[dimension.name]?.type;
+      if ((fieldType === "date" || fieldType === "datetime") && !dimension.granularity) {
+        const granularity = unusedGranularities[dimension.name]?.values().next().value || "year";
+        unusedGranularities[dimension.name]?.delete(granularity);
+        dimension.granularity = granularity;
+      }
+    }
+    return {
+      ...definition,
+      columns: columnsWithGranularity,
+      rows: rowsWithGranularity,
+    };
+  }
+
+  private getUnusedDateTimeGranularities(fields: PivotFields, definition: PivotCoreDefinition) {
+    const { columns, rows } = definition;
+    const dateFields = columns.concat(rows).filter((dimension) => {
+      const fieldType = fields[dimension.name]?.type;
+      return fieldType === "date" || fieldType === "datetime";
+    });
+    const granularities = ["year", "quarter", "month", "week", "day"];
+    const granularitiesPerFields = {};
+    for (const field of dateFields) {
+      granularitiesPerFields[field.name] = new Set(granularities);
+    }
+    for (const field of dateFields) {
+      granularitiesPerFields[field.name].delete(field.granularity);
+    }
+    return granularitiesPerFields;
+  }
+}

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -25,6 +25,7 @@ import { ClipboardPasteOptions } from "./clipboard";
 import { FigureSize } from "./figure";
 import { SearchOptions } from "./find_and_replace";
 import { Image } from "./image";
+import { PivotCoreDefinition, SPTableData } from "./pivot";
 import { RangeData } from "./range";
 import { CoreTableType, TableConfig } from "./table";
 
@@ -117,6 +118,12 @@ export const invalidateEvaluationCommands = new Set<CommandTypes>([
   "REDO",
   "ADD_MERGE",
   "UPDATE_LOCALE",
+  "ADD_PIVOT",
+  "UPDATE_PIVOT",
+  "INSERT_PIVOT",
+  "RENAME_PIVOT",
+  "REMOVE_PIVOT",
+  "DUPLICATE_PIVOT",
 ]);
 
 export const invalidateDependenciesCommands = new Set<CommandTypes>(["MOVE_RANGES"]);
@@ -231,6 +238,14 @@ export const coreTypes = new Set<CoreCommandTypes>([
 
   /** MISC */
   "UPDATE_LOCALE",
+
+  /** PIVOT */
+  "ADD_PIVOT",
+  "UPDATE_PIVOT",
+  "INSERT_PIVOT",
+  "RENAME_PIVOT",
+  "REMOVE_PIVOT",
+  "DUPLICATE_PIVOT",
 ]);
 
 export function isCoreCommand(cmd: Command): cmd is CoreCommand {
@@ -554,6 +569,44 @@ export interface UpdateLocaleCommand {
 }
 
 // ------------------------------------------------
+// PIVOT
+// ------------------------------------------------
+export interface AddPivotCommand {
+  type: "ADD_PIVOT";
+  pivotId: UID;
+  pivot: PivotCoreDefinition;
+}
+
+export interface UpdatePivotCommand {
+  type: "UPDATE_PIVOT";
+  pivotId: UID;
+  pivot: PivotCoreDefinition;
+}
+
+export interface InsertPivotCommand extends PositionDependentCommand {
+  type: "INSERT_PIVOT";
+  pivotId: UID;
+  table: SPTableData;
+}
+
+export interface RenamePivotCommand {
+  type: "RENAME_PIVOT";
+  pivotId: UID;
+  name: string;
+}
+
+export interface RemovePivotCommand {
+  type: "REMOVE_PIVOT";
+  pivotId: UID;
+}
+
+export interface DuplicatePivotCommand {
+  type: "DUPLICATE_PIVOT";
+  pivotId: UID;
+  newPivotId: string;
+}
+
+// ------------------------------------------------
 // DATA CLEANUP
 // ------------------------------------------------
 
@@ -867,6 +920,11 @@ export interface RenderCanvasCommand {
   type: "RENDER_CANVAS";
 }
 
+export interface RefreshPivotCommand {
+  type: "REFRESH_PIVOT";
+  id: UID;
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -950,7 +1008,15 @@ export type CoreCommand =
   | RemoveDataValidationCommand
 
   /** MISC */
-  | UpdateLocaleCommand;
+  | UpdateLocaleCommand
+
+  /** PIVOT */
+  | AddPivotCommand
+  | UpdatePivotCommand
+  | InsertPivotCommand
+  | RenamePivotCommand
+  | RemovePivotCommand
+  | DuplicatePivotCommand;
 
 export type LocalCommand =
   | RequestUndoCommand
@@ -999,7 +1065,8 @@ export type LocalCommand =
   | RemoveDuplicatesCommand
   | TrimWhitespaceCommand
   | RenderCanvasCommand
-  | ResizeTableCommand;
+  | ResizeTableCommand
+  | RefreshPivotCommand;
 
 export type Command = CoreCommand | LocalCommand;
 
@@ -1160,6 +1227,8 @@ export const enum CommandResult {
   InvalidInputId = "InvalidInputId",
   SheetIsHidden = "SheetIsHidden",
   InvalidTableResize = "InvalidTableResize",
+  PivotIdNotFound = "PivotIdNotFound",
+  EmptyName = "EmptyName",
 }
 
 export interface CommandHandler<T> {

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -9,6 +9,7 @@ import { HeaderSizePlugin } from "../plugins/core/header_size";
 import { HeaderVisibilityPlugin } from "../plugins/core/header_visibility";
 import { ImagePlugin } from "../plugins/core/image";
 import { MergePlugin } from "../plugins/core/merge";
+import { PivotCorePlugin } from "../plugins/core/pivot";
 import { RangeAdapter } from "../plugins/core/range";
 import { SettingsPlugin } from "../plugins/core/settings";
 import { SheetPlugin } from "../plugins/core/sheet";
@@ -20,6 +21,7 @@ import { DynamicTablesPlugin } from "../plugins/ui_core_views/dynamic_tables";
 import { EvaluationChartPlugin } from "../plugins/ui_core_views/evaluation_chart";
 import { EvaluationConditionalFormatPlugin } from "../plugins/ui_core_views/evaluation_conditional_format";
 import { HeaderSizeUIPlugin } from "../plugins/ui_core_views/header_sizes_ui";
+import { PivotUIPlugin } from "../plugins/ui_core_views/pivot_ui";
 import { AutofillPlugin } from "../plugins/ui_feature/autofill";
 import { AutomaticSumPlugin } from "../plugins/ui_feature/automatic_sum";
 import { CellComputedStylePlugin } from "../plugins/ui_feature/cell_computed_style";
@@ -108,7 +110,8 @@ export type CoreGetters = PluginGetters<typeof SheetPlugin> &
   PluginGetters<typeof TablePlugin> &
   PluginGetters<typeof SettingsPlugin> &
   PluginGetters<typeof HeaderGroupingPlugin> &
-  PluginGetters<typeof DataValidationPlugin>;
+  PluginGetters<typeof DataValidationPlugin> &
+  PluginGetters<typeof PivotCorePlugin>;
 
 export type Getters = {
   isReadonly: () => boolean;
@@ -138,4 +141,5 @@ export type Getters = {
   PluginGetters<typeof HeaderPositionsUIPlugin> &
   PluginGetters<typeof TableStylePlugin> &
   PluginGetters<typeof CellComputedStylePlugin> &
-  PluginGetters<typeof DynamicTablesPlugin>;
+  PluginGetters<typeof DynamicTablesPlugin> &
+  PluginGetters<typeof PivotUIPlugin>;

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -1,0 +1,100 @@
+import { CellValue } from "./cells";
+import { Format } from "./format";
+import { Locale } from "./locale";
+
+export type Aggregator =
+  | "array_agg"
+  | "count"
+  | "count_distinct"
+  | "bool_and"
+  | "bool_or"
+  | "max"
+  | "min"
+  | "avg"
+  | "sum";
+
+export type Granularity = "day" | "week" | "month" | "quarter" | "year";
+
+export interface PivotCoreDimension {
+  name: string;
+  order?: "asc" | "desc";
+  granularity?: Granularity | string;
+}
+
+export interface PivotCoreMeasure {
+  name: string;
+  aggregator?: Aggregator | string;
+}
+
+export interface CommonPivotCoreDefinition {
+  columns: PivotCoreDimension[];
+  rows: PivotCoreDimension[];
+  measures: PivotCoreMeasure[];
+  name: string;
+}
+
+export interface SpreadsheetPivotCoreDefinition extends CommonPivotCoreDefinition {
+  type: "SPREADSHEET";
+}
+
+export type PivotCoreDefinition = SpreadsheetPivotCoreDefinition;
+
+export interface PivotField {
+  name: string;
+  type: string;
+  string: string;
+  relation?: string;
+  searchable?: boolean;
+  aggregator?: string;
+  store?: boolean;
+  groupable?: boolean;
+  help?: string;
+}
+
+export type PivotFields = Record<string, PivotField | undefined>;
+
+export interface PivotMeasure extends PivotCoreMeasure {
+  nameWithAggregator: string;
+  displayName: string;
+  type: string;
+}
+
+export interface PivotDimension extends PivotCoreDimension {
+  nameWithGranularity: string;
+  displayName: string;
+  type: string;
+}
+
+export interface SPTableColumn {
+  fields: string[];
+  values: string[];
+  width: number;
+  offset: number;
+}
+
+export interface SPTableRow {
+  fields: string[];
+  values: string[];
+  indent: number;
+}
+
+export interface SPTableData {
+  cols: SPTableColumn[][];
+  rows: SPTableRow[];
+  measures: string[];
+  rowTitle?: string;
+}
+
+export interface SPTableCell {
+  isHeader: boolean;
+  domain?: string[];
+  content?: string;
+  measure?: string;
+}
+
+export interface PivotTimeAdapter<T> {
+  normalizeFunctionValue: (value: string) => T;
+  formatValue: (normalizedValue: T, locale?: Locale) => string;
+  getFormat: (locale?: Locale) => Format | undefined;
+  toCellValue: (normalizedValue: T) => CellValue;
+}

--- a/src/types/workbook_data.ts
+++ b/src/types/workbook_data.ts
@@ -3,6 +3,7 @@ import { ExcelChartDefinition } from "./chart/chart";
 import { ConditionalFormat } from "./conditional_formatting";
 import { Image } from "./image";
 import { Border, Dimension, HeaderGroup, PaneDivision, Pixel, Style, UID } from "./misc";
+import { PivotCoreDefinition } from "./pivot";
 import { CoreTableType, TableConfig } from "./table";
 
 export interface Dependencies {
@@ -56,12 +57,18 @@ interface WorkbookSettings {
   locale: Locale;
 }
 
+interface PivotData extends PivotCoreDefinition {
+  formulaId: string;
+}
+
 export interface WorkbookData {
   version: number;
   sheets: SheetData[];
   styles: { [key: number]: Style };
   formats: { [key: number]: Format };
   borders: { [key: number]: Border };
+  pivots: { [key: string]: PivotData };
+  pivotNextId: number;
   revisionId: UID;
   uniqueFigureIds: boolean;
   settings: WorkbookSettings;

--- a/tests/menus/menu_items_registry.test.ts
+++ b/tests/menus/menu_items_registry.test.ts
@@ -211,12 +211,12 @@ describe("Menu Item actions", () => {
 
   test("Edit -> paste_special should be hidden after a CUT ", () => {
     model.dispatch("CUT");
-    expect(getNode(["edit", "paste_special"]).isVisible(env)).toBeFalsy();
+    expect(getNode(["edit", "paste_special"], env).isVisible(env)).toBeFalsy();
   });
 
   test("Edit -> paste_special should not be hidden after a COPY ", () => {
     copy(model, env.model.getters.getSelectedZones().map(zoneToXc).join(","));
-    expect(getNode(["edit", "paste_special"]).isVisible(env)).toBeTruthy();
+    expect(getNode(["edit", "paste_special"], env).isVisible(env)).toBeTruthy();
   });
 
   test("Edit -> paste_special -> paste_special_value", async () => {
@@ -324,7 +324,7 @@ describe("Menu Item actions", () => {
       selectRow(model, 4, "newAnchor");
       selectRow(model, lastRow, "updateAnchor");
 
-      expect(getNode(path).isVisible(env)).toBeFalsy();
+      expect(getNode(path, env).isVisible(env)).toBeFalsy();
     });
 
     test("Delete row option unavailable when selecting all rows with folded row grouping", () => {
@@ -335,7 +335,7 @@ describe("Menu Item actions", () => {
 
       selectRow(model, 3, "newAnchor");
       selectRow(model, lastRow, "updateAnchor");
-      expect(getNode(path).isVisible(env)).toBeFalsy();
+      expect(getNode(path, env).isVisible(env)).toBeFalsy();
     });
   });
 
@@ -408,7 +408,7 @@ describe("Menu Item actions", () => {
       selectColumn(model, 3, "newAnchor");
       selectColumn(model, lastColumn, "updateAnchor");
 
-      expect(getNode(path).isVisible(env)).toBeFalsy();
+      expect(getNode(path, env).isVisible(env)).toBeFalsy();
     });
   });
 
@@ -418,7 +418,7 @@ describe("Menu Item actions", () => {
     test("A selected row", () => {
       selectRow(model, 4, "overrideSelection");
       expect(getName(insertRowBeforePath, env)).toBe("Row above");
-      expect(getNode(insertRowBeforePath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected rows", () => {
@@ -433,24 +433,24 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(insertRowBeforePath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected rows", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(insertRowBeforePath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getNode(insertRowBeforePath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
       expect(getName(insertRowBeforePath, env)).toBe("Row above");
-      expect(getNode(insertRowBeforePath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -465,7 +465,7 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(insertRowBeforePath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowBeforePath, env).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -475,7 +475,7 @@ describe("Menu Item actions", () => {
     test("A selected row", () => {
       selectRow(model, 4, "overrideSelection");
       expect(getName(addRowBeforePath, env, rowMenuRegistry)).toBe("Insert row above");
-      expect(getNode(addRowBeforePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addRowBeforePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected rows", () => {
@@ -490,18 +490,18 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(addRowBeforePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addRowBeforePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected rows", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(addRowBeforePath, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(addRowBeforePath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });
 
     test("Full sheet selected", () => {
       selectAll(model);
-      expect(getNode(addRowBeforePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addRowBeforePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -511,7 +511,7 @@ describe("Menu Item actions", () => {
     test("A selected row", () => {
       selectRow(model, 4, "overrideSelection");
       expect(getName(insertRowAfterPath, env)).toBe("Row below");
-      expect(getNode(insertRowAfterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected rows", () => {
@@ -526,24 +526,24 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(insertRowAfterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected rows", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(insertRowAfterPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getNode(insertRowAfterPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
       expect(getName(insertRowAfterPath, env)).toBe("Row below");
-      expect(getNode(insertRowAfterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -558,7 +558,7 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(insertRowAfterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertRowAfterPath, env).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -568,7 +568,7 @@ describe("Menu Item actions", () => {
     test("A selected row", () => {
       selectRow(model, 4, "overrideSelection");
       expect(getName(addRowAfterPath, env, rowMenuRegistry)).toBe("Insert row below");
-      expect(getNode(addRowAfterPath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addRowAfterPath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected rows", () => {
@@ -583,18 +583,18 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(addRowAfterPath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addRowAfterPath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected rows", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(addRowAfterPath, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(addRowAfterPath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });
 
     test("Full sheet selected", () => {
       selectAll(model);
-      expect(getNode(addRowAfterPath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addRowAfterPath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -604,7 +604,7 @@ describe("Menu Item actions", () => {
     test("A selected column", () => {
       selectColumn(model, 4, "overrideSelection");
       expect(getName(insertColBeforePath, env)).toBe("Column left");
-      expect(getNode(insertColBeforePath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected columns", () => {
@@ -619,24 +619,24 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(insertColBeforePath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected columns", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(insertColBeforePath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected row should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getNode(insertColBeforePath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
       expect(getName(insertColBeforePath, env)).toBe("Column left");
-      expect(getNode(insertColBeforePath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -651,7 +651,7 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(insertColBeforePath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColBeforePath, env).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -661,7 +661,7 @@ describe("Menu Item actions", () => {
     test("A selected column", () => {
       selectColumn(model, 4, "overrideSelection");
       expect(getName(addColBeforePath, env, colMenuRegistry)).toBe("Insert column left");
-      expect(getNode(addColBeforePath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addColBeforePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected columns", () => {
@@ -676,18 +676,18 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "before",
       });
-      expect(getNode(addColBeforePath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addColBeforePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected columns", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(addColBeforePath, colMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(addColBeforePath, env, colMenuRegistry).isVisible(env)).toBeFalsy();
     });
 
     test("Full sheet selected", () => {
       selectAll(model);
-      expect(getNode(addColBeforePath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addColBeforePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -697,7 +697,7 @@ describe("Menu Item actions", () => {
     test("A selected column", () => {
       selectColumn(model, 4, "overrideSelection");
       expect(getName(insertColAfterPath, env)).toBe("Column right");
-      expect(getNode(insertColAfterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected columns", () => {
@@ -712,24 +712,24 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(insertColAfterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected columns", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(insertColAfterPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected row should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getNode(insertColAfterPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
       selectCell(model, "D4");
       expect(getName(insertColAfterPath, env)).toBe("Column right");
-      expect(getNode(insertColAfterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -744,7 +744,7 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(insertColAfterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertColAfterPath, env).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -754,7 +754,7 @@ describe("Menu Item actions", () => {
     test("A selected column", () => {
       selectColumn(model, 4, "overrideSelection");
       expect(getName(addColAfterPath, env, colMenuRegistry)).toBe("Insert column right");
-      expect(getNode(addColAfterPath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addColAfterPath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple consecutive selected columns", () => {
@@ -769,18 +769,18 @@ describe("Menu Item actions", () => {
         quantity: 2,
         position: "after",
       });
-      expect(getNode(addColAfterPath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addColAfterPath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple inconsecutive selected columns", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(addColAfterPath, colMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(addColAfterPath, env, colMenuRegistry).isVisible(env)).toBeFalsy();
     });
 
     test("Full sheet selected", () => {
       selectAll(model);
-      expect(getNode(addColAfterPath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(addColAfterPath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -789,36 +789,36 @@ describe("Menu Item actions", () => {
 
     test("A selected row should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Multiple consecutive selected columns should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Multiple inconsecutive selected columns should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Multiple consecutive selected rows should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Multiple inconsecutive selected rows should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
@@ -829,7 +829,7 @@ describe("Menu Item actions", () => {
         zone: env.model.getters.getSelectedZone(),
         shiftDimension: "ROW",
       });
-      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -841,7 +841,7 @@ describe("Menu Item actions", () => {
         zone: env.model.getters.getSelectedZone(),
         shiftDimension: "ROW",
       });
-      expect(getNode(insertCellShiftDownPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertCellShiftDownPath, env).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -850,36 +850,36 @@ describe("Menu Item actions", () => {
 
     test("A selected row should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
-      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected column should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
-      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Multiple consecutive selected columns should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 5, "updateAnchor");
-      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Multiple inconsecutive selected columns should hide the item", () => {
       selectColumn(model, 4, "overrideSelection");
       selectColumn(model, 6, "newAnchor");
-      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Multiple consecutive selected rows should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 5, "updateAnchor");
-      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Multiple inconsecutive selected rows should hide the item", () => {
       selectRow(model, 4, "overrideSelection");
       selectRow(model, 6, "newAnchor");
-      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeFalsy();
+      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("A selected cell", () => {
@@ -890,7 +890,7 @@ describe("Menu Item actions", () => {
         zone: env.model.getters.getSelectedZone(),
         shiftDimension: "COL",
       });
-      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected cells", () => {
@@ -902,7 +902,7 @@ describe("Menu Item actions", () => {
         zone: env.model.getters.getSelectedZone(),
         shiftDimension: "COL",
       });
-      expect(getNode(insertCellShiftRightPath).isVisible(env)).toBeTruthy();
+      expect(getNode(insertCellShiftRightPath, env).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -934,9 +934,10 @@ describe("Menu Item actions", () => {
       returns: ["NUMBER"],
     });
     const env = makeTestEnv();
-    const allFunctions = getNode(["insert", "insert_function", "categorie_function_all"]).children(
+    const allFunctions = getNode(
+      ["insert", "insert_function", "categorie_function_all"],
       env
-    );
+    ).children(env);
     expect(allFunctions.map((f) => f.name(env))).toContain("TEST.FUNC");
     restoreDefaultFunctions();
   });
@@ -961,18 +962,19 @@ describe("Menu Item actions", () => {
       category: "hidden",
     });
     const env = makeTestEnv();
-    const functionCategories = getNode(["insert", "insert_function"]).children(env);
+    const functionCategories = getNode(["insert", "insert_function"], env).children(env);
     expect(functionCategories.map((f) => f.name(env))).not.toContain("hidden");
-    const allFunctions = getNode(["insert", "insert_function", "categorie_function_all"]).children(
+    const allFunctions = getNode(
+      ["insert", "insert_function", "categorie_function_all"],
       env
-    );
+    ).children(env);
     expect(allFunctions.map((f) => f.name(env))).not.toContain("HIDDEN.FUNC");
     restoreDefaultFunctions();
   });
 
   describe("Format -> numbers", () => {
     test("Automatic", () => {
-      const action = getNode(["format", "format_number", "format_number_automatic"]);
+      const action = getNode(["format", "format_number", "format_number_automatic"], env);
       action.execute?.(env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -983,7 +985,7 @@ describe("Menu Item actions", () => {
     });
 
     test("Number", () => {
-      const action = getNode(["format", "format_number", "format_number_number"]);
+      const action = getNode(["format", "format_number", "format_number_number"], env);
       expect(action.isActive?.(env)).toBe(false);
       action.execute?.(env);
       expect(dispatch).toHaveBeenCalledWith("SET_FORMATTING", {
@@ -1004,7 +1006,7 @@ describe("Menu Item actions", () => {
       ["format_number_date_time", "9/26/2023 10:43:00 PM"],
       ["format_number_duration", "27:51:38"],
     ])("number formatting description with default locale", (actionId, expectedDescription) => {
-      const action = getNode(["format", "format_number", actionId]);
+      const action = getNode(["format", "format_number", actionId], env);
       expect(action.description(env)).toBe(expectedDescription);
     });
 
@@ -1019,7 +1021,7 @@ describe("Menu Item actions", () => {
       ["format_number_duration", "27:51:38"],
     ])("number formatting description with custom locale", (actionId, expectedDescription) => {
       updateLocale(model, FR_LOCALE);
-      const action = getNode(["format", "format_number", actionId]);
+      const action = getNode(["format", "format_number", actionId], env);
       expect(action.description(env)).toBe(expectedDescription);
     });
 
@@ -1033,14 +1035,14 @@ describe("Menu Item actions", () => {
     });
 
     test("currency format with default currency", () => {
-      const action = getNode(["format", "format_number", "format_number_currency"]);
+      const action = getNode(["format", "format_number", "format_number_currency"], env);
       expect(action.description(env)).toBe("$1,000.12");
       action.execute?.(env);
       expect(getCell(model, "A1")?.format).toBe("[$$]#,##0.00");
     });
 
     test("rounded currency format with default currency", () => {
-      const action = getNode(["format", "format_number", "format_number_currency_rounded"]);
+      const action = getNode(["format", "format_number", "format_number_currency_rounded"], env);
       expect(action.description(env)).toBe("$1,000");
       action.execute?.(env);
       expect(getCell(model, "A1")?.format).toBe("[$$]#,##0");
@@ -1049,7 +1051,7 @@ describe("Menu Item actions", () => {
     test("currency format with custom default currency", () => {
       const model = new Model({}, { defaultCurrencyFormat: "[$€]#,##0.000" });
       env = makeTestEnv({ model });
-      const action = getNode(["format", "format_number", "format_number_currency"]);
+      const action = getNode(["format", "format_number", "format_number_currency"], env);
       expect(action.description(env)).toBe("€1,000.120");
       action.execute?.(env);
       expect(getCell(model, "A1")?.format).toBe("[$€]#,##0.000");
@@ -1058,7 +1060,7 @@ describe("Menu Item actions", () => {
     test("rounded currency format with custom default currency", () => {
       const model = new Model({}, { defaultCurrencyFormat: "[$€]#,##0.000" });
       env = makeTestEnv({ model });
-      const action = getNode(["format", "format_number", "format_number_currency_rounded"]);
+      const action = getNode(["format", "format_number", "format_number_currency_rounded"], env);
       expect(action.description(env)).toBe("€1,000");
       action.execute?.(env);
       expect(getCell(model, "A1")?.format).toBe("[$€]#,##0");
@@ -1067,7 +1069,7 @@ describe("Menu Item actions", () => {
     test("rounded currency format is invisible if the custom default format is already rounded", () => {
       const model = new Model({}, { defaultCurrencyFormat: "[$€]#,##0" });
       env = makeTestEnv({ model });
-      const action = getNode(["format", "format_number", "format_number_currency_rounded"]);
+      const action = getNode(["format", "format_number", "format_number_currency_rounded"], env);
       expect(action.isVisible(env)).toBe(false);
     });
 
@@ -1075,7 +1077,7 @@ describe("Menu Item actions", () => {
       const model = new Model({}, { defaultCurrencyFormat: "[$€]#,##0.000" });
       env = makeTestEnv({ model });
       updateLocale(model, FR_LOCALE);
-      const action = getNode(["format", "format_number", "format_number_currency"]);
+      const action = getNode(["format", "format_number", "format_number_currency"], env);
       expect(action.description(env)).toBe("€1 000,120");
     });
 
@@ -1127,8 +1129,14 @@ describe("Menu Item actions", () => {
     test("Automatic format is active when format is computed", () => {
       selectCell(env.model, "A1");
       setCellContent(env.model, "A1", "1");
-      const setNumberFormatAction = getNode(["format", "format_number", "format_number_number"]);
-      const setAutoFormatAction = getNode(["format", "format_number", "format_number_automatic"]);
+      const setNumberFormatAction = getNode(
+        ["format", "format_number", "format_number_number"],
+        env
+      );
+      const setAutoFormatAction = getNode(
+        ["format", "format_number", "format_number_automatic"],
+        env
+      );
       setNumberFormatAction.execute?.(env);
       expect(getCell(model, "A1")?.format).toBe("#,##0.00");
       setCellContent(env.model, "B1", "=A1");
@@ -1288,13 +1296,13 @@ describe("Menu Item actions", () => {
 
   test("Data -> Split to columns is disabled when multiple cols are selected", () => {
     setSelection(model, ["A1"]);
-    expect(getNode(["data", "split_to_columns"]).isEnabled(env)).toBeTruthy();
+    expect(getNode(["data", "split_to_columns"], env).isEnabled(env)).toBeTruthy();
 
     setSelection(model, ["A1:C1"]);
-    expect(getNode(["data", "split_to_columns"]).isEnabled(env)).toBeFalsy();
+    expect(getNode(["data", "split_to_columns"], env).isEnabled(env)).toBeFalsy();
 
     setSelection(model, ["A1", "B1"]);
-    expect(getNode(["data", "split_to_columns"]).isEnabled(env)).toBeFalsy();
+    expect(getNode(["data", "split_to_columns"], env).isEnabled(env)).toBeFalsy();
   });
 
   test("Data -> Sort ascending", () => {
@@ -1325,12 +1333,12 @@ describe("Menu Item actions", () => {
     test("A selected zone", () => {
       setSelection(model, ["A1:A2"]);
       expect(getName(pathSort, env)).toBe("Sort range");
-      expect(getNode(pathSort).isVisible(env)).toBeTruthy();
+      expect(getNode(pathSort, env).isVisible(env)).toBeTruthy();
     });
 
     test("Multiple selected zones", () => {
       setSelection(model, ["A1:A2", "B1:B2"]);
-      expect(getNode(pathSort).isVisible(env)).toBeFalsy();
+      expect(getNode(pathSort, env).isVisible(env)).toBeFalsy();
     });
   });
   describe("Hide/Unhide Columns", () => {
@@ -1339,7 +1347,7 @@ describe("Menu Item actions", () => {
     test("Action on single column selection", () => {
       selectColumn(model, 1, "overrideSelection");
       expect(getName(hidePath, env, colMenuRegistry)).toBe("Hide column B");
-      expect(getNode(hidePath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(hidePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(hidePath, env, colMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -1350,7 +1358,7 @@ describe("Menu Item actions", () => {
     test("Action with at least one active column", () => {
       setSelection(model, ["B1:B100", "C5"]);
       expect(getName(hidePath, env, colMenuRegistry)).toBe("Hide columns B - C");
-      expect(getNode(hidePath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(hidePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(hidePath, env, colMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -1361,7 +1369,7 @@ describe("Menu Item actions", () => {
     test("Action without any active column", () => {
       setSelection(model, ["B1"]);
       expect(getName(hidePath, env, colMenuRegistry)).toBe("Hide columns");
-      expect(getNode(hidePath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(hidePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(hidePath, env, colMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -1372,13 +1380,13 @@ describe("Menu Item actions", () => {
 
     test("Inactive menu item on invalid selection", () => {
       setSelection(model, ["A1:A100", "A4:Z4"]);
-      expect(getNode(hidePath, colMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(hidePath, env, colMenuRegistry).isVisible(env)).toBeFalsy();
     });
 
     test("Unhide cols from Col menu", () => {
       hideColumns(model, ["C"]);
       setSelection(model, ["B1:E100"]);
-      expect(getNode(unhidePath, colMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(unhidePath, env, colMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(unhidePath, env, colMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("UNHIDE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -1388,13 +1396,13 @@ describe("Menu Item actions", () => {
     });
     test("Unhide rows from Col menu without hidden cols", () => {
       setSelection(model, ["B1:E100"]);
-      expect(getNode(unhidePath, colMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(unhidePath, env, colMenuRegistry).isVisible(env)).toBeFalsy();
     });
     test("Unhide all cols from top menu", () => {
       // no hidden rows
-      expect(getNode(["edit", "edit_unhide_columns"]).isVisible(env)).toBeFalsy();
+      expect(getNode(["edit", "edit_unhide_columns"], env).isVisible(env)).toBeFalsy();
       hideColumns(model, ["C"]);
-      expect(getNode(["edit", "edit_unhide_columns"]).isVisible(env)).toBeTruthy();
+      expect(getNode(["edit", "edit_unhide_columns"], env).isVisible(env)).toBeTruthy();
       doAction(["edit", "edit_unhide_columns"], env);
       const sheetId = env.model.getters.getActiveSheetId();
       expect(dispatch).toHaveBeenCalledWith("UNHIDE_COLUMNS_ROWS", {
@@ -1410,7 +1418,7 @@ describe("Menu Item actions", () => {
     test("Action on single row selection", () => {
       selectRow(model, 1, "overrideSelection");
       expect(getName(hidePath, env, rowMenuRegistry)).toBe("Hide row 2");
-      expect(getNode(hidePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(hidePath, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -1421,7 +1429,7 @@ describe("Menu Item actions", () => {
     test("Action with at least one active row", () => {
       setSelection(model, ["A2:Z2", "C3"]);
       expect(getName(hidePath, env, rowMenuRegistry)).toBe("Hide rows 2 - 3");
-      expect(getNode(hidePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(hidePath, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -1432,7 +1440,7 @@ describe("Menu Item actions", () => {
     test("Action without any active column", () => {
       setSelection(model, ["B1"]);
       expect(getName(hidePath, env, rowMenuRegistry)).toBe("Hide rows");
-      expect(getNode(hidePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(hidePath, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("HIDE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -1443,13 +1451,13 @@ describe("Menu Item actions", () => {
 
     test("Inactive menu item on invalid selection", () => {
       setSelection(model, ["A1:A100", "A4:Z4"]);
-      expect(getNode(hidePath, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });
 
     test("Unhide rows from Row menu with hidden rows", () => {
       hideRows(model, [2]);
       setSelection(model, ["A1:Z4"]);
-      expect(getNode(unhidePath, rowMenuRegistry).isVisible(env)).toBeTruthy();
+      expect(getNode(unhidePath, env, rowMenuRegistry).isVisible(env)).toBeTruthy();
       doAction(unhidePath, env, rowMenuRegistry);
       expect(dispatch).toHaveBeenCalledWith("UNHIDE_COLUMNS_ROWS", {
         sheetId: env.model.getters.getActiveSheetId(),
@@ -1459,14 +1467,14 @@ describe("Menu Item actions", () => {
     });
     test("Unhide rows from Row menu without hidden rows", () => {
       setSelection(model, ["A1:Z4"]);
-      expect(getNode(unhidePath, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(unhidePath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });
 
     test("Unhide all rows from top menu", () => {
       // no hidden rows
-      expect(getNode(["edit", "edit_unhide_rows"]).isVisible(env)).toBeFalsy();
+      expect(getNode(["edit", "edit_unhide_rows"], env).isVisible(env)).toBeFalsy();
       hideRows(model, [2]);
-      expect(getNode(["edit", "edit_unhide_rows"]).isVisible(env)).toBeTruthy();
+      expect(getNode(["edit", "edit_unhide_rows"], env).isVisible(env)).toBeTruthy();
       doAction(["edit", "edit_unhide_rows"], env);
       const sheetId = env.model.getters.getActiveSheetId();
       expect(dispatch).toHaveBeenCalledWith("UNHIDE_COLUMNS_ROWS", {
@@ -1484,7 +1492,7 @@ describe("Menu Item actions", () => {
 
       selectRow(model, 3, "newAnchor");
       selectRow(model, lastRow, "updateAnchor");
-      expect(getNode(hidePath, rowMenuRegistry).isVisible(env)).toBeFalsy();
+      expect(getNode(hidePath, env, rowMenuRegistry).isVisible(env)).toBeFalsy();
     });
 
     describe("Table and filters", () => {
@@ -1512,13 +1520,13 @@ describe("Menu Item actions", () => {
 
       test("Insert -> Table is not visible if there is already a table in the selection, or if the selection is not continuous", () => {
         setSelection(model, ["A1", "B2"]);
-        expect(getNode(insertTablePath).isVisible(env)).toBeFalsy();
+        expect(getNode(insertTablePath, env).isVisible(env)).toBeFalsy();
 
         setSelection(model, ["A1:A5"]);
-        expect(getNode(insertTablePath).isVisible(env)).toBeTruthy();
+        expect(getNode(insertTablePath, env).isVisible(env)).toBeTruthy();
 
         createTable(model, "A1:A5");
-        expect(getNode(insertTablePath).isVisible(env)).toBeFalsy();
+        expect(getNode(insertTablePath, env).isVisible(env)).toBeFalsy();
       });
 
       test("Insert -> Table creates a dynamic table if it's called on a spreading cell", () => {
@@ -1570,9 +1578,9 @@ describe("Menu Item actions", () => {
       });
 
       test("Edit -> Table (topbar) is not visible if there is no table in the selection", () => {
-        expect(getNode(editTablePath).isVisible(env)).toBeFalsy();
+        expect(getNode(editTablePath, env).isVisible(env)).toBeFalsy();
         createTable(model, "A1:A5");
-        expect(getNode(editTablePath).isVisible(env)).toBeTruthy();
+        expect(getNode(editTablePath, env).isVisible(env)).toBeTruthy();
       });
 
       test("Edit table (cellRegistry)", () => {
@@ -1599,20 +1607,20 @@ describe("Menu Item actions", () => {
       });
 
       test("Edit/delete table (cellRegistry) visible only with a single table in the selection", () => {
-        expect(getNode(["edit_table"], cellMenuRegistry).isVisible(env)).toBeFalsy();
-        expect(getNode(["delete_table"], cellMenuRegistry).isVisible(env)).toBeFalsy();
+        expect(getNode(["edit_table"], env, cellMenuRegistry).isVisible(env)).toBeFalsy();
+        expect(getNode(["delete_table"], env, cellMenuRegistry).isVisible(env)).toBeFalsy();
 
         createTable(model, "A1:A5");
-        expect(getNode(["edit_table"], cellMenuRegistry).isVisible(env)).toBeTruthy();
-        expect(getNode(["delete_table"], cellMenuRegistry).isVisible(env)).toBeTruthy();
+        expect(getNode(["edit_table"], env, cellMenuRegistry).isVisible(env)).toBeTruthy();
+        expect(getNode(["delete_table"], env, cellMenuRegistry).isVisible(env)).toBeTruthy();
 
         setSelection(model, ["A1:B5"]);
-        expect(getNode(["edit_table"], cellMenuRegistry).isVisible(env)).toBeTruthy();
-        expect(getNode(["delete_table"], cellMenuRegistry).isVisible(env)).toBeTruthy();
+        expect(getNode(["edit_table"], env, cellMenuRegistry).isVisible(env)).toBeTruthy();
+        expect(getNode(["delete_table"], env, cellMenuRegistry).isVisible(env)).toBeTruthy();
 
         createTable(model, "B1:B5");
-        expect(getNode(["edit_table"], cellMenuRegistry).isVisible(env)).toBeFalsy();
-        expect(getNode(["delete_table"], cellMenuRegistry).isVisible(env)).toBeFalsy();
+        expect(getNode(["edit_table"], env, cellMenuRegistry).isVisible(env)).toBeFalsy();
+        expect(getNode(["delete_table"], env, cellMenuRegistry).isVisible(env)).toBeFalsy();
       });
 
       test("Filters -> Create filter", () => {
@@ -1663,14 +1671,14 @@ describe("Menu Item actions", () => {
 
       test("Filters -> Create filter is disabled when the selection is not continuous", () => {
         setSelection(model, ["A1", "B6"]);
-        expect(getNode(filterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(filterPath).isEnabled(env)).toBeFalsy();
+        expect(getNode(filterPath, env).isVisible(env)).toBeTruthy();
+        expect(getNode(filterPath, env).isEnabled(env)).toBeFalsy();
       });
 
       test("Filters -> Create filter is enabled for continuous selection of multiple zones", () => {
         setSelection(model, ["A1", "A2:A5", "B1:B5"]);
-        expect(getNode(filterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(filterPath).isEnabled(env)).toBeTruthy();
+        expect(getNode(filterPath, env).isVisible(env)).toBeTruthy();
+        expect(getNode(filterPath, env).isEnabled(env)).toBeTruthy();
       });
 
       test("Filters -> Remove filter is displayed instead of add filter when the selection contains a filter", () => {
@@ -1696,16 +1704,16 @@ describe("Menu Item actions", () => {
     });
 
     expect(getName(path_gridlines, env)).toBe("Gridlines");
-    expect(getNode(path_gridlines).isVisible(env)).toBeTruthy();
-    expect(getNode(path_gridlines).isActive?.(env)).toBeTruthy();
+    expect(getNode(path_gridlines, env).isVisible(env)).toBeTruthy();
+    expect(getNode(path_gridlines, env).isActive?.(env)).toBeTruthy();
 
     model.dispatch("SET_GRID_LINES_VISIBILITY", {
       sheetId,
       areGridLinesVisible: false,
     });
     expect(getName(path_gridlines, env)).toBe("Gridlines");
-    expect(getNode(path_gridlines).isVisible(env)).toBeTruthy();
-    expect(getNode(path_gridlines).isActive?.(env)).toBeFalsy();
+    expect(getNode(path_gridlines, env).isVisible(env)).toBeTruthy();
+    expect(getNode(path_gridlines, env).isActive?.(env)).toBeFalsy();
 
     doAction(path_gridlines, env);
     expect(dispatch).toHaveBeenCalledWith("SET_GRID_LINES_VISIBILITY", {
@@ -1729,14 +1737,14 @@ describe("Menu Item actions", () => {
     expect(model.getters.shouldShowFormulas()).toBe(false);
 
     expect(getName(path_formulas, env)).toBe("Formulas");
-    expect(getNode(path_formulas).isVisible(env)).toBeTruthy();
-    expect(getNode(path_formulas).isActive?.(env)).toBeFalsy();
+    expect(getNode(path_formulas, env).isVisible(env)).toBeTruthy();
+    expect(getNode(path_formulas, env).isActive?.(env)).toBeFalsy();
     doAction(path_formulas, env);
     expect(model.getters.shouldShowFormulas()).toBe(true);
 
     expect(getName(path_formulas, env)).toBe("Formulas");
-    expect(getNode(path_formulas).isVisible(env)).toBeTruthy();
-    expect(getNode(path_formulas).isActive?.(env)).toBeTruthy();
+    expect(getNode(path_formulas, env).isVisible(env)).toBeTruthy();
+    expect(getNode(path_formulas, env).isActive?.(env)).toBeTruthy();
     doAction(path_formulas, env);
     expect(model.getters.shouldShowFormulas()).toBe(false);
   });
@@ -1759,13 +1767,13 @@ describe("Menu Item actions", () => {
 
     test("Cannot group multiple selections", () => {
       setSelection(model, ["A1:B3", "C1:C3"]);
-      expect(getNode(groupColsPath).isVisible(env)).toBeFalsy();
+      expect(getNode(groupColsPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Cannot re-group same selection of columns", () => {
       setSelection(model, ["A1:B3"]);
-      getNode(groupColsPath).execute?.(env);
-      expect(getNode(groupColsPath).isVisible(env)).toBeFalsy();
+      getNode(groupColsPath, env).execute?.(env);
+      expect(getNode(groupColsPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Can ungroup columns", () => {
@@ -1778,10 +1786,10 @@ describe("Menu Item actions", () => {
 
     test("Cannot ungroup columns when there's no group in the selection", () => {
       setSelection(model, ["A1:C3"]);
-      expect(getNode(ungroupColsPath).isVisible(env)).toBeFalsy();
+      expect(getNode(ungroupColsPath, env).isVisible(env)).toBeFalsy();
 
       groupColumns(model, "A", "C");
-      expect(getNode(ungroupColsPath).isVisible(env)).toBeTruthy();
+      expect(getNode(ungroupColsPath, env).isVisible(env)).toBeTruthy();
     });
 
     test("Can group rows", () => {
@@ -1796,13 +1804,13 @@ describe("Menu Item actions", () => {
 
     test("Cannot group multiple selections", () => {
       setSelection(model, ["A1:C1", "A2:C2"]);
-      expect(getNode(groupRowsPath).isVisible(env)).toBeFalsy();
+      expect(getNode(groupRowsPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Cannot re-group same selection of rows", () => {
       setSelection(model, ["A1:B3"]);
-      getNode(groupRowsPath).execute?.(env);
-      expect(getNode(groupRowsPath).isVisible(env)).toBeFalsy();
+      getNode(groupRowsPath, env).execute?.(env);
+      expect(getNode(groupRowsPath, env).isVisible(env)).toBeFalsy();
     });
 
     test("Can ungroup rows", () => {
@@ -1815,10 +1823,10 @@ describe("Menu Item actions", () => {
 
     test("Cannot ungroup rows when there's no group in the selection", () => {
       setSelection(model, ["A1:C3"]);
-      expect(getNode(ungroupRowsPath).isVisible(env)).toBeFalsy();
+      expect(getNode(ungroupRowsPath, env).isVisible(env)).toBeFalsy();
 
       groupRows(model, 0, 2);
-      expect(getNode(ungroupRowsPath).isVisible(env)).toBeTruthy();
+      expect(getNode(ungroupRowsPath, env).isVisible(env)).toBeTruthy();
     });
   });
 
@@ -1869,9 +1877,9 @@ describe("Menu Item actions", () => {
     });
 
     test("unfreeze actions visibility", () => {
-      const unfreezeColAction = getNode(["view", "freeze_panes", "unfreeze_columns"]);
-      const unfreezeRowAction = getNode(["view", "freeze_panes", "unfreeze_rows"]);
-      const unfreezeAllAction = getNode(["view", "unfreeze_panes"]);
+      const unfreezeColAction = getNode(["view", "freeze_panes", "unfreeze_columns"], env);
+      const unfreezeRowAction = getNode(["view", "freeze_panes", "unfreeze_rows"], env);
+      const unfreezeAllAction = getNode(["view", "unfreeze_panes"], env);
 
       expect(unfreezeColAction.isVisible(env)).toBe(false);
       expect(unfreezeRowAction.isVisible(env)).toBe(false);

--- a/tests/model/__snapshots__/model.test.ts.snap
+++ b/tests/model/__snapshots__/model.test.ts.snap
@@ -4,6 +4,8 @@ exports[`Model export formula with unbound zone stays unbound 1`] = `
 {
   "borders": {},
   "formats": {},
+  "pivotNextId": 1,
+  "pivots": {},
   "revisionId": "START_REVISION",
   "settings": {
     "locale": {
@@ -51,6 +53,6 @@ exports[`Model export formula with unbound zone stays unbound 1`] = `
   ],
   "styles": {},
   "uniqueFigureIds": true,
-  "version": 15,
+  "version": 16,
 }
 `;

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -640,6 +640,8 @@ test("complete import, then export", () => {
         headerGroups: { COL: [], ROW: [] },
       },
     ],
+    pivots: {},
+    pivotNextId: 1,
     settings: { locale: DEFAULT_LOCALE },
     styles: {
       1: { bold: true, textColor: "#674EA7", fontSize: 12 },
@@ -724,6 +726,8 @@ test("import then export (figures)", () => {
         headerGroups: { COL: [], ROW: [] },
       },
     ],
+    pivots: {},
+    pivotNextId: 1,
     styles: {},
     formats: {},
     borders: {},

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -1,5 +1,7 @@
+import { SpreadsheetPivotTable } from "../../src";
 import { BACKGROUND_CHART_COLOR, DEFAULT_BORDER_DESC } from "../../src/constants";
 import { CoreCommand, CoreCommandTypes, DEFAULT_LOCALE, Locale, TableStyle } from "../../src/types";
+import { PivotCoreDefinition } from "../../src/types/pivot";
 import { target, toRangesData } from "./helpers";
 
 export const TEST_CHART_DATA = {
@@ -54,6 +56,14 @@ export const TEST_CHART_DATA = {
       },
     },
   },
+};
+
+const PIVOT: PivotCoreDefinition = {
+  columns: [],
+  rows: [],
+  measures: [],
+  name: "pivot",
+  type: "SPREADSHEET",
 };
 
 type CommandMapping = {
@@ -376,6 +386,38 @@ export const TEST_COMMANDS: CommandMapping = {
     type: "REMOVE_DATA_VALIDATION_RULE",
     sheetId: "sheetId",
     id: "dvId",
+  },
+  ADD_PIVOT: {
+    type: "ADD_PIVOT",
+    pivotId: "1",
+    pivot: PIVOT,
+  },
+  INSERT_PIVOT: {
+    type: "INSERT_PIVOT",
+    pivotId: "1",
+    sheetId: "sheetId",
+    col: 0,
+    row: 0,
+    table: new SpreadsheetPivotTable([[]], [], []).export(),
+  },
+  REMOVE_PIVOT: {
+    type: "REMOVE_PIVOT",
+    pivotId: "1",
+  },
+  UPDATE_PIVOT: {
+    type: "UPDATE_PIVOT",
+    pivotId: "1",
+    pivot: PIVOT,
+  },
+  DUPLICATE_PIVOT: {
+    type: "DUPLICATE_PIVOT",
+    pivotId: "1",
+    newPivotId: "2",
+  },
+  RENAME_PIVOT: {
+    type: "RENAME_PIVOT",
+    pivotId: "1",
+    name: "newName",
   },
 };
 

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -743,12 +743,13 @@ export async function doAction(
   env: SpreadsheetChildEnv,
   menuRegistry: MenuItemRegistry = topbarMenuRegistry
 ) {
-  const node = getNode(path, menuRegistry);
+  const node = getNode(path, env, menuRegistry);
   await node.execute?.(env);
 }
 
 export function getNode(
   _path: string[],
+  env: SpreadsheetChildEnv,
   menuRegistry: MenuItemRegistry = topbarMenuRegistry
 ): Action {
   const path = [..._path];
@@ -762,7 +763,7 @@ export function getNode(
     if (path.length === 0) {
       return item;
     }
-    items = item.children({} as SpreadsheetChildEnv);
+    items = item.children(env);
   }
   throw new Error(`Menu item not found`);
 }
@@ -772,7 +773,7 @@ export function getName(
   env: SpreadsheetChildEnv,
   menuRegistry: MenuItemRegistry = topbarMenuRegistry
 ): string {
-  const node = getNode(path, menuRegistry);
+  const node = getNode(path, env, menuRegistry);
   return node.name(env).toString();
 }
 

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -446,7 +446,7 @@ describe("TopBar component", () => {
     expect(fixture.querySelectorAll(".o-topbar-menu")).toHaveLength(number);
     await click(fixture, ".o-topbar-menu[data-id='edit']");
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
-    const edit = getNode(["edit"], topbarMenuRegistry);
+    const edit = getNode(["edit"], env, topbarMenuRegistry);
     const numberChild = edit.children(parent.env).filter((item) => item.isVisible(env)).length;
     expect(fixture.querySelectorAll(".o-menu-item")).toHaveLength(numberChild);
     await click(fixture, ".o-spreadsheet-topbar");
@@ -455,15 +455,15 @@ describe("TopBar component", () => {
 
   test("Can open a Topbar menu with pointermove", async () => {
     const { parent } = await mountParent();
-    await click(fixture, ".o-topbar-menu[data-id='edit']");
-    const edit = getNode(["edit"], topbarMenuRegistry);
     const env = parent.env;
+    await click(fixture, ".o-topbar-menu[data-id='edit']");
+    const edit = getNode(["edit"], env, topbarMenuRegistry);
     let numberChild = edit.children(env).filter((item) => item.isVisible(env)).length;
     expect(fixture.querySelectorAll(".o-menu-item")).toHaveLength(numberChild);
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);
     triggerMouseEvent(".o-topbar-menu[data-id='insert']", "mouseover");
     await nextTick();
-    const insert = getNode(["insert"], topbarMenuRegistry);
+    const insert = getNode(["insert"], env, topbarMenuRegistry);
     numberChild = insert?.children(parent.env).filter((item) => item.isVisible(parent.env)).length;
     expect(fixture.querySelectorAll(".o-menu-item")).toHaveLength(numberChild);
     expect(fixture.querySelectorAll(".o-menu")).toHaveLength(1);


### PR DESCRIPTION
This commit prepares the ground to the introduction of the spreadsheet
pivot table. It's basically a move of the plumbing necessary to make
a pivot works from odoo codebase to o-spreadsheet codebase.

Some notes on this commit:
- No tests are added, we trust the tests in Odoo.

Adding some tests would require to make a dummy pivot, which is
not ideal. Let's write tests during/after the introduction of spreadsheet
pivot.
- Some references to Odoo are included here

In order to make this commit only a move and not a move/ref, we decided
to introduce some concepts of Odoo here (like Fields, many2one, odoo classes, ...)
As far as possible, these concepts will be reworked/removed/renamed later.

Odoo PRs:
- https://github.com/odoo/odoo/pull/159259
- https://github.com/odoo/enterprise/pull/59423

Task: 3748583

Task: : [3748583](https://www.odoo.com/web#id=3748583&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo