### PR TITLE
[FIX] find_and_replace: fix previous command

### DIFF
--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -769,3 +769,32 @@ describe("number of match counts", () => {
     expect(store.specificRangeMatchesCount).toBe(1);
   });
 });
+
+test("Selecting a previous match located in a previous sheet will select the last occurrence of the previous sheet and go backward in order", () => {
+  setCellContent(model, "A1", "9", sheetId1);
+  setCellContent(model, "B2", "9", sheetId1);
+  setCellContent(model, "P14", "9", sheetId1);
+  createSheet(model, { sheetId: "sh2" });
+  setCellContent(model, "H34", "9", "sh2");
+
+  updateSearch(model, "9", { searchScope: "allSheets" });
+  expect(store.activeSheetMatchesCount).toStrictEqual(3);
+
+  store.selectNextMatch();
+  store.selectNextMatch();
+  store.selectNextMatch();
+
+  expect(store.activeSheetMatchesCount).toStrictEqual(1);
+
+  expect(store.selectedMatchIndex).toStrictEqual(3);
+  expect(getActivePosition(model)).toBe("H34");
+  store.selectPreviousMatch();
+  expect(getActivePosition(model)).toBe("P14");
+  expect(store.selectedMatchIndex).toStrictEqual(2);
+  store.selectPreviousMatch();
+  expect(getActivePosition(model)).toBe("B2");
+  expect(store.selectedMatchIndex).toStrictEqual(1);
+  store.selectPreviousMatch();
+  expect(getActivePosition(model)).toBe("A1");
+  expect(store.selectedMatchIndex).toStrictEqual(0);
+});


### PR DESCRIPTION
### [FIX] find_and_replace: fix previous command

Problem
-----
The problem occurs when we perform a search using "Find & Replace". In fact, when going backward to a previous occurrence that is  located in the previous sheet, we match the first occurrence of that sheet, when actually we need to match on the last occurrence of that sheet.

Solution
-----
This commit solves the issue by checking whether the sheet switch is automatic (coming from the Previous button).

Task: [3839575](https://www.odoo.com/web#id=3839575&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo