### PR TITLE
[IMP] sheetview: prevent useless SET_VIEWPORT_OFFSET

### DIFF
--- a/src/helpers/internal_viewport.ts
+++ b/src/helpers/internal_viewport.ts
@@ -207,6 +207,13 @@ export class InternalViewport {
     this.adjustViewportZoneY();
   }
 
+  willNewOffsetScrollViewport(offsetX: Pixel, offsetY: Pixel) {
+    return (
+      (this.canScrollHorizontally && this.offsetScrollbarX !== offsetX) ||
+      (this.canScrollVertically && this.offsetScrollbarY !== offsetY)
+    );
+  }
+
   setViewportOffset(offsetX: Pixel, offsetY: Pixel) {
     this.setViewportOffsetX(offsetX);
     this.setViewportOffsetY(offsetY);

--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -19,6 +19,7 @@ import {
   Rect,
   ResizeViewportCommand,
   ScrollDirection,
+  SetViewportOffsetCommand,
   SheetDOMScrollInfo,
   SheetScrollInfo,
   UID,
@@ -128,7 +129,10 @@ export class SheetViewPlugin extends UIPlugin {
   allowDispatch(cmd: LocalCommand): CommandResult | CommandResult[] {
     switch (cmd.type) {
       case "SET_VIEWPORT_OFFSET":
-        return this.checkScrollingDirection(cmd);
+        return this.chainValidations(
+          this.checkScrollingDirection,
+          this.checkViewportsWillChange
+        )(cmd);
       case "RESIZE_SHEETVIEW":
         return this.chainValidations(
           this.checkValuesAreDifferent,
@@ -638,6 +642,18 @@ export class SheetViewPlugin extends UIPlugin {
       return CommandResult.InvalidScrollingDirection;
     }
     return CommandResult.Success;
+  }
+
+  private checkViewportsWillChange({ offsetX, offsetY }: SetViewportOffsetCommand) {
+    const sheetId = this.getters.getActiveSheetId();
+    const { maxOffsetX, maxOffsetY } = this.getMaximumSheetOffset();
+    const willScroll = this.getSubViewports(sheetId).some((viewport) =>
+      viewport.willNewOffsetScrollViewport(
+        clip(offsetX, 0, maxOffsetX),
+        clip(offsetY, 0, maxOffsetY)
+      )
+    );
+    return willScroll ? CommandResult.Success : CommandResult.NoViewportScroll;
   }
 
   private getMainViewport(sheetId: UID): Viewport {

--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -131,7 +131,7 @@ export class SheetViewPlugin extends UIPlugin {
       case "SET_VIEWPORT_OFFSET":
         return this.chainValidations(
           this.checkScrollingDirection,
-          this.checkViewportsWillChange
+          this.checkIfViewportsWillChange
         )(cmd);
       case "RESIZE_SHEETVIEW":
         return this.chainValidations(
@@ -267,8 +267,7 @@ export class SheetViewPlugin extends UIPlugin {
       this.resetViewports(sheetId);
       if (this.shouldAdjustViewports) {
         const position = this.getters.getSheetPosition(sheetId);
-        const viewports = this.getSubViewports(sheetId);
-        Object.values(viewports).forEach((viewport) => {
+        this.getSubViewports(sheetId).forEach((viewport) => {
           viewport.adjustPosition(position);
         });
       }
@@ -644,7 +643,7 @@ export class SheetViewPlugin extends UIPlugin {
     return CommandResult.Success;
   }
 
-  private checkViewportsWillChange({ offsetX, offsetY }: SetViewportOffsetCommand) {
+  private checkIfViewportsWillChange({ offsetX, offsetY }: SetViewportOffsetCommand) {
     const sheetId = this.getters.getActiveSheetId();
     const { maxOffsetX, maxOffsetY } = this.getMaximumSheetOffset();
     const willScroll = this.getSubViewports(sheetId).some((viewport) =>
@@ -653,7 +652,7 @@ export class SheetViewPlugin extends UIPlugin {
         clip(offsetY, 0, maxOffsetY)
       )
     );
-    return willScroll ? CommandResult.Success : CommandResult.NoViewportScroll;
+    return willScroll ? CommandResult.Success : CommandResult.ViewportScrollLimitsReached;
   }
 
   private getMainViewport(sheetId: UID): Viewport {
@@ -703,7 +702,7 @@ export class SheetViewPlugin extends UIPlugin {
   private setSheetViewOffset(offsetX: Pixel, offsetY: Pixel) {
     const sheetId = this.getters.getActiveSheetId();
     const { maxOffsetX, maxOffsetY } = this.getMaximumSheetOffset();
-    Object.values(this.getSubViewports(sheetId)).forEach((viewport) =>
+    this.getSubViewports(sheetId).forEach((viewport) =>
       viewport.setViewportOffset(clip(offsetX, 0, maxOffsetX), clip(offsetY, 0, maxOffsetY))
     );
   }
@@ -798,7 +797,7 @@ export class SheetViewPlugin extends UIPlugin {
    * Adjust the viewport such that the anchor position is visible
    */
   private refreshViewport(sheetId: UID, anchorPosition: Position) {
-    Object.values(this.getSubViewports(sheetId)).forEach((viewport) => {
+    this.getSubViewports(sheetId).forEach((viewport) => {
       viewport.adjustViewportZone();
       viewport.adjustPosition(anchorPosition);
     });

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1097,7 +1097,7 @@ export const enum CommandResult {
   Readonly = "Readonly",
   InvalidViewportSize = "InvalidViewportSize",
   InvalidScrollingDirection = "InvalidScrollingDirection",
-  NoViewportScroll = "NoViewportScroll",
+  ViewportScrollLimitsReached = "ViewportScrollLimitsReached",
   FigureDoesNotExist = "FigureDoesNotExist",
   InvalidConditionalFormatId = "InvalidConditionalFormatId",
   InvalidCellPopover = "InvalidCellPopover",

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1097,6 +1097,7 @@ export const enum CommandResult {
   Readonly = "Readonly",
   InvalidViewportSize = "InvalidViewportSize",
   InvalidScrollingDirection = "InvalidScrollingDirection",
+  NoViewportScroll = "NoViewportScroll",
   FigureDoesNotExist = "FigureDoesNotExist",
   InvalidConditionalFormatId = "InvalidConditionalFormatId",
   InvalidCellPopover = "InvalidCellPopover",

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -72,6 +72,13 @@ describe("Viewport of Simple sheet", () => {
     model = new Model();
   });
 
+  test("SET_VIEWPORT_OFFSET is refused if it won't scroll any viewport", () => {
+    expect(setViewportOffset(model, 0, 0)).toBeCancelledBecause(CommandResult.NoViewportScroll);
+
+    expect(setViewportOffset(model, 10, 10)).toBeSuccessfullyDispatched();
+    expect(setViewportOffset(model, 10, 10)).toBeCancelledBecause(CommandResult.NoViewportScroll);
+  });
+
   test("Select cell correctly affects offset", () => {
     // Since we rely on the adjustViewportPosition function here, the offsets will be linear combinations of the cells width and height
     selectCell(model, "P1");
@@ -935,6 +942,16 @@ describe("Multi Panes viewport", () => {
   beforeEach(async () => {
     model = new Model();
   });
+
+  test("SET_VIEWPORT_OFFSET is refused if it won't scroll any viewport", () => {
+    freezeColumns(model, 4);
+    freezeRows(model, 5);
+    expect(setViewportOffset(model, 0, 0)).toBeCancelledBecause(CommandResult.NoViewportScroll);
+
+    expect(setViewportOffset(model, 10, 10)).toBeSuccessfullyDispatched();
+    expect(setViewportOffset(model, 10, 10)).toBeCancelledBecause(CommandResult.NoViewportScroll);
+  });
+
   test("Freezing row generates 2 panes", () => {
     const getPanesEntries = () => Object.keys(getPanes());
     expect(getPanesEntries()).toEqual(["bottomRight"]);

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -73,10 +73,14 @@ describe("Viewport of Simple sheet", () => {
   });
 
   test("SET_VIEWPORT_OFFSET is refused if it won't scroll any viewport", () => {
-    expect(setViewportOffset(model, 0, 0)).toBeCancelledBecause(CommandResult.NoViewportScroll);
+    expect(setViewportOffset(model, 0, 0)).toBeCancelledBecause(
+      CommandResult.ViewportScrollLimitsReached
+    );
 
     expect(setViewportOffset(model, 10, 10)).toBeSuccessfullyDispatched();
-    expect(setViewportOffset(model, 10, 10)).toBeCancelledBecause(CommandResult.NoViewportScroll);
+    expect(setViewportOffset(model, 10, 10)).toBeCancelledBecause(
+      CommandResult.ViewportScrollLimitsReached
+    );
   });
 
   test("Select cell correctly affects offset", () => {
@@ -946,10 +950,14 @@ describe("Multi Panes viewport", () => {
   test("SET_VIEWPORT_OFFSET is refused if it won't scroll any viewport", () => {
     freezeColumns(model, 4);
     freezeRows(model, 5);
-    expect(setViewportOffset(model, 0, 0)).toBeCancelledBecause(CommandResult.NoViewportScroll);
+    expect(setViewportOffset(model, 0, 0)).toBeCancelledBecause(
+      CommandResult.ViewportScrollLimitsReached
+    );
 
     expect(setViewportOffset(model, 10, 10)).toBeSuccessfullyDispatched();
-    expect(setViewportOffset(model, 10, 10)).toBeCancelledBecause(CommandResult.NoViewportScroll);
+    expect(setViewportOffset(model, 10, 10)).toBeCancelledBecause(
+      CommandResult.ViewportScrollLimitsReached
+    );
   });
 
   test("Freezing row generates 2 panes", () => {


### PR DESCRIPTION
## [IMP] sheetview: prevent useless SET_VIEWPORT_OFFSET:

When the user scrolls at the boundaries of a sheet, a lot of
SET_VIEWPORT_OFFSET commands are dispatched and trigger new renders,
even if the viewport offset is not actually changed.

This commit adds an allowDispatch in the sheetview plugin to prevent the
dispatch of SET_VIEWPORT_OFFSET that won't scroll any viewport.

## [IMP] sheetview: remove useless Object.values()

The SheetView plugin was doing Object.values() on arrays, which was
both useless and allocated some memory for new arrays.

This commit removes the useless Object.values() calls.


Task: : [3846620](https://www.odoo.com/web#id=3846620&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo