### PR TITLE
[FIX] menu: remove leftover comments from forwardport

### DIFF
--- a/src/actions/data_actions.ts
+++ b/src/actions/data_actions.ts
@@ -42,19 +42,6 @@ export const addRemoveDataFilter: ActionSpec = {
   icon: "o-spreadsheet-Icon.MENU_FILTER_ICON",
 };
 
-// export const removeDataFilter: ActionSpec = {
-//   name: _lt("Remove filter"),
-//   execute: (env) => {
-//     const sheetId = env.model.getters.getActiveSheetId();
-//     env.model.dispatch("REMOVE_FILTER_TABLE", {
-//       sheetId,
-//       target: env.model.getters.getSelectedZones(),
-//     });
-//   },
-//   isVisible: ACTIONS.SELECTION_CONTAINS_FILTER,
-//   icon: "o-spreadsheet-Icon.MENU_FILTER_ICON",
-// };
-
 export const splitToColumns: ActionSpec = {
   name: _lt("Split text to columns"),
   sequence: 1,

--- a/tests/menu_items_registry.test.ts
+++ b/tests/menu_items_registry.test.ts
@@ -1433,7 +1433,6 @@ describe("Menu Item actions", () => {
 
   describe("Filters", () => {
     const FilterItemPath = ["data", "add_remove_data_filter"];
-    // const removeFilterPath = ["data", "remove_data_filter"];
 
     test("Filters -> Create filter", () => {
       setSelection(model, ["A1:A5"]);


### PR DESCRIPTION
## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo