### PR TITLE
[IMP] pivot_layout_configurator: allow to flip axis

### DIFF
--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.ts
@@ -49,6 +49,11 @@ export class CogWheelMenu extends Component<Props, SpreadsheetChildEnv> {
     });
   }
 
+  onClick(item: CogWheelMenuItem) {
+    item.onClick();
+    this.popover.isOpen = false;
+  }
+
   get popoverProps() {
     const { x, y, width, height } = this.buttonRef.el!.getBoundingClientRect();
     return {

--- a/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.xml
+++ b/src/components/side_panel/components/cog_wheel_menu/cog_wheel_menu.xml
@@ -7,7 +7,7 @@
           t-foreach="props.items"
           t-as="item"
           t-key="item.name"
-          t-on-click="item.onClick"
+          t-on-click="() => this.onClick(item)"
           class="btn btn-link me-3">
           <i t-if="item.icon" t-att-class="'me-2 fa ' + item.icon"/>
           <t t-esc="item.name"/>

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -92,6 +92,14 @@ export class PivotSpreadsheetSidePanel extends Component<Props, SpreadsheetChild
     }
   }
 
+  flipAxis() {
+    const { rows, columns } = this.definition;
+    this.onDimensionsUpdated({
+      rows: columns,
+      columns: rows,
+    });
+  }
+
   onDimensionsUpdated(definition: Partial<SpreadsheetPivotCoreDefinition>) {
     this.store.update(definition);
   }

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-PivotSpreadsheetSidePanel">
     <div class="d-flex flex-column h-100 justify-content-between overflow-hidden">
       <div class="h-100 overflow-auto">
-        <PivotTitleSection pivotId="props.pivotId"/>
+        <PivotTitleSection pivotId="props.pivotId" flipAxis.bind="flipAxis"/>
         <Section>
           <t t-set-slot="title">Range</t>
           <SelectionInput

--- a/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
+++ b/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
@@ -7,6 +7,7 @@ import { EditableName } from "../editable_name/editable_name";
 
 interface Props {
   pivotId: UID;
+  flipAxis: () => void;
 }
 
 export class PivotTitleSection extends Component<Props, SpreadsheetChildEnv> {
@@ -14,17 +15,23 @@ export class PivotTitleSection extends Component<Props, SpreadsheetChildEnv> {
   static components = { CogWheelMenu, Section, EditableName };
   static props = {
     pivotId: String,
+    flipAxis: Function,
   };
 
   get cogWheelMenuItems() {
     return [
       {
-        name: "Duplicate",
+        name: _t("Flip axes"),
+        icon: "fa-exchange",
+        onClick: this.props.flipAxis,
+      },
+      {
+        name: _t("Duplicate"),
         icon: "fa-copy",
         onClick: () => this.duplicatePivot(),
       },
       {
-        name: "Delete",
+        name: _t("Delete"),
         icon: "fa-trash",
         onClick: () => this.delete(),
       },

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -112,6 +112,22 @@ describe("Spreadsheet pivot side panel", () => {
     expect(fixture.querySelector(".o-sidePanelTitle")?.textContent).toEqual("Pivot #2");
   });
 
+  test("Can flip axes of a pivot", async () => {
+    updatePivot(model, "1", {
+      rows: [{ name: "Contact Name", order: "asc" }],
+      columns: [{ name: "Active", order: "asc" }],
+    });
+    await click(fixture, SELECTORS.COG_WHEEL);
+    await click(fixture, SELECTORS.FLIP_AXIS_PIVOT);
+    const pivotId = model.getters.getPivotId("1")!;
+    expect(model.getters.getPivotCoreDefinition(pivotId).rows).toEqual([
+      { name: "Active", order: "asc" },
+    ]);
+    expect(model.getters.getPivotCoreDefinition(pivotId).columns).toEqual([
+      { name: "Contact Name", order: "asc" },
+    ]);
+  });
+
   test("Pivot dimensions are ordered 'asc' by default", async () => {
     setCellContent(model, "A1", "amount");
     setCellContent(model, "A2", "10");

--- a/tests/test_helpers/pivot_helpers.ts
+++ b/tests/test_helpers/pivot_helpers.ts
@@ -61,4 +61,5 @@ export const SELECTORS = {
   COG_WHEEL: ".os-cog-wheel-menu-icon",
   DUPLICATE_PIVOT: ".os-cog-wheel-menu .fa-copy",
   DELETE_PIVOT: ".os-cog-wheel-menu .fa-trash",
+  FLIP_AXIS_PIVOT: ".os-cog-wheel-menu .fa-exchange",
 };


### PR DESCRIPTION
This commit adds the possibility to flip the axis of the pivot table in the PivotLayoutConfigurator. This is useful when the user wants to switch the rows and columns of the pivot table.

Task: 3959002

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo