### PR TITLE
[FIX] data_validation: wrong popover position

### DIFF
--- a/src/components/side_panel/select_menu/select_menu.ts
+++ b/src/components/side_panel/select_menu/select_menu.ts
@@ -1,6 +1,7 @@
 import { Component, useRef, useState } from "@odoo/owl";
 import { Action } from "../../../actions/action";
-import { DOMCoordinates, SpreadsheetChildEnv } from "../../../types";
+import { UuidGenerator } from "../../../helpers";
+import { DOMCoordinates, MenuMouseEvent, SpreadsheetChildEnv } from "../../../types";
 import { useAbsoluteBoundingRect } from "../../helpers/position_hook";
 import { Menu } from "../../menu/menu";
 
@@ -19,6 +20,8 @@ export class SelectMenu extends Component<SelectMenuProps, SpreadsheetChildEnv> 
   static template = "o-spreadsheet-SelectMenu";
   static components = { Menu };
 
+  menuId = new UuidGenerator().uuidv4();
+
   selectRef = useRef("select");
   selectRect = useAbsoluteBoundingRect(this.selectRef);
 
@@ -26,8 +29,11 @@ export class SelectMenu extends Component<SelectMenuProps, SpreadsheetChildEnv> 
     isMenuOpen: false,
   });
 
-  onClick() {
-    this.state.isMenuOpen = true;
+  onClick(ev: MenuMouseEvent) {
+    if (ev.closedMenuId === this.menuId) {
+      return;
+    }
+    this.state.isMenuOpen = !this.state.isMenuOpen;
   }
 
   onMenuClosed() {
@@ -37,7 +43,7 @@ export class SelectMenu extends Component<SelectMenuProps, SpreadsheetChildEnv> 
   get menuPosition(): DOMCoordinates {
     return {
       x: this.selectRect.x,
-      y: this.selectRect.y,
+      y: this.selectRect.y + this.selectRect.height,
     };
   }
 }

--- a/src/components/side_panel/select_menu/select_menu.xml
+++ b/src/components/side_panel/select_menu/select_menu.xml
@@ -12,6 +12,7 @@
       menuItems="props.menuItems"
       position="menuPosition"
       onClose.bind="onMenuClosed"
+      menuId="menuId"
     />
   </t>
 </templates>

--- a/tests/test_helpers/mock_helpers.ts
+++ b/tests/test_helpers/mock_helpers.ts
@@ -1,4 +1,4 @@
-const originalGetBoundingClientRect = HTMLDivElement.prototype.getBoundingClientRect;
+const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
 
 export function mockGetBoundingClientRect(
   classesWithMocks: Record<string, (el: HTMLElement) => Partial<DOMRect>>
@@ -6,8 +6,8 @@ export function mockGetBoundingClientRect(
   const mockedClasses = Object.keys(classesWithMocks);
 
   jest
-    .spyOn(HTMLDivElement.prototype, "getBoundingClientRect")
-    .mockImplementation(function (this: HTMLDivElement) {
+    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+    .mockImplementation(function (this: HTMLElement) {
       const mockedClass = mockedClasses.find((className) => this.classList.contains(className));
       if (mockedClass) {
         const rect = populateDOMRect(classesWithMocks[mockedClass](this));


### PR DESCRIPTION
## Description

The popover to select the type of data validation was positioned at the top of the select element instead of the bottom.

Also clicking again on the select element was not toggling the popover.

Task: : [3981399](https://www.odoo.com/web#id=3981399&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo