### PR TITLE
[IMP] clipboard: improve cut formula behaviour

### DIFF
--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -238,15 +238,17 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
       return;
     }
 
-    const content =
-      origin.cell && origin.cell.isFormula && !clipboardOption?.isCutOperation
-        ? this.getters.getTranslatedCellFormula(
-            sheetId,
-            col - origin.position.col,
-            row - origin.position.row,
-            origin.cell.compiledFormula
-          )
-        : origin.cell?.content;
+    let content = origin.cell?.content;
+    if (origin.cell?.isFormula && !clipboardOption?.isCutOperation) {
+      content = this.getters.getTranslatedCellFormula(
+        sheetId,
+        col - origin.position.col,
+        row - origin.position.row,
+        origin.cell.compiledFormula
+      );
+    } else if (origin.cell?.isFormula) {
+      content = this.getters.getFormulaMovedInSheet(sheetId, origin.cell.compiledFormula);
+    }
     if (content !== "" || origin.cell?.format || origin.cell?.style) {
       this.dispatch("UPDATE_CELL", {
         ...target,

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -178,7 +178,8 @@ export class RangeImpl implements Range {
           : this.parts.map((part) => {
               return { rowFixed: part.rowFixed, colFixed: part.colFixed };
             }),
-        prefixSheet: rangeParams?.prefixSheet ? rangeParams.prefixSheet : this.prefixSheet,
+        prefixSheet:
+          rangeParams?.prefixSheet !== undefined ? rangeParams.prefixSheet : this.prefixSheet,
       },
       this.getSheetSize
     );

--- a/src/model.ts
+++ b/src/model.ts
@@ -223,6 +223,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     this.coreGetters.isRangeValid = this.range.isRangeValid.bind(this.range);
     this.coreGetters.extendRange = this.range.extendRange.bind(this.range);
     this.coreGetters.getRangesUnion = this.range.getRangesUnion.bind(this.range);
+    this.coreGetters.removeRangesSheetPrefix = this.range.removeRangesSheetPrefix.bind(this.range);
 
     this.getters = {
       isReadonly: () => this.config.mode === "readonly" || this.config.mode === "dashboard",

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -62,6 +62,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     "getTranslatedCellFormula",
     "getCellStyle",
     "getCellById",
+    "getFormulaMovedInSheet",
   ] as const;
   readonly nextId = 1;
   public readonly cells: { [sheetId: string]: { [id: string]: Cell } } = {};
@@ -371,6 +372,12 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       sheetId
     );
     return this.getFormulaCellContent(sheetId, compiledFormula, adaptedDependencies);
+  }
+
+  getFormulaMovedInSheet(targetSheetId: UID, compiledFormula: RangeCompiledFormula) {
+    const dependencies = compiledFormula.dependencies;
+    const adaptedDependencies = this.getters.removeRangesSheetPrefix(targetSheetId, dependencies);
+    return this.getFormulaCellContent(targetSheetId, compiledFormula, adaptedDependencies);
   }
 
   getCellStyle(position: CellPosition): Style {

--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -52,6 +52,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
     "getRangesUnion",
     "recomputeRanges",
     "isRangeValid",
+    "removeRangesSheetPrefix",
   ] as const;
 
   // ---------------------------------------------------------------------------
@@ -289,6 +290,19 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
             ((range.parts[1] || range.parts[0]).rowFixed ? 0 : offsetY),
       };
       return range.clone({ sheetId: copySheetId, zone: unboundZone }).orderZone();
+    });
+  }
+
+  /**
+   * Remove the sheet name prefix if a range is part of the given sheet.
+   */
+  removeRangesSheetPrefix(sheetId: UID, ranges: Range[]): Range[] {
+    return ranges.map((range) => {
+      const rangeImpl = RangeImpl.fromRange(range, this.getters);
+      if (rangeImpl.prefixSheet && rangeImpl.sheetId === sheetId) {
+        return rangeImpl.clone({ prefixSheet: false });
+      }
+      return rangeImpl;
     });
   }
 

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -1371,6 +1371,19 @@ describe("clipboard", () => {
     expect(getCellText(model, "B2")).toBe("=SUM(C1:C2)");
   });
 
+  test("cut/paste a formula with references in another sheet updates the sheet references in the formula", () => {
+    const model = new Model();
+    createSheet(model, { sheetId: "sh2", name: "Sheet2" });
+    setCellContent(model, "A1", "=SUM(C1:C2)");
+    setCellContent(model, "B1", "=Sheet2!A1 + A2");
+    cut(model, "A1:B1");
+
+    activateSheet(model, "sh2");
+    paste(model, "A1");
+    expect(getCellText(model, "A1")).toBe("=SUM(Sheet1!C1:C2)");
+    expect(getCellText(model, "B1")).toBe("=A1 + Sheet1!A2");
+  });
+
   test("copy/paste a zone present in formulas references does not update references", () => {
     const model = new Model();
     setCellContent(model, "A1", "=B2");


### PR DESCRIPTION
## Description

Previously, when cutting a formula `=A1` in sheet1, and pasting it in sheet2, the pasted formula would refer to `A1` in sheet2. The more correct behaviour is to refer to `A1` in sheet1, transforming the pasted formula to `=Sheet1!A1`.

Also when cutting a formula `=Sheet2!A1` from sheet1 tp sheet2, we can drop the prefix `Sheet2!` and only paste `=A1` in sheet2.

Task: : [3898438](https://www.odoo.com/web#id=3898438&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo