### PR TITLE
[FIX] spreadsheet: fix scroll issue on chromium core 125

### DIFF
--- a/src/components/spreadsheet/spreadsheet.ts
+++ b/src/components/spreadsheet/spreadsheet.ts
@@ -188,6 +188,11 @@ export class Spreadsheet extends Component<SpreadsheetProps, SpreadsheetChildEnv
     useExternalListener(window as any, "resize", () => this.render(true));
     useExternalListener(window, "beforeunload", this.unbindModelEvents.bind(this));
 
+    // For some reason, the wheel event is not properly registered inside templates
+    // in Chromium-based browsers based on chromium 125
+    // This hack ensures the event declared in the template is properly registered/working
+    useExternalListener(document.body, "wheel", () => {});
+
     this.bindModelEvents();
     onMounted(() => {
       this.checkViewportSize();


### PR DESCRIPTION
Since the update of chromium-based browsers to chromium 125, our `wheel` listeners declared inside a template are no longer properly registered. It turns out that registering another event listener of the same type fixes the template scroll.
This revision proposes this simple hack/fix as we still struggle to find the actual reason behind this (might be owl related) to unblock users.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo