### PR TITLE
[FIX] cf: drag & drop CF break on scroll

### DIFF
--- a/src/components/helpers/drag_and_drop.ts
+++ b/src/components/helpers/drag_and_drop.ts
@@ -4,19 +4,26 @@ import { HeaderIndex } from "../../types/misc";
 import { gridOverlayPosition } from "./dom_helpers";
 type EventFn = (ev: MouseEvent) => void;
 
+/**
+ * Start listening to pointer events and apply the given callbacks.
+ *
+ * @returns A function to remove the listeners.
+ */
 export function startDnd(
   onMouseMove: EventFn,
   onMouseUp: EventFn,
   onMouseDown: EventFn = () => {}
 ) {
-  const _onMouseUp = (ev: MouseEvent) => {
-    onMouseUp(ev);
-
+  const removeListeners = () => {
     window.removeEventListener("pointerdown", onMouseDown);
     window.removeEventListener("pointerup", _onMouseUp);
     window.removeEventListener("dragstart", _onDragStart);
     window.removeEventListener("pointermove", onMouseMove);
     window.removeEventListener("wheel", onMouseMove);
+  };
+  const _onMouseUp = (ev: MouseEvent) => {
+    onMouseUp(ev);
+    removeListeners();
   };
   function _onDragStart(ev: DragEvent) {
     ev.preventDefault();
@@ -29,6 +36,8 @@ export function startDnd(
   // preventDefault() is not allowed in passive event handler.
   // https://chromestatus.com/feature/6662647093133312
   window.addEventListener("wheel", onMouseMove, { passive: false });
+
+  return removeListeners;
 }
 
 /**

--- a/src/components/helpers/drag_and_drop_hook.ts
+++ b/src/components/helpers/drag_and_drop_hook.ts
@@ -60,6 +60,7 @@ export function useDragAndDropListItems() {
       state.itemsStyle = {};
       document.body.style.cursor = previousCursor;
       args.onCancel?.();
+      cleanUp();
     };
 
     const onDragEnd = (itemId: UID, indexAtEnd: number) => {
@@ -83,7 +84,11 @@ export function useDragAndDropListItems() {
       onDragEnd,
       onCancel: state.cancel,
     });
-    startDnd(dndHelper.onMouseMove.bind(dndHelper), dndHelper.onMouseUp.bind(dndHelper));
+    const stopListening = startDnd(
+      dndHelper.onMouseMove.bind(dndHelper),
+      dndHelper.onMouseUp.bind(dndHelper)
+    );
+    cleanupFns.push(stopListening);
 
     const onScroll = dndHelper.onScroll.bind(dndHelper);
     args.containerEl.addEventListener("scroll", onScroll);
@@ -182,7 +187,7 @@ class DOMDndHelper {
   }
 
   onMouseMove(ev: MouseEvent) {
-    if (ev.button !== -1) {
+    if (ev.button > 1) {
       this.onCancel();
       return;
     }

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -18,6 +18,7 @@ import {
   keyDown,
   setInputValueAndTrigger,
   triggerMouseEvent,
+  triggerWheelEvent,
 } from "../test_helpers/dom_helper";
 import {
   createColorScale,
@@ -471,6 +472,31 @@ describe("UI of conditional formats", () => {
       await nextTick();
 
       expect(previewEl.style.transition).toBe("");
+    });
+
+    test("Drag & drop is not canceled on wheel event", async () => {
+      const previewEl = fixture.querySelector<HTMLElement>(`.o-cf-preview[data-id="1"]`)!;
+      await dragElement(previewEl, { x: 0, y: 200 });
+
+      expect(previewEl!.classList).toContain("o-cf-dragging");
+      triggerWheelEvent(previewEl, { deltaY: 100 });
+      await nextTick();
+
+      expect(previewEl!.classList).toContain("o-cf-dragging");
+    });
+
+    test("Drag & drop is canceled on right click", async () => {
+      let previewEl = fixture.querySelector<HTMLElement>(`.o-cf-preview[data-id="1"]`)!;
+      await dragElement(previewEl, { x: 0, y: 200 });
+
+      expect(previewEl!.classList).toContain("o-cf-dragging");
+      triggerMouseEvent(previewEl.parentElement, "pointermove", 0, 0, { button: 2 });
+      await nextTick();
+      expect(previewEl!.classList).not.toContain("o-cf-dragging");
+
+      triggerMouseEvent(previewEl.parentElement, "pointermove", 0, 200);
+      await nextTick();
+      expect(previewEl!.classList).not.toContain("o-cf-dragging");
     });
   });
 


### PR DESCRIPTION
## Description

When dragging a CF in its side panel and scrolling, the drag & drop breaks. The CF first go back to its original position after the wheel event, then is dragged with a wrong CSS when moving the mouse again.

There was 2 issues:
1) Since b900a0b the drag & drop is canceled on wheel button. This is by changing which button cancels the drag & drop.
2) the `onCancel` callback in the `DOMDndHelper` didn't work properly. It didn't clean the even listeners, and the drag & drop was still going until the next mouseUp.

Task: : [3951043](https://www.odoo.com/web#id=3951043&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo