### PR TITLE
[FIX] grid: prevent paste default

### DIFF
--- a/src/components/figures/figure_container/figure_container.xml
+++ b/src/components/figures/figure_container/figure_container.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-FiguresContainer">
-    <div>
+    <div class="position-absolute">
       <t t-foreach="containers" t-as="container" t-key="container.type">
         <div
           class="o-figure-container position-absolute pe-none overflow-hidden"

--- a/src/components/grid/grid.ts
+++ b/src/components/grid/grid.ts
@@ -628,6 +628,7 @@ export class Grid extends Component<Props, SpreadsheetChildEnv> {
     }
 
     if (clipboardData.types.indexOf(ClipboardMIMEType.PlainText) > -1) {
+      ev.preventDefault();
       const content = clipboardData.getData(ClipboardMIMEType.PlainText);
       const target = this.env.model.getters.getSelectedZones();
       const clipboardString = this.env.model.getters.getClipboardTextContent();

--- a/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/dashboard_grid_component.test.ts.snap
@@ -13,7 +13,9 @@ exports[`Grid component in dashboard mode simple dashboard rendering snapshot 1`
       class="o-grid-overlay overflow-hidden"
       style="height:100%; width:100%; "
     >
-      <div>
+      <div
+        class="position-absolute"
+      >
         
       </div>
       

--- a/tests/grid/__snapshots__/grid_component.test.ts.snap
+++ b/tests/grid/__snapshots__/grid_component.test.ts.snap
@@ -9,7 +9,9 @@ exports[`Grid component simple rendering snapshot 1`] = `
     class="o-grid-overlay overflow-hidden"
     style="top:26px; left:48px; height:calc(100% - 41px); width:calc(100% - 63px); "
   >
-    <div>
+    <div
+      class="position-absolute"
+    >
       
     </div>
     

--- a/tests/grid/grid_component.test.ts
+++ b/tests/grid/grid_component.test.ts
@@ -1375,6 +1375,14 @@ describe("Copy paste keyboard shortcut", () => {
     ({ parent, model, fixture } = await mountSpreadsheet());
     sheetId = model.getters.getActiveSheetId();
   });
+
+  test("Default paste is prevented when handled by the grid", async () => {
+    clipboardData.setText("Excalibur");
+    const pasteEvent = getClipboardEvent("paste", clipboardData);
+    document.body.dispatchEvent(pasteEvent);
+    expect(pasteEvent.defaultPrevented).toBeTruthy();
+  });
+
   test("Can paste from OS", async () => {
     selectCell(model, "A1");
     clipboardData.setText("Excalibur");

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -624,7 +624,9 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
           class="o-grid-overlay overflow-hidden"
           style="top:26px; left:48px; height:calc(100% - 41px); width:calc(100% - 63px); "
         >
-          <div>
+          <div
+            class="position-absolute"
+          >
             
           </div>
           

--- a/tests/test_helpers/clipboard.ts
+++ b/tests/test_helpers/clipboard.ts
@@ -44,7 +44,7 @@ export function getClipboardEvent(
   type: "copy" | "paste" | "cut",
   clipboardData: MockClipboardData
 ) {
-  const event = new Event(type, { bubbles: true });
+  const event = new Event(type, { bubbles: true, cancelable: true });
   //@ts-ignore
   event.clipboardData = clipboardData;
   return event;


### PR DESCRIPTION
Followup of https://github.com/odoo/o-spreadsheet/pull/4298 The issue of the replacement of DOM elements still occured when we'd paste a chart is a specific way (see #How to reproduce). This commit ensures that the default paste behaviour is prevented when the lib has a custom handler, not just through the composer.

In this case, it is `FigureContainer` that is affected. After the paste effect, it replaces itself outside the visible part of its container `GridOverlay`. This issue would arise in Firefox and not Chromium-based browser. It to be linked to how the two handle the repositioning of [`static`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#static) elements. This revision addresses this by setting the  position of `FigureContainer` to absolute and not static.

How to reproduce:
On Firefox,
- select a chart and open its sidepanel
- cut it (Ctrl-x)
- Focus a selectionInput in the sidepanel
- click on the grid to update the selectionInput
- immediatly paste the chart (Ctrl-v) -> the page layout is broken. On the demo spreadsheet, the charts all disappeared and the "Add rows" button is visible even if the bottom of the grid is way below the viewport.

Task: 3949903

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [3949903](https://www.odoo.com/web#id=3949903&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo