### PR TITLE
[FIX] chart: preserve label order when aggregate

### DIFF
--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -73,10 +73,10 @@ export function aggregateDataForLabels(
   }
 
   return {
-    labels: Object.keys(labelMap),
+    labels: Array.from(labelSet),
     dataSetsValues: datasets.map((dataset, indexOfDataset) => ({
       ...dataset,
-      data: Object.values(labelMap).map((dataOfLabel: any[]) => dataOfLabel[indexOfDataset]),
+      data: Array.from(labelSet).map((label) => labelMap[label][indexOfDataset]),
     })),
   };
 }


### PR DESCRIPTION
## Description:

Previously, the labels were not preserving their order when data was aggregated. This was due to the labels being stored in an object, whose order is not guaranteed. This PR addresses the issue by returning a labelSet and mapping the data accordingly.

Task: : [3834222](https://www.odoo.com/web#id=3834222&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo