### PR TITLE
[REF] evaluation: remove useless method

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/compilation_parameters.ts
@@ -98,13 +98,6 @@ class CompilationParametersBuilder {
       );
     }
     const position = { sheetId: range.sheetId, col: range.zone.left, row: range.zone.top };
-    return this.readCell(position);
-  }
-
-  private readCell(position: CellPosition): FPayload {
-    if (!this.getters.tryGetSheet(position.sheetId)) {
-      throw new EvaluationError(_t("Invalid sheet name"));
-    }
     return this.computeCell(position);
   }
 
@@ -143,7 +136,7 @@ class CompilationParametersBuilder {
       matrix[colIndex] = new Array(height);
       for (let row = _zone.top; row <= _zone.bottom; row++) {
         const rowIndex = row - _zone.top;
-        matrix[colIndex][rowIndex] = this.readCell({ sheetId, col, row });
+        matrix[colIndex][rowIndex] = this.computeCell({ sheetId, col, row });
       }
     }
 


### PR DESCRIPTION

## Description:

Since c96021f142, the sheet is checked before-hand. The method is useless and removed.

Task: : [/](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo