### PR TITLE
[REL] 17.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "17.1.10",
+  "version": "17.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "17.1.10",
+      "version": "17.1.11",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "17.1.10",
+  "version": "17.1.11",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o-spreadsheet.cjs.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/77a846e9a [FIX] Charts: format of negative values
https://github.com/odoo/o-spreadsheet/commit/5be336bc8 [FIX] misc: faster `deepEquals`
https://github.com/odoo/o-spreadsheet/commit/4753c6db9 [FIX] xlsx: Shortcut `deepEquals` for primitive types in `pushElement` Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/f53d7959a [FIX]xlsx: replace json.stringify with deepEquals Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/af0293b8f [FIX] xlsx: remove useless normalization Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/2b0c7afe6 [FIX] XLSX: simplify `pushElement` helper Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/737937bfc [FIX] Evaluation: ignore invalid ranges in dependency graph
https://github.com/odoo/o-spreadsheet/commit/aa8e9c6d4 [FIX] Grid: Context menu position was broken
https://github.com/odoo/o-spreadsheet/commit/306121fc0 [FIX]: Filters: Do not export 1-row filters to xlsx files Task: 3839556
