### PR TITLE
[FIX] misc: Fix `deepEquals` behaviour

### DIFF
--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -369,7 +369,9 @@ export function deepEquals(o1: any, o2: any, ignoreFunctions?: "ignoreFunctions"
     if (typeOfO1Key === "object") {
       if (!deepEquals(o1[key], o2[key], ignoreFunctions)) return false;
     } else {
-      if (ignoreFunctions && typeOfO1Key === "function") return true;
+      if (ignoreFunctions && typeOfO1Key === "function") {
+        continue;
+      }
       if (o1[key] !== o2[key]) return false;
     }
   }

--- a/tests/helpers/misc_helpers.test.ts
+++ b/tests/helpers/misc_helpers.test.ts
@@ -234,10 +234,16 @@ test.each([
 });
 
 test("deepEquals with argument ignoring functions", () => {
-  const o1 = { a: 1, b: () => 2 };
-  const o2 = { a: 1, b: () => 2 };
+  const o1 = { a: 1, b: () => 2, c: 2 };
+  const o2 = { a: 1, b: () => 2, c: 2 };
+  const o3 = { a: 1, b: () => 2, c: 3 };
+  const o4 = { a: 2, b: () => 2, c: 2 };
   expect(deepEquals(o1, o2)).toEqual(false);
   expect(deepEquals(o1, o2, "ignoreFunctions")).toEqual(true);
+  expect(deepEquals(o1, o3)).toEqual(false);
+  expect(deepEquals(o1, o3, "ignoreFunctions")).toEqual(false);
+  expect(deepEquals(o1, o4)).toEqual(false);
+  expect(deepEquals(o1, o4, "ignoreFunctions")).toEqual(false);
 });
 
 describe("isConsecutive", () => {


### PR DESCRIPTION
Since PR 4066, we can compare objects while ignoring functions inside them as the function references might differ. However, the implementation was faulty and would mistakenly consider two object to be equals as soon as they both contained a function for the same key.

Task: 3942782

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo