### PR TITLE
[REM] tests: remove useless code in unit tests

### DIFF
--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -1655,7 +1655,7 @@ describe("clipboard", () => {
       sheetId: sheet1Id,
     });
 
-    model.dispatch("COPY", { target: target("A1") });
+    copy(model, "A1");
     activateSheet(model, sheet2Id);
     model.dispatch("PASTE", { target: target("A1") });
     expect(model.getters.getConditionalFormats(sheet2Id)).toMatchObject([
@@ -1668,7 +1668,7 @@ describe("clipboard", () => {
       sheetId: sheet1Id,
     });
     activateSheet(model, sheet1Id);
-    model.dispatch("COPY", { target: target("A1") });
+    copy(model, "A1");
     activateSheet(model, sheet2Id);
     model.dispatch("PASTE", { target: target("B2") });
     expect(model.getters.getConditionalFormats(sheet2Id)).toMatchObject([


### PR DESCRIPTION
## Description:

This commit will get rid of some dead useless code that was left in the clipboard plugin tests. It was probably forgotten when the code was refactored.

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo