### PR TITLE
[FIX] FindAndReplaceSidePanel: Fix range update

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace.ts
@@ -1,4 +1,4 @@
-import { Component, onMounted, useRef } from "@odoo/owl";
+import { Component, onMounted, useRef, useState } from "@odoo/owl";
 import { zoneToXc } from "../../../helpers";
 import { Store, useLocalStore } from "../../../store_engine";
 import { _t } from "../../../translation";
@@ -47,10 +47,9 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
     onCloseSidePanel: Function,
   };
 
-  private dataRange: string = "";
   private searchInput = useRef("searchInput");
-
   private store!: Store<FindAndReplaceStore>;
+  private state!: { dataRange: string };
 
   get hasSearchResult() {
     return this.store.selectedMatchIndex !== null;
@@ -86,6 +85,7 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
 
   setup() {
     this.store = useLocalStore(FindAndReplaceStore);
+    this.state = useState({ dataRange: "" });
     onMounted(() => this.searchInput.el?.focus());
   }
 
@@ -131,16 +131,16 @@ export class FindAndReplacePanel extends Component<Props, SpreadsheetChildEnv> {
   }
 
   onSearchRangeChanged(ranges: string[]) {
-    this.dataRange = ranges[0];
+    this.state.dataRange = ranges[0];
   }
 
   updateDataRange() {
-    if (!this.dataRange || this.searchOptions.searchScope !== "specificRange") {
+    if (!this.state.dataRange || this.searchOptions.searchScope !== "specificRange") {
       return;
     }
     const specificRange = this.env.model.getters.getRangeFromSheetXC(
       this.env.model.getters.getActiveSheetId(),
-      this.dataRange
+      this.state.dataRange
     );
     this.store.updateSearchOptions({ specificRange });
   }

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -30,7 +30,7 @@
         </select>
         <div t-if="searchOptions.searchScope === 'specificRange'">
           <SelectionInput
-            ranges="[this.dataRange]"
+            ranges="[this.state.dataRange]"
             onSelectionChanged="(ranges) => this.onSearchRangeChanged(ranges)"
             onSelectionConfirmed.bind="updateDataRange"
             hasSingleRange="true"
@@ -59,7 +59,7 @@
           />
         </div>
         <div class="o-matches-count mt-4" t-if="store.toSearch !== ''">
-          <div t-if="searchOptions.searchScope === 'specificRange' and dataRange != ''">
+          <div t-if="searchOptions.searchScope === 'specificRange' and state.dataRange != ''">
             <t t-esc="specificRangeMatchesCount"/>
           </div>
           <div>


### PR DESCRIPTION
How to reproduce:
- Open the F&R SidePanel.
- Choose the 'Specific Range' Search Option from the dropdown.
- Attempt to pick a large range from the grid.

The component SelectionInput heavily relies on the fact its props are updated by the parent component after SelectionInput invoked `props.onSelectionChanged`.

The dataRange stored in the component `FindAndReplacePanel` was not observed, which means the after `SelectionInput` called `onSelectionChanged`, the update of the datarange would not update the props passed to `SelectionInput`. This would cause a desynchronized state which lead to an infinite loop because one of the conditions in `SelectionInput.onWillUpdateProps` would be triggered 100% of the time and the said condition unfortunately updates a store, then forcing a render(true), hence the infinite loop.

In this revision, we fix the bad state management of `FindAndReplace` but is seems again that `SelectionInput` is wobbly, so is using it. We should try to fix its behaviour once and for all.

Task: 3972409

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo