### PR TITLE
[FIX] chart: duplicated t-key in chart design panel

### DIFF
--- a/src/components/side_panel/chart/chart_with_axis/design_panel.xml
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.xml
@@ -28,7 +28,7 @@
             class="o-input data-series-selector"
             t-model="state.label"
             t-on-change="(ev) => this.updateSerieEditor(ev)">
-            <t t-foreach="getDataSeries()" t-as="serie" t-key="serie" t-index="index">
+            <t t-foreach="getDataSeries()" t-as="serie" t-key="serie_index">
               <option
                 t-att-value="serie"
                 t-att-selected="state.index === serie_index"

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -605,6 +605,16 @@ describe("charts", () => {
     ]);
   });
 
+  test("can open design panel of chart with duplicated dataset", async () => {
+    createChart(
+      model,
+      { dataSets: [{ dataRange: "C1:C4" }, { dataRange: "C1:C4" }], type: "line" },
+      chartId
+    );
+    await openChartDesignSidePanel(chartId);
+    expect(1).toBe(1);
+  });
+
   test("changing property and selecting another chart does not change first chart", async () => {
     createChart(
       model,


### PR DESCRIPTION
## Description

If a chart have multiple time the same dataset, and that the dataset has a header, trying to open the design panel will result in a traceback.

Task: : [3978316](https://www.odoo.com/web#id=3978316&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo