### PR TITLE
[IMP] tests: rename duplicated viewport tests names

### DIFF
--- a/tests/sheet/sheetview_plugin.test.ts
+++ b/tests/sheet/sheetview_plugin.test.ts
@@ -1238,34 +1238,18 @@ describe("shift viewport up/down", () => {
     expect(model.getters.getActiveMainViewport().top).toBe(0);
   });
 
-  test("RENAME move viewport not starting from the top", () => {
+  test.each([
+    [DEFAULT_CELL_HEIGHT * 3, 3],
+    [DEFAULT_CELL_HEIGHT * 3 + 1, 3],
+    [DEFAULT_CELL_HEIGHT * 3 - 1, 2],
+  ])("Move viewport not starting from the top", (scrollValue, expectedTop) => {
     selectCell(model, "A4");
     const { bottom } = model.getters.getActiveMainViewport();
-    setViewportOffset(model, 0, DEFAULT_CELL_HEIGHT * 3);
+    setViewportOffset(model, 0, scrollValue);
     model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveMainViewport().top).toBe(bottom + 3);
+    expect(model.getters.getActiveMainViewport().top).toBe(bottom + expectedTop);
     model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveMainViewport().top).toBe(3);
-  });
-
-  test("RENAME move viewport not starting from the top", () => {
-    selectCell(model, "A4");
-    const { bottom } = model.getters.getActiveMainViewport();
-    setViewportOffset(model, 0, DEFAULT_CELL_HEIGHT * 3 + 1);
-    model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveMainViewport().top).toBe(bottom + 3);
-    model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveMainViewport().top).toBe(3);
-  });
-
-  test("RENAME move viewport not starting from the top", () => {
-    selectCell(model, "A4");
-    const { bottom } = model.getters.getActiveMainViewport();
-    setViewportOffset(model, 0, DEFAULT_CELL_HEIGHT * 3 - 1);
-    model.dispatch("SHIFT_VIEWPORT_DOWN");
-    expect(model.getters.getActiveMainViewport().top).toBe(bottom + 2);
-    model.dispatch("SHIFT_VIEWPORT_UP");
-    expect(model.getters.getActiveMainViewport().top).toBe(2);
+    expect(model.getters.getActiveMainViewport().top).toBe(expectedTop);
   });
 
   test("move all the way down and up again", () => {


### PR DESCRIPTION
Leftover from the frozen pane pull request, there were 3 slighly different tests with the same name. This revision groups them in a single test.

Task: 3857195

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo