### PR TITLE
[FIX] composer: Prevent default paste in composer

### DIFF
--- a/src/components/composer/composer/composer.ts
+++ b/src/components/composer/composer/composer.ts
@@ -339,7 +339,13 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
 
   onPaste(ev: ClipboardEvent) {
     if (this.env.model.getters.getEditionMode() !== "inactive") {
+      // let the browser clipboard work
       ev.stopPropagation();
+    } else {
+      // the user meant to paste in the sheet, not open the composer with the pasted content
+      // While we're not editing, we still have the focus and should therefore prevent
+      // the native "paste" to occur.
+      ev.preventDefault();
     }
   }
 
@@ -348,12 +354,6 @@ export class Composer extends Component<ComposerProps, SpreadsheetChildEnv> {
    * */
   onInput(ev: InputEvent) {
     if (!this.shouldProcessInputEvents) {
-      return;
-    }
-    if (
-      ev.inputType === "insertFromPaste" &&
-      this.env.model.getters.getEditionMode() === "inactive"
-    ) {
       return;
     }
     ev.stopPropagation();

--- a/src/components/composer/grid_composer/grid_composer.ts
+++ b/src/components/composer/grid_composer/grid_composer.ts
@@ -84,10 +84,7 @@ export class GridComposer extends Component<Props, SpreadsheetChildEnv> {
 
   get containerStyle(): string {
     if (this.env.model.getters.getEditionMode() === "inactive" || !this.rect) {
-      return `
-        position: absolute;
-        z-index: -1000;
-      `;
+      return `z-index: -1000;`;
     }
     const isFormula = this.env.model.getters.getCurrentContent().startsWith("=");
     const cell = this.env.model.getters.getActiveCell();

--- a/tests/components/__snapshots__/grid.test.ts.snap
+++ b/tests/components/__snapshots__/grid.test.ts.snap
@@ -53,10 +53,7 @@ exports[`Grid component simple rendering snapshot 1`] = `
   
   <div
     class="o-grid-composer"
-    style="
-        position: absolute;
-        z-index: -1000;
-      "
+    style="z-index: -1000;"
   >
     <div
       class="o-composer-container"

--- a/tests/components/__snapshots__/spreadsheet.test.ts.snap
+++ b/tests/components/__snapshots__/spreadsheet.test.ts.snap
@@ -458,10 +458,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
     
     <div
       class="o-grid-composer"
-      style="
-        position: absolute;
-        z-index: -1000;
-      "
+      style="z-index: -1000;"
     >
       <div
         class="o-composer-container"

--- a/tests/components/composer.test.ts
+++ b/tests/components/composer.test.ts
@@ -604,16 +604,12 @@ describe("composer", () => {
     await nextTick();
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
-  test("input event triggered from a paste should not open composer", async () => {
-    gridInputEl.dispatchEvent(
-      new InputEvent("input", {
-        data: "d",
-        bubbles: true,
-        isComposing: false,
-        inputType: "insertFromPaste",
-      })
-    );
+
+  test("Default paste is prevented in a closed composer", async () => {
+    const pasteEvent = new Event("paste", { cancelable: true });
+    gridInputEl.dispatchEvent(pasteEvent);
     await nextTick();
+    expect(pasteEvent.defaultPrevented).toBeTruthy();
     expect(model.getters.getEditionMode()).toBe("inactive");
   });
 


### PR DESCRIPTION
Steps to reproduce:
- click on the column A
- copy/paste the column -> the layout is broken, some divs were shifted up and are hidden by the topbar. Namely, The column header is not visible anymore.

This issue is related to the one addressed in this pr[^1]. While we would prevent the handling of `insertFromPaste` inputs, the default browser behaviour would still occur and modify the `contentEditableHelper`. This would trigger a replacement of some components DOM elements, notably the header overlay. Since, from a position POV, the canvas is positioned just below the said overlay, it was also shifted.

This revision is taking a more aggressive approach than the one in [^1], we stop the paste event totally (not just the following input) in the composer when we are not editing.

[^1]: https://github.com/odoo/o-spreadsheet/pull/2254

Task: 3864000

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo