### PR TITLE
[FIX] table: update table style on `DELETE_CONTENT`

### DIFF
--- a/src/plugins/core/tables.ts
+++ b/src/plugins/core/tables.ts
@@ -169,10 +169,9 @@ export class TablePlugin extends CorePlugin<TableState> implements TableState {
         for (const tableId in tables) {
           const table = tables[tableId];
           if (table && cmd.target.some((zone) => isZoneInside(table.range.zone, zone))) {
-            delete tables[tableId];
+            this.dispatch("REMOVE_TABLE", { sheetId: cmd.sheetId, target: [table.range.zone] });
           }
         }
-        this.history.update("tables", cmd.sheetId, tables);
         break;
       }
     }

--- a/tests/table/table_style_plugin.test.ts
+++ b/tests/table/table_style_plugin.test.ts
@@ -4,6 +4,7 @@ import { TABLE_PRESETS } from "../../src/helpers/table_presets";
 import { Style, UID } from "../../src/types";
 import {
   createTable,
+  deleteContent,
   deleteTable,
   foldHeaderGroup,
   groupRows,
@@ -20,6 +21,7 @@ import {
   updateFilter,
   updateTableConfig,
 } from "../test_helpers/commands_helpers";
+import { getTable } from "../test_helpers/getters_helpers";
 import { toCellPosition } from "../test_helpers/helpers";
 
 let model: Model;
@@ -169,6 +171,15 @@ describe("Table style", () => {
           expect(tableBorder).toEqual(expected);
         }
       }
+    });
+
+    test("Cell style is updated when a table is deleted with DELETE_CONTENT", () => {
+      createTable(model, "A1:B4");
+      expect(getCellStyle("A1")).not.toEqual({});
+
+      deleteContent(model, ["A1:B4"]);
+      expect(getTable(model, "A1")).toBeUndefined();
+      expect(getCellStyle("A1")).toEqual({});
     });
   });
 


### PR DESCRIPTION
## Description

The computed cell style wasn't updated when an empty table was deleted by a `DELETE_CONTENT` command. This was because `invalidateTableStyleCommandsSet` don't includes `DELETE_CONTENT`.

Rather than adding DELETE_CONTENT to `invalidateTableStyleCommandsSet`, this commit fix the issue by dispatching a `REMOVE_TABLE` command when a table is deleted because of `DELETE_CONTENT`. This ensure that all plugin can correctly react to the deletion of a table.

Task: : [3884466](https://www.odoo.com/web#id=3884466&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo