### PR TITLE
[REF] autofill: simplify automatic autofill

### DIFF
--- a/src/plugins/ui_feature/autofill.ts
+++ b/src/plugins/ui_feature/autofill.ts
@@ -298,10 +298,7 @@ export class AutofillPlugin extends UIPlugin {
 
     if (col > 0) {
       let leftPosition = { sheetId, col: col - 1, row };
-      while (
-        this.getters.getCorrespondingFormulaCell(leftPosition) ||
-        this.getters.getCell(leftPosition)?.content
-      ) {
+      while (this.getters.getEvaluatedCell(leftPosition).type !== CellValueType.empty) {
         row += 1;
         leftPosition = { sheetId, col: col - 1, row };
       }
@@ -310,10 +307,7 @@ export class AutofillPlugin extends UIPlugin {
       col = zone.right;
       if (col <= this.getters.getNumberCols(sheetId)) {
         let rightPosition = { sheetId, col: col + 1, row };
-        while (
-          this.getters.getCorrespondingFormulaCell(rightPosition) ||
-          this.getters.getCell(rightPosition)?.content
-        ) {
+        while (this.getters.getEvaluatedCell(rightPosition).type !== CellValueType.empty) {
           row += 1;
           rightPosition = { sheetId, col: col + 1, row };
         }

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -9,7 +9,7 @@ import {
   splitTextToWidth,
 } from "../../helpers/index";
 import { localizeFormula } from "../../helpers/locale";
-import { Command, CommandResult, LocalCommand, UID } from "../../types";
+import { CellValueType, Command, CommandResult, LocalCommand, UID } from "../../types";
 import { CellPosition, HeaderIndex, Pixel, Style, Zone } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
@@ -176,10 +176,7 @@ export class SheetUIPlugin extends UIPlugin {
    */
   private isCellEmpty(position: CellPosition): boolean {
     const mainPosition = this.getters.getMainCellPosition(position);
-    return !(
-      this.getters.getCorrespondingFormulaCell(mainPosition) ||
-      this.getters.getCell(mainPosition)?.content
-    );
+    return this.getters.getEvaluatedCell(mainPosition).type === CellValueType.empty;
   }
 
   private getColMaxWidth(sheetId: UID, index: HeaderIndex): number {


### PR DESCRIPTION


## Description:

Before commit e8f8fa321 an evaluated cell with the type "empty" could be empty or have a formula whose result is an empty string.

After the mention commit, only really empty cells (no content) have the evaluated type "empty". Empty string result is now mapped to the "text" type.

This change allow to slightly simplify the autofill code as we no longer needs to check the cell content or any potential array formula that would spread on the value.

The code is also now faster since checking `cell.content` can be expensice since it re-builds the entire formula string from the tokens and the dependencies.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo