### PR TITLE
[IMP] formats: add quarter date formatting

### DIFF
--- a/src/actions/format_actions.ts
+++ b/src/actions/format_actions.ts
@@ -133,6 +133,18 @@ export const formatNumberDuration = createFormatActionSpec({
   format: "hhhh:mm:ss",
 });
 
+export const formatNumberQuarter = createFormatActionSpec({
+  name: _t("Quarter"),
+  descriptionValue: EXAMPLE_DATE,
+  format: "qq yyyy",
+});
+
+export const formatNumberFullQuarter = createFormatActionSpec({
+  name: _t("Full quarter"),
+  descriptionValue: EXAMPLE_DATE,
+  format: "qqqq yyyy",
+});
+
 export const moreFormats: ActionSpec = {
   name: _t("More date formats"),
   execute: (env) => env.openSidePanel("MoreFormats", {}),

--- a/src/components/side_panel/more_formats/more_formats.ts
+++ b/src/components/side_panel/more_formats/more_formats.ts
@@ -8,7 +8,9 @@ import {
   formatNumberDuration,
   formatNumberFullDateTime,
   formatNumberFullMonth,
+  formatNumberFullQuarter,
   formatNumberFullWeekDayAndMonth,
+  formatNumberQuarter,
   formatNumberShortMonth,
   formatNumberShortWeekDay,
   formatNumberTime,
@@ -48,6 +50,8 @@ const DATE_FORMAT_ACTIONS = createActions([
   formatNumberTime,
   formatNumberDateTime,
   formatNumberDuration,
+  formatNumberQuarter,
+  formatNumberFullQuarter,
 ]);
 
 export class MoreFormatsPanel extends Component<Props, SpreadsheetChildEnv> {

--- a/src/helpers/dates.ts
+++ b/src/helpers/dates.ts
@@ -81,6 +81,10 @@ export class DateTime {
     return this.jsDate.getUTCMonth();
   }
 
+  getQuarter() {
+    return Math.floor(this.getMonth() / 3) + 1;
+  }
+
   getDate() {
     return this.jsDate.getUTCDate();
   }

--- a/tests/formats/format_helpers.test.ts
+++ b/tests/formats/format_helpers.test.ts
@@ -324,6 +324,15 @@ describe("formatValue on number", () => {
     expect(() => formatValue(1234, { format: "[$][]#,##0.0", locale })).toThrow();
   });
 
+  test.each(["#,##0 dd", "dd #,##0", "#,##0 dd/mm/yyyy", "dd/mm/yyyy #,##0"])(
+    "mixing date and numbers",
+    (format) => {
+      expect(() => formatValue(1234, { format, locale })).toThrow(
+        `Invalid number format: ${format}`
+      );
+    }
+  );
+
   test("multiple strings in one format", () => {
     expect(formatValue(1234, { format: "[$TEST]#,##0[$TEST]", locale })).toBe("TEST1,234TEST");
     expect(formatValue(1234, { format: "#,##0[$TEST][$TEST]", locale })).toBe("1,234TESTTEST");
@@ -437,6 +446,9 @@ describe("formatValue on date and time", () => {
     "mmm-yy",
     "mmmm-yy",
     "mmmmm-yy",
+    "qq",
+    "qq yyyy",
+    "qqqq yyyy",
   ])("detect date time format %s", (format) => {
     expect(isDateTimeFormat(format)).toBe(true);
   });
@@ -786,6 +798,35 @@ describe("formatValue on date and time", () => {
       expect(
         formatValue(parseDateTime(value, locale)!.value, { format: "dddd-mm-yyyy", locale })
       ).toBe(result);
+    });
+
+    test.each([
+      ["2023/01/01", "Q1"],
+      ["2023/02/01", "Q1"],
+      ["2024/02/29", "Q1"], // Leap year
+      ["2023/03/01", "Q1"],
+      ["2023/04/01", "Q2"],
+      ["2023/05/01", "Q2"],
+      ["2023/06/01", "Q2"],
+      ["2023/07/01", "Q3"],
+      ["2023/08/01", "Q3"],
+      ["2023/09/01", "Q3"],
+      ["2023/10/01", "Q4"],
+      ["2023/11/01", "Q4"],
+      ["2023/12/01", "Q4"],
+      ["2023/12/31", "Q4"],
+    ])("quarter %s", (value, result) => {
+      expect(formatValue(parseDateTime(value, locale)!.value, { format: "qq", locale })).toBe(
+        result
+      );
+    });
+
+    test("quarter with year", () => {
+      const date = parseDateTime("2023/01/01", locale)!.value;
+      expect(formatValue(date, { format: "qq yyyy", locale })).toBe("Q1 2023");
+      expect(formatValue(date, { format: "qqqq yyyy", locale })).toBe("Quarter 1 2023");
+      expect(formatValue(date, { format: "yyyy qq", locale })).toBe("2023 Q1");
+      expect(formatValue(date, { format: "qq/yyyy", locale })).toBe("Q1/2023");
     });
 
     test.each([

--- a/tests/xlsx/xlsx_export.test.ts
+++ b/tests/xlsx/xlsx_export.test.ts
@@ -16,6 +16,7 @@ import {
   groupHeaders,
   merge,
   setCellContent,
+  setCellFormat,
   setFormat,
   updateFilter,
 } from "../test_helpers/commands_helpers";
@@ -631,6 +632,19 @@ describe("Test XLSX export", () => {
       });
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
+
+    test("does not export quarter format", async () => {
+      const model = new Model();
+
+      setCellFormat(model, "A1", "qq yyyy");
+      setCellFormat(model, "A2", "qqqq yyyy");
+
+      const exported = getExportedExcelData(model);
+      expect(exported.sheets[0].cells.A1?.format).toBeUndefined();
+      expect(exported.sheets[0].cells.A2?.format).toBeUndefined();
+      expect(exported.formats).toEqual({});
+    });
+
     test("Conditional formatting with formula cannot be exported (for now)", async () => {
       jest.spyOn(global.console, "warn").mockImplementation();
       const model = new Model({


### PR DESCRIPTION
With this commit, dates can now be formatted by their quarter: "Q2 2023"

This also prepares the ground for the upcoming pivot features where we'll be able to group dates by quarter.

Tecnical note on the implementation: I initially wanted to reused the string part of formats [$...] to display the leading Q.
Format "q yyyy" would give "3 2023" and "[$Q] q yyyy" would give "Q3 2023" because of the leading string part. There's a translation issue though. How translator would be able to translate "Q" on its own, without any context? In some languages, it's also different than the first letter of the word "quarter". In Danish it's "3. kvt 2023".

Given that, "q" in a format automatically adds the leading "Q". It's less flexible, but it allows to have context for translators.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3864187](https://www.odoo.com/web#id=3864187&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo