### PR TITLE
[FIX] clipboard: cannot paste chart with deleted ranges

### DIFF
--- a/src/helpers/charts/bar_chart.ts
+++ b/src/helpers/charts/bar_chart.ts
@@ -23,7 +23,7 @@ import {
 import { LegendPosition, VerticalAxisPosition } from "../../types/chart/common_chart";
 import { Validator } from "../../types/validator";
 import { toXlsxHexColor } from "../../xlsx/helpers/colors";
-import { createRange } from "../range";
+import { createValidRange } from "../range";
 import { AbstractChart } from "./abstract_chart";
 import {
   ChartColors,
@@ -77,7 +77,7 @@ export class BarChart extends AbstractChart {
       sheetId,
       definition.dataSetsHaveTitle
     );
-    this.labelRange = createRange(getters, sheetId, definition.labelRange);
+    this.labelRange = createValidRange(getters, sheetId, definition.labelRange);
     this.background = definition.background;
     this.verticalAxisPosition = definition.verticalAxisPosition;
     this.legendPosition = definition.legendPosition;

--- a/src/helpers/charts/chart_common.ts
+++ b/src/helpers/charts/chart_common.ts
@@ -149,8 +149,8 @@ export function createDataSets(
   const dataSets: DataSet[] = [];
   for (const sheetXC of dataSetsString) {
     const dataRange = getters.getRangeFromSheetXC(sheetId, sheetXC);
-    const { unboundedZone: zone, sheetId: dataSetSheetId, invalidSheetName } = dataRange;
-    if (invalidSheetName) {
+    const { unboundedZone: zone, sheetId: dataSetSheetId, invalidSheetName, invalidXc } = dataRange;
+    if (invalidSheetName || invalidXc) {
       continue;
     }
     // It's a rectangle. We treat all columns (arbitrary) as different data series.

--- a/src/helpers/charts/gauge_chart.ts
+++ b/src/helpers/charts/gauge_chart.ts
@@ -30,7 +30,7 @@ import {
 } from "../../types/chart/gauge_chart";
 import { Validator } from "../../types/validator";
 import { clip } from "../index";
-import { createRange } from "../range";
+import { createValidRange } from "../range";
 import { rangeReference } from "../references";
 import { toUnboundedZone, zoneToXc } from "../zones";
 import { AbstractChart } from "./abstract_chart";
@@ -156,7 +156,7 @@ export class GaugeChart extends AbstractChart {
 
   constructor(definition: GaugeChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
-    this.dataRange = createRange(this.getters, this.sheetId, definition.dataRange);
+    this.dataRange = createValidRange(this.getters, this.sheetId, definition.dataRange);
     this.sectionRule = definition.sectionRule;
     this.background = definition.background;
   }

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -29,7 +29,7 @@ import { getChartTimeOptions, timeFormatMomentCompatible } from "../chart_date";
 import { colorToRGBA, rgbaToHex } from "../color";
 import { formatValue } from "../format";
 import { deepCopy, findNextDefinedValue } from "../misc";
-import { createRange } from "../range";
+import { createValidRange } from "../range";
 import { AbstractChart } from "./abstract_chart";
 import {
   ChartColors,
@@ -87,7 +87,7 @@ export class LineChart extends AbstractChart {
       sheetId,
       definition.dataSetsHaveTitle
     );
-    this.labelRange = createRange(this.getters, sheetId, definition.labelRange);
+    this.labelRange = createValidRange(this.getters, sheetId, definition.labelRange);
     this.background = definition.background;
     this.verticalAxisPosition = definition.verticalAxisPosition;
     this.legendPosition = definition.legendPosition;

--- a/src/helpers/charts/pie_chart.ts
+++ b/src/helpers/charts/pie_chart.ts
@@ -31,7 +31,7 @@ import { PieChartDefinition, PieChartRuntime } from "../../types/chart/pie_chart
 import { Validator } from "../../types/validator";
 import { toXlsxHexColor } from "../../xlsx/helpers/colors";
 import { largeMax } from "../misc";
-import { createRange } from "../range";
+import { createValidRange } from "../range";
 import { AbstractChart } from "./abstract_chart";
 import {
   ChartColors,
@@ -83,7 +83,7 @@ export class PieChart extends AbstractChart {
       sheetId,
       definition.dataSetsHaveTitle
     );
-    this.labelRange = createRange(getters, sheetId, definition.labelRange);
+    this.labelRange = createValidRange(getters, sheetId, definition.labelRange);
     this.background = definition.background;
     this.legendPosition = definition.legendPosition;
   }

--- a/src/helpers/charts/scorecard_chart.ts
+++ b/src/helpers/charts/scorecard_chart.ts
@@ -21,7 +21,7 @@ import {
   ScorecardChartRuntime,
 } from "../../types/chart/scorecard_chart";
 import { Validator } from "../../types/validator";
-import { createRange } from "../range";
+import { createValidRange } from "../range";
 import { rangeReference } from "../references";
 import { toUnboundedZone, zoneToXc } from "../zones";
 import { AbstractChart } from "./abstract_chart";
@@ -74,8 +74,8 @@ export class ScorecardChart extends AbstractChart {
 
   constructor(definition: ScorecardChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
-    this.keyValue = createRange(getters, sheetId, definition.keyValue);
-    this.baseline = createRange(getters, sheetId, definition.baseline);
+    this.keyValue = createValidRange(getters, sheetId, definition.keyValue);
+    this.baseline = createValidRange(getters, sheetId, definition.baseline);
     this.baselineMode = definition.baselineMode;
     this.baselineDescr = definition.baselineDescr;
     this.background = definition.background;

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -169,6 +169,12 @@ export function copyRangeWithNewSheetId(sheetIdFrom: UID, sheetIdTo: UID, range:
 /**
  * Create a range from a xc. If the xc is empty, this function returns undefined.
  */
-export function createRange(getters: CoreGetters, sheetId: UID, range?: string): Range | undefined {
-  return range ? getters.getRangeFromSheetXC(sheetId, range) : undefined;
+export function createValidRange(
+  getters: CoreGetters,
+  sheetId: UID,
+  xc?: string
+): Range | undefined {
+  if (!xc) return;
+  const range = getters.getRangeFromSheetXC(sheetId, xc);
+  return !(range.invalidSheetName || range.invalidXc) ? range : undefined;
 }

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -360,6 +360,9 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     if (range.invalidXc) {
       return range.invalidXc;
     }
+    if (!this.getters.tryGetSheet(range.sheetId)) {
+      return INCORRECT_RANGE_STRING;
+    }
     if (range.zone.bottom - range.zone.top < 0 || range.zone.right - range.zone.left < 0) {
       return INCORRECT_RANGE_STRING;
     }

--- a/tests/formulas/compiler.test.ts
+++ b/tests/formulas/compiler.test.ts
@@ -2,7 +2,7 @@ import { Model } from "../../src";
 import { functionCache } from "../../src/formulas/compiler";
 import { compile } from "../../src/formulas/index";
 import { functionRegistry } from "../../src/functions";
-import { createRange } from "../../src/helpers";
+import { createValidRange } from "../../src/helpers";
 import { ArgType, CompiledFormula } from "../../src/types";
 import { getCellError, setCellContent } from "../test_helpers";
 import { evaluateCell, evaluateCellFormat, restoreDefaultFunctions } from "../test_helpers/helpers";
@@ -460,8 +460,8 @@ describe("compile functions", () => {
 
       const ctx = { USEMETAARG: () => {}, NOTUSEMETAARG: () => {} };
 
-      const rangeA1 = createRange(m.getters, "ABC", "A1")!;
-      const rangeA1ToB2 = createRange(m.getters, "ABC", "A1:B2")!;
+      const rangeA1 = createValidRange(m.getters, "ABC", "A1")!;
+      const rangeA1ToB2 = createValidRange(m.getters, "ABC", "A1:B2")!;
 
       compiledFormula1.execute([rangeA1], refFn, ensureRange, ctx);
       expect(refFn).toHaveBeenCalledWith(rangeA1, true, "USEMETAARG", 1);

--- a/tests/plugins/clipboard_figure.test.ts
+++ b/tests/plugins/clipboard_figure.test.ts
@@ -137,6 +137,21 @@ describe("Clipboard for figures", () => {
     expect(model.getters.getFigures(sheetId)).toHaveLength(0);
   });
 
+  test("Can paste a chart with ranges that were deleted between the copy and the paste", () => {
+    createSheet(model, { sheetId: "sheet2Id", name: "Sheet2" });
+    updateChart(model, chartId, { dataSets: ["Sheet1!A1:A5", "Sheet2!B1:B5"], labelRange: "B1" });
+    model.dispatch("SELECT_FIGURE", { id: chartId });
+    copy(model);
+    model.dispatch("DELETE_SHEET", { sheetId: "Sheet1" });
+    paste(model, "A1");
+    expect(model.getters.getFigures("sheet2Id")).toHaveLength(1);
+    const newChartId = model.getters.getFigures("sheet2Id")[0].id;
+    expect(model.getters.getChartDefinition(newChartId)).toMatchObject({
+      dataSets: ["B1:B5"],
+      labelRange: undefined,
+    });
+  });
+
   describe("Paste command result", () => {
     test("Cannot paste with empty target", () => {
       model.dispatch("SELECT_FIGURE", { id: chartId });

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -563,6 +563,14 @@ describe("range plugin", () => {
       }
     );
   });
+
+  test("getRangeString does not crash with deleted sheet", () => {
+    const range = m.getters.getRangeFromSheetXC("s1", "A1");
+    expect(m.getters.getRangeString(range)).toBe("s1!A1");
+    createSheet(m, { sheetId: "s2" });
+    deleteSheet(m, "s1");
+    expect(m.getters.getRangeString(range)).toBe(INCORRECT_RANGE_STRING);
+  });
 });
 
 describe("Helpers", () => {


### PR DESCRIPTION
## Description

Before this commit, when pasting a chart with ranges in its data/labels that were deleted between the copy and the paste, the clipboard would traceback.

That's because `getRangeString` crashed when the sheetId does not exist anymore. Fixed it by making the function return a string with an invalidSheetName error rather than crashing.

Also replace the uses of `getRangeString` with `getValidRangeString`,
which will return undefined for invalid ranges so the typing forces us
to handle it properly.

Task: : [3618758](https://www.odoo.com/web#id=3618758&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo