### PR TITLE
[IMP] charts: add Area chart

### DIFF
--- a/src/components/side_panel/chart/chart_type_picker/chart_previews.xml
+++ b/src/components/side_panel/chart/chart_type_picker/chart_previews.xml
@@ -6,6 +6,22 @@
       <path stroke="#0074d9" style="fill:none" d="M6,25 l12,-12 l18,18 l6,-6"/>
     </svg>
   </t>
+  <t t-name="o-spreadsheet-ChartPreview.STACKED_LINE_CHART">
+    <svg viewBox="0 0 48 48" class="o-chart-preview" xmlns="http://www.w3.org/2000/svg">
+      <path stroke="#0074d9" style="fill:none" d="M3,30 l12,-12 l6,6 l18,-18"/>
+      <path stroke="#eb6d00" style="fill:none" d="M3,40 l12,-12 l6,6 l18,-12"/>
+      <path fill="#444" d="M2,2 v44 h1 v-44 M3,45 h42 v1 h-42"/>
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-ChartPreview.AREA_CHART">
+    <svg viewBox="0 0 48 48" class="o-chart-preview" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#c4e4ff" d="M3,45 V25 l12,-12 l18,18 l6,-6 V45"/>
+      <path fill="#ffe1c8" d="M3,45 V40 l12,-12 l6,6 l18,-18 V45"/>
+      <path stroke="#eb6d00" style="fill:none" d="M3,40 l12,-12 l6,6 l18,-18"/>
+      <path stroke="#0074d9" style="fill:none" d="M3,25 l12,-12 l18,18 l6,-6"/>
+      <path fill="#444" d="M2,2 v44 h1 v-44 M3,45 h42 v1 h-42"/>
+    </svg>
+  </t>
   <t t-name="o-spreadsheet-ChartPreview.STACKED_AREA_CHART">
     <svg viewBox="0 0 48 48" class="o-chart-preview" xmlns="http://www.w3.org/2000/svg">
       <path fill="#c4e4ff" d="M3,45 h36 v-39 l-18,18 l-6,-6 l-12,12"/>

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
@@ -14,6 +14,11 @@ export class LineConfigPanel extends GenericChartConfigPanel {
     return false;
   }
 
+  get stackedLabel(): string {
+    const definition = this.props.definition as LineChartDefinition;
+    return definition.fillArea ? this.chartTerms.StackedAreaChart : this.chartTerms.StackedBarChart;
+  }
+
   getLabelRangeOptions() {
     const options = super.getLabelRangeOptions();
     if (this.canTreatLabelsAsText) {

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -4,7 +4,7 @@
       <Section class="'pt-0'">
         <Checkbox
           name="'stacked'"
-          label="chartTerms.StackedLineChart"
+          label="stackedLabel"
           value="props.definition.stacked"
           onChange.bind="onUpdateStacked"
         />

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -52,6 +52,7 @@ export const ChartTerms = {
   BackgroundColor: _t("Background color"),
   StackedBarChart: _t("Stacked bar chart"),
   StackedLineChart: _t("Stacked line chart"),
+  StackedAreaChart: _t("Stacked area chart"),
   CumulativeData: _t("Cumulative data"),
   TreatLabelsAsText: _t("Treat labels as text"),
   AggregatedChart: _t("Aggregate"),

--- a/src/helpers/figures/charts/chart_common_line_scatter.ts
+++ b/src/helpers/figures/charts/chart_common_line_scatter.ts
@@ -253,7 +253,8 @@ export function createLineOrScatterChartRuntime(
     };
   }
 
-  const stacked = "stacked" in chart ? chart.stacked : false;
+  const areaChart = "fillArea" in chart ? chart.fillArea : false;
+  const stackedChart = "stacked" in chart ? chart.stacked : false;
   const cumulative = "cumulative" in chart ? chart.cumulative : false;
 
   const colors = new ColorGenerator();
@@ -265,7 +266,7 @@ export function createLineOrScatterChartRuntime(
     }
     const color = colors.next();
     let backgroundRGBA = colorToRGBA(color);
-    if (stacked) {
+    if (areaChart) {
       backgroundRGBA.a = LINE_FILL_TRANSPARENCY;
     }
     if (cumulative) {
@@ -288,7 +289,7 @@ export function createLineOrScatterChartRuntime(
       borderColor: color,
       backgroundColor,
       pointBackgroundColor: color,
-      fill: stacked ? getFillingMode(index) : false,
+      fill: areaChart ? getFillingMode(index, stackedChart) : false,
     };
     config.data!.datasets!.push(dataset);
   }

--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -262,13 +262,17 @@ export function getChartDatasetValues(getters: Getters, dataSets: DataSet[]): Da
   return datasetValues;
 }
 
-/** See https://www.chartjs.org/docs/latest/charts/area.html#filling-modes */
-export function getFillingMode(index: number): "origin" | number {
-  if (index === 0) {
+/**
+ * If the chart is a stacked area chart, we want to fill until the next dataset.
+ * If the chart is a simple area chart, we want to fill until the origin (bottom axis).
+ *
+ * See https://www.chartjs.org/docs/latest/charts/area.html#filling-modes
+ */
+export function getFillingMode(index: number, stackedChart: boolean): string {
+  if (!stackedChart) {
     return "origin";
-  } else {
-    return index - 1;
   }
+  return index === 0 ? "origin" : "-1";
 }
 
 export function chartToImage(

--- a/src/helpers/figures/charts/line_chart.ts
+++ b/src/helpers/figures/charts/line_chart.ts
@@ -55,6 +55,7 @@ export class LineChart extends AbstractChart {
   readonly cumulative: boolean;
   readonly dataSetDesign?: DatasetDesign[];
   readonly axesDesign?: AxesDesign;
+  readonly fillArea?: boolean;
 
   constructor(definition: LineChartDefinition, sheetId: UID, getters: CoreGetters) {
     super(definition, sheetId, getters);
@@ -74,6 +75,7 @@ export class LineChart extends AbstractChart {
     this.cumulative = definition.cumulative;
     this.dataSetDesign = definition.dataSets;
     this.axesDesign = definition.axesDesign;
+    this.fillArea = definition.fillArea;
   }
 
   static validateChartDefinition(
@@ -104,6 +106,7 @@ export class LineChart extends AbstractChart {
       aggregated: context.aggregated ?? false,
       cumulative: context.cumulative ?? false,
       axesDesign: context.axesDesign,
+      fillArea: context.fillArea,
     };
   }
 
@@ -138,6 +141,7 @@ export class LineChart extends AbstractChart {
       aggregated: this.aggregated,
       cumulative: this.cumulative,
       axesDesign: this.axesDesign,
+      fillArea: this.fillArea,
     };
   }
 

--- a/src/registries/chart_types.ts
+++ b/src/registries/chart_types.ts
@@ -186,6 +186,7 @@ export const chartCategories = {
   line: _t("Line"),
   column: _t("Column"),
   bar: _t("Bar"),
+  area: _t("Area"),
   pie: _t("Pie"),
   misc: _t("Miscellaneous"),
 };
@@ -208,21 +209,43 @@ export interface ChartSubtypeProperties {
 export const chartSubtypeRegistry = new Registry<ChartSubtypeProperties>();
 chartSubtypeRegistry
   .add("line", {
-    matcher: (definition) => definition.type === "line" && !definition.stacked,
+    matcher: (definition) =>
+      definition.type === "line" && !definition.stacked && !definition.fillArea,
     displayName: _t("Line"),
     chartType: "line",
     chartSubtype: "line",
-    subtypeDefinition: { stacked: false },
+    subtypeDefinition: { stacked: false, fillArea: false },
     category: "line",
     preview: "o-spreadsheet-ChartPreview.LINE_CHART",
   })
   .add("stacked_line", {
-    matcher: (definition) => definition.type === "line" && definition.stacked,
+    matcher: (definition) =>
+      definition.type === "line" && !definition.fillArea && !!definition.stacked,
     displayName: _t("Stacked Line"),
     chartType: "line",
     chartSubtype: "stacked_line",
-    subtypeDefinition: { stacked: true },
+    subtypeDefinition: { stacked: true, fillArea: false },
     category: "line",
+    preview: "o-spreadsheet-ChartPreview.STACKED_LINE_CHART",
+  })
+  .add("area", {
+    matcher: (definition) =>
+      definition.type === "line" && !definition.stacked && !!definition.fillArea,
+    displayName: _t("Area"),
+    chartType: "line",
+    chartSubtype: "area",
+    subtypeDefinition: { stacked: false, fillArea: true },
+    category: "area",
+    preview: "o-spreadsheet-ChartPreview.AREA_CHART",
+  })
+  .add("stacked_area", {
+    matcher: (definition) =>
+      definition.type === "line" && definition.stacked && !!definition.fillArea,
+    displayName: _t("Stacked Area"),
+    chartType: "line",
+    chartSubtype: "stacked_area",
+    subtypeDefinition: { stacked: true, fillArea: true },
+    category: "area",
     preview: "o-spreadsheet-ChartPreview.STACKED_AREA_CHART",
   })
   .add("scatter", {

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -137,4 +137,5 @@ export interface ChartCreationContext {
   readonly firstValueAsSubtotal?: boolean;
   readonly legendPosition?: LegendPosition;
   readonly axesDesign?: AxesDesign;
+  readonly fillArea?: boolean;
 }

--- a/src/types/chart/line_chart.ts
+++ b/src/types/chart/line_chart.ts
@@ -16,6 +16,7 @@ export interface LineChartDefinition {
   readonly aggregated?: boolean;
   readonly cumulative: boolean;
   readonly axesDesign?: AxesDesign;
+  readonly fillArea?: boolean;
 }
 
 export type LineChartRuntime = {

--- a/tests/figures/chart/bar_chart_plugin.test.ts
+++ b/tests/figures/chart/bar_chart_plugin.test.ts
@@ -1,7 +1,13 @@
 import { ChartCreationContext, Model } from "../../../src";
 import { BarChart } from "../../../src/helpers/figures/charts";
 import { BarChartRuntime } from "../../../src/types/chart";
-import { createChart, setCellContent, setFormat } from "../../test_helpers/commands_helpers";
+import { isChartAxisStacked } from "../../test_helpers/chart_helpers";
+import {
+  createChart,
+  setCellContent,
+  setFormat,
+  updateChart,
+} from "../../test_helpers/commands_helpers";
 
 let model: Model;
 describe("bar chart", () => {
@@ -21,6 +27,7 @@ describe("bar chart", () => {
       showConnectorLines: false,
       showSubTotals: true,
       axesDesign: {},
+      fillArea: true,
     };
     const definition = BarChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({
@@ -35,6 +42,17 @@ describe("bar chart", () => {
       stacked: true,
       axesDesign: {},
     });
+  });
+
+  test("Stacked bar", () => {
+    const model = new Model();
+    createChart(model, { type: "bar", stacked: false }, "chartId");
+    expect(isChartAxisStacked(model, "chartId", "x")).toBeUndefined();
+    expect(isChartAxisStacked(model, "chartId", "y")).toBeUndefined();
+
+    updateChart(model, "chartId", { stacked: true });
+    expect(isChartAxisStacked(model, "chartId", "x")).toBe(true);
+    expect(isChartAxisStacked(model, "chartId", "y")).toBe(true);
   });
 
   describe("Horizontal bar chart", () => {

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -1,6 +1,6 @@
 import { ChartType as ChartJSType, TooltipItem } from "chart.js";
 import { CommandResult, Model } from "../../../src";
-import { ChartDefinition, UID } from "../../../src/types";
+import { ChartDefinition } from "../../../src/types";
 import {
   BarChartDefinition,
   BarChartRuntime,
@@ -37,17 +37,13 @@ import { toZone, zoneToXc } from "../../../src/helpers";
 import { BarChart } from "../../../src/helpers/figures/charts";
 import { ChartPlugin } from "../../../src/plugins/core";
 import { ScatterChartRuntime } from "../../../src/types/chart/scatter_chart";
+import { getChartConfiguration } from "../../test_helpers/chart_helpers";
 import { FR_LOCALE } from "../../test_helpers/constants";
 import { getCellContent } from "../../test_helpers/getters_helpers";
 
 jest.mock("../../../src/helpers/uuid", () => require("../../__mocks__/uuid"));
 
 let model: Model;
-
-function getChartConfiguration(model: Model, chartId: UID) {
-  const runtime = model.getters.getChartRuntime(chartId) as any;
-  return runtime.chartJsConfig;
-}
 
 beforeEach(() => {
   model = new Model({
@@ -1650,24 +1646,6 @@ describe("Chart design configuration", () => {
     expect(model.getters.getChartDefinition("42")!.background).toBe("#000000");
   });
 
-  test("Stacked bar", () => {
-    createChart(model, defaultChart, "42");
-    expect(isChartAxisStacked(model, "42", "x")).toBeUndefined();
-    expect(isChartAxisStacked(model, "42", "y")).toBeUndefined();
-
-    updateChart(model, "42", { stacked: true });
-    expect(isChartAxisStacked(model, "42", "x")).toBe(true);
-    expect(isChartAxisStacked(model, "42", "y")).toBe(true);
-
-    updateChart(model, "42", { type: "line" });
-    expect(isChartAxisStacked(model, "42", "x")).toBeUndefined();
-    expect(isChartAxisStacked(model, "42", "y")).toBe(true);
-
-    updateChart(model, "42", { type: "line", stacked: false });
-    expect(isChartAxisStacked(model, "42", "x")).toBeUndefined();
-    expect(isChartAxisStacked(model, "42", "y")).toBeUndefined();
-  });
-
   test("empty data points are not displayed in the chart", () => {
     const model = new Model({
       sheets: [
@@ -2612,7 +2590,3 @@ test("Duplicating a sheet dispatches `CREATE_CHART` for each chart", () => {
   expect(spyDispatch).toHaveBeenNthCalledWith(3, "CREATE_CHART", expect.any(Object));
   expect(spyDispatch).toHaveBeenNthCalledWith(4, "CREATE_FIGURE", expect.any(Object));
 });
-
-function isChartAxisStacked(model: Model, chartId: UID, axis: "x" | "y"): boolean {
-  return getChartConfiguration(model, chartId).options?.scales?.[axis]?.stacked;
-}

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -1804,4 +1804,33 @@ describe("Change chart type", () => {
     });
     expect(select.value).toBe("pie");
   });
+
+  test("Can change from (stacked)line to (stacked)area chart", async () => {
+    createChart(model, { type: "line", stacked: false, fillArea: false }, chartId);
+    await mountChartSidePanel(chartId);
+    const select = fixture.querySelector(".o-type-selector") as HTMLSelectElement;
+
+    updateChart(model, chartId, { fillArea: true }, sheetId);
+    await nextTick();
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+      stacked: false,
+      fillArea: true,
+    });
+    expect(select.value).toBe("area");
+
+    await changeChartType("stacked_area");
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+      stacked: true,
+      fillArea: true,
+    });
+    expect(select.value).toBe("stacked_area");
+
+    updateChart(model, chartId, { fillArea: false }, sheetId);
+    await nextTick();
+    expect(model.getters.getChartDefinition(chartId)).toMatchObject({
+      stacked: true,
+      fillArea: false,
+    });
+    expect(select.value).toBe("stacked_line");
+  });
 });

--- a/tests/figures/chart/combo_chart_plugin.test.ts
+++ b/tests/figures/chart/combo_chart_plugin.test.ts
@@ -20,6 +20,7 @@ describe("combo chart", () => {
       showConnectorLines: false,
       showSubTotals: true,
       axesDesign: {},
+      fillArea: true,
     };
     const definition = ComboChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({

--- a/tests/figures/chart/gauge_chart_plugin.test.ts
+++ b/tests/figures/chart/gauge_chart_plugin.test.ts
@@ -127,6 +127,7 @@ describe("datasource tests", function () {
       showConnectorLines: false,
       showSubTotals: true,
       axesDesign: {},
+      fillArea: true,
     };
     const definition = GaugeChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({

--- a/tests/figures/chart/pie_chart_plugin.test.ts
+++ b/tests/figures/chart/pie_chart_plugin.test.ts
@@ -18,6 +18,7 @@ describe("pie chart", () => {
       showConnectorLines: false,
       showSubTotals: true,
       axesDesign: {},
+      fillArea: true,
     };
     const definition = PieChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({

--- a/tests/figures/chart/pyramid_chart_plugin.test.ts
+++ b/tests/figures/chart/pyramid_chart_plugin.test.ts
@@ -21,6 +21,7 @@ describe("population pyramid chart", () => {
       showConnectorLines: false,
       showSubTotals: true,
       axesDesign: {},
+      fillArea: true,
     };
     const definition = PyramidChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({

--- a/tests/figures/chart/scorecard_chart_plugin.test.ts
+++ b/tests/figures/chart/scorecard_chart_plugin.test.ts
@@ -95,6 +95,7 @@ describe("datasource tests", function () {
       showConnectorLines: false,
       showSubTotals: true,
       axesDesign: {},
+      fillArea: true,
     };
     const definition = ScorecardChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({

--- a/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
+++ b/tests/figures/chart/waterfall/waterfall_chart_plugin.test.ts
@@ -279,6 +279,7 @@ describe("Waterfall chart", () => {
       showConnectorLines: false,
       showSubTotals: true,
       axesDesign: {},
+      fillArea: true,
     };
     const definition = WaterfallChart.getDefinitionFromContextCreation(context);
     expect(definition).toEqual({

--- a/tests/test_helpers/chart_helpers.ts
+++ b/tests/test_helpers/chart_helpers.ts
@@ -1,0 +1,10 @@
+import { Model, UID } from "../../src";
+
+export function isChartAxisStacked(model: Model, chartId: UID, axis: "x" | "y"): boolean {
+  return getChartConfiguration(model, chartId).options?.scales?.[axis]?.stacked;
+}
+
+export function getChartConfiguration(model: Model, chartId: UID) {
+  const runtime = model.getters.getChartRuntime(chartId) as any;
+  return runtime.chartJsConfig;
+}


### PR DESCRIPTION
## Description:

This commit implements the "Area Chart", which is a line chart but
with the area below the line filled with a color. This was a previous
behaviour of the stacked line chart, but now it is a separate chart,
and the stacked line chart has no fill color.

Task: : [3981124](https://www.odoo.com/web#id=3981124&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo