### PR TITLE
[FIX] ComposerStore: missing previous range

### DIFF
--- a/src/plugins/ui_stateful/edition.ts
+++ b/src/plugins/ui_stateful/edition.ts
@@ -618,10 +618,8 @@ export class EditionPlugin extends UIPlugin {
         return isEqual(this.getters.expandZone(activeSheetId, refRange.zone), oldZone);
       });
 
-    // this function assumes that the previous range is always found because
-    // it's called when changing a highlight, which exists by definition
     if (!previousRefToken) {
-      throw new Error("Previous range not found");
+      return;
     }
 
     const previousRange = this.getters.getRangeFromSheetXC(activeSheetId, previousRefToken.value);

--- a/tests/composer/composer_component.test.ts
+++ b/tests/composer/composer_component.test.ts
@@ -2,12 +2,14 @@ import {
   selectionIndicatorClass,
   tokenColors,
 } from "../../src/components/composer/composer/composer";
+import { DEFAULT_CELL_HEIGHT, DEFAULT_CELL_WIDTH } from "../../src/constants";
 import { colors, toCartesian, toZone } from "../../src/helpers/index";
 import { Model } from "../../src/model";
 import { Highlight } from "../../src/types";
 import { ContentEditableHelper } from "../__mocks__/content_editable_helper";
 import { MockClipboardData, getClipboardEvent } from "../test_helpers/clipboard";
 import {
+  createFilter,
   createSheet,
   createSheetWithName,
   merge,
@@ -28,6 +30,7 @@ import {
   getCellContent,
   getCellText,
   getEvaluatedCell,
+  getFilterTable,
   getSelectionAnchorCellXc,
 } from "../test_helpers/getters_helpers";
 import {
@@ -506,6 +509,19 @@ describe("composer", () => {
     keyUp({ key: "d" });
     await nextTick();
     expect(model.getters.getEditionMode()).toBe("inactive");
+  });
+
+  test("should create a table when a cell is double clicked in edit mode", async () => {
+    ({ model, fixture } = await mountSpreadsheet());
+    selectCell(model, "A1");
+    triggerMouseEvent(
+      ".o-grid-overlay",
+      "dblclick",
+      0.5 * DEFAULT_CELL_WIDTH,
+      0.5 * DEFAULT_CELL_HEIGHT
+    );
+    createFilter(model, "A1");
+    expect(getFilterTable(model, "A1")).toBeTruthy();
   });
 
   test("edit link cell changes the label", async () => {


### PR DESCRIPTION
## Description:

The updateComposerRange function previously assumed that a previous range would always be found because it was only called when changing a highlight, which was a valid assumption under past conditions.

However, this assumption is no longer accurate. There are now two scenarios where this function can be called without a previous range:

1. With [PR#3809](https://github.com/odoo/o-spreadsheet/pull/3809), entering edition mode in a cell and opening the link editor causes a traceback due to the missing previous range.
2. Opening a cell in editing mode and creating a data filter while the cell is in edition mode also results in the same traceback.

To resolve this issue, we can return early if no update or replacement is needed within the composer range.

Task: : [3972392](https://www.odoo.com/web#id=3972392&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo