### PR TITLE
[IMP] text: avoid useless context context savepoints

### DIFF
--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -55,20 +55,23 @@ export function computeTextWidth(
   fontUnit: "px" | "pt" = "pt"
 ) {
   const font = computeTextFont(style, fontUnit);
-  context.save();
-  context.font = font;
-  const width = computeCachedTextWidth(context, text);
-  context.restore();
+  const width = computeCachedTextWidth(context, text, font);
   return width;
 }
 
-export function computeCachedTextWidth(context: CanvasRenderingContext2D, text: string) {
-  const font = context.font;
+export function computeCachedTextWidth(
+  context: CanvasRenderingContext2D,
+  text: string,
+  font: string = context.font
+) {
   if (!textWidthCache[font]) {
     textWidthCache[font] = {};
   }
   if (textWidthCache[font][text] === undefined) {
+    context.save();
+    context.font = font;
     textWidthCache[font][text] = context.measureText(text).width;
+    context.restore();
   }
   return textWidthCache[font][text];
 }


### PR DESCRIPTION
`computeTextWidth` would make a savepoint of the context before calling `computeCachedTextWidth` but if the result of the latter was already cached, there was no need to do so.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo