### PR TITLE
[FIX] chart: deepCopy support object without prototype

### DIFF
--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -5,7 +5,7 @@ import { _t } from "../../../translation";
 import { Color, Figure, Format, Getters, LocaleFormat, Range } from "../../../types";
 import { ChartRuntime, DataSet, DatasetValues, LabelValues } from "../../../types/chart/chart";
 import { formatValue, isDateTimeFormat } from "../../format";
-import { range } from "../../misc";
+import { deepCopy, range } from "../../misc";
 import { recomputeZones, zoneToXc } from "../../zones";
 import { AbstractChart } from "./abstract_chart";
 import { drawScoreChart } from "./scorecard_chart";
@@ -260,7 +260,7 @@ export function chartToImage(runtime: ChartRuntime, figure: Figure, type: string
   if ("chartJsConfig" in runtime) {
     runtime.chartJsConfig.plugins = [backgroundColorChartJSPlugin];
     // @ts-ignore
-    const chart = new window.Chart(canvas, runtime.chartJsConfig);
+    const chart = new window.Chart(canvas, deepCopy(runtime.chartJsConfig));
     const imgContent = chart.toBase64Image();
     chart.destroy();
     div.remove();

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -70,7 +70,12 @@ export function deepCopy<T>(obj: T): T {
  * Check if the object is a plain old javascript object.
  */
 function isPlainObject(obj: unknown): boolean {
-  return typeof obj === "object" && obj?.constructor === Object;
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    // obj.constructor can be undefined when there's no prototype (`Object.create(null, {})`)
+    (obj?.constructor === Object || obj?.constructor === undefined)
+  );
 }
 
 /**

--- a/tests/helpers/misc_helpers.test.ts
+++ b/tests/helpers/misc_helpers.test.ts
@@ -85,6 +85,19 @@ describe("deepCopy", () => {
     expect("b" in obj).toBe(false);
   });
 
+  test("copy object without any prototype", () => {
+    const obj = Object.create(null, {
+      foo: {
+        writable: true,
+        configurable: true,
+        enumerable: true,
+        value: "hello",
+      },
+    });
+    const copy = deepCopy(obj);
+    expect(copy.foo).toBe("hello");
+  });
+
   test("nested objects is not mutated", () => {
     const obj = { z: { a: 1 } };
     const copy = deepCopy(obj);


### PR DESCRIPTION


## Description:

In odoo:
- Go to CRM app graph
- insert a bar chart in a spreadsheet
- click on File > Downloas => crash

Two issues are combining, leading to this crash.

- Chartjs lib mutates the runtime we generated. It replaces some object with an object without prototype (e.g. `Object.create(null, {})`)

- our `deepCopy` implementation doesn't support such objects because `obj.constructor` is `undefined`

Bug since 6eb43533dae

opw: : [3950324](https://www.odoo.com/web#id=3950324&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
opw: : [3936138](https://www.odoo.com/web#id=3936138&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo