### PR TITLE
[FIX] Charts: format of negative values

### DIFF
--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -233,7 +233,10 @@ function getBarConfiguration(
           value = Number(value);
           if (isNaN(value)) return value;
           const { locale, format } = localeFormat;
-          return formatValue(value, { locale, format: !format && value > 1000 ? "#,##" : format });
+          return formatValue(value, {
+            locale,
+            format: !format && Math.abs(value) >= 1000 ? "#,##" : format,
+          });
         },
       },
     },

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -136,7 +136,7 @@ export function getDefaultChartJsRuntime(
             const xLabel = tooltipItem.dataset?.label || tooltipItem.label;
             // tooltipItem.parsed.y can be an object or a number for pie charts
             const yLabel = tooltipItem.parsed.y ?? tooltipItem.parsed;
-            const toolTipFormat = !format && yLabel > 1000 ? "#,##" : format;
+            const toolTipFormat = !format && Math.abs(yLabel) >= 1000 ? "#,##" : format;
             const yLabelStr = formatValue(yLabel, { format: toolTipFormat, locale });
             return xLabel ? `${xLabel}: ${yLabelStr}` : yLabelStr;
           },

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -336,7 +336,10 @@ function getLineConfiguration(
           value = Number(value);
           if (isNaN(value)) return value;
           const { locale, format } = localeFormat;
-          return formatValue(value, { locale, format: !format && value > 1000 ? "#,##" : format });
+          return formatValue(value, {
+            locale,
+            format: !format && Math.abs(value) >= 1000 ? "#,##" : format,
+          });
         },
       },
     },

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -227,7 +227,7 @@ function getPieConfiguration(
 
     const xLabel = tooltipItem.label || tooltipItem.dataset.label;
     const yLabel = tooltipItem.parsed.y ?? tooltipItem.parsed;
-    const toolTipFormat = !format && yLabel > 1000 ? "#,##" : format;
+    const toolTipFormat = !format && Math.abs(yLabel) >= 1000 ? "#,##" : format;
     const yLabelStr = formatValue(yLabel, { format: toolTipFormat, locale });
 
     return xLabel ? `${xLabel}: ${yLabelStr} (${percentage}%)` : `${yLabelStr} (${percentage}%)`;

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -1568,6 +1568,10 @@ describe("Chart design configuration", () => {
         expect(runtime.chartJsConfig.options.scales.y?.ticks.callback!(60000000)).toEqual(
           "60,000,000"
         );
+        //@ts-ignore
+        expect(runtime.chartJsConfig.options.scales.y?.ticks.callback!(-60000000)).toEqual(
+          "-60,000,000"
+        );
       }
     );
 
@@ -1580,6 +1584,10 @@ describe("Chart design configuration", () => {
         //@ts-ignore
         expect(runtime.chartJsConfig.options.scales.y?.ticks.callback!(60000000)).toEqual(
           "60 000 000"
+        );
+        // @ts-ignore
+        expect(runtime.chartJsConfig.options.scales.y?.ticks.callback!(-60000000)).toEqual(
+          "-60 000 000"
         );
       }
     );
@@ -1603,7 +1611,7 @@ describe("Chart design configuration", () => {
     });
 
     test.each(["bar", "line"])(
-      "Basic chart tooltip label, cell without format: thousand separator",
+      "Basic chart tooltip label, cell without format: thousand separator for positive values",
       (chartType) => {
         setCellContent(model, "A2", "60000000");
         createChart(model, { ...defaultChart, type: chartType as "bar" | "line" | "pie" }, "42");
@@ -1614,14 +1622,17 @@ describe("Chart design configuration", () => {
       }
     );
 
-    test.each(["bar", "line"])("Basic chart tooltip label, cell with format", (chartType) => {
-      setCellContent(model, "A2", "6000");
-      setCellFormat(model, "A2", "[$$]#,##0.00");
-      createChart(model, { ...defaultChart, type: chartType as "bar" | "line" | "pie" }, "42");
-      const runtime = model.getters.getChartRuntime("42") as BarChartRuntime;
-      const label = getTooltipLabel(runtime, 0, 0);
-      expect(label).toEqual("$6,000.00");
-    });
+    test.each(["bar", "line"])(
+      "Basic chart tooltip label, cell without format: thousand separator for negative values",
+      (chartType) => {
+        setCellContent(model, "A2", "-60000000");
+        createChart(model, { ...defaultChart, type: chartType as "bar" | "line" | "pie" }, "42");
+        const runtime = model.getters.getChartRuntime("42") as BarChartRuntime;
+        const label = getTooltipLabel(runtime, 0, 0);
+
+        expect(label).toEqual("-60,000,000");
+      }
+    );
 
     test.each(["bar", "line"])("Basic chart tooltip label, date format is ignored", (chartType) => {
       setCellContent(model, "A2", "6000");
@@ -1671,6 +1682,24 @@ describe("Chart design configuration", () => {
 
       expect(label).toBe("P1: $6,000.00 (100.00%)");
     });
+  });
+
+  test("pie chart tooltip label with negative value", () => {
+    setCellContent(model, "A1", "P1");
+    setCellContent(model, "A2", "-6000");
+    createChart(
+      model,
+      {
+        dataSets: ["A1:A2"],
+        labelRange: "A1",
+        type: "pie",
+      },
+      "1"
+    );
+    const chart = model.getters.getChartRuntime("1") as PieChartRuntime;
+    const label = getTooltipLabel(chart, 0, 0);
+
+    expect(label).toBe("P1: -6,000 (100.00%)");
   });
 });
 


### PR DESCRIPTION
## Description:

- Rectified the display format of negative values within tooltips and axis labels in charts.

Task: : [3829782](https://www.odoo.com/web#id=3829782&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo