### PR TITLE
[FIX] charts: fix padding computation

### DIFF
--- a/src/helpers/figures/charts/bar_chart.ts
+++ b/src/helpers/figures/charts/bar_chart.ts
@@ -243,7 +243,7 @@ function getBarConfiguration(
   }
   config.options.plugins!.legend = { ...config.options.plugins?.legend, ...legend };
   config.options.layout = {
-    padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
+    padding: { left: 20, right: 20, top: chart.title.text ? 10 : 25, bottom: 10 },
   };
   config.options.indexAxis = chart.horizontal ? "y" : "x";
 

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -138,7 +138,7 @@ function getLineOrScatterConfiguration(
   }
   Object.assign(config.options.plugins!.legend || {}, legend);
   config.options.layout = {
-    padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
+    padding: { left: 20, right: 20, top: chart.title.text ? 10 : 25, bottom: 10 },
   };
 
   config.options.scales = {

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -110,7 +110,7 @@ export function getDefaultChartJsRuntime(
     horizontalChart,
   }: LocaleFormat & { truncateLabels?: boolean; horizontalChart?: boolean }
 ): Required<ChartConfiguration> {
-  const chartTitle = chart.title.text ? chart.title : { ...chart.title, content: "" };
+  const chartTitle = chart.title.text ? chart.title : { ...chart.title, text: "" };
   const options: ChartOptions = {
     // https://www.chartjs.org/docs/latest/general/responsive.html
     responsive: true, // will resize when its container is resized

--- a/src/helpers/figures/charts/combo_chart.ts
+++ b/src/helpers/figures/charts/combo_chart.ts
@@ -256,7 +256,7 @@ export function createComboChartRuntime(chart: ComboChart, getters: Getters): Co
   }
   config.options.plugins!.legend = { ...config.options.plugins?.legend, ...legend };
   config.options.layout = {
-    padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
+    padding: { left: 20, right: 20, top: chart.title.text ? 10 : 25, bottom: 10 },
   };
 
   config.options.scales = {

--- a/src/helpers/figures/charts/pie_chart.ts
+++ b/src/helpers/figures/charts/pie_chart.ts
@@ -222,7 +222,7 @@ function getPieConfiguration(
   }
   Object.assign(config.options.plugins!.legend || {}, legend);
   config.options.layout = {
-    padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
+    padding: { left: 20, right: 20, top: chart.title.text ? 10 : 25, bottom: 10 },
   };
   config.options.plugins!.tooltip!.callbacks!.title = function (tooltipItems) {
     return tooltipItems[0].dataset.label;

--- a/src/helpers/figures/charts/waterfall_chart.ts
+++ b/src/helpers/figures/charts/waterfall_chart.ts
@@ -264,7 +264,7 @@ function getWaterfallConfiguration(
   }
   config.options.plugins!.legend = { ...config.options.plugins?.legend, ...legend };
   config.options.layout = {
-    padding: { left: 20, right: 20, top: chart.title ? 10 : 25, bottom: 10 },
+    padding: { left: 20, right: 20, top: chart.title.text ? 10 : 25, bottom: 10 },
   };
 
   config.options.scales = {


### PR DESCRIPTION
## Task Description

Since the chart design refactoring, the value of the title is now stored in an object as chart.title.text, instead of the previous chart.title. During the introduction of the design customization, the computation of the padding hasn't been updated, considering now that the title is alsway defined, which is not the case. This PR aims to thix this behavior by changing the condition used in the padding computation.

## Related Task:

- Task: 0

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo