### PR TITLE
[FIX] autocomplete_dropdown_store: use correct navigation order

### DIFF
--- a/src/components/composer/autocomplete_dropdown/autocomplete_dropdown_store.ts
+++ b/src/components/composer/autocomplete_dropdown/autocomplete_dropdown_store.ts
@@ -34,7 +34,7 @@ export class AutoCompleteStore extends SpreadsheetStore {
       this.selectedIndex = 0;
       return;
     }
-    if (direction === "next") {
+    if (direction === "previous") {
       this.selectedIndex--;
       if (this.selectedIndex < 0) {
         this.selectedIndex = this.provider.proposals.length - 1;

--- a/tests/pivots/add_dimension_button.test.ts
+++ b/tests/pivots/add_dimension_button.test.ts
@@ -1,0 +1,54 @@
+import { Component } from "@odoo/owl";
+import { AddDimensionButton } from "../../src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button";
+import { click, keyDown } from "../test_helpers/dom_helper";
+import { mountComponentWithPortalTarget } from "../test_helpers/helpers";
+
+async function mountAddDimensionButton(
+  props: Partial<AddDimensionButton["props"]>
+): Promise<{ component: AddDimensionButton; fixture: HTMLElement }> {
+  let parent: Component;
+  let fixture: HTMLElement;
+  ({ parent, fixture } = await mountComponentWithPortalTarget(AddDimensionButton, {
+    props: {
+      fields: [],
+      onFieldPicked: () => {},
+      ...props,
+    },
+  }));
+  return { component: parent as AddDimensionButton, fixture };
+}
+
+describe("Add dimension button", () => {
+  test("Can navigate with arrow keys", async () => {
+    const onFieldPicked = jest.fn();
+    const { fixture } = await mountAddDimensionButton({
+      fields: [
+        { name: "Amount", type: "integer", string: "Amount" },
+        { name: "Product", type: "char", string: "Product" },
+      ],
+      onFieldPicked,
+    });
+    await click(fixture.querySelector(".add-dimension")!);
+    let options = [...fixture.querySelectorAll(".o-popover .o-autocomplete-dropdown > div")];
+    expect(
+      options.every((el) => !el.className.includes("o-autocomplete-value-focus"))
+    ).toBeTruthy();
+    await keyDown({ key: "ArrowDown" });
+    options = [...fixture.querySelectorAll(".o-popover .o-autocomplete-dropdown > div")];
+    expect(options[0].className.includes("o-autocomplete-value-focus")).toBeTruthy();
+    expect(options[1].className.includes("o-autocomplete-value-focus")).toBeFalsy();
+
+    await keyDown({ key: "ArrowDown" });
+    options = [...fixture.querySelectorAll(".o-popover .o-autocomplete-dropdown > div")];
+    expect(options[0].className.includes("o-autocomplete-value-focus")).toBeFalsy();
+    expect(options[1].className.includes("o-autocomplete-value-focus")).toBeTruthy();
+
+    await keyDown({ key: "ArrowUp" });
+    options = [...fixture.querySelectorAll(".o-popover .o-autocomplete-dropdown > div")];
+    expect(options[0].className.includes("o-autocomplete-value-focus")).toBeTruthy();
+    expect(options[1].className.includes("o-autocomplete-value-focus")).toBeFalsy();
+
+    await keyDown({ key: "Enter" });
+    expect(onFieldPicked).toHaveBeenCalledWith("Amount");
+  });
+});


### PR DESCRIPTION
The navigation order was incorrect, causing the arrow up going to the next item instead of the previous one. This commit fixes the issue.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo