### PR TITLE
[IMP] pivot: improve pivot duplication

### DIFF
--- a/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
+++ b/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
@@ -48,9 +48,11 @@ export class PivotTitleSection extends Component<Props, SpreadsheetChildEnv> {
 
   duplicatePivot() {
     const newPivotId = this.env.model.uuidGenerator.uuidv4();
-    const result = this.env.model.dispatch("DUPLICATE_PIVOT", {
+    const newSheetId = this.env.model.uuidGenerator.uuidv4();
+    const result = this.env.model.dispatch("DUPLICATE_PIVOT_IN_NEW_SHEET", {
       pivotId: this.props.pivotId,
       newPivotId,
+      newSheetId,
     });
     const text = result.isSuccessful ? _t("Pivot duplicated.") : _t("Pivot duplication failed");
     const type = result.isSuccessful ? "success" : "danger";

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -945,6 +945,13 @@ export interface InsertNewPivotCommand {
   newSheetId: UID;
 }
 
+export interface DuplicatePivotInNewSheetCommand {
+  type: "DUPLICATE_PIVOT_IN_NEW_SHEET";
+  pivotId: UID;
+  newPivotId: UID;
+  newSheetId: UID;
+}
+
 export type CoreCommand =
   // /** History */
   // | SelectiveUndoCommand
@@ -1088,7 +1095,8 @@ export type LocalCommand =
   | TrimWhitespaceCommand
   | ResizeTableCommand
   | RefreshPivotCommand
-  | InsertNewPivotCommand;
+  | InsertNewPivotCommand
+  | DuplicatePivotInNewSheetCommand;
 
 export type Command = CoreCommand | LocalCommand;
 


### PR DESCRIPTION
### [IMP] pivot: improve pivot duplication

Problem
-----
Before this commit, when we duplicate a pivot table, it's duplicated in-place, meaning that you just see the new reference on the side panel but nothing new appears on the sheet. This is not user friendly and a bit confusing for the end user.

Solution
-----
This commit will mitigate this behaviour by adding a new option to duplicate the pivot in a new clean sheet.

Task: [3848336](https://www.odoo.com/odoo/project/2328/tasks/3848336?cids=1)

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo