### PR TITLE
[FIX] chart: wrong line dot size

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -67,8 +67,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
     this.chart!.config.options!.plugins!.tooltip = chartData.options!.plugins!.tooltip;
     this.chart!.config.options!.plugins!.legend = chartData.options!.plugins!.legend;
     this.chart!.config.options!.scales = chartData.options?.scales;
-    // ?
-    this.chart!.update("active");
+    this.chart!.update();
   }
 }
 

--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -1,5 +1,6 @@
 import { Component, onMounted, useEffect, useRef } from "@odoo/owl";
 import type { Chart, ChartConfiguration } from "chart.js";
+import { deepCopy, deepEquals } from "../../../../helpers";
 import { Figure, SpreadsheetChildEnv } from "../../../../types";
 import { ChartJSRuntime } from "../../../../types/chart/chart";
 import { GaugeChartConfiguration, GaugeChartOptions } from "../../../../types/chart/gauge_chart";
@@ -13,6 +14,7 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
 
   private canvas = useRef("graphContainer");
   private chart?: Chart;
+  private currentRuntime!: ChartJSRuntime;
 
   get background(): string {
     return this.chartRuntime.background;
@@ -33,12 +35,17 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   setup() {
     onMounted(() => {
       const runtime = this.chartRuntime;
-      this.createChart(runtime.chartJsConfig);
+      this.currentRuntime = runtime;
+      // Note: chartJS modify the runtime in place, so it's important to give it a copy
+      this.createChart(deepCopy(runtime.chartJsConfig));
     });
-    useEffect(
-      () => this.updateChartJs(this.chartRuntime),
-      () => [this.chartRuntime]
-    );
+    useEffect(() => {
+      const runtime = this.chartRuntime;
+      if (!deepEquals(runtime, this.currentRuntime, "ignoreFunctions")) {
+        this.currentRuntime = runtime;
+        this.updateChartJs(deepCopy(runtime));
+      }
+    });
   }
 
   private createChart(chartData: ChartConfiguration | GaugeChartConfiguration) {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -350,7 +350,7 @@ export function getAddHeaderStartIndex(position: "before" | "after", base: numbe
 /**
  * Compares two objects.
  */
-export function deepEquals(o1: any, o2: any): boolean {
+export function deepEquals(o1: any, o2: any, ignoreFunctions?: "ignoreFunctions"): boolean {
   if (o1 === o2) return true;
   if ((o1 && !o2) || (o2 && !o1)) return false;
   if (typeof o1 !== typeof o2) return false;
@@ -364,10 +364,12 @@ export function deepEquals(o1: any, o2: any): boolean {
   }
 
   for (const key in o1) {
-    if (typeof o1[key] !== typeof o2[key]) return false;
-    if (typeof o1[key] === "object") {
-      if (!deepEquals(o1[key], o2[key])) return false;
+    const typeOfO1Key = typeof o1[key];
+    if (typeOfO1Key !== typeof o2[key]) return false;
+    if (typeOfO1Key === "object") {
+      if (!deepEquals(o1[key], o2[key], ignoreFunctions)) return false;
     } else {
+      if (ignoreFunctions && typeOfO1Key === "function") return true;
       if (o1[key] !== o2[key]) return false;
     }
   }

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1125,6 +1125,15 @@ describe("charts", () => {
     await keyDown({ key: "Z", ctrlKey: true });
     expect(getCellContent(model, "D6")).toEqual("");
   });
+
+  test("Chart is not re-rendered if its runtime do not change", async () => {
+    const updateChart = jest.spyOn((window as any).Chart.prototype, "update");
+    createTestChart("basicChart");
+    await nextTick();
+    setCellContent(model, "C3", "value");
+    await nextTick();
+    expect(updateChart).not.toHaveBeenCalled();
+  });
 });
 
 describe("charts with multiple sheets", () => {

--- a/tests/helpers/misc_helpers.test.ts
+++ b/tests/helpers/misc_helpers.test.ts
@@ -233,6 +233,13 @@ test.each([
   expect(deepEquals(o2, o1)).toEqual(expectedResult);
 });
 
+test("deepEquals with argument ignoring functions", () => {
+  const o1 = { a: 1, b: () => 2 };
+  const o2 = { a: 1, b: () => 2 };
+  expect(deepEquals(o1, o2)).toEqual(false);
+  expect(deepEquals(o1, o2, "ignoreFunctions")).toEqual(true);
+});
+
 describe("isConsecutive", () => {
   test("consecutive", () => {
     expect(isConsecutive([2, 3, 1])).toBeTruthy();

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -621,7 +621,7 @@ export const mockChart = () => {
     }
     toBase64Image = () => "";
     destroy = () => {};
-    update = () => {};
+    update() {}
     options = mockChartData.options;
     config = mockChartData;
   }


### PR DESCRIPTION

## [FIX] chart: wrong line dot size

There was a problem that the doz sizes in the line charts were at their
"hover" size by default. This was caused by the "active" parameters
given to window.chart.update(), which updated the chart animations
to be in "active" state.

## [FIX] chart: avoid useless chart updates

There was an `useEffect` in the `chartJS` component to update the
chartJS object on runtime change. There was 2 problems:

1) useEffect on object compare the references, so if the chart plugin
was ever changed to return copy of runtime it would break
2) the chart plugin re-build every chartRuntime on each command that
could affect a chart. This created a chart update at each UPDATE_CELL
even if the actual runtime didn't change.

This commit replace the `useEffect` dependency with a `deepEquals`

Task: : [3697660](https://www.odoo.com/web#id=3697660&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo