### PR TITLE
[FIX] dashboard: Add a test for clickable cells

### DIFF
--- a/tests/components/dashboard_grid.test.ts
+++ b/tests/components/dashboard_grid.test.ts
@@ -6,7 +6,14 @@ import {
   FILTER_ICON_MARGIN,
 } from "../../src/constants";
 import { Model } from "../../src/model";
-import { createFilter, selectCell, setCellContent } from "../test_helpers/commands_helpers";
+import { clickableCellRegistry } from "../../src/registries/cell_clickable_registry";
+import { Cell } from "../../src/types";
+import {
+  createFilter,
+  selectCell,
+  setCellContent,
+  setViewportOffset,
+} from "../test_helpers/commands_helpers";
 import { simulateClick } from "../test_helpers/dom_helper";
 import { getActiveXc } from "../test_helpers/getters_helpers";
 import { mountSpreadsheet, nextTick, spyDispatch } from "../test_helpers/helpers";
@@ -117,5 +124,33 @@ describe("Grid component in dashboard mode", () => {
     selectCell(model, "A2");
     document.body.dispatchEvent(getEmptyClipboardEvent("paste"));
     expect(spy).not.toHaveBeenCalledWith("PASTE");
+  });
+
+  test("Clickable cells actions are properly udpated on viewport scroll", async () => {
+    const fn = jest.fn();
+    clickableCellRegistry.add("fake", {
+      condition: (cell: Cell) => cell.content.startsWith("__"),
+      action: (cell, env) => {
+        const { top, left } = env.model.getters.getActiveMainViewport();
+        fn(left, top);
+      },
+      sequence: 5,
+    });
+    setCellContent(model, "A1", "__test1");
+    setCellContent(model, "A10", "__test1");
+    model.updateMode("dashboard");
+    await nextTick();
+
+    await simulateClick("div.o-dashboard-clickable-cell", 10, 10); // first visible cell
+    expect(fn).toHaveBeenCalledWith(0, 0);
+
+    setViewportOffset(
+      model,
+      DEFAULT_CELL_WIDTH /** scroll to column B */,
+      9 * DEFAULT_CELL_HEIGHT /** scroll to row 10 */
+    );
+
+    await simulateClick("div.o-dashboard-clickable-cell", 10, 10);
+    expect(fn).toHaveBeenCalledWith(1, 9);
   });
 });


### PR DESCRIPTION
Adding a test for the changes of the previous commit.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo