### PR TITLE
[IMP] charts: add show values options for bar chart

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -3,6 +3,7 @@ import { Chart, ChartConfiguration } from "chart.js/auto";
 import { deepCopy } from "../../../../helpers";
 import { Figure, SpreadsheetChildEnv } from "../../../../types";
 import { ChartJSRuntime } from "../../../../types/chart/chart";
+import { chartShowValuesPlugin } from "./chartjs_show_values_plugin";
 import { waterfallLinesPlugin } from "./chartjs_waterfall_plugin";
 
 interface Props {
@@ -10,6 +11,7 @@ interface Props {
 }
 
 window.Chart?.register(waterfallLinesPlugin);
+window.Chart?.register(chartShowValuesPlugin);
 
 export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-ChartJsComponent";

--- a/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
+++ b/src/components/figures/chart/chartJs/chartjs_show_values_plugin.ts
@@ -1,0 +1,96 @@
+import { ChartType, Plugin } from "chart.js";
+import { chartFontColor } from "../../../../helpers/figures/charts/chart_common";
+import { Color } from "../../../../types";
+
+interface ChartShowValuesPluginOptions {
+  showValues: boolean;
+  background?: Color;
+  horizontal?: boolean;
+  callback: (value: number | string) => string;
+}
+
+declare module "chart.js" {
+  interface PluginOptionsByType<TType extends ChartType> {
+    chartShowValuesPlugin?: ChartShowValuesPluginOptions;
+  }
+}
+
+/** This is a chartJS plugin that will draw the values of each data next to the point/bar/pie slice */
+export const chartShowValuesPlugin: Plugin = {
+  id: "chartShowValuesPlugin",
+  afterDatasetsDraw(chart: any, args, options: ChartShowValuesPluginOptions) {
+    if (!options.showValues) {
+      return;
+    }
+    const drawData = chart._metasets?.[0]?.data;
+    if (!drawData) {
+      return;
+    }
+    const ctx = chart.ctx;
+    ctx.save();
+
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillStyle = chartFontColor(options.background);
+    ctx.strokeStyle = chartFontColor(ctx.fillStyle);
+
+    chart._metasets.forEach(function (dataset) {
+      switch (dataset.type) {
+        case "doughnut":
+        case "pie": {
+          for (let i = 0; i < dataset._parsed.length; i++) {
+            const bar = dataset.data[i];
+            const { startAngle, endAngle, innerRadius, outerRadius } = bar;
+            const midAngle = (startAngle + endAngle) / 2;
+            const midRadius = (innerRadius + outerRadius) / 2;
+            const x = bar.x + midRadius * Math.cos(midAngle);
+            const y = bar.y + midRadius * Math.sin(midAngle) + 7;
+
+            ctx.fillStyle = chartFontColor(bar.options.backgroundColor);
+            ctx.strokeStyle = chartFontColor(ctx.fillStyle);
+
+            const value = options.callback(dataset._parsed[i]);
+            ctx.strokeText(value, x, y);
+            ctx.fillText(value, x, y);
+          }
+          break;
+        }
+        case "bar":
+        case "line": {
+          const yOffset = dataset.type === "bar" && !options.horizontal ? 0 : 3;
+          for (let i = 0; i < dataset._parsed.length; i++) {
+            const point = dataset.data[i];
+            const value = options.horizontal ? dataset._parsed[i].x : dataset._parsed[i].y;
+            const displayedValue = options.callback(value - 0);
+            let xPosition = 0,
+              yPosition = 0;
+            if (options.horizontal) {
+              yPosition = point.y;
+              if (value < 0) {
+                ctx.textAlign = "right";
+                xPosition = point.x - yOffset;
+              } else {
+                ctx.textAlign = "left";
+                xPosition = point.x + yOffset;
+              }
+            } else {
+              xPosition = point.x;
+              if (value < 0) {
+                ctx.textBaseline = "top";
+                yPosition = point.y + yOffset;
+              } else {
+                ctx.textBaseline = "bottom";
+                yPosition = point.y - yOffset;
+              }
+            }
+            ctx.strokeText(displayedValue, xPosition, yPosition);
+            ctx.fillText(displayedValue, xPosition, yPosition);
+          }
+          break;
+        }
+      }
+    });
+
+    ctx.restore();
+  },
+};

--- a/src/components/side_panel/chart/chart_with_axis/design_panel.ts
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.ts
@@ -8,6 +8,8 @@ import {
   SpreadsheetChildEnv,
   UID,
 } from "../../../../types/index";
+import { ChartTerms } from "../../../translations_terms";
+import { Checkbox } from "../../components/checkbox/checkbox";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
 import { Section } from "../../components/section/section";
@@ -32,6 +34,7 @@ export class ChartWithAxisDesignPanel extends Component<Props, SpreadsheetChildE
     Section,
     AxisDesignEditor,
     RoundColorPicker,
+    Checkbox,
   };
   static props = {
     figureId: String,
@@ -130,5 +133,13 @@ export class ChartWithAxisDesignPanel extends Component<Props, SpreadsheetChildE
   getDataSerieLabel() {
     const dataSets = this.props.definition.dataSets;
     return dataSets[this.state.index]?.label || this.getDataSeries()[this.state.index];
+  }
+
+  get showValuesLabel(): string {
+    return ChartTerms.ShowValues;
+  }
+
+  updateShowValues(showValues: boolean) {
+    this.props.updateChart(this.props.figureId, { showValues });
   }
 }

--- a/src/components/side_panel/chart/chart_with_axis/design_panel.xml
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.xml
@@ -18,6 +18,14 @@
             <option value="right">Right</option>
           </select>
         </Section>
+        <Section class="'pt-0'">
+          <Checkbox
+            name="'showValues'"
+            label="showValuesLabel"
+            value="props.definition.showValues"
+            onChange="showValues => props.updateChart(this.props.figureId, {showValues})"
+          />
+        </Section>
       </t>
     </GeneralDesignEditor>
     <SidePanelCollapsible collapsedAtInit="true">

--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.ts
@@ -1,6 +1,8 @@
 import { Component } from "@odoo/owl";
 import { DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types";
 import { PieChartDefinition } from "../../../../types/chart";
+import { ChartTerms } from "../../../translations_terms";
+import { Checkbox } from "../../components/checkbox/checkbox";
 import { Section } from "../../components/section/section";
 import { GeneralDesignEditor } from "../building_blocks/general_design/general_design_editor";
 
@@ -16,6 +18,7 @@ export class PieChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
   static components = {
     GeneralDesignEditor,
     Section,
+    Checkbox,
   };
   static props = {
     figureId: String,
@@ -28,5 +31,9 @@ export class PieChartDesignPanel extends Component<Props, SpreadsheetChildEnv> {
     this.props.updateChart(this.props.figureId, {
       legendPosition: ev.target.value,
     });
+  }
+
+  get showValuesLabel(): string {
+    return ChartTerms.ShowValues;
   }
 }

--- a/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
+++ b/src/components/side_panel/chart/pie_chart/pie_chart_design_panel.xml
@@ -18,6 +18,14 @@
             <option value="right">Right</option>
           </select>
         </Section>
+        <Section>
+          <Checkbox
+            name="'showValues'"
+            label="showValuesLabel"
+            value="props.definition.showValues"
+            onChange="showValues => props.updateChart(this.props.figureId, {showValues})"
+          />
+        </Section>
       </t>
     </GeneralDesignEditor>
   </t>

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.ts
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.ts
@@ -7,6 +7,7 @@ import {
 import { _t } from "../../../../translation";
 import { Color, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types";
 import { WaterfallChartDefinition } from "../../../../types/chart/waterfall_chart";
+import { ChartTerms } from "../../../translations_terms";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
 import { Section } from "../../components/section/section";
@@ -95,5 +96,13 @@ export class WaterfallChartDesignPanel extends Component<Props, SpreadsheetChild
     this.props.updateChart(this.props.figureId, {
       verticalAxisPosition: ev.target.value,
     });
+  }
+
+  get showValuesLabel(): string {
+    return ChartTerms.ShowValues;
+  }
+
+  updateShowValues(showValues: boolean) {
+    this.props.updateChart(this.props.figureId, { showValues });
   }
 }

--- a/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
+++ b/src/components/side_panel/chart/waterfall_chart/waterfall_chart_design_panel.xml
@@ -28,6 +28,14 @@
             <option value="right">Right</option>
           </select>
         </Section>
+        <Section>
+          <Checkbox
+            name="'showValues'"
+            label="showValuesLabel"
+            value="props.definition.showValues"
+            onChange="showValues => props.updateChart(this.props.figureId, {showValues})"
+          />
+        </Section>
       </t>
     </GeneralDesignEditor>
     <SidePanelCollapsible collapsedAtInit="true">

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -56,6 +56,7 @@ export const ChartTerms = {
   CumulativeData: _t("Cumulative data"),
   TreatLabelsAsText: _t("Treat labels as text"),
   AggregatedChart: _t("Aggregate"),
+  ShowValues: _t("Show values"),
   Errors: {
     Unexpected: _t("The chart definition is invalid for an unknown reason"),
     // BASIC CHART ERRORS (LINE | BAR | PIE)

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -150,19 +150,20 @@ function getLineOrScatterConfiguration(
       title: getChartAxisTitleRuntime(chart.axesDesign?.x),
     },
   };
+  const formatCallback = (value) => {
+    value = Number(value);
+    if (isNaN(value)) return value;
+    const { locale, format } = options;
+    return formatValue(value, {
+      locale,
+      format: !format && Math.abs(value) >= 1000 ? "#,##" : format,
+    });
+  };
   const yAxis = {
     beginAtZero: true, // the origin of the y axis is always zero
     ticks: {
       color: fontColor,
-      callback: (value) => {
-        value = Number(value);
-        if (isNaN(value)) return value;
-        const { locale, format } = options;
-        return formatValue(value, {
-          locale,
-          format: !format && Math.abs(value) >= 1000 ? "#,##" : format,
-        });
-      },
+      callback: formatCallback,
     },
   };
   const { useLeftAxis, useRightAxis } = getDefinedAxis(chart.getDefinition());
@@ -190,6 +191,11 @@ function getLineOrScatterConfiguration(
       config.options.scales!.y1!.stacked = true;
     }
   }
+  config.options.plugins!.chartShowValuesPlugin = {
+    showValues: chart.showValues,
+    background: chart.background,
+    callback: formatCallback,
+  };
   return config;
 }
 

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -65,6 +65,7 @@ export class ComboChart extends AbstractChart {
   readonly dataSetDesign?: DatasetDesign[];
   readonly axesDesign?: AxesDesign;
   readonly type = "combo";
+  readonly showValues?: boolean;
 
   constructor(definition: ComboChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -81,6 +82,7 @@ export class ComboChart extends AbstractChart {
     this.dataSetsHaveTitle = definition.dataSetsHaveTitle;
     this.dataSetDesign = definition.dataSets;
     this.axesDesign = definition.axesDesign;
+    this.showValues = definition.showValues;
   }
 
   static transformDefinition(
@@ -142,6 +144,7 @@ export class ComboChart extends AbstractChart {
       title: this.title,
       aggregated: this.aggregated,
       axesDesign: this.axesDesign,
+      showValues: this.showValues,
     };
   }
 
@@ -194,6 +197,7 @@ export class ComboChart extends AbstractChart {
       labelRange: context.auxiliaryRange || undefined,
       type: "combo",
       axesDesign: context.axesDesign,
+      showValues: context.showValues,
     };
   }
 
@@ -308,6 +312,11 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
       title: getChartAxisTitleRuntime(chart.axesDesign?.y1),
     };
   }
+  config.options.plugins!.chartShowValuesPlugin = {
+    showValues: chart.showValues,
+    background: chart.background,
+    callback: formatCallback(mainDataSetFormat),
+  };
 
   const colors = new ColorGenerator();
 

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -5,7 +5,6 @@ import {
   Color,
   CommandResult,
   CoreGetters,
-  Getters,
   Range,
   RemoveColumnsRowsCommand,
   UID,
@@ -20,7 +19,7 @@ import {
   ExcelChartDefinition,
 } from "../../../types/chart/chart";
 import { LegendPosition } from "../../../types/chart/common_chart";
-import { LineChartDefinition, LineChartRuntime } from "../../../types/chart/line_chart";
+import { LineChartDefinition } from "../../../types/chart/line_chart";
 import { CellErrorType } from "../../../types/errors";
 import { Validator } from "../../../types/validator";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
@@ -40,7 +39,6 @@ import {
   transformChartDefinitionWithDataSetsWithZone,
   updateChartRangesWithDataSets,
 } from "./chart_common";
-import { createLineOrScatterChartRuntime } from "./chart_common_line_scatter";
 
 export class LineChart extends AbstractChart {
   readonly dataSets: DataSet[];
@@ -56,6 +54,7 @@ export class LineChart extends AbstractChart {
   readonly dataSetDesign?: DatasetDesign[];
   readonly axesDesign?: AxesDesign;
   readonly fillArea?: boolean;
+  readonly showValues?: boolean;
 
   constructor(definition: LineChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -76,6 +75,7 @@ export class LineChart extends AbstractChart {
     this.dataSetDesign = definition.dataSets;
     this.axesDesign = definition.axesDesign;
     this.fillArea = definition.fillArea;
+    this.showValues = definition.showValues;
   }
 
   static validateChartDefinition(
@@ -107,6 +107,7 @@ export class LineChart extends AbstractChart {
       cumulative: context.cumulative ?? false,
       axesDesign: context.axesDesign,
       fillArea: context.fillArea,
+      showValues: context.showValues,
     };
   }
 
@@ -142,6 +143,7 @@ export class LineChart extends AbstractChart {
       cumulative: this.cumulative,
       axesDesign: this.axesDesign,
       fillArea: this.fillArea,
+      showValues: this.showValues,
     };
   }
 
@@ -213,9 +215,4 @@ export class LineChart extends AbstractChart {
     );
     return new LineChart(definition, sheetId, this.getters);
   }
-}
-
-export function createLineChartRuntime(chart: LineChart, getters: Getters): LineChartRuntime {
-  const { chartJsConfig, background } = createLineOrScatterChartRuntime(chart, getters);
-  return { chartJsConfig, background };
 }

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -67,6 +67,7 @@ export class PieChart extends AbstractChart {
   readonly aggregated?: boolean;
   readonly dataSetsHaveTitle: boolean;
   readonly isDoughnut?: boolean;
+  readonly showValues?: boolean;
 
   constructor(definition: PieChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -82,6 +83,7 @@ export class PieChart extends AbstractChart {
     this.aggregated = definition.aggregated;
     this.dataSetsHaveTitle = definition.dataSetsHaveTitle;
     this.isDoughnut = definition.isDoughnut;
+    this.showValues = definition.showValues;
   }
 
   static transformDefinition(
@@ -109,6 +111,7 @@ export class PieChart extends AbstractChart {
       labelRange: context.auxiliaryRange || undefined,
       aggregated: context.aggregated ?? false,
       isDoughnut: false,
+      showValues: context.showValues,
     };
   }
 
@@ -147,6 +150,7 @@ export class PieChart extends AbstractChart {
       title: this.title,
       aggregated: this.aggregated,
       isDoughnut: this.isDoughnut,
+      showValues: this.showValues,
     };
   }
 
@@ -236,6 +240,8 @@ function getPieConfiguration(
 
     return xLabel ? `${xLabel}: ${yLabelStr} (${percentage}%)` : `${yLabelStr} (${percentage}%)`;
   };
+
+  config.options.plugins!.chartShowValuesPlugin = { showValues: chart.showValues };
   return config;
 }
 

--- a/src/helpers/figures/charts/pyramid_chart.ts
+++ b/src/helpers/figures/charts/pyramid_chart.ts
@@ -47,6 +47,7 @@ export class PyramidChart extends AbstractChart {
   readonly axesDesign?: AxesDesign;
   readonly horizontal = true;
   readonly stacked = true;
+  readonly showValues?: boolean;
 
   constructor(definition: PyramidChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -63,6 +64,7 @@ export class PyramidChart extends AbstractChart {
     this.dataSetsHaveTitle = definition.dataSetsHaveTitle;
     this.dataSetDesign = definition.dataSets;
     this.axesDesign = definition.axesDesign;
+    this.showValues = definition.showValues;
   }
 
   static transformDefinition(
@@ -92,6 +94,7 @@ export class PyramidChart extends AbstractChart {
       axesDesign: context.axesDesign,
       horizontal: true,
       stacked: true,
+      showValues: context.showValues,
     };
   }
 
@@ -158,6 +161,7 @@ export class PyramidChart extends AbstractChart {
       axesDesign: this.axesDesign,
       horizontal: true,
       stacked: true,
+      showValues: this.showValues,
     };
   }
 
@@ -205,6 +209,9 @@ export function createPyramidChartRuntime(
     const tooltipItem = { ...item, parsed: { y: item.parsed.y, x: Math.abs(item.parsed.x) } };
     return tooltipLabelCallback(tooltipItem);
   };
+  const callback = config.options!.plugins!.chartShowValuesPlugin!.callback;
+  config.options!.plugins!.chartShowValuesPlugin!.callback = (x) =>
+    callback!(Math.abs(x as number));
 
   return { chartJsConfig: config, background: chart.background || BACKGROUND_CHART_COLOR };
 }

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -56,6 +56,7 @@ export class ScatterChart extends AbstractChart {
   readonly dataSetsHaveTitle: boolean;
   readonly dataSetDesign?: DatasetDesign[];
   readonly axesDesign?: AxesDesign;
+  readonly showValues?: boolean;
 
   constructor(definition: ScatterChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -73,6 +74,7 @@ export class ScatterChart extends AbstractChart {
     this.dataSetsHaveTitle = definition.dataSetsHaveTitle;
     this.dataSetDesign = definition.dataSets;
     this.axesDesign = definition.axesDesign;
+    this.showValues = definition.showValues;
   }
 
   static validateChartDefinition(
@@ -101,6 +103,7 @@ export class ScatterChart extends AbstractChart {
       labelRange: context.auxiliaryRange || undefined,
       aggregated: context.aggregated ?? false,
       axesDesign: context.axesDesign,
+      showValues: context.showValues,
     };
   }
 
@@ -133,6 +136,7 @@ export class ScatterChart extends AbstractChart {
       labelsAsText: this.labelsAsText,
       aggregated: this.aggregated,
       axesDesign: this.axesDesign,
+      showValues: this.showValues,
     };
   }
 

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -73,6 +73,7 @@ export class WaterfallChart extends AbstractChart {
   readonly subTotalValuesColor?: Color;
   readonly dataSetDesign: CustomizedDataSet[];
   readonly axesDesign?: AxesDesign;
+  readonly showValues?: boolean;
 
   constructor(definition: WaterfallChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -96,6 +97,7 @@ export class WaterfallChart extends AbstractChart {
     this.firstValueAsSubtotal = definition.firstValueAsSubtotal;
     this.dataSetDesign = definition.dataSets;
     this.axesDesign = definition.axesDesign;
+    this.showValues = definition.showValues;
   }
 
   static transformDefinition(
@@ -127,6 +129,7 @@ export class WaterfallChart extends AbstractChart {
       showConnectorLines: context.showConnectorLines ?? true,
       firstValueAsSubtotal: context.firstValueAsSubtotal ?? false,
       axesDesign: context.axesDesign,
+      showValues: context.showValues,
     };
   }
 
@@ -198,6 +201,7 @@ export class WaterfallChart extends AbstractChart {
       subTotalValuesColor: this.subTotalValuesColor,
       firstValueAsSubtotal: this.firstValueAsSubtotal,
       axesDesign: this.axesDesign,
+      showValues: this.showValues,
     };
   }
 
@@ -309,6 +313,10 @@ function getWaterfallConfiguration(
     },
   };
   config.options.plugins!.waterfallLinesPlugin = { showConnectorLines: chart.showConnectorLines };
+  config.options.plugins!.chartShowValuesPlugin = {
+    showValues: chart.showValues,
+    background: chart.background,
+  };
 
   return config;
 }

--- a/src/registries/chart_types.ts
+++ b/src/registries/chart_types.ts
@@ -4,9 +4,10 @@ import { GaugeChartComponent } from "../components/figures/chart/gauge/gauge_cha
 import { ScorecardChart as ScorecardChartComponent } from "../components/figures/chart/scorecard/chart_scorecard";
 import { AbstractChart } from "../helpers/figures/charts/abstract_chart";
 import { BarChart, createBarChartRuntime } from "../helpers/figures/charts/bar_chart";
+import { createLineOrScatterChartRuntime } from "../helpers/figures/charts/chart_common_line_scatter";
 import { ComboChart, createComboChartRuntime } from "../helpers/figures/charts/combo_chart";
 import { GaugeChart, createGaugeChartRuntime } from "../helpers/figures/charts/gauge_chart";
-import { LineChart, createLineChartRuntime } from "../helpers/figures/charts/line_chart";
+import { LineChart } from "../helpers/figures/charts/line_chart";
 import { PieChart, createPieChartRuntime } from "../helpers/figures/charts/pie_chart";
 import { PyramidChart, createPyramidChartRuntime } from "../helpers/figures/charts/pyramid_chart";
 import { ScatterChart, createScatterChartRuntime } from "../helpers/figures/charts/scatter_chart";
@@ -102,7 +103,7 @@ chartRegistry.add("line", {
   match: (type) => type === "line",
   createChart: (definition, sheetId, getters) =>
     new LineChart(definition as LineChartDefinition, sheetId, getters),
-  getChartRuntime: createLineChartRuntime,
+  getChartRuntime: createLineOrScatterChartRuntime,
   validateChartDefinition: LineChart.validateChartDefinition,
   transformDefinition: LineChart.transformDefinition,
   getChartDefinitionFromContextCreation: LineChart.getDefinitionFromContextCreation,

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -138,4 +138,5 @@ export interface ChartCreationContext {
   readonly legendPosition?: LegendPosition;
   readonly axesDesign?: AxesDesign;
   readonly fillArea?: boolean;
+  readonly showValues?: boolean;
 }

--- a/src/types/chart/common_bar_combo.ts
+++ b/src/types/chart/common_bar_combo.ts
@@ -11,4 +11,5 @@ export interface ComboBarChartDefinition {
   readonly legendPosition: LegendPosition;
   readonly aggregated?: boolean;
   readonly axesDesign?: AxesDesign;
+  readonly showValues?: boolean;
 }

--- a/src/types/chart/line_chart.ts
+++ b/src/types/chart/line_chart.ts
@@ -17,6 +17,7 @@ export interface LineChartDefinition {
   readonly cumulative: boolean;
   readonly axesDesign?: AxesDesign;
   readonly fillArea?: boolean;
+  readonly showValues?: boolean;
 }
 
 export type LineChartRuntime = {

--- a/src/types/chart/pie_chart.ts
+++ b/src/types/chart/pie_chart.ts
@@ -14,6 +14,7 @@ export interface PieChartDefinition {
   readonly aggregated?: boolean;
   readonly axesDesign?: AxesDesign;
   readonly isDoughnut?: boolean;
+  readonly showValues?: boolean;
 }
 
 export type PieChartRuntime = {

--- a/src/types/chart/waterfall_chart.ts
+++ b/src/types/chart/waterfall_chart.ts
@@ -20,6 +20,7 @@ export interface WaterfallChartDefinition {
   readonly negativeValuesColor?: Color;
   readonly subTotalValuesColor?: Color;
   readonly axesDesign?: AxesDesign;
+  readonly showValues?: boolean;
 }
 
 export type WaterfallChartRuntime = {

--- a/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
+++ b/tests/figures/chart/__snapshots__/chart_plugin.test.ts.snap
@@ -55,6 +55,11 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": "#010101",
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#FFFFFF",
@@ -106,6 +111,31 @@ exports[`Linear/Time charts font color is white with a dark background color 1`]
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        11,
+        12,
+        13,
+      ],
+      "label": "10",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "20",
+      "19",
+      "18",
+      "17",
+    ],
+    "values": [
+      "19",
+      "18",
+      "17",
+    ],
   },
 }
 `;
@@ -170,6 +200,11 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -227,6 +262,33 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for date char
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        10,
+        11,
+        12,
+        13,
+      ],
+      "label": "Series 1",
+    },
+  ],
+  "labelFormat": "m/d/yyyy",
+  "labelValues": {
+    "formattedValues": [
+      "1/19/1900",
+      "1/18/1900",
+      "1/17/1900",
+      "1/16/1900",
+    ],
+    "values": [
+      "20",
+      "19",
+      "18",
+      "17",
+    ],
   },
 }
 `;
@@ -291,6 +353,11 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -343,6 +410,33 @@ exports[`Linear/Time charts snapshot test of chartJS configuration for linear ch
     "plugins": [],
     "type": "line",
   },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        10,
+        11,
+        12,
+        13,
+      ],
+      "label": "Series 1",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "20",
+      "19",
+      "18",
+      "17",
+    ],
+    "values": [
+      "20",
+      "19",
+      "18",
+      "17",
+    ],
+  },
 }
 `;
 
@@ -386,6 +480,12 @@ exports[`datasource tests create a chart with stacked bar 1`] = `
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "horizontal": undefined,
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -481,6 +581,11 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -529,6 +634,24 @@ exports[`datasource tests create chart with a dataset of one cell (no title) 1`]
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        30,
+      ],
+      "label": "Series 1",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "P4",
+    ],
+    "values": [
+      "P4",
+    ],
   },
 }
 `;
@@ -592,6 +715,11 @@ exports[`datasource tests create chart with column datasets 1`] = `
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -640,6 +768,38 @@ exports[`datasource tests create chart with column datasets 1`] = `
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        10,
+        11,
+        12,
+      ],
+      "label": "first column dataset",
+    },
+    {
+      "data": [
+        20,
+        19,
+        18,
+      ],
+      "label": "second column datase…",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "P1",
+      "P2",
+      "P3",
+    ],
+    "values": [
+      "P1",
+      "P2",
+      "P3",
+    ],
   },
 }
 `;
@@ -703,6 +863,11 @@ exports[`datasource tests create chart with column datasets with category title 
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -751,6 +916,39 @@ exports[`datasource tests create chart with column datasets with category title 
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        10,
+        11,
+        12,
+      ],
+      "label": "first column dataset",
+    },
+    {
+      "data": [
+        20,
+        19,
+        18,
+      ],
+      "label": "second column datase…",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "P1",
+      "P2",
+      "P3",
+    ],
+    "values": [
+      "",
+      "P1",
+      "P2",
+      "P3",
+    ],
   },
 }
 `;
@@ -814,6 +1012,11 @@ exports[`datasource tests create chart with column datasets without series title
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -863,6 +1066,38 @@ exports[`datasource tests create chart with column datasets without series title
     "plugins": [],
     "type": "line",
   },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        10,
+        11,
+        12,
+      ],
+      "label": "Series 1",
+    },
+    {
+      "data": [
+        20,
+        19,
+        18,
+      ],
+      "label": "Series 2",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "P1",
+      "P2",
+      "P3",
+    ],
+    "values": [
+      "P1",
+      "P2",
+      "P3",
+    ],
+  },
 }
 `;
 
@@ -910,6 +1145,11 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -958,6 +1198,28 @@ exports[`datasource tests create chart with only the dataset title (no data) 1`]
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        undefined,
+        undefined,
+      ],
+      "label": "30",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "P5",
+      "P6",
+    ],
+    "values": [
+      "P4",
+      "P5",
+      "P6",
+    ],
   },
 }
 `;
@@ -1021,6 +1283,11 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -1069,6 +1336,38 @@ exports[`datasource tests create chart with rectangle dataset 1`] = `
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        10,
+        11,
+        12,
+      ],
+      "label": "first column dataset",
+    },
+    {
+      "data": [
+        20,
+        19,
+        18,
+      ],
+      "label": "second column datase…",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "P1",
+      "P2",
+      "P3",
+    ],
+    "values": [
+      "P1",
+      "P2",
+      "P3",
+    ],
   },
 }
 `;
@@ -1132,6 +1431,11 @@ exports[`datasource tests create chart with row datasets 1`] = `
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -1180,6 +1484,38 @@ exports[`datasource tests create chart with row datasets 1`] = `
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        30,
+        31,
+        32,
+      ],
+      "label": "first row dataset",
+    },
+    {
+      "data": [
+        40,
+        41,
+        42,
+      ],
+      "label": "second row dataset",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "P4",
+      "P5",
+      "P6",
+    ],
+    "values": [
+      "P4",
+      "P5",
+      "P6",
+    ],
   },
 }
 `;
@@ -1243,6 +1579,11 @@ exports[`datasource tests create chart with row datasets with category title 1`]
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -1291,6 +1632,39 @@ exports[`datasource tests create chart with row datasets with category title 1`]
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        30,
+        31,
+        32,
+      ],
+      "label": "first row dataset",
+    },
+    {
+      "data": [
+        40,
+        41,
+        42,
+      ],
+      "label": "second row dataset",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "P4",
+      "P5",
+      "P6",
+    ],
+    "values": [
+      "",
+      "P4",
+      "P5",
+      "P6",
+    ],
   },
 }
 `;
@@ -1354,6 +1728,11 @@ exports[`datasource tests create chart with row datasets without series title 1`
       },
       "maintainAspectRatio": false,
       "plugins": {
+        "chartShowValuesPlugin": {
+          "background": undefined,
+          "callback": [Function],
+          "showValues": undefined,
+        },
         "legend": {
           "labels": {
             "color": "#000000",
@@ -1402,6 +1781,38 @@ exports[`datasource tests create chart with row datasets without series title 1`
     "platform": undefined,
     "plugins": [],
     "type": "line",
+  },
+  "dataSetFormat": undefined,
+  "dataSetsValues": [
+    {
+      "data": [
+        30,
+        31,
+        32,
+      ],
+      "label": "Series 1",
+    },
+    {
+      "data": [
+        40,
+        41,
+        42,
+      ],
+      "label": "Series 2",
+    },
+  ],
+  "labelFormat": undefined,
+  "labelValues": {
+    "formattedValues": [
+      "P4",
+      "P5",
+      "P6",
+    ],
+    "values": [
+      "P4",
+      "P5",
+      "P6",
+    ],
   },
 }
 `;

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -28,6 +28,7 @@ describe("bar chart", () => {
       showSubTotals: true,
       axesDesign: {},
       fillArea: true,
+      showValues: false,
     };
     const definition = BarChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({
@@ -41,6 +42,7 @@ describe("bar chart", () => {
       aggregated: true,
       stacked: true,
       axesDesign: {},
+      showValues: false,
     });
   });
 

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -7,6 +7,7 @@ import { ScorecardChart } from "../../../src/helpers/figures/charts";
 import { CHART_TYPES, ChartDefinition, ChartType, SpreadsheetChildEnv } from "../../../src/types";
 import { BarChartDefinition } from "../../../src/types/chart/bar_chart";
 import { LineChartDefinition } from "../../../src/types/chart/line_chart";
+import { getChartConfiguration } from "../../test_helpers/chart_helpers";
 import {
   copy,
   createChart,
@@ -1494,6 +1495,32 @@ describe("charts", () => {
         { dataRange: "A1" },
       ]);
     });
+  });
+
+  test("showValues checkbox updates the chart", async () => {
+    createTestChart("basicChart");
+    updateChart(model, chartId, {
+      type: "line",
+      labelRange: "C2:C4",
+      dataSets: [{ dataRange: "B2:B4" }],
+    });
+    await mountChartSidePanel();
+    await openChartDesignSidePanel();
+
+    expect(
+      (model.getters.getChartDefinition(chartId) as LineChartDefinition).showValues
+    ).toBeFalsy();
+
+    let options = getChartConfiguration(model, chartId).options;
+    expect(options.plugins.chartShowValuesPlugin.showValues).toBeFalsy();
+
+    await simulateClick("input[name='showValues']");
+    expect(
+      (model.getters.getChartDefinition(chartId) as LineChartDefinition).showValues
+    ).toBeTruthy();
+
+    options = getChartConfiguration(model, chartId).options;
+    expect(options.plugins.chartShowValuesPlugin.showValues).toBeTruthy();
   });
 
   describe("aggregate", () => {

--- a/tests/figures/chart/combo_chart_plugin.test.ts
+++ b/tests/figures/chart/combo_chart_plugin.test.ts
@@ -21,6 +21,7 @@ describe("combo chart", () => {
       showSubTotals: true,
       axesDesign: {},
       fillArea: true,
+      showValues: false,
     };
     const definition = ComboChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({
@@ -33,6 +34,7 @@ describe("combo chart", () => {
       dataSetsHaveTitle: true,
       aggregated: true,
       axesDesign: {},
+      showValues: false,
     });
   });
 

--- a/tests/figures/chart/gauge_chart_plugin.test.ts
+++ b/tests/figures/chart/gauge_chart_plugin.test.ts
@@ -128,6 +128,7 @@ describe("datasource tests", function () {
       showSubTotals: true,
       axesDesign: {},
       fillArea: true,
+      showValues: false,
     };
     const definition = GaugeChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({

--- a/tests/figures/chart/line_chart_plugin.test.ts
+++ b/tests/figures/chart/line_chart_plugin.test.ts
@@ -21,6 +21,7 @@ describe("line chart", () => {
       showSubTotals: true,
       axesDesign: {},
       fillArea: true,
+      showValues: false,
     };
     const definition = LineChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({
@@ -37,6 +38,7 @@ describe("line chart", () => {
       cumulative: true,
       axesDesign: {},
       fillArea: true,
+      showValues: false,
     });
   });
 

--- a/tests/figures/chart/pie_chart_plugin.test.ts
+++ b/tests/figures/chart/pie_chart_plugin.test.ts
@@ -19,6 +19,7 @@ describe("pie chart", () => {
       showSubTotals: true,
       axesDesign: {},
       fillArea: true,
+      showValues: false,
     };
     const definition = PieChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({
@@ -31,6 +32,7 @@ describe("pie chart", () => {
       dataSetsHaveTitle: true,
       aggregated: true,
       isDoughnut: false,
+      showValues: false,
     });
   });
 });

--- a/tests/figures/chart/pyramid_chart_plugin.test.ts
+++ b/tests/figures/chart/pyramid_chart_plugin.test.ts
@@ -22,6 +22,7 @@ describe("population pyramid chart", () => {
       showSubTotals: true,
       axesDesign: {},
       fillArea: true,
+      showValues: false,
     };
     const definition = PyramidChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({
@@ -36,6 +37,7 @@ describe("population pyramid chart", () => {
       stacked: true,
       axesDesign: {},
       horizontal: true,
+      showValues: false,
     });
   });
 

--- a/tests/figures/chart/scorecard_chart_plugin.test.ts
+++ b/tests/figures/chart/scorecard_chart_plugin.test.ts
@@ -96,6 +96,7 @@ describe("datasource tests", function () {
       showSubTotals: true,
       axesDesign: {},
       fillArea: true,
+      showValues: false,
     };
     const definition = ScorecardChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({

--- a/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
+++ b/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
@@ -280,6 +280,7 @@ describe("Waterfall chart", () => {
       showSubTotals: true,
       axesDesign: {},
       fillArea: true,
+      showValues: false,
     };
     const definition = WaterfallChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({
@@ -296,6 +297,7 @@ describe("Waterfall chart", () => {
       showSubTotals: true,
       axesDesign: {},
       verticalAxisPosition: "left",
+      showValues: false,
     });
   });
 });


### PR DESCRIPTION
## Task Description

This task aims to add the possibility to show the value of the
serie on the chart (above the point for scatter/line chart, above
the bar for bar/combo chart and inside part for pie chart).

## Related Task

- Task: [3953835](https://www.odoo.com/odoo/project/2328/tasks/3953835?cids=1)

## Review Checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo