### PR TITLE
[FIX] chartjs: remove forced hover dot size

### DIFF
--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -174,14 +174,6 @@ export function createScatterChartRuntime(
   chartJsConfig.type = "line";
 
   const configOptions = chartJsConfig.options!;
-  configOptions.elements = {
-    point: {
-      radius: 3,
-      hoverRadius: 3, // chartJS seems bugged, the point starts with the "hoverRadius" value
-      hitRadius: 8,
-    },
-  };
-
   const locale = getters.getLocale();
 
   configOptions.plugins!.tooltip!.callbacks!.title = () => "";


### PR DESCRIPTION
## Description

Because of a wrong configuration of ChartJs, we had to force the size of hovered chart points to be the same as the default size.

Since the chartJs config was fixed in 14ef3a65, it's no longer needed.

Task: : [3869065](https://www.odoo.com/web#id=3869065&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo