### PR TITLE
[FIX] Composer: too long auto-complete dropdown

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -196,6 +196,8 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
         // render left
         assistantStyle.right = `0px`;
       }
+    } else if (this.props.delimitation) {
+      assistantStyle["max-height"] = `${this.props.delimitation.height}px`;
     }
     return cssPropertiesToCss(assistantStyle);
   }

--- a/src/components/composer/top_bar_composer/top_bar_composer.ts
+++ b/src/components/composer/top_bar_composer/top_bar_composer.ts
@@ -6,7 +6,7 @@ import {
   TOPBAR_TOOLBAR_HEIGHT,
 } from "../../../constants";
 import { Store, useStore } from "../../../store_engine";
-import { CSSProperties, SpreadsheetChildEnv } from "../../../types/index";
+import { CSSProperties, DOMDimension, SpreadsheetChildEnv } from "../../../types/index";
 import { css, cssPropertiesToCss } from "../../helpers/css";
 import { Composer } from "../composer/composer";
 import { ComposerSelection } from "../composer/composer_store";
@@ -75,6 +75,14 @@ export class TopBarComposer extends Component<any, SpreadsheetChildEnv> {
     return cssPropertiesToCss({
       "border-color": SELECTION_BORDER_COLOR,
     });
+  }
+
+  get delimitation(): DOMDimension {
+    const { width, height } = this.env.model.getters.getSheetViewDimensionWithHeaders();
+    return {
+      width,
+      height,
+    };
   }
 
   onFocus(selection: ComposerSelection) {

--- a/src/components/composer/top_bar_composer/top_bar_composer.xml
+++ b/src/components/composer/top_bar_composer/top_bar_composer.xml
@@ -4,7 +4,12 @@
       class="o-topbar-composer bg-white user-select-text"
       t-on-click.stop=""
       t-att-style="containerStyle">
-      <Composer focus="focus" inputStyle="composerStyle" onComposerContentFocused.bind="onFocus"/>
+      <Composer
+        focus="focus"
+        inputStyle="composerStyle"
+        onComposerContentFocused.bind="onFocus"
+        delimitation="delimitation"
+      />
     </div>
   </t>
 </templates>


### PR DESCRIPTION
## Description:

Previously, when there were too many proposals in the auto-complete dropdown, it extended beyond the screen.

This PR addresses the problem by limiting the dropdown's height and making it scrollable.

Task: : [3838954](https://www.odoo.com/web#id=3838954&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo