### PR TITLE
[IMP] evaluation: addDependencies now evaluate cell

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1,6 +1,6 @@
 import { getFullReference, range, toXC, toZone } from "../helpers/index";
 import { _t } from "../translation";
-import { AddFunctionDescription, CellPosition, CellValue, FPayload, Matrix, Maybe } from "../types";
+import { AddFunctionDescription, CellPosition, FPayload, Matrix, Maybe } from "../types";
 import { CellErrorType, EvaluationError, InvalidReferenceError } from "../types/errors";
 import { arg } from "./arguments";
 import {
@@ -312,15 +312,7 @@ export const INDIRECT: AddFunctionDescription = {
       const colValues: FPayload[] = [];
       for (let row = range.zone.top; row <= range.zone.bottom; row++) {
         const position = { sheetId: range.sheetId, col, row };
-        // The below 'value' is typed as CellValue because the evaluateFormula will have to
-        // evaluate a string containing the A1 reference of a single cell, so this will
-        // return a CellValue.
-        const value = this.getters.evaluateFormula(range.sheetId, toXC(col, row)) as CellValue;
-        const evaluatedCell = this.getters.getEvaluatedCell(position);
-        colValues.push({
-          ...evaluatedCell,
-          value,
-        });
+        colValues.push(this.getters.getEvaluatedCell(position));
       }
       values.push(colValues);
     }

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -89,8 +89,9 @@ export class Evaluator {
     this.formulaDependencies().addDependencies(position, dependencies);
   }
 
-  addDependencies(position: CellPosition, dependencies: Range[]) {
+  private addDependencies(position: CellPosition, dependencies: Range[]) {
     this.formulaDependencies().addDependencies(position, dependencies);
+    this.computeAndSave(position);
   }
 
   private updateCompilationParameters() {


### PR DESCRIPTION
## Task Description

When adding a new dependency to a cell (like in the INDIRECT formula), we have to make sure the dependency have been evaluated before computing the formula result. To make sure it has at the first evaluation cycle, we need to force the evaluation of the dependency. This was done by triggering the evaluation of a new formula, by evaluating a string containing only a reference to the dependency (the XC path). This PR update the addDependency method to directly evaluate (if needed) the new dependency when adding it, in the evaluator, instead of using the hack of triggering an evaluation after.

## Related Task:

- Task: [3916213](https://www.odoo.com/web#cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form&id=3916213)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo