### PR TITLE
[FIX] PivotSidePanel: Ensure pivot is initialized in side panel

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -38,7 +38,6 @@ export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChild
 
   setup() {
     this.store = useLocalStore(PivotSidePanelStore, this.props.pivotId);
-    this.pivot.init();
     this.state = useState({
       range: undefined,
       rangeHasChanged: false,

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -117,7 +117,10 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
 
   get definition() {
     if (!this._definition) {
-      throw new Error("Pivot not loaded yet");
+      this.init();
+    }
+    if (!this._definition) {
+      throw new Error("Pivot definition should be defined at this point.");
     }
     return this._definition;
   }

--- a/tests/pivots/pivot_side_panel.test.ts
+++ b/tests/pivots/pivot_side_panel.test.ts
@@ -1,4 +1,5 @@
 import { Model, SpreadsheetChildEnv } from "../../src";
+import { createSheet, deleteSheet } from "../test_helpers/commands_helpers";
 import { click } from "../test_helpers/dom_helper";
 import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 import { addPivot, removePivot } from "../test_helpers/pivot_helpers";
@@ -83,5 +84,17 @@ describe("Pivot side panel", () => {
     await click(fixture.querySelector(".sp_delete")!);
     expect(model.getters.getPivotIds()).toEqual([]);
     expect(fixture.querySelector(".o-sidePanel")).toBeNull();
+  });
+
+  test("Sidepanel pivot definition is properly reinitialized", async () => {
+    removePivot(model, "1");
+    env.openSidePanel("PivotSidePanel", { pivotId: "2" });
+    await nextTick();
+    createSheet(model, { sheetId: "toDelete", activate: true });
+    await nextTick();
+    // force the invalidation of the pivot definition
+    deleteSheet(model, "toDelete");
+    await nextTick();
+    expect(fixture.querySelector(".o-sidePanel")).not.toBeNull();
   });
 });


### PR DESCRIPTION
When we dispatch commands that invalidate the evaluation, we also invalidate the `SpreadsheetPivot` instances. The sidepanel which uses the said pivot would initialize it at the setup on the component, but this should be done after an invalidation as well.

This revision moves the initialization inside the sidepanel store.

Task: 3941944

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo