### PR TITLE
[FIX] FigureComponent: Stop Ctrl+A propagation

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -7,6 +7,7 @@ import {
 import { figureRegistry } from "../../../registries";
 import { Figure, Pixel, ResizeDirection, SpreadsheetChildEnv, UID } from "../../../types/index";
 import { css, cssPropertiesToCss } from "../../helpers/css";
+import { keyboardEventToShortcutString } from "../../helpers/dom_helpers";
 
 type ResizeAnchor =
   | "top left"
@@ -181,8 +182,9 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
 
   onKeyDown(ev: KeyboardEvent) {
     const figure = this.props.figure;
+    const keyDownShortcut = keyboardEventToShortcutString(ev);
 
-    switch (ev.key) {
+    switch (keyDownShortcut) {
       case "Delete":
         this.env.model.dispatch("DELETE_FIGURE", {
           sheetId: this.env.model.getters.getActiveSheetId(),
@@ -209,6 +211,21 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
           x: figure.x + delta[0],
           y: figure.y + delta[1],
         });
+        ev.preventDefault();
+        ev.stopPropagation();
+        break;
+      case "Ctrl+A":
+        // Maybe in the future we will implement a way to select all figures
+        ev.preventDefault();
+        ev.stopPropagation();
+        break;
+      case "Ctrl+Y":
+      case "Ctrl+Z":
+        if (keyDownShortcut === "Ctrl+Y") {
+          this.env.model.dispatch("REQUEST_REDO");
+        } else if (keyDownShortcut === "Ctrl+Z") {
+          this.env.model.dispatch("REQUEST_UNDO");
+        }
         ev.preventDefault();
         ev.stopPropagation();
         break;

--- a/src/components/helpers/dom_helpers.ts
+++ b/src/components/helpers/dom_helpers.ts
@@ -1,5 +1,7 @@
 const macRegex = /Mac/i;
 
+const MODIFIER_KEYS = ["Shift", "Control", "Alt", "Meta"];
+
 /**
  * Return true if the event was triggered from
  * a child element.
@@ -19,6 +21,33 @@ export function gridOverlayPosition() {
 
 export function getOpenedMenus(): HTMLElement[] {
   return Array.from(document.querySelectorAll<HTMLElement>(".o-spreadsheet .o-menu"));
+}
+
+const letterRegex = /^[a-zA-Z]$/;
+
+/**
+ * Transform a keyboard event into a shortcut string that represent this event. The letters keys will be uppercased.
+ *
+ * @argument ev - The keyboard event to transform
+ * @argument mode - Use either ev.key of ev.code to get the string shortcut
+ *
+ * @example
+ * event : { ctrlKey: true, key: "a" } => "Ctrl+A"
+ * event : { shift: true, alt: true, key: "Home" } => "Alt+Shift+Home"
+ */
+export function keyboardEventToShortcutString(
+  ev: KeyboardEvent,
+  mode: "key" | "code" = "key"
+): string {
+  let keyDownString = "";
+  if (!MODIFIER_KEYS.includes(ev.key)) {
+    if (isCtrlKey(ev)) keyDownString += "Ctrl+";
+    if (ev.altKey) keyDownString += "Alt+";
+    if (ev.shiftKey) keyDownString += "Shift+";
+  }
+  const key = mode === "key" ? ev.key : ev.code;
+  keyDownString += letterRegex.test(key) ? key.toUpperCase() : key;
+  return keyDownString;
 }
 
 export function isMacOS(): boolean {

--- a/tests/components/charts.test.ts
+++ b/tests/components/charts.test.ts
@@ -13,6 +13,7 @@ import {
   createScorecardChart,
   createSheet,
   paste,
+  selectCell,
   setCellContent,
   setStyle,
   updateChart,
@@ -1310,6 +1311,18 @@ describe("figures", () => {
         "A1",
       ]);
     });
+  });
+
+  test("When a figure is selected, pressing Ctrl+A will not propagate to the grid to select all cells", async () => {
+    selectCell(model, "A1");
+    createTestChart("gauge");
+    await nextTick();
+
+    await simulateClick(".o-figure");
+    await keyDown("A", { ctrlKey: true });
+
+    expect(model.getters.getSelectedFigureId()).toBe("someuuid");
+    expect(model.getters.getSelectedZone()).toEqual(toZone("A1"));
   });
 
   test("Can undo multiple times after pasting figure", async () => {


### PR DESCRIPTION
## Description:

Previously, when a figure was selected, And pressing CTRL + A would select all rows and columns in the sheet, and pressing the Delete key would delete the selected figure. This occurred because all key events were bubbling up to the grid component.

This PR stops the propagation for the Ctrl+A key event in the figure component.

Task: : [3863300](https://www.odoo.com/web#id=3863300&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo