### PR TITLE
[FIX] style: Correctly recompute cell styles

### DIFF
--- a/src/plugins/ui_feature/cell_computed_style.ts
+++ b/src/plugins/ui_feature/cell_computed_style.ts
@@ -1,6 +1,11 @@
 import { LINK_COLOR } from "../../constants";
 import { isObjectEmptyRecursive, removeFalsyAttributes } from "../../helpers/index";
-import { Command, invalidateCFEvaluationCommands, invalidateEvaluationCommands } from "../../types";
+import {
+  Command,
+  invalidateBordersCommands,
+  invalidateCFEvaluationCommands,
+  invalidateEvaluationCommands,
+} from "../../types";
 import { Border, CellPosition, Style, UID } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 import { doesCommandInvalidatesTableStyle } from "./table_style";
@@ -30,6 +35,10 @@ export class CellComputedStylePlugin extends UIPlugin {
 
     if (invalidateCFEvaluationCommands.has(cmd.type)) {
       this.styles = {};
+      return;
+    }
+    if (invalidateBordersCommands.has(cmd.type)) {
+      this.borders = {};
       return;
     }
   }

--- a/src/plugins/ui_feature/table_style.ts
+++ b/src/plugins/ui_feature/table_style.ts
@@ -191,6 +191,7 @@ const invalidateTableStyleCommands = [
   "CREATE_TABLE",
   "UPDATE_TABLE",
   "UPDATE_FILTER",
+  "REMOVE_TABLE",
 ] as const;
 const invalidateTableStyleCommandsSet = new Set<CommandTypes>(invalidateTableStyleCommands);
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -129,6 +129,12 @@ export const invalidateCFEvaluationCommands = new Set<CommandTypes>([
   "CHANGE_CONDITIONAL_FORMAT_PRIORITY",
 ]);
 
+export const invalidateBordersCommands = new Set<CommandTypes>([
+  "AUTOFILL_CELL",
+  "SET_BORDER",
+  "SET_ZONE_BORDERS",
+]);
+
 export const readonlyAllowedCommands = new Set<CommandTypes>([
   "START",
   "ACTIVATE_SHEET",

--- a/tests/borders/border_plugin.test.ts
+++ b/tests/borders/border_plugin.test.ts
@@ -14,7 +14,12 @@ import {
   setZoneBorders,
   undo,
 } from "../test_helpers/commands_helpers";
-import { getBorder, getCell, getCellContent } from "../test_helpers/getters_helpers";
+import {
+  getBorder,
+  getCell,
+  getCellContent,
+  getComputedBorder,
+} from "../test_helpers/getters_helpers";
 import "../test_helpers/helpers"; // to have getcontext mocks
 
 describe("borders", () => {
@@ -737,5 +742,21 @@ describe("Borders formatting", () => {
       bottom: DEFAULT_BORDER_DESC,
       right: { style: "dashed", color: "#0000FF" },
     });
+  });
+});
+
+describe("Computed borders", () => {
+  test("SET_BORDER command recomputes the borders", () => {
+    const model = new Model();
+    expect(getComputedBorder(model, "A1")).toBeNull();
+    setBorders(model, "A1", { top: DEFAULT_BORDER_DESC });
+    expect(getComputedBorder(model, "A1")).not.toBeNull();
+  });
+
+  test("SET_ZONE_BORDERS command recomputes the borders", () => {
+    const model = new Model();
+    expect(getComputedBorder(model, "A1")).toBeNull();
+    setZoneBorders(model, { position: "all" }, ["A1"]);
+    expect(getComputedBorder(model, "A1")).not.toBeNull();
   });
 });

--- a/tests/table/table_style_plugin.test.ts
+++ b/tests/table/table_style_plugin.test.ts
@@ -4,6 +4,7 @@ import { TABLE_PRESETS } from "../../src/helpers/table_presets";
 import { Style, UID } from "../../src/types";
 import {
   createTable,
+  deleteTable,
   foldHeaderGroup,
   groupRows,
   hideColumns,
@@ -236,6 +237,13 @@ describe("Table style", () => {
       expect(getFullTableStyle("A1:B4")).not.toEqual(tableStyle);
       redo(model);
       expect(getFullTableStyle("A1:B4")).toEqual(tableStyle);
+    });
+
+    test("Style is updated when deleting a table", () => {
+      setStyle(model, "A1", { fillColor: "#f00" });
+      const tableStyle = getFullTableStyle("A1:B4");
+      deleteTable(model, "A1:B4");
+      expect(getFullTableStyle("A1:B4")).not.toEqual(tableStyle);
     });
   });
 });

--- a/tests/test_helpers/getters_helpers.ts
+++ b/tests/test_helpers/getters_helpers.ts
@@ -123,6 +123,18 @@ export function getBorder(
 }
 
 /**
+ * Get the computed borders at the given XC
+ */
+export function getComputedBorder(
+  model: Model,
+  xc: string,
+  sheetId: UID = model.getters.getActiveSheetId()
+): Border | null {
+  const { col, row } = toCartesian(xc);
+  return model.getters.getCellComputedBorder({ sheetId, col, row });
+}
+
+/**
  * Get the list of the merges
  */
 export function getMerges(model: Model): Record<number, Merge> {


### PR DESCRIPTION
Since PR #3746, we cache the computed cell style and borders. Unfortunately, it did not account for the border related commands to invalidate that cache.
The issue is also present with the 'REMOVE_TABLE' command

Task: 3849364

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo