### PR TITLE
[IMP] pivot: remove label of first row group by

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -38,8 +38,7 @@ export function dataEntriesToSpreadsheetPivotTable(
   });
 
   const measureNames = definition.measures.map((m) => m.name);
-  const rowTitle = rows.length > 0 ? rows[0].values[0] : "";
-  return new SpreadsheetPivotTable(cols, rows, measureNames, rowTitle);
+  return new SpreadsheetPivotTable(cols, rows, measureNames);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot.ts
@@ -46,16 +46,10 @@ export class SpreadsheetPivotTable {
   readonly columns: PivotTableColumn[][];
   readonly rows: PivotTableRow[];
   readonly measures: string[];
-  readonly rowTitle?: string;
   readonly maxIndent: number;
   readonly pivotCells: { [key: string]: PivotTableCell[][] } = {};
 
-  constructor(
-    columns: PivotTableColumn[][],
-    rows: PivotTableRow[],
-    measures: string[],
-    rowTitle: string = ""
-  ) {
+  constructor(columns: PivotTableColumn[][], rows: PivotTableRow[], measures: string[]) {
     this.columns = columns.map((row) => {
       // offset in the pivot table
       // starts at 1 because the first column is the row title
@@ -68,7 +62,6 @@ export class SpreadsheetPivotTable {
     });
     this.rows = rows;
     this.measures = measures;
-    this.rowTitle = rowTitle;
     this.maxIndent = Math.max(...this.rows.map((row) => row.indent));
   }
 
@@ -114,9 +107,7 @@ export class SpreadsheetPivotTable {
 
   private getPivotCell(col: number, row: number, includeTotal = true): PivotTableCell {
     const colHeadersHeight = this.columns.length;
-    if (col === 0 && row === colHeadersHeight - 1) {
-      return { content: this.rowTitle, isHeader: true };
-    } else if (row <= colHeadersHeight - 1) {
+    if (row <= colHeadersHeight - 1) {
       const domain = this.getColHeaderDomain(col, row);
       return { domain, isHeader: true };
     } else if (col === 0) {
@@ -174,7 +165,6 @@ export class SpreadsheetPivotTable {
       cols: this.columns,
       rows: this.rows,
       measures: this.measures,
-      rowTitle: this.rowTitle,
     };
   }
 }

--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -83,8 +83,8 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
       case "INSERT_PIVOT": {
         const { sheetId, col, row, pivotId, table } = cmd;
         const position = { sheetId, col, row };
-        const { cols, rows, measures, rowTitle } = table;
-        const spTable = new SpreadsheetPivotTable(cols, rows, measures, rowTitle);
+        const { cols, rows, measures } = table;
+        const spTable = new SpreadsheetPivotTable(cols, rows, measures);
         const formulaId = this.getPivotFormulaId(pivotId);
         this.insertPivot(position, formulaId, spTable);
         break;
@@ -237,7 +237,7 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
 
     this.dispatch("UPDATE_CELL", {
       ...position,
-      content: pivotCell.content || (args ? makePivotFormula(formula, args) : undefined),
+      content: args ? makePivotFormula(formula, args) : undefined,
     });
   }
 

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -101,13 +101,11 @@ export interface PivotTableData {
   cols: PivotTableColumn[][];
   rows: PivotTableRow[];
   measures: string[];
-  rowTitle?: string;
 }
 
 export interface PivotTableCell {
   isHeader: boolean;
   domain?: string[];
-  content?: string;
   measure?: string;
 }
 


### PR DESCRIPTION
This commit removes the label of the first row group by in the pivot table. It was done to ease the creation of a chart from a pivot table, but it was confusing for the user.

For the record, it was introduced here: https://github.com/odoo/odoo/pull/107220

Task: 3975326

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo