### PR TITLE
[IMP] clipboard: preserve cell style and format when copy/pasting cross spreadsheets

### DIFF
--- a/src/clipboard_handlers/tables_clipboard.ts
+++ b/src/clipboard_handlers/tables_clipboard.ts
@@ -7,7 +7,7 @@ import {
   ClipboardPasteTarget,
   CoreTableType,
   HeaderIndex,
-  Range,
+  RangeData,
   Style,
   TableConfig,
   UID,
@@ -21,7 +21,7 @@ interface TableStyle {
 }
 
 interface CopiedTable {
-  range: Range;
+  range: RangeData;
   config: TableConfig;
   type: CoreTableType;
 }
@@ -68,7 +68,7 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
           }
           tableCellsInRow.push({
             table: {
-              range: coreTable.range,
+              range: coreTable.range.rangeData,
               config: coreTable.config,
               type: coreTable.type,
             },
@@ -125,7 +125,7 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
         if (tableCell.table) {
           this.dispatch("REMOVE_TABLE", {
             sheetId: content.sheetId,
-            target: [tableCell.table.range.zone],
+            target: [this.getters.getRangeFromRangeData(tableCell.table.range).zone],
           });
         }
       }
@@ -168,7 +168,7 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
   ) {
     if (tableCell.table && !options?.pasteOption) {
       const { range: tableRange } = tableCell.table;
-      const zoneDims = zoneToDimension(tableRange.zone);
+      const zoneDims = zoneToDimension(this.getters.getRangeFromRangeData(tableRange).zone);
       const newTableZone = {
         left: position.col,
         top: position.row,

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -344,6 +344,9 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     dependencies: Range[],
     useFixedReference: boolean = false
   ): string {
+    if (!dependencies.length) {
+      return concat(compiledFormula.tokens.map((token) => token.value));
+    }
     let rangeIndex = 0;
     return concat(
       compiledFormula.tokens.map((token) => {

--- a/src/plugins/ui_core_views/evaluation_conditional_format.ts
+++ b/src/plugins/ui_core_views/evaluation_conditional_format.ts
@@ -114,12 +114,7 @@ export class EvaluationConditionalFormatPlugin extends UIPlugin {
                       sheetId,
                       col - zone.left,
                       row - zone.top,
-                      {
-                        ...compiledFormula,
-                        dependencies: compiledFormula.dependencies.map((d) =>
-                          this.getters.getRangeFromSheetXC(sheetId, d)
-                        ),
-                      }
+                      compiledFormula.tokens
                     );
                   }
                   return value;

--- a/src/plugins/ui_core_views/evaluation_data_validation.ts
+++ b/src/plugins/ui_core_views/evaluation_data_validation.ts
@@ -210,12 +210,7 @@ export class EvaluationDataValidationPlugin extends UIPlugin {
         sheetId,
         offset.col,
         offset.row,
-        {
-          ...formula,
-          dependencies: formula.dependencies.map((d) =>
-            this.getters.getRangeFromSheetXC(sheetId, d)
-          ),
-        }
+        formula.tokens
       );
 
       const evaluated = this.getters.evaluateFormula(sheetId, translatedFormula);

--- a/src/plugins/ui_feature/sort.ts
+++ b/src/plugins/ui_feature/sort.ts
@@ -157,7 +157,7 @@ export class SortPlugin extends UIPlugin {
               sheetId,
               0,
               newRow - position.row,
-              cell.compiledFormula
+              cell.compiledFormula.tokens
             );
           }
           newCellValues.style = cell.style;

--- a/src/registries/autofill_modifiers.ts
+++ b/src/registries/autofill_modifiers.ts
@@ -106,7 +106,7 @@ autofillModifiersRegistry
         return { cellData: {} };
       }
       const sheetId = data.sheetId;
-      const content = getters.getTranslatedCellFormula(sheetId, x, y, cell.compiledFormula);
+      const content = getters.getTranslatedCellFormula(sheetId, x, y, cell.compiledFormula.tokens);
       return {
         cellData: {
           border: data.border,

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -3,6 +3,7 @@ import { HeaderIndex, UID, Zone } from "./misc";
 export enum ClipboardMIMEType {
   PlainText = "text/plain",
   Html = "text/html",
+  OSpreadsheet = "web application/o-spreadsheet",
 }
 
 export type ClipboardContent = { [type in ClipboardMIMEType]?: string };

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -22,7 +22,7 @@ import {
 } from "./misc";
 
 import { ChartDefinition } from "./chart/chart";
-import { ClipboardPasteOptions } from "./clipboard";
+import { ClipboardContent, ClipboardPasteOptions } from "./clipboard";
 import { FigureSize } from "./figure";
 import { SearchOptions } from "./find_and_replace";
 import { Image } from "./image";
@@ -756,7 +756,7 @@ export interface CancelPaintFormatCommand {
 export interface PasteFromOSClipboardCommand {
   type: "PASTE_FROM_OS_CLIPBOARD";
   target: Zone[];
-  text: string;
+  clipboardContent: ClipboardContent;
   pasteOption?: ClipboardPasteOptions;
 }
 

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -1,4 +1,4 @@
-import { Cell, CellValue, EvaluatedCell } from "./cells";
+import { CellValue, EvaluatedCell } from "./cells";
 
 import { CommandResult } from "./commands";
 // -----------------------------------------------------------------------------
@@ -199,10 +199,13 @@ export function isMatrix(x: any): x is Matrix<any> {
 }
 
 export interface ClipboardCell {
-  cell?: Cell;
   evaluatedCell: EvaluatedCell;
-  border?: Border;
   position: CellPosition;
+  content: string;
+  style?: Style | undefined;
+  format?: Format | undefined;
+  tokens?: Token[];
+  border?: Border;
 }
 
 export interface HeaderDimensions {

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -54,7 +54,7 @@ export interface TableElementStyle {
   size?: number;
 }
 
-interface TableBorder extends Border {
+export interface TableBorder extends Border {
   // used to describe borders inside of a zone
   horizontal?: BorderDescr;
   vertical?: BorderDescr;

--- a/tests/clipboard/__snapshots__/clipboard_plugin.test.ts.snap
+++ b/tests/clipboard/__snapshots__/clipboard_plugin.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`clipboard Copied cells HTML Copied HTML table snapshot 1`] = `"<table border="1" style="border-collapse:collapse"><tr><td style="">1</td><td style="">2</td></tr><tr><td style="">3</td><td style=""></td></tr></table>"`;

--- a/tests/clipboard/clipboard_figure_plugin.test.ts
+++ b/tests/clipboard/clipboard_figure_plugin.test.ts
@@ -1,6 +1,6 @@
 import { CommandResult, Model } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
-import { UID } from "../../src/types";
+import { ClipboardMIMEType, UID } from "../../src/types";
 import { BarChartDefinition } from "../../src/types/chart";
 import {
   activateSheet,
@@ -174,6 +174,17 @@ describe.each(["chart", "image"])("Clipboard for %s figures", (type: string) => 
       dataSets: [{ dataRange: "B1:B5" }],
       labelRange: undefined,
     });
+  });
+
+  test("Chart clipboard content is not serialized at copy", () => {
+    model.dispatch("SELECT_FIGURE", { id: figureId });
+    copy(model);
+    const clipboardSpreadsheetContent = JSON.parse(
+      model.getters.getClipboardContent()[ClipboardMIMEType.OSpreadsheet]!
+    );
+    expect(clipboardSpreadsheetContent.figureId).toBe(undefined);
+    expect(clipboardSpreadsheetContent.copiedFigure).toBe(undefined);
+    expect(clipboardSpreadsheetContent.copiedChart).toBe(undefined);
   });
 
   describe("Paste command result", () => {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -1458,6 +1458,18 @@ describe("clipboard", () => {
     });
   });
 
+  test("can cut and paste an invalid formula", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "=(+)");
+    setCellContent(model, "A2", "=C1{C2");
+    cut(model, "A1:A2");
+    paste(model, "C1");
+    expect(getCellText(model, "C1")).toBe("=(+)");
+    expect(getCellText(model, "C2")).toBe("=C1{C2");
+    expect(getCellText(model, "A1")).toBe("");
+    expect(getCellText(model, "A2")).toBe("");
+  });
+
   test("cut/paste a formula with references does not update references in the formula", () => {
     const model = new Model();
     setCellContent(model, "A1", "=SUM(C1:C2)");

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -1,7 +1,8 @@
 import { clipboardHandlersRegistries } from "../../src/clipboard_handlers";
-import { DEFAULT_BORDER_DESC } from "../../src/constants";
-import { toCartesian, toZone, zoneToXc } from "../../src/helpers";
+import { DEFAULT_BORDER_DESC, LINK_COLOR } from "../../src/constants";
+import { markdownLink, toCartesian, toZone, zoneToXc } from "../../src/helpers";
 import { getClipboardDataPositions } from "../../src/helpers/clipboard/clipboard_helpers";
+import { urlRepresentation } from "../../src/helpers/links";
 import { Model } from "../../src/model";
 import {
   ClipboardMIMEType,
@@ -203,9 +204,9 @@ describe("clipboard", () => {
     clipboardData.setData(ClipboardMIMEType.PlainText, "Excalibur");
 
     const content = clipboardData.getData(ClipboardMIMEType.PlainText);
-    pasteFromOSClipboard(model, "C2", content);
+    pasteFromOSClipboard(model, "C2", { [ClipboardMIMEType.PlainText]: content });
     expect(getCellContent(model, "C2")).toBe(content);
-    pasteFromOSClipboard(model, "C3", content, "onlyFormat");
+    pasteFromOSClipboard(model, "C3", { [ClipboardMIMEType.PlainText]: content }, "onlyFormat");
     expect(getCellContent(model, "C3")).toBe("");
   });
 
@@ -552,7 +553,8 @@ describe("clipboard", () => {
       setCellContent(model, "A2", "3");
       copy(model, "A1:B2");
       const htmlContent = model.getters.getClipboardContent()[ClipboardMIMEType.Html]!;
-      expect(htmlContent).toMatchSnapshot();
+      const expectedHtmlContent = `<div data-clipboard-id="${model.getters.getClipboardId()}"><table border="1" style="border-collapse:collapse"><tr><td style="">1</td><td style="">2</td></tr><tr><td style="">3</td><td style=""></td></tr></table></div>`;
+      expect(htmlContent).toBe(expectedHtmlContent);
     });
 
     test("Copied group of cells are represented as a valid HTML table in the clipboard", async () => {
@@ -563,7 +565,7 @@ describe("clipboard", () => {
       const htmlContent = model.getters.getClipboardContent()[ClipboardMIMEType.Html]!;
       const parsedHTML = parseXML(new XMLString(htmlContent), "text/html");
 
-      expect(parsedHTML.body.firstElementChild?.tagName).toBe("TABLE");
+      expect(parsedHTML.body.firstElementChild?.tagName).toBe("DIV");
       const tableRows = parsedHTML.querySelectorAll("tr");
       expect(tableRows).toHaveLength(2);
       expect(tableRows[0].querySelectorAll("td")).toHaveLength(2);
@@ -663,7 +665,7 @@ describe("clipboard", () => {
 
   test("can paste multiple cells from os clipboard", () => {
     const model = new Model();
-    pasteFromOSClipboard(model, "C1", "a\t1\nb\t2");
+    pasteFromOSClipboard(model, "C1", { [ClipboardMIMEType.PlainText]: "a\t1\nb\t2" });
 
     expect(getCellContent(model, "C1")).toBe("a");
     expect(getCellContent(model, "C2")).toBe("b");
@@ -675,7 +677,9 @@ describe("clipboard", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
     merge(model, "B2:C3");
-    const result = pasteFromOSClipboard(model, "B2", "a\t1\nb\t2");
+    const result = pasteFromOSClipboard(model, "B2", {
+      [ClipboardMIMEType.PlainText]: "a\t1\nb\t2",
+    });
     expect(result).toBeCancelledBecause(CommandResult.WillRemoveExistingMerge);
     expect(model.getters.getMerges(sheetId).map(zoneToXc)).toEqual(["B2:C3"]);
   });
@@ -683,13 +687,13 @@ describe("clipboard", () => {
   test("pasting from OS will not change the viewport", () => {
     const model = new Model();
     const viewport = model.getters.getActiveMainViewport();
-    pasteFromOSClipboard(model, "C60", "a\t1\nb\t2");
+    pasteFromOSClipboard(model, "C60", { [ClipboardMIMEType.PlainText]: "a\t1\nb\t2" });
     expect(model.getters.getActiveMainViewport()).toEqual(viewport);
   });
 
   test("pasting numbers from windows clipboard => interpreted as number", () => {
     const model = new Model();
-    pasteFromOSClipboard(model, "C1", "1\r\n2\r\n3");
+    pasteFromOSClipboard(model, "C1", { [ClipboardMIMEType.PlainText]: "1\r\n2\r\n3" });
 
     expect(getCellContent(model, "C1")).toBe("1");
     expect(getEvaluatedCell(model, "C1").value).toBe(1);
@@ -2291,7 +2295,7 @@ describe("clipboard: pasting outside of sheet", () => {
   test("can paste multiple cells from os to outside of sheet", () => {
     const model = new Model();
     createSheet(model, { activate: true, sheetId: "2", rows: 2, cols: 2 });
-    pasteFromOSClipboard(model, "B2", "A\nque\tcoucou\nBOB");
+    pasteFromOSClipboard(model, "B2", { [ClipboardMIMEType.PlainText]: "A\nque\tcoucou\nBOB" });
     expect(getCellContent(model, "B2")).toBe("A");
     expect(getCellContent(model, "B3")).toBe("que");
     expect(getCellContent(model, "C3")).toBe("coucou");
@@ -2303,7 +2307,7 @@ describe("clipboard: pasting outside of sheet", () => {
       rows: 2,
       cols: 2,
     });
-    pasteFromOSClipboard(model, "B2", "A\nque\tcoucou\tPatrick");
+    pasteFromOSClipboard(model, "B2", { [ClipboardMIMEType.PlainText]: "A\nque\tcoucou\tPatrick" });
     expect(getCellContent(model, "B2")).toBe("A");
     expect(getCellContent(model, "B3")).toBe("que");
     expect(getCellContent(model, "C3")).toBe("coucou");
@@ -2318,7 +2322,7 @@ describe("clipboard: pasting outside of sheet", () => {
       formulaArgSeparator: ";",
       thousandsSeparator: " ",
     });
-    pasteFromOSClipboard(model, "A1", "=SUM(5 ; 3,14)");
+    pasteFromOSClipboard(model, "A1", { [ClipboardMIMEType.PlainText]: "=SUM(5 ; 3,14)" });
     expect(getCell(model, "A1")?.content).toBe("=SUM(5 , 3.14)");
     expect(getEvaluatedCell(model, "A1").value).toBe(8.14);
   });
@@ -2620,6 +2624,173 @@ describe("clipboard: pasting outside of sheet", () => {
       expect(getCellContent(model, "A1")).toBe("1");
       expect(getCellContent(model, "A2")).toBe("2");
     });
+  });
+});
+
+describe("cross spreadsheet copy/paste", () => {
+  test("should copy/paste a cell with basic formatting", () => {
+    const modelA = new Model();
+    const modelB = new Model();
+    const cellStyle = { bold: true, fillColor: "#00FF00", fontSize: 20 };
+
+    setCellContent(modelA, "B2", "b2");
+    setStyle(modelA, "B2", cellStyle);
+
+    expect(getCell(modelA, "B2")).toMatchObject({
+      content: "b2",
+      style: cellStyle,
+    });
+
+    copy(modelA, "B2");
+    const clipboardContent = modelA.getters.getClipboardContent();
+
+    expect(clipboardContent["text/plain"]).toBe("b2");
+
+    pasteFromOSClipboard(modelB, "D2", clipboardContent);
+
+    expect(getCell(modelA, "B2")?.content).toBe("b2");
+    expect(getCell(modelB, "D2")?.content).toBe("b2");
+    expect(getStyle(modelA, "B2")).toEqual(cellStyle);
+    expect(getStyle(modelB, "D2")).toEqual(cellStyle);
+  });
+
+  test("should copy/paste a cell with a border", () => {
+    const modelA = new Model();
+    const modelB = new Model();
+
+    selectCell(modelA, "B2");
+    setZoneBorders(modelA, { position: "top" });
+
+    expect(getBorder(modelA, "B2")).toEqual({ top: DEFAULT_BORDER_DESC });
+
+    copy(modelA, "B2");
+    const clipboardContent = modelA.getters.getClipboardContent();
+
+    pasteFromOSClipboard(modelB, "D2", clipboardContent);
+
+    expect(getBorder(modelA, "B2")).toEqual({ top: DEFAULT_BORDER_DESC });
+    expect(getBorder(modelB, "D2")).toEqual({ top: DEFAULT_BORDER_DESC });
+  });
+
+  test("should copy/paste a cell with a formula", () => {
+    const modelA = new Model();
+    const modelB = new Model();
+
+    setCellContent(modelA, "A1", "=SUM(1,2)");
+    setCellContent(modelA, "A2", "=SUM(1,2)");
+    setCellFormat(modelA, "A2", "0%");
+    setCellContent(modelA, "A3", "=DATE(2024,1,1)");
+    setCellContent(modelA, "A4", "=DATE(2024,1,1)");
+    setCellFormat(modelA, "A4", "m/d/yyyy hh:mm:ss a");
+    setCellContent(modelA, "A5", "=SOMME(1,2)");
+
+    copy(modelA, "A1:A5");
+    const clipboardContent = modelA.getters.getClipboardContent();
+    pasteFromOSClipboard(modelB, "D1", clipboardContent);
+
+    expect(getCell(modelB, "D1")?.content).toBe("=SUM(1,2)");
+    expect(getCell(modelB, "D2")?.content).toBe("=SUM(1,2)");
+    expect(getCell(modelB, "D3")?.content).toBe("=DATE(2024,1,1)");
+    expect(getCell(modelB, "D4")?.content).toBe("=DATE(2024,1,1)");
+    expect(getCell(modelB, "D5")?.content).toBe("=SOMME(1,2)");
+  });
+
+  test("should copy/paste a cell with a markdown link", () => {
+    const modelA = new Model();
+    const modelB = new Model();
+    const url = "https://www.odoo.com";
+    const urlLabel = "Odoo Website";
+
+    setCellContent(modelA, "A1", markdownLink(urlLabel, url));
+    copy(modelA, "A1");
+    const clipboardContent = modelA.getters.getClipboardContent();
+    pasteFromOSClipboard(modelB, "D1", clipboardContent);
+
+    const cell = getEvaluatedCell(modelB, "D1");
+    expect(cell.link?.label).toBe(urlLabel);
+    expect(cell.link?.url).toBe(url);
+    expect(urlRepresentation(cell.link!, modelB.getters)).toBe(url);
+    expect(getCell(modelB, "D1")?.content).toBe("[Odoo Website](https://www.odoo.com)");
+    expect(getStyle(modelB, "D1")).toEqual({ textColor: LINK_COLOR });
+    expect(getCellText(modelB, "D1")).toBe("Odoo Website");
+  });
+
+  test("should copy/paste a table", () => {
+    const modelA = new Model();
+    const modelB = new Model();
+
+    createTable(modelA, "A1:B2");
+    const tableA = modelA.getters.getCoreTables(modelA.getters.getActiveSheetId())[0];
+
+    expect(tableA).toMatchObject({ range: { zone: toZone("A1:B2") }, type: "static" });
+
+    copy(modelA, "A1:B2");
+    const clipboardContent = modelA.getters.getClipboardContent();
+    pasteFromOSClipboard(modelB, "D1", clipboardContent);
+
+    const tableB = modelB.getters.getCoreTables(modelA.getters.getActiveSheetId())[0];
+
+    expect(tableB).toMatchObject({ range: { zone: toZone("D1:E2") }, type: "static" });
+    expect(tableB.config).toEqual(tableA.config);
+  });
+
+  test("should copy/paste a cell with the cell content and format copied last from an external spreadsheet", () => {
+    const modelA = new Model();
+    const modelB = new Model();
+    const cellStyle = { bold: true, fillColor: "#00FF00", fontSize: 20 };
+
+    setCellContent(modelA, "A1", "a1");
+    setStyle(modelA, "A1", cellStyle);
+    setCellContent(modelB, "C1", "c1");
+    setStyle(modelB, "C1", cellStyle);
+
+    expect(getCell(modelA, "A1")).toMatchObject({
+      content: "a1",
+      style: cellStyle,
+    });
+
+    expect(getCell(modelB, "C1")).toMatchObject({
+      content: "c1",
+      style: cellStyle,
+    });
+
+    copy(modelB, "C1");
+    copy(modelA, "A1");
+    const clipboardContent = modelA.getters.getClipboardContent();
+
+    expect(clipboardContent["text/plain"]).toBe("a1");
+
+    pasteFromOSClipboard(modelB, "B1", {
+      [ClipboardMIMEType.PlainText]: clipboardContent["text/plain"]
+        ? clipboardContent["text/plain"]
+        : "",
+      [ClipboardMIMEType.OSpreadsheet]: clipboardContent["web application/o-spreadsheet"],
+    });
+
+    expect(getCell(modelA, "A1")).toMatchObject({
+      content: "a1",
+    });
+    expect(getCell(modelB, "B1")).toMatchObject({
+      content: "a1",
+    });
+    expect(getStyle(modelA, "A1")).toMatchObject(cellStyle);
+    expect(getStyle(modelB, "B1")).toMatchObject(cellStyle);
+  });
+
+  test("should copy/paste a formula cell with dependencies", () => {
+    const modelA = new Model({ sheets: [{ id: "sheetA" }] });
+    const modelB = new Model({ sheets: [{ id: "sheetB" }] });
+
+    setCellContent(modelA, "C1", "=A1*B1");
+    setCellContent(modelA, "C2", "=A2*B2");
+    setCellContent(modelA, "C3", "=A3*B3");
+
+    copy(modelA, "A1:C3");
+    pasteFromOSClipboard(modelB, "E1", modelA.getters.getClipboardContent());
+
+    expect(getCell(modelB, "G1")?.content).toBe("=E1*F1");
+    expect(getCell(modelB, "G2")?.content).toBe("=E2*F2");
+    expect(getCell(modelB, "G3")?.content).toBe("=E3*F3");
   });
 });
 

--- a/tests/evaluation/formulas.test.ts
+++ b/tests/evaluation/formulas.test.ts
@@ -13,7 +13,12 @@ function moveFormula(model: Model, formula: string, offsetX: number, offsetY: nu
   const sheetId = model.getters.getActiveSheetId();
   setCellContent(model, "A1", formula);
   const cell = getCell(model, "A1") as FormulaCell;
-  return model.getters.getTranslatedCellFormula(sheetId, offsetX, offsetY, cell.compiledFormula);
+  return model.getters.getTranslatedCellFormula(
+    sheetId,
+    offsetX,
+    offsetY,
+    cell.compiledFormula.tokens
+  );
 }
 
 describe("createAdaptedRanges", () => {

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -12,6 +12,7 @@ import { figureRegistry } from "../../src/registries";
 import { CreateFigureCommand, Pixel, SpreadsheetChildEnv, UID } from "../../src/types";
 
 import { FigureComponent } from "../../src/components/figures/figure/figure";
+import { ClipboardMIMEType } from "../../src/types/clipboard";
 import {
   activateSheet,
   addColumns,
@@ -525,9 +526,10 @@ describe("figures", () => {
         await simulateClick(".o-figure");
         await simulateClick(".o-figure-menu-item");
         await simulateClick(".o-menu div[data-name='copy']");
-        const envClipBoardContent = await env.clipboard.readText();
+        const envClipBoardContent = await env.clipboard.read();
         if (envClipBoardContent.status === "ok") {
-          expect(envClipBoardContent.content).toEqual(
+          const envClipboardTextContent = envClipBoardContent.content[ClipboardMIMEType.PlainText];
+          expect(envClipboardTextContent).toEqual(
             model.getters.getClipboardContent()["text/plain"]
           );
         }
@@ -543,9 +545,10 @@ describe("figures", () => {
         await simulateClick(".o-figure");
         await simulateClick(".o-figure-menu-item");
         await simulateClick(".o-menu div[data-name='cut']");
-        const envClipBoardContent = await env.clipboard.readText();
+        const envClipBoardContent = await env.clipboard.read();
         if (envClipBoardContent.status === "ok") {
-          expect(envClipBoardContent.content).toEqual(
+          const envClipboardTextContent = envClipBoardContent.content[ClipboardMIMEType.PlainText];
+          expect(envClipboardTextContent).toEqual(
             model.getters.getClipboardContent()["text/plain"]
           );
         }

--- a/tests/helpers/ui_helpers.test.ts
+++ b/tests/helpers/ui_helpers.test.ts
@@ -252,7 +252,9 @@ describe("UI Helpers", () => {
       const clipboardString = "a\t1\nb\t2";
 
       test("Can interactive paste", () => {
-        interactivePasteFromOS(env, target("D2"), clipboardString);
+        interactivePasteFromOS(env, target("D2"), {
+          "text/plain": clipboardString,
+        });
         expect(getCellContent(model, "D2")).toBe("a");
         expect(getCellContent(model, "E2")).toBe("1");
         expect(getCellContent(model, "D3")).toBe("b");
@@ -262,7 +264,9 @@ describe("UI Helpers", () => {
       test("Pasting content that will destroy a merge will notify the user", async () => {
         merge(model, "B2:C3");
         selectCell(model, "A1");
-        interactivePasteFromOS(env, model.getters.getSelectedZones(), clipboardString);
+        interactivePasteFromOS(env, model.getters.getSelectedZones(), {
+          "text/plain": clipboardString,
+        });
         expect(notifyUserTextSpy).toHaveBeenCalledWith(
           PasteInteractiveContent.willRemoveExistingMerge.toString()
         );

--- a/tests/menus/menu_items_registry_cross_spreadsheet.test.ts
+++ b/tests/menus/menu_items_registry_cross_spreadsheet.test.ts
@@ -1,0 +1,42 @@
+import { SpreadsheetChildEnv } from "../../src/types";
+import { selectCell, setCellContent, setStyle } from "../test_helpers/commands_helpers";
+import { getCell } from "../test_helpers/getters_helpers";
+import { doAction, makeTestEnv } from "../test_helpers/helpers";
+
+import { Model } from "../../src";
+
+describe("cross spreadsheet copy/paste", () => {
+  test("should copy/paste from Edit menu", async () => {
+    const envA: SpreadsheetChildEnv = makeTestEnv();
+    const envB: SpreadsheetChildEnv = makeTestEnv();
+    const modelA: Model = envA.model;
+    const modelB: Model = envB.model;
+
+    const cellStyle = { bold: true, fillColor: "#00FF00", fontSize: 20 };
+
+    setCellContent(modelA, "A1", "a1");
+    setStyle(modelA, "A1", cellStyle);
+    expect(getCell(modelA, "A1")).toMatchObject({
+      content: "a1",
+      style: cellStyle,
+    });
+
+    selectCell(modelA, "A1");
+    await doAction(["edit", "copy"], envA);
+
+    /**
+     * Copy the clipboard from envA to envB because
+     * in this context we need to simulate that
+     * the clipboard is shared between the two environments
+     * given that in a real world scenario we are using one
+     * clipboard which is the machine clipboard.
+     */
+    envB.clipboard = envA.clipboard;
+
+    selectCell(modelB, "B1");
+    await doAction(["edit", "paste"], envB);
+
+    expect(getCell(modelB, "B1")?.content).toEqual("a1");
+    expect(getCell(modelB, "B1")?.style).toMatchObject(cellStyle);
+  });
+});

--- a/tests/spreadsheet/spreadsheet_component.test.ts
+++ b/tests/spreadsheet/spreadsheet_component.test.ts
@@ -358,7 +358,6 @@ describe("Composer / selectionInput interactions", () => {
     }));
   });
 
-  jest.setTimeout(500000000);
   test("Switching from selection input to composer should update the highlihts", async () => {
     const composerStore = env.getStore(CellComposerStore);
     //open cf sidepanel

--- a/tests/test_helpers/clipboard.ts
+++ b/tests/test_helpers/clipboard.ts
@@ -5,18 +5,31 @@ import {
 import { ClipboardContent, ClipboardMIMEType } from "../../src/types";
 
 export class MockClipboard implements ClipboardInterface {
-  private content: string | undefined = "Some random clipboard content";
+  private content: ClipboardContent = {};
 
-  async readText(): Promise<ClipboardReadResult> {
-    return { status: "ok", content: this.content || "" };
+  async read(): Promise<ClipboardReadResult> {
+    return {
+      status: "ok",
+      content: {
+        [ClipboardMIMEType.PlainText]: this.content[ClipboardMIMEType.PlainText],
+        [ClipboardMIMEType.Html]: this.content[ClipboardMIMEType.Html],
+        [ClipboardMIMEType.OSpreadsheet]: this.content[ClipboardMIMEType.OSpreadsheet],
+      },
+    };
   }
 
   async writeText(text: string): Promise<void> {
-    this.content = text;
+    this.content[ClipboardMIMEType.PlainText] = text;
+    this.content[ClipboardMIMEType.Html] = "";
+    this.content[ClipboardMIMEType.OSpreadsheet] = "";
   }
 
   async write(content: ClipboardContent) {
-    this.content = content[ClipboardMIMEType.PlainText];
+    this.content = {
+      [ClipboardMIMEType.PlainText]: content[ClipboardMIMEType.PlainText],
+      [ClipboardMIMEType.Html]: content[ClipboardMIMEType.Html],
+      [ClipboardMIMEType.OSpreadsheet]: content[ClipboardMIMEType.OSpreadsheet],
+    };
   }
 }
 

--- a/tests/test_helpers/commands_helpers.ts
+++ b/tests/test_helpers/commands_helpers.ts
@@ -11,6 +11,7 @@ import {
   BorderData,
   ChartDefinition,
   ChartWithAxisDefinition,
+  ClipboardContent,
   ClipboardPasteOptions,
   CreateSheetCommand,
   CreateTableStyleCommand,
@@ -328,11 +329,11 @@ export function paste(
 export function pasteFromOSClipboard(
   model: Model,
   range: string,
-  content: string,
+  content: ClipboardContent,
   pasteOption?: ClipboardPasteOptions
 ): DispatchResult {
   return model.dispatch("PASTE_FROM_OS_CLIPBOARD", {
-    text: content,
+    clipboardContent: content,
     target: target(range),
     pasteOption,
   });


### PR DESCRIPTION
### [IMP] clipboard: preserve cell style and format when copy/pasting cross spreadsheets

Problem
-----
Before this commit, copying and pasting content cross spreadsheets removes all cell style and format and only keeps cell values. This is because the model clipboard is invalidated from one instance to another.

Solution
-----
This commit solves the issue by adding a new custom type in the os clipboard (`application/o-spreadsheet`) and using the content saved in this key to re-create the cell style and format in the new spreadsheet.

NOTE: After an assessment of the capabilities and limitations of most modern browsers, here's the bottom line till the date of this commit:

For Google Chrome (and all chromium browsers: Opera, Edge, Brave,...): read/write are supported for custom types; Therefore cross spreadsheet copy/paste works like a charm.

For Safari and Mozilla Firefox: saving custom types in the os clipboard is not supported; Therefore, cross spreadsheet copy/paste does not work.

Task: [3597039](https://www.odoo.com/web#id=3597039&cids=1&menu_id=4722&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo