### PR TITLE
[FIX] border: bottom sheet borders removed on DELETE_ROWS

### DIFF
--- a/src/plugins/core/borders.ts
+++ b/src/plugins/core/borders.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_BORDER_DESC } from "../../constants";
-import { deepEquals, range, toCartesian, toXC, toZone } from "../../helpers/index";
+import { deepEquals, isDefined, range, toCartesian, toXC, toZone } from "../../helpers/index";
 import {
   AddColumnsRowsCommand,
   Border,
@@ -220,6 +220,21 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
   }
 
   /**
+   * Get all the rows which contains at least a border
+   */
+  private getRowsWithBorders(sheetId: UID): number[] {
+    const sheetBorders = this.borders[sheetId]?.filter(isDefined);
+    if (!sheetBorders) return [];
+    const rowsWithBorders = new Set<number>();
+    for (const rowBorders of sheetBorders) {
+      for (const rowBorder in rowBorders) {
+        rowsWithBorders.add(parseInt(rowBorder, 10));
+      }
+    }
+    return Array.from(rowsWithBorders);
+  }
+
+  /**
    * Get the range of all the rows in the sheet
    */
   private getRowsRange(sheetId: UID): number[] {
@@ -278,7 +293,7 @@ export class BordersPlugin extends CorePlugin<BordersPluginState> implements Bor
         destructive: false,
       });
     }
-    this.getRowsRange(sheetId)
+    this.getRowsWithBorders(sheetId)
       .filter((row) => row >= start)
       .sort((a, b) => (delta < 0 ? a - b : b - a)) // start by the end when moving up
       .forEach((row) => {

--- a/tests/plugins/borders.test.ts
+++ b/tests/plugins/borders.test.ts
@@ -6,6 +6,7 @@ import {
   addColumns,
   addRows,
   deleteCells,
+  deleteRows,
   selectCell,
   setBorder,
   setCellContent,
@@ -469,5 +470,33 @@ describe("Grid manipulation", () => {
     expect(getBorder(model, "A3")).toEqual({ right: b });
     expect(getBorder(model, "B3")).toEqual({ bottom: b, top: b, left: b, right: b });
     expect(getBorder(model, "C3")).toEqual({ left: b });
+  });
+
+  test("Remove multiple rows before borders at the bottom of the sheet starting from the first column", () => {
+    const b = DEFAULT_BORDER_DESC;
+    setBorder(model, "external", "A98:C100");
+    deleteRows(model, [0, 1, 2, 3]);
+    expect(getBorder(model, "A94")).toEqual({ left: b, top: b });
+    expect(getBorder(model, "B94")).toEqual({ top: b });
+    expect(getBorder(model, "C94")).toEqual({ top: b, right: b });
+    expect(getBorder(model, "A95")).toEqual({ left: b });
+    expect(getBorder(model, "C95")).toEqual({ right: b });
+    expect(getBorder(model, "A96")).toEqual({ bottom: b, left: b });
+    expect(getBorder(model, "B96")).toEqual({ bottom: b });
+    expect(getBorder(model, "C96")).toEqual({ right: b, bottom: b });
+  });
+
+  test("Remove multiple rows before borders at the bottom of the sheet starting from the second column", () => {
+    const b = DEFAULT_BORDER_DESC;
+    setBorder(model, "external", "B98:D100");
+    deleteRows(model, [0, 1, 2, 3]);
+    expect(getBorder(model, "B94")).toEqual({ left: b, top: b });
+    expect(getBorder(model, "C94")).toEqual({ top: b });
+    expect(getBorder(model, "D94")).toEqual({ top: b, right: b });
+    expect(getBorder(model, "B95")).toEqual({ left: b });
+    expect(getBorder(model, "D95")).toEqual({ right: b });
+    expect(getBorder(model, "B96")).toEqual({ bottom: b, left: b });
+    expect(getBorder(model, "C96")).toEqual({ bottom: b });
+    expect(getBorder(model, "D96")).toEqual({ right: b, bottom: b });
   });
 });


### PR DESCRIPTION
### [FIX] border: bottom sheet borders removed on DELETE_ROWS

Problem
-----
Before this commit, when we add borders at the bottom of a sheet (at very the last rows), if we delete some rows in a position before the borders, some/all borders disappear (depending on how many rows we deleted). The reason being that the sheet plugin updates the total rows before we loop through them to shift the borders.

Solution
-----
This commit fixes this behaviour by redefining the way we get the border to shift.

Task: [3911695](https://www.odoo.com/web#id=3911695&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo