### PR TITLE
[FIX] link: don't copy link style on row addition

### DIFF
--- a/src/helpers/cells/cell_types.ts
+++ b/src/helpers/cells/cell_types.ts
@@ -1,4 +1,4 @@
-import { DATETIME_FORMAT, LINK_COLOR, LOADING } from "../../constants";
+import { DATETIME_FORMAT, LOADING } from "../../constants";
 import { _lt } from "../../translation";
 import {
   BooleanEvaluation,
@@ -144,14 +144,6 @@ export abstract class LinkCell extends AbstractCell<TextEvaluation> implements I
 
   constructor(id: UID, content: string, properties: CellDisplayProperties = {}) {
     const link = parseMarkdownLink(content);
-    properties = {
-      ...properties,
-      style: {
-        ...properties.style,
-        textColor: properties.style?.textColor || LINK_COLOR,
-        underline: true,
-      },
-    };
     super(id, { value: link.label, type: CellValueType.text }, properties);
     this.link = link;
     this.content = content;

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -1,4 +1,4 @@
-import { FORMULA_REF_IDENTIFIER, NULL_FORMAT } from "../../constants";
+import { FORMULA_REF_IDENTIFIER, LINK_COLOR, NULL_FORMAT } from "../../constants";
 import { cellFactory } from "../../helpers/cells/cell_factory";
 import { FormulaCell } from "../../helpers/cells/index";
 import { deepEquals, isInside, range, toCartesian, toXC, UuidGenerator } from "../../helpers/index";
@@ -23,6 +23,8 @@ import {
 import { CorePlugin } from "../core_plugin";
 
 const nbspRegexp = new RegExp(String.fromCharCode(160), "g");
+
+const LINK_STYLE = { textColor: LINK_COLOR, underline: true };
 
 interface CoreState {
   // this.cells[sheetId][cellId] --> cell|undefined
@@ -311,7 +313,8 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
   }
 
   getCellStyle(cell: Cell): Style {
-    return cell.style || {};
+    const linkStyle = cell.isLink() ? LINK_STYLE : {};
+    return { ...linkStyle, ...cell.style };
   }
 
   /**

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -12607,9 +12607,8 @@ Object {
             <name val=\\"Calibri\\"/>
         </font>
         <font>
-            <u/>
             <sz val=\\"10\\"/>
-            <color rgb=\\"0000FF\\"/>
+            <color rgb=\\"000000\\"/>
             <name val=\\"Arial\\"/>
         </font>
     </fonts>
@@ -13107,9 +13106,8 @@ Object {
             <name val=\\"Calibri\\"/>
         </font>
         <font>
-            <u/>
             <sz val=\\"10\\"/>
-            <color rgb=\\"0000FF\\"/>
+            <color rgb=\\"000000\\"/>
             <name val=\\"Arial\\"/>
         </font>
     </fonts>

--- a/tests/plugins/cell.test.ts
+++ b/tests/plugins/cell.test.ts
@@ -81,7 +81,8 @@ describe("link cell", () => {
       expect(cell.link.label).toBe("my label");
       expect(cell.link.url).toBe(url);
       expect(cell.urlRepresentation).toBe(url);
-      expect(cell.style).toEqual({ textColor: "#00f", underline: true });
+      expect(cell.style).toBeUndefined();
+      expect(model.getters.getCellStyle(cell)).toEqual({ textColor: "#00f", underline: true });
       expect(getCellText(model, "A1")).toBe("my label");
     }
   );
@@ -200,14 +201,18 @@ describe("link cell", () => {
   test("link text color is applied if a custom style is specified", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
+    const style = { fillColor: "#555", bold: true, textColor: "#111" };
+
     model.dispatch("UPDATE_CELL", {
       col: 0,
       row: 0,
       sheetId,
       content: "[my label](odoo.com)",
-      style: { fillColor: "#555", bold: true, textColor: "#111" },
+      style,
     });
-    expect(getCell(model, "A1")?.style).toEqual({
+    const cell = getCell(model, "A1")!;
+    expect(cell?.style).toEqual(style);
+    expect(model.getters.getCellStyle(cell)).toEqual({
       fillColor: "#555",
       bold: true,
       textColor: "#111",
@@ -218,14 +223,13 @@ describe("link cell", () => {
   test("link text color is not overwritten if there is a custom style", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
-    model.dispatch("UPDATE_CELL", {
-      col: 0,
-      row: 0,
-      sheetId,
-      style: { fillColor: "#555", bold: true, textColor: "#111" },
-    });
+    const style = { fillColor: "#555", bold: true, textColor: "#111" };
+    model.dispatch("UPDATE_CELL", { col: 0, row: 0, sheetId, style });
+
     setCellContent(model, "A1", `[my label](odoo.com)`);
-    expect(getCell(model, "A1")?.style).toEqual({
+    const cell = getCell(model, "A1")!;
+    expect(cell?.style).toEqual(style);
+    expect(model.getters.getCellStyle(cell)).toEqual({
       fillColor: "#555",
       bold: true,
       textColor: "#111",
@@ -264,16 +268,19 @@ describe("link cell", () => {
   test("copy-paste custom style", () => {
     const model = new Model();
     const sheetId = model.getters.getActiveSheetId();
+    const style = { fillColor: "#555", bold: true, textColor: "#111" };
     model.dispatch("UPDATE_CELL", {
       col: 1,
       row: 1,
       sheetId,
       content: "[my label](odoo.com)",
-      style: { fillColor: "#555", bold: true, textColor: "#111" },
+      style,
     });
     model.dispatch("COPY", { target: [toZone("B2")] });
     model.dispatch("PASTE", { target: [toZone("D2")] });
-    expect(getCell(model, "D2")?.style).toEqual({
+    const cell = getCell(model, "D2")!;
+    expect(cell.style).toEqual(style);
+    expect(model.getters.getCellStyle(cell)).toEqual({
       fillColor: "#555",
       bold: true,
       textColor: "#111",

--- a/tests/plugins/grid_manipulation.test.ts
+++ b/tests/plugins/grid_manipulation.test.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_CELL_HEIGHT,
   DEFAULT_CELL_WIDTH,
   INCORRECT_RANGE_STRING,
+  LINK_COLOR,
 } from "../../src/constants";
 import { lettersToNumber, toXC, toZone } from "../../src/helpers";
 import { Model } from "../../src/model";
@@ -1385,6 +1386,17 @@ describe("Rows", () => {
         top: 2,
         bottom: 5,
         topLeft: toPosition("D3"),
+      });
+    });
+
+    test("Link style is not propagated on row addition", () => {
+      setCellContent(model, "D4", `[my label](www.google.com)`);
+      expect(getCell(model, "D4")?.isLink()).toBe(true);
+      addRows(model, "before", 3, 1);
+
+      expect(getCell(model, "D4")).toBeUndefined();
+      expect(model.getters.getCellStyle(getCell(model, "D5")!)).toMatchObject({
+        textColor: LINK_COLOR,
       });
     });
 


### PR DESCRIPTION
## Description

When adding a row after another, the style of the cells is copied from the previous row. This should not be the case for the style of links.

This happened because the link style was hard-coded in the cell. Now the link color is not present ont he cell.style, but only in the getter getCellStyle().

Note that it means that link style is not exported in Excel anymore.

Task: : [3869699](https://www.odoo.com/web#id=3869699&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo