### PR TITLE
[FIX] gridOverlay: self-handle grid clicks

### DIFF
--- a/src/components/dashboard/dashboard.xml
+++ b/src/components/dashboard/dashboard.xml
@@ -1,10 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-SpreadsheetDashboard">
-    <div
-      class="o-grid o-two-columns"
-      tabindex="-1"
-      t-on-wheel="onMouseWheel"
-      t-on-pointerdown="onClosePopover">
+    <div class="o-grid o-two-columns" tabindex="-1" t-on-wheel="onMouseWheel">
       <div class="mx-auto h-100 position-relative" t-ref="grid" t-att-style="gridContainer">
         <GridOverlay
           onCellHovered.bind="onCellHovered"

--- a/src/components/filters/filter_icons_overlay/filter_icons_overlay.ts
+++ b/src/components/filters/filter_icons_overlay/filter_icons_overlay.ts
@@ -3,15 +3,9 @@ import { CellPosition, SpreadsheetChildEnv } from "../../../types";
 import { GridCellIcon } from "../../grid_cell_icon/grid_cell_icon";
 import { FilterIcon } from "../filter_icon/filter_icon";
 
-interface Props {
-  onMouseDown: (ev: MouseEvent) => void;
-}
-
-export class FilterIconsOverlay extends Component<Props, SpreadsheetChildEnv> {
+export class FilterIconsOverlay extends Component<{}, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-FilterIconsOverlay";
-  static props = {
-    onMouseDown: Function,
-  };
+
   static components = {
     GridCellIcon,
     FilterIcon,

--- a/src/components/filters/filter_icons_overlay/filter_icons_overlay.xml
+++ b/src/components/filters/filter_icons_overlay/filter_icons_overlay.xml
@@ -1,14 +1,12 @@
 <templates>
   <t t-name="o-spreadsheet-FilterIconsOverlay">
-    <div t-on-pointerdown.stop="this.props.onMouseDown">
-      <t
-        t-foreach="getFilterHeadersPositions()"
-        t-as="position"
-        t-key="'filter'+position.col + '_' + position.row">
-        <GridCellIcon cellPosition="position" horizontalAlign="'right'">
-          <FilterIcon cellPosition="position"/>
-        </GridCellIcon>
-      </t>
-    </div>
+    <t
+      t-foreach="getFilterHeadersPositions()"
+      t-as="position"
+      t-key="'filter'+position.col + '_' + position.row">
+      <GridCellIcon cellPosition="position" horizontalAlign="'right'">
+        <FilterIcon cellPosition="position"/>
+      </GridCellIcon>
+    </t>
   </t>
 </templates>

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -470,9 +470,6 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
   // ---------------------------------------------------------------------------
 
   onCellClicked(col: HeaderIndex, row: HeaderIndex, modifiers: GridClickModifiers) {
-    if (modifiers.closePopover && this.cellPopovers.isOpen) {
-      this.cellPopovers.close();
-    }
     if (this.composerStore.editionMode === "editing") {
       this.composerStore.stopEdition();
     }

--- a/src/components/grid_overlay/grid_overlay.xml
+++ b/src/components/grid_overlay/grid_overlay.xml
@@ -10,7 +10,7 @@
       t-on-contextmenu.stop.prevent="onContextMenu">
       <FiguresContainer onFigureDeleted="props.onFigureDeleted"/>
       <DataValidationOverlay/>
-      <FilterIconsOverlay onMouseDown="(ev) => this.onMouseDown(ev, {closePopover: false})"/>
+      <FilterIconsOverlay/>
       <GridAddRowsFooter
         t-if="!env.model.getters.isReadonly()"
         t-key="env.model.getters.getActiveSheetId()"

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -376,5 +376,4 @@ export type DebouncedFunction<T> = T & {
 export interface GridClickModifiers {
   addZone: boolean;
   expandZone: boolean;
-  closePopover: boolean;
 }

--- a/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
@@ -22,9 +22,7 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
       
       
       
-      <div>
-        
-      </div>
+      
       
       
       

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -18,9 +18,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
     
     
     
-    <div>
-      
-    </div>
+    
     
     
     <div

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -647,9 +647,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           
           
           
-          <div>
-            
-          </div>
+          
           
           
           <div

--- a/tests/table/filter_icon_overlay.test.ts
+++ b/tests/table/filter_icon_overlay.test.ts
@@ -1,8 +1,9 @@
 import { Model } from "../../src";
 import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
+import { toZone } from "../../src/helpers";
 import { createTable } from "../test_helpers/commands_helpers";
-import { simulateClick } from "../test_helpers/dom_helper";
-import { mountSpreadsheet } from "../test_helpers/helpers";
+import { edgeScrollDelay, simulateClick, triggerMouseEvent } from "../test_helpers/dom_helper";
+import { mountSpreadsheet, nextTick } from "../test_helpers/helpers";
 
 describe("Filter Icon Overlay component", () => {
   test("Overlapping filters are overwritten by the latest inserted", async () => {
@@ -20,14 +21,29 @@ describe("Filter Icon Overlay component", () => {
     expect(fixture.querySelectorAll(".o-filter-icon").length).toBe(3);
   });
 
-  test("Click on filter icon bubble and select the underlying cell", async () => {
+  test("MouseEvent on filter icon bubbles and selects the underlying cell", async () => {
+    jest.useFakeTimers();
     const model = new Model();
     createTable(model, "B2:B3");
     const sheetId = model.getters.getActiveSheetId();
     const {} = await mountSpreadsheet({ model });
     expect(model.getters.getActivePosition()).toEqual({ sheetId, col: 0, row: 0 });
+    const { width } = model.getters.getSheetViewDimension();
 
     await simulateClick(".o-filter-icon", DEFAULT_CELL_WIDTH, DEFAULT_CELL_HEIGHT);
+
+    triggerMouseEvent(".o-filter-icon", "pointerdown", DEFAULT_CELL_WIDTH, DEFAULT_CELL_HEIGHT);
+    await nextTick();
     expect(model.getters.getActivePosition()).toEqual({ sheetId, col: 1, row: 1 });
+    triggerMouseEvent(
+      ".o-filter-icon",
+      "pointermove",
+      2.5 * DEFAULT_CELL_WIDTH,
+      DEFAULT_CELL_HEIGHT
+    );
+    const advanceTimer = edgeScrollDelay(1.5 * width, DEFAULT_CELL_HEIGHT);
+
+    jest.advanceTimersByTime(advanceTimer);
+    expect(model.getters.getSelectedZone()).toEqual(toZone("B2:C2"));
   });
 });


### PR DESCRIPTION
How to reproduce:

- Add a filter on a spreadsheet,
- MouseDown on the filter icon (in the grid),
- drag the mouse -> KABOOM

This issue is present since this PR[^1]. Using the behaviour of a parent component just for the sake of sparing some code/ behaviour redundancy seems risky and the bug introduced with [^1] is an example. This revision considers another approach where `FilterIconOverlay` is not aware of its parent behaviour. We simply let events bubble and both `GridOverlay` and `Grid` take their own responsibilities.

[^1]: https://github.com/odoo/o-spreadsheet/pull/3726

Task: 3868838

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo