### PR TITLE
[FIX] clipboard: do not change clipboard state on INSERT_CELLS

### DIFF
--- a/src/clipboard_handlers/sheet_clipboard.ts
+++ b/src/clipboard_handlers/sheet_clipboard.ts
@@ -6,7 +6,6 @@ type ClipboardContent = {
   cells: any[][];
   zones: Zone[];
   sheetId: UID;
-  isCutOperation: boolean;
 };
 
 export class SheetClipboardHandler extends AbstractCellClipboardHandler<ClipboardContent, any> {

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -8,9 +8,9 @@ export enum ClipboardMIMEType {
 export type ClipboardContent = { [type in ClipboardMIMEType]?: string };
 
 export interface ClipboardOptions {
+  isCutOperation: boolean;
   pasteOption?: ClipboardPasteOptions;
   selectTarget?: boolean;
-  isCutOperation?: boolean;
 }
 export type ClipboardPasteOptions = "onlyFormat" | "asValue";
 export type ClipboardOperation = "CUT" | "COPY";

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -17,9 +17,11 @@ import {
   createSheet,
   createSheetWithName,
   cut,
+  deleteCells,
   deleteColumns,
   deleteRows,
   deleteSheet,
+  insertCells,
   merge,
   paste,
   pasteFromOSClipboard,
@@ -1900,6 +1902,43 @@ describe("clipboard: pasting outside of sheet", () => {
     expect(getStyle(model, "B3")).toEqual({ bold: true, fillColor: "red" });
     expect(getCellContent(model, "C2")).toBe("c2");
     expect(getCellContent(model, "C3")).toBe("c2");
+  });
+
+  test("CopyPasteAboveCell and copyPasteCellsOnLeft do not change the clipboard state", () => {
+    const model = new Model();
+    setCellContent(model, "B3", "b3");
+    cut(model, "B3");
+    setSelection(model, ["A1:B2"]);
+    copyPasteAboveCells(model);
+
+    expect(model.getters.isCutOperation()).toBe(true);
+    paste(model, "A2");
+    expect(getCellContent(model, "A2")).toBe("b3");
+
+    setCellContent(model, "B3", "b3");
+    cut(model, "B3");
+    setSelection(model, ["A1:B2"]);
+    copyPasteCellsOnLeft(model);
+
+    expect(model.getters.isCutOperation()).toBe(true);
+    paste(model, "A2");
+    expect(getCellContent(model, "A2")).toBe("b3");
+  });
+
+  test("Delete Cell and Insert Cell do not invalidate the clipboard", () => {
+    const model = new Model();
+    setCellContent(model, "B3", "b3");
+    copy(model, "B3");
+
+    deleteCells(model, "A1", "up");
+    expect(model.getters.isCutOperation()).toBe(false);
+    paste(model, "A2");
+    expect(getCellContent(model, "A2")).toBe("b3");
+
+    insertCells(model, "A1", "down");
+    expect(model.getters.isCutOperation()).toBe(false);
+    paste(model, "A5");
+    expect(getCellContent(model, "A5")).toBe("b3");
   });
 
   test("fill right selection with multiple columns -> copies first column and pastes in each subsequent column, ", async () => {


### PR DESCRIPTION
## Description

Commands `INSERT_CELLS`, `DELETE_CELLS`, `COPY_PASTE_CELLS_ABOVE`, and `COPY_PASTE_CELLS_ON_LEFT` and handled by the clipboard plugin. The problem is that since the last refactor of the clipboard plugin, these commands also invalidated the state of the copy/paste.

This commit fixes the issue by not changing the clipboard state when handling those commands.

Task: : [3874117](https://www.odoo.com/web#id=3874117&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo