### PR TITLE
[IMP] clipboard: paste conditional format, data validation & merge content when original content is deleted

### DIFF
--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -93,7 +93,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
     content: ClipboardContent,
     clipboardOptions: ClipboardOptions
   ): CommandResult {
-    if (!("cells" in content)) {
+    if (!content.cells) {
       return CommandResult.Success;
     }
     if (clipboardOptions?.isCutOperation && clipboardOptions?.pasteOption !== undefined) {
@@ -105,6 +105,19 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
       // zones selected
       if (content.cells.length > 1 || content.cells[0].length > 1) {
         return CommandResult.WrongPasteSelection;
+      }
+    }
+    const clipboardHeight = content.cells.length;
+    const clipboardWidth = content.cells[0].length;
+    for (const zone of getPasteZones(target, content.cells)) {
+      if (this.getters.doesIntersectMerge(sheetId, zone)) {
+        if (
+          target.length > 1 ||
+          !this.getters.isSingleCellOrMerge(sheetId, target[0]) ||
+          clipboardHeight * clipboardWidth !== 1
+        ) {
+          return CommandResult.WillRemoveExistingMerge;
+        }
       }
     }
     return CommandResult.Success;


### PR DESCRIPTION
### [IMP] clipboard: paste conditional format, data validation & merge content when original content is deleted

Problem
-----
Before this commit, when copy/pasting cells  with CF/DV/merge, if we delete the CF/DV/merge before pasting the cells, the paste content will not contain the previously copied content.

Solution
-----
This commit solves the issue by adding  new attributes cfRules, merges, dataValidationRules in the clipboard content and using the content saved in this key to re-create the features.

Task: [3870289](https://www.odoo.com/web#id=3870289&cids=1&menu_id=4722&action=333&active_id=2328&model=project.task&view_type=form)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo