### PR TITLE
[FIX] Composer: F4 handler should not bubble out of the composer

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -195,7 +195,7 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     Enter: this.processEnterKey,
     Escape: this.processEscapeKey,
     F2: () => console.warn("Not implemented"),
-    F4: this.processF4Key,
+    F4: (ev: KeyboardEvent) => this.processF4Key(ev),
     Tab: (ev: KeyboardEvent) => this.processTabKey(ev),
   };
 
@@ -329,9 +329,10 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
     this.env.model.dispatch("STOP_EDITION", { cancel: true });
   }
 
-  private processF4Key() {
+  private processF4Key(ev: KeyboardEvent) {
     this.env.model.dispatch("CYCLE_EDITION_REFERENCES");
     this.processContent();
+    ev.stopPropagation();
   }
 
   onCompositionStart() {

--- a/tests/components/composer_integration.test.ts
+++ b/tests/components/composer_integration.test.ts
@@ -9,7 +9,9 @@ import {
 import { colors, toHex, toZone } from "../../src/helpers";
 import {
   activateSheet,
+  copy,
   createSheet,
+  paste,
   renameSheet,
   resizeColumns,
   resizeRows,
@@ -30,6 +32,7 @@ import {
 import {
   getActivePosition,
   getActiveSheetFullScrollInfo,
+  getCellContent,
   getCellText,
   getSelectionAnchorCellXc,
 } from "../test_helpers/getters_helpers";
@@ -472,6 +475,19 @@ describe("Grid composer", () => {
     await simulateClick(fixture.querySelectorAll(".o-sheet")[1]);
     expect(model.getters.getActiveSheetId()).toEqual("42");
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer")!);
+  });
+
+  test("pressing F4 loops the references without impacting the 'redo' feature of the grid", async () => {
+    setCellContent(model, "A1", "coucou");
+    setCellContent(model, "A2", "coucou2");
+    copy(model, "A1:A2");
+    paste(model, "A3:A4");
+    selectCell(model, "B1");
+    await startComposition("=C4");
+    model.dispatch("CHANGE_COMPOSER_CURSOR_SELECTION", { start: 1, end: 1 });
+    await nextTick();
+    await keyDown({ key: "F4" });
+    expect(getCellContent(model, "B2")).toBe("");
   });
 
   describe("grid composer basic style", () => {


### PR DESCRIPTION
Since pull request 2126[^1], the shortcut F4 is handled by the grid component. Unfortunately, the same shortcut is handled in the composer as well and its propabation was not stopped. This means that a user wanting to loop the references inside their formula could see some unexpected side effects due to the grid replaying some commands.

[^1]: https://github.com/odoo/o-spreadsheet/issues/2126

Task: 3916488

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo