### PR TITLE
[IMP] pivot: support PIVOT.VALUE and PIVOT.HEADER

### DIFF
--- a/src/functions/module_lookup.ts
+++ b/src/functions/module_lookup.ts
@@ -1,5 +1,4 @@
 import { getFullReference, range, toXC, toZone } from "../helpers/index";
-import { supportedPivotExplodedFormulaRegistry } from "../helpers/pivot/pivot_exploded_formula_registry";
 import { toPivotDomain } from "../helpers/pivot/pivot_helpers";
 import { _t } from "../translation";
 import { AddFunctionDescription, CellPosition, FPayload, Matrix, Maybe } from "../types";
@@ -711,12 +710,7 @@ export const PIVOT_VALUE = {
     assertDomainLength(_domainArgs);
     const pivot = this.getters.getPivot(pivotId);
     const coreDefinition = this.getters.getPivotCoreDefinition(pivotId);
-    if (!supportedPivotExplodedFormulaRegistry.get(coreDefinition.type)) {
-      return {
-        value: CellErrorType.GenericError,
-        message: _t("This pivot does not support PIVOT.VALUE formula"),
-      };
-    }
+
     addPivotDependencies(this, coreDefinition);
     const error = pivot.assertIsValid({ throwOnError: false });
     if (error) {
@@ -748,12 +742,6 @@ export const PIVOT_HEADER = {
     assertDomainLength(_domainArgs);
     const pivot = this.getters.getPivot(_pivotId);
     const coreDefinition = this.getters.getPivotCoreDefinition(_pivotId);
-    if (!supportedPivotExplodedFormulaRegistry.get(coreDefinition.type)) {
-      return {
-        value: CellErrorType.GenericError,
-        message: _t("This pivot does not support PIVOT.VALUE formula"),
-      };
-    }
     addPivotDependencies(this, coreDefinition);
     const error = pivot.assertIsValid({ throwOnError: false });
     if (error) {

--- a/src/helpers/pivot/pivot_composer_helpers.ts
+++ b/src/helpers/pivot/pivot_composer_helpers.ts
@@ -13,11 +13,15 @@ const PIVOT_FUNCTIONS = ["PIVOT.VALUE", "PIVOT.HEADER", "PIVOT"];
 export function makeFieldProposal(field: PivotField, granularity?: Granularity) {
   const groupBy = granularity ? `${field.name}:${granularity}` : field.name;
   const quotedGroupBy = `"${groupBy}"`;
+  const fuzzySearchKey =
+    field.string !== field.name
+      ? field.string + quotedGroupBy // search on translated name and on technical name
+      : quotedGroupBy;
   return {
     text: quotedGroupBy,
     description: field.string + (field.help ? ` (${field.help})` : ""),
     htmlContent: [{ value: quotedGroupBy, color: tokenColors.STRING }],
-    fuzzySearchKey: field.string + quotedGroupBy, // search on translated name and on technical name
+    fuzzySearchKey,
   };
 }
 

--- a/src/helpers/pivot/pivot_exploded_formula_registry.ts
+++ b/src/helpers/pivot/pivot_exploded_formula_registry.ts
@@ -1,4 +1,0 @@
-import { Registry } from "../../registries/registry";
-//TODO This registry is only used to disable the support of exploded pivot for spreadsheet
-export const supportedPivotExplodedFormulaRegistry = new Registry<boolean>();
-supportedPivotExplodedFormulaRegistry.add("SPREADSHEET", false);

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -31,7 +31,7 @@ const NUMBER_CHAR_AGGREGATORS = ["max", "min", "avg", "sum", "count_distinct", "
 const AGGREGATORS_BY_FIELD_TYPE = {
   integer: NUMBER_CHAR_AGGREGATORS,
   char: NUMBER_CHAR_AGGREGATORS,
-  //TODO Support for date and boolean
+  boolean: ["count_distinct", "count", "bool_and", "bool_or"],
 };
 
 export const AGGREGATORS = {};

--- a/src/helpers/pivot/pivot_positional_formula_registry.ts
+++ b/src/helpers/pivot/pivot_positional_formula_registry.ts
@@ -1,0 +1,10 @@
+import { Registry } from "../../registries/registry";
+
+/**
+ * Registry to enable or disable the support of positional arguments
+ * (with a leading #) in pivot functions
+ * e.g. =PIVOT.VALUE(1,"probability","#stage",1)
+ */
+export const supportedPivotPositionalFormulaRegistry = new Registry<boolean>();
+
+supportedPivotPositionalFormulaRegistry.add("SPREADSHEET", false);

--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -61,7 +61,7 @@ function dataEntriesToRows(
   }
   const row = rows[index];
   const rowName = row.nameWithGranularity;
-  const groups = groupBy(dataEntries, row);
+  const groups = groupPivotDataEntriesBy(dataEntries, row);
   const orderedKeys = orderDataEntriesKeys(groups, row);
   const pivotTableRows: PivotTableRow[] = [];
   const _fields = fields.concat(rowName);
@@ -97,7 +97,7 @@ function dataEntriesToColumnsTree(
   }
   const column = columns[index];
   const colName = columns[index].nameWithGranularity;
-  const groups = groupBy(dataEntries, column);
+  const groups = groupPivotDataEntriesBy(dataEntries, column);
   const orderedKeys = orderDataEntriesKeys(groups, columns[index]);
   return orderedKeys.map((value) => {
     return {
@@ -205,7 +205,7 @@ function columnsTreeToColumns(
 /**
  * Group the dataEntries based on the given dimension
  */
-function groupBy(dataEntries: DataEntries, dimension: PivotDimension) {
+export function groupPivotDataEntriesBy(dataEntries: DataEntries, dimension: PivotDimension) {
   return Object.groupBy(dataEntries, keySelector(dimension));
 }
 

--- a/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
@@ -1,6 +1,7 @@
 import { toJsDate, toNumber } from "../../../functions/helpers";
 import { Locale } from "../../../types";
 import { PivotDimension } from "../../../types/pivot";
+import { toNormalizedPivotValue } from "../pivot_helpers";
 import { FieldValue } from "./data_entry_spreadsheet_pivot";
 
 export function createDate(dimension: PivotDimension, value: FieldValue["value"], locale: Locale) {
@@ -20,7 +21,7 @@ export function createDate(dimension: PivotDimension, value: FieldValue["value"]
         number = Math.floor(date.getMonth() / 3) + 1;
         break;
       case "month_number":
-        number = date.getMonth();
+        number = date.getMonth() + 1;
         break;
       case "iso_week_number":
         number = date.getIsoWeek();
@@ -32,7 +33,10 @@ export function createDate(dimension: PivotDimension, value: FieldValue["value"]
         number = Math.floor(toNumber(value, locale));
         break;
     }
-    MAP_VALUE_DIMENSION_DATE[granularity].values[`${value}`] = number;
+    MAP_VALUE_DIMENSION_DATE[granularity].values[`${value}`] = toNormalizedPivotValue(
+      dimension,
+      number
+    );
   }
   return MAP_VALUE_DIMENSION_DATE[granularity].values[`${value}`];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ import {
   insertTokenAfterLeftParenthesis,
   makeFieldProposal,
 } from "./helpers/pivot/pivot_composer_helpers";
-import { supportedPivotExplodedFormulaRegistry } from "./helpers/pivot/pivot_exploded_formula_registry";
+import { supportedPivotPositionalFormulaRegistry } from "./helpers/pivot/pivot_positional_formula_registry";
 
 import {
   flatPivotDomain,
@@ -268,7 +268,7 @@ export const registries = {
   pivotTimeAdapterRegistry,
   pivotSidePanelRegistry,
   pivotNormalizationValueRegistry,
-  supportedPivotExplodedFormulaRegistry,
+  supportedPivotPositionalFormulaRegistry,
 };
 export const helpers = {
   arg,

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,8 @@ import {
   isDateField,
   makePivotFormula,
   parseDimension,
+  pivotNormalizationValueRegistry,
+  toNormalizedPivotValue,
   toPivotDomain,
 } from "./helpers/pivot/pivot_helpers";
 import { getPivotHighlights } from "./helpers/pivot/pivot_highlight";
@@ -265,6 +267,7 @@ export const registries = {
   pivotRegistry,
   pivotTimeAdapterRegistry,
   pivotSidePanelRegistry,
+  pivotNormalizationValueRegistry,
   supportedPivotExplodedFormulaRegistry,
 };
 export const helpers = {
@@ -274,6 +277,7 @@ export const helpers = {
   toJsDate,
   toNumber,
   toString,
+  toNormalizedPivotValue,
   toXC,
   toZone,
   toUnboundedZone,

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -89,6 +89,9 @@ export class Evaluator {
   }
 
   updateDependencies(position: CellPosition) {
+    // removing dependencies is slow because it requires
+    // to traverse the entire r-tree.
+    // The data structure is optimized for searches the other way around
     this.formulaDependencies().removeAllDependencies(position);
     const dependencies = this.getDirectDependencies(position);
     this.formulaDependencies().addDependencies(position, dependencies);

--- a/src/types/pivot_runtime.ts
+++ b/src/types/pivot_runtime.ts
@@ -1,7 +1,13 @@
 import { PivotRuntimeDefinition } from "../helpers/pivot/pivot_runtime_definition";
 import { SpreadsheetPivotTable } from "../helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot";
 import { FPayload } from "./misc";
-import { PivotCoreDefinition, PivotDomain, PivotFields, PivotMeasure } from "./pivot";
+import {
+  PivotCoreDefinition,
+  PivotDimension,
+  PivotDomain,
+  PivotFields,
+  PivotMeasure,
+} from "./pivot";
 
 export interface InitPivotParams {
   reload?: boolean;
@@ -22,6 +28,8 @@ export interface Pivot<T = PivotRuntimeDefinition> {
   getMeasure: (name: string) => PivotMeasure;
 
   assertIsValid({ throwOnError }: { throwOnError: boolean }): FPayload | undefined;
-  getPossibleFieldValues(groupBy: string): { value: string | boolean | number; label: string }[];
+  getPossibleFieldValues(
+    dimension: PivotDimension
+  ): { value: string | boolean | number; label: string }[];
   needsReevaluation: boolean;
 }

--- a/tests/composer/auto_complete/pivot_auto_complete_store.test.ts
+++ b/tests/composer/auto_complete/pivot_auto_complete_store.test.ts
@@ -1,0 +1,573 @@
+import { ComposerStore } from "../../../src/components/composer/composer/composer_store";
+import { addPivot, createModelWithPivot, updatePivot } from "../../test_helpers/pivot_helpers";
+import { makeStoreWithModel } from "../../test_helpers/stores";
+
+describe("spreadsheet pivot auto complete", () => {
+  test("PIVOT.VALUE.* autocomplete pivot id", async () => {
+    const model = createModelWithPivot("A1:I5");
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    addPivot(
+      model,
+      "A1:A4",
+      {
+        name: "My pivot 2",
+        columns: [],
+        rows: [],
+        measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+      },
+      "pivot2"
+    );
+    for (const func of ["PIVOT", "PIVOT.HEADER", "PIVOT.VALUE"]) {
+      composer.startEdition(`=${func}(`);
+      const autoComplete = composer.autocompleteProvider;
+      expect(autoComplete?.proposals).toEqual([
+        {
+          description: "My pivot",
+          fuzzySearchKey: "1My pivot",
+          htmlContent: [{ color: "#02c39a", value: "1" }],
+          text: "1",
+        },
+        {
+          description: "My pivot 2",
+          fuzzySearchKey: "2My pivot 2",
+          htmlContent: [{ color: "#02c39a", value: "2" }],
+          text: "2",
+        },
+      ]);
+      autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+      expect(composer.currentContent).toBe(`=${func}(1`);
+      expect(composer.autocompleteProvider).toBeUndefined();
+      composer.cancelEdition();
+    }
+  });
+
+  test("do not show autocomplete if pivot id already set", async () => {
+    const model = createModelWithPivot("A1:I5");
+    addPivot(model, "A1:A4", {
+      columns: [],
+      rows: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    for (const func of ["PIVOT", "PIVOT.HEADER", "PIVOT.VALUE"]) {
+      // id as a number
+      composer.startEdition(`=${func}(1`);
+      expect(composer.autocompleteProvider).toBeUndefined();
+      composer.cancelEdition();
+
+      // id as a string
+      composer.startEdition(`=${func}("1"`);
+      expect(composer.autocompleteProvider).toBeUndefined();
+      composer.cancelEdition();
+    }
+  });
+
+  test("PIVOT.VALUE measuresgd", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }, { name: "__count" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition("=PIVOT.VALUE(1,");
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        description: "Expected Revenue",
+        fuzzySearchKey: '"Expected Revenue"',
+        htmlContent: [{ color: "#00a82d", value: '"Expected Revenue"' }],
+        text: '"Expected Revenue"',
+      },
+      {
+        description: "Count",
+        fuzzySearchKey: 'Count"__count"',
+        htmlContent: [{ color: "#00a82d", value: '"__count"' }],
+        text: '"__count"',
+      },
+    ]);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe('=PIVOT.VALUE(1,"Expected Revenue"');
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE measure with the pivot id as a string", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE("1",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual(['"Expected Revenue"']);
+  });
+
+  test("PIVOT.VALUE measure with pivot id that does not exist", async () => {
+    const model = createModelWithPivot("A1:I5");
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition(`=PIVOT.VALUE(9999,`);
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE measure without any pivot id", async () => {
+    const model = createModelWithPivot("A1:I5");
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition(`=PIVOT.VALUE(,`);
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE group with a single col group", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [{ name: "Stage" }],
+      rows: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        description: "Stage",
+        fuzzySearchKey: '"Stage"',
+        htmlContent: [{ color: "#00a82d", value: '"Stage"' }],
+        text: '"Stage"',
+      },
+    ]);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe('=PIVOT.VALUE(1,"Expected Revenue","Stage"');
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE group with a pivot id as string", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [{ name: "Stage" }],
+      rows: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE("1","Expected Revenue",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual(['"Stage"']);
+  });
+
+  test("PIVOT.VALUE group with a single row group", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ name: "Stage" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        description: "Stage",
+        fuzzySearchKey: '"Stage"',
+        htmlContent: [{ color: "#00a82d", value: '"Stage"' }],
+        text: '"Stage"',
+      },
+    ]);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe('=PIVOT.VALUE(1,"Expected Revenue","Stage"');
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE group with a single date grouped by day", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ name: "Created on", granularity: "day" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        description: "Created on",
+        fuzzySearchKey: '"Created on:day"',
+        htmlContent: [{ color: "#00a82d", value: '"Created on:day"' }],
+        text: '"Created on:day"',
+      },
+    ]);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe('=PIVOT.VALUE(1,"Expected Revenue","Created on:day"');
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE search field", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ name: "Stage" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue","sta');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual(['"Stage"']);
+  });
+
+  test("PIVOT.VALUE search field with both col and row group", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [{ name: "Stage" }],
+      rows: [{ name: "Created on", granularity: "month_number" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue", ');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual([
+      '"Stage"',
+      '"Created on:month_number"',
+    ]);
+  });
+
+  test("PIVOT.VALUE group with row and col groups for the first group", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [{ name: "Created on", granularity: "month_number" }],
+      rows: [{ name: "Stage" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual([
+      '"Created on:month_number"',
+      '"Stage"',
+    ]);
+  });
+
+  test("PIVOT.VALUE group with row and col groups for the col group", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [{ name: "Created on", granularity: "month_number" }],
+      rows: [{ name: "Stage" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue","Stage",1,');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual(['"Created on:month_number"']);
+  });
+
+  test("PIVOT.VALUE group with two rows, on the first group", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      rows: [{ name: "Stage" }, { name: "Created on", granularity: "month_number" }],
+      columns: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition(
+      '=PIVOT.VALUE(1,"Expected Revenue", ,"Won","Created on:month_number", 11)'
+    );
+    //.......................................................^ set the cursor here
+    composer.changeComposerCursorSelection(34, 34);
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual(['"Stage"']);
+  });
+
+  test("PIVOT.VALUE autocomplete text field for group value", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ name: "Stage" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue","Stage",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        description: "",
+        fuzzySearchKey: "New",
+        htmlContent: [{ color: "#00a82d", value: '"New"' }],
+        text: '"New"',
+      },
+      {
+        description: "",
+        fuzzySearchKey: "Won",
+        htmlContent: [{ color: "#00a82d", value: '"Won"' }],
+        text: '"Won"',
+      },
+    ]);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe('=PIVOT.VALUE(1,"Expected Revenue","Stage","New"');
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE autocomplete date month_number field for group value", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ name: "Created on", granularity: "month_number" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue","Created on:month_number",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        description: "January",
+        fuzzySearchKey: "January",
+        htmlContent: [{ color: "#02c39a", value: "1" }],
+        text: "1",
+      },
+      {
+        description: "February",
+        fuzzySearchKey: "February",
+        htmlContent: [{ color: "#02c39a", value: "2" }],
+        text: "2",
+      },
+      {
+        description: "March",
+        fuzzySearchKey: "March",
+        htmlContent: [{ color: "#02c39a", value: "3" }],
+        text: "3",
+      },
+      {
+        description: "April",
+        fuzzySearchKey: "April",
+        htmlContent: [{ color: "#02c39a", value: "4" }],
+        text: "4",
+      },
+      {
+        description: "May",
+        fuzzySearchKey: "May",
+        htmlContent: [{ color: "#02c39a", value: "5" }],
+        text: "5",
+      },
+      {
+        description: "June",
+        fuzzySearchKey: "June",
+        htmlContent: [{ color: "#02c39a", value: "6" }],
+        text: "6",
+      },
+      {
+        description: "July",
+        fuzzySearchKey: "July",
+        htmlContent: [{ color: "#02c39a", value: "7" }],
+        text: "7",
+      },
+      {
+        description: "August",
+        fuzzySearchKey: "August",
+        htmlContent: [{ color: "#02c39a", value: "8" }],
+        text: "8",
+      },
+      {
+        description: "September",
+        fuzzySearchKey: "September",
+        htmlContent: [{ color: "#02c39a", value: "9" }],
+        text: "9",
+      },
+      {
+        description: "October",
+        fuzzySearchKey: "October",
+        htmlContent: [{ color: "#02c39a", value: "10" }],
+        text: "10",
+      },
+      {
+        description: "November",
+        fuzzySearchKey: "November",
+        htmlContent: [{ color: "#02c39a", value: "11" }],
+        text: "11",
+      },
+      {
+        description: "December",
+        fuzzySearchKey: "December",
+        htmlContent: [{ color: "#02c39a", value: "12" }],
+        text: "12",
+      },
+    ]);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe(
+      '=PIVOT.VALUE(1,"Expected Revenue","Created on:month_number",1'
+    );
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE autocomplete date quarter_number field for group value", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ name: "Created on", granularity: "quarter_number" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue","Created on:quarter_number",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toEqual([
+      {
+        description: "Quarter 1",
+        fuzzySearchKey: "1",
+        htmlContent: [{ color: "#02c39a", value: "1" }],
+        text: "1",
+      },
+      {
+        description: "Quarter 2",
+        fuzzySearchKey: "2",
+        htmlContent: [{ color: "#02c39a", value: "2" }],
+        text: "2",
+      },
+      {
+        description: "Quarter 3",
+        fuzzySearchKey: "3",
+        htmlContent: [{ color: "#02c39a", value: "3" }],
+        text: "3",
+      },
+      {
+        description: "Quarter 4",
+        fuzzySearchKey: "4",
+        htmlContent: [{ color: "#02c39a", value: "4" }],
+        text: "4",
+      },
+    ]);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe(
+      '=PIVOT.VALUE(1,"Expected Revenue","Created on:quarter_number",1'
+    );
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE autocomplete date day_of_month field for group value", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ name: "Created on", granularity: "day_of_month" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue","Created on:day_of_month",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toHaveLength(31);
+    expect(autoComplete?.proposals[0]).toEqual({
+      description: "",
+      fuzzySearchKey: "1",
+      htmlContent: [{ color: "#02c39a", value: "1" }],
+      text: "1",
+    });
+    expect(autoComplete?.proposals[30]).toEqual({
+      description: "",
+      fuzzySearchKey: "31",
+      htmlContent: [{ color: "#02c39a", value: "31" }],
+      text: "31",
+    });
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe(
+      '=PIVOT.VALUE(1,"Expected Revenue","Created on:day_of_month",1'
+    );
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE autocomplete date iso_week_number field for group value", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ name: "Created on", granularity: "iso_week_number" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue","Created on:iso_week_number",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals).toHaveLength(54);
+    expect(autoComplete?.proposals[0]).toEqual({
+      description: "",
+      fuzzySearchKey: "0",
+      htmlContent: [{ color: "#02c39a", value: "0" }],
+      text: "0",
+    });
+    expect(autoComplete?.proposals[53]).toEqual({
+      description: "",
+      fuzzySearchKey: "53",
+      htmlContent: [{ color: "#02c39a", value: "53" }],
+      text: "53",
+    });
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe(
+      '=PIVOT.VALUE(1,"Expected Revenue","Created on:iso_week_number",0'
+    );
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.VALUE autocomplete field after a date field", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [{ name: "Stage" }],
+      rows: [{ name: "Created on", granularity: "month_number" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue","Created on:month_number",11,');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual(['"Stage"']);
+  });
+
+  test("PIVOT.VALUE no autocomplete value for wrong group field", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [],
+      rows: [{ name: "Stage" }],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.VALUE(1,"Expected Revenue","not a dimension",');
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.HEADER first field", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [{ name: "Stage" }],
+      rows: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition("=PIVOT.HEADER(1,");
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual(['"Stage"']);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe('=PIVOT.HEADER(1,"Stage"');
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.HEADER search field", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [{ name: "Stage" }],
+      rows: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.HEADER(1,"sta');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual(['"Stage"']);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe('=PIVOT.HEADER(1,"Stage"');
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+
+  test("PIVOT.HEADER group value", async () => {
+    const model = createModelWithPivot("A1:I5");
+    updatePivot(model, "1", {
+      columns: [{ name: "Stage" }],
+      rows: [],
+      measures: [{ name: "Expected Revenue", aggregator: "sum" }],
+    });
+    const { store: composer } = makeStoreWithModel(model, ComposerStore);
+    composer.startEdition('=PIVOT.HEADER(1,"Stage",');
+    const autoComplete = composer.autocompleteProvider;
+    expect(autoComplete?.proposals.map((p) => p.text)).toEqual(['"New"', '"Won"']);
+    autoComplete?.selectProposal(autoComplete?.proposals[0].text);
+    expect(composer.currentContent).toBe('=PIVOT.HEADER(1,"Stage","New"');
+    expect(composer.autocompleteProvider).toBeUndefined();
+  });
+});

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -1,0 +1,185 @@
+import { toNormalizedPivotValue } from "../../src/helpers/pivot/pivot_helpers";
+
+describe("toNormalizedPivotValue", () => {
+  test("parse values of char field", () => {
+    const dimension = {
+      type: "char",
+      displayName: "A field",
+      name: "field_name",
+    };
+    expect(toNormalizedPivotValue(dimension, "won")).toBe("won");
+    expect(toNormalizedPivotValue(dimension, "1")).toBe("1");
+    expect(toNormalizedPivotValue(dimension, 1)).toBe("1");
+    expect(toNormalizedPivotValue(dimension, "11/2020")).toBe("11/2020");
+    expect(toNormalizedPivotValue(dimension, "2020")).toBe("2020");
+    expect(toNormalizedPivotValue(dimension, "01/11/2020")).toBe("01/11/2020");
+    expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+    expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+    expect(toNormalizedPivotValue(dimension, "true")).toBe("true");
+  });
+
+  test("parse values of time fields", () => {
+    for (const fieldType of ["date", "datetime"]) {
+      const dimension = {
+        type: fieldType,
+        displayName: "A field",
+        name: "field_name",
+        granularity: "day",
+      };
+      // day
+      expect(toNormalizedPivotValue(dimension, "1/11/2020")).toBe("01/11/2020");
+      expect(toNormalizedPivotValue(dimension, "01/11/2020")).toBe("01/11/2020");
+      expect(toNormalizedPivotValue(dimension, "11/2020")).toBe("11/01/2020");
+      expect(toNormalizedPivotValue(dimension, "1")).toBe("12/31/1899");
+      expect(toNormalizedPivotValue(dimension, 1)).toBe("12/31/1899");
+      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+      // week
+      dimension.granularity = "week";
+      expect(toNormalizedPivotValue(dimension, "11/2020")).toBe("11/2020");
+      expect(toNormalizedPivotValue(dimension, "1/2020")).toBe("1/2020");
+      expect(toNormalizedPivotValue(dimension, "01/2020")).toBe("1/2020");
+      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+      // month
+      dimension.granularity = "month";
+      expect(toNormalizedPivotValue(dimension, "11/2020")).toBe("11/2020");
+      expect(toNormalizedPivotValue(dimension, "1/2020")).toBe("01/2020");
+      expect(toNormalizedPivotValue(dimension, "01/2020")).toBe("01/2020");
+      expect(toNormalizedPivotValue(dimension, "2/11/2020")).toBe("02/2020");
+      expect(toNormalizedPivotValue(dimension, "2/1/2020")).toBe("02/2020");
+      expect(toNormalizedPivotValue(dimension, 1)).toBe("12/1899");
+      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+      // year
+      dimension.granularity = "year";
+      expect(toNormalizedPivotValue(dimension, "2020")).toBe(2020);
+      expect(toNormalizedPivotValue(dimension, 2020)).toBe(2020);
+      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+
+      dimension.granularity = "year_number";
+      expect(toNormalizedPivotValue(dimension, "2020")).toBe(2020);
+      expect(toNormalizedPivotValue(dimension, 2020)).toBe(2020);
+      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+
+      dimension.granularity = "day_of_month";
+      expect(toNormalizedPivotValue(dimension, "1")).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 1)).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 31)).toBe(31);
+      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+      expect(toNormalizedPivotValue(dimension, null)).toBe(null);
+      expect(() => toNormalizedPivotValue(dimension, 0)).toThrow(
+        "0 is not a valid day of month (it should be a number between 1 and 31)"
+      );
+      expect(() => toNormalizedPivotValue(dimension, 32)).toThrow(
+        "32 is not a valid day of month (it should be a number between 1 and 31)"
+      );
+
+      dimension.granularity = "iso_week_number";
+      expect(toNormalizedPivotValue(dimension, "1")).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 1)).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 53)).toBe(53);
+      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+      expect(toNormalizedPivotValue(dimension, null)).toBe(null);
+      expect(() => toNormalizedPivotValue(dimension, -1)).toThrow(
+        "-1 is not a valid week (it should be a number between 0 and 53)"
+      );
+      expect(() => toNormalizedPivotValue(dimension, 54)).toThrow(
+        "54 is not a valid week (it should be a number between 0 and 53)"
+      );
+
+      dimension.granularity = "month_number";
+      expect(toNormalizedPivotValue(dimension, "1")).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 1)).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 12)).toBe(12);
+      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+      expect(toNormalizedPivotValue(dimension, null)).toBe(null);
+      expect(() => toNormalizedPivotValue(dimension, 0)).toThrow(
+        "0 is not a valid month (it should be a number between 1 and 12)"
+      );
+      expect(() => toNormalizedPivotValue(dimension, 13)).toThrow(
+        "13 is not a valid month (it should be a number between 1 and 12)"
+      );
+
+      dimension.granularity = "quarter_number";
+      expect(toNormalizedPivotValue(dimension, "1")).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 1)).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 4)).toBe(4);
+      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+      expect(toNormalizedPivotValue(dimension, null)).toBe(null);
+      expect(() => toNormalizedPivotValue(dimension, 0)).toThrow(
+        "0 is not a valid quarter (it should be a number between 1 and 4)"
+      );
+      expect(() => toNormalizedPivotValue(dimension, 5)).toThrow(
+        "5 is not a valid quarter (it should be a number between 1 and 4)"
+      );
+
+      dimension.granularity = "month";
+      expect(() => toNormalizedPivotValue(dimension, "true")).toThrow();
+      expect(() => toNormalizedPivotValue(dimension, true)).toThrow();
+      expect(() => toNormalizedPivotValue(dimension, "won")).toThrow();
+    }
+  });
+
+  test("parse values of boolean field", () => {
+    const dimension = {
+      type: "boolean",
+      displayName: "A field",
+      name: "field_name",
+    };
+    expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+    expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+    expect(toNormalizedPivotValue(dimension, "true")).toBe(true);
+    expect(toNormalizedPivotValue(dimension, true)).toBe(true);
+    expect(() => toNormalizedPivotValue(dimension, "11/2020")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "2020")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "01/11/2020")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "1")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, 1)).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "won")).toThrow();
+  });
+
+  test("parse values of numeric fields", () => {
+    const dimension = {
+      type: "integer",
+      displayName: "A field",
+      name: "field_name",
+    };
+    expect(toNormalizedPivotValue(dimension, "2020")).toBe(2020);
+    expect(toNormalizedPivotValue(dimension, "01/11/2020")).toBe(43841); // a date is actually a number in a spreadsheet
+    expect(toNormalizedPivotValue(dimension, "11/2020")).toBe(44136); // 1st of november 2020
+    expect(toNormalizedPivotValue(dimension, "1")).toBe(1);
+    expect(toNormalizedPivotValue(dimension, 1)).toBe(1);
+    expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
+    expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+    expect(() => toNormalizedPivotValue(dimension, "true")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, true)).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "won")).toThrow();
+  });
+
+  test("parse values of unsupported fields", () => {
+    const dimension = {
+      type: "random type",
+      displayName: "A field",
+      name: "field_name",
+    };
+    expect(() => toNormalizedPivotValue(dimension, "false")).toThrow(
+      "Field A field is not supported because of its type (random type)"
+    );
+    expect(() => toNormalizedPivotValue(dimension, false)).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "true")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, true)).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "11/2020")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "2020")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "01/11/2020")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "1")).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, 1)).toThrow();
+    expect(() => toNormalizedPivotValue(dimension, "won")).toThrow();
+  });
+});

--- a/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
@@ -26,26 +26,26 @@ describe("Date Spreadsheet Pivot", () => {
 
     expect(createDate(YEAR_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(2024);
     expect(createDate(QUARTER_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(2);
-    expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(3);
+    expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(4);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(14);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(5);
-    expect(createDate(DAY_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(d05_april_2024);
+    expect(createDate(DAY_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe("04/05/2024");
 
     const d04_may_2024 = 45_416;
     expect(createDate(YEAR_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(2024);
     expect(createDate(QUARTER_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(2);
-    expect(createDate(MONTH_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(4);
+    expect(createDate(MONTH_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(5);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(18);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(4);
-    expect(createDate(DAY_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(d04_may_2024);
+    expect(createDate(DAY_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe("05/04/2024");
 
     const d01_january_2019 = 43_466;
     expect(createDate(YEAR_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(2019);
     expect(createDate(QUARTER_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
-    expect(createDate(MONTH_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(0);
+    expect(createDate(MONTH_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
-    expect(createDate(DAY_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(d01_january_2019);
+    expect(createDate(DAY_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe("01/01/2019");
   });
 
   test("createDate with datetime values", () => {
@@ -53,12 +53,10 @@ describe("Date Spreadsheet Pivot", () => {
 
     expect(createDate(YEAR_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(2024);
     expect(createDate(QUARTER_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(2);
-    expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(3);
+    expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(4);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(14);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(5);
-    expect(createDate(DAY_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(
-      Math.floor(d05_april_2024_15h)
-    );
+    expect(createDate(DAY_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe("04/05/2024");
   });
 
   test("createDate throw with unknown granularity", () => {


### PR DESCRIPTION
## Description:

This commit adds the support of PIVOT.VALUE and PIVOT.HEADER functions
for spreadsheet pivots.

Task: : [3897857](https://www.odoo.com/web#id=3897857&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo