### PR TITLE
[FIX] SplitIntoColumnsPanel: Panel closes instantly

### DIFF
--- a/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
+++ b/src/components/side_panel/split_to_columns_panel/split_to_columns_panel.ts
@@ -47,7 +47,14 @@ export class SplitIntoColumnsPanel extends Component<Props, SpreadsheetChildEnv>
     const composerStore = useStore(ComposerStore);
     // The feature makes no sense if we are editing a cell, because then the selection isn't active
     // Stop the edition when the panel is mounted, and close the panel if the user start editing a cell
-    useEffect(this.props.onCloseSidePanel, () => [composerStore.editionMode]);
+    useEffect(
+      (editionMode) => {
+        if (editionMode !== "inactive") {
+          this.props.onCloseSidePanel();
+        }
+      },
+      () => [composerStore.editionMode]
+    );
 
     onMounted(() => {
       composerStore.stopEdition();

--- a/tests/split_to_column/split_to_columns_panel.test.ts
+++ b/tests/split_to_column/split_to_columns_panel.test.ts
@@ -166,6 +166,7 @@ describe("split to columns sidePanel component", () => {
   });
 
   test("Panel is closed if the user starts to edit a cell", async () => {
+    expect(onCloseSidePanel).not.toHaveBeenCalled();
     const composerStore = parent.env.getStore(ComposerStore);
     composerStore.startEdition();
     await nextTick();


### PR DESCRIPTION
There was a mistake in the code adaptation when we introduced the stores.

How to reproduce:
- Open a spreadsheet
- Open "Topbar menu > Split text to columns" -> The sidepanel opens and closes instantly

Task: 3829192

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo