### PR TITLE
[FIX] demo: fix initial revision id

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -2507,7 +2507,7 @@ export const demoData = {
     34: { top: { style: "dotted", color: "#0000FF" } },
     35: { left: { style: "dashed", color: "#93C47D" } },
   },
-  revisionId: "a9983fa2-a614-45e5-9117-1c120bdb9392",
+  revisionId: "START_REVISION",
   uniqueFigureIds: true,
   settings: {
     locale: {


### PR DESCRIPTION
Since b1976e5e16, all revisions done in the demo sheet are rejected by the server because the data revision id doesn't match the initial server hard-coded revision id.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo