### PR TITLE
[FIX] Checkbox: unused className prop in checkbox

### DIFF
--- a/src/components/side_panel/components/checkbox/checkbox.xml
+++ b/src/components/side_panel/components/checkbox/checkbox.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet.Checkbox">
-    <label class="o-checkbox">
+    <label class="o-checkbox" t-attf-class="{{props.className}}">
       <input
         type="checkbox"
         t-att-name="props.name"

--- a/tests/side_panels/components/checkbox.test.ts
+++ b/tests/side_panels/components/checkbox.test.ts
@@ -45,4 +45,9 @@ describe("Checkbox", () => {
     await mountCheckbox({ value: true, onChange: () => {}, name: "My name" });
     expect(fixture.querySelector("input")!.getAttribute("name")).toEqual("My name");
   });
+
+  test("Can render a checkbox with a custom className on the label", async () => {
+    await mountCheckbox({ value: true, onChange: () => {}, className: "custom-checkbox" });
+    expect(fixture.querySelector("label")!.classList.contains("custom-checkbox")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Description:

- Modified the checkbox.xml file to incorporate the className prop within the Checkbox component.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo