### PR TITLE
[IMP] package: update Typescript to version 5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,9 @@
         "rollup-plugin-dts": "^5.3.1",
         "rollup-plugin-typescript2": "^0.35.0",
         "ts-jest": "^29.1.0",
-        "typedoc": "0.24.8",
-        "typedoc-plugin-markdown": "3.11.1",
-        "typescript": "^5.1.6",
+        "typedoc": "0.25.12",
+        "typedoc-plugin-markdown": "3.17.1",
+        "typescript": "^5.4.3",
         "xml-formatter": "^2.4.0"
       }
     },
@@ -1674,9 +1674,10 @@
       }
     },
     "node_modules/ansi-sequence-parser": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -7109,9 +7110,10 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -9436,9 +9438,10 @@
       "license": "MIT"
     },
     "node_modules/shiki": {
-      "version": "0.14.2",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
@@ -10372,48 +10375,52 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.24.8",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.12.tgz",
+      "integrity": "sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.3.0",
-        "minimatch": "^9.0.0",
-        "shiki": "^0.14.1"
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 14.14"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {
-      "version": "3.11.1",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz",
+      "integrity": "sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "handlebars": "^4.7.7"
       },
       "peerDependencies": {
-        "typedoc": ">=0.22.0"
+        "typedoc": ">=0.24.0"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.1",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -10425,9 +10432,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10650,13 +10657,15 @@
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
     },
     "node_modules/vscode-textmate": {
       "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -88,9 +88,9 @@
     "rollup-plugin-dts": "^5.3.1",
     "rollup-plugin-typescript2": "^0.35.0",
     "ts-jest": "^29.1.0",
-    "typedoc": "0.24.8",
-    "typedoc-plugin-markdown": "3.11.1",
-    "typescript": "^5.1.6",
+    "typedoc": "0.25.12",
+    "typedoc-plugin-markdown": "3.17.1",
+    "typescript": "^5.4.3",
     "xml-formatter": "^2.4.0"
   },
   "prettier": {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -292,7 +292,7 @@ export function debounce<T extends (...args: any) => void>(
   let timeout: any | undefined = undefined;
   const debounced = function (this: any): void {
     const context = this;
-    const args = arguments;
+    const args = Array.from(arguments);
     function later() {
       timeout = undefined;
       if (!immediate) {

--- a/tests/__mocks__/mock_misc_helpers.ts
+++ b/tests/__mocks__/mock_misc_helpers.ts
@@ -3,7 +3,7 @@ import { DebouncedFunction } from "../../src/types";
 /** Mocked debounce that doesn't actually do any debouncing, but just calls the function directly */
 export function debounce<T extends (...args: any) => void>(func: T): DebouncedFunction<T> {
   const debounced = function (this: any): void {
-    func.apply(this, arguments);
+    func.apply(this, Array.from(arguments));
   };
   debounced.isDebouncePending = () => false;
   debounced.stopDebounce = () => {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "noImplicitThis": true,
     "moduleResolution": "node",
     "removeComments": false,
-    "target": "es2022",
+    "target": "ESNext",
     "outDir": "build/js",
     "alwaysStrict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Changelog
5.2 https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html
5.3 https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-3.html
5.4 https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/

With this update, Object.groupBy is now supported.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo