### PR TITLE
[IMP] table: add button to edit custom style

### DIFF
--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
@@ -7,24 +7,13 @@ import {
   TableStyle,
   TableStyleTemplateName,
 } from "../../../types";
-import { ColorPickerWidget } from "../../color_picker/color_picker_widget";
 import { css, cssPropertiesToCss } from "../../helpers";
 import { TableStylePreview } from "../../tables/table_style_preview/table_style_preview";
+import { RoundColorPicker } from "../components/round_color_picker/round_color_picker";
 import { Section } from "../components/section/section";
 
 css/* scss */ `
   .o-table-style-editor-panel {
-    .o-color-preview {
-      width: 30px;
-      height: 15px;
-      margin-left: 2px;
-      outline: 1px solid #3d85c6;
-      outline-offset: 1px;
-      margin-right: 10px;
-
-      cursor: pointer;
-    }
-
     .o-table-style-list-item {
       margin: 1px 3px;
       padding: 3px 6px;
@@ -55,7 +44,7 @@ export class TableStyleEditorPanel extends Component<
   SpreadsheetChildEnv
 > {
   static template = "o-spreadsheet-TableStyleEditorPanel";
-  static components = { Section, ColorPickerWidget, TableStylePreview };
+  static components = { Section, RoundColorPicker, TableStylePreview };
   static props = {
     onCloseSidePanel: Function,
     onStylePicked: { type: Function, optional: true },

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.ts
@@ -23,6 +23,11 @@ css/* scss */ `
         height: 61px;
       }
     }
+
+    .o-sidePanelButtons .o-delete:hover:enabled {
+      color: #ffffff;
+      background: #d94b4b;
+    }
   }
 `;
 
@@ -95,6 +100,14 @@ export class TableStyleEditorPanel extends Component<
   }
 
   onCancel() {
+    this.props.onCloseSidePanel();
+  }
+
+  onDelete() {
+    if (!this.props.styleId) {
+      return;
+    }
+    this.env.model.dispatch("REMOVE_TABLE_STYLE", { tableStyleId: this.props.styleId });
     this.props.onCloseSidePanel();
   }
 

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
@@ -8,19 +8,8 @@
       <Section class="'pt-1'">
         <t t-set-slot="title">Style color</t>
         <div class="d-flex align-items-center">
-          <div
-            class="o-color-preview"
-            t-att-style="colorPreviewStyle"
-            t-on-click.stop="togglePicker"
-          />
-          <span class="pe-1">Primary table style color</span>
-          <ColorPickerWidget
-            currentColor="state.primaryColor"
-            showColorPicker="state.pickerOpened"
-            toggleColorPicker.bind="togglePicker"
-            onColorPicked.bind="onColorPicked"
-            icon="'o-spreadsheet-Icon.FILL_COLOR'"
-          />
+          <span class="pe-2">Primary table style color</span>
+          <RoundColorPicker currentColor="state.primaryColor" onColorPicked.bind="onColorPicked"/>
         </div>
       </Section>
       <Section class="'pt-1'">

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
@@ -26,8 +26,16 @@
           </t>
         </div>
         <div class="o-sidePanelButtons">
-          <button t-on-click="onCancel" class="o-cancel o-button">Cancel</button>
-          <button t-on-click="onConfirm" class="o-confirm o-button">Confirm</button>
+          <button
+            t-if="props.styleId"
+            t-on-click="onDelete"
+            class="o-delete o-button o-button-grey danger">
+            Delete
+          </button>
+          <button t-on-click="onCancel" class="o-cancel o-button o-button-grey">Cancel</button>
+          <button t-on-click="onConfirm" class="o-confirm o-button o-button-grey primary">
+            Confirm
+          </button>
         </div>
       </Section>
     </div>

--- a/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
+++ b/src/components/side_panel/table_style_editor_panel/table_style_editor_panel.xml
@@ -15,20 +15,15 @@
       <Section class="'pt-1'">
         <t t-set-slot="title">Style template</t>
         <div class="d-flex flex-wrap">
-          <div
-            class="o-table-style-list-item"
-            t-foreach="tableTemplates"
-            t-as="templateName"
-            t-key="templateName"
-            t-att-class="{ 'selected': templateName === state.selectedTemplateName }"
-            t-on-click="() => this.onTemplatePicked(templateName)">
-            <div class="o-table-style-edit-template-preview">
-              <TableStylePreview
-                tableConfig="previewTableConfig"
-                tableStyle="computeTableStyle(templateName)"
-              />
-            </div>
-          </div>
+          <t t-foreach="tableTemplates" t-as="templateName" t-key="templateName">
+            <TableStylePreview
+              class="'o-table-style-edit-template-preview'"
+              selected="templateName === state.selectedTemplateName"
+              tableConfig="previewTableConfig"
+              tableStyle="computeTableStyle(templateName)"
+              onClick="() => this.onTemplatePicked(templateName)"
+            />
+          </t>
         </div>
         <div class="o-sidePanelButtons">
           <button t-on-click="onCancel" class="o-cancel o-button">Cancel</button>

--- a/src/components/tables/table_style_picker/table_style_picker.ts
+++ b/src/components/tables/table_style_picker/table_style_picker.ts
@@ -1,9 +1,7 @@
 import { Component, useState } from "@odoo/owl";
-import { createTableStyleContextMenuActions } from "../../../registries/menus/table_style_menu_registry";
 import { SpreadsheetChildEnv } from "../../../types";
 import { Table } from "../../../types/table";
 import { css } from "../../helpers";
-import { Menu, MenuState } from "../../menu/menu";
 import { PopoverProps } from "../../popover/popover";
 import { TableStylePreview } from "../table_style_preview/table_style_preview";
 import {
@@ -48,11 +46,10 @@ css/* scss */ `
 
 export class TableStylePicker extends Component<TableStylePickerProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TableStylePicker";
-  static components = { TableStylesPopover, TableStylePreview, Menu };
+  static components = { TableStylesPopover, TableStylePreview };
   static props = { table: Object };
 
   state = useState<TableStylePickerState>({ popoverProps: undefined });
-  menu: MenuState = useState({ isOpen: false, position: null, menuItems: [] });
 
   getDisplayedTableStyles() {
     const allStyles = this.env.model.getters.getTableStyles();
@@ -95,21 +92,5 @@ export class TableStylePicker extends Component<TableStylePickerProps, Spreadshe
 
   private closePopover() {
     this.state.popoverProps = undefined;
-  }
-
-  getStyleName(styleId: string): string {
-    return this.env.model.getters.getTableStyle(styleId).displayName;
-  }
-
-  onContextMenu(event: MouseEvent, styleId: string) {
-    this.menu.menuItems = createTableStyleContextMenuActions(this.env, styleId);
-    this.menu.isOpen = true;
-    this.menu.position = { x: event.clientX, y: event.clientY };
-  }
-
-  closeMenu() {
-    this.menu.isOpen = false;
-    this.menu.position = null;
-    this.menu.menuItems = [];
   }
 }

--- a/src/components/tables/table_style_picker/table_style_picker.xml
+++ b/src/components/tables/table_style_picker/table_style_picker.xml
@@ -2,23 +2,16 @@
   <t t-name="o-spreadsheet-TableStylePicker">
     <div class="o-table-style-picker d-flex flew-row justify-content-between ps-1">
       <div class="d-flex flex-row overflow-hidden">
-        <div
-          class="o-table-style-list-item"
-          t-att-class="{ 'selected': styleId === props.table.config.styleId }"
-          t-foreach="getDisplayedTableStyles()"
-          t-as="styleId"
-          t-key="styleId"
-          t-att-title="getStyleName(styleId)"
-          t-att-data-id="styleId"
-          t-on-click="() => this.onStylePicked(styleId)"
-          t-on-contextmenu.prevent="(ev) => this.onContextMenu(ev, styleId)">
-          <div class="o-table-style-picker-preview">
-            <TableStylePreview
-              tableConfig="props.table.config"
-              tableStyle="env.model.getters.getTableStyle(styleId)"
-            />
-          </div>
-        </div>
+        <t t-foreach="getDisplayedTableStyles()" t-as="styleId" t-key="styleId">
+          <TableStylePreview
+            class="'o-table-style-picker-preview'"
+            selected="styleId === props.table.config.styleId"
+            tableConfig="props.table.config"
+            tableStyle="env.model.getters.getTableStyle(styleId)"
+            styleId="styleId"
+            onClick="() => this.onStylePicked(styleId)"
+          />
+        </t>
       </div>
       <div
         class="o-table-style-picker-arrow d-flex align-items-center px-1"
@@ -32,12 +25,6 @@
       onStylePicked.bind="onStylePicked"
       popoverProps="state.popoverProps"
       closePopover.bind="closePopover"
-    />
-    <Menu
-      t-if="menu.isOpen"
-      menuItems="menu.menuItems"
-      position="menu.position"
-      onClose.bind="this.closeMenu"
     />
   </t>
 </templates>

--- a/src/components/tables/table_style_preview/table_style_preview.ts
+++ b/src/components/tables/table_style_preview/table_style_preview.ts
@@ -27,6 +27,20 @@ css/* scss */ `
 
     &:hover {
       background: #ddd;
+      .o-table-style-edit-button {
+        display: block !important;
+        right: 0;
+        top: 0;
+        background: #fff;
+        cursor: pointer;
+        border: 1px solid #ddd;
+        padding: 1px 1px 1px 2px;
+        .o-icon {
+          font-size: 12px;
+          width: 12px;
+          height: 12px;
+        }
+      }
     }
   }
 `;
@@ -87,5 +101,16 @@ export class TableStylePreview extends Component<Props, SpreadsheetChildEnv> {
       return "";
     }
     return this.env.model.getters.getTableStyle(this.props.styleId).displayName;
+  }
+
+  get isStyleEditable(): boolean {
+    if (!this.props.styleId) {
+      return false;
+    }
+    return this.env.model.getters.isTableStyleEditable(this.props.styleId);
+  }
+
+  editTableStyle() {
+    this.env.openSidePanel("TableStyleEditorPanel", { styleId: this.props.styleId });
   }
 }

--- a/src/components/tables/table_style_preview/table_style_preview.xml
+++ b/src/components/tables/table_style_preview/table_style_preview.xml
@@ -1,5 +1,21 @@
 <templates>
   <t t-name="o-spreadsheet-TableStylePreview">
-    <canvas t-ref="canvas" class="w-100 h-100"/>
+    <div
+      class="o-table-style-list-item"
+      t-att-class="{ 'selected': props.selected }"
+      t-att-data-id="props.styleId"
+      t-att-title="styleName"
+      t-on-click="props.onClick"
+      t-on-contextmenu.prevent="(ev) => this.onContextMenu(ev)">
+      <div t-att-class="props.class">
+        <canvas t-ref="canvas" class="w-100 h-100"/>
+      </div>
+    </div>
+    <Menu
+      t-if="menu.isOpen"
+      menuItems="menu.menuItems"
+      position="menu.position"
+      onClose.bind="this.closeMenu"
+    />
   </t>
 </templates>

--- a/src/components/tables/table_style_preview/table_style_preview.xml
+++ b/src/components/tables/table_style_preview/table_style_preview.xml
@@ -1,7 +1,7 @@
 <templates>
   <t t-name="o-spreadsheet-TableStylePreview">
     <div
-      class="o-table-style-list-item"
+      class="o-table-style-list-item position-relative"
       t-att-class="{ 'selected': props.selected }"
       t-att-data-id="props.styleId"
       t-att-title="styleName"
@@ -9,6 +9,13 @@
       t-on-contextmenu.prevent="(ev) => this.onContextMenu(ev)">
       <div t-att-class="props.class">
         <canvas t-ref="canvas" class="w-100 h-100"/>
+      </div>
+      <div
+        class="o-table-style-edit-button position-absolute d-none"
+        t-if="isStyleEditable"
+        t-on-click="this.editTableStyle"
+        title="Edit custom table style">
+        <t t-call="o-spreadsheet-Icon.EDIT"/>
       </div>
     </div>
     <Menu

--- a/src/components/tables/table_styles_popover/table_styles_popover.ts
+++ b/src/components/tables/table_styles_popover/table_styles_popover.ts
@@ -1,11 +1,10 @@
 import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
 import { TABLE_STYLE_CATEGORIES } from "../../../helpers/table_presets";
-import { createTableStyleContextMenuActions } from "../../../registries/menus/table_style_menu_registry";
 import { SpreadsheetChildEnv } from "../../../types";
 import { TableConfig } from "../../../types/table";
 import { css } from "../../helpers";
 import { isChildEvent } from "../../helpers/dom_helpers";
-import { Menu, MenuState } from "../../menu/menu";
+import { MenuState } from "../../menu/menu";
 import { Popover, PopoverProps } from "../../popover/popover";
 import { TableStylePreview } from "../table_style_preview/table_style_preview";
 
@@ -46,18 +45,6 @@ css/* scss */ `
       }
     }
   }
-
-  .o-table-style-list-item {
-    border: 1px solid transparent;
-    &.selected {
-      border: 1px solid #007eff;
-      background: #f5f5f5;
-    }
-
-    &:hover {
-      background: #ddd;
-    }
-  }
 `;
 
 export type CustomTablePopoverMouseEvent = MouseEvent & { hasClosedTableStylesPopover?: boolean };
@@ -68,7 +55,7 @@ export interface State {
 
 export class TableStylesPopover extends Component<TableStylesPopoverProps, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-TableStylesPopover";
-  static components = { Popover, TableStylePreview, Menu };
+  static components = { Popover, TableStylePreview };
   static props = {
     tableConfig: Object,
     popoverProps: { type: Object, optional: true },
@@ -107,26 +94,10 @@ export class TableStylesPopover extends Component<TableStylesPopoverProps, Sprea
       : "medium";
   }
 
-  getStyleName(styleId: string): string {
-    return this.env.model.getters.getTableStyle(styleId).displayName;
-  }
-
   newTableStyle() {
     this.props.closePopover();
     this.env.openSidePanel("TableStyleEditorPanel", {
       onStylePicked: this.props.onStylePicked,
     });
-  }
-
-  onContextMenu(event: MouseEvent, styleId: string) {
-    this.menu.menuItems = createTableStyleContextMenuActions(this.env, styleId);
-    this.menu.isOpen = true;
-    this.menu.position = { x: event.clientX, y: event.clientY };
-  }
-
-  closeMenu() {
-    this.menu.isOpen = false;
-    this.menu.position = null;
-    this.menu.menuItems = [];
   }
 }

--- a/src/components/tables/table_styles_popover/table_styles_popover.xml
+++ b/src/components/tables/table_styles_popover/table_styles_popover.xml
@@ -28,22 +28,16 @@
         </div>
         <hr class="hr my-2"/>
         <div class="d-flex flex-wrap">
-          <div
-            class="o-table-style-list-item"
-            t-att-class="{ 'selected': styleId === props.selectedStyleId }"
-            t-foreach="displayedStyles"
-            t-as="styleId"
-            t-key="styleId"
-            t-att-title="getStyleName(styleId)"
-            t-on-click="() => this.props.onStylePicked(styleId)"
-            t-on-contextmenu.prevent="(ev) => this.onContextMenu(ev, styleId)">
-            <div class="o-table-style-popover-preview">
-              <TableStylePreview
-                tableConfig="props.tableConfig"
-                tableStyle="env.model.getters.getTableStyle(styleId)"
-              />
-            </div>
-          </div>
+          <t t-foreach="displayedStyles" t-as="styleId" t-key="styleId">
+            <TableStylePreview
+              class="'o-table-style-popover-preview'"
+              styleId="styleId"
+              selected="styleId === props.selectedStyleId"
+              tableConfig="props.tableConfig"
+              tableStyle="env.model.getters.getTableStyle(styleId)"
+              onClick="() => this.props.onStylePicked(styleId)"
+            />
+          </t>
           <div
             t-if="state.selectedCategory === 'custom'"
             class="o-new-table-style o-table-style-list-item o-table-style-popover-preview d-flex justify-content-center align-items-center"
@@ -52,12 +46,6 @@
           </div>
         </div>
       </div>
-      <Menu
-        t-if="menu.isOpen"
-        menuItems="menu.menuItems"
-        position="menu.position"
-        onClose.bind="this.closeMenu"
-      />
     </Popover>
   </t>
 </templates>

--- a/src/registries/menus/table_style_menu_registry.ts
+++ b/src/registries/menus/table_style_menu_registry.ts
@@ -14,13 +14,13 @@ export function createTableStyleContextMenuActions(
       id: "editTableStyle",
       name: _t("Edit table style"),
       execute: (env) => env.openSidePanel("TableStyleEditorPanel", { styleId }),
-      icon: "o-spreadsheet-Icon.EDIT_TABLE",
+      icon: "o-spreadsheet-Icon.EDIT",
     },
     {
       id: "deleteTableStyle",
       name: _t("Delete table style"),
       execute: (env) => env.model.dispatch("REMOVE_TABLE_STYLE", { tableStyleId: styleId }),
-      icon: "o-spreadsheet-Icon.DELETE_TABLE",
+      icon: "o-spreadsheet-Icon.TRASH",
     },
   ]);
 }

--- a/tests/table/table_style_editor_panel_component.test.ts
+++ b/tests/table/table_style_editor_panel_component.test.ts
@@ -60,7 +60,7 @@ describe("Table style editor panel", () => {
 
   test("Can change the style primary color", async () => {
     await mountPanel();
-    await click(fixture, ".o-color-picker-button");
+    await click(fixture, ".o-round-color-picker-button");
     await click(fixture, 'div[data-color="#FF9900"]');
     click(fixture, ".o-sidePanel .o-confirm");
     expect(getTableStyleFromName("Custom Table Style")).toMatchObject(

--- a/tests/table/table_style_editor_panel_component.test.ts
+++ b/tests/table/table_style_editor_panel_component.test.ts
@@ -86,4 +86,18 @@ describe("Table style editor panel", () => {
     await click(fixture, ".o-sidePanel .o-confirm");
     expect(onStylePicked).toBeCalledWith(getTableStyleIdFromName("Custom Table Style"));
   });
+
+  test("Can delete table style from the panel", async () => {
+    createTableStyle(model, "Custom Table Style");
+    expect(getTableStyleFromName("Custom Table Style")).not.toBeUndefined();
+
+    await mountPanel({ styleId: "Custom Table Style" });
+    click(fixture, ".o-sidePanel .o-delete");
+    expect(getTableStyleFromName("Custom Table Style")).toBeUndefined();
+  });
+
+  test("Delete button is not present when creating a new table style", async () => {
+    await mountPanel();
+    expect(fixture.querySelector(".o-sidePanel .o-delete")).toBeNull();
+  });
 });

--- a/tests/table/table_styles_popover_component.test.ts
+++ b/tests/table/table_styles_popover_component.test.ts
@@ -92,6 +92,11 @@ describe("Table style editor panel", () => {
       await click(fixture, ".form-check-input[value='custom']");
     });
 
+    test("Can edit a custom table style with the top-right hover button", async () => {
+      click(fixture, ".o-table-style-edit-button");
+      expect(openSidePanel).toHaveBeenCalledWith("TableStyleEditorPanel", { styleId: "MyStyle" });
+    });
+
     test("Can edit a custom table style with the context menu", async () => {
       triggerMouseEvent('.o-table-style-list-item[title="MyStyle"]', "contextmenu");
       await nextTick();


### PR DESCRIPTION
## Description:

## [IMP] tables: RoundColorPicker in table style editor

Replace the custom color picker with the `RoundColorPicker` in the
side panel to edit a custom table style.

Task: 3890174

## [REF] tables: factorize table preview xml

Every time we used the `TableStylePreview` component, we did the same
kind of loop around it, with the same callbacks. This commit factorizes
this code inside the `TablePreview` component.

Task: 3890174

## [IMP] table: add button to edit custom style

This commit adds a button on hover on the table style preview to edit
a custom table style. The functionality was previously hidden in
a context menu, that the user couldn't know existed if he didn't
try right-clicking on the table style preview or had previous experience
on Excel.

Task: 3890174

Task: : [3890174](https://www.odoo.com/web#id=3890174&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo