### PR TITLE
[IMP] Figure: delete figures with `Backspace` key

### DIFF
--- a/src/components/figures/figure/figure.ts
+++ b/src/components/figures/figure/figure.ts
@@ -232,6 +232,7 @@ export class FigureComponent extends Component<Props, SpreadsheetChildEnv> {
 
     switch (ev.key) {
       case "Delete":
+      case "Backspace":
         this.env.model.dispatch("DELETE_FIGURE", {
           sheetId: this.env.model.getters.getActiveSheetId(),
           id: figure.id,

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -168,6 +168,15 @@ describe("figures", () => {
     expect(getCellContent(model, "A1")).toBe("content");
   });
 
+  test("Can delete a figure with `Backspace`", async () => {
+    createFigure(model);
+    await nextTick();
+    fixture.querySelector(".o-figure")!;
+    await simulateClick(".o-figure");
+    await keyDown({ key: "Backspace" });
+    expect(fixture.querySelector(".o-figure")).toBeNull();
+  });
+
   test("Add a figure on sheet2, scroll down on sheet 1, switch to sheet 2, the figure should be displayed", async () => {
     createSheet(model, { sheetId: "42", position: 1 });
     createFigure(model, {}, "42");


### PR DESCRIPTION
Some laptop keyboards (looking at you, Apple) do not have a `Delete` key which prevented the users of such machines to delete figures. This revision takes the same approach as we did for the grid, which is to map the `Backspace` key to have the exact same behaviour as `Delete`.

Task: 3950404

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo