### PR TITLE
[IMP] zones: add comment explaining `hasHeader` flag

### DIFF
--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -82,6 +82,13 @@ export interface UnboundedZone {
   bottom: HeaderIndex | undefined;
   left: HeaderIndex;
   right: HeaderIndex | undefined;
+  /**
+   * The hasHeader flag is used to determine if the zone has a header (eg. A2:A or C3:3).
+   *
+   * The main issue is that the zone A1:A and A:A have different behavior. The "correct" way to handle this would be to
+   * allow the top/left to be undefined, but this make typing and using unbounded zones VERY annoying. So we use this
+   * boolean instead.
+   */
   hasHeader?: boolean;
 }
 


### PR DESCRIPTION
There is a flag `hasHeader` in the unbounded zone that is used to differentiate between a zone `A1:A` and `A:A`. This commit adds a comment to explain why it's needed.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo