### PR TITLE
[REL] 17.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "17.2.2",
+  "version": "17.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@odoo/o-spreadsheet",
-      "version": "17.2.2",
+      "version": "17.2.3",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@odoo/owl": "2.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odoo/o-spreadsheet",
-  "version": "17.2.2",
+  "version": "17.2.3",
   "description": "A spreadsheet component",
   "type": "module",
   "main": "dist/o-spreadsheet.cjs.js",


### PR DESCRIPTION
### Contains the following commits:

https://github.com/odoo/o-spreadsheet/commit/90de3100e [FIX] misc: faster `deepEquals`
https://github.com/odoo/o-spreadsheet/commit/541fceb01 [FIX] xlsx: Shortcut `deepEquals` for primitive types in `pushElement` Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/4fd463493 [FIX]xlsx: replace json.stringify with deepEquals Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/7055f5201 [FIX] xlsx: remove useless normalization Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/4d88f4fd0 [FIX] XLSX: simplify `pushElement` helper Task: 3733743
https://github.com/odoo/o-spreadsheet/commit/7b815ea80 [FIX] Evaluation: ignore invalid ranges in dependency graph
https://github.com/odoo/o-spreadsheet/commit/ce13344ad [FIX] Composer: too long auto-complete dropdown
https://github.com/odoo/o-spreadsheet/commit/51ad91f18 [FIX] Grid: Context menu position was broken
https://github.com/odoo/o-spreadsheet/commit/f7ec2b7a0 [FIX]: Filters: Do not export 1-row filters to xlsx files Task: 3839556
