### PR TITLE
[FIX] sheetview: pageUp/Down with frozen rows

### DIFF
--- a/src/plugins/ui/sheetview.ts
+++ b/src/plugins/ui/sheetview.ts
@@ -134,12 +134,13 @@ export class SheetViewPlugin extends UIPlugin {
       case "AlterZoneCorner":
         break;
       case "ZonesSelected":
+        const sheetId = this.getters.getActiveSheetId();
         let { col, row } = findCellInNewZone(event.previousAnchor.zone, event.anchor.zone);
         if (event.mode === "updateAnchor") {
           const oldZone = event.previousAnchor.zone;
           const newZone = event.anchor.zone;
           // altering a zone should not move the viewport in a dimension that wasn't changed
-          const { top, bottom, left, right } = this.getters.getActiveMainViewport();
+          const { top, bottom, left, right } = this.getMainInternalViewport(sheetId);
           if (oldZone.left === newZone.left && oldZone.right === newZone.right) {
             col = left > col || col > right ? left : col;
           }
@@ -147,10 +148,9 @@ export class SheetViewPlugin extends UIPlugin {
             row = top > row || row > bottom ? top : row;
           }
         }
-        const sheetId = this.getters.getActiveSheetId();
         col = Math.min(col, this.getters.getNumberCols(sheetId) - 1);
         row = Math.min(row, this.getters.getNumberRows(sheetId) - 1);
-        this.refreshViewport(this.getters.getActiveSheetId(), { col, row });
+        this.refreshViewport(sheetId, { col, row });
         break;
     }
   }
@@ -176,20 +176,16 @@ export class SheetViewPlugin extends UIPlugin {
         this.setSheetViewOffset(cmd.offsetX, cmd.offsetY);
         break;
       case "SHIFT_VIEWPORT_DOWN":
-        const { top } = this.getActiveMainViewport();
         const sheetId = this.getters.getActiveSheetId();
-        const shiftedOffsetY = this.clipOffsetY(
-          this.getters.getRowDimensions(sheetId, top).start + this.sheetViewHeight
-        );
-        this.shiftVertically(shiftedOffsetY);
+        const { top, viewportHeight, offsetCorrectionY } = this.getMainInternalViewport(sheetId);
+        const topRowDims = this.getters.getRowDimensions(sheetId, top);
+        this.shiftVertically(topRowDims.start + viewportHeight - offsetCorrectionY);
         break;
       case "SHIFT_VIEWPORT_UP": {
-        const { top } = this.getActiveMainViewport();
         const sheetId = this.getters.getActiveSheetId();
-        const shiftedOffsetY = this.clipOffsetY(
-          this.getters.getRowDimensions(sheetId, top).end - this.sheetViewHeight
-        );
-        this.shiftVertically(shiftedOffsetY);
+        const { top, viewportHeight, offsetCorrectionY } = this.getMainInternalViewport(sheetId);
+        const topRowDims = this.getters.getRowDimensions(sheetId, top);
+        this.shiftVertically(topRowDims.end - offsetCorrectionY - viewportHeight);
         break;
       }
       case "REMOVE_COLUMNS_ROWS":
@@ -605,18 +601,6 @@ export class SheetViewPlugin extends UIPlugin {
     );
   }
 
-  /**
-   * Clip the vertical offset within the allowed range.
-   * Not above the sheet, nor below the sheet.
-   */
-  private clipOffsetY(offsetY: Pixel): Pixel {
-    const { height } = this.getMainViewportRect();
-    const maxOffset = height - this.sheetViewHeight;
-    offsetY = Math.min(offsetY, maxOffset);
-    offsetY = Math.max(offsetY, 0);
-    return offsetY;
-  }
-
   private getViewportOffset(sheetId: UID) {
     return {
       x: this.viewports[sheetId]?.bottomRight.offsetScrollbarX || 0,
@@ -704,12 +688,15 @@ export class SheetViewPlugin extends UIPlugin {
    * viewport top.
    */
   private shiftVertically(offset: Pixel) {
-    const { top } = this.getActiveMainViewport();
+    const sheetId = this.getters.getActiveSheetId();
+    const { top } = this.getMainInternalViewport(sheetId);
     const { scrollX } = this.getActiveSheetScrollInfo();
     this.setSheetViewOffset(scrollX, offset);
     const { anchor } = this.getters.getSelection();
-    const deltaRow = this.getActiveMainViewport().top - top;
-    this.selection.selectCell(anchor.cell.col, anchor.cell.row + deltaRow);
+    if (anchor.cell.row >= this.getters.getPaneDivisions(sheetId).ySplit) {
+      const deltaRow = this.getMainInternalViewport(sheetId).top - top;
+      this.selection.selectCell(anchor.cell.col, anchor.cell.row + deltaRow);
+    }
   }
 
   getVisibleFigures(): Figure[] {

--- a/tests/plugins/sheetview.test.ts
+++ b/tests/plugins/sheetview.test.ts
@@ -1381,6 +1381,47 @@ describe("shift viewport up/down", () => {
     });
   });
 
+  describe("shift down/up with frozen panes", () => {
+    test("shift down/up with frozen rows and with selection in frozen rows", () => {
+      freezeRows(model, 5);
+      const { bottom, top } = model.getters.getActiveMainViewport();
+      model.dispatch("SHIFT_VIEWPORT_DOWN");
+      expect(model.getters.getActiveMainViewport().top).toBe(bottom);
+      expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A1");
+      model.dispatch("SHIFT_VIEWPORT_UP");
+      expect(model.getters.getActiveMainViewport().top).toBe(top);
+      expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A1");
+    });
+
+    test("shift down/up with frozen rows and with selection not in frozen rows", () => {
+      freezeRows(model, 5);
+      selectCell(model, "A6");
+      const { bottom, top } = model.getters.getActiveMainViewport();
+      model.dispatch("SHIFT_VIEWPORT_DOWN");
+      expect(model.getters.getActiveMainViewport().top).toBe(bottom);
+      expect(zoneToXc(model.getters.getSelectedZone())).toEqual(toXC(0, bottom));
+      model.dispatch("SHIFT_VIEWPORT_UP");
+      expect(model.getters.getActiveMainViewport().top).toBe(top);
+      expect(zoneToXc(model.getters.getSelectedZone())).toEqual("A6");
+    });
+
+    test("shift down scrolls until the last row if there are frozen rows", () => {
+      const sheetId = model.getters.getActiveSheetId();
+      const numberOfRows = model.getters.getNumberRows(sheetId);
+      freezeRows(model, 10);
+      let { bottom } = model.getters.getActiveMainViewport();
+      while (true) {
+        model.dispatch("SHIFT_VIEWPORT_DOWN");
+        const newBottom = model.getters.getActiveMainViewport().bottom;
+        if (newBottom === bottom) {
+          break;
+        }
+        bottom = newBottom;
+      }
+      expect(model.getters.getActiveMainViewport().bottom).toBe(numberOfRows - 1);
+    });
+  });
+
   test.each(["A1", "A2"])(
     "viewport and selection %s do not move when its already the end of the sheet",
     (selectedCell) => {


### PR DESCRIPTION
## Description

There was two issues with the commands `SHIFT_VIEWPORT_UP/DOWN` when some rows were frozen:

- the viewport was never scrolled all the way down to the last row with pageDown
- pageDown/Up scrolled more than a "page" (the size of the viewport)

This commit fixes both issues.

Also replaced calls from `getActiveMainViewport` to `getMainInternalViewport`
in the plugin `SheetView` as it needs slightly less computations.

Task: : [3847414](https://www.odoo.com/web#id=3847414&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo