### PR TITLE
[FIX] ranges: getRangeFromSheetXC with invalid sheetId

### DIFF
--- a/src/plugins/core/range.ts
+++ b/src/plugins/core/range.ts
@@ -292,7 +292,7 @@ export class RangeAdapter implements CommandHandler<CoreCommand> {
    * @param sheetXC the string description of a range, in the form SheetName!XC:XC
    */
   getRangeFromSheetXC(defaultSheetId: UID, sheetXC: string): RangeImpl {
-    if (!rangeReference.test(sheetXC)) {
+    if (!rangeReference.test(sheetXC) || !this.getters.tryGetSheet(defaultSheetId)) {
       return new RangeImpl(
         {
           sheetId: "",

--- a/tests/plugins/range.test.ts
+++ b/tests/plugins/range.test.ts
@@ -571,6 +571,28 @@ describe("range plugin", () => {
     deleteSheet(m, "s1");
     expect(m.getters.getRangeString(range)).toBe(INCORRECT_RANGE_STRING);
   });
+
+  test("getRangeFromSheetXC on invalid sheet", () => {
+    let getRange = () => m.getters.getRangeFromSheetXC("NotASheet", "A1");
+    expect(getRange).not.toThrow();
+    expect(getRange().invalidXc).toBe("A1");
+
+    getRange = () => m.getters.getRangeFromSheetXC("NotASheet", "A:A");
+    expect(getRange).not.toThrow();
+    expect(getRange().invalidXc).toBe("A:A");
+
+    getRange = () => m.getters.getRangeFromSheetXC("NotASheet", "Sheet1!A1");
+    expect(getRange).not.toThrow();
+    expect(getRange().invalidXc).toBe("Sheet1!A1");
+
+    getRange = () => m.getters.getRangeFromSheetXC("", "Sheet1!A:A");
+    expect(getRange).not.toThrow();
+    expect(getRange().invalidXc).toBe("Sheet1!A:A");
+
+    getRange = () => m.getters.getRangeFromSheetXC("", "A1:A2");
+    expect(getRange).not.toThrow();
+    expect(getRange().invalidXc).toBe("A1:A2");
+  });
 });
 
 describe("Helpers", () => {


### PR DESCRIPTION
## Description

When `getRangeFromSheetXC` is called, it either crashes or returns an corrupted range. The getter should handle this case, and return an invalid range.

Task: : [3578461](https://www.odoo.com/web#id=3578461&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo