### PR TITLE
[IMP] functions: Add #SPILL! error

### DIFF
--- a/src/helpers/rendering.ts
+++ b/src/helpers/rendering.ts
@@ -16,6 +16,9 @@ export function drawHighlight(
 
   const { ctx } = renderingContext;
   if (!highlight.noBorder) {
+    if (highlight.dashed) {
+      ctx.setLineDash([5, 3]);
+    }
     ctx.strokeStyle = color;
     if (highlight.thinLine) {
       ctx.lineWidth = 1;

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -274,8 +274,8 @@ export class EvaluationPlugin extends UIPlugin {
   /**
    * Return the spread zone the position is part of, if any
    */
-  getSpreadZone(position: CellPosition): Zone | undefined {
-    return this.evaluator.getSpreadZone(position);
+  getSpreadZone(position: CellPosition, options = { ignoreSpillError: false }): Zone | undefined {
+    return this.evaluator.getSpreadZone(position, options);
   }
 
   getArrayFormulaSpreadingOn(position: CellPosition): CellPosition | undefined {

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -56,11 +56,15 @@ export class Evaluator {
     return this.evaluatedCells.get(position) || EMPTY_CELL;
   }
 
-  getSpreadZone(position: CellPosition): Zone | undefined {
+  getSpreadZone(position: CellPosition, options = { ignoreSpillError: false }): Zone | undefined {
     if (!this.spreadingRelations.isArrayFormula(position)) {
       return undefined;
     }
-    if (this.evaluatedCells.get(position)?.type === CellValueType.error) {
+    const evaluatedCell = this.evaluatedCells.get(position);
+    if (
+      evaluatedCell?.type === CellValueType.error &&
+      !(options.ignoreSpillError && evaluatedCell?.value === CellErrorType.SpilledBlocked)
+    ) {
       return positionToZone(position);
     }
     const spreadPositions = Array.from(this.spreadingRelations.getArrayResultPositions(position));

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -20,7 +20,7 @@ import {
   Zone,
   isMatrix,
 } from "../../../types";
-import { CellErrorType, CircularDependencyError, EvaluationError } from "../../../types/errors";
+import { CellErrorType, CircularDependencyError, SplillBlockedError } from "../../../types/errors";
 import { CompilationParameters, buildCompilationParameters } from "./compilation_parameters";
 import { FormulaDependencyGraph } from "./formula_dependency_graph";
 import { PositionMap } from "./position_map";
@@ -325,18 +325,18 @@ export class Evaluator {
     }
 
     if (enoughCols) {
-      throw new EvaluationError(
+      throw new SplillBlockedError(
         _t("Result couldn't be automatically expanded. Please insert more rows.")
       );
     }
 
     if (enoughRows) {
-      throw new EvaluationError(
+      throw new SplillBlockedError(
         _t("Result couldn't be automatically expanded. Please insert more columns.")
       );
     }
 
-    throw new EvaluationError(
+    throw new SplillBlockedError(
       _t("Result couldn't be automatically expanded. Please insert more columns and rows.")
     );
   }
@@ -363,7 +363,7 @@ export class Evaluator {
         this.getters.getEvaluatedCell(position).type !== CellValueType.empty
       ) {
         this.blockedArrayFormulas.add(formulaPosition);
-        throw new EvaluationError(
+        throw new SplillBlockedError(
           _t(
             "Array result was not expanded because it would overwrite data in %s.",
             toXC(position.col, position.row)

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -7,6 +7,7 @@ export const CellErrorType = {
   CircularDependency: "#CYCLE",
   UnknownFunction: "#NAME?",
   DivisionByZero: "#DIV/0!",
+  SpilledBlocked: "#SPILL!",
   GenericError: "#ERROR",
 } as const;
 
@@ -44,5 +45,11 @@ export class NotAvailableError extends EvaluationError {
 export class UnknownFunctionError extends EvaluationError {
   constructor(message = _t("Unknown function")) {
     super(message, CellErrorType.UnknownFunction);
+  }
+}
+
+export class SplillBlockedError extends EvaluationError {
+  constructor(message = _t("Spill range is not empty")) {
+    super(message, CellErrorType.SpilledBlocked);
   }
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -239,6 +239,7 @@ export interface Highlight {
   /** transparency of the fill color (0-1) */
   fillAlpha?: number;
   noBorder?: boolean;
+  dashed?: boolean;
 }
 
 export interface PaneDivision {

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -107,7 +107,7 @@ describe("evaluate formulas that return an array", () => {
       description: "Get error",
       compute: () => {
         const error = {
-          value: "#ERROR",
+          value: "#SPILL!",
           message: "Function [[FUNCTION_NAME]] failed",
         };
         return [[{ value: 42 }, error]];
@@ -227,14 +227,14 @@ describe("evaluate formulas that return an array", () => {
     test("throw error on the formula when collide with cell having content", () => {
       setCellContent(model, "B2", "kikou");
       setCellContent(model, "A1", "=MFILL(2,2, 42)");
-      expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getCellError(model, "A1")).toBe(
         "Array result was not expanded because it would overwrite data in B2."
       );
 
       setCellContent(model, "A4", "kikou");
       setCellContent(model, "A3", "=MFILL(2,2, 42)");
-      expect(getEvaluatedCell(model, "A3").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A3").value).toBe("#SPILL!");
       expect(getCellError(model, "A3")).toBe(
         "Array result was not expanded because it would overwrite data in A4."
       );
@@ -243,7 +243,7 @@ describe("evaluate formulas that return an array", () => {
     test("throw error on the formula when collide with other formula ", () => {
       setCellContent(model, "B2", "=SUM(42+24)");
       setCellContent(model, "A1", "=MFILL(2,2, 42)");
-      expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getCellError(model, "A1")).toBe(
         "Array result was not expanded because it would overwrite data in B2."
       );
@@ -256,7 +256,7 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "A1", "=MFILL(1,3, 42)");
       setCellContent(model, "A2", "kikou");
       setCellContent(model, "A3", "kikou");
-      expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getCellError(model, "A1")).toBe(
         "Array result was not expanded because it would overwrite data in A2."
       );
@@ -266,7 +266,7 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "A1", "=MFILL(3,1, 42)");
       setCellContent(model, "B1", "kikou");
       setCellContent(model, "C1", "kikou");
-      expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getCellError(model, "A1")).toBe(
         "Array result was not expanded because it would overwrite data in B1."
       );
@@ -351,7 +351,7 @@ describe("evaluate formulas that return an array", () => {
         setCellContent(model, "B2", "kikou");
         setCellContent(model, "A1", "=MFILL(2,2, 42)");
         setCellContent(model, "B2", "Aquecoucou");
-        expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
         expect(getEvaluatedCell(model, "A2").value).toBe(null);
         expect(getEvaluatedCell(model, "B1").value).toBe(null);
         expect(getEvaluatedCell(model, "B2").value).toBe("Aquecoucou");
@@ -361,7 +361,7 @@ describe("evaluate formulas that return an array", () => {
         setCellContent(model, "A1", "=MFILL(2,2, 42)");
         setCellContent(model, "B2", "kikou");
         setCellContent(model, "B2", "Aquecoucou");
-        expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
         expect(getEvaluatedCell(model, "A2").value).toBe(null);
         expect(getEvaluatedCell(model, "B1").value).toBe(null);
         expect(getEvaluatedCell(model, "B2").value).toBe("Aquecoucou");
@@ -375,7 +375,7 @@ describe("evaluate formulas that return an array", () => {
         expect(getEvaluatedCell(model, "A1").value).toBe(42);
 
         setCellContent(model, "A3", "kikou");
-        expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       });
 
       test("limit located on the formula row", () => {
@@ -384,7 +384,7 @@ describe("evaluate formulas that return an array", () => {
         expect(getEvaluatedCell(model, "A1").value).toBe(42);
 
         setCellContent(model, "C1", "kikou");
-        expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       });
 
       test("limit located before the formula column", () => {
@@ -405,7 +405,7 @@ describe("evaluate formulas that return an array", () => {
         expect(getEvaluatedCell(model, "A1").value).toBe(42);
 
         setCellContent(model, "A1", "=MFILL(2,3,42)");
-        expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       });
 
       test("limit located after the formula row", () => {
@@ -414,7 +414,7 @@ describe("evaluate formulas that return an array", () => {
         expect(getEvaluatedCell(model, "A1").value).toBe(42);
 
         setCellContent(model, "A1", "=MFILL(3,2,42)");
-        expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       });
 
       test("multiple limit test", () => {
@@ -424,7 +424,7 @@ describe("evaluate formulas that return an array", () => {
         setCellContent(model, "C5", "kikou");
         expect(getEvaluatedCell(model, "A1").value).toBe(42);
         setCellContent(model, "D3", "colision");
-        expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       });
     });
   });
@@ -445,7 +445,7 @@ describe("evaluate formulas that return an array", () => {
 
     test("throw error message concerning the column encountered horizontally", () => {
       setCellContent(model, "B1", "=MFILL(3,3, 42)");
-      expect(getEvaluatedCell(model, "B1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "B1").value).toBe("#SPILL!");
       expect(getCellError(model, "B1")).toBe(
         "Result couldn't be automatically expanded. Please insert more columns."
       );
@@ -453,7 +453,7 @@ describe("evaluate formulas that return an array", () => {
 
     test("throw error message concerning the row encountered verticaly", () => {
       setCellContent(model, "A2", "=MFILL(3,3, 42)");
-      expect(getEvaluatedCell(model, "A2").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A2").value).toBe("#SPILL!");
       expect(getCellError(model, "A2")).toBe(
         "Result couldn't be automatically expanded. Please insert more rows."
       );
@@ -461,7 +461,7 @@ describe("evaluate formulas that return an array", () => {
 
     test("throw error message concerning the row and column encountered", () => {
       setCellContent(model, "B2", "=MFILL(3,3, 42)");
-      expect(getEvaluatedCell(model, "B2").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "B2").value).toBe("#SPILL!");
       expect(getCellError(model, "B2")).toBe(
         "Result couldn't be automatically expanded. Please insert more columns and rows."
       );
@@ -469,7 +469,7 @@ describe("evaluate formulas that return an array", () => {
 
     test("do not spread result when collide", () => {
       setCellContent(model, "B2", "=MFILL(3,3, 42)");
-      expect(getEvaluatedCell(model, "B2").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "B2").value).toBe("#SPILL!");
       expect(getEvaluatedCell(model, "B3").value).toBe(null);
       expect(getEvaluatedCell(model, "C2").value).toBe(null);
       expect(getEvaluatedCell(model, "C3").value).toBe(null);
@@ -477,10 +477,10 @@ describe("evaluate formulas that return an array", () => {
 
     test("spread result when add columns", () => {
       setCellContent(model, "C1", "=MFILL(3,3, 42)");
-      expect(getEvaluatedCell(model, "C1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "C1").value).toBe("#SPILL!");
 
       addColumns(model, "after", "C", 1);
-      expect(getEvaluatedCell(model, "C1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "C1").value).toBe("#SPILL!");
 
       addColumns(model, "after", "D", 1);
       expect(getEvaluatedCell(model, "C1").value).toBe(42);
@@ -489,10 +489,10 @@ describe("evaluate formulas that return an array", () => {
 
     test("spread result when add rows", () => {
       setCellContent(model, "A3", "=MFILL(3,3, 42)");
-      expect(getEvaluatedCell(model, "A3").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A3").value).toBe("#SPILL!");
 
       addRows(model, "after", 2, 1);
-      expect(getEvaluatedCell(model, "A3").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A3").value).toBe("#SPILL!");
 
       addRows(model, "after", 3, 1);
       expect(getEvaluatedCell(model, "A3").value).toBe(42);
@@ -505,7 +505,7 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "C3").value).toBe(42);
 
       deleteColumns(model, ["B"]);
-      expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getEvaluatedCell(model, "B1").value).toBe(null);
     });
 
@@ -515,7 +515,7 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "C3").value).toBe(42);
 
       deleteRows(model, [2]);
-      expect(getEvaluatedCell(model, "A1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
       expect(getEvaluatedCell(model, "A2").value).toBe(null);
     });
   });
@@ -613,7 +613,7 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "B2").value).toBe(42);
       expect(getEvaluatedCell(model, "B3").value).toBe(42);
 
-      expect(getEvaluatedCell(model, "A3").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A3").value).toBe("#SPILL!");
     });
 
     test("recompute cell depending on spread values computed in between", () => {
@@ -643,7 +643,7 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "B1", formula);
       setCellContent(model, "A2", formula);
       expect(getEvaluatedCell(model, "B1").value).toBe(42);
-      expect(getEvaluatedCell(model, "A2").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A2").value).toBe("#SPILL!");
       expect(getCellError(model, "A2")).toBe(
         "Array result was not expanded because it would overwrite data in B2."
       );
@@ -652,7 +652,7 @@ describe("evaluate formulas that return an array", () => {
     test("throw error message concerning the first cell encountered vertically", () => {
       setCellContent(model, "A2", "=MFILL(2,2,42)");
       setCellContent(model, "B1", "=MFILL(1,3,42)");
-      expect(getEvaluatedCell(model, "B1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "B1").value).toBe("#SPILL!");
       expect(getEvaluatedCell(model, "A2").value).toBe(42);
       expect(getCellError(model, "B1")).toBe(
         "Array result was not expanded because it would overwrite data in B2."
@@ -662,7 +662,7 @@ describe("evaluate formulas that return an array", () => {
     test("throw error message concerning the first cell encountered horizontally", () => {
       setCellContent(model, "A2", "=MFILL(3,1,42)");
       setCellContent(model, "B1", "=MFILL(2,2,42)");
-      expect(getEvaluatedCell(model, "B1").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "B1").value).toBe("#SPILL!");
       expect(getEvaluatedCell(model, "A2").value).toBe(42);
       expect(getCellError(model, "B1")).toBe(
         "Array result was not expanded because it would overwrite data in B2."
@@ -675,7 +675,7 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "A2", formula);
       expect(getEvaluatedCell(model, "B1").value).toBe(42);
       expect(getEvaluatedCell(model, "B2").value).toBe(42);
-      expect(getEvaluatedCell(model, "A2").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A2").value).toBe("#SPILL!");
       expect(getEvaluatedCell(model, "A3").value).toBe(null);
       expect(getEvaluatedCell(model, "B3").value).toBe(null);
     });
@@ -685,7 +685,7 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "A2", "=MFILL(2,2,42)");
       expect(getEvaluatedCell(model, "B1").value).toBe(24);
       expect(getEvaluatedCell(model, "B2").value).toBe(24);
-      expect(getEvaluatedCell(model, "A2").value).toBe("#ERROR");
+      expect(getEvaluatedCell(model, "A2").value).toBe("#SPILL!");
       expect(getEvaluatedCell(model, "A3").value).toBe(null);
       expect(getEvaluatedCell(model, "B3").value).toBe(null);
       setCellContent(model, "B1", "");
@@ -704,14 +704,14 @@ describe("evaluate formulas that return an array", () => {
         setCellContent(model, "B4", formula);
         setCellContent(model, "C3", formula);
         expect(getEvaluatedCell(model, "B4").value).toBe(result);
-        expect(getEvaluatedCell(model, "C3").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "C3").value).toBe("#SPILL!");
       });
 
       test("covering formula located on the covered formula rows", () => {
         setCellContent(model, "C3", formula);
         setCellContent(model, "D2", formula);
         expect(getEvaluatedCell(model, "C3").value).toBe(result);
-        expect(getEvaluatedCell(model, "D2").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "D2").value).toBe("#SPILL!");
       });
 
       test("covering formula located before the covered formula columns", () => {
@@ -750,13 +750,13 @@ describe("evaluate formulas that return an array", () => {
         setCellContent(model, "A2", formula);
         setCellContent(model, "B1", formula);
         expect(getEvaluatedCell(model, "A2").value).toBe(result);
-        expect(getEvaluatedCell(model, "B1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "B1").value).toBe("#SPILL!");
       });
 
       test("order 2: set B1, set A2 --> error on A2", () => {
         setCellContent(model, "B1", formula);
         setCellContent(model, "A2", formula);
-        expect(getEvaluatedCell(model, "A2").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "A2").value).toBe("#SPILL!");
         expect(getEvaluatedCell(model, "B1").value).toBe(result);
       });
     });
@@ -768,13 +768,13 @@ describe("evaluate formulas that return an array", () => {
         setCellContent(model, "A2", formula);
         setCellContent(model, "B1", formula);
         expect(getEvaluatedCell(model, "A2").value).toBe(result);
-        expect(getEvaluatedCell(model, "B1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "B1").value).toBe("#SPILL!");
       });
 
       test("order 2: get B1, get A2", () => {
         setCellContent(model, "A2", formula);
         setCellContent(model, "B1", formula);
-        expect(getEvaluatedCell(model, "B1").value).toBe("#ERROR");
+        expect(getEvaluatedCell(model, "B1").value).toBe("#SPILL!");
         expect(getEvaluatedCell(model, "A2").value).toBe(result);
       });
     });

--- a/tests/grid/array_formula_highlights_store.test.ts
+++ b/tests/grid/array_formula_highlights_store.test.ts
@@ -15,11 +15,32 @@ describe("array function highlights", () => {
       color: "#17A2B8",
       noFill: true,
       thinLine: true,
+      dashed: false,
     };
     selectCell(model, "A2"); // main cell
     expect(getHighlightsFromStore(container)).toEqual([highlight]);
     selectCell(model, "A3"); // array function cell
     expect(getHighlightsFromStore(container)).toEqual([highlight]);
+  });
+
+  test("Selecting an array formula that cannot spill is still highlighted", () => {
+    const { model, container } = makeStore(ArrayFormulaHighlight);
+    setCellContent(model, "A2", "=TRANSPOSE(A1:C1)");
+    setCellContent(model, "A4", "blocking the spread");
+    expect(getHighlightsFromStore(container)).toEqual([]);
+    selectCell(model, "A2"); // main cell
+    expect(getHighlightsFromStore(container)).toEqual([
+      {
+        sheetId: model.getters.getActiveSheetId(),
+        zone: toZone("A2:A4"),
+        color: "#17A2B8",
+        noFill: true,
+        thinLine: true,
+        dashed: true,
+      },
+    ]);
+    selectCell(model, "A3"); // no highlight as the function does not spill
+    expect(getHighlightsFromStore(container)).toEqual([]);
   });
 
   test("Non-array formula are not highlighted", () => {


### PR DESCRIPTION
## Description:

This revision adds the #SPILL! error to give an insight to the user
about the type of error in the cell.
The cell itself or its formula are not broken or incorrect, they just
happen to be blocked, either by a lack of dimension in the sheet or
another cell content that prevent the formula to spread itself.

Task: : [3874364](https://www.odoo.com/web#id=3874364&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo