### PR TITLE
[FIX] Composer: pressing enter in the link editor

### DIFF
--- a/src/components/link/link_editor/link_editor.ts
+++ b/src/components/link/link_editor/link_editor.ts
@@ -178,6 +178,7 @@ export class LinkEditor extends Component<LinkEditorProps, SpreadsheetChildEnv> 
         if (this.state.link.url) {
           this.save();
         }
+        ev.preventDefault();
         break;
       case "Escape":
         this.cancel();

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -627,6 +627,19 @@ describe("composer", () => {
     expect(cell.link.url).toBe("http://odoo.com");
   });
 
+  test("Pressing Enter while editing a label does not open grid composer", async () => {
+    setCellContent(model, "A1", "[label](url.com)");
+    await simulateClick(".o-topbar-menu[data-id='insert']");
+    await simulateClick(".o-menu-item[data-name='insert_link']");
+    const editor = fixture.querySelector(".o-link-editor");
+    expect(editor).toBeTruthy();
+
+    editor!.querySelectorAll("input")[0].focus();
+    await keyDown("Enter");
+    expect(fixture.querySelector(".o-link-editor")).toBeFalsy();
+    expect(model.getters.getEditionMode()).toBe("inactive");
+  });
+
   test("Hitting enter on topbar composer will properly update it and stop the edition", async () => {
     setCellContent(model, "A1", "I am Tabouret");
     await clickCell(model, "A1");


### PR DESCRIPTION
## Description:

Previously, pressing Enter in the link editor would inadvertently open the grid composer in edit mode, which was not the expected behavior. This PR addresses the issue by adding a check in the onInput method of the composer component.

Task: : [3796114](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo