### PR TITLE
[FIX] pivot store: add missing mutators

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -14,7 +14,15 @@ import {
 } from "../../../../types/pivot";
 
 export class PivotSidePanelStore extends SpreadsheetStore {
-  mutators = ["applyUpdate", "renamePivot", "update"] as const;
+  mutators = [
+    "reset",
+    "deferUpdates",
+    "applyUpdate",
+    "discardPendingUpdate",
+    "renamePivot",
+    "update",
+  ] as const;
+
   private updatesAreDeferred: boolean = true;
   private draft: PivotCoreDefinition | null = null;
   constructor(get: Get, private pivotId: UID) {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -124,4 +124,14 @@ describe("Spreadsheet pivot side panel", () => {
       { name: "amount", order: "asc" },
     ]);
   });
+
+  test("should reset side panel if discard is clicked", async () => {
+    expect(fixture.querySelectorAll(".pivot-dimension")).toHaveLength(0);
+    await click(fixture.querySelector(".add-dimension")!);
+    expect(fixture.querySelector(".o-popover")).toBeDefined();
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[0]);
+    expect(fixture.querySelectorAll(".pivot-dimension")).toHaveLength(1);
+    await click(fixture.querySelector(".fa-undo")!);
+    expect(fixture.querySelectorAll(".pivot-dimension")).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Before this commit, some functions were missing in the pivot store. The visible effect was that the pivot side panel was not correctly discarded when the button `discard` was clicked.

Added in 17.2 here: https://github.com/odoo/enterprise/pull/63194/files#diff-22d5f9014b7dd5a2e99f66d075d443ad86a7b3b3db419658c963174d99a287a8R15

Task: 3959087

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo