### PR TITLE
[FIX] dataValidation: Display suggestions on dv-icon click

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -1,4 +1,4 @@
-import { Component, onMounted, onPatched, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, useEffect, useRef, useState } from "@odoo/owl";
 import { COMPOSER_ASSISTANT_COLOR, DEFAULT_FONT, NEWLINE } from "../../../constants";
 import { EnrichedToken } from "../../../formulas/index";
 import { functionRegistry } from "../../../functions/index";
@@ -221,19 +221,18 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
         this.env.focusableElement.setFocusableElement(el);
       }
       this.contentHelper.updateEl(el);
-      this.processTokenAtCursor();
     });
 
     useEffect(() => {
       this.processContent();
     });
 
-    onPatched(() => {
-      // Required because typing '=SUM' and double-clicking another cell leaves ShowProvider/ShowDescription true
-      if (this.env.model.getters.getEditionMode() === "inactive") {
+    useEffect(
+      () => {
         this.processTokenAtCursor();
-      }
-    });
+      },
+      () => [this.env.model.getters.getEditionMode() !== "inactive"]
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -722,6 +721,7 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
       this.env.model.getters.getAutoCompleteDataValidationValues();
     if (!content.startsWith("=") && dataValidationAutocompleteValues.length) {
       this.showDataValidationAutocomplete(dataValidationAutocompleteValues);
+      return;
     }
 
     if (content.startsWith("=")) {

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -15,11 +15,8 @@ import {
   ComposerWrapper,
   clearFunctions,
   mountComposerWrapper,
-  mountSpreadsheet,
   nextTick,
   restoreDefaultFunctions,
-  startGridComposition,
-  typeInComposerGrid,
   typeInComposerHelper,
 } from "../test_helpers/helpers";
 jest.mock("../../src/components/composer/content_editable_helper.ts", () =>
@@ -258,16 +255,15 @@ describe("Functions autocomplete", () => {
     });
 
     test("autocomplete should not appear when typing '=S', clicking outside, and edting back", async () => {
-      const { model, fixture } = await mountSpreadsheet();
-      await typeInComposerGrid("=S", true);
+      await typeInComposer("=S", true);
       expect(fixture.querySelectorAll(".o-autocomplete-value")).toHaveLength(2);
 
       model.dispatch("STOP_EDITION");
       await nextTick();
+      await nextTick();
       expect(fixture.querySelector(".o-autocomplete-dropdown")).toBeFalsy();
 
-      await startGridComposition();
-      await nextTick();
+      await keyDown({ key: "Enter" });
       expect(fixture.querySelector(".o-autocomplete-dropdown")).toBeFalsy();
     });
   });
@@ -312,15 +308,16 @@ describe("Autocomplete parenthesis", () => {
   });
 
   test("=sum( + enter + edit does not show the formula assistant", async () => {
-    const { fixture, model } = await mountSpreadsheet();
-    await typeInComposerGrid("=sum(");
+    await typeInComposer("=sum(");
     expect(fixture.querySelector(".o-formula-assistant-container")).toBeTruthy();
 
     model.dispatch("STOP_EDITION");
     await nextTick();
+    await nextTick();
     expect(fixture.querySelector(".o-formula-assistant-container")).toBeFalsy();
 
-    await startGridComposition();
+    selectCell(model, "B4");
+    await keyDown({ key: "Enter" });
     expect(fixture.querySelector(".o-formula-assistant-container")).toBeFalsy();
   });
 

--- a/tests/data_validation/data_validation_list_component.test.ts
+++ b/tests/data_validation/data_validation_list_component.test.ts
@@ -203,10 +203,13 @@ describe("autocomplete in composer", () => {
 
     test("Values displayed are not filtered when the user opens the composer with a valid value", async () => {
       setCellContent(model, "A1", "hello");
-      model.dispatch("START_EDITION", {});
-      ({ fixture, parent } = await mountComposerWrapper(model, { focus: "cellFocus" }));
+      ({ fixture, parent } = await mountComposerWrapper(model, { focus: "inactive" }));
+      parent.startComposition();
+      // start edition
       await nextTick();
-      expect(fixture.querySelectorAll<HTMLElement>(".o-autocomplete-value")).toHaveLength(3);
+      // autocomplete update
+      await nextTick();
+      expect(document.querySelectorAll<HTMLElement>(".o-autocomplete-value")).toHaveLength(3);
     });
 
     test("Values displayed are not filtered when the input has no match in valid values", async () => {
@@ -305,12 +308,18 @@ describe("Selection arrow icon in grid", () => {
     );
   });
 
-  test("Clicking on the icon opens the composer", async () => {
+  test("Clicking on the icon opens the composer with suggestions", async () => {
     setSelection(model, ["B2"]);
     ({ fixture } = await mountSpreadsheet({ model }));
     await click(fixture, ".o-dv-list-icon");
+    await nextTick();
     expect(model.getters.getEditionMode()).toBe("editing");
     expect(model.getters.getCurrentEditedCell()).toEqual({ sheetId, col: 0, row: 0 });
+    const suggestions = fixture.querySelectorAll(".o-autocomplete-dropdown .o-autocomplete-value");
+    expect(suggestions.length).toBe(3);
+    expect(suggestions[0].textContent).toBe("ok");
+    expect(suggestions[1].textContent).toBe("hello");
+    expect(suggestions[2].textContent).toBe("okay");
   });
 
   test("Icon is not displayed when display style is plainText", async () => {

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -741,12 +741,12 @@ export class ComposerWrapper extends Component<ComposerWrapperProps, Spreadsheet
 
   get composerProps(): ComposerProps {
     return {
+      ...this.props.composerProps,
       onComposerContentFocused: () => {
         this.state.focusComposer = "contentFocus";
         this.setEdition({});
       },
       focus: this.state.focusComposer,
-      ...this.props.composerProps,
     };
   }
 


### PR DESCRIPTION
## Description:
Following the fix for persistent composition, starting the edition of a
cell related to a data validation list would not display the values of
the list in the composer assistant.

Task: 3872312
description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo