### PR TITLE
[FIX] stores: bye bye reactivity 👋

### DIFF
--- a/src/components/composer/composer_focus_store.ts
+++ b/src/components/composer/composer_focus_store.ts
@@ -4,6 +4,7 @@ import { ComposerSelection, ComposerStore } from "./composer/composer_store";
 export type ComposerFocusType = "inactive" | "cellFocus" | "contentFocus";
 
 export class ComposerFocusStore extends SpreadsheetStore {
+  mutators = ["focusTopBarComposer", "focusGridComposerContent", "focusGridComposerCell"] as const;
   private composerStore = this.get(ComposerStore);
 
   private topBarFocus: Exclude<ComposerFocusType, "cellFocus"> = "inactive";

--- a/src/components/focus_store.ts
+++ b/src/components/focus_store.ts
@@ -1,7 +1,6 @@
-import { toRaw } from "@odoo/owl";
-
 // The name is misleading and can be confused with the DOM focus.
 export class FocusStore {
+  mutators = ["focus", "unfocus"] as const;
   public focusedElement: object | null = null;
 
   focus(element: object) {
@@ -9,7 +8,7 @@ export class FocusStore {
   }
 
   unfocus(element: object) {
-    if (this.focusedElement && toRaw(this.focusedElement) === toRaw(element)) {
+    if (this.focusedElement && this.focusedElement === element) {
       this.focusedElement = null;
     }
   }

--- a/src/components/grid/hovered_cell_store.ts
+++ b/src/components/grid/hovered_cell_store.ts
@@ -2,6 +2,7 @@ import { SpreadsheetStore } from "../../stores";
 import { Command, Position } from "../../types";
 
 export class HoveredCellStore extends SpreadsheetStore {
+  mutators = ["clear", "hover"] as const;
   col: number | undefined;
   row: number | undefined;
 

--- a/src/components/helpers/draw_grid_hook.ts
+++ b/src/components/helpers/draw_grid_hook.ts
@@ -9,7 +9,7 @@ import { DOMDimension, OrderedLayers } from "../../types";
 export function useGridDrawing(refName: string, model: Model, canvasSize: () => DOMDimension) {
   const canvasRef = useRef(refName);
   useEffect(drawGrid);
-  const rendererManager = useStore(RendererStore);
+  const rendererStore = useStore(RendererStore);
   useStore(GridRenderer);
 
   function drawGrid() {
@@ -39,7 +39,11 @@ export function useGridDrawing(refName: string, model: Model, canvasSize: () => 
 
     for (const layer of OrderedLayers()) {
       model.drawLayer(renderingContext, layer);
-      rendererManager.drawLayer(renderingContext, layer);
+      // @ts-ignore 'drawLayer' is not declated as a mutator because:
+      // it does not mutate anything. Most importantly it's used
+      // during rendering. Invoking a mutator during rendering would
+      // trigger another rendering, ultimately resulting in an infinite loop.
+      rendererStore.drawLayer(renderingContext, layer);
     }
   }
 }

--- a/src/components/helpers/highlight_hook.ts
+++ b/src/components/helpers/highlight_hook.ts
@@ -1,12 +1,12 @@
-import { onMounted, useEffect, useEnv } from "@odoo/owl";
-import { useLocalStore } from "../../store_engine";
+import { onMounted, useEffect } from "@odoo/owl";
+import { useLocalStore, useStoreProvider } from "../../store_engine";
 import { HighlightProvider, HighlightStore } from "../../stores/highlight_store";
-import { Ref, SpreadsheetChildEnv } from "../../types";
+import { Ref } from "../../types";
 import { useHoveredElement } from "./listener_hook";
 
 export function useHighlightsOnHover(ref: Ref<HTMLElement>, highlightProvider: HighlightProvider) {
   const hoverState = useHoveredElement(ref);
-  const env = useEnv() as SpreadsheetChildEnv;
+  const stores = useStoreProvider();
 
   useHighlights({
     get highlights() {
@@ -15,7 +15,7 @@ export function useHighlightsOnHover(ref: Ref<HTMLElement>, highlightProvider: H
   });
   useEffect(
     () => {
-      env.model.dispatch("RENDER_CANVAS");
+      stores.trigger("store-updated");
     },
     () => [hoverState.hovered]
   );

--- a/src/components/popover/cell_popover_store.ts
+++ b/src/components/popover/cell_popover_store.ts
@@ -11,6 +11,8 @@ import {
 import { HoveredCellStore } from "../grid/hovered_cell_store";
 
 export class CellPopoverStore extends SpreadsheetStore {
+  mutators = ["open", "close"] as const;
+
   private persistentPopover?: CellPosition & { type: CellPopoverType };
 
   protected hoveredCell = this.get(HoveredCellStore);

--- a/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
+++ b/src/components/side_panel/chart/main_chart_panel/main_chart_panel_store.ts
@@ -1,6 +1,7 @@
 import { SpreadsheetStore } from "../../../../stores";
 
 export class MainChartPanelStore extends SpreadsheetStore {
+  mutators = ["activatePanel"];
   panel: "configuration" | "design" = "configuration";
 
   activatePanel(panel: "configuration" | "design") {

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -2,7 +2,6 @@ import { debounce, getSearchRegex, isInside, positionToZone } from "../../../hel
 import { HighlightProvider, HighlightStore } from "../../../stores/highlight_store";
 import { CellPosition, Color, Command, Highlight } from "../../../types";
 
-import { toRaw } from "@odoo/owl";
 import { Get } from "../../../store_engine";
 import { SpreadsheetStore } from "../../../stores";
 import { SearchOptions } from "../../../types/find_and_replace";
@@ -16,6 +15,14 @@ enum Direction {
 }
 
 export class FindAndReplaceStore extends SpreadsheetStore implements HighlightProvider {
+  mutators = [
+    "updateSearchOptions",
+    "updateSearchContent",
+    "searchFormulas",
+    "selectPreviousMatch",
+    "selectNextMatch",
+    "replace",
+  ] as const;
   private allSheetsMatches: CellPosition[] = [];
   private activeSheetMatches: CellPosition[] = [];
   private specificRangeMatches: CellPosition[] = [];
@@ -44,11 +51,11 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     this.searchOptions.searchFormulas = this.initialShowFormulaState;
 
     const highlightStore = get(HighlightStore);
-    highlightStore.register(toRaw(this));
+    highlightStore.register(this);
     this.onDispose(() => {
       this.model.dispatch("SET_FORMULA_VISIBILITY", { show: this.initialShowFormulaState });
       this.updateSearchContent.stopDebounce();
-      highlightStore.unRegister(toRaw(this));
+      highlightStore.unRegister(this);
     });
   }
 

--- a/src/components/side_panel/side_panel/side_panel_store.ts
+++ b/src/components/side_panel/side_panel/side_panel_store.ts
@@ -19,6 +19,7 @@ interface ClosedSidePanel {
 export type SidePanelState = OpenSidePanel | ClosedSidePanel;
 
 export class SidePanelStore extends SpreadsheetStore {
+  mutators = ["open", "toggle", "close"] as const;
   initialPanelProps: SidePanelProps = {};
   componentTag: string = "";
 

--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -29,6 +29,7 @@ import {
   SEPARATOR_COLOR,
   TOPBAR_HEIGHT,
 } from "../../constants";
+import { batched } from "../../helpers";
 import { ImageProvider } from "../../helpers/figures/images/image_provider";
 import { Model } from "../../model";
 import { Store, useStore, useStoreProvider } from "../../store_engine";
@@ -341,10 +342,15 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
       }
     });
 
+    const render = batched(this.render.bind(this, true));
     onMounted(() => {
       this.checkViewportSize();
+      stores.on("store-updated", this, render);
     });
-    onWillUnmount(() => this.unbindModelEvents());
+    onWillUnmount(() => {
+      this.unbindModelEvents();
+      stores.off("store-updated", this);
+    });
     onPatched(() => {
       this.checkViewportSize();
     });

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -313,6 +313,27 @@ export function debounce<T extends (...args: any) => void>(
   return debounced as DebouncedFunction<T>;
 }
 
+/**
+ * Creates a batched version of a callback so that all calls to it in the same
+ * microtick will only call the original callback once.
+ *
+ * @param callback the callback to batch
+ * @returns a batched version of the original callback
+ *
+ * Copied from odoo/owl repo.
+ */
+export function batched(callback: () => void): () => void {
+  let scheduled = false;
+  return async (...args) => {
+    if (!scheduled) {
+      scheduled = true;
+      await Promise.resolve();
+      scheduled = false;
+      callback(...args);
+    }
+  };
+}
+
 /*
  * Concatenate an array of strings.
  */

--- a/src/store_engine/dependency_container.ts
+++ b/src/store_engine/dependency_container.ts
@@ -1,9 +1,14 @@
+import { EventBus } from "../helpers/event_bus";
 import { Get, StoreConstructor, StoreParams } from "./store";
+
+interface StoreUpdateEvent {
+  type: "store-updated";
+}
 
 /**
  * A type-safe dependency container
  */
-export class DependencyContainer {
+export class DependencyContainer extends EventBus<StoreUpdateEvent> {
   private dependencies: Map<StoreConstructor, any> = new Map();
   private factory = new StoreFactory(this.get.bind(this));
 

--- a/src/store_engine/store_hooks.ts
+++ b/src/store_engine/store_hooks.ts
@@ -1,4 +1,4 @@
-import { onWillUnmount, useEnv, useState, useSubEnv } from "@odoo/owl";
+import { onWillUnmount, status, useComponent, useEnv, useSubEnv } from "@odoo/owl";
 import { DependencyContainer } from "./dependency_container";
 import { LocalStoreConstructor, Store, StoreConstructor, StoreParams } from "./store";
 
@@ -13,7 +13,10 @@ export function useStoreProvider() {
   const container = new DependencyContainer();
   useSubEnv({
     __spreadsheet_stores__: container,
-    getStore: container.get.bind(container),
+    getStore: <T extends StoreConstructor>(Store: T) => {
+      const store = container.get(Store);
+      return proxifyStoreMutation(store, () => container.trigger("store-updated"));
+    },
   });
   return container;
 }
@@ -26,7 +29,8 @@ type Env = ReturnType<typeof useEnv>;
 export function useStore<T extends StoreConstructor>(Store: T): Store<InstanceType<T>> {
   const env: Env = useEnv();
   const container = getDependencyContainer(env);
-  return useState(container.get(Store));
+  const store = container.get(Store);
+  return useStoreRenderProxy(container, store);
 }
 
 export function useLocalStore<T extends LocalStoreConstructor<any>>(
@@ -35,9 +39,59 @@ export function useLocalStore<T extends LocalStoreConstructor<any>>(
 ): Store<InstanceType<T>> {
   const env = useEnv();
   const container = getDependencyContainer(env);
-  const store = useState(container.instantiate(Store, ...args));
+  const store = container.instantiate(Store, ...args);
   onWillUnmount(() => store.dispose());
-  return store;
+  return useStoreRenderProxy(container, store);
+}
+
+/**
+ * Trigger an event to re-render the app (deep render) when
+ * a store is mutated by invoking one of its mutator methods.
+ */
+function useStoreRenderProxy<S extends { mutators: readonly (keyof S)[] }>(
+  container: DependencyContainer,
+  store: S
+): S {
+  const component = useComponent();
+  const proxy = proxifyStoreMutation(store, () => {
+    if (status(component) === "mounted") {
+      container.trigger("store-updated");
+    }
+  });
+  return proxy as S;
+}
+
+/**
+ * Creates a proxied version of a store object with mutation tracking.
+ * Whenever a mutator method of the store is called, the provided callback function is invoked.
+ */
+export function proxifyStoreMutation<S extends { mutators: readonly (keyof S)[] }>(
+  store: S,
+  callback: () => void
+): S {
+  const proxy = new Proxy(store as object, {
+    get(target, property, receiver) {
+      const thisStore = target;
+      // The third argument is `thisStore` (target) instead of `receiver`.
+      // The goal is to always have the same `this` value in getter functions
+      // (when `target[property]` is an accessor property).
+      // `thisStore` is always the same object reference. `receiver` however is the
+      // object on which the property is called, which is the Proxy object which is different for each component.
+      const value = Reflect.get(target, property, thisStore);
+      if (store.mutators.includes(property as keyof S)) {
+        const functionProxy = new Proxy(value, {
+          // trap the function call
+          apply(target, thisArg, argArray) {
+            Reflect.apply(target, thisStore, argArray);
+            callback();
+          },
+        });
+        return functionProxy;
+      }
+      return value;
+    },
+  });
+  return proxy as S;
 }
 
 function getDependencyContainer(env: Env) {

--- a/src/stores/DOM_focus_store.ts
+++ b/src/stores/DOM_focus_store.ts
@@ -1,4 +1,5 @@
 export class DOMFocusableElementStore {
+  mutators = ["setFocusableElement", "focus"] as const;
   private focusableElement: HTMLElement | undefined = undefined;
 
   setFocusableElement(element: HTMLElement) {

--- a/src/stores/grid_renderer_store.ts
+++ b/src/stores/grid_renderer_store.ts
@@ -1,4 +1,3 @@
-import { markRaw } from "@odoo/owl";
 import { ModelStore } from ".";
 import { ICONS } from "../components/icons/icons";
 import {
@@ -64,13 +63,6 @@ export class GridRenderer {
     this.getters = get(ModelStore).getters;
     this.renderer = get(RendererStore);
     this.renderer.register(this);
-    /**
-     * Mark the instance as raw to avoid reactivity as this class is instanciated
-     * as a Store by `useGridDrawing` (which casts it as reactive).
-     *
-     * Calling `this.` on a reactive instance is significantly slower than on a raw object.
-     */
-    markRaw(this);
   }
 
   get renderingLayers() {

--- a/src/stores/highlight_store.ts
+++ b/src/stores/highlight_store.ts
@@ -1,4 +1,3 @@
-import { toRaw } from "@odoo/owl";
 import { zoneToDimension } from "../helpers";
 import { drawHighlight } from "../helpers/rendering";
 import { Get } from "../store_engine";
@@ -10,6 +9,7 @@ export interface HighlightProvider {
 }
 
 export class HighlightStore extends SpreadsheetStore {
+  mutators = ["register", "unRegister"] as const;
   private providers: HighlightProvider[] = [];
 
   constructor(get: Get) {
@@ -46,7 +46,7 @@ export class HighlightStore extends SpreadsheetStore {
   }
 
   unRegister(highlightProvider: HighlightProvider) {
-    this.providers = this.providers.filter((h) => toRaw(h) !== toRaw(highlightProvider));
+    this.providers = this.providers.filter((h) => h !== highlightProvider);
   }
 
   drawLayer(ctx: GridRenderingContext, layer: LayerName): void {

--- a/src/stores/notification_store.ts
+++ b/src/stores/notification_store.ts
@@ -2,6 +2,7 @@ import { createAbstractStore } from "../store_engine";
 import { InformationNotification } from "../types";
 
 export interface NotificationStore {
+  mutators: readonly ["notifyUser", "raiseError", "askConfirmation"];
   notifyUser: (notification: InformationNotification) => any;
   raiseError: (text: string, callback?: () => void) => any;
   askConfirmation: (content: string, confirm: () => any, cancel?: () => any) => any;

--- a/src/stores/renderer_store.ts
+++ b/src/stores/renderer_store.ts
@@ -1,4 +1,3 @@
-import { ReactiveStore } from "../store_engine";
 import { GridRenderingContext, LayerName } from "../types";
 
 export interface Renderer {
@@ -6,7 +5,8 @@ export interface Renderer {
   renderingLayers: Readonly<LayerName[]>;
 }
 
-export class RendererStore extends ReactiveStore {
+export class RendererStore {
+  mutators = ["register", "unRegister"] as const;
   private renderers: Partial<Record<LayerName, Renderer[]>> = {};
 
   register(renderer: Renderer) {

--- a/src/stores/spreadsheet_store.ts
+++ b/src/stores/spreadsheet_store.ts
@@ -1,5 +1,3 @@
-import { markRaw } from "@odoo/owl";
-
 import { Model } from "../model";
 import { DisposableStore, Get } from "../store_engine";
 import { Command, GridRenderingContext, LayerName } from "../types";
@@ -9,7 +7,7 @@ import { RendererStore } from "./renderer_store";
 export class SpreadsheetStore extends DisposableStore {
   // cast the model store as Model to allow model.dispatch to return the DispatchResult
   protected model = this.get(ModelStore) as Model;
-  protected getters = markRaw(this.model.getters);
+  protected getters = this.model.getters;
   private renderer = this.get(RendererStore);
 
   constructor(get: Get) {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -851,10 +851,6 @@ export interface SplitTextIntoColumnsCommand {
   force?: boolean;
 }
 
-export interface RenderCanvasCommand {
-  type: "RENDER_CANVAS";
-}
-
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -986,8 +982,7 @@ export type LocalCommand =
   | UpdateFilterCommand
   | SplitTextIntoColumnsCommand
   | RemoveDuplicatesCommand
-  | TrimWhitespaceCommand
-  | RenderCanvasCommand;
+  | TrimWhitespaceCommand;
 
 export type Command = CoreCommand | LocalCommand;
 

--- a/tests/selection_input/selection_input_component.test.ts
+++ b/tests/selection_input/selection_input_component.test.ts
@@ -1,4 +1,4 @@
-import { App, Component, onMounted, onWillUnmount, useSubEnv, xml } from "@odoo/owl";
+import { App, Component, useSubEnv, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { OPEN_CF_SIDEPANEL_ACTION } from "../../src/actions/menu_items_actions";
 import { SelectionInput } from "../../src/components/selection_input/selection_input";
@@ -85,11 +85,6 @@ class Parent extends Component<any> {
     this.model = model;
     this.onChanged = this.props.config.onChanged || jest.fn();
     this.onConfirmed = this.props.config.onConfirmed || jest.fn();
-    onMounted(() => {
-      this.model.on("update", this, () => this.render(true));
-      this.render(true);
-    });
-    onWillUnmount(() => this.model.off("update", this));
   }
 }
 
@@ -112,11 +107,6 @@ class MultiParent extends Component<any> {
     });
     const stores = useStoreProvider();
     stores.inject(ModelStore, this.props.model);
-    onMounted(() => {
-      this.props.model.on("update", this, () => this.render(true));
-      this.render(true);
-    });
-    onWillUnmount(() => this.props.model.off("update", this));
   }
 }
 

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -1,12 +1,4 @@
-import {
-  App,
-  Component,
-  ComponentConstructor,
-  onMounted,
-  onWillUnmount,
-  useState,
-  xml,
-} from "@odoo/owl";
+import { App, Component, ComponentConstructor, useState, xml } from "@odoo/owl";
 import type { ChartConfiguration } from "chart.js";
 import format from "xml-formatter";
 import { Action } from "../../src/actions/action";
@@ -22,6 +14,7 @@ import { matrixMap } from "../../src/functions/helpers";
 import { functionRegistry } from "../../src/functions/index";
 import { ImageProvider } from "../../src/helpers/figures/images/image_provider";
 import {
+  batched,
   range,
   toCartesian,
   toUnboundedZone,
@@ -36,7 +29,13 @@ import { UIPluginConstructor } from "../../src/plugins/ui_plugin";
 import { topbarMenuRegistry } from "../../src/registries";
 import { MenuItemRegistry } from "../../src/registries/menu_items_registry";
 import { Registry } from "../../src/registries/registry";
-import { DependencyContainer, Get, Store, useStore } from "../../src/store_engine";
+import {
+  DependencyContainer,
+  Store,
+  StoreConstructor,
+  proxifyStoreMutation,
+  useStore,
+} from "../../src/store_engine";
 import { ModelStore } from "../../src/stores";
 import { HighlightProvider, HighlightStore } from "../../src/stores/highlight_store";
 import { NotificationStore } from "../../src/stores/notification_store";
@@ -142,9 +141,6 @@ export function makeTestFixture() {
 }
 
 class FakeRendererStore extends RendererStore {
-  constructor(get: Get) {
-    super(get);
-  }
   // we don't want to actually draw anything on the canvas as it cannot be tested
   drawLayer(renderingContext: GridRenderingContext, layer: LayerName) {}
 }
@@ -154,15 +150,17 @@ export function makeTestEnv(mockEnv: Partial<SpreadsheetChildEnv> = {}): Spreads
   const container = new DependencyContainer();
   container.inject(ModelStore, model);
   const notificationStore = {
+    mutators: ["notifyUser", "raiseError", "askConfirmation"],
     notifyUser: mockEnv.notifyUser || (() => {}),
     raiseError: mockEnv.raiseError || (() => {}),
     askConfirmation: mockEnv.askConfirmation || (() => {}),
-  };
+  } as const;
 
   container.inject(NotificationStore, notificationStore);
-  container.inject(RendererStore, new FakeRendererStore(container.get));
+  container.inject(RendererStore, new FakeRendererStore());
 
-  const sidePanelStore = container.get(SidePanelStore);
+  const store = container.get(SidePanelStore);
+  const sidePanelStore = proxifyStoreMutation(store, () => container.trigger("store-updated"));
   return {
     model,
     isDashboard: mockEnv.isDashboard || (() => false),
@@ -180,7 +178,10 @@ export function makeTestEnv(mockEnv: Partial<SpreadsheetChildEnv> = {}): Spreads
         return [] as Currency[];
       }),
     loadLocales: mockEnv.loadLocales || (async () => DEFAULT_LOCALES),
-    getStore: container.get.bind(container),
+    getStore<T extends StoreConstructor>(Store: T) {
+      const store = container.get(Store);
+      return proxifyStoreMutation(store, () => container.trigger("store-updated"));
+    },
     // @ts-ignore
     __spreadsheet_stores__: container,
   };
@@ -220,14 +221,19 @@ export async function mountComponent<Props extends { [key: string]: any }>(
   const fixture = optionalArgs?.fixture || makeTestFixture();
   const parent = await app.mount(fixture);
 
+  const render = batched(parent.render.bind(parent, true));
   if (optionalArgs.renderOnModelUpdate === undefined || optionalArgs.renderOnModelUpdate) {
-    model.on("update", null, () => parent.render(true));
+    model.on("update", null, render);
   }
+  // @ts-ignore
+  env.__spreadsheet_stores__.on("store-updated", null, render);
 
   registerCleanup(() => {
     app.destroy();
     fixture.remove();
     model.off("update", null);
+    // @ts-ignore
+    env.__spreadsheet_stores__.off("store-updated", null);
   });
 
   return { app, parent, model, fixture, env: parent.env };
@@ -774,8 +780,6 @@ export class ComposerWrapper extends Component<ComposerWrapperProps, Spreadsheet
   setup() {
     this.state.focusComposer = this.props.focusComposer;
     this.composerStore = useStore(ComposerStore);
-    onMounted(() => this.env.model.on("update", this, () => this.render(true)));
-    onWillUnmount(() => this.env.model.off("update", this));
   }
 
   get composerProps(): ComposerProps {
@@ -851,6 +855,7 @@ export function getHighlightsFromStore(env: SpreadsheetChildEnv): Highlight[] {
 
 export function makeTestNotificationStore(): NotificationStore {
   return {
+    mutators: ["notifyUser", "raiseError", "askConfirmation"],
     notifyUser: () => {},
     raiseError: () => {},
     askConfirmation: () => {},


### PR DESCRIPTION
## Description:

Reactivity is very very (very) slow, with potential overhead exceeding 90%.

With a reactive store, every `this.something` call traverses the reactive
proxy, incurring significant cost.

This commit completely revisit the way store updates trigger app rendering.
Previously, this process relied entirely on Owl's reactivity system.

Instead, it introduces a new approach where store updates are triggered by
explicitly declared public methods (mutators)
Since stores follow the CQS principle all public methods actually
mutate state in a store, they cannot have any other effect since they
can't return anything.

The new approach also relies on proxies to track mutators calls, but
the proxy is only on the surface. A mutator is usually only called once
in the component. A properties is also usually accessed only once for
rendering. The internal working of the store is not affected and can
run at full speed without any overhead.

Note the loss of fined-grained rendering. However, as observed, bypassing
reactivity might result in faster overall app rendering compared to
relying on reactivity for fine-grained rendering, even if it means rendering
the entire app rather than a few components.

Reactivity had another unexpected error-prone issue: since everything
was proxied, we could never compare objects references without using
`toRaw` to retrieve the underlying un-proxied object. It was very
error prone and added noise in the code.

On the large number data set, open the find & replace panel and search for "1"
It currently takes 1080ms (search + rendering)
With this commit, that time is reduced to just 111ms, nearly a tenfold
improvement!

Task: : [3829125](https://www.odoo.com/web#id=3829125&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo