### PR TITLE
[REL] 16.4.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.4.28",
+  "version": "16.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "16.4.28",
+      "version": "16.4.29",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "16.4.28",
+  "version": "16.4.29",
   "description": "A spreadsheet component",
   "main": "dist/o-spreadsheet.cjs.js",
   "browser": "dist/o-spreadsheet.iife.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/cbd04c969 [FIX] Composer: pressing enter in the link editor
https://github.com/odoo/o-spreadsheet/commit/162a8f3c4 [FIX] sheetview: pageUp/Down with frozen rows Task: 3847414
https://github.com/odoo/o-spreadsheet/commit/0fab128d8 [FIX] misc: faster `deepEquals`
https://github.com/odoo/o-spreadsheet/commit/1bfbc258e [FIX] xlsx: Shortcut `deepEquals` for primitive types in `pushElement` Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/e1b603539 [FIX]xlsx: replace json.stringify with deepEquals Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/ad80df06b [FIX] xlsx: remove useless normalization Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/aaddf5c08 [FIX] XLSX: simplify `pushElement` helper Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/8506c9257 [FIX] Evaluation: ignore invalid ranges in dependency graph
https://github.com/odoo/o-spreadsheet/commit/b42af1edf [FIX] Grid: Context menu position was broken
https://github.com/odoo/o-spreadsheet/commit/696d944be [FIX]: Filters: Do not export 1-row filters to xlsx files Task: 3839556
