### PR TITLE
[REF] evaluation: simplify getSpreadPositionsOf

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -149,7 +149,7 @@ export class EvaluationPlugin extends UIPlugin {
     "getEvaluatedCell",
     "getEvaluatedCells",
     "getEvaluatedCellsInZone",
-    "getSpreadPositionsOf",
+    "getSpreadZone",
     "getArrayFormulaSpreadingOn",
     "isEmpty",
   ] as const;
@@ -271,8 +271,11 @@ export class EvaluationPlugin extends UIPlugin {
     );
   }
 
-  getSpreadPositionsOf(position: CellPosition): CellPosition[] {
-    return this.evaluator.getSpreadPositionsOf(position);
+  /**
+   * Return the spread zone the position is part of, if any
+   */
+  getSpreadZone(position: CellPosition): Zone | undefined {
+    return this.evaluator.getSpreadZone(position);
   }
 
   getArrayFormulaSpreadingOn(position: CellPosition): CellPosition | undefined {

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -1,7 +1,7 @@
 import { compile } from "../../../formulas";
 import { implementationErrorMessage } from "../../../functions";
 import { matrixMap } from "../../../functions/helpers";
-import { lazy, positionToZone, toXC } from "../../../helpers";
+import { lazy, positionToZone, toXC, union, unionPositionsToZone } from "../../../helpers";
 import { createEvaluatedCell, evaluateLiteral } from "../../../helpers/cells";
 import { ModelConfig } from "../../../model";
 import { _t } from "../../../translation";
@@ -17,6 +17,7 @@ import {
   Range,
   RangeCompiledFormula,
   UID,
+  Zone,
   isMatrix,
 } from "../../../types";
 import { CellErrorType, CircularDependencyError, EvaluationError } from "../../../types/errors";
@@ -55,15 +56,15 @@ export class Evaluator {
     return this.evaluatedCells.get(position) || EMPTY_CELL;
   }
 
-  getSpreadPositionsOf(position: CellPosition): CellPosition[] {
+  getSpreadZone(position: CellPosition): Zone | undefined {
     if (!this.spreadingRelations.isArrayFormula(position)) {
-      return [];
+      return undefined;
     }
     if (this.evaluatedCells.get(position)?.type === CellValueType.error) {
-      return [position];
+      return positionToZone(position);
     }
     const spreadPositions = Array.from(this.spreadingRelations.getArrayResultPositions(position));
-    return [position, ...spreadPositions];
+    return union(positionToZone(position), unionPositionsToZone(spreadPositions));
   }
 
   getEvaluatedPositions(): CellPosition[] {

--- a/src/plugins/ui_core_views/dynamic_tables.ts
+++ b/src/plugins/ui_core_views/dynamic_tables.ts
@@ -6,7 +6,6 @@ import {
   overlap,
   toZone,
   union,
-  unionPositionsToZone,
   zoneToXc,
 } from "../../helpers";
 import { createFilter } from "../../helpers/table_helpers";
@@ -177,9 +176,9 @@ export class DynamicTablesPlugin extends UIPlugin {
       return true;
     }
 
-    const spreadPositions = this.getters.getSpreadPositionsOf(parentSpreadingCell);
+    const zone = this.getters.getSpreadZone(parentSpreadingCell);
 
-    return deepEquals(unionZone, unionPositionsToZone(spreadPositions));
+    return deepEquals(unionZone, zone);
   }
 
   private coreTableToTable(sheetId: UID, table: CoreTable): Table {
@@ -189,8 +188,7 @@ export class DynamicTablesPlugin extends UIPlugin {
 
     const tableZone = table.range.zone;
     const tablePosition = { sheetId, col: tableZone.left, row: tableZone.top };
-    const spreadPositions = this.getters.getSpreadPositionsOf(tablePosition);
-    const zone = spreadPositions.length ? unionPositionsToZone(spreadPositions) : table.range.zone;
+    const zone = this.getters.getSpreadZone(tablePosition) ?? table.range.zone;
     const range = this.getters.getRangeFromZone(sheetId, zone);
     const filters = this.getDynamicTableFilters(sheetId, table, zone);
     return { id: table.id, range, filters, config: table.config };

--- a/src/stores/array_formula_highlight.ts
+++ b/src/stores/array_formula_highlight.ts
@@ -1,4 +1,3 @@
-import { positionToZone, union } from "../helpers";
 import { Get } from "../store_engine";
 import { Highlight, Zone } from "../types";
 import { HighlightStore } from "./highlight_store";
@@ -33,15 +32,9 @@ export class ArrayFormulaHighlight extends SpreadsheetStore {
   private getHighlightZone(): Zone | undefined {
     const position = this.model.getters.getActivePosition();
     const spreader = this.model.getters.getArrayFormulaSpreadingOn(position);
-    const spreadPositions = spreader
-      ? this.model.getters.getSpreadPositionsOf(spreader)
-      : this.model.getters.getSpreadPositionsOf(position);
-
-    if (spreadPositions.length) {
-      const zones = spreadPositions.map(positionToZone);
-      return union(...zones);
-    } else {
-      return undefined;
-    }
+    const spreadZone = spreader
+      ? this.model.getters.getSpreadZone(spreader)
+      : this.model.getters.getSpreadZone(position);
+    return spreadZone;
   }
 }

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -1,6 +1,7 @@
 import { arg, functionRegistry } from "../../src/functions";
 import { toScalar } from "../../src/functions/helper_matrices";
 import { toMatrix, toNumber } from "../../src/functions/helpers";
+import { toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { DEFAULT_LOCALE, UID } from "../../src/types";
 import {
@@ -772,36 +773,29 @@ describe("evaluate formulas that return an array", () => {
       });
     });
 
-    test("getSpreadPositionsOf getter returns the cells the formula spread on, as well as the cell the formula is on", () => {
+    test("getSpreadZone getter returns the cells the formula spread on, as well as the cell the formula is on", () => {
       setCellContent(model, "A1", "=MFILL(2,2,42)");
       const sheetId = model.getters.getActiveSheetId();
-      expect(model.getters.getSpreadPositionsOf({ sheetId, col: 0, row: 0 })).toEqual([
-        { sheetId, col: 0, row: 0 },
-        { sheetId, col: 0, row: 1 },
-        { sheetId, col: 1, row: 0 },
-        { sheetId, col: 1, row: 1 },
-      ]);
+      expect(model.getters.getSpreadZone({ sheetId, col: 0, row: 0 })).toEqual(toZone("A1:B2"));
     });
 
-    test("getSpreadPositionsOf does only return self if the formula could not spread", () => {
+    test("getSpreadZone does only return self if the formula could not spread", () => {
       setCellContent(model, "A1", "=MFILL(2,2,42)");
       setCellContent(model, "A2", "(ツ)_/¯");
-      expect(model.getters.getSpreadPositionsOf({ sheetId, col: 0, row: 0 })).toEqual([
-        { sheetId, col: 0, row: 0 },
-      ]);
+      expect(model.getters.getSpreadZone({ sheetId, col: 0, row: 0 })).toEqual(toZone("A1"));
     });
 
-    test("getSpreadPositionsOf is correct after the evaluation changed so the formula can spread again", () => {
+    test("getSpreadZone is correct after the evaluation changed so the formula can spread again", () => {
       setCellContent(model, "H1", "5");
       setCellContent(model, "A1", "=MFILL(H1,H1,42)");
 
-      expect(model.getters.getSpreadPositionsOf({ sheetId, col: 0, row: 0 })).toHaveLength(25);
+      expect(model.getters.getSpreadZone({ sheetId, col: 0, row: 0 })).toEqual(toZone("A1:E5"));
 
       setCellContent(model, "A4", "Block spread");
-      expect(model.getters.getSpreadPositionsOf({ sheetId, col: 0, row: 0 })).toHaveLength(1);
+      expect(model.getters.getSpreadZone({ sheetId, col: 0, row: 0 })).toEqual(toZone("A1"));
 
       setCellContent(model, "H1", "2");
-      expect(model.getters.getSpreadPositionsOf({ sheetId, col: 0, row: 0 })).toHaveLength(4);
+      expect(model.getters.getSpreadZone({ sheetId, col: 0, row: 0 })).toEqual(toZone("A1:B2"));
     });
   });
 });


### PR DESCRIPTION

## Description:

Everytime the getter `getSpreadPositionsOf` was used, the resulting positions were converted to a zone.

With this commit, the conversion is made inside the getter itself, which simplifies the code.

Task: : [3839856](https://www.odoo.com/web#id=3839856&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo