### PR TITLE
[PERF] history: reduce history memory usage

### DIFF
--- a/src/history/factory.ts
+++ b/src/history/factory.ts
@@ -1,7 +1,6 @@
 import { transformAll } from "../collaborative/ot/ot";
 import { Revision } from "../collaborative/revisions";
 import { inverseCommand } from "../helpers/inverse_commands";
-import { createEmptyStructure } from "../helpers/state_manager_helpers";
 import { StateObserver } from "../state_observer";
 import { CoreCommand, HistoryChange, UID } from "../types";
 import { SelectiveHistory } from "./selective_history";
@@ -56,7 +55,7 @@ function revertChanges(revisions: readonly Revision[]) {
   for (const revision of revisions.slice().reverse()) {
     for (let i = revision.changes.length - 1; i >= 0; i--) {
       const change = revision.changes[i];
-      applyChange(change, "before");
+      applyChange(change);
     }
   }
 }
@@ -64,20 +63,13 @@ function revertChanges(revisions: readonly Revision[]) {
 /**
  * Apply the changes of the given HistoryChange to the state
  */
-function applyChange(change: HistoryChange, target: "before" | "after") {
-  let val = change.path[0];
-  const key = change.path.at(-1);
-  for (let pathIndex = 1; pathIndex < change.path.slice(0, -1).length; pathIndex++) {
-    const p = change.path[pathIndex];
-    if (val[p] === undefined) {
-      const nextPath = change.path[pathIndex + 1];
-      val[p] = createEmptyStructure(nextPath);
-    }
-    val = val[p];
-  }
-  if (change[target] === undefined) {
-    delete val[key];
+function applyChange(change: HistoryChange) {
+  const target = change.target;
+  const key = change.key;
+  const before = change.before;
+  if (before === undefined) {
+    delete target[key];
   } else {
-    val[key] = change[target];
+    target[key] = before;
   }
 }

--- a/src/state_observer.ts
+++ b/src/state_observer.ts
@@ -1,6 +1,8 @@
 import { createEmptyStructure } from "./helpers/state_manager_helpers";
 import { CoreCommand, HistoryChange } from "./types";
 
+type HistoryPath = [any, ...(number | string)[]];
+
 export class StateObserver {
   private changes: HistoryChange[] = [];
   private commands: CoreCommand[] = [];
@@ -20,7 +22,7 @@ export class StateObserver {
     this.commands.push(command);
   }
 
-  addChange(...args: [...HistoryChange["path"], any]) {
+  addChange(...args: [...HistoryPath, any]) {
     const val: any = args.pop();
     const root = args[0];
     let value = root as any;
@@ -38,9 +40,9 @@ export class StateObserver {
       return;
     }
     this.changes.push({
-      path: args,
+      key,
+      target: value,
       before: value[key],
-      after: val,
     });
     if (val === undefined) {
       delete value[key];

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -9,9 +9,9 @@ export interface CreateRevisionOptions {
 }
 
 export interface HistoryChange {
-  path: [any, ...(number | string)[]];
+  key: string;
+  target: any;
   before: any;
-  after: any;
 }
 
 export interface WorkbookHistory<Plugin> {


### PR DESCRIPTION
## Description:

This commit reduces the amount of memory used to keep track of history
changes.

Currently, for each change, we keep the full path of keys from the root plugin
to the deepest data structure which is actually updated.
`[BordersPlugin, 'borders', 'sheet1', 0, 1, 'horizontal']`

This is useless, it is enough to keep a reference to the updated object and
the updated key.
Note that `after` was never used.

On the large formula data set, with 20k rows, here are the amounts of memory
used (after GC has run)

adding a column left of A:
- before 613Mb
- after  487Mb

adding borders on all cells, all sides:
- before 451Mb
- after 384Mb

Undoing a revision is also faster since we no longer needs to iterate over
all keys of the path.

Adding a column before A, then undo and reload. Replaying both commands
goes from `~1700ms` to `~1200ms`

Task: : [3940604](https://www.odoo.com/web#id=3940604&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo