### PR TITLE
[FIX] spreadsheet: fix `useSpreadsheetRect`

### DIFF
--- a/src/components/helpers/position_hook.ts
+++ b/src/components/helpers/position_hook.ts
@@ -10,8 +10,7 @@ type Ref = ReturnType<typeof useRef>;
  */
 export function useSpreadsheetRect(): Rect {
   const position = useState({ x: 0, y: 0, width: 0, height: 0 });
-  let spreadsheetElement = document.querySelector(".o-spreadsheet");
-  updatePosition();
+  let spreadsheetElement: Element | null = null;
   function updatePosition() {
     if (!spreadsheetElement) {
       spreadsheetElement = document.querySelector(".o-spreadsheet");


### PR DESCRIPTION
## Description

The hook `useSpreadsheetRect` was doing a querySelector(".o-spreadsheet") as soon as it was called, instead of waiting for the `onMounted`.

That meant that when creating a new spreadsheet component after destroying another, the hook would return the rect of the old spreadsheet.

Task: : [3965147](https://www.odoo.com/web#id=3965147&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo