### PR TITLE
[FIX] filter: recompute header position

### DIFF
--- a/tests/data_filter/filter_evaluation_plugin.test.ts
+++ b/tests/data_filter/filter_evaluation_plugin.test.ts
@@ -5,6 +5,7 @@ import { UID } from "../../src/types";
 import {
   addRows,
   createFilter,
+  createSheet,
   deleteFilter,
   deleteRows,
   foldHeaderGroup,
@@ -236,5 +237,17 @@ describe("Filter Evaluation Plugin", () => {
     expect(model.getters.getHeaderGroups(sheetId, "ROW")).toMatchObject([{ start: 0, end: 7 }]);
     expect(model.getters.isRowFiltered(sheetId, 6)).toEqual(true);
     expect(model.getters.isRowFiltered(sheetId, 7)).toEqual(true);
+  });
+
+  test("row filtered in an inactive sheet", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+
+    createFilter(model, "A6:A8");
+    setCellContent(model, "A7", "Hi");
+    updateFilter(model, "A6", ["Hi"]);
+
+    createSheet(model, { sheetId: "sh2", activate: true });
+    expect(model.getters.isRowFiltered(sheetId, 6)).toEqual(true);
   });
 });

--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -13,6 +13,7 @@ import {
   addColumns,
   addRows,
   createFilter,
+  createSheet,
   deleteColumns,
   deleteRows,
   foldHeaderGroup,
@@ -1067,6 +1068,30 @@ describe("Multi Panes viewport", () => {
     originalActiveMainViewport = model.getters.getActiveMainViewport();
     hideColumns(model, ["E", "F", "G", "H"]);
     expect(model.getters.getActiveMainViewport()).toEqual(originalActiveMainViewport);
+  });
+
+  test("filtered row rect after updating another sheet", () => {
+    const model = new Model();
+    const sheetId = model.getters.getActiveSheetId();
+    createSheet(model, { sheetId: "sh2" });
+    setCellContent(model, "A1", "Hi");
+    setCellContent(model, "A2", "Hello");
+
+    createFilter(model, "A1:A3");
+
+    updateFilter(model, "A1", ["Hello"]);
+    expect(model.getters.isRowHidden(sheetId, 1)).toEqual(true);
+    const rectA2 = {
+      x: 0,
+      y: DEFAULT_CELL_HEIGHT,
+      width: DEFAULT_CELL_WIDTH,
+      height: 0,
+    };
+    expect(model.getters.getVisibleRect(toZone("A2"))).toEqual(rectA2);
+    activateSheet(model, "sh2");
+    setCellContent(model, "A1", "hi");
+    activateSheet(model, sheetId);
+    expect(model.getters.getVisibleRect(toZone("A2"))).toEqual(rectA2);
   });
 
   test("Viewport remains unaffected when hiding all rows below frozen panes by data filter", () => {


### PR DESCRIPTION
Steps to reproduce:
- create a spreadsheet
- add a second sheet
- on the first sheet, add values in A1,A2,A3
- create a filter on A1:A3
- filter one or more values
- go to the second sheet
- update a cell
- go back to the first sheet => the positions of headers/cells are broken

Reason: the filter evaluation plugin currently only store the filtered rows of the active sheet. If the sheet is inactive, all rows are considered as visible (early return `false`)

When you update a cell in the second sheet however, the header positions are recomputed for all sheets. When computing the header positions of the first sheet, the visibilty is therefore wrong (considered as visible even though it's filtered)

opw-3858512
Task: 3858512

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3858512](https://www.odoo.com/web#id=3858512&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo