### PR TITLE
[IMP] Spreadsheet: prevent OS default swipe

### DIFF
--- a/src/components/grid/grid.xml
+++ b/src/components/grid/grid.xml
@@ -5,7 +5,7 @@
       tabindex="-1"
       t-on-click="focusDefaultElement"
       t-on-keydown="onKeydown"
-      t-on-wheel="onMouseWheel"
+      t-on-wheel.prevent="onMouseWheel"
       t-ref="grid">
       <GridOverlay
         onCellClicked.bind="onCellClicked"


### PR DESCRIPTION
Some operating systems (like Mac OS) offer the possibility to swipe between pages with trackpad movements. This behaviour can conflict with the scrolling of a spreadsheet.

Task: 3947621

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo