### PR TITLE
[REF] *: use less string.split

### DIFF
--- a/src/components/selection_input/selection_input.ts
+++ b/src/components/selection_input/selection_input.ts
@@ -80,6 +80,7 @@ interface SelectionRange extends Omit<RangeInputValue, "color"> {
   isValidRange: boolean;
   color?: Color;
 }
+
 /**
  * This component can be used when the user needs to input some
  * ranges. He can either input the ranges with the regular DOM `<input/>`
@@ -178,7 +179,13 @@ export class SelectionInput extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private extractRanges(value: string): string {
-    return this.props.hasSingleRange ? value.split(",")[0] : value;
+    if (this.props.hasSingleRange) {
+      const indexOfComma = value.indexOf(",");
+      if (indexOfComma !== -1) {
+        return value.substring(0, indexOfComma);
+      }
+    }
+    return value;
   }
 
   focus(rangeId: number) {

--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -56,6 +56,7 @@ export function isNumber(value: string | undefined, locale: Locale): boolean {
 const getInvaluableSymbolsRegexp = memoize(function getInvaluableSymbolsRegexp(locale: Locale) {
   return new RegExp(`[\$€${escapeRegExp(locale.thousandsSeparator)}]`, "g");
 });
+
 /**
  * Convert a string into a number. It assumes that the string actually represents
  * a number (as determined by the isNumber function)
@@ -70,10 +71,13 @@ export function parseNumber(str: string, locale: Locale): number {
   // remove invaluable characters
   str = str.replace(getInvaluableSymbolsRegexp(locale), "");
   let n = Number(str);
-  if (isNaN(n) && str.includes("%")) {
-    n = Number(str.split("%")[0]);
-    if (!isNaN(n)) {
-      return n / 100;
+  if (isNaN(n)) {
+    const indexOfPercent = str.indexOf("%");
+    if (indexOfPercent !== -1) {
+      n = Number(str.substring(0, indexOfPercent));
+      if (!isNaN(n)) {
+        return n / 100;
+      }
     }
   }
   return n;

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -106,11 +106,11 @@ export const MEASURES_TYPES = ["integer", "float", "monetary"];
  * e.g "create_date:month" => { name: "create_date", granularity: "month" }
  */
 export function parseDimension(dimension: string): PivotCoreDimension {
-  const [name, granularity] = dimension.split(":");
-  if (granularity) {
-    return { name, granularity };
+  const indexOfColon = dimension.indexOf(":");
+  if (indexOfColon === -1) {
+    return { name: dimension };
   }
-  return { name };
+  return { name: dimension.slice(0, indexOfColon), granularity: dimension.slice(indexOfColon + 1) };
 }
 
 export function isDateField(field: PivotField) {

--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -61,15 +61,16 @@ const dayAdapter: PivotTimeAdapter<string> = {
  */
 const weekAdapter: PivotTimeAdapter<string> = {
   normalizeFunctionValue(value) {
-    const [week, year] = value.split("/");
-    return `${Number(week)}/${Number(year)}`;
+    const index = value.indexOf("/");
+    return `${value.slice(0, index)}/${value.slice(index + 1)}`;
   },
   getFormat() {
     return undefined;
   },
   formatValue(normalizedValue) {
-    const [week, year] = normalizedValue.split("/");
-    return _t("W%(week)s %(year)s", { week, year });
+    const index = normalizedValue.indexOf("/");
+    const parts = { week: normalizedValue.slice(0, index), year: normalizedValue.slice(index + 1) };
+    return _t("W%(week)s %(year)s", parts);
   },
   toCellValue(normalizedValue) {
     return this.formatValue(normalizedValue);
@@ -104,15 +105,16 @@ const monthAdapter: PivotTimeAdapter<string> = {
  */
 const quarterAdapter: PivotTimeAdapter<string> = {
   normalizeFunctionValue(value) {
-    const [quarter, year] = value.split("/");
-    return `${quarter}/${year}`;
+    const index = value.indexOf("/");
+    return `${value.slice(0, index)}/${value.slice(index + 1)}`;
   },
   getFormat() {
     return undefined;
   },
   formatValue(normalizedValue) {
-    const [quarter, year] = normalizedValue.split("/");
-    return _t("Q%(quarter)s %(year)s", { quarter, year });
+    const index = normalizedValue.indexOf("/");
+    const parts = { week: normalizedValue.slice(0, index), year: normalizedValue.slice(index + 1) };
+    return _t("Q%(quarter)s %(year)s", parts);
   },
   toCellValue(normalizedValue) {
     return this.formatValue(normalizedValue);

--- a/src/helpers/range.ts
+++ b/src/helpers/range.ts
@@ -76,7 +76,9 @@ export class RangeImpl implements Range {
   }
 
   static getRangeParts(xc: string, zone: UnboundedZone): RangePart[] {
-    const parts = xc.split(":").map((p) => {
+    const index = xc.indexOf(":");
+    let originalParts = [xc.slice(0, index), xc.slice(index + 1)];
+    const parts = originalParts.map((p) => {
       const isFullRow = isRowReference(p);
       return {
         colFixed: isFullRow ? false : p.startsWith("$"),

--- a/src/helpers/reference_type.ts
+++ b/src/helpers/reference_type.ts
@@ -16,11 +16,16 @@ type FixedReferenceType = "col" | "row" | "colrow" | "none";
 export function loopThroughReferenceType(token: Readonly<Token>): Token {
   if (token.type !== "REFERENCE") return token;
   const { xc, sheetName } = splitReference(token.value);
-  const [left, right] = xc.split(":") as [string, string | undefined];
-
-  const updatedLeft = getTokenNextReferenceType(left);
-  const updatedRight = right ? `:${getTokenNextReferenceType(right)}` : "";
-  return { ...token, value: getFullReference(sheetName, updatedLeft + updatedRight) };
+  const indexOfColon = xc.indexOf(":");
+  if (indexOfColon !== -1) {
+    const left = xc.slice(0, indexOfColon);
+    const right = xc.slice(indexOfColon + 1);
+    const updatedRight = getTokenNextReferenceType(right);
+    const updatedLeft = getTokenNextReferenceType(left);
+    return { ...token, value: getFullReference(sheetName, `${updatedLeft}:${updatedRight}`) };
+  }
+  const updatedLeft = getTokenNextReferenceType(xc);
+  return { ...token, value: getFullReference(sheetName, updatedLeft) };
 }
 
 /**

--- a/src/helpers/references.ts
+++ b/src/helpers/references.ts
@@ -65,12 +65,12 @@ export function isSingleCellReference(xc: string): boolean {
 }
 
 export function splitReference(ref: string): { sheetName?: string; xc: string } {
-  if (!ref.includes("!")) {
+  const indexOfSheet = ref.lastIndexOf("!");
+  if (indexOfSheet === -1) {
     return { xc: ref };
   }
-  const parts = ref.split("!");
-  const xc = parts.pop()!;
-  const sheetName = getUnquotedSheetName(parts.join("!")) || undefined;
+  const xc = ref.slice(indexOfSheet + 1);
+  const sheetName = getUnquotedSheetName(ref.slice(0, indexOfSheet)) || undefined;
   return { sheetName, xc };
 }
 

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -22,18 +22,19 @@ import { isColReference, isRowReference } from "./references";
  *
  */
 export function toZoneWithoutBoundaryChanges(xc: string): UnboundedZone {
-  if (xc.includes("!")) {
-    xc = xc.split("!").at(-1)!;
+  const indexOfExclamation = xc.lastIndexOf("!");
+  if (indexOfExclamation !== -1) {
+    xc = xc.slice(indexOfExclamation + 1);
   }
   if (xc.includes("$")) {
     xc = xc.replaceAll("$", "");
   }
   let firstRangePart: string = "";
   let secondRangePart: string | undefined;
-  if (xc.includes(":")) {
-    [firstRangePart, secondRangePart] = xc.split(":");
-    firstRangePart = firstRangePart.trim();
-    secondRangePart = secondRangePart.trim();
+  const indexOfColon = xc.indexOf(":");
+  if (indexOfColon !== -1) {
+    firstRangePart = xc.slice(0, indexOfColon).trim();
+    secondRangePart = xc.slice(indexOfColon + 1).trim();
   } else {
     firstRangePart = xc.trim();
   }

--- a/src/plugins/core/merge.ts
+++ b/src/plugins/core/merge.ts
@@ -176,7 +176,8 @@ export class MergePlugin extends CorePlugin<MergeState> implements MergeState {
     const rangeString = this.getters.getRangeString(expandedRange, forSheetId);
     if (this.isSingleCellOrMerge(rangeImpl.sheetId, rangeImpl.zone)) {
       const { sheetName, xc } = splitReference(rangeString);
-      return getFullReference(sheetName, xc.split(":")[0]);
+      const indexOfColumn = xc.indexOf(":");
+      return getFullReference(sheetName, indexOfColumn !== -1 ? xc.slice(0, indexOfColumn) : xc);
     }
     return rangeString;
   }

--- a/src/xlsx/functions/conditional_formatting.ts
+++ b/src/xlsx/functions/conditional_formatting.ts
@@ -81,7 +81,7 @@ function addCellIsRule(cf: ConditionalFormat, rule: CellIsRule, dxfs: XLSXDxf[])
 }
 
 function cellRuleFormula(ranges: string[], rule: CellIsRule): string[] {
-  const firstCell = ranges[0].split(":")[0];
+  const firstCell = ranges[0].slice(0, ranges[0].indexOf(":"));
   const values = rule.values;
   switch (rule.operator) {
     case "ContainsText":


### PR DESCRIPTION
In most cases, when we want to split a string in exactly 1 or 2 parts, using indexOf(delimiter) is faster than split.

updated code like
```
const index = xc.lastIndexOf("!")
if (index !== -1) {
  xc = xc.slice(index + 1)
}
```

is 2x faster than the original:
```
if (ref.includes("!")) {
  ref = ref.split("!").at(-1)
}
```


![image](https://github.com/odoo/o-spreadsheet/assets/7260798/4c006a59-7934-4809-af91-e826513891a5)


## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo