### PR TITLE
[REL] 16.0.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.0.37",
+  "version": "16.0.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.0.37",
+      "version": "16.0.38",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.0.37",
+  "version": "16.0.38",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/51860d7d6 [FIX] sheetview: pageUp/Down with frozen rows Task: 3847414
https://github.com/odoo/o-spreadsheet/commit/bb5d10e8e [FIX] misc: faster `deepEquals`
https://github.com/odoo/o-spreadsheet/commit/a9ff24f74 [FIX] xlsx: Shortcut `deepEquals` for primitive types in `pushElement` Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/76151cdf1 [FIX]xlsx: replace json.stringify with deepEquals Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/de8a78ff6 [FIX] xlsx: remove useless normalization Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/fb640e4d6 [FIX] XLSX: simplify `pushElement` helper Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/9fcb43d2f [FIX] Composer: pressing enter in the link editor
