### PR TITLE
[FIX] charts: time axis broken with long formatted date

### DIFF
--- a/src/helpers/charts/chart_ui_common.ts
+++ b/src/helpers/charts/chart_ui_common.ts
@@ -66,7 +66,8 @@ export function truncateLabel(label: string | undefined): string {
 export function getDefaultChartJsRuntime(
   chart: AbstractChart,
   labels: string[],
-  fontColor: Color
+  fontColor: Color,
+  truncateLabels: boolean = true
 ): ChartConfiguration {
   return {
     type: chart.type,
@@ -106,7 +107,7 @@ export function getDefaultChartJsRuntime(
       },
     },
     data: {
-      labels: labels.map(truncateLabel),
+      labels: truncateLabels ? labels.map(truncateLabel) : labels,
       datasets: [],
     },
   };

--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -283,9 +283,18 @@ function canBeLinearChart(chart: LineChart, getters: Getters): boolean {
   return true;
 }
 
-function getLineConfiguration(chart: LineChart, labels: string[]): ChartConfiguration {
+function getLineConfiguration(
+  chart: LineChart,
+  labels: string[],
+  truncateLabels: boolean
+): ChartConfiguration {
   const fontColor = chartFontColor(chart.background);
-  const config: ChartConfiguration = getDefaultChartJsRuntime(chart, labels, fontColor);
+  const config: ChartConfiguration = getDefaultChartJsRuntime(
+    chart,
+    labels,
+    fontColor,
+    truncateLabels
+  );
   const legend: ChartLegendOptions = {
     labels: {
       fontColor,
@@ -349,7 +358,8 @@ function createLineChartRuntime(chart: LineChart, getters: Getters): LineChartRu
   if (axisType === "time") {
     ({ labels, dataSetsValues } = fixEmptyLabelsForDateCharts(labels, dataSetsValues));
   }
-  const config = getLineConfiguration(chart, labels);
+  const truncateLabels = axisType === "category";
+  const config = getLineConfiguration(chart, labels, truncateLabels);
   const labelFormat = getLabelFormat(getters, chart.labelRange)!;
   if (axisType === "time") {
     config.options!.scales!.xAxes![0].type = "time";

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -1,6 +1,6 @@
 import { Model } from "../../../src";
 import { ChartTerms } from "../../../src/components/translations_terms";
-import { FIGURE_ID_SPLITTER } from "../../../src/constants";
+import { FIGURE_ID_SPLITTER, MAX_CHAR_LABEL } from "../../../src/constants";
 import { BarChart } from "../../../src/helpers/charts";
 import { toZone, zoneToXc } from "../../../src/helpers/zones";
 import { ChartPlugin } from "../../../src/plugins/core/chart";
@@ -8,6 +8,7 @@ import { BorderCommand, CommandResult } from "../../../src/types";
 import { BarChartDefinition, BarChartRuntime } from "../../../src/types/chart/bar_chart";
 import { LineChartDefinition, LineChartRuntime } from "../../../src/types/chart/line_chart";
 import { PieChartRuntime } from "../../../src/types/chart/pie_chart";
+import { getCellContent } from "../../test_helpers";
 import {
   activateSheet,
   addColumns,
@@ -1597,6 +1598,33 @@ describe("Linear/Time charts", () => {
     const chart = (model.getters.getChartRuntime(chartId) as LineChartRuntime).chartJsConfig;
     expect(chart.data!.labels![1]).toEqual("1/17/1900");
     expect(chart.data!.datasets![0].data![1]).toEqual({ y: undefined, x: "1/17/1900" });
+  });
+
+  test("date chart: long labels are not truncated", () => {
+    model.dispatch("SET_FORMATTING", {
+      sheetId: model.getters.getActiveSheetId(),
+      target: [toZone("C2")],
+      format: "m/d/yyyy hh:mm:ss a",
+    });
+    setCellContent(model, "C2", "300");
+    setCellContent(model, "B2", "10");
+    const formattedValue = getCellContent(model, "C2");
+    expect(formattedValue).toEqual("10/26/1900 12:00:00 AM");
+    expect(formattedValue.length).toBeGreaterThan(MAX_CHAR_LABEL);
+    createChart(
+      model,
+      {
+        type: "line",
+        dataSets: ["B2"],
+        labelRange: "C2",
+        labelsAsText: false,
+        dataSetsHaveTitle: false,
+      },
+      chartId
+    );
+    const chart = (model.getters.getChartRuntime(chartId) as LineChartRuntime).chartJsConfig;
+    expect(chart.data!.labels![0]).toEqual(formattedValue);
+    expect(chart.data!.datasets![0].data![0]).toEqual({ y: 10, x: formattedValue });
   });
 
   test("linear chart: label 0 isn't set to undefined", () => {


### PR DESCRIPTION
## Description

In the charts, we truncate the labels if they are too long (>20 characters)[1]. But in line chart with time axis, chartJS parses the labels to get a date. This parsing obviously fails if the label is truncated.

This commit fixes the issue by not truncating the labels if the axis is a time axis.

[1] e.g. a format like "12/04/2024 12:34:56 AM".

Task: : [3857242](https://www.odoo.com/web#id=3857242&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo