### PR TITLE
[IMP] Dashboard: Cache clickable cells

### DIFF
--- a/src/components/dashboard/clickable_cell_store.ts
+++ b/src/components/dashboard/clickable_cell_store.ts
@@ -1,0 +1,88 @@
+import { markRaw } from "@odoo/owl";
+import { positionToZone, toXC } from "../../helpers";
+import { CellClickableItem, clickableCellRegistry } from "../../registries/cell_clickable_registry";
+import { SpreadsheetStore } from "../../stores/spreadsheet_store";
+import {
+  CellPosition,
+  Command,
+  Rect,
+  SpreadsheetChildEnv,
+  UID,
+  invalidateEvaluationCommands,
+} from "../../types";
+
+type Garbage = ((position: CellPosition, env: SpreadsheetChildEnv) => void) | false;
+
+export interface ClickableCell {
+  coordinates: Rect;
+  position: CellPosition;
+  action: (position: CellPosition, env: SpreadsheetChildEnv) => void;
+}
+
+export class ClickableCellsStore extends SpreadsheetStore {
+  private _clickableCells: Record<UID, Record<string, Garbage>> = markRaw({});
+  private _registryItems: CellClickableItem[] = markRaw(
+    clickableCellRegistry.getAll().sort((a, b) => a.sequence - b.sequence)
+  );
+
+  handle(cmd: Command) {
+    if (
+      invalidateEvaluationCommands.has(cmd.type) ||
+      cmd.type === "EVALUATE_CELLS" ||
+      (cmd.type === "UPDATE_CELL" && ("content" in cmd || "format" in cmd))
+    ) {
+      this._clickableCells = markRaw({});
+      this._registryItems = markRaw(
+        clickableCellRegistry.getAll().sort((a, b) => a.sequence - b.sequence)
+      );
+    }
+  }
+
+  private getClickableAction(position: CellPosition): Garbage {
+    const { sheetId, col, row } = position;
+    const clickableCells = this._clickableCells;
+    const xc = toXC(col, row);
+    if (!clickableCells[sheetId]) {
+      clickableCells[sheetId] = {};
+    }
+    if (!(xc in clickableCells[sheetId]!)) {
+      clickableCells[sheetId][xc] = this.findClickableAction(position);
+    }
+    return clickableCells[sheetId][xc];
+  }
+
+  private findClickableAction(position: CellPosition) {
+    const getters = this.getters;
+    for (const item of this._registryItems) {
+      if (item.condition(position, getters)) {
+        return item.execute;
+      }
+    }
+    return false;
+  }
+
+  get clickableCells(): ClickableCell[] {
+    const cells: ClickableCell[] = [];
+    const getters = this.getters;
+    const sheetId = getters.getActiveSheetId();
+    for (const col of getters.getSheetViewVisibleCols()) {
+      for (const row of getters.getSheetViewVisibleRows()) {
+        const position = { sheetId, col, row };
+        if (!getters.isMainCellPosition(position)) {
+          continue;
+        }
+        const action = this.getClickableAction(position);
+        if (!action) {
+          continue;
+        }
+        const zone = getters.expandZone(sheetId, positionToZone(position));
+        cells.push({
+          coordinates: getters.getVisibleRect(zone),
+          position,
+          action,
+        });
+      }
+    }
+    return cells;
+  }
+}

--- a/src/registries/cell_clickable_registry.ts
+++ b/src/registries/cell_clickable_registry.ts
@@ -1,9 +1,9 @@
 import { openLink } from "../helpers/links";
-import { CellPosition, SpreadsheetChildEnv } from "../types";
+import { CellPosition, Getters, SpreadsheetChildEnv } from "../types";
 import { Registry } from "./registry";
 
 export interface CellClickableItem {
-  condition: (position: CellPosition, env: SpreadsheetChildEnv) => boolean;
+  condition: (position: CellPosition, getters: Getters) => boolean;
   execute: (position: CellPosition, env: SpreadsheetChildEnv) => void;
   sequence: number;
 }
@@ -11,8 +11,9 @@ export interface CellClickableItem {
 export const clickableCellRegistry = new Registry<CellClickableItem>();
 
 clickableCellRegistry.add("link", {
-  condition: (position: CellPosition, env: SpreadsheetChildEnv) =>
-    !!env.model.getters.getEvaluatedCell(position).link,
+  condition: (position: CellPosition, getters: Getters) => {
+    return !!getters.getEvaluatedCell(position).link;
+  },
   execute: (position: CellPosition, env: SpreadsheetChildEnv) =>
     openLink(env.model.getters.getEvaluatedCell(position).link!, env),
   sequence: 5,

--- a/tests/grid/dashboard_grid_component.test.ts
+++ b/tests/grid/dashboard_grid_component.test.ts
@@ -124,7 +124,9 @@ describe("Grid component in dashboard mode", () => {
   test("Clickable cells actions are properly udpated on viewport scroll", async () => {
     const fn = jest.fn();
     clickableCellRegistry.add("fake", {
-      condition: (position, env) => !!env.model.getters.getCell(position)?.content.startsWith("__"),
+      condition: (position, getters) => {
+        return !!getters.getCell(position)?.content.startsWith("__");
+      },
       execute: (position) => fn(position.col, position.row),
       sequence: 5,
     });


### PR DESCRIPTION
## Description:

The computation of the clickable cells visibility condition can
sometimes be costy (per cell). At the moment, we recompute those
conditions at each rendering request, which can become quickly costy
if we simply scroll the viewport.

This revision introduces a caching of this computations to smooth out
the user experience when scrolling a dashboard.

Task: 3869752

Task: : [3869752](https://www.odoo.com/web#id=3869752&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo