### PR TITLE
[REL] 16.4.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.4.27",
+  "version": "16.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.4.27",
+      "version": "16.4.28",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.4.27",
+  "version": "16.4.28",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/19b25635a [FIX] chart: preserve label order when aggregate
https://github.com/odoo/o-spreadsheet/commit/023ed5430 [IMP] package: update owl to version 2.2.10
https://github.com/odoo/o-spreadsheet/commit/c2a7220c4 [FIX] *: Compute max/min on huge arrays Task: 3802691
https://github.com/odoo/o-spreadsheet/commit/91d7a1982 [FIX] BottomBarSheet: Rename a sheet with style content on Firefox Task: 3754944
https://github.com/odoo/o-spreadsheet/commit/4731b7089 [FIX] bottom_bar: disable sheet drag & drop in readonly Task: 3820888
