### PR TITLE
[FIX] border: bottom sheet borders removed on DELETE_ROWS

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -105,7 +105,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
           if (cmd.dimension === "COL") {
             this.shiftBordersHorizontally(cmd.sheetId, el + 1, -1);
           } else {
-            this.shiftBordersVertically(cmd.sheetId, el + 1, -1);
+            this.shiftBordersVertically(cmd.sheetId, el + 1, -1, cmd.elements.length);
           }
         }
         break;
@@ -152,13 +152,13 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     let rowAboveInsertion: HeaderIndex;
     let rowBelowInsertion: HeaderIndex;
     if (cmd.position === "before") {
-      this.shiftBordersVertically(cmd.sheetId, cmd.base, cmd.quantity, {
+      this.shiftBordersVertically(cmd.sheetId, cmd.base, cmd.quantity, 0, {
         moveFirstTopBorder: true,
       });
       rowAboveInsertion = cmd.base - 1;
       rowBelowInsertion = cmd.base + cmd.quantity;
     } else {
-      this.shiftBordersVertically(cmd.sheetId, cmd.base + 1, cmd.quantity, {
+      this.shiftBordersVertically(cmd.sheetId, cmd.base + 1, cmd.quantity, 0, {
         moveFirstTopBorder: false,
       });
       rowAboveInsertion = cmd.base;
@@ -320,6 +320,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
     sheetId: UID,
     start: HeaderIndex,
     delta: number,
+    totalDeletedRows: number,
     { moveFirstTopBorder }: { moveFirstTopBorder?: boolean } = {}
   ) {
     const borders = this.borders[sheetId];
@@ -329,7 +330,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
         destructive: false,
       });
     }
-    this.getRowsRange(sheetId)
+    range(0, this.getters.getNumberRows(sheetId) + totalDeletedRows + 1)
       .filter((row) => row >= start)
       .sort((a, b) => (delta < 0 ? a - b : b - a)) // start by the end when moving up
       .forEach((row) => {

--- a/tests/borders/border_plugin.test.ts
+++ b/tests/borders/border_plugin.test.ts
@@ -4,6 +4,7 @@ import { BorderDescr, CommandResult } from "../../src/types/index";
 import {
   addColumns,
   addRows,
+  createSheet,
   cut,
   deleteCells,
   deleteColumns,
@@ -593,6 +594,17 @@ describe("Grid manipulation", () => {
     expect(getBorder(model, "A1")).toEqual({ top: b, left: b, right: b, bottom: b });
     expect(getBorder(model, "B1")).toEqual({ left: b });
     expect(getBorder(model, "A2")).toEqual({ top: b });
+  });
+
+  test("Remove multiple rows before borders at the bottom of the sheet", () => {
+    createSheet(model, { activate: true, sheetId: "sh1", rows: 5, cols: 2 });
+    const b = DEFAULT_BORDER_DESC;
+    setZoneBorders(model, { position: "external" }, ["A4:B5"]);
+    deleteRows(model, [0, 1]);
+    expect(getBorder(model, "A2")).toEqual({ left: b, top: b });
+    expect(getBorder(model, "A3")).toEqual({ left: b, bottom: b });
+    expect(getBorder(model, "B2")).toEqual({ right: b, top: b });
+    expect(getBorder(model, "B3")).toEqual({ right: b, bottom: b });
   });
 
   test("Borders are correctly duplicated on sheet dup", () => {


### PR DESCRIPTION
### [FIX] border: bottom sheet borders removed on DELETE_ROWS

Problem
-----
Before this commit, when we add border at the bottom of the sheet (at very the last rows), if we delete some rows in a position before the border, some/all border disappear. The reason being that the sheet plugin updates the total rows before we loop through them to shift the border.

Solution
------
This commit fixes this behaviour by adding the total deleted rows to the loop that takes care of shifting the borders.

Task: [3911695](https://www.odoo.com/web#id=3911695&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo