### PR TITLE
[FIX] translation: replace placeholders even if translation is not lo…

### DIFF
--- a/src/translation.ts
+++ b/src/translation.ts
@@ -40,7 +40,7 @@ class LazyTranslatedString extends String {
 
   valueOf() {
     const str = super.valueOf();
-    return _loaded() ? sprintf(_translate(str), ...this.values) : str;
+    return _loaded() ? sprintf(_translate(str), ...this.values) : sprintf(str, ...this.values);
   }
   toString() {
     return this.valueOf();

--- a/tests/helpers/translation_helpers.test.ts
+++ b/tests/helpers/translation_helpers.test.ts
@@ -1,4 +1,4 @@
-import { _t } from "../../src/translation";
+import { _t, setTranslationMethod } from "../../src/translation";
 
 describe("Translations", () => {
   test("placeholders in string translation are replaced with their given value", () => {
@@ -20,5 +20,14 @@ describe("Translations", () => {
 
   test("can have named placeholders", () => {
     expect(_t("%(x1)s %(thing)s", { x1: "Hello", thing: "World" })).toBe("Hello World");
+  });
+
+  test("should replace placeholders even if the translation is not loaded", () => {
+    setTranslationMethod(
+      (str, ...values) => str,
+      () => false
+    );
+    const str = _t("%(x1)s %(thing)s", { x1: "Hello", thing: "World" });
+    expect(`${str}`).toBe("Hello World");
   });
 });


### PR DESCRIPTION
…aded

Before this commit, if the translation was not loaded, the placeholders were not replaced.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo