### PR TITLE
[IMP] spreadsheet: various fixes & imp

### DIFF
--- a/src/clipboard_handlers/abstract_clipboard_handler.ts
+++ b/src/clipboard_handlers/abstract_clipboard_handler.ts
@@ -31,8 +31,13 @@ export class ClipboardHandler<T> {
     return CommandResult.Success;
   }
 
-  getPasteTarget(target: Zone[], content: T, options: ClipboardOptions): ClipboardPasteTarget {
-    return { zones: [] };
+  getPasteTarget(
+    sheetId: UID,
+    target: Zone[],
+    content: T,
+    options: ClipboardOptions
+  ): ClipboardPasteTarget {
+    return { zones: [], sheetId };
   }
 
   convertOSClipboardData(data: any): T | undefined {

--- a/src/clipboard_handlers/borders_clipboard.ts
+++ b/src/clipboard_handlers/borders_clipboard.ts
@@ -18,7 +18,7 @@ export class BorderClipboardHandler extends AbstractCellClipboardHandler<
   Border | null
 > {
   copy(data: ClipboardCellData): ClipboardContent | undefined {
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = data.sheetId;
     if (data.zones.length === 0) {
       return;
     }
@@ -40,7 +40,7 @@ export class BorderClipboardHandler extends AbstractCellClipboardHandler<
     if (!content) {
       return;
     }
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = target.sheetId;
     if (options?.pasteOption === "asValue") {
       return;
     }

--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -35,7 +35,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
     if (!("zones" in data) || !data.zones.length) {
       return;
     }
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = data.sheetId;
     const zones = data.zones;
     if (!zones.length) {
       return {
@@ -82,7 +82,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
     return {
       cells: clippedCells,
       zones: clippedZones,
-      sheetId: this.getters.getActiveSheetId(),
+      sheetId: data.sheetId,
     };
   }
 
@@ -121,7 +121,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
       return;
     }
     const zones = target.zones;
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = target.sheetId;
     if (!options?.isCutOperation) {
       this.pasteFromCopy(sheetId, zones, content.cells, options);
     } else {
@@ -130,6 +130,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
   }
 
   getPasteTarget(
+    sheetId: UID,
     target: Zone[],
     content: ClipboardContent,
     options?: ClipboardOptions
@@ -138,6 +139,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
     const height = content.cells.length;
     if (options?.isCutOperation) {
       return {
+        sheetId,
         zones: [
           {
             left: target[0].left,
@@ -149,11 +151,9 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
       };
     }
     if (width === 1 && height === 1) {
-      return { zones: [] };
+      return { zones: [], sheetId };
     }
-    return {
-      zones: getPasteZones(target, content.cells),
-    };
+    return { sheetId, zones: getPasteZones(target, content.cells) };
   }
 
   private pasteFromCut(

--- a/src/clipboard_handlers/chart_clipboard.ts
+++ b/src/clipboard_handlers/chart_clipboard.ts
@@ -19,7 +19,7 @@ type ClipboardContent = {
 
 export class ChartClipboardHandler extends AbstractFigureClipboardHandler<ClipboardContent> {
   copy(data: ClipboardFigureData): ClipboardContent | undefined {
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = data.sheetId;
     const figure = this.getters.getFigure(sheetId, data.figureId);
     if (!figure) {
       throw new Error(`No figure for the given id: ${data.figureId}`);
@@ -41,18 +41,16 @@ export class ChartClipboardHandler extends AbstractFigureClipboardHandler<Clipbo
   }
 
   getPasteTarget(
+    sheetId: UID,
     target: Zone[],
     content: ClipboardContent,
     options?: ClipboardOptions
   ): ClipboardPasteTarget {
     if (!content?.copiedFigure || !content?.copiedChart) {
-      return { zones: [] };
+      return { zones: [], sheetId };
     }
     const newId = new UuidGenerator().uuidv4();
-    return {
-      zones: [],
-      figureId: newId,
-    };
+    return { zones: [], figureId: newId, sheetId };
   }
 
   paste(target: ClipboardPasteTarget, clippedContent: ClipboardContent, options: ClipboardOptions) {
@@ -60,7 +58,7 @@ export class ChartClipboardHandler extends AbstractFigureClipboardHandler<Clipbo
       return;
     }
     const { zones, figureId } = target;
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = target.sheetId;
     const numCols = this.getters.getNumberCols(sheetId);
     const numRows = this.getters.getNumberRows(sheetId);
     const targetX = this.getters.getColDimensions(sheetId, zones[0].left).start;

--- a/src/clipboard_handlers/conditional_format_clipboard.ts
+++ b/src/clipboard_handlers/conditional_format_clipboard.ts
@@ -27,7 +27,7 @@ export class ConditionalFormatClipboardHandler extends AbstractCellClipboardHand
     }
 
     const { rowsIndexes, columnsIndexes } = data;
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = data.sheetId;
     const cellPositions = rowsIndexes.map((row) =>
       columnsIndexes.map((col) => ({ col, row, sheetId }))
     );
@@ -51,7 +51,7 @@ export class ConditionalFormatClipboardHandler extends AbstractCellClipboardHand
       return;
     }
     const zones = target.zones;
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = target.sheetId;
 
     if (!options?.isCutOperation) {
       this.pasteFromCopy(sheetId, zones, clippedContent.cellPositions);

--- a/src/clipboard_handlers/data_validation_clipboard.ts
+++ b/src/clipboard_handlers/data_validation_clipboard.ts
@@ -27,7 +27,7 @@ export class DataValidationClipboardHandler extends AbstractCellClipboardHandler
     }
 
     const { rowsIndexes, columnsIndexes } = data;
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = data.sheetId;
     const cellPositions = rowsIndexes.map((row) =>
       columnsIndexes.map((col) => ({ col, row, sheetId }))
     );
@@ -52,7 +52,7 @@ export class DataValidationClipboardHandler extends AbstractCellClipboardHandler
       return;
     }
     const zones = target.zones;
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = target.sheetId;
 
     if (!options?.isCutOperation) {
       this.pasteFromCopy(sheetId, zones, clippedContent.cellPositions);

--- a/src/clipboard_handlers/image_clipboard.ts
+++ b/src/clipboard_handlers/image_clipboard.ts
@@ -20,7 +20,7 @@ type ClipboardContent = {
 
 export class ImageClipboardHandler extends AbstractFigureClipboardHandler<ClipboardContent> {
   copy(data: ClipboardFigureData): ClipboardContent | undefined {
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = data.sheetId;
     const figure = this.getters.getFigure(sheetId, data.figureId);
     if (!figure) {
       throw new Error(`No figure for the given id: ${data.figureId}`);
@@ -40,18 +40,16 @@ export class ImageClipboardHandler extends AbstractFigureClipboardHandler<Clipbo
   }
 
   getPasteTarget(
+    sheetId: UID,
     target: Zone[],
     content: ClipboardContent,
     options?: ClipboardOptions
   ): ClipboardPasteTarget {
     if (!content?.copiedFigure || !content?.copiedImage) {
-      return { zones: [] };
+      return { zones: [], sheetId };
     }
     const newId = new UuidGenerator().uuidv4();
-    return {
-      zones: [],
-      figureId: newId,
-    };
+    return { sheetId, zones: [], figureId: newId };
   }
 
   paste(target: ClipboardPasteTarget, clippedContent: ClipboardContent, options: ClipboardOptions) {

--- a/src/clipboard_handlers/merge_clipboard.ts
+++ b/src/clipboard_handlers/merge_clipboard.ts
@@ -48,8 +48,7 @@ export class MergeClipboardHandler extends AbstractCellClipboardHandler<
     if (options?.isCutOperation || !("zones" in target) || !target.zones.length) {
       return;
     }
-    const sheetId = this.getters.getActiveSheetId();
-    this.pasteFromCopy(sheetId, target.zones, content.cells, options);
+    this.pasteFromCopy(target.sheetId, target.zones, content.cells, options);
   }
 
   pasteZone(sheetId: UID, col: HeaderIndex, row: HeaderIndex, cells: ClipboardCell[][]) {

--- a/src/clipboard_handlers/tables_clipboard.ts
+++ b/src/clipboard_handlers/tables_clipboard.ts
@@ -41,7 +41,7 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
   TableCell
 > {
   copy(data: ClipboardCellData): ClipboardContent {
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = data.sheetId;
 
     const { rowsIndexes, columnsIndexes, zones } = data;
     if (!zones || !rowsIndexes.length || !columnsIndexes.length) {
@@ -86,7 +86,7 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
 
     return {
       tableCells,
-      sheetId: this.getters.getActiveSheetId(),
+      sheetId: data.sheetId,
     };
   }
 
@@ -112,7 +112,7 @@ export class TableClipboardHandler extends AbstractCellClipboardHandler<
       return;
     }
     const zones = target.zones;
-    const sheetId = this.getters.getActiveSheetId();
+    const sheetId = target.sheetId;
     if (!options?.isCutOperation) {
       this.pasteFromCopy(sheetId, zones, content.tableCells, options);
     } else {

--- a/src/helpers/clipboard/clipboard_helpers.ts
+++ b/src/helpers/clipboard/clipboard_helpers.ts
@@ -1,7 +1,7 @@
-import { ClipboardCellData, Zone } from "../../types";
+import { ClipboardCellData, UID, Zone } from "../../types";
 import { mergeOverlappingZones, positions } from "../zones";
 
-export function getClipboardDataPositions(zones: Zone[]): ClipboardCellData {
+export function getClipboardDataPositions(sheetId: UID, zones: Zone[]): ClipboardCellData {
   const lefts = new Set(zones.map((z) => z.left));
   const rights = new Set(zones.map((z) => z.right));
   const tops = new Set(zones.map((z) => z.top));
@@ -19,7 +19,7 @@ export function getClipboardDataPositions(zones: Zone[]): ClipboardCellData {
   const cellsPosition = clippedZones.map((zone) => positions(zone)).flat();
   const columnsIndexes = [...new Set(cellsPosition.map((p) => p.col))].sort((a, b) => a - b);
   const rowsIndexes = [...new Set(cellsPosition.map((p) => p.row))].sort((a, b) => a - b);
-  return { zones, clippedZones, columnsIndexes, rowsIndexes };
+  return { sheetId, zones, clippedZones, columnsIndexes, rowsIndexes };
 }
 
 /**

--- a/src/helpers/zones.ts
+++ b/src/helpers/zones.ts
@@ -609,22 +609,19 @@ export function unionPositionsToZone(positions: Position[]): Zone {
  * Check if two zones are contiguous, ie. that they share a border
  */
 function areZoneContiguous(zone1: Zone, zone2: Zone) {
-  const u = union(zone1, zone2);
   if (zone1.right + 1 === zone2.left || zone1.left === zone2.right + 1) {
-    return getZoneHeight(u) <= getZoneHeight(zone1) + getZoneHeight(zone2);
+    return (
+      (zone1.top <= zone2.bottom && zone1.top >= zone2.top) ||
+      (zone2.top <= zone1.bottom && zone2.top >= zone1.top)
+    );
   }
   if (zone1.bottom + 1 === zone2.top || zone1.top === zone2.bottom + 1) {
-    return getZoneWidth(u) <= getZoneWidth(zone1) + getZoneWidth(zone2);
+    return (
+      (zone1.left <= zone2.right && zone1.left >= zone2.left) ||
+      (zone2.left <= zone1.right && zone2.left >= zone1.left)
+    );
   }
   return false;
-}
-
-function getZoneHeight(zone: Zone) {
-  return zone.bottom - zone.top + 1;
-}
-
-function getZoneWidth(zone: Zone) {
-  return zone.right - zone.left + 1;
 }
 
 /**

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -149,6 +149,7 @@ export class EvaluationPlugin extends UIPlugin {
     "getEvaluatedCell",
     "getEvaluatedCells",
     "getEvaluatedCellsInZone",
+    "getEvaluatedCellsPositions",
     "getSpreadZone",
     "getArrayFormulaSpreadingOn",
     "isEmpty",
@@ -251,14 +252,14 @@ export class EvaluationPlugin extends UIPlugin {
     return this.evaluator.getEvaluatedCell(position);
   }
 
-  getEvaluatedCells(sheetId: UID): Record<UID, EvaluatedCell> {
-    const rawCells = this.getters.getCells(sheetId) || {};
-    const record: Record<UID, EvaluatedCell> = {};
-    for (let cellId of Object.keys(rawCells)) {
-      const position = this.getters.getCellPosition(cellId);
-      record[cellId] = this.getEvaluatedCell(position);
-    }
-    return record;
+  getEvaluatedCells(sheetId: UID): EvaluatedCell[] {
+    return this.evaluator
+      .getEvaluatedPositionsInSheet(sheetId)
+      .map((position) => this.getEvaluatedCell(position));
+  }
+
+  getEvaluatedCellsPositions(sheetId: UID): CellPosition[] {
+    return this.evaluator.getEvaluatedPositionsInSheet(sheetId);
   }
 
   getEvaluatedCellsInZone(sheetId: UID, zone: Zone): EvaluatedCell[] {

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -76,6 +76,10 @@ export class Evaluator {
     return this.evaluatedCells.keys();
   }
 
+  getEvaluatedPositionsInSheet(sheetId: UID): CellPosition[] {
+    return this.evaluatedCells.keysForSheet(sheetId);
+  }
+
   getArrayFormulaSpreadingOn(position: CellPosition): CellPosition | undefined {
     if (!this.spreadingRelations.hasArrayFormulaResult(position)) {
       return this.spreadingRelations.isArrayFormula(position) ? position : undefined;

--- a/src/plugins/ui_core_views/cell_evaluation/position_map.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/position_map.ts
@@ -18,6 +18,10 @@ export class PositionMap<T> {
     return this.map[sheetId]?.[col]?.[row];
   }
 
+  getSheet(sheetId: UID): Record<number, Record<number, T>> | undefined {
+    return this.map[sheetId];
+  }
+
   has({ sheetId, col, row }: CellPosition): boolean {
     return this.map[sheetId]?.[col]?.[row] !== undefined;
   }
@@ -26,7 +30,7 @@ export class PositionMap<T> {
     delete this.map[sheetId]?.[col]?.[row];
   }
 
-  keys() {
+  keys(): CellPosition[] {
     const map = this.map;
     const keys: CellPosition[] = [];
     for (const sheetId in map) {
@@ -34,6 +38,20 @@ export class PositionMap<T> {
         for (const row in map[sheetId][col]) {
           keys.push({ sheetId, col: parseInt(col), row: parseInt(row) });
         }
+      }
+    }
+    return keys;
+  }
+
+  keysForSheet(sheetId: UID): CellPosition[] {
+    const map = this.map[sheetId];
+    if (!map) {
+      return [];
+    }
+    const keys: CellPosition[] = [];
+    for (const col in map) {
+      for (const row in map[col]) {
+        keys.push({ sheetId, col: parseInt(col), row: parseInt(row) });
       }
     }
     return keys;

--- a/src/plugins/ui_feature/data_cleanup.ts
+++ b/src/plugins/ui_feature/data_cleanup.ts
@@ -84,7 +84,7 @@ export class DataCleanupPlugin extends UIPlugin {
     }));
 
     const handler = new CellClipboardHandler(this.getters, this.dispatch);
-    const data = handler.copy(getClipboardDataPositions(rowsToKeep));
+    const data = handler.copy(getClipboardDataPositions(sheetId, rowsToKeep));
     if (!data) {
       return;
     }
@@ -100,7 +100,7 @@ export class DataCleanupPlugin extends UIPlugin {
       bottom: zone.top,
     };
 
-    handler.paste({ zones: [zonePasted] }, data, { isCutOperation: false });
+    handler.paste({ zones: [zonePasted], sheetId }, data, { isCutOperation: false });
 
     const remainingZone = {
       left: zone.left,

--- a/src/plugins/ui_stateful/clipboard.ts
+++ b/src/plugins/ui_stateful/clipboard.ts
@@ -371,12 +371,14 @@ export class ClipboardPlugin extends UIPlugin {
     }
     let zone: Zone | undefined = undefined;
     let selectedZones: Zone[] = [];
+    const sheetId = this.getters.getActiveSheetId();
     let target: ClipboardPasteTarget = {
+      sheetId,
       zones,
     };
     const handlers = this.selectClipboardHandlers(copiedData);
     for (const handler of handlers) {
-      const currentTarget = handler.getPasteTarget(zones, copiedData, options);
+      const currentTarget = handler.getPasteTarget(sheetId, zones, copiedData, options);
       if (currentTarget.figureId) {
         target.figureId = currentTarget.figureId;
       }
@@ -577,11 +579,12 @@ export class ClipboardPlugin extends UIPlugin {
   }
 
   private getClipboardData(zones: Zone[]): ClipboardData {
+    const sheetId = this.getters.getActiveSheetId();
     const selectedFigureId = this.getters.getSelectedFigureId();
     if (selectedFigureId) {
-      return { figureId: selectedFigureId };
+      return { figureId: selectedFigureId, sheetId };
     }
-    return getClipboardDataPositions(zones);
+    return getClipboardDataPositions(sheetId, zones);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/plugins/ui_stateful/selection.ts
+++ b/src/plugins/ui_stateful/selection.ts
@@ -559,8 +559,9 @@ export class GridSelectionPlugin extends UIPlugin {
       },
     ];
 
+    const sheetId = this.getActiveSheetId();
     const handler = new CellClipboardHandler(this.getters, this.dispatch);
-    const data = handler.copy(getClipboardDataPositions(target));
+    const data = handler.copy(getClipboardDataPositions(sheetId, target));
     if (!data) {
       return;
     }
@@ -573,7 +574,7 @@ export class GridSelectionPlugin extends UIPlugin {
         bottom: !isCol ? base + thickness - 1 : this.getters.getNumberRows(cmd.sheetId) - 1,
       },
     ];
-    handler.paste({ zones: pasteTarget }, data, { isCutOperation: true });
+    handler.paste({ zones: pasteTarget, sheetId }, data, { isCutOperation: true });
 
     const toRemove = isBasedBefore ? cmd.elements.map((el) => el + thickness) : cmd.elements;
     let currentIndex = cmd.base;

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -16,6 +16,7 @@ export type ClipboardPasteOptions = "onlyFormat" | "asValue";
 export type ClipboardOperation = "CUT" | "COPY";
 
 export type ClipboardCellData = {
+  sheetId: UID;
   zones: Zone[];
   rowsIndexes: HeaderIndex[];
   columnsIndexes: HeaderIndex[];
@@ -23,12 +24,14 @@ export type ClipboardCellData = {
 };
 
 export type ClipboardFigureData = {
+  sheetId: UID;
   figureId: UID;
 };
 
 export type ClipboardData = ClipboardCellData | ClipboardFigureData;
 
 export type ClipboardPasteTarget = {
+  sheetId: UID;
   zones: Zone[];
   figureId?: UID;
 };

--- a/tests/bottom_bar/automatic_sum_model.test.ts
+++ b/tests/bottom_bar/automatic_sum_model.test.ts
@@ -31,13 +31,13 @@ describe("automatic sum", () => {
   test("1d zone in an empty sheet", () => {
     automaticSum(model, "A3:B3");
     const sheetId = model.getters.getActiveSheetId();
-    expect(model.getters.getEvaluatedCells(sheetId)).toEqual({});
+    expect(model.getters.getEvaluatedCells(sheetId)).toEqual([]);
   });
 
   test("2d zone in an empty sheet", () => {
     automaticSum(model, "A3:D4");
     const sheetId = model.getters.getActiveSheetId();
-    expect(model.getters.getEvaluatedCells(sheetId)).toEqual({});
+    expect(model.getters.getEvaluatedCells(sheetId)).toEqual([]);
   });
 
   test("from A1", () => {
@@ -518,7 +518,7 @@ describe("automatic sum", () => {
   test("multiple selected zones in an empty sheet", () => {
     automaticSumMulti(model, ["A1:A2", "B1:B3"]);
     const sheetId = model.getters.getActiveSheetId();
-    expect(model.getters.getEvaluatedCells(sheetId)).toEqual({});
+    expect(model.getters.getEvaluatedCells(sheetId)).toEqual([]);
   });
 
   test("multiple selected zones", () => {

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -145,7 +145,7 @@ describe("clipboard", () => {
       content: "a1",
     });
     activateSheet(model, to);
-    expect(model.getters.getEvaluatedCells(to)).toEqual({});
+    expect(model.getters.getEvaluatedCells(to)).toEqual([]);
 
     expect(getClipboardVisibleZones(model).length).toBe(0);
 

--- a/tests/composer/composer_store.test.ts
+++ b/tests/composer/composer_store.test.ts
@@ -64,14 +64,14 @@ describe("edition", () => {
     // adding
     composerStore.startEdition("a");
     composerStore.stopEdition();
-    expect(Object.keys(model.getters.getEvaluatedCells(sheetId))).toHaveLength(1);
+    expect(model.getters.getEvaluatedCells(sheetId)).toHaveLength(1);
     expect(getCellContent(model, "A1")).toBe("a");
 
     // removing
     composerStore.startEdition();
     composerStore.setCurrentContent("");
     composerStore.stopEdition();
-    expect(model.getters.getEvaluatedCells(sheetId)).toEqual({});
+    expect(model.getters.getEvaluatedCells(sheetId)).toEqual([]);
   });
 
   test("deleting a cell with style does not remove it", () => {

--- a/tests/evaluation/evaluation.test.ts
+++ b/tests/evaluation/evaluation.test.ts
@@ -1284,4 +1284,14 @@ describe("evaluate formula getter", () => {
     expect((getEvaluatedCell(model, "A1") as ErrorCell).message).toBe("Function GETERR failed");
     functionRegistry.remove("GETERR");
   });
+
+  test("Getter getEvaluatedCells return spreaded cells", () => {
+    setCellContent(model, "A1", "=MUNIT(3)");
+    expect(model.getters.getEvaluatedCells(sheetId)).toHaveLength(9);
+  });
+
+  test("Getter getEvaluatedCells does not return cells with only a style", () => {
+    setStyle(model, "B1", { fillColor: "red" });
+    expect(model.getters.getEvaluatedCells(sheetId)).toHaveLength(0);
+  });
 });

--- a/tests/sheet/sheet_manipulation_plugin.test.ts
+++ b/tests/sheet/sheet_manipulation_plugin.test.ts
@@ -121,9 +121,7 @@ describe("Clear columns", () => {
     clearColumns(["B", "C"]);
     const style = { textColor: "#fe0000" };
     expect(getCell(model, "B2")).toBeUndefined();
-    expect(
-      Object.keys(model.getters.getEvaluatedCells(model.getters.getActiveSheetId()))
-    ).toHaveLength(5);
+    expect(Object.keys(model.getters.getCells(model.getters.getActiveSheetId()))).toHaveLength(5);
     expect(getCell(model, "A1")).toMatchObject({ content: "A1" });
     expect(getCell(model, "A2")).toMatchObject({ content: "A2" });
     expect(getCell(model, "A3")).toMatchObject({ content: "A3" });
@@ -167,9 +165,7 @@ describe("Clear rows", () => {
     clearRows([1, 2]);
     const style = { textColor: "#fe0000" };
     expect(getCell(model, "B2")).toBeUndefined();
-    expect(
-      Object.keys(model.getters.getEvaluatedCells(model.getters.getActiveSheetId()))
-    ).toHaveLength(5);
+    expect(Object.keys(model.getters.getCells(model.getters.getActiveSheetId()))).toHaveLength(5);
     expect(getCell(model, "A1")).toMatchObject({ content: "A1" });
     expect(getCell(model, "A2")).toMatchObject({ style });
     expect(getBorder(model, "A2")).toEqual(border);
@@ -1060,12 +1056,12 @@ describe("Rows", () => {
       const s = { style: "thin", color: "#000000" };
       const style = { textColor: "#fe0000" };
       const sheetId = model.getters.getActiveSheetId();
-      expect(Object.keys(model.getters.getEvaluatedCells(sheetId))).toHaveLength(8); // 7 NumberCells + 1 emptyCell in merge with style
+      expect(Object.keys(model.getters.getCells(sheetId))).toHaveLength(8); // 7 NumberCells + 1 emptyCell in merge with style
       deleteRows(model, [1]);
       expect(getCell(model, "A2")).toBeUndefined();
       expect(getCell(model, "B2")).toBeUndefined();
       expect(getCell(model, "C2")).toBeUndefined();
-      expect(Object.values(model.getters.getEvaluatedCells(sheetId))).toHaveLength(5); // 4 NumberCells +1 emptyCell with no merge, but with style
+      expect(Object.values(model.getters.getCells(sheetId))).toHaveLength(5); // 4 NumberCells +1 emptyCell with no merge, but with style
       expect(getCell(model, "A1")).toMatchObject({ style });
       expect(getCell(model, "A3")).toMatchObject({ style });
       expect(getBorder(model, "B1")).toEqual({ top: s, bottom: s });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -322,9 +322,9 @@ type GridStyleDescr = { [xc: string]: Style | undefined };
 function getCellGrid(model: Model): { [xc: string]: EvaluatedCell } {
   const result = {};
   const sheetId = model.getters.getActiveSheetId();
-  for (let cellId in model.getters.getEvaluatedCells(sheetId)) {
-    const { col, row } = model.getters.getCellPosition(cellId);
-    const cell = model.getters.getEvaluatedCell({ sheetId, col, row });
+  for (const position of model.getters.getEvaluatedCellsPositions(sheetId)) {
+    const { col, row } = position;
+    const cell = model.getters.getEvaluatedCell(position);
     result[toXC(col, row)] = cell;
   }
   return result;


### PR DESCRIPTION
## Description:

Commits that were part of #4182 before it was cancelled

Not sure commit [[REF] clipboard: expose paste logic](https://github.com/odoo/o-spreadsheet/pull/4332/commits/8ec6ad2675e37fd6ceae9975b78cc39c56632e55) is something we want right now. The other commit all seems like good ideas

## [IMP] mergeContiguousZones: add test & fix diagonal
This commit moves the tests of mergeContiguousZones from Odoo
to o-spreadsheet.

It also fixes a bug where the algorithm was merging zones that were
diagonal to each other.

## [REF] clipboard: decouple clipboards and active sheet
This commit make the clipboards handlers independent from the active
sheet, thus allowing to use them to copy/paste things in any sheet.

## [FIX] evaluation: `getEvaluatedCells` with spreading cells
The getter `getEvaluatedCells` does't return spreaded cells. It
also returns empty evaluated cells that have some style.

This is not the expected behaviour. `getEvaluatedCells` should return
all the non-empty evaluated cells of a sheet.

Task: : [3965270](https://www.odoo.com/web#id=3965270&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo