### PR TITLE
[FIX] charts: fix typo in side panels

### DIFF
--- a/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.xml
+++ b/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-AxisDesignEditor">
-    <t t-set="editor_label">Axis Title</t>
+    <t t-set="editor_label">Axis title</t>
     <Section class="'py-0'">
       <select class="o-input o-axis-selector" t-on-change="this.updateAxisEditor">
         <t t-foreach="props.axesList" t-as="axis" t-key="axis.id">

--- a/src/components/side_panel/chart/building_blocks/general_design/general_design_editor.xml
+++ b/src/components/side_panel/chart/building_blocks/general_design/general_design_editor.xml
@@ -1,12 +1,12 @@
 <templates>
   <t t-name="o-spreadsheet-GeneralDesignEditor">
-    <t t-set="chart_title">Chart Title</t>
+    <t t-set="chart_title">Chart title</t>
     <SidePanelCollapsible collapsedAtInit="false">
       <t t-set-slot="title">General</t>
       <t t-set-slot="content">
         <Section class="'o-chart-background-color pt-0 pb-0'">
           <div class="d-flex align-items-center mt-0">
-            <span class="o-section-title mb-0 pe-2">Background Color</span>
+            <span class="o-section-title mb-0 pe-2">Background color</span>
             <RoundColorPicker
               currentColor="props.definition.background"
               onColorPicked.bind="updateBackgroundColor"

--- a/src/components/side_panel/chart/chart_with_axis/design_panel.xml
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.xml
@@ -21,7 +21,7 @@
       </t>
     </GeneralDesignEditor>
     <SidePanelCollapsible collapsedAtInit="true">
-      <t t-set-slot="title">Data Series</t>
+      <t t-set-slot="title">Data series</t>
       <t t-set-slot="content">
         <Section class="'pt-0 pb-0'">
           <select
@@ -38,7 +38,7 @@
           </select>
           <Section class="'px-0'">
             <div class="d-flex align-items-center">
-              <span class="o-section-title mb-0 pe-2">Serie Color</span>
+              <span class="o-section-title mb-0 pe-2">Series color</span>
               <RoundColorPicker
                 currentColor="getDataSerieColor()"
                 onColorPicked.bind="updateDataSeriesColor"
@@ -56,7 +56,7 @@
             </select>
           </Section>
           <Section class="'pt-0 px-0'">
-            <t t-set-slot="title">Serie name</t>
+            <t t-set-slot="title">Series name</t>
             <input
               class="o-input o-serie-label-editor"
               t-att-value="getDataSerieLabel()"

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
@@ -31,7 +31,7 @@
       </t>
     </GeneralDesignEditor>
     <SidePanelCollapsible collapsedAtInit="true">
-      <t t-set-slot="title">Waterfall Design</t>
+      <t t-set-slot="title">Waterfall design</t>
       <t t-set-slot="content">
         <Section class="'pt-0'">
           <t t-set-slot="title">Waterfall options</t>
@@ -84,7 +84,7 @@
       </t>
     </SidePanelCollapsible>
     <SidePanelCollapsible collapsedAtInit="true">
-      <t t-set-slot="title">Axis Title</t>
+      <t t-set-slot="title">Axis title</t>
       <t t-set-slot="content">
         <AxisDesignEditor
           axesList="axesList"


### PR DESCRIPTION
## Task Description:

This task aims to fix some typos in the charts design panels

## Related Task:

Task: 0

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo