### PR TITLE
[FIX] compiler: translatable error message

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -121,10 +121,8 @@ export function compileTokens(tokens: Token[]): CompiledFormula {
           if (!isRangeInput(currentArg)) {
             throw new BadExpressionError(
               _t(
-                "Function %s expects the parameter %s to be reference to a cell or range, not a %s.",
-                functionName,
-                (i + 1).toString(),
-                currentArg.type.toLowerCase()
+                "Function %(function_name)s expects the parameter %(arg_index)s to be a reference to a cell or a range.",
+                { function_name: functionName, arg_index: i + 1 }
               )
             );
           }

--- a/tests/evaluation/compiler.test.ts
+++ b/tests/evaluation/compiler.test.ts
@@ -267,18 +267,18 @@ describe("compile functions", () => {
       });
 
       expect(() => compiledBaseFunction("=RANGEEXPECTED(42)")).toThrowError(
-        "Function RANGEEXPECTED expects the parameter 1 to be reference to a cell or range, not a number."
+        "Function RANGEEXPECTED expects the parameter 1 to be a reference to a cell or a range."
       );
       expect(() => compiledBaseFunction('=RANGEEXPECTED("test")')).toThrowError(
-        "Function RANGEEXPECTED expects the parameter 1 to be reference to a cell or range, not a string."
+        "Function RANGEEXPECTED expects the parameter 1 to be a reference to a cell or a range."
       );
       expect(() => compiledBaseFunction("=RANGEEXPECTED(TRUE)")).toThrowError(
-        "Function RANGEEXPECTED expects the parameter 1 to be reference to a cell or range, not a boolean."
+        "Function RANGEEXPECTED expects the parameter 1 to be a reference to a cell or a range."
       );
       expect(() =>
         compiledBaseFunction("=RANGEEXPECTED(FORMULA_NOT_RETURNING_RANGE())")
       ).toThrowError(
-        "Function RANGEEXPECTED expects the parameter 1 to be reference to a cell or range, not a funcall."
+        "Function RANGEEXPECTED expects the parameter 1 to be a reference to a cell or a range."
       );
 
       expect(() => compiledBaseFunction("=RANGEEXPECTED(A1)")).not.toThrow();


### PR DESCRIPTION
Steps to reproduce (in odoo, in stable):
- change your language to french
- type in a cell '=AVERAGEIFS(1,1,)' or '=AVERAGEIFS(1,1,)' => the end of the error message isn't translated

"La fonction AVERAGEIFS s'attend à ce que le paramètre 1 fasse référence à une cellule ou à une plage, et non à un number."

`currentArg.type.toLowerCase()` is not translated.

I removed the type of the actual parameter from the error message because it's difficult to have a sentence contruction that work well in all languages and for all types. Think about an empty argument, you don't want the "a": "...or range, not a empty" is wrong. But you want it if it's a number: "...or range, not a number"

I also changed the placeholder to named placeholder to help translators to re-order them if needed in a given language.


Task: : [3872025](https://www.odoo.com/web#id=3872025&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo