### PR TITLE
[IMP] tests: add `mountComponentWithPortalTarget` helper

### DIFF
--- a/tests/borders/border_editor_component.test.ts
+++ b/tests/borders/border_editor_component.test.ts
@@ -1,10 +1,8 @@
-import { Component, xml } from "@odoo/owl";
 import { BorderEditor, BorderEditorProps } from "../../src/components/border_editor/border_editor";
 import { DEFAULT_BORDER_DESC } from "../../src/constants";
 import { Model } from "../../src/model";
-import { SpreadsheetChildEnv } from "../../src/types";
 import { simulateClick } from "../test_helpers/dom_helper";
-import { makeTestFixture, mountComponent } from "../test_helpers/helpers";
+import { makeTestFixture, mountComponentWithPortalTarget } from "../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
@@ -16,15 +14,6 @@ async function setDefaultBorder(name: string) {
     await simulateClick('div[title="Line style"]');
     await simulateClick(`div[title="${DEFAULT_BORDER_DESC.style}"]`);
   }
-}
-
-class BorderEditorTestParent extends Component<BorderEditorProps, SpreadsheetChildEnv> {
-  static template = xml/* xml */ `
-    <div class="o-spreadsheet">
-      <BorderEditor t-props="props"/>
-    </div>
-  `;
-  static components = { BorderEditor };
 }
 
 async function mountBorderEditor(
@@ -41,7 +30,7 @@ async function mountBorderEditor(
     maxHeight: partialProps.maxHeight !== undefined ? partialProps.maxHeight : 1000,
     anchorRect: partialProps.anchorRect || { x: 0, y: 0, width: 0, height: 0 },
   };
-  ({ fixture } = await mountComponent(BorderEditorTestParent, { model, props }));
+  ({ fixture } = await mountComponentWithPortalTarget(BorderEditor, { model, props }));
 }
 
 let onBorderColorPicked: jest.Mock;

--- a/tests/colors/color_picker_component.test.ts
+++ b/tests/colors/color_picker_component.test.ts
@@ -1,15 +1,14 @@
-import { Component, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { ColorPicker, ColorPickerProps } from "../../src/components/color_picker/color_picker";
 import { toHex } from "../../src/helpers";
-import { Color, SpreadsheetChildEnv } from "../../src/types";
+import { Color } from "../../src/types";
 import { setStyle } from "../test_helpers/commands_helpers";
 import {
   getElComputedStyle,
   setInputValueAndTrigger,
   simulateClick,
 } from "../test_helpers/dom_helper";
-import { mountComponent } from "../test_helpers/helpers";
+import { mountComponentWithPortalTarget } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 
 mockGetBoundingClientRect({
@@ -18,15 +17,6 @@ mockGetBoundingClientRect({
 
 let fixture: HTMLElement;
 
-class ColorPickerTestParent extends Component<ColorPickerProps, SpreadsheetChildEnv> {
-  static template = xml/* xml */ `
-    <div class="o-spreadsheet">
-      <ColorPicker t-props="props"/>
-    </div>
-  `;
-  static components = { ColorPicker };
-}
-
 async function mountColorPicker(partialProps: Partial<ColorPickerProps> = {}, model = new Model()) {
   const props = {
     onColorPicked: partialProps.onColorPicked || (() => {}),
@@ -34,7 +24,7 @@ async function mountColorPicker(partialProps: Partial<ColorPickerProps> = {}, mo
     maxHeight: partialProps.maxHeight !== undefined ? partialProps.maxHeight : 1000,
     anchorRect: partialProps.anchorRect || { x: 0, y: 0, width: 0, height: 0 },
   };
-  ({ fixture } = await mountComponent(ColorPickerTestParent, { model, props }));
+  ({ fixture } = await mountComponentWithPortalTarget(ColorPicker, { model, props }));
 }
 
 test("Color picker is correctly positioned", async () => {

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -1,4 +1,4 @@
-import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { Model } from "../../src";
 import { ConditionalFormattingPanel } from "../../src/components/side_panel/conditional_formatting/conditional_formatting";
 import { toHex, toZone } from "../../src/helpers";
@@ -24,7 +24,7 @@ import {
   createEqualCF,
   getHighlightsFromStore,
   getPlugin,
-  mountComponent,
+  mountComponentWithPortalTarget,
   mountSpreadsheet,
   nextTick,
   spyModelDispatch,
@@ -33,23 +33,6 @@ import {
 } from "../test_helpers/helpers";
 import { mockGetBoundingClientRect } from "../test_helpers/mock_helpers";
 import { FR_LOCALE } from "./../test_helpers/constants";
-
-interface ParentProps {
-  onCloseSidePanel: () => void;
-}
-
-class Parent extends Component<ParentProps, SpreadsheetChildEnv> {
-  static components = { ConditionalFormattingPanel };
-  static template = xml/*xml*/ `
-  <div class="o-spreadsheet">
-    <ConditionalFormattingPanel onCloseSidePanel="props.onCloseSidePanel"/>
-  </div>
-  `;
-  setup() {
-    onMounted(() => this.env.model.on("update", this, () => this.render(true)));
-    onWillUnmount(() => this.env.model.off("update", this));
-  }
-}
 
 function errorMessages(): string[] {
   return textContentAll(selectors.error);
@@ -136,7 +119,7 @@ describe("UI of conditional formats", () => {
   });
 
   beforeEach(async () => {
-    ({ model, fixture, env } = await mountComponent(Parent, {
+    ({ model, fixture, env } = await mountComponentWithPortalTarget(ConditionalFormattingPanel, {
       props: { onCloseSidePanel: () => {} },
     }));
     sheetId = model.getters.getActiveSheetId();

--- a/tests/data_validation/data_validation_generics_side_panel_component.test.ts
+++ b/tests/data_validation/data_validation_generics_side_panel_component.test.ts
@@ -1,29 +1,17 @@
-import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { DataValidationPanel } from "../../src/components/side_panel/data_validation/data_validation_panel";
-import { SpreadsheetChildEnv, UID } from "../../src/types";
+import { UID } from "../../src/types";
 import { addDataValidation, updateLocale } from "../test_helpers/commands_helpers";
 import { FR_LOCALE } from "../test_helpers/constants";
 import { click, setInputValueAndTrigger, simulateClick } from "../test_helpers/dom_helper";
-import { getDataValidationRules, mountComponent, nextTick } from "../test_helpers/helpers";
-
-interface ParentProps {
-  onCloseSidePanel: () => void;
-}
-class Parent extends Component<ParentProps, SpreadsheetChildEnv> {
-  static components = { DataValidationPanel };
-  static template = xml/*xml*/ `
-    <div class="o-spreadsheet" /> <!-- portal target -->
-    <DataValidationPanel onCloseSidePanel="props.onCloseSidePanel"/>
-  `;
-  setup() {
-    onMounted(() => this.env.model.on("update", this, () => this.render(true)));
-    onWillUnmount(() => this.env.model.off("update", this));
-  }
-}
+import {
+  getDataValidationRules,
+  mountComponentWithPortalTarget,
+  nextTick,
+} from "../test_helpers/helpers";
 
 export async function mountDataValidationPanel(model?: Model) {
-  return mountComponent(Parent, {
+  return mountComponentWithPortalTarget(DataValidationPanel, {
     model: model || new Model(),
     props: { onCloseSidePanel: () => {} },
   });

--- a/tests/header_group/header_group_component.test.ts
+++ b/tests/header_group/header_group_component.test.ts
@@ -1,4 +1,3 @@
-import { Component, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { HeaderGroupContainer } from "../../src/components/header_group/header_group_container";
 import {
@@ -25,20 +24,10 @@ import {
 import { click, triggerMouseEvent } from "../test_helpers/dom_helper";
 import {
   getStylePropertyInPx,
-  mountComponent,
+  mountComponentWithPortalTarget,
   mountSpreadsheet,
   nextTick,
 } from "../test_helpers/helpers";
-
-class Parent extends Component {
-  static components = { HeaderGroupContainer };
-  // o-spreadsheet div for portal target
-  static template = xml/*xml*/ `
-    <div class="o-spreadsheet">
-      <HeaderGroupContainer t-props="props"/>
-    </div>
-  `;
-}
 
 describe("Integration tests", () => {
   let model: Model;
@@ -143,7 +132,7 @@ describe("Header group component test", () => {
 
   async function mountHeaderGroups(model: Model, dimension: Dimension) {
     const layers = model.getters.getGroupsLayers(sheetId, dimension);
-    ({ fixture } = await mountComponent(Parent, {
+    ({ fixture } = await mountComponentWithPortalTarget(HeaderGroupContainer, {
       props: { layers, dimension },
       model,
     }));

--- a/tests/select_menu_component.test.ts
+++ b/tests/select_menu_component.test.ts
@@ -1,21 +1,7 @@
-import { Component, xml } from "@odoo/owl";
 import { Action, createActions } from "../src/actions/action";
 import { SelectMenu, SelectMenuProps } from "../src/components/side_panel/select_menu/select_menu";
-import { SpreadsheetChildEnv } from "../src/types";
 import { click } from "./test_helpers/dom_helper";
-import { mountComponent } from "./test_helpers/helpers";
-
-interface ParentProps {
-  selectMenuProps: SelectMenuProps;
-}
-
-class Parent extends Component<ParentProps, SpreadsheetChildEnv> {
-  static components = { SelectMenu };
-  static template = xml/*xml*/ `
-      <div class="o-spreadsheet" /> <!-- portal target -->
-      <SelectMenu t-props="props.selectMenuProps"/>
-    `;
-}
+import { mountComponentWithPortalTarget } from "./test_helpers/helpers";
 
 const testMenuItems: Action[] = createActions([
   { name: "item1", id: "item1" },
@@ -26,9 +12,7 @@ describe("data validation sidePanel component", () => {
   let fixture: HTMLElement;
 
   async function mountSelectMenu(props: SelectMenuProps) {
-    ({ fixture } = await mountComponent(Parent, {
-      props: { selectMenuProps: props },
-    }));
+    ({ fixture } = await mountComponentWithPortalTarget(SelectMenu, { props }));
   }
 
   test("Clicking on the select opens a menu", async () => {

--- a/tests/side_panels/building_blocks/color.test.ts
+++ b/tests/side_panels/building_blocks/color.test.ts
@@ -1,24 +1,11 @@
-import { Component, xml } from "@odoo/owl";
 import { ChartColor } from "../../../src/components/side_panel/chart/building_blocks/color/color";
-import { SpreadsheetChildEnv } from "../../../src/types";
 import { click } from "../../test_helpers/dom_helper";
-import { mountComponent } from "../../test_helpers/helpers";
+import { mountComponentWithPortalTarget } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-type Props = ChartColor["props"];
-
-class Container extends Component<Props, SpreadsheetChildEnv> {
-  static template = xml/* xml */ `
-    <div class="o-spreadsheet">
-      <ChartColor t-props="props"/>
-    </div>
-  `;
-  static components = { ChartColor };
-}
-
-async function mountChartColor(props: Props) {
-  ({ fixture } = await mountComponent(Container, { props }));
+async function mountChartColor(props: ChartColor["props"]) {
+  ({ fixture } = await mountComponentWithPortalTarget(ChartColor, { props }));
 }
 
 describe("Chart color", () => {

--- a/tests/split_to_column/split_to_columns_panel.test.ts
+++ b/tests/split_to_column/split_to_columns_panel.test.ts
@@ -1,4 +1,4 @@
-import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { Model } from "../../src";
 import { ComposerStore } from "../../src/components/composer/composer/composer_store";
 import { SplitIntoColumnsPanel } from "../../src/components/side_panel/split_to_columns_panel/split_to_columns_panel";
@@ -11,20 +11,6 @@ import {
 } from "../test_helpers/dom_helper";
 import { mountComponent, nextTick, setGrid, spyModelDispatch } from "../test_helpers/helpers";
 
-interface ParentProps {
-  onCloseSidePanel: () => void;
-}
-class Parent extends Component<ParentProps, SpreadsheetChildEnv> {
-  static components = { SplitIntoColumnsPanel };
-  static template = xml/*xml*/ `
-    <SplitIntoColumnsPanel onCloseSidePanel="props.onCloseSidePanel"/>
-  `;
-  setup() {
-    onMounted(() => this.env.model.on("update", this, () => this.render(true)));
-    onWillUnmount(() => this.env.model.off("update", this));
-  }
-}
-
 describe("split to columns sidePanel component", () => {
   let model: Model;
   let fixture: HTMLElement;
@@ -32,11 +18,11 @@ describe("split to columns sidePanel component", () => {
   let confirmButton: HTMLButtonElement;
   let checkBox: HTMLInputElement;
   let onCloseSidePanel: jest.Mock;
-  let parent: Component<ParentProps, SpreadsheetChildEnv>;
+  let parent: Component<SplitIntoColumnsPanel["props"], SpreadsheetChildEnv>;
 
   beforeEach(async () => {
     onCloseSidePanel = jest.fn();
-    ({ model, fixture, parent } = await mountComponent(Parent, {
+    ({ model, fixture, parent } = await mountComponent(SplitIntoColumnsPanel, {
       props: { onCloseSidePanel: () => onCloseSidePanel() },
     }));
     dispatch = spyModelDispatch(model);

--- a/tests/table/table_dropdown_button_component.test.ts
+++ b/tests/table/table_dropdown_button_component.test.ts
@@ -1,11 +1,10 @@
-import { Component, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { TableDropdownButton } from "../../src/components/tables/table_dropdown_button/table_dropdown_button";
 import { toZone } from "../../src/helpers";
-import { SpreadsheetChildEnv, UID } from "../../src/types";
+import { UID } from "../../src/types";
 import { createTable, setSelection } from "../test_helpers/commands_helpers";
 import { click } from "../test_helpers/dom_helper";
-import { makeTestEnv, mountComponent } from "../test_helpers/helpers";
+import { makeTestEnv, mountComponentWithPortalTarget } from "../test_helpers/helpers";
 
 let model: Model;
 let sheetId: UID;
@@ -13,20 +12,11 @@ let fixture: HTMLElement;
 let openSidePanelSpy: jest.Mock<any, any>;
 let toggleSidePanelSpy: jest.Mock<any, any>;
 
-class Parent extends Component<{}, SpreadsheetChildEnv> {
-  static components = { TableDropdownButton };
-  static template = xml/*xml*/ `
-  <div class="o-spreadsheet">
-    <TableDropdownButton />
-  </div>
-  `;
-}
-
 beforeEach(async () => {
   openSidePanelSpy = jest.fn();
   toggleSidePanelSpy = jest.fn();
   const env = makeTestEnv({ openSidePanel: openSidePanelSpy, toggleSidePanel: toggleSidePanelSpy });
-  ({ model, fixture } = await mountComponent(Parent, { env }));
+  ({ model, fixture } = await mountComponentWithPortalTarget(TableDropdownButton, { env }));
   sheetId = model.getters.getActiveSheetId();
 });
 

--- a/tests/table/table_panel_component.test.ts
+++ b/tests/table/table_panel_component.test.ts
@@ -1,4 +1,3 @@
-import { Component, xml } from "@odoo/owl";
 import { RangeImpl, toUnboundedZone, toZone, zoneToXc } from "../../src/helpers";
 import { SpreadsheetChildEnv, Table, UID } from "../../src/types";
 import {
@@ -9,21 +8,11 @@ import {
   updateTableConfig,
 } from "../test_helpers/commands_helpers";
 import { click, setInputValueAndTrigger, simulateClick } from "../test_helpers/dom_helper";
-import { mountComponent, nextTick } from "../test_helpers/helpers";
+import { mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
 
 import { Model } from "../../src";
 import { SidePanel } from "../../src/components/side_panel/side_panel/side_panel";
 import { TableTerms } from "../../src/components/translations_terms";
-
-class Parent extends Component<{}, SpreadsheetChildEnv> {
-  static components = { SidePanel };
-  static template = xml/*xml*/ `
-  <!-- Portal target -->
-  <div class="o-spreadsheet">
-    <SidePanel />
-  </div>
-  `;
-}
 
 function getTable(model: Model, sheetId: UID): Table {
   return model.getters.getTables(sheetId)[0];
@@ -43,7 +32,7 @@ describe("Table side panel", () => {
     model = new Model();
     sheetId = model.getters.getActiveSheetId();
     createTable(model, "A1:C3");
-    ({ fixture, env } = await mountComponent(Parent, { model }));
+    ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
     env.openSidePanel("TableSidePanel", {});
     await nextTick();
   });

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -1,4 +1,4 @@
-import { Component, onMounted, onWillUnmount, xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { Model } from "../src";
 import { ComposerStore } from "../src/components/composer/composer/composer_store";
 import { TopBar } from "../src/components/top_bar/top_bar";
@@ -63,11 +63,6 @@ class Parent extends Component<any, SpreadsheetChildEnv> {
     </div>
   `;
   static components = { TopBar };
-
-  setup() {
-    onMounted(() => this.env.model.on("update", this, () => this.render(true)));
-    onWillUnmount(() => this.env.model.off("update", this));
-  }
 
   get gridHeight(): Pixel {
     const { height } = this.env.model.getters.getSheetViewDimension();


### PR DESCRIPTION
## Description

In a lot of tests, we need create a Parent component that does nothing except adding a "\<div class="o-spreadsheet" /\>" that is used as portal target.

This commit creates an helper to do that, this'll save some line of setup in the tests.

Task: : [3839384](https://www.odoo.com/web#id=3839384&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo