### PR TITLE
[PERF] cell: use fastIdStrategy

### DIFF
--- a/src/helpers/uuid.ts
+++ b/src/helpers/uuid.ts
@@ -7,6 +7,10 @@ export class UuidGenerator {
 
   private fastIdStart = 0;
 
+  constructor(isFast: boolean = false) {
+    this.setIsFastStrategy(isFast);
+  }
+
   setIsFastStrategy(isFast: boolean) {
     this.isFastIdStrategy = isFast;
   }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -1,7 +1,7 @@
 import { FORMULA_REF_IDENTIFIER, NULL_FORMAT } from "../../constants";
 import { cellFactory } from "../../helpers/cells/cell_factory";
 import { FormulaCell } from "../../helpers/cells/index";
-import { deepEquals, isInside, range, toCartesian, toXC } from "../../helpers/index";
+import { deepEquals, isInside, range, toCartesian, toXC, UuidGenerator } from "../../helpers/index";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -46,6 +46,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   ];
 
   public readonly cells: { [sheetId: string]: { [id: string]: Cell } } = {};
+  private cellUuidGenerator = new UuidGenerator(true);
   private createCell = cellFactory(this.getters);
 
   adaptRanges(applyChange: ApplyRangeChange, sheetId?: UID) {
@@ -248,7 +249,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
 
   importCell(sheet: Sheet, cellData: CellData, normalizedStyles: { [key: number]: Style }): Cell {
     const style = (cellData.style && normalizedStyles[cellData.style]) || undefined;
-    const cellId = this.uuidGenerator.uuidv4();
+    const cellId = this.cellUuidGenerator.uuidv4();
     const properties = { format: cellData?.format, style };
     return this.createCell(cellId, cellData?.content || "", properties, sheet.id);
   }
@@ -455,7 +456,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       return;
     }
 
-    const cellId = before?.id || this.uuidGenerator.uuidv4();
+    const cellId = before?.id || this.cellUuidGenerator.uuidv4();
     const didContentChange = hasContent;
     const properties = { format, style };
     const cell = this.createCell(cellId, afterContent, properties, sheet.id);


### PR DESCRIPTION
__Current behavior before commit:__
`UuidGenerator` is used to generate cell ids at startup. However the shared `uuidGenerator` doesn't use the fast id strategy, therefore it generates them with `window.crypto.getRandomValues` which is slow and unnecessary.

__Description of the fix:__
A dedicated `UuidGenerator` for the cell id has been added. A new `UuidGenerator` constructor has been implemented in order to be able to set the fastIdStrategy at instantiation which allows to get incremental ids it is sufficient.

__Benchmark:__
Add 30k cells to a sheet and refresh the page.
Total time spent inside `uuidv4()`:
- Before: 1.22 s
- After: 1.48 ms

Backport and adaptation of: https://github.com/odoo/o-spreadsheet/pull/1738

opw-3794716

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo