### PR TITLE
[REM] merge: remove useless topLeft attribute from Merge interface

### DIFF
--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -254,11 +254,14 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
   }
 
   getMainCellPosition(position: CellPosition): CellPosition {
-    if (!this.isInMerge(position)) {
-      return position;
-    }
-    const mergeTopLeftPos = this.getMerge(position)!.topLeft;
-    return { sheetId: position.sheetId, col: mergeTopLeftPos.col, row: mergeTopLeftPos.row };
+    const mergeZone = this.getMerge(position);
+    return mergeZone
+      ? {
+          sheetId: position.sheetId,
+          col: mergeZone.left,
+          row: mergeZone.top,
+        }
+      : position;
   }
 
   isMergeHidden(sheetId: UID, merge: Merge): boolean {
@@ -539,7 +542,6 @@ function exportMerges(merges: Record<number, Range | undefined>): string[] {
 function rangeToMerge(mergeId: number, range: Range): Merge {
   return {
     ...range.zone,
-    topLeft: { col: range.zone.left, row: range.zone.top },
     id: mergeId,
   };
 }

--- a/src/plugins/ui_feature/autofill.ts
+++ b/src/plugins/ui_feature/autofill.ts
@@ -443,7 +443,7 @@ export class AutofillPlugin extends UIPlugin {
       }
     }
     const originMerge = this.getters.getMerge(originPosition);
-    if (originMerge?.topLeft.col === originCol && originMerge?.topLeft.row === originRow) {
+    if (originMerge?.left === originCol && originMerge?.top === originRow) {
       this.dispatch("ADD_MERGE", {
         sheetId,
         target: [

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -226,7 +226,6 @@ export interface PixelPosition {
 
 export interface Merge extends Zone {
   id: number;
-  topLeft: Position;
 }
 
 export interface Highlight {

--- a/tests/autofill/autofill_plugin.test.ts
+++ b/tests/autofill/autofill_plugin.test.ts
@@ -657,9 +657,9 @@ describe("Autofill", () => {
       XCToMergeCellMap(model, ["A1", "A2", "A4", "A5", "A7", "A8"])
     );
     expect(getMerges(model)).toEqual({
-      "1": { bottom: 1, id: 1, left: 0, right: 0, top: 0, topLeft: toCartesian("A1") },
-      "2": { bottom: 4, id: 2, left: 0, right: 0, top: 3, topLeft: toCartesian("A4") },
-      "3": { bottom: 7, id: 3, left: 0, right: 0, top: 6, topLeft: toCartesian("A7") },
+      "1": { bottom: 1, id: 1, left: 0, right: 0, top: 0 },
+      "2": { bottom: 4, id: 2, left: 0, right: 0, top: 3 },
+      "3": { bottom: 7, id: 3, left: 0, right: 0, top: 6 },
     });
     expect(getCellContent(model, "A1")).toBe("1");
     expect(getCellContent(model, "A4")).toBe("2");
@@ -672,8 +672,8 @@ describe("Autofill", () => {
     autofill("A1:A2", "A5");
     expect(getMergeCellMap(model)).toEqual(XCToMergeCellMap(model, ["A1", "A2", "A3", "A4"]));
     expect(getMerges(model)).toEqual({
-      "1": { bottom: 1, id: 1, left: 0, right: 0, top: 0, topLeft: toCartesian("A1") },
-      "2": { bottom: 3, id: 2, left: 0, right: 0, top: 2, topLeft: toCartesian("A3") },
+      "1": { bottom: 1, id: 1, left: 0, right: 0, top: 0 },
+      "2": { bottom: 3, id: 2, left: 0, right: 0, top: 2 },
     });
   });
 

--- a/tests/cells/merges_plugin.test.ts
+++ b/tests/cells/merges_plugin.test.ts
@@ -57,7 +57,7 @@ describe("merges", () => {
     expect(getCellContent(model, "B2", sheet1)).toBe("b2");
     expect(getMergeCellMap(model)).toEqual(XCToMergeCellMap(model, ["B2", "B3"]));
     expect(getMerges(model)).toEqual({
-      "1": { bottom: 2, id: 1, left: 1, right: 1, top: 1, topLeft: toCartesian("B2") },
+      "1": { bottom: 2, id: 1, left: 1, right: 1, top: 1 },
     });
   });
 
@@ -69,7 +69,7 @@ describe("merges", () => {
     });
     expect(getMergeCellMap(model)).toEqual(XCToMergeCellMap(model, ["B2", "B3"]));
     expect(getMerges(model)).toEqual({
-      "1": { bottom: 2, id: 1, left: 1, right: 1, top: 1, topLeft: toCartesian("B2") },
+      "1": { bottom: 2, id: 1, left: 1, right: 1, top: 1 },
     });
 
     selectCell(model, "B2");
@@ -90,8 +90,8 @@ describe("merges", () => {
     });
     merge(model, "B2:B3", secondSheetId);
     expect(model.getters.getMerges(secondSheetId)).toEqual([
-      { ...toZone("C2:C3"), id: 2, topLeft: toCartesian("C2") },
-      { ...toZone("B2:B3"), id: 3, topLeft: toCartesian("B2") },
+      { ...toZone("C2:C3"), id: 2 },
+      { ...toZone("B2:B3"), id: 3 },
     ]);
     expect(model.getters.getMerge({ sheetId: secondSheetId, col: 2, row: 1 })?.id).toBe(2);
     expect(model.getters.getMerge({ sheetId: secondSheetId, col: 1, row: 1 })?.id).toBe(3);
@@ -451,7 +451,7 @@ describe("merges", () => {
     });
   });
 
-  test("setting border to topleft => setting style => merging => unmerging", () => {
+  test("setting border to  => setting style => merging => unmerging", () => {
     const model = new Model();
     setZoneBorders(model, { position: "external" }, ["A1"]);
     setStyle(model, "A1", { fillColor: "red" });
@@ -507,7 +507,7 @@ describe("merges", () => {
 
     expect(getMergeCellMap(model)).toEqual(XCToMergeCellMap(model, ["B2", "B3"]));
     expect(getMerges(model)).toEqual({
-      "1": { bottom: 2, id: 1, left: 1, right: 1, top: 1, topLeft: toCartesian("B2") },
+      "1": { bottom: 2, id: 1, left: 1, right: 1, top: 1 },
     });
 
     // undo
@@ -519,7 +519,7 @@ describe("merges", () => {
     redo(model);
     expect(getMergeCellMap(model)).toEqual(XCToMergeCellMap(model, ["B2", "B3"]));
     expect(getMerges(model)).toEqual({
-      "2": { bottom: 2, id: 2, left: 1, right: 1, top: 1, topLeft: toCartesian("B2") },
+      "2": { bottom: 2, id: 2, left: 1, right: 1, top: 1 },
     });
   });
 
@@ -612,12 +612,8 @@ describe("merges", () => {
       sheetIdTo: secondSheetId,
     });
     addColumns(model, "before", "A", 1, "42");
-    expect(model.getters.getMerges(firstSheetId)).toEqual([
-      { ...toZone("C1:C2"), id: 1, topLeft: toCartesian("C1") },
-    ]);
-    expect(model.getters.getMerges(secondSheetId)).toEqual([
-      { ...toZone("D1:D2"), id: 2, topLeft: toCartesian("D1") },
-    ]);
+    expect(model.getters.getMerges(firstSheetId)).toEqual([{ ...toZone("C1:C2"), id: 1 }]);
+    expect(model.getters.getMerges(secondSheetId)).toEqual([{ ...toZone("D1:D2"), id: 2 }]);
   });
 
   describe("isSingleCellOrMerge getter", () => {

--- a/tests/collaborative/collaborative.test.ts
+++ b/tests/collaborative/collaborative.test.ts
@@ -1,7 +1,7 @@
 import { Model, UIPlugin } from "../../src";
 import { DEFAULT_REVISION_ID, MESSAGE_VERSION } from "../../src/constants";
 import { functionRegistry } from "../../src/functions";
-import { getDefaultCellHeight, range, toCartesian, toZone } from "../../src/helpers";
+import { getDefaultCellHeight, range, toZone } from "../../src/helpers";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
 import { featurePluginRegistry } from "../../src/plugins";
 import { Command, CommandResult, CoreCommand, DataValidationCriterion } from "../../src/types";
@@ -284,13 +284,13 @@ describe("Multi users synchronisation", () => {
 
     expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "B3"), undefined);
     expect(alice.getters.getMerges(sheetId)).toMatchObject([
-      { bottom: 2, left: 0, top: 0, right: 1, topLeft: toCartesian("A1") },
+      { bottom: 2, left: 0, top: 0, right: 1 },
     ]);
     expect(bob.getters.getMerges(sheetId)).toMatchObject([
-      { bottom: 2, left: 0, top: 0, right: 1, topLeft: toCartesian("A1") },
+      { bottom: 2, left: 0, top: 0, right: 1 },
     ]);
     expect(charlie.getters.getMerges(sheetId)).toMatchObject([
-      { bottom: 2, left: 0, top: 0, right: 1, topLeft: toCartesian("A1") },
+      { bottom: 2, left: 0, top: 0, right: 1 },
     ]);
     undo(bob);
     expect([alice, bob, charlie]).toHaveSynchronizedValue((user) => getCell(user, "B3"), undefined);
@@ -364,10 +364,6 @@ describe("Multi users synchronisation", () => {
         {
           ...toZone("A80:A98"),
           id: 1,
-          topLeft: {
-            col: 0,
-            row: 79,
-          },
         },
       ]
     );

--- a/tests/model/model_import_export.test.ts
+++ b/tests/model/model_import_export.test.ts
@@ -486,7 +486,7 @@ describe("Import", () => {
     expect(Object.keys(getMerges(model))).toHaveLength(0);
     activateSheet(model, sheet1);
     expect(Object.keys(getMerges(model))).toHaveLength(1);
-    expect(Object.values(getMerges(model))[0].topLeft).toEqual(toCartesian("A2"));
+    expect(getMerges(model)[1]).toMatchObject(toZone("A2:B2"));
   });
 
   test("can import cell without content", () => {

--- a/tests/sheet/sheet_manipulation_plugin.test.ts
+++ b/tests/sheet/sheet_manipulation_plugin.test.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_BORDER_DESC, DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
-import { lettersToNumber, toCartesian, toXC, toZone } from "../../src/helpers";
+import { lettersToNumber, toXC, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
 import { Border, CommandResult } from "../../src/types";
 import { CellErrorType } from "../../src/types/errors";
@@ -267,9 +267,9 @@ describe("Columns", () => {
     test("On deletion", () => {
       deleteColumns(model, ["B", "D"]);
       expect(getMerges(model)).toEqual({
-        1: { id: 1, topLeft: toCartesian("A1"), top: 0, bottom: 0, left: 0, right: 2 },
-        2: { id: 2, topLeft: toCartesian("B2"), top: 1, bottom: 1, left: 1, right: 2 },
-        3: { id: 3, topLeft: toCartesian("B3"), top: 2, bottom: 2, left: 1, right: 2 },
+        1: { id: 1, top: 0, bottom: 0, left: 0, right: 2 },
+        2: { id: 2, top: 1, bottom: 1, left: 1, right: 2 },
+        3: { id: 3, top: 2, bottom: 2, left: 1, right: 2 },
       });
       expect(getMergeCellMap(model)).toEqual(
         XCToMergeCellMap(model, ["A1", "B1", "C1", "B2", "C2", "B3", "C3"])
@@ -280,10 +280,10 @@ describe("Columns", () => {
       addColumns(model, "before", "B", 1);
       addColumns(model, "after", "A", 1);
       expect(getMerges(model)).toEqual({
-        1: { id: 1, topLeft: toCartesian("A1"), top: 0, bottom: 0, left: 0, right: 6 },
-        2: { id: 2, topLeft: toCartesian("D2"), top: 1, bottom: 1, left: 3, right: 6 },
-        3: { id: 3, topLeft: toCartesian("E3"), top: 2, bottom: 2, left: 4, right: 6 },
-        4: { id: 4, topLeft: toCartesian("D4"), top: 3, bottom: 3, left: 3, right: 5 },
+        1: { id: 1, top: 0, bottom: 0, left: 0, right: 6 },
+        2: { id: 2, top: 1, bottom: 1, left: 3, right: 6 },
+        3: { id: 3, top: 2, bottom: 2, left: 4, right: 6 },
+        4: { id: 4, top: 3, bottom: 3, left: 3, right: 5 },
       });
       // prettier-ignore
       expect(getMergeCellMap(model)).toEqual(
@@ -512,7 +512,6 @@ describe("Columns", () => {
       expect(Object.values(getMerges(model))[0]).toMatchObject({
         left: 2,
         right: 5,
-        topLeft: toCartesian("C4"),
       });
     });
   });
@@ -997,9 +996,9 @@ describe("Rows", () => {
     test("On deletion", () => {
       deleteRows(model, [1, 3]);
       expect(getMerges(model)).toEqual({
-        1: { id: 1, topLeft: toCartesian("A1"), top: 0, bottom: 2, left: 0, right: 0 },
-        2: { id: 2, topLeft: toCartesian("B2"), top: 1, bottom: 2, left: 1, right: 1 },
-        3: { id: 3, topLeft: toCartesian("C2"), top: 1, bottom: 2, left: 2, right: 2 },
+        1: { id: 1, top: 0, bottom: 2, left: 0, right: 0 },
+        2: { id: 2, top: 1, bottom: 2, left: 1, right: 1 },
+        3: { id: 3, top: 1, bottom: 2, left: 2, right: 2 },
       });
       expect(getMergeCellMap(model)).toEqual(
         XCToMergeCellMap(model, ["A1", "A2", "A3", "B2", "B3", "C2", "C3"])
@@ -1009,10 +1008,10 @@ describe("Rows", () => {
       addRows(model, "before", 1, 1);
       addRows(model, "after", 0, 1);
       expect(getMerges(model)).toEqual({
-        1: { id: 1, topLeft: toCartesian("A1"), top: 0, bottom: 6, left: 0, right: 0 },
-        2: { id: 2, topLeft: toCartesian("B4"), top: 3, bottom: 6, left: 1, right: 1 },
-        3: { id: 3, topLeft: toCartesian("C5"), top: 4, bottom: 6, left: 2, right: 2 },
-        4: { id: 4, topLeft: toCartesian("D4"), top: 3, bottom: 5, left: 3, right: 3 },
+        1: { id: 1, top: 0, bottom: 6, left: 0, right: 0 },
+        2: { id: 2, top: 3, bottom: 6, left: 1, right: 1 },
+        3: { id: 3, top: 4, bottom: 6, left: 2, right: 2 },
+        4: { id: 4, top: 3, bottom: 5, left: 3, right: 3 },
       });
       // prettier-ignore
       expect(getMergeCellMap(model)).toEqual(
@@ -1124,7 +1123,6 @@ describe("Rows", () => {
       expect(Object.values(getMerges(model))[0]).toMatchObject({
         top: 2,
         bottom: 5,
-        topLeft: toCartesian("D3"),
       });
     });
 


### PR DESCRIPTION
## Description:

merge: remove useless topLeft attribute from Merge interface.

Context
-----
The "topLeft" attribute in the Merge interface was used as a shortcut to get the top left position of the merge zone. However, this was creating redundant code.

Task: [3912050](https://www.odoo.com/web#cids=1&menu_id=4722&action=333&active_id=2328&model=project.task&view_type=form&id=3912050)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo