### PR TITLE
[PERF] evaluation: faster spreading

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -40,7 +40,7 @@ export class Evaluator {
     new FormulaDependencyGraph(this.createEmptyPositionSet.bind(this))
   );
   private blockedArrayFormulas = new PositionSet({});
-  private spreadingRelations = new SpreadingRelation(this.createEmptyPositionSet.bind(this));
+  private spreadingRelations = new SpreadingRelation();
 
   constructor(private readonly context: ModelConfig["custom"], getters: Getters) {
     this.getters = getters;
@@ -139,7 +139,7 @@ export class Evaluator {
 
   buildDependencyGraph() {
     this.blockedArrayFormulas = this.createEmptyPositionSet();
-    this.spreadingRelations = new SpreadingRelation(this.createEmptyPositionSet.bind(this));
+    this.spreadingRelations = new SpreadingRelation();
     this.formulaDependencies = lazy(() => {
       const dependencies = [...this.getAllCells()].flatMap((position) =>
         this.getDirectDependencies(position)

--- a/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/spreading_relation.ts
@@ -1,6 +1,5 @@
 import { CellPosition } from "../../../types";
 import { PositionMap } from "./position_map";
-import { PositionSet } from "./position_set";
 
 /**
  * Contains, for each cell, the array
@@ -43,10 +42,8 @@ export class SpreadingRelation {
    * - (B1) --> (B2, B3, B4)  meaning B1 spreads on B2, B3 and B4
    *
    */
-  private readonly resultsToArrayFormulas: PositionMap<PositionSet> = new PositionMap();
-  private readonly arrayFormulasToResults: PositionMap<PositionSet> = new PositionMap();
-
-  constructor(private readonly createEmptyPositionSet: () => PositionSet) {}
+  private readonly resultsToArrayFormulas: PositionMap<CellPosition[]> = new PositionMap();
+  private readonly arrayFormulasToResults: PositionMap<CellPosition[]> = new PositionMap();
 
   getFormulaPositionsSpreadingOn(resultPosition: CellPosition): Iterable<CellPosition> {
     return this.resultsToArrayFormulas.get(resultPosition) || EMPTY_ARRAY;
@@ -75,13 +72,13 @@ export class SpreadingRelation {
     resultPosition: CellPosition;
   }): void {
     if (!this.resultsToArrayFormulas.has(resultPosition)) {
-      this.resultsToArrayFormulas.set(resultPosition, this.createEmptyPositionSet());
+      this.resultsToArrayFormulas.set(resultPosition, []);
     }
-    this.resultsToArrayFormulas.get(resultPosition)?.add(arrayFormulaPosition);
+    this.resultsToArrayFormulas.get(resultPosition)?.push(arrayFormulaPosition);
     if (!this.arrayFormulasToResults.has(arrayFormulaPosition)) {
-      this.arrayFormulasToResults.set(arrayFormulaPosition, this.createEmptyPositionSet());
+      this.arrayFormulasToResults.set(arrayFormulaPosition, []);
     }
-    this.arrayFormulasToResults.get(arrayFormulaPosition)?.add(resultPosition);
+    this.arrayFormulasToResults.get(arrayFormulaPosition)?.push(resultPosition);
   }
 
   hasArrayFormulaResult(position: CellPosition): boolean {


### PR DESCRIPTION
## Description:

This commit improves the speed of spreading a large array formula result.

Reference a large zone `=transpose(transpose(A1:E3000))`

before: 1.22s
after:  387ms

Instanciating a PositionSet is not free (it allocates memory)

Here, PositionSets were used but the properties of sets are actually not used
(uniquness of values in the set, O(1) lookup), and we add each position
only once and we never have to check if a position is in the set.
Using a simple arry is perfectly fine.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo