### PR TITLE
[FIX] Notificiation: set a default notification store

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -10,7 +10,6 @@ const {
   xml,
   Component,
   whenReady,
-  useSubEnv,
   onWillStart,
   onMounted,
   useState,
@@ -21,7 +20,7 @@ const {
 
 const { Spreadsheet, Model, setTranslationMethod } = o_spreadsheet;
 const { topbarMenuRegistry } = o_spreadsheet.registries;
-const { useStoreProvider, NotificationStore } = o_spreadsheet.stores;
+const { useStoreProvider } = o_spreadsheet.stores;
 
 setTranslationMethod(
   (str, ...values) => str,
@@ -191,11 +190,6 @@ class Demo extends Component {
           }
           await this.initiateConnection(inputFiles);
           stores.resetStores();
-          stores.inject(NotificationStore, {
-            notifyUser: this.notifyUser,
-            raiseError: this.raiseError,
-            askConfirmation: this.askConfirmation,
-          });
           this.state.key = this.state.key + 1;
 
           // note : the onchange won't be called if we cancel the dialog w/o selecting a file, so this won't be called.
@@ -208,16 +202,7 @@ class Demo extends Component {
     });
 
     const stores = useStoreProvider();
-    stores.inject(NotificationStore, {
-      notifyUser: this.notifyUser,
-      raiseError: this.raiseError,
-      askConfirmation: this.askConfirmation,
-    });
-    useSubEnv({
-      notifyUser: this.notifyUser,
-      raiseError: this.raiseError,
-      askConfirmation: this.askConfirmation,
-    });
+
     useExternalListener(window, "beforeunload", this.leaveCollaborativeSession.bind(this));
     useExternalListener(window, "unhandledrejection", () => {
       this.notifyUser({
@@ -283,13 +268,6 @@ class Demo extends Component {
     this.model.joinSession();
     this.activateFirstSheet();
   }
-  askConfirmation(content, confirm, cancel) {
-    if (window.confirm(content)) {
-      confirm();
-    } else {
-      cancel?.();
-    }
-  }
 
   activateFirstSheet() {
     const sheetId = this.model.getters.getActiveSheetId();
@@ -323,11 +301,6 @@ class Demo extends Component {
     }
   }
 
-  raiseError(content, callback) {
-    window.alert(content);
-    callback?.();
-  }
-
   /**
    * Fetch the list of revisions of the server since the
    * start of the session.
@@ -344,7 +317,7 @@ Demo.template = xml/* xml */ `
   <div t-if="state.displayHeader" class="d-flex flex flex-column justify-content vh-100">
     <div class="p-3 border-bottom">A header</div>
     <div class="flex-fill">
-      <Spreadsheet model="model" t-key="state.key"/>
+      <Spreadsheet model="model" notifyUser="notifyUser" t-key="state.key"/>
     </div>
   </div>
   <div t-else="" class="vh-100">

--- a/doc/integrating/integration.md
+++ b/doc/integrating/integration.md
@@ -9,13 +9,18 @@ const { Spreadsheet, Model } = o_spreadsheet;
 
 const model = new Model();
 const templates = await(await fetch("../dist/o_spreadsheet.xml")).text();
-const env = {
-  notifyUser: () => window.alert(content),
-  askConfirmation: (message, confirm, cancel) => confirm(),
-};
 const app = new owl.App(Spreadsheet, {
-  props: { model },
-  env,
+  props: {
+    model,
+    // optionals
+    notifyUser: () => window.alert(content),
+    askConfirmation: (message, confirm, cancel) => window.confirm(message),
+    raiseError: (content, callback) => {
+      window.alert(content);
+      callback?.();
+    },
+  },
+  {},
   templates,
 });
 app.mount(document.body);
@@ -25,8 +30,22 @@ app.mount(document.body);
 
 Spreadsheet component takes the following props:
 
+**required**:
+
 - `model`
   The spreadsheet model to be used with the component.
+
+**optional**:
+
+- `notifyUser`
+  A function used to notify the user. It supports several levels of severity as well as a sticky behaviour.
+  See its [`interface`](../../src/types/env.ts#L15)
+- `askConfirmation`
+  A function used to ask the user confirmation before applying a callback
+- `raiseError`
+  A function to warn the user when a manipulation error occurs.
+
+The optional props should implement [`NotificationStoreMethods`](../../src/stores/notification_store.ts#L3).
 
 ## Model creation
 
@@ -136,3 +155,7 @@ const model = new Model(data, {
   },
 });
 ```
+
+## Managing application state with stores
+
+See [Managing application state with stores](/src/store_engine/README.md)

--- a/src/stores/notification_store.ts
+++ b/src/stores/notification_store.ts
@@ -1,10 +1,34 @@
-import { createAbstractStore } from "../store_engine";
 import { InformationNotification } from "../types";
 
-export interface NotificationStore {
-  mutators: readonly ["notifyUser", "raiseError", "askConfirmation"];
-  notifyUser: (notification: InformationNotification) => any;
-  raiseError: (text: string, callback?: () => void) => any;
-  askConfirmation: (content: string, confirm: () => any, cancel?: () => any) => any;
+export interface NotificationStoreMethods {
+  notifyUser: (notification: InformationNotification) => void;
+  raiseError: (text: string, callback?: () => void) => void;
+  askConfirmation: (content: string, confirm: () => void, cancel?: () => void) => void;
 }
-export const NotificationStore = createAbstractStore<NotificationStore>("Notifications");
+
+export class NotificationStore {
+  mutators = [
+    "notifyUser",
+    "raiseError",
+    "askConfirmation",
+    "updateNotificationCallbacks",
+  ] as const;
+  notifyUser: NotificationStoreMethods["notifyUser"] = (notification) => window.alert(notification);
+  askConfirmation: NotificationStoreMethods["askConfirmation"] = (content, confirm, cancel) => {
+    if (window.confirm(content)) {
+      confirm();
+    } else {
+      cancel?.();
+    }
+  };
+  raiseError: NotificationStoreMethods["raiseError"] = (text, callback) => {
+    window.alert(text);
+    callback?.();
+  };
+
+  updateNotificationCallbacks(methods: Partial<NotificationStoreMethods>) {
+    this.notifyUser = methods.notifyUser || this.notifyUser;
+    this.raiseError = methods.raiseError || this.raiseError;
+    this.askConfirmation = methods.askConfirmation || this.askConfirmation;
+  }
+}

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -1,6 +1,7 @@
 import { Model } from "..";
 import { ClipboardInterface } from "../helpers/clipboard/navigator_clipboard_wrapper";
 import { Get } from "../store_engine";
+import { NotificationStoreMethods } from "../stores/notification_store";
 import { Currency } from "./currency";
 import { ImageProviderInterface } from "./files";
 import { Locale } from "./locale";
@@ -18,13 +19,7 @@ export interface InformationNotification {
   sticky: boolean;
 }
 
-export interface SpreadsheetEnv {
-  notifyUser: (notification: InformationNotification) => any;
-  raiseError: (text: string, callback?: () => void) => any;
-  askConfirmation: (content: string, confirm: () => any, cancel?: () => any) => any;
-}
-
-export interface SpreadsheetChildEnv extends SpreadsheetEnv {
+export interface SpreadsheetChildEnv extends NotificationStoreMethods {
   model: Model;
   imageProvider?: ImageProviderInterface;
   isDashboard: () => boolean;


### PR DESCRIPTION
Following the introduction of stores, the minimal setup has evolved as it requires to instanciate a some stores before the creation of a spreadsheet app. The documentation was not updated accordingly.

More specifically, the only store that we required to instantiate manually was the `NotificationStore` and we had to add it to the App env as well. These last step are a pain for developpers that only want to set a quick and minimal integration.

This commit sets default notification methods (raiseError, notifyUser, askConfirmation) which can be updated by calling `NotificationStore.updateNotificationCallbacks`.

Task: 3919166

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3919166](https://www.odoo.com/web#id=3919166&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo