### PR TITLE
[FIX] evaluation: fix function name interpolation in errors

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -409,6 +409,16 @@ export function matrixMap<T, M>(matrix: Matrix<T>, fn: (value: T) => M): Matrix<
   return generateMatrix(matrix.length, matrix[0].length, (col, row) => fn(matrix[col][row]));
 }
 
+export function matrixForEach<T>(matrix: Matrix<T>, fn: (value: T) => void): void {
+  const numberOfCols = matrix.length;
+  const numberOfRows = matrix[0]?.length ?? 0;
+  for (let col = 0; col < numberOfCols; col++) {
+    for (let row = 0; row < numberOfRows; row++) {
+      fn(matrix[col][row]);
+    }
+  }
+}
+
 export function transposeMatrix<T>(matrix: Matrix<T>): Matrix<T> {
   if (!matrix.length) {
     return [];

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -13,7 +13,7 @@ import {
 } from "../types";
 import { EvaluationError } from "../types/errors";
 import { addMetaInfoFromArg, validateArguments } from "./arguments";
-import { isEvaluationError, matrixMap } from "./helpers";
+import { isEvaluationError, matrixForEach, matrixMap } from "./helpers";
 import * as array from "./module_array";
 import * as misc from "./module_custom";
 import * as database from "./module_database";
@@ -74,7 +74,7 @@ class FunctionRegistry extends Registry<FunctionDescription> {
     }
     const descr = addMetaInfoFromArg(addDescr);
     validateArguments(descr.args);
-    this.mapping[name] = addErrorHandling(addResultHandling(addInputHandling(descr)), name);
+    this.mapping[name] = addErrorHandling(addResultHandling(addInputHandling(descr), name), name);
     super.add(name, descr);
     return this;
   }
@@ -132,9 +132,7 @@ function handleError(e: unknown, functionName: string): FPayload {
   // so we fallback to a generic error
   if (hasStringValue(e) && isEvaluationError(e.value)) {
     if (hasStringMessage(e)) {
-      if (e.message?.includes("[[FUNCTION_NAME]]")) {
-        e.message = e.message.replace("[[FUNCTION_NAME]]", functionName);
-      }
+      replaceFunctionNamePlaceholder(e, functionName);
     }
     return e;
   }
@@ -159,24 +157,39 @@ function hasStringMessage(obj: unknown): obj is { message: string } {
 }
 
 function addResultHandling(
-  compute: ComputeFunction<FPayload | Matrix<FPayload> | CellValue | Matrix<CellValue>>
+  compute: ComputeFunction<FPayload | Matrix<FPayload> | CellValue | Matrix<CellValue>>,
+  functionName: string
 ): ComputeFunction<FPayload | Matrix<FPayload>> {
-  return function (this: EvalContext, ...args: Arg[]): FPayload | Matrix<FPayload> {
+  return function computeWithResultHandling(
+    this: EvalContext,
+    ...args: Arg[]
+  ): FPayload | Matrix<FPayload> {
     const result = compute.apply(this, args);
 
     if (!isMatrix(result)) {
       if (typeof result === "object" && result !== null && "value" in result) {
+        replaceFunctionNamePlaceholder(result, functionName);
         return result;
       }
       return { value: result };
     }
 
     if (typeof result[0][0] === "object" && result[0][0] !== null && "value" in result[0][0]) {
+      matrixForEach(result as Matrix<FPayload>, (result) =>
+        replaceFunctionNamePlaceholder(result, functionName)
+      );
       return result as Matrix<FPayload>;
     }
 
     return matrixMap(result as Matrix<CellValue>, (row) => ({ value: row }));
   };
+}
+
+function replaceFunctionNamePlaceholder(fPayload: FPayload, functionName: string) {
+  // for performance reasons: change in place and only if needed
+  if (fPayload.message?.includes("[[FUNCTION_NAME]]")) {
+    fPayload.message = fPayload.message.replace("[[FUNCTION_NAME]]", functionName);
+  }
 }
 
 export const functionRegistry = new FunctionRegistry();

--- a/tests/evaluation/evaluation.test.ts
+++ b/tests/evaluation/evaluation.test.ts
@@ -1254,4 +1254,24 @@ describe("evaluate formula getter", () => {
     expect((getEvaluatedCell(model, "A1") as ErrorCell).message).toBe("Error2");
     functionRegistry.remove("GETVALUE");
   });
+
+  test("return error message with function name placeholder", () => {
+    functionRegistry.add("GETERR", {
+      description: "Get error",
+      compute: () => {
+        return {
+          value: "#ERROR",
+          message: "Function [[FUNCTION_NAME]] failed",
+        };
+      },
+      args: [],
+      returns: ["ANY"],
+    });
+    setCellContent(model, "A1", "=GETERR()");
+    expect(getEvaluatedCell(model, "A1").type).toBe(CellValueType.error);
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).message).toBe("Function GETERR failed");
+    setCellContent(model, "A1", "=SUM(GETERR())");
+    expect((getEvaluatedCell(model, "A1") as ErrorCell).message).toBe("Function GETERR failed");
+    functionRegistry.remove("GETERR");
+  });
 });

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -2,7 +2,7 @@ import { arg, functionRegistry } from "../../src/functions";
 import { toScalar } from "../../src/functions/helper_matrices";
 import { toMatrix, toNumber } from "../../src/functions/helpers";
 import { Model } from "../../src/model";
-import { DEFAULT_LOCALE } from "../../src/types";
+import { DEFAULT_LOCALE, ErrorCell } from "../../src/types";
 import {
   addColumns,
   addRows,
@@ -96,6 +96,23 @@ describe("evaluate formulas that return an array", () => {
     setCellContent(model, "B1", "=TRANSPOSE(A1:A2)");
     expect(getEvaluatedCell(model, "B1").value).toBe(42);
     expect(getEvaluatedCell(model, "C1").value).toBe("#ERROR");
+  });
+
+  test("can interpolate function name when error is returned", () => {
+    functionRegistry.add("GETERR", {
+      description: "Get error",
+      compute: () => {
+        const error = {
+          value: "#ERROR",
+          message: "Function [[FUNCTION_NAME]] failed",
+        };
+        return [[{ value: 42 }, error]];
+      },
+      args: [],
+      returns: ["ANY"],
+    });
+    setCellContent(model, "A1", "=GETERR()");
+    expect((getEvaluatedCell(model, "A2") as ErrorCell).message).toBe("Function GETERR failed");
   });
 
   describe("spread matrix with format", () => {


### PR DESCRIPTION
## Description:

Write a VLOOKUP function that doesn't match anything such that it returns #N/A 

=> look at the error message, it contains [[FUNCTION_NAME]] instead of VLOOKUP

Task: : [3839097](https://www.odoo.com/web#id=3839097&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo