### PR TITLE
[FIX] xlsx: accelerate xlsx export

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -256,7 +256,7 @@ export function deepEquals(o1: any, o2: any): boolean {
   if (o1 === o2) return true;
   if ((o1 && !o2) || (o2 && !o1)) return false;
   if (typeof o1 !== typeof o2) return false;
-  if (typeof o1 !== "object") return o1 === o2;
+  if (typeof o1 !== "object") return false;
 
   // Objects can have different keys if the values are undefined
   const keys = new Set<string>();

--- a/src/types/xlsx.ts
+++ b/src/types/xlsx.ts
@@ -103,7 +103,7 @@ export interface XLSXStyle {
 export interface ExtractedStyle {
   font: XLSXFont;
   fill: XLSXFill;
-  border: Border;
+  border: number;
   numFmt: string | undefined;
   verticalAlignment: Align;
   horizontalAlignment: Align;

--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -70,15 +70,14 @@ export function addContent(
   attrs: XMLAttributes;
   node: XMLString;
 } {
-  let value: string = content;
+  let value: string | number = content;
   const attrs: XMLAttributes = [];
 
   if (["TRUE", "FALSE"].includes(value.trim())) {
     value = value === "TRUE" ? "1" : "0";
     attrs.push(["t", "b"]);
   } else if (!isNumber(value)) {
-    const { id } = pushElement(content, sharedStrings);
-    value = id.toString();
+    value = pushElement(content, sharedStrings);
     attrs.push(["t", "s"]);
   }
   return { attrs, node: escapeXml/*xml*/ `<v>${value}</v>` };

--- a/src/xlsx/functions/conditional_formatting.ts
+++ b/src/xlsx/functions/conditional_formatting.ts
@@ -69,8 +69,7 @@ function addCellIsRule(cf: ConditionalFormat, rule: CellIsRule, dxfs: XLSXDxf[])
   if (rule.style.fillColor) {
     dxf.fill = { fgColor: rule.style.fillColor };
   }
-  const { id } = pushElement(dxf, dxfs);
-  ruleAttributes.push(["dxfId", id]);
+  ruleAttributes.push(["dxfId", pushElement(dxf, dxfs)]);
 
   return escapeXml/*xml*/ `
     <conditionalFormatting sqref="${cf.ranges.join(" ")}">

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -1,7 +1,6 @@
 import { DEFAULT_FONT_SIZE } from "../../constants";
 import {
   Align,
-  Border,
   CellData,
   ConditionalFormattingOperatorValues,
   Style,
@@ -64,10 +63,6 @@ export function extractStyle(cell: CellData, data: WorkbookData): ExtractedStyle
   if (cell.style) {
     style = data.styles[cell.style];
   }
-  let border: Border = {};
-  if (cell.border) {
-    border = data.borders[cell.border];
-  }
   const styles = {
     font: {
       size: style?.fontSize || DEFAULT_FONT_SIZE,
@@ -81,7 +76,7 @@ export function extractStyle(cell: CellData, data: WorkbookData): ExtractedStyle
         }
       : { reservedAttribute: "none" },
     numFmt: cell.format,
-    border: border || {},
+    border: cell.border || 0,
     verticalAlignment: "center" as Align, // we always center vertically for now
     horizontalAlignment: style?.align,
   };
@@ -97,9 +92,9 @@ export function normalizeStyle(construct: XLSXStructure, styles: ExtractedStyle)
   // Normalize this
   const numFmtId = convertFormat(styles["numFmt"], construct.numFmts);
   const style = {
-    fontId: pushElement(styles["font"], construct.fonts),
-    fillId: pushElement(styles["fill"], construct.fills),
-    borderId: pushElement(styles["border"], construct.borders),
+    fontId: pushElement(styles.font, construct.fonts),
+    fillId: pushElement(styles.fill, construct.fills),
+    borderId: styles.border,
     numFmtId,
     verticalAlignment: styles["verticalAlignment"] as string,
     horizontalAlignment: styles["horizontalAlignment"] as string,

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FONT_SIZE } from "../../constants";
+import { deepEquals } from "../../helpers";
 import {
   Align,
   CellData,
@@ -138,17 +139,15 @@ export function addRelsToFile(
 }
 
 export function pushElement<T>(property: T, propertyList: T[]): number {
-  for (let [key, value] of Object.entries(propertyList)) {
-    if (JSON.stringify(value) === JSON.stringify(property)) {
-      return parseInt(key, 10);
+  let len = propertyList.length;
+  for (let i = 0; i < len; i++) {
+    if (deepEquals(property, propertyList[i])) {
+      return i;
     }
   }
-  let elemId = propertyList.findIndex((elem) => JSON.stringify(elem) === JSON.stringify(property));
-  if (elemId === -1) {
-    propertyList.push(property);
-    elemId = propertyList.length - 1;
-  }
-  return elemId;
+
+  propertyList[propertyList.length] = property;
+  return propertyList.length - 1;
 }
 
 const chartIds: UID[] = [];

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -140,8 +140,9 @@ export function addRelsToFile(
 
 export function pushElement<T>(property: T, propertyList: T[]): number {
   let len = propertyList.length;
+  const operator = typeof property === "object" ? deepEquals : (a: T, b: T) => a === b;
   for (let i = 0; i < len; i++) {
-    if (deepEquals(property, propertyList[i])) {
+    if (operator(property, propertyList[i])) {
       return i;
     }
   }

--- a/src/xlsx/helpers/content_helpers.ts
+++ b/src/xlsx/helpers/content_helpers.ts
@@ -11,11 +11,6 @@ import {
 import { ExtractedStyle, XLSXRel, XLSXRelFile, XLSXStructure } from "../../types/xlsx";
 import { FIRST_NUMFMT_ID, HEIGHT_FACTOR, WIDTH_FACTOR, XLSX_FORMAT_MAP } from "../constants";
 
-type PropertyPosition<T> = {
-  id: number;
-  list: T[];
-};
-
 // -------------------------------------
 //            CF HELPERS
 // -------------------------------------
@@ -99,22 +94,17 @@ export function extractStyle(cell: CellData, data: WorkbookData): ExtractedStyle
 }
 
 export function normalizeStyle(construct: XLSXStructure, styles: ExtractedStyle): number {
-  const { id: fontId } = pushElement(styles["font"], construct.fonts);
-  const { id: fillId } = pushElement(styles["fill"], construct.fills);
-  const { id: borderId } = pushElement(styles["border"], construct.borders);
   // Normalize this
   const numFmtId = convertFormat(styles["numFmt"], construct.numFmts);
   const style = {
-    fontId,
-    fillId,
-    borderId,
+    fontId: pushElement(styles["font"], construct.fonts),
+    fillId: pushElement(styles["fill"], construct.fills),
+    borderId: pushElement(styles["border"], construct.borders),
     numFmtId,
     verticalAlignment: styles["verticalAlignment"] as string,
     horizontalAlignment: styles["horizontalAlignment"] as string,
   };
-  const { id } = pushElement(style, construct.styles);
-
-  return id;
+  return pushElement(style, construct.styles);
 }
 
 export function convertFormat(format: string | undefined, numFmtStructure: string[]): number {
@@ -123,8 +113,7 @@ export function convertFormat(format: string | undefined, numFmtStructure: strin
   }
   let formatId: number | undefined = XLSX_FORMAT_MAP[format];
   if (!formatId) {
-    const { id } = pushElement(format, numFmtStructure);
-    formatId = id + FIRST_NUMFMT_ID;
+    formatId = pushElement(format, numFmtStructure) + FIRST_NUMFMT_ID;
   }
   return formatId;
 }
@@ -153,10 +142,10 @@ export function addRelsToFile(
   return id;
 }
 
-export function pushElement<T>(property: T, propertyList: T[]): PropertyPosition<T> {
+export function pushElement<T>(property: T, propertyList: T[]): number {
   for (let [key, value] of Object.entries(propertyList)) {
     if (JSON.stringify(value) === JSON.stringify(property)) {
-      return { id: parseInt(key, 10), list: propertyList };
+      return parseInt(key, 10);
     }
   }
   let elemId = propertyList.findIndex((elem) => JSON.stringify(elem) === JSON.stringify(property));
@@ -164,10 +153,7 @@ export function pushElement<T>(property: T, propertyList: T[]): PropertyPosition
     propertyList.push(property);
     elemId = propertyList.length - 1;
   }
-  return {
-    id: elemId,
-    list: propertyList,
-  };
+  return elemId;
 }
 
 const chartIds: UID[] = [];

--- a/src/xlsx/helpers/xml_helpers.ts
+++ b/src/xlsx/helpers/xml_helpers.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FONT_SIZE } from "../../constants";
+import { ExcelWorkbookData } from "../../types";
 import {
   XLSXExportFile,
   XLSXStructure,
@@ -56,7 +57,8 @@ export function parseXML(xmlString: XMLString): XMLDocument {
   return document;
 }
 
-export function getDefaultXLSXStructure(): XLSXStructure {
+export function getDefaultXLSXStructure(data: ExcelWorkbookData): XLSXStructure {
+  const borders = [{}, ...Object.values(data.borders)];
   return {
     relsFiles: [],
     sharedStrings: [],
@@ -79,7 +81,7 @@ export function getDefaultXLSXStructure(): XLSXStructure {
       },
     ],
     fills: [{ reservedAttribute: "none" }, { reservedAttribute: "gray125" }],
-    borders: [{}],
+    borders,
     numFmts: [],
     dxfs: [],
   };

--- a/src/xlsx/xlsx_writer.ts
+++ b/src/xlsx/xlsx_writer.ts
@@ -44,7 +44,7 @@ import {
  */
 export function getXLSX(data: ExcelWorkbookData): XLSXExport {
   const files: XLSXExportFile[] = [];
-  const construct = getDefaultXLSXStructure();
+  const construct = getDefaultXLSXStructure(data);
   files.push(createWorkbook(data, construct));
 
   files.push(...createWorksheets(data, construct));

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -8001,42 +8001,21 @@ Object {
         </border>
         <border>
             <left/>
+            <right style=\\"thin\\" color=\\"000000\\"/>
+            <top/>
+            <bottom/>
+            <diagonal/>
+        </border>
+        <border>
+            <left style=\\"thin\\" color=\\"000000\\"/>
             <right/>
             <top/>
-            <bottom style=\\"thin\\" color=\\"000000\\"/>
+            <bottom/>
             <diagonal/>
         </border>
         <border>
             <left/>
-            <right style=\\"thin\\" color=\\"000000\\"/>
-            <top/>
-            <bottom/>
-            <diagonal/>
-        </border>
-        <border>
-            <left style=\\"thin\\" color=\\"000000\\"/>
-            <right style=\\"thin\\" color=\\"000000\\"/>
-            <top style=\\"thin\\" color=\\"000000\\"/>
-            <bottom/>
-            <diagonal/>
-        </border>
-        <border>
-            <left style=\\"thin\\" color=\\"000000\\"/>
             <right/>
-            <top/>
-            <bottom/>
-            <diagonal/>
-        </border>
-        <border>
-            <left style=\\"thin\\" color=\\"000000\\"/>
-            <right style=\\"thin\\" color=\\"000000\\"/>
-            <top/>
-            <bottom/>
-            <diagonal/>
-        </border>
-        <border>
-            <left style=\\"thin\\" color=\\"000000\\"/>
-            <right style=\\"thin\\" color=\\"000000\\"/>
             <top/>
             <bottom style=\\"thin\\" color=\\"000000\\"/>
             <diagonal/>
@@ -8052,6 +8031,27 @@ Object {
             <left style=\\"thin\\" color=\\"000000\\"/>
             <right style=\\"thin\\" color=\\"000000\\"/>
             <top style=\\"thin\\" color=\\"000000\\"/>
+            <bottom style=\\"thin\\" color=\\"000000\\"/>
+            <diagonal/>
+        </border>
+        <border>
+            <left style=\\"thin\\" color=\\"000000\\"/>
+            <right style=\\"thin\\" color=\\"000000\\"/>
+            <top style=\\"thin\\" color=\\"000000\\"/>
+            <bottom/>
+            <diagonal/>
+        </border>
+        <border>
+            <left style=\\"thin\\" color=\\"000000\\"/>
+            <right style=\\"thin\\" color=\\"000000\\"/>
+            <top/>
+            <bottom/>
+            <diagonal/>
+        </border>
+        <border>
+            <left style=\\"thin\\" color=\\"000000\\"/>
+            <right style=\\"thin\\" color=\\"000000\\"/>
+            <top/>
             <bottom style=\\"thin\\" color=\\"000000\\"/>
             <diagonal/>
         </border>
@@ -8069,19 +8069,19 @@ Object {
         <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"0\\">
             <alignment vertical=\\"center\\"/>
         </xf>
-        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"1\\">
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"3\\">
             <alignment vertical=\\"center\\"/>
         </xf>
         <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"4\\" borderId=\\"0\\">
             <alignment vertical=\\"center\\" horizontal=\\"left\\"/>
         </xf>
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"1\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"6\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
         <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"2\\">
-            <alignment vertical=\\"center\\"/>
-        </xf>
-        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"3\\">
-            <alignment vertical=\\"center\\"/>
-        </xf>
-        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"4\\">
             <alignment vertical=\\"center\\"/>
         </xf>
         <xf numFmtId=\\"0\\" fillId=\\"2\\" fontId=\\"3\\" borderId=\\"0\\">
@@ -8090,16 +8090,16 @@ Object {
         <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"5\\" borderId=\\"0\\">
             <alignment vertical=\\"center\\"/>
         </xf>
-        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"5\\">
-            <alignment vertical=\\"center\\"/>
-        </xf>
-        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"6\\">
-            <alignment vertical=\\"center\\"/>
-        </xf>
         <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"7\\">
             <alignment vertical=\\"center\\"/>
         </xf>
         <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"8\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"4\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"5\\">
             <alignment vertical=\\"center\\"/>
         </xf>
         <xf numFmtId=\\"10\\" fillId=\\"0\\" fontId=\\"3\\" borderId=\\"0\\">


### PR DESCRIPTION
This Pull request addresses the slowness of the `pushElement` helper.
The two main improvments concern the iteration over the array elements and the comparison operations.

## Benchmark of `getXLSX` function

On a 30k random string cells (heavy use of `pushElement`) averaged on 10 runs


|         | Firefox     | Chrome |
|-----------------|-----------|------------|
| Before | 153 s    |    81 s     |
| After      | 6.2 s   |   4.8 s    |


With the same patch applied to the mater branch on RNG's super sheet

|         | Firefox     | Chrome |
|-----------------|-----------|------------|
| Before | 351 s    |    95 s     |
| After      | 17.4 s   |   8 s    |


## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3733743](https://www.odoo.com/web#id=3733743&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo