### PR TITLE
[FIX] xlsx: Skip non-exported formula with no result

### DIFF
--- a/src/xlsx/functions/cells.ts
+++ b/src/xlsx/functions/cells.ts
@@ -22,10 +22,12 @@ import { FORCE_DEFAULT_ARGS_FUNCTIONS, NON_RETROCOMPATIBLE_FUNCTIONS } from "../
 import { getCellType, pushElement } from "../helpers/content_helpers";
 import { escapeXml } from "../helpers/xml_helpers";
 
-export function addFormula(cell: ExcelCellData): {
-  attrs: XMLAttributes;
-  node: XMLString;
-} {
+export function addFormula(cell: ExcelCellData):
+  | {
+      attrs: XMLAttributes;
+      node: XMLString;
+    }
+  | undefined {
   const formula = cell.content!;
   const functions = functionRegistry.content;
   const tokens = tokenize(formula);
@@ -56,6 +58,12 @@ export function addFormula(cell: ExcelCellData): {
   } else {
     // Shouldn't we always output the value then ?
     const value = cell.value;
+    // If the cell contains a non-exported formula and that is evaluates to
+    // nothing* ,we don't export it.
+    // * non-falsy value are relevant and so are 0 and FALSE, which only leaves
+    // the empty string.
+    if (value === "") return undefined;
+
     const type = getCellType(value);
     attrs.push(["t", type]);
     node = escapeXml/*xml*/ `<v>${value}</v>`;

--- a/src/xlsx/functions/worksheet.ts
+++ b/src/xlsx/functions/worksheet.ts
@@ -73,7 +73,11 @@ export function addRows(
         let cellNode = escapeXml``;
         // Either formula or static value inside the cell
         if (cell.isFormula) {
-          ({ attrs: additionalAttrs, node: cellNode } = addFormula(cell));
+          const res = addFormula(cell);
+          if (!res) {
+            continue;
+          }
+          ({ attrs: additionalAttrs, node: cellNode } = res);
         } else if (cell.content && isMarkdownLink(cell.content)) {
           const { label } = parseMarkdownLink(cell.content);
           ({ attrs: additionalAttrs, node: cellNode } = addContent(label, construct.sharedStrings));

--- a/tests/__snapshots__/xlsx.test.ts.snap
+++ b/tests/__snapshots__/xlsx.test.ts.snap
@@ -12505,6 +12505,116 @@ Object {
 }
 `;
 
+exports[`Test XLSX export formulas Non exportable functions that is evaluated as nothing (aka empty string) 1`] = `
+Object {
+  "files": Array [
+    Object {
+      "content": "<workbook xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <sheets>
+        <sheet name=\\"Sheet1\\" sheetId=\\"1\\" r:id=\\"rId1\\"/>
+    </sheets>
+</workbook>",
+      "contentType": "workbook",
+      "path": "xl/workbook.xml",
+    },
+    Object {
+      "content": "<worksheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <sheetFormatPr defaultRowHeight=\\"17.25\\" defaultColWidth=\\"13.68\\"/>
+    <cols>
+        <col min=\\"1\\" max=\\"1\\" width=\\"13.68\\" customWidth=\\"1\\" hidden=\\"0\\"/>
+    </cols>
+    <sheetData>
+    </sheetData>
+</worksheet>",
+      "contentType": "sheet",
+      "path": "xl/worksheets/sheet0.xml",
+    },
+    Object {
+      "content": "<styleSheet xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" xmlns:r=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\">
+    <numFmts count=\\"0\\">
+    </numFmts>
+    <fonts count=\\"2\\">
+        <font>
+            <sz val=\\"10\\"/>
+            <color rgb=\\"000000\\"/>
+            <name val=\\"Calibri\\"/>
+        </font>
+        <font>
+            <sz val=\\"10\\"/>
+            <color rgb=\\"000000\\"/>
+            <name val=\\"Arial\\"/>
+        </font>
+    </fonts>
+    <fills count=\\"2\\">
+        <fill>
+            <patternFill patternType=\\"none\\"/>
+        </fill>
+        <fill>
+            <patternFill patternType=\\"gray125\\"/>
+        </fill>
+    </fills>
+    <borders count=\\"1\\">
+        <border>
+            <left/>
+            <right/>
+            <top/>
+            <bottom/>
+            <diagonal/>
+        </border>
+    </borders>
+    <cellXfs count=\\"2\\">
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"0\\" borderId=\\"0\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+        <xf numFmtId=\\"0\\" fillId=\\"0\\" fontId=\\"1\\" borderId=\\"0\\">
+            <alignment vertical=\\"center\\"/>
+        </xf>
+    </cellXfs>
+    <dxfs count=\\"0\\">
+    </dxfs>
+</styleSheet>",
+      "contentType": "styles",
+      "path": "xl/styles.xml",
+    },
+    Object {
+      "content": "<sst xmlns=\\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\\" count=\\"0\\" uniqueCount=\\"0\\">
+</sst>",
+      "contentType": "sharedStrings",
+      "path": "xl/sharedStrings.xml",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Target=\\"worksheets/sheet0.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\\"/>
+    <Relationship Id=\\"rId2\\" Target=\\"sharedStrings.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\\"/>
+    <Relationship Id=\\"rId3\\" Target=\\"styles.xml\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "xl/_rels/workbook.xml.rels",
+    },
+    Object {
+      "content": "<Types xmlns=\\"http://schemas.openxmlformats.org/package/2006/content-types\\">
+    <Default Extension=\\"rels\\" ContentType=\\"application/vnd.openxmlformats-package.relationships+xml\\"/>
+    <Default Extension=\\"xml\\" ContentType=\\"application/xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\\" PartName=\\"/xl/workbook.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\\" PartName=\\"/xl/worksheets/sheet0.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml\\" PartName=\\"/xl/styles.xml\\"/>
+    <Override ContentType=\\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\\" PartName=\\"/xl/sharedStrings.xml\\"/>
+</Types>",
+      "contentType": undefined,
+      "path": "[Content_Types].xml",
+    },
+    Object {
+      "content": "<Relationships xmlns=\\"http://schemas.openxmlformats.org/package/2006/relationships\\">
+    <Relationship Id=\\"rId1\\" Type=\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\\" Target=\\"xl/workbook.xml\\"/>
+</Relationships>",
+      "contentType": undefined,
+      "path": "_rels/.rels",
+    },
+  ],
+  "name": "my_spreadsheet.xlsx",
+}
+`;
+
 exports[`Test XLSX export link cells 1`] = `
 Object {
   "files": Array [

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -626,6 +626,13 @@ describe("Test XLSX export", () => {
       expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
     });
 
+    test("Non exportable functions that is evaluated as nothing (aka empty string)", async () => {
+      const model = new Model({
+        sheets: [{ cells: { A1: { content: '=join("", A2:A3)' } }, rowNumber: 3, colNumber: 1 }],
+      });
+      expect(await exportPrettifiedXlsx(model)).toMatchSnapshot();
+    });
+
     test("Multi-Sheets exportable functions", async () => {
       const model = new Model({
         sheets: [allExportableFormulasData.sheets[0], { cells: { A1: { content: "=wait(10)" } } }],


### PR DESCRIPTION
Our library, as long as Google Sheet, support the ability to manipulate apples and oranges (e.g. A1: "" , A2: =A1+2 - will work and yield 2 in our library) while Excel will reject it.

This revision adds some compatibility with the Excel export. In the case of a non-exportable formula which returns nothing as in : a falsy value which retains no information.

There are three types of falsy values:
- FALSE
- 0
- an empty string `""`

The two first cases contain information, as they can be the result nad boolean data. The third case could only be an empty formula result or the result of a string manipulation but in both cases, the information is the same as in an empty cell.
As such, this revision targets empty strings and skips them during the export (again only when they result from a formula non supported by Excel).

Task: 3491974

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo