### PR TITLE
[FIX] data menu: Auto-select adjacent cells on filter menu

### DIFF
--- a/src/actions/menu_items_actions.ts
+++ b/src/actions/menu_items_actions.ts
@@ -737,9 +737,12 @@ export const INSERT_LINK_NAME = (env: SpreadsheetChildEnv) => {
 //------------------------------------------------------------------------------
 
 export const FILTERS_CREATE_FILTER_TABLE = (env: SpreadsheetChildEnv) => {
+  const zones = env.model.getters.getSelectedZones();
+  if (zones.length === 1 && getZoneArea(zones[0]) === 1) {
+    env.model.selection.selectTableAroundSelection();
+  }
   const sheetId = env.model.getters.getActiveSheetId();
-  const selection = env.model.getters.getSelection().zones;
-  interactiveAddFilter(env, sheetId, selection);
+  interactiveAddFilter(env, sheetId, env.model.getters.getSelectedZones());
 };
 
 export const FILTERS_REMOVE_FILTER_TABLE = (env: SpreadsheetChildEnv) => {

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -1316,80 +1316,99 @@ describe("Menu Item actions", () => {
         dimension: "ROW",
       });
     });
+  });
 
-    describe("Filters", () => {
-      const createFilterPath = ["data", "add_data_filter"];
-      const removeFilterPath = ["data", "remove_data_filter"];
+  describe("Filters", () => {
+    const createFilterPath = ["data", "add_data_filter"];
+    const removeFilterPath = ["data", "remove_data_filter"];
 
-      test("Filters -> Create filter", () => {
-        setSelection(model, ["A1:A5"]);
-        expect(getName(createFilterPath, env)).toBe("Create filter");
-        expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
-        doAction(createFilterPath, env);
-        expect(dispatch).toHaveBeenCalledWith("CREATE_FILTER_TABLE", {
-          sheetId: model.getters.getActiveSheetId(),
-          target: target("A1:A5"),
-        });
+    test("Filters -> Create filter", () => {
+      setSelection(model, ["A1:A5"]);
+      expect(getName(createFilterPath, env)).toBe("Create filter");
+      expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
+      doAction(createFilterPath, env);
+      expect(dispatch).toHaveBeenCalledWith("CREATE_FILTER_TABLE", {
+        sheetId: model.getters.getActiveSheetId(),
+        target: target("A1:A5"),
       });
+    });
 
-      test("Filters -> Remove filter", () => {
-        createFilter(model, "A1:A5");
-        setSelection(model, ["A1:A5"]);
-        expect(getName(removeFilterPath, env)).toBe("Remove filter");
-        expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
-        doAction(removeFilterPath, env);
-        expect(dispatch).toHaveBeenCalledWith("REMOVE_FILTER_TABLE", {
-          sheetId: model.getters.getActiveSheetId(),
-          target: target("A1:A5"),
-        });
+    test("Filters -> Remove filter", () => {
+      createFilter(model, "A1:A5");
+      setSelection(model, ["A1:A5"]);
+      expect(getName(removeFilterPath, env)).toBe("Remove filter");
+      expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
+      doAction(removeFilterPath, env);
+      expect(dispatch).toHaveBeenCalledWith("REMOVE_FILTER_TABLE", {
+        sheetId: model.getters.getActiveSheetId(),
+        target: target("A1:A5"),
       });
+    });
 
-      test("Filters -> Create filter is disabled when the selection isn't continuous", () => {
-        setSelection(model, ["A1", "B6"]);
-        expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(createFilterPath).isEnabled(env)).toBeFalsy();
-      });
+    test("Filters -> Create filter is disabled when the selection isn't continuous", () => {
+      setSelection(model, ["A1", "B6"]);
+      expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(createFilterPath).isEnabled(env)).toBeFalsy();
+    });
 
-      test("Filters -> Create filter is enabled for continuous selection of multiple zones", () => {
-        setSelection(model, ["A1", "A2:A5", "B1:B5"]);
-        expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(createFilterPath).isEnabled(env)).toBeTruthy();
-      });
+    test("Filters -> Create filter is enabled for continuous selection of multiple zones", () => {
+      setSelection(model, ["A1", "A2:A5", "B1:B5"]);
+      expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(createFilterPath).isEnabled(env)).toBeTruthy();
+    });
 
-      test("Filters -> Remove filter is displayed instead of add filter when the selection contains a filter", () => {
-        setSelection(model, ["A1:A5"]);
-        expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
-        expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
+    test("Filters -> Remove filter is displayed instead of add filter when the selection contains a filter", () => {
+      setSelection(model, ["A1:A5"]);
+      expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
+      expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
 
-        createFilter(model, "A1:B5");
-        expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
+      createFilter(model, "A1:B5");
+      expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
 
-        setSelection(model, ["A1:B9"]);
-        expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
+      setSelection(model, ["A1:B9"]);
+      expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
 
-        setSelection(model, ["A1"]);
-        expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
+      setSelection(model, ["A1"]);
+      expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
 
-        setSelection(model, ["B5"]);
-        expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
+      setSelection(model, ["B5"]);
+      expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
 
-        setSelection(model, ["C3", "A3"]);
-        expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
-        expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
+      setSelection(model, ["C3", "A3"]);
+      expect(getNode(removeFilterPath).isVisible(env)).toBeTruthy();
+      expect(getNode(createFilterPath).isVisible(env)).toBeFalsy();
 
-        setSelection(model, ["C3"]);
-        expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
-        expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
+      setSelection(model, ["C3"]);
+      expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
+      expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
 
-        setSelection(model, ["C3", "D3"]);
-        expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
-        expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
+      setSelection(model, ["C3", "D3"]);
+      expect(getNode(removeFilterPath).isVisible(env)).toBeFalsy();
+      expect(getNode(createFilterPath).isVisible(env)).toBeTruthy();
+    });
+
+    test("Filters -> Adjacent cells selection while applying filter on single cell", async () => {
+      setCellContent(model, "A1", "A");
+      setCellContent(model, "A2", "A3");
+      setCellContent(model, "B2", "B");
+      setCellContent(model, "B3", "3");
+      setCellContent(model, "C3", "B4");
+      setCellContent(model, "C4", "Hello");
+      setCellContent(model, "D4", "2");
+      selectCell(model, "A1");
+
+      doAction(createFilterPath, env);
+      const selection = model.getters.getSelectedZone();
+      expect(zoneToXc(selection)).toEqual("A1:D4");
+      expect(dispatch).toHaveBeenCalledWith("CREATE_FILTER_TABLE", {
+        sheetId: model.getters.getActiveSheetId(),
+        target: target("A1:D4"),
       });
     });
   });


### PR DESCRIPTION
This is a followup of PR #1970. There are two entry points to insert a filter from the interface and only one of them was amended.

Task: 3839869

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3839869](https://www.odoo.com/web#id=3839869&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo