### PR TITLE
[FIX] Export xlsx: export value for non-exportable formulas

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -301,8 +301,8 @@ export class EvaluationPlugin extends UIPlugin {
       const format = newFormat
         ? getItemId<Format>(newFormat, data.formats)
         : exportedCellData.format;
-      let content;
-      if (formulaCell instanceof FormulaCellWithDependencies) {
+      let content: string | undefined;
+      if (isExported && formulaCell instanceof FormulaCellWithDependencies) {
         content = this.getters.buildFormulaContent(
           exportedSheetData.id,
           formulaCell,

--- a/tests/xlsx_export.test.ts
+++ b/tests/xlsx_export.test.ts
@@ -1,4 +1,4 @@
-import { functionRegistry } from "../src/functions";
+import { arg, functionRegistry } from "../src/functions";
 import { buildSheetLink, toXC } from "../src/helpers";
 import { createEmptyExcelWorkbookData } from "../src/migrations/data";
 import { Model } from "../src/model";
@@ -733,7 +733,7 @@ describe("Test XLSX export", () => {
 
       functionRegistry.add("NON.EXPORTABLE", {
         description: "a non exportable formula",
-        args: [],
+        args: [arg('range (any, range<any>, ,default="asdf")', "")],
         returns: ["NUMBER"],
         compute: function (): number {
           return 42;
@@ -745,10 +745,12 @@ describe("Test XLSX export", () => {
       });
 
       setCellContent(model, "A1", "=1+NON.EXPORTABLE()");
+      setCellContent(model, "A2", "=1+NON.EXPORTABLE(A1)");
 
       const exported = getExportedExcelData(model);
 
       expect(exported.sheets[0].cells["A1"]?.content).toEqual("43");
+      expect(exported.sheets[0].cells["A2"]?.content).toEqual("43");
       const formatId = exported.sheets[0].cells["A1"]?.format;
       expect(formatId).toEqual(1);
       expect(exported.formats[formatId!]).toEqual("0.00%");


### PR DESCRIPTION
The recent fix in https://github.com/odoo/o-spreadsheet/pull/3622 combined with a slight refactoring of the export for Excel in https://github.com/odoo/o-spreadsheet/pull/2090 let to a situation where cells with non-exportable formulas containing references did not have their content replaced by the evaluated result.

Task: 3895465

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo