### PR TITLE
[FIX] table: disable sort option for dynamic table

### DIFF
--- a/src/components/filters/filter_menu/filter_menu.ts
+++ b/src/components/filters/filter_menu/filter_menu.ts
@@ -149,8 +149,15 @@ export class FilterMenu extends Component<Props, SpreadsheetChildEnv> {
     this.state.values = this.getFilterHiddenValues(this.props.filterPosition);
   }
 
-  get isReadonly() {
-    return this.env.model.getters.isReadonly();
+  get isSortable() {
+    if (!this.table) {
+      return false;
+    }
+    const coreTable = this.env.model.getters.getCoreTableMatchingTopLeft(
+      this.table.range.sheetId,
+      this.table.range.zone
+    );
+    return !this.env.model.getters.isReadonly() && coreTable?.type !== "dynamic";
   }
 
   private getFilterHiddenValues(position: Position): Value[] {

--- a/src/components/filters/filter_menu/filter_menu.xml
+++ b/src/components/filters/filter_menu/filter_menu.xml
@@ -1,15 +1,17 @@
 <templates>
   <t t-name="o-spreadsheet-FilterMenu">
     <div class="o-filter-menu d-flex flex-column bg-white" t-on-wheel.stop="">
-      <div t-if="!isReadonly">
-        <div class="o-filter-menu-item" t-on-click="() => this.sortFilterZone('ascending')">
-          Sort ascending (A ⟶ Z)
+      <t t-if="isSortable">
+        <div>
+          <div class="o-filter-menu-item" t-on-click="() => this.sortFilterZone('ascending')">
+            Sort ascending (A ⟶ Z)
+          </div>
+          <div class="o-filter-menu-item" t-on-click="() => this.sortFilterZone('descending')">
+            Sort descending (Z ⟶ A)
+          </div>
         </div>
-        <div class="o-filter-menu-item" t-on-click="() => this.sortFilterZone('descending')">
-          Sort descending (Z ⟶ A)
-        </div>
-      </div>
-      <div class="o-separator" t-if="!isReadonly"/>
+        <div class="o-separator"/>
+      </t>
       <div class="o-filter-menu-actions">
         <div class="o-filter-menu-action-text" t-on-click="selectAll">Select all</div>
         <div class="o-filter-menu-action-text" t-on-click="clearAll">Clear</div>

--- a/tests/table/__snapshots__/filter_menu_component.test.ts.snap
+++ b/tests/table/__snapshots__/filter_menu_component.test.ts.snap
@@ -16,7 +16,6 @@ exports[`Filter menu component Filter Tests Filter menu is correctly rendered 1`
        Sort descending (Z ⟶ A) 
     </div>
   </div>
-  
   <div
     class="o-separator"
   />

--- a/tests/table/filter_menu_component.test.ts
+++ b/tests/table/filter_menu_component.test.ts
@@ -1,6 +1,7 @@
 import { Model } from "../../src";
 import { UID } from "../../src/types";
 import {
+  createDynamicTable,
   createTable,
   hideRows,
   setCellContent,
@@ -330,12 +331,22 @@ describe("Filter menu component", () => {
     await nextTick();
     await openFilterMenu();
     expect(
-      [...fixture.querySelectorAll(".o-filter-menu-item")].map((el) => el.textContent)
-    ).toEqual([" Sort ascending (A ⟶ Z) ", " Sort descending (Z ⟶ A) ", "✓(Blanks)"]);
+      [...fixture.querySelectorAll(".o-filter-menu-item")].map((el) => el.textContent?.trim())
+    ).toEqual(["Sort ascending (A ⟶ Z)", "Sort descending (Z ⟶ A)", "✓(Blanks)"]);
     model.updateMode("readonly");
     await nextTick();
     expect(
-      [...fixture.querySelectorAll(".o-filter-menu-item")].map((el) => el.textContent)
+      [...fixture.querySelectorAll(".o-filter-menu-item")].map((el) => el.textContent?.trim())
     ).toEqual(["✓(Blanks)"]);
+  });
+
+  test("cannot sort dynamic table", async () => {
+    setCellContent(model, "A10", "=MUNIT(2)");
+    createDynamicTable(model, "A10");
+    await nextTick();
+    await openFilterMenu();
+    expect(
+      [...fixture.querySelectorAll(".o-filter-menu-item")].map((el) => el.textContent?.trim())
+    ).not.toContain("Sort ascending (A ⟶ Z)");
   });
 });


### PR DESCRIPTION
## Description

The sort option in the filter menu make no sense for dynamic tables, since they depend on an array formula which is not sortable.

Task: : [3872756](https://www.odoo.com/web#id=3872756&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo