### PR TITLE
[FIX] BottomBarSheet: give focus back to grid after sheet name edition

### DIFF
--- a/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
+++ b/src/components/bottom_bar_sheet/bottom_bar_sheet.ts
@@ -139,9 +139,11 @@ export class BottomBarSheet extends Component<Props, SpreadsheetChildEnv> {
     if (ev.key === "Enter") {
       ev.preventDefault();
       this.stopEdition();
+      this.env.focusableElement.focus();
     }
     if (ev.key === "Escape") {
       this.cancelEdition();
+      this.env.focusableElement.focus();
     }
   }
 

--- a/tests/components/bottom_bar.test.ts
+++ b/tests/components/bottom_bar.test.ts
@@ -61,11 +61,16 @@ function isDragAndDropActive(): boolean {
 
 async function mountBottomBar(
   model: Model = new Model(),
-  env: Partial<SpreadsheetChildEnv> = {}
-): Promise<{ parent: Parent; model: Model }> {
+  partialEnv: Partial<SpreadsheetChildEnv> = {}
+): Promise<{ parent: Parent; model: Model; env: SpreadsheetChildEnv }> {
   let parent: Component;
-  ({ fixture, parent } = await mountComponent(Parent, { model, env, props: { model } }));
-  return { parent: parent as Parent, model };
+  let env: SpreadsheetChildEnv;
+  ({ fixture, parent, env } = await mountComponent(Parent, {
+    model,
+    env: partialEnv,
+    props: { model },
+  }));
+  return { parent: parent as Parent, model, env };
 }
 
 describe("BottomBar component", () => {
@@ -245,12 +250,13 @@ describe("BottomBar component", () => {
   describe("Rename a sheet", () => {
     let model: Model;
     let raiseError: jest.Mock;
+    let env: SpreadsheetChildEnv;
     beforeEach(async () => {
       raiseError = jest.fn((string, callback) => {
         callback();
       });
-      ({ model } = await mountBottomBar(new Model(), { raiseError }));
-      model;
+      ({ model, env } = await mountBottomBar(new Model(), { raiseError }));
+      env.focusableElement.focus = jest.fn();
     });
 
     test("Double click on the sheet name make it editable and give it the focus", async () => {
@@ -353,6 +359,19 @@ describe("BottomBar component", () => {
 
       expect(sheetName.innerText).toEqual("HELLO");
     });
+
+    test.each(["Enter", "Escape"])(
+      "Pressing %s ends the edition and yields back the DOM focus",
+      async (key) => {
+        const sheetName = fixture.querySelector<HTMLElement>(".o-sheet-name")!;
+        // will give focus back to the component main node
+        triggerMouseEvent(sheetName, "dblclick");
+        await nextTick();
+        sheetName.textContent = "New name";
+        await keyDown({ key });
+        expect(env.focusableElement.focus).toHaveBeenCalled();
+      }
+    );
   });
 
   test("Can't rename a sheet in readonly mode", async () => {


### PR DESCRIPTION
The DOM focus was lost (i.e. fell back on `body`) after we stopped the edition of the sheet name.

How to reproduce:
----------------
- Edit the sheet name from the bottom bar
- either confirm with `Enter` or discard with `Escape`

-> the DOM focus is now on body rather than the grid composer, which means you can no longer navigate the grid with the keyboard.

Task: 3945145

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo