### PR TITLE
[FIX]: Filters: Do not export 1-row filters to xlsx files

### DIFF
--- a/src/plugins/core/filters.ts
+++ b/src/plugins/core/filters.ts
@@ -353,6 +353,16 @@ export class FiltersPlugin extends CorePlugin<FiltersState> implements FiltersSt
   }
 
   exportForExcel(data: ExcelWorkbookData) {
-    this.export(data);
+    for (const sheet of data.sheets) {
+      for (const filterTable of this.getFilterTables(sheet.id)) {
+        if (zoneToDimension(filterTable.zone).height === 1) {
+          continue;
+        }
+        sheet.filterTables.push({
+          range: zoneToXc(filterTable.zone),
+          filters: [],
+        });
+      }
+    }
   }
 }

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -1085,6 +1085,15 @@ describe("Test XLSX export", () => {
       expect(exported.sheets[0].filterTables[0].filters).toHaveLength(0);
     });
 
+    test("Filters with only one row are not exported", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "Hello");
+      setCellContent(model, "B1", "Hello");
+      createFilter(model, "A1:B1");
+      const exported = getExportedExcelData(model);
+      expect(exported.sheets[0].filterTables).toHaveLength(0);
+    });
+
     test("Filtered values are not duplicated", () => {
       const model = new Model();
       createFilter(model, "A1:B4");


### PR DESCRIPTION
When exporting the data to Excel format,  the filters are processed as if they were tables but unfortunately, Excel does not tables that span over a single row.

As the very concept of a single row filter is not useful to the end-user, we just skip it when exporting the data to the xlsx format.

Task: 3839556

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo