### PR TITLE
[FIX] pivot: support Reference fields in pivot side panel

### DIFF
--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -30,6 +30,7 @@ const AGGREGATORS_BY_FIELD_TYPE = {
   boolean: ["count_distinct", "count", "bool_and", "bool_or"],
   char: ["count_distinct", "count"],
   many2one: ["count_distinct", "count"],
+  reference: ["count_distinct", "count"],
 };
 
 export const AGGREGATORS = {};


### PR DESCRIPTION
Steps to reproduce the issue on a fresh runbot database:
- open the Subscription dashboard in edit mode
- Right click on cell "Data!B7" => boom

The pivot `#11` measure is `order_reference` which is a Reference field. This type of field had no aggregator specified which crashes the side panel.

Note: UI test added in the Enterprise branch.

Task: 3869693

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo