### PR TITLE
[IMP] evaluation: prevent array formula spread on merge

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -189,10 +189,6 @@ export class EvaluationPlugin extends UIPlugin {
           this.evaluator.updateDependencies(cmd);
         }
         break;
-      case "DUPLICATE_SHEET":
-      case "CREATE_SHEET":
-        this.shouldRebuildDependenciesGraph = true;
-        break;
       case "EVALUATE_CELLS":
         this.evaluator.evaluateAllCells();
         break;

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -327,6 +327,7 @@ export class Evaluator {
     const nbRows = formulaReturn[0].length;
 
     forEachSpreadPositionInMatrix(nbColumns, nbRows, this.updateSpreadRelation(formulaPosition));
+    this.assertNoMergedCellsInSpreadZone(formulaPosition, formulaReturn);
     forEachSpreadPositionInMatrix(nbColumns, nbRows, this.checkCollision(formulaPosition));
     forEachSpreadPositionInMatrix(
       nbColumns,
@@ -369,6 +370,26 @@ export class Evaluator {
 
     throw new SplillBlockedError(
       _t("Result couldn't be automatically expanded. Please insert more columns and rows.")
+    );
+  }
+
+  private assertNoMergedCellsInSpreadZone(
+    { sheetId, col, row }: CellPosition,
+    matrixResult: Matrix<FPayload>
+  ) {
+    const mergedCells = this.getters.getMergesInZone(sheetId, {
+      top: row,
+      bottom: row + matrixResult.length,
+      left: col,
+      right: col + matrixResult[0].length,
+    });
+
+    if (mergedCells.length === 0) {
+      return;
+    }
+
+    throw new SplillBlockedError(
+      _t("Merged cells found in the spill zone. Please unmerge cells before using array formulas.")
     );
   }
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -118,6 +118,7 @@ export const invalidateEvaluationCommands = new Set<CommandTypes>([
   "UNDO",
   "REDO",
   "ADD_MERGE",
+  "REMOVE_MERGE",
   "UPDATE_LOCALE",
   "ADD_PIVOT",
   "UPDATE_PIVOT",

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -113,6 +113,7 @@ export const invalidateEvaluationCommands = new Set<CommandTypes>([
   "RENAME_SHEET",
   "DELETE_SHEET",
   "CREATE_SHEET",
+  "DUPLICATE_SHEET",
   "ADD_COLUMNS_ROWS",
   "REMOVE_COLUMNS_ROWS",
   "UNDO",


### PR DESCRIPTION
## Description:

This PR ensures that array formulas do not spread when users merge cells containing them. Instead, a `#SPILL` error is triggered if users attempt to merge cells containing array formulas.

Task: : [3888401](https://www.odoo.com/web#id=3888401&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo