### PR TITLE
[PERF] helpers: faster default cell height

### DIFF
--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -22,7 +22,9 @@ export function getDefaultCellHeight(
   cell: Cell | undefined,
   colSize: number
 ) {
-  if (!cell || !cell.content) return DEFAULT_CELL_HEIGHT;
+  if (!cell || (!cell.isFormula && !cell.content)) {
+    return DEFAULT_CELL_HEIGHT;
+  }
   const maxWidth = cell.style?.wrapping === "wrap" ? colSize - 2 * MIN_CELL_TEXT_MARGIN : undefined;
 
   const numberOfLines = cell.isFormula


### PR DESCRIPTION


## Description:

`cell.content` can be expensive for formulas as the content is a computed property which rebuilds the entire formula string based on the tokens and the dependency ranges.

With this commit, we first check if the cell is a formula, in which case we know it has a content.

When loading the Timesheet report on odoo.com, the total time spent in `getDefaultCellHeight` goes from ~280ms (~2.5%) to less than 5ms (0.0%)

Task: : [3845472](https://www.odoo.com/web#id=3845472&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo