### PR TITLE
[FIX] charts: format combo chart axis

### DIFF
--- a/tests/figures/chart/combo_chart_plugin.test.ts
+++ b/tests/figures/chart/combo_chart_plugin.test.ts
@@ -1,5 +1,7 @@
-import { ChartCreationContext } from "../../../src";
+import { ChartCreationContext, Model } from "../../../src";
 import { getChartDefinitionFromContextCreation } from "../../../src/helpers/figures/charts";
+import { ComboChartRuntime } from "../../../src/types/chart/combo_chart";
+import { createChart, setCellContent, setCellFormat } from "../../test_helpers/commands_helpers";
 
 describe("combo chart", () => {
   test("create combo chart from creation context", () => {
@@ -32,5 +34,44 @@ describe("combo chart", () => {
       aggregated: true,
       useBothYAxis: false,
     });
+  });
+
+  test("both axis formats are based on their data set", () => {
+    const model = new Model();
+    setCellContent(model, "A1", "Alice");
+    setCellContent(model, "A2", "Bob");
+
+    // first data set
+    setCellContent(model, "B1", "1");
+    setCellContent(model, "B2", "2");
+    setCellFormat(model, "B1", "0.00%");
+    setCellFormat(model, "B2", "0.00%");
+
+    // second data set
+    setCellContent(model, "C1", "10");
+    setCellContent(model, "C2", "20");
+    setCellFormat(model, "C1", "0.00[$$]");
+    setCellFormat(model, "C2", "0.00[$$]");
+
+    createChart(
+      model,
+      {
+        type: "combo",
+        labelRange: "A1:A2",
+        dataSets: ["B1:B2", "C1:C2"],
+        useBothYAxis: true,
+        dataSetsHaveTitle: false,
+      },
+      "1"
+    );
+    const runtime = model.getters.getChartRuntime("1") as ComboChartRuntime;
+    const index = 0; // because chart.js types expects an index
+    const ticks = []; // because chart.js types expects the ticks
+    expect(
+      runtime.chartJsConfig.options?.scales?.y?.ticks?.callback?.apply(null, [1, index, ticks])
+    ).toBe("100.00%");
+    expect(
+      runtime.chartJsConfig.options?.scales?.y1?.ticks?.callback?.apply(null, [1, index, ticks])
+    ).toBe("1.00$");
   });
 });


### PR DESCRIPTION
## Description:

Steps to reproduce:
- create a combo chart with 2 data sets
- set a different format on both data sets
- check "Use right axis for line series" => both axis are formatted with the same format instead of using the format of the related datasets
- 
Task: : [3893708](https://www.odoo.com/web#id=3893708&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo