### PR TITLE
[REL] 17.0.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "17.0.17",
+  "version": "17.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "17.0.17",
+      "version": "17.0.18",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "17.0.17",
+  "version": "17.0.18",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o-spreadsheet.cjs.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/0d8547c82 [FIX] misc: faster `deepEquals`
https://github.com/odoo/o-spreadsheet/commit/b934dcafc [FIX] xlsx: Shortcut `deepEquals` for primitive types in `pushElement` Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/0b2be2266 [FIX]xlsx: replace json.stringify with deepEquals Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/0e0f31a38 [FIX] xlsx: remove useless normalization Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/a87b0d0b5 [FIX] XLSX: simplify `pushElement` helper Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/9f6996086 [FIX] Evaluation: ignore invalid ranges in dependency graph
https://github.com/odoo/o-spreadsheet/commit/c678905b3 [FIX] Grid: Context menu position was broken
https://github.com/odoo/o-spreadsheet/commit/fe8161032 [FIX]: Filters: Do not export 1-row filters to xlsx files Task: 3839556
