### PR TITLE
[IMP] pivot: do not delay update by default

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -23,7 +23,7 @@ export class PivotSidePanelStore extends SpreadsheetStore {
     "update",
   ] as const;
 
-  private updatesAreDeferred: boolean = true;
+  private updatesAreDeferred: boolean = false;
   private draft: PivotCoreDefinition | null = null;
   constructor(get: Get, private pivotId: UID) {
     super(get);

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -55,6 +55,7 @@ describe("Spreadsheet pivot side panel", () => {
     addPivot(model, "A1:A3", {}, "3");
     env.openSidePanel("PivotSidePanel", { pivotId: "3" });
     await nextTick();
+    await click(fixture.querySelector(".pivot-defer-update input")!);
     await click(fixture.querySelector(".add-dimension")!);
     expect(fixture.querySelector(".o-popover")).toBeDefined();
     await click(fixture, ".o-autocomplete-value");
@@ -66,6 +67,7 @@ describe("Spreadsheet pivot side panel", () => {
   });
 
   test("it should not defer update when the dataset is updated", async () => {
+    await click(fixture.querySelector(".pivot-defer-update input")!);
     expect((fixture.querySelector(".pivot-defer-update input")! as HTMLInputElement).checked).toBe(
       true
     );
@@ -119,13 +121,13 @@ describe("Spreadsheet pivot side panel", () => {
     await click(fixture.querySelector(".add-dimension")!);
     expect(fixture.querySelector(".o-popover")).toBeDefined();
     await click(fixture, ".o-autocomplete-value");
-    await click(fixture.querySelector(".sp_apply_update")!);
     expect(model.getters.getPivotCoreDefinition("3").columns).toEqual([
       { name: "amount", order: "asc" },
     ]);
   });
 
   test("should reset side panel if discard is clicked", async () => {
+    await click(fixture.querySelector(".pivot-defer-update input")!);
     expect(fixture.querySelectorAll(".pivot-dimension")).toHaveLength(0);
     await click(fixture.querySelector(".add-dimension")!);
     expect(fixture.querySelector(".o-popover")).toBeDefined();


### PR DESCRIPTION
Before this commit, the pivot definition was updated only after the user clicked on the "Update" button. This could be confusing for the user, as the pivot definition was not updated when the user changed the pivot configuration.

Task: 3953753

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo