### PR TITLE
[REL] 16.3.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.3.31",
+  "version": "16.3.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.3.31",
+      "version": "16.3.32",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.3.31",
+  "version": "16.3.32",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/f0d610b7b [FIX] data menu: Auto-select adjacent cells on filter menu Task: 3839869
https://github.com/odoo/o-spreadsheet/commit/680cdeb90 [FIX] sheetview: pageUp/Down with frozen rows Task: 3847414
https://github.com/odoo/o-spreadsheet/commit/40bb725e0 [FIX] misc: faster `deepEquals`
https://github.com/odoo/o-spreadsheet/commit/74182892b [FIX] xlsx: Shortcut `deepEquals` for primitive types in `pushElement` Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/93d65f089 [FIX]xlsx: replace json.stringify with deepEquals Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/6b91e371c [FIX] xlsx: remove useless normalization Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/a68230a4c [FIX] XLSX: simplify `pushElement` helper Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/5ca9bb4ac [FIX] Composer: pressing enter in the link editor
https://github.com/odoo/o-spreadsheet/commit/10cf3e612 [FIX] Grid: Context menu position was broken
https://github.com/odoo/o-spreadsheet/commit/75a6c4162 [FIX]: Filters: Do not export 1-row filters to xlsx files Task: 3839556
