### PR TITLE
[FIX] clipboard: wrong clipboard invalidation

### DIFF
--- a/src/plugins/ui/clipboard.ts
+++ b/src/plugins/ui/clipboard.ts
@@ -127,7 +127,7 @@ export class ClipboardPlugin extends UIPlugin {
         this.status = "invisible";
 
         // If we add a col/row inside or before the cut area, we invalidate the clipboard
-        if (this.state?.operation !== "CUT") {
+        if (this.state?.operation !== "CUT" || cmd.sheetId !== this.state?.sheetId) {
           return;
         }
         const isClipboardDirty = this.isColRowDirtyingClipboard(
@@ -143,7 +143,7 @@ export class ClipboardPlugin extends UIPlugin {
         this.status = "invisible";
 
         // If we remove a col/row inside or before the cut area, we invalidate the clipboard
-        if (this.state?.operation !== "CUT") {
+        if (this.state?.operation !== "CUT" || cmd.sheetId !== this.state?.sheetId) {
           return;
         }
         for (let el of cmd.elements) {

--- a/tests/plugins/clipboard.test.ts
+++ b/tests/plugins/clipboard.test.ts
@@ -1598,6 +1598,20 @@ describe("clipboard: pasting outside of sheet", () => {
       expect(getCellContent(model, "C1")).toBe("");
       expect(getCellContent(model, "C3")).toBe("");
     });
+
+    test("Adding rows in another sheet does not invalidate the clipboard", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "1");
+      setCellContent(model, "A2", "2");
+      model.dispatch("CUT", { target: target("A1:A2") });
+
+      createSheet(model, { activate: true });
+      addRows(model, "after", 0, 5);
+
+      model.dispatch("PASTE", { target: target("A1") });
+      expect(getCellContent(model, "A1")).toBe("1");
+      expect(getCellContent(model, "A2")).toBe("2");
+    });
   });
 
   describe("remove col/row can invalidate the clipboard of cut", () => {
@@ -1679,6 +1693,20 @@ describe("clipboard: pasting outside of sheet", () => {
       model.dispatch("PASTE", { target: [toZone("D1")] });
       expect(getCellContent(model, "B2")).toBe("1");
       expect(getCellContent(model, "D1")).toBe("");
+    });
+
+    test("Removing rows in another sheet does not invalidate the clipboard", () => {
+      const model = new Model();
+      setCellContent(model, "A1", "1");
+      setCellContent(model, "A2", "2");
+      model.dispatch("CUT", { target: target("A1:A2") });
+
+      createSheet(model, { activate: true });
+      deleteRows(model, [1]);
+
+      model.dispatch("PASTE", { target: target("A1") });
+      expect(getCellContent(model, "A1")).toBe("1");
+      expect(getCellContent(model, "A2")).toBe("2");
     });
   });
 });


### PR DESCRIPTION
## Description

The CUT clipboard should be invalidated when inserting rows inside of the CUT zone.

But we didn't check the sheet where the rows are
inserted, so the clipboard was invalidating when inserting rows inside another sheet.

Task: : [3901961](https://www.odoo.com/web#id=3901961&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo