### PR TITLE
[REL] 15.0.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "15.0.20",
+  "version": "15.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "15.0.20",
+      "version": "15.0.21",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "^1.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "15.0.20",
+  "version": "15.0.21",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/82d18b5a0 [FIX] misc: faster `deepEquals`
https://github.com/odoo/o-spreadsheet/commit/b9c198d74 [FIX] xlsx: Shortcut `deepEquals` for primitive types in `pushElement` Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/ef9c0bfc2 [FIX]xlsx: replace json.stringify with deepEquals Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/8d687cc2b [FIX] xlsx: remove useless normalization Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/7a9c9e0f4 [FIX] XLSX: simplify `pushElement` helper Task: 3733743
