### PR TITLE
[IMP] pivot: improve handling of empty string values

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -25,7 +25,7 @@ export function dataEntriesToSpreadsheetPivotTable(
   dataEntries: DataEntries,
   definition: SpreadsheetPivotRuntimeDefinition
 ) {
-  const columnsTree = dateEntriesToColumnsTree(dataEntries, definition.columns, 0);
+  const columnsTree = dataEntriesToColumnsTree(dataEntries, definition.columns, 0);
   computeWidthOfColumnsNodes(columnsTree, definition.measures.length);
   const cols = columnsTreeToColumns(columnsTree, definition);
 
@@ -88,7 +88,7 @@ function dataEntriesToRows(
 /**
  * Create the columns tree from data entries.
  */
-function dateEntriesToColumnsTree(
+function dataEntriesToColumnsTree(
   dataEntries: DataEntries,
   columns: PivotDimension[],
   index: number
@@ -104,7 +104,7 @@ function dateEntriesToColumnsTree(
     return {
       value,
       field: colName,
-      children: dateEntriesToColumnsTree(groups[value] || [], columns, index + 1),
+      children: dataEntriesToColumnsTree(groups[value] || [], columns, index + 1),
       width: 0,
     };
   });

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -363,7 +363,11 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
         if (!field) {
           throw new Error(`Field ${this.fieldKeys[index]} does not exist`);
         }
-        entry[field.name] = cell;
+        if (cell.value === "") {
+          entry[field.name] = { value: null, type: CellValueType.empty };
+        } else {
+          entry[field.name] = cell;
+        }
       }
       entry["__count"] = { value: 1, type: CellValueType.number };
       dataEntries.push(entry);

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -278,6 +278,21 @@ describe("Spreadsheet Pivot", () => {
     ]);
   });
 
+  test("Empty string values are treated the same as blank cells", () => {
+    const model = createModelWithPivot("A1:I5");
+    setCellContent(model, "C3", '=""');
+    setCellContent(model, "C5", "");
+    setCellContent(model, "A26", "=pivot(1)");
+
+    updatePivot(model, "1", {
+      columns: [{ name: "Contact Name", order: "asc" }],
+    });
+
+    expect(getEvaluatedGrid(model, "B26:F26")).toEqual([
+      ["Alice", "Michel", "(Undefined)", "Total", ""],
+    ]);
+  });
+
   test("Cannot load a pivot with a field in error", () => {
     const model = createModelWithPivot("A1:I5");
     setCellContent(model, "A1", `=1/0`);


### PR DESCRIPTION
## Description:

Currently if we groupBy a pivot on a column that have both empty string
and empty cells, the empty cells will be displayed as `(Undefined)`
in the groupBy, and the empty string will be displayed as "" (empty).

This commit improves the behaviour so that both empty cells and empty
strings are displayed as `(Undefined)` in the groupBy.

Task: : [3940307](https://www.odoo.com/web#id=3940307&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo