### PR TITLE
[FIX] borders: wrong borders on remove rows

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -79,7 +79,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
         this.clearBorders(cmd.sheetId, cmd.target);
         break;
       case "REMOVE_COLUMNS_ROWS":
-        for (let el of cmd.elements) {
+        for (let el of [...cmd.elements].sort((a, b) => b - a)) {
           if (cmd.dimension === "COL") {
             this.shiftBordersHorizontally(cmd.sheetId, el + 1, -1);
           } else {

--- a/tests/plugins/borders.test.ts
+++ b/tests/plugins/borders.test.ts
@@ -6,6 +6,8 @@ import {
   addRows,
   cut,
   deleteCells,
+  deleteColumns,
+  deleteRows,
   paste,
   selectCell,
   setAnchorCorner,
@@ -441,6 +443,20 @@ describe("Grid manipulation", () => {
     expect(getBorder(model, "B3")).toEqual({ top: b, left: b, right: b, bottom: b });
     expect(getBorder(model, "C2")).toBeNull();
     expect(getBorder(model, "B4")).toEqual({ top: b });
+  });
+
+  test("Remove multiple headers before the borders", () => {
+    setBorder(model, "external", "C3");
+    deleteRows(model, [0, 1]);
+    expect(getBorder(model, "B1")).toEqual({ right: b });
+    expect(getBorder(model, "C1")).toEqual({ top: b, left: b, right: b, bottom: b });
+    expect(getBorder(model, "D1")).toEqual({ left: b });
+    expect(getBorder(model, "C2")).toEqual({ top: b });
+
+    deleteColumns(model, ["A", "B"]);
+    expect(getBorder(model, "A1")).toEqual({ top: b, left: b, right: b, bottom: b });
+    expect(getBorder(model, "B1")).toEqual({ left: b });
+    expect(getBorder(model, "A2")).toEqual({ top: b });
   });
 
   test("Borders are correctly duplicated on sheet dup", () => {


### PR DESCRIPTION
## Description

When removing multiple headers, the borders are not shifted correctly, leading to incorrect borders.

This happens because we modify the borders for each deleted rows separately. But we don't sort the rows before modifying the borders. So we first delete the row 1, then the row 2. But the row 2 is now the row 1, since the old row 1 has been deleted. So we end up with wrong operations.

This is solved by simply sorting the rows in reverse order before modifying the borders.

Task: : [3884112](https://www.odoo.com/web#id=3884112&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo