### PR TITLE
[IMP] charts: preserve more options when changing types

### DIFF
--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel.ts
@@ -1,10 +1,7 @@
 import { Component } from "@odoo/owl";
 import { ChartSidePanel, chartSidePanelComponentRegistry } from "..";
 import { BACKGROUND_HEADER_COLOR } from "../../../../constants";
-import {
-  getChartDefinitionFromContextCreation,
-  getChartTypes,
-} from "../../../../helpers/figures/charts";
+import { getChartTypes } from "../../../../helpers/figures/charts";
 import { Store, useLocalStore } from "../../../../store_engine";
 import { ChartDefinition, ChartType, SpreadsheetChildEnv, UID } from "../../../../types/index";
 import { css } from "../../../helpers/css";
@@ -90,16 +87,7 @@ export class ChartPanel extends Component<Props, SpreadsheetChildEnv> {
     if (!this.figureId) {
       return;
     }
-    const context = this.env.model.getters.getContextCreationChart(this.figureId);
-    if (!context) {
-      throw new Error("Chart not defined.");
-    }
-    const definition = getChartDefinitionFromContextCreation(context, type);
-    this.env.model.dispatch("UPDATE_CHART", {
-      definition,
-      id: this.figureId,
-      sheetId: this.env.model.getters.getFigureSheetId(this.figureId)!,
-    });
+    this.store.changeChartType(this.figureId, type);
   }
 
   get chartPanel(): ChartSidePanel {

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
@@ -1,9 +1,25 @@
+import { getChartDefinitionFromContextCreation } from "../../../../helpers/figures/charts";
 import { SpreadsheetStore } from "../../../../stores";
+import { ChartType, UID } from "../../../../types";
 
 export class MainChartPanelStore extends SpreadsheetStore {
   panel: "configuration" | "design" = "configuration";
 
   activatePanel(panel: "configuration" | "design") {
     this.panel = panel;
+  }
+
+  changeChartType(figureId: UID, type: ChartType) {
+    const context = this.getters.getContextCreationChart(figureId);
+    const sheetId = this.getters.getFigureSheetId(figureId);
+    if (!context || !sheetId) {
+      return;
+    }
+    const definition = getChartDefinitionFromContextCreation(context, type);
+    this.model.dispatch("UPDATE_CHART", {
+      definition,
+      id: figureId,
+      sheetId,
+    });
   }
 }

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
@@ -1,21 +1,25 @@
 import { getChartDefinitionFromContextCreation } from "../../../../helpers/figures/charts";
 import { SpreadsheetStore } from "../../../../stores";
-import { ChartType, UID } from "../../../../types";
+import { ChartCreationContext, ChartType, UID } from "../../../../types";
 
 export class MainChartPanelStore extends SpreadsheetStore {
   panel: "configuration" | "design" = "configuration";
+  private creationContext: ChartCreationContext = {};
 
   activatePanel(panel: "configuration" | "design") {
     this.panel = panel;
   }
 
   changeChartType(figureId: UID, type: ChartType) {
-    const context = this.getters.getContextCreationChart(figureId);
+    this.creationContext = {
+      ...this.creationContext,
+      ...this.getters.getContextCreationChart(figureId),
+    };
     const sheetId = this.getters.getFigureSheetId(figureId);
-    if (!context || !sheetId) {
+    if (!sheetId) {
       return;
     }
-    const definition = getChartDefinitionFromContextCreation(context, type);
+    const definition = getChartDefinitionFromContextCreation(this.creationContext, type);
     this.model.dispatch("UPDATE_CHART", {
       definition,
       id: figureId,

--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -96,28 +96,26 @@ export class BarChart extends AbstractChart {
     return {
       background: context.background,
       dataSets: context.range ? context.range : [],
-      dataSetsHaveTitle: false,
-      stacked: false,
+      dataSetsHaveTitle: context.dataSetsHaveTitle ?? false,
+      stacked: context.stacked ?? false,
       aggregated: context.aggregated ?? false,
-      legendPosition: "top",
+      legendPosition: context.legendPosition ?? "top",
       title: context.title || "",
       type: "bar",
-      verticalAxisPosition: "left",
+      verticalAxisPosition: context.verticalAxisPosition ?? "left",
       labelRange: context.auxiliaryRange || undefined,
     };
   }
 
   getContextCreation(): ChartCreationContext {
     return {
-      background: this.background,
-      title: this.title,
+      ...this,
       range: this.dataSets.map((ds: DataSet) =>
         this.getters.getRangeString(ds.dataRange, this.sheetId)
       ),
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
-      aggregated: this.aggregated,
     };
   }
 

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -90,15 +90,13 @@ export class ComboChart extends AbstractChart {
 
   getContextCreation(): ChartCreationContext {
     return {
-      background: this.background,
-      title: this.title,
+      ...this,
       range: this.dataSets.map((ds: DataSet) =>
         this.getters.getRangeString(ds.dataRange, this.sheetId)
       ),
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
-      aggregated: this.aggregated,
     };
   }
 
@@ -168,12 +166,12 @@ export class ComboChart extends AbstractChart {
   static getDefinitionFromContextCreation(context: ChartCreationContext): ComboChartDefinition {
     return {
       background: context.background,
-      dataSets: context.range ? context.range : [],
-      dataSetsHaveTitle: false,
+      dataSets: context.range ?? [],
+      dataSetsHaveTitle: context.dataSetsHaveTitle ?? false,
       aggregated: context.aggregated,
-      legendPosition: "top",
+      legendPosition: context.legendPosition ?? "top",
       title: context.title || "",
-      verticalAxisPosition: "left",
+      verticalAxisPosition: context.verticalAxisPosition ?? "left",
       labelRange: context.auxiliaryRange || undefined,
       type: "combo",
       useBothYAxis: false,

--- a/src/helpers/figures/charts/gauge_chart.ts
+++ b/src/helpers/figures/charts/gauge_chart.ts
@@ -238,8 +238,7 @@ export class GaugeChart extends AbstractChart {
 
   getContextCreation(): ChartCreationContext {
     return {
-      background: this.background,
-      title: this.title,
+      ...this,
       range: this.dataRange
         ? [this.getters.getRangeString(this.dataRange, this.sheetId)]
         : undefined,

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -88,16 +88,16 @@ export class LineChart extends AbstractChart {
     return {
       background: context.background,
       dataSets: context.range ? context.range : [],
-      dataSetsHaveTitle: false,
-      labelsAsText: false,
-      legendPosition: "top",
+      dataSetsHaveTitle: context.dataSetsHaveTitle ?? false,
+      labelsAsText: context.labelsAsText ?? false,
+      legendPosition: context.legendPosition ?? "top",
       title: context.title || "",
       type: "line",
-      verticalAxisPosition: "left",
+      verticalAxisPosition: context.verticalAxisPosition ?? "left",
       labelRange: context.auxiliaryRange || undefined,
-      stacked: false,
+      stacked: context.stacked ?? false,
       aggregated: context.aggregated ?? false,
-      cumulative: false,
+      cumulative: context.cumulative ?? false,
     };
   }
 
@@ -132,15 +132,13 @@ export class LineChart extends AbstractChart {
 
   getContextCreation(): ChartCreationContext {
     return {
-      background: this.background,
-      title: this.title,
+      ...this,
       range: this.dataSets.map((ds: DataSet) =>
         this.getters.getRangeString(ds.dataRange, this.sheetId)
       ),
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
-      aggregated: this.aggregated,
     };
   }
 

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -100,8 +100,8 @@ export class PieChart extends AbstractChart {
     return {
       background: context.background,
       dataSets: context.range ? context.range : [],
-      dataSetsHaveTitle: false,
-      legendPosition: "top",
+      dataSetsHaveTitle: context.dataSetsHaveTitle ?? false,
+      legendPosition: context.legendPosition ?? "top",
       title: context.title || "",
       type: "pie",
       labelRange: context.auxiliaryRange || undefined,
@@ -115,15 +115,13 @@ export class PieChart extends AbstractChart {
 
   getContextCreation(): ChartCreationContext {
     return {
-      background: this.background,
-      title: this.title,
+      ...this,
       range: this.dataSets.map((ds: DataSet) =>
         this.getters.getRangeString(ds.dataRange, this.sheetId)
       ),
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
-      aggregated: this.aggregated,
     };
   }
 

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -87,12 +87,12 @@ export class ScatterChart extends AbstractChart {
     return {
       background: context.background,
       dataSets: context.range ? context.range : [],
-      dataSetsHaveTitle: false,
-      labelsAsText: false,
-      legendPosition: "top",
+      dataSetsHaveTitle: context.dataSetsHaveTitle ?? false,
+      labelsAsText: context.labelsAsText ?? false,
+      legendPosition: context.legendPosition ?? "top",
       title: context.title || "",
       type: "scatter",
-      verticalAxisPosition: "left",
+      verticalAxisPosition: context.verticalAxisPosition ?? "left",
       labelRange: context.auxiliaryRange || undefined,
       aggregated: context.aggregated ?? false,
     };
@@ -127,15 +127,13 @@ export class ScatterChart extends AbstractChart {
 
   getContextCreation(): ChartCreationContext {
     return {
-      background: this.background,
-      title: this.title,
+      ...this,
       range: this.dataSets.map((ds: DataSet) =>
         this.getters.getRangeString(ds.dataRange, this.sheetId)
       ),
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
-      aggregated: this.aggregated,
     };
   }
 

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -242,8 +242,7 @@ export class ScorecardChart extends AbstractChart {
 
   getContextCreation(): ChartCreationContext {
     return {
-      background: this.background,
-      title: this.title,
+      ...this,
       range: this.keyValue ? [this.getters.getRangeString(this.keyValue, this.sheetId)] : undefined,
       auxiliaryRange: this.baseline
         ? this.getters.getRangeString(this.baseline, this.sheetId)

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -105,30 +105,28 @@ export class WaterfallChart extends AbstractChart {
     return {
       background: context.background,
       dataSets: context.range ? context.range : [],
-      dataSetsHaveTitle: false,
+      dataSetsHaveTitle: context.dataSetsHaveTitle ?? false,
       aggregated: context.aggregated ?? false,
-      legendPosition: "top",
+      legendPosition: context.legendPosition ?? "top",
       title: context.title || "",
       type: "waterfall",
-      verticalAxisPosition: "left",
+      verticalAxisPosition: context.verticalAxisPosition ?? "left",
       labelRange: context.auxiliaryRange || undefined,
-      showSubTotals: true,
-      showConnectorLines: true,
-      firstValueAsSubtotal: false,
+      showSubTotals: context.showSubTotals ?? false,
+      showConnectorLines: context.showConnectorLines ?? true,
+      firstValueAsSubtotal: context.firstValueAsSubtotal ?? false,
     };
   }
 
   getContextCreation(): ChartCreationContext {
     return {
-      background: this.background,
-      title: this.title,
+      ...this,
       range: this.dataSets.map((ds: DataSet) =>
         this.getters.getRangeString(ds.dataRange, this.sheetId)
       ),
       auxiliaryRange: this.labelRange
         ? this.getters.getRangeString(this.labelRange, this.sheetId)
         : undefined,
-      aggregated: this.aggregated,
     };
   }
 

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -90,5 +90,13 @@ export interface ChartCreationContext {
   readonly background?: string;
   readonly auxiliaryRange?: string;
   readonly aggregated?: boolean;
-  readonly type?: string;
+  readonly stacked?: boolean;
+  readonly cumulative?: boolean;
+  readonly dataSetsHaveTitle?: boolean;
+  readonly labelsAsText?: boolean;
+  readonly showSubTotals?: boolean;
+  readonly showConnectorLines?: boolean;
+  readonly firstValueAsSubtotal?: boolean;
+  readonly verticalAxisPosition?: VerticalAxisPosition;
+  readonly legendPosition?: LegendPosition;
 }

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -1,0 +1,36 @@
+import { ChartCreationContext } from "../../../src";
+import { getChartDefinitionFromContextCreation } from "../../../src/helpers/figures/charts";
+
+describe("bar chart", () => {
+  test("create bar chart from creation context", () => {
+    const context: Required<ChartCreationContext> = {
+      background: "#123456",
+      title: "hello there",
+      range: ["Sheet1!B1:B4"],
+      auxiliaryRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      cumulative: true,
+      labelsAsText: true,
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      stacked: true,
+      firstValueAsSubtotal: true,
+      showConnectorLines: false,
+      showSubTotals: true,
+    };
+    const definition = getChartDefinitionFromContextCreation(context, "bar");
+    expect(definition).toEqual({
+      type: "bar",
+      background: "#123456",
+      title: "hello there",
+      dataSets: ["Sheet1!B1:B4"],
+      labelRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      stacked: true,
+    });
+  });
+});

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -447,13 +447,8 @@ describe("charts", () => {
     await setInputValueAndTrigger(chartType, "pie");
     setInputValueAndTrigger(dataSeriesValues, "B2:B5");
     await click(hasTitle);
-    // dataSetsHaveTitle is not propagated
-    expect((mockChartData.data! as any).datasets[0].data).toEqual([
-      "first column dataset",
-      10,
-      11,
-      12,
-    ]);
+    expect((mockChartData.data! as any).datasets[0].label).toEqual("first column dataset");
+    expect((mockChartData.data! as any).datasets[0].data).toEqual([10, 11, 12]);
     expect(mockChartData.type).toBe("pie");
     expect((mockChartData.options?.plugins!.title as any).text).toBe("hello");
   });
@@ -1162,6 +1157,21 @@ describe("charts", () => {
         const checkbox = document.querySelector("input[name='aggregated']") as HTMLInputElement;
         expect(checkbox.checked).toBe(true);
       }
+    });
+
+    test("dataSetsHaveTitle value is kept when changing to a chart without aggregate option then back again", async () => {
+      createTestChart("basicChart");
+      updateChart(model, chartId, { dataSetsHaveTitle: true, type: "pie" });
+      await openChartConfigSidePanel();
+      let checkbox = document.querySelector("input[name='dataSetsHaveTitle']") as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+
+      await setInputValueAndTrigger(".o-type-selector", "gauge");
+      expect(document.querySelector("input[name='dataSetsHaveTitle']")).toBeFalsy();
+
+      await setInputValueAndTrigger(".o-type-selector", "pie");
+      checkbox = document.querySelector("input[name='dataSetsHaveTitle']") as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
     });
   });
 

--- a/tests/figures/chart/combo_chart_plugin.test.ts
+++ b/tests/figures/chart/combo_chart_plugin.test.ts
@@ -1,0 +1,36 @@
+import { ChartCreationContext } from "../../../src";
+import { getChartDefinitionFromContextCreation } from "../../../src/helpers/figures/charts";
+
+describe("combo chart", () => {
+  test("create combo chart from creation context", () => {
+    const context: Required<ChartCreationContext> = {
+      background: "#123456",
+      title: "hello there",
+      range: ["Sheet1!B1:B4"],
+      auxiliaryRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      cumulative: true,
+      labelsAsText: true,
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      stacked: true,
+      firstValueAsSubtotal: true,
+      showConnectorLines: false,
+      showSubTotals: true,
+    };
+    const definition = getChartDefinitionFromContextCreation(context, "combo");
+    expect(definition).toEqual({
+      type: "combo",
+      background: "#123456",
+      title: "hello there",
+      dataSets: ["Sheet1!B1:B4"],
+      labelRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      useBothYAxis: false,
+    });
+  });
+});

--- a/tests/figures/chart/gauge_chart_plugin.test.ts
+++ b/tests/figures/chart/gauge_chart_plugin.test.ts
@@ -1,6 +1,9 @@
-import { CommandResult, Model } from "../../../src";
+import { ChartCreationContext, CommandResult, Model } from "../../../src";
 import { deepCopy, zoneToXc } from "../../../src/helpers";
-import { GaugeChart } from "../../../src/helpers/figures/charts";
+import {
+  GaugeChart,
+  getChartDefinitionFromContextCreation,
+} from "../../../src/helpers/figures/charts";
 import {
   GaugeChartDefinition,
   GaugeChartRuntime,
@@ -109,6 +112,33 @@ describe("datasource tests", function () {
       sectionRule: defaultSectionRule,
     });
     expect(model.getters.getChartRuntime("1") as GaugeChartRuntime).toMatchSnapshot();
+  });
+
+  test("create gauge from creation context", () => {
+    const context: Required<ChartCreationContext> = {
+      background: "#123456",
+      title: "hello there",
+      range: ["Sheet1!B1:B4"],
+      auxiliaryRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      cumulative: true,
+      labelsAsText: true,
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      stacked: true,
+      firstValueAsSubtotal: true,
+      showConnectorLines: false,
+      showSubTotals: true,
+    };
+    const definition = getChartDefinitionFromContextCreation(context, "gauge");
+    expect(definition).toEqual({
+      type: "gauge",
+      background: "#123456",
+      title: "hello there",
+      dataRange: "Sheet1!B1:B4",
+      sectionRule: expect.any(Object),
+    });
   });
 
   test("ranges in gauge definition change automatically", () => {

--- a/tests/figures/chart/line_chart_plugin.test.ts
+++ b/tests/figures/chart/line_chart_plugin.test.ts
@@ -1,0 +1,38 @@
+import { ChartCreationContext } from "../../../src";
+import { getChartDefinitionFromContextCreation } from "../../../src/helpers/figures/charts";
+
+describe("line chart", () => {
+  test("create line chart from creation context", () => {
+    const context: Required<ChartCreationContext> = {
+      background: "#123456",
+      title: "hello there",
+      range: ["Sheet1!B1:B4"],
+      auxiliaryRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      cumulative: true,
+      labelsAsText: true,
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      stacked: true,
+      firstValueAsSubtotal: true,
+      showConnectorLines: false,
+      showSubTotals: true,
+    };
+    const definition = getChartDefinitionFromContextCreation(context, "line");
+    expect(definition).toEqual({
+      type: "line",
+      background: "#123456",
+      title: "hello there",
+      dataSets: ["Sheet1!B1:B4"],
+      labelRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      stacked: true,
+      labelsAsText: true,
+      cumulative: true,
+    });
+  });
+});

--- a/tests/figures/chart/pie_chart_plugin.test.ts
+++ b/tests/figures/chart/pie_chart_plugin.test.ts
@@ -1,0 +1,34 @@
+import { ChartCreationContext } from "../../../src";
+import { getChartDefinitionFromContextCreation } from "../../../src/helpers/figures/charts";
+
+describe("pie chart", () => {
+  test("create pie chart from creation context", () => {
+    const context: Required<ChartCreationContext> = {
+      background: "#123456",
+      title: "hello there",
+      range: ["Sheet1!B1:B4"],
+      auxiliaryRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      cumulative: true,
+      labelsAsText: true,
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      stacked: true,
+      firstValueAsSubtotal: true,
+      showConnectorLines: false,
+      showSubTotals: true,
+    };
+    const definition = getChartDefinitionFromContextCreation(context, "pie");
+    expect(definition).toEqual({
+      type: "pie",
+      background: "#123456",
+      title: "hello there",
+      dataSets: ["Sheet1!B1:B4"],
+      labelRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      dataSetsHaveTitle: true,
+      aggregated: true,
+    });
+  });
+});

--- a/tests/figures/chart/scorecard_chart_plugin.test.ts
+++ b/tests/figures/chart/scorecard_chart_plugin.test.ts
@@ -1,10 +1,14 @@
-import { CommandResult, Model } from "../../../src";
+import { ChartCreationContext, CommandResult, Model } from "../../../src";
 import {
   DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
   DEFAULT_SCORECARD_BASELINE_COLOR_UP,
+  DEFAULT_SCORECARD_BASELINE_MODE,
 } from "../../../src/constants";
 import { zoneToXc } from "../../../src/helpers";
-import { ScorecardChart } from "../../../src/helpers/figures/charts";
+import {
+  ScorecardChart,
+  getChartDefinitionFromContextCreation,
+} from "../../../src/helpers/figures/charts";
 import {
   ScorecardChartDefinition,
   ScorecardChartRuntime,
@@ -75,6 +79,36 @@ describe("datasource tests", function () {
       title: "",
       baselineArrow: "neutral",
       baselineColor: undefined,
+    });
+  });
+
+  test("create scorecard from creation context", () => {
+    const context: Required<ChartCreationContext> = {
+      background: "#123456",
+      title: "hello there",
+      range: ["Sheet1!B1:B4"],
+      auxiliaryRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      cumulative: true,
+      labelsAsText: true,
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      stacked: true,
+      firstValueAsSubtotal: true,
+      showConnectorLines: false,
+      showSubTotals: true,
+    };
+    const definition = getChartDefinitionFromContextCreation(context, "scorecard");
+    expect(definition).toEqual({
+      type: "scorecard",
+      background: "#123456",
+      title: "hello there",
+      keyValue: "Sheet1!B1:B4",
+      baseline: "Sheet1!A1:A4",
+      baselineMode: DEFAULT_SCORECARD_BASELINE_MODE,
+      baselineColorUp: DEFAULT_SCORECARD_BASELINE_COLOR_UP,
+      baselineColorDown: DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
     });
   });
 

--- a/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
+++ b/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
@@ -1,9 +1,10 @@
-import { Model, UID } from "../../../../src";
+import { ChartCreationContext, Model, UID } from "../../../../src";
 import {
   CHART_WATERFALL_NEGATIVE_COLOR,
   CHART_WATERFALL_POSITIVE_COLOR,
   CHART_WATERFALL_SUBTOTAL_COLOR,
 } from "../../../../src/constants";
+import { getChartDefinitionFromContextCreation } from "../../../../src/helpers/figures/charts";
 import { WaterfallChartRuntime } from "../../../../src/types/chart/waterfall_chart";
 import { createWaterfallChart, setCellContent, updateChart } from "../../../test_helpers";
 
@@ -260,5 +261,39 @@ describe("Waterfall chart", () => {
     updateChart(model, chartId, { legendPosition: "none" });
     runtime = getWaterfallRuntime(chartId);
     expect(runtime.chartJsConfig.options?.plugins?.legend?.display).toEqual(false);
+  });
+
+  test("create waterfall chart from creation context", () => {
+    const context: Required<ChartCreationContext> = {
+      background: "#123456",
+      title: "hello there",
+      range: ["Sheet1!B1:B4"],
+      auxiliaryRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      cumulative: true,
+      labelsAsText: true,
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      stacked: true,
+      firstValueAsSubtotal: true,
+      showConnectorLines: false,
+      showSubTotals: true,
+    };
+    const definition = getChartDefinitionFromContextCreation(context, "waterfall");
+    expect(definition).toEqual({
+      type: "waterfall",
+      background: "#123456",
+      title: "hello there",
+      dataSets: ["Sheet1!B1:B4"],
+      labelRange: "Sheet1!A1:A4",
+      legendPosition: "bottom",
+      verticalAxisPosition: "right",
+      dataSetsHaveTitle: true,
+      aggregated: true,
+      firstValueAsSubtotal: true,
+      showConnectorLines: false,
+      showSubTotals: true,
+    });
   });
 });


### PR DESCRIPTION
## Description:

Changing the type of a chart, many options are currently lost or reset,
such as "cumulative", "stacked", "Use row X as headers", etc.

With this commit, those options are preserved when changing the chart
type. The design options are still reset for now. It's less important because
the user is only likely to change the design once the chart definition is
properly setup and it won't change anymore.

Task: [3833884](https://www.odoo.com/web#id=3833884&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo