### PR TITLE
[FIX] Evaluator: Prevent incorrect invalidations

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/formula_dependency_graph.ts
@@ -48,7 +48,7 @@ export class FormulaDependencyGraph {
   }
 
   /**
-   * Return the cell and all cells that depend on it,
+   * Return all the cells that depend on the provided ranges,
    * in the correct order they should be evaluated.
    * This is called a topological ordering (excluding cycles)
    */

--- a/tests/plugins/evaluation_formula_array.test.ts
+++ b/tests/plugins/evaluation_formula_array.test.ts
@@ -657,6 +657,72 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "D1").value).toBe(32);
     });
 
+    test("Spreaded formulas with range deps Do not invalidate themselves on evaluation", () => {
+      let c = 0;
+      functionRegistry.add("INCREMENTONEVAL", {
+        description: "returns the input, but fancy. Like transpose(transpose(range))",
+        args: [arg("range (any, range<any>)", "The matrix to be transposed.")],
+        returns: ["RANGE<ANY>"],
+        compute: function (values) {
+          c++;
+          return values;
+        } as ComputeFunction<ArgValue, FunctionReturnValue>,
+        isExported: true,
+      });
+      setCellContent(model, "A1", "0");
+      setCellContent(model, "A2", "1");
+      setCellContent(model, "A3", "2");
+      setCellContent(model, "A4", "3");
+      setCellContent(model, "A5", "=INCREMENTONEVAL(A2:A3)");
+      expect(c).toEqual(1);
+      setCellContent(model, "A5", "=INCREMENTONEVAL(A1:A2)");
+      expect(c).toEqual(2);
+      setCellContent(model, "A5", "=INCREMENTONEVAL(A1:B2)");
+      expect(c).toEqual(3);
+    });
+
+    test("Spreaded formulas with range deps invalidate only once the dependencies of themselves", () => {
+      let c = 0;
+      functionRegistry.add("INCREMENTONEVAL", {
+        description: "",
+        args: [arg("range (any, range<any>)", "")],
+        returns: ["RANGE<ANY>"],
+        compute: function () {
+          c++;
+          return 5;
+        } as ComputeFunction<ArgValue, FunctionReturnValue>,
+        isExported: false,
+      });
+      setCellContent(model, "A1", "0");
+      setCellContent(model, "A2", "1");
+      setCellContent(model, "A5", "=TRANSPOSE(A1:A2)");
+      setCellContent(model, "B1", "=INCREMENTONEVAL(A5)"); // depends on array formula (main cell)
+      expect(c).toEqual(1);
+      setCellContent(model, "A2", "2");
+      expect(c).toEqual(2);
+    });
+
+    test("Spreaded formulas with range deps invalidate only once the dependencies of result", () => {
+      let c = 0;
+      functionRegistry.add("INCREMENTONEVAL", {
+        description: "",
+        args: [arg("range (any, range<any>)", "")],
+        returns: ["RANGE<ANY>"],
+        compute: function () {
+          c++;
+          return 5;
+        } as ComputeFunction<ArgValue, FunctionReturnValue>,
+        isExported: false,
+      });
+      setCellContent(model, "A1", "0");
+      setCellContent(model, "A2", "1");
+      setCellContent(model, "A5", "=TRANSPOSE(A1:A2)");
+      setCellContent(model, "B1", "=INCREMENTONEVAL(B5)"); // depends on array formula (not the main cell)
+      expect(c).toEqual(1);
+      setCellContent(model, "A2", "2");
+      expect(c).toEqual(2);
+    });
+
     test("have collision when spread size zone change", () => {
       setCellContent(model, "A1", "1");
       setCellContent(model, "B1", "=MFILL(1,A1+1,42)");

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -9,6 +9,7 @@ import {
 } from "@odoo/owl";
 import { ChartConfiguration } from "chart.js";
 import format from "xml-formatter";
+import { functionCache } from "../../src";
 import { Action } from "../../src/actions/action";
 import { Composer, ComposerProps } from "../../src/components/composer/composer/composer";
 import {
@@ -439,6 +440,9 @@ export function clearFunctions() {
 }
 
 export function restoreDefaultFunctions() {
+  for (let f in functionCache) {
+    delete functionCache[f];
+  }
   clearFunctions();
   Object.keys(functionMapRestore).forEach((k) => {
     functionMap[k] = functionMapRestore[k];


### PR DESCRIPTION
## Description:
This commit solves an issue with the invalidation process of spreaded
formulas. While marking the positions invalidated by a given position,
we would mistakenly mark the latter to be recomputed as well,
effectively creating an infinite loop (position is invalid > invalidate
its dependencies > position is invalidated > etc ...).

This issue was introduced by a bugfix in https://github.com/odoo/o-spreadsheet/pull/3125
and was not discovered as the infinite loop is actually stopped by our
maximum iteration limit.

Avoiding these useless iterations implies a performance improvement of a
factor 30 when reevaluating a spreaded formula.

Co-authored-by: Lucas Lefèvre <lul@odoo.com>

Task:  3883954

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo