### PR TITLE
[PERF] helpers: reduce toZone memory allocation

### DIFF
--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -25,21 +25,22 @@ export function toZoneWithoutBoundaryChanges(xc: string): UnboundedZone {
     xc = xc.split("!").at(-1)!;
   }
   if (xc.includes("$")) {
-    xc = xc.replace(/\$/g, "");
+    xc = xc.replaceAll("$", "");
   }
-  let ranges: string[];
+  let firstRangePart: string = "";
+  let secondRangePart: string | undefined;
   if (xc.includes(":")) {
-    ranges = xc.split(":").map((x) => x.trim());
+    [firstRangePart, secondRangePart] = xc.split(":");
+    firstRangePart = firstRangePart.trim();
+    secondRangePart = secondRangePart.trim();
   } else {
-    ranges = [xc.trim()];
+    firstRangePart = xc.trim();
   }
 
   let top: number, bottom: number, left: number, right: number;
   let fullCol = false;
   let fullRow = false;
   let hasHeader = false;
-  const firstRangePart = ranges[0];
-  const secondRangePart = ranges[1] && ranges[1];
 
   if (isColReference(firstRangePart)) {
     left = right = lettersToNumber(firstRangePart);
@@ -55,7 +56,7 @@ export function toZoneWithoutBoundaryChanges(xc: string): UnboundedZone {
     top = bottom = c.row;
     hasHeader = true;
   }
-  if (ranges.length === 2) {
+  if (secondRangePart) {
     if (isColReference(secondRangePart)) {
       right = lettersToNumber(secondRangePart);
       fullCol = true;


### PR DESCRIPTION
On RNG' spreadsheet, this changes reduces memory allocation of `toZoneWithoutBoundaryChanges` by ~40Mb when loading the spreadsheet. It was ~93Mb before.

Two changes:
- avoid compiling a regexp every time
- avoid useless array allocation when it's a single cell reference

Each change accounts for ~20Mb saved.

Task: 3915798

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo