### PR TITLE
[FIX] autocomplete: fix pivot group autocomplete

### DIFF
--- a/src/registries/auto_completes/pivot_auto_complete.ts
+++ b/src/registries/auto_completes/pivot_auto_complete.ts
@@ -233,17 +233,19 @@ autoCompleteProviders.add("pivot_group_values", {
     if (!groupByField) {
       return;
     }
-    return dataSource.getPossibleFieldValues(groupByField.split(":")[0]).map(({ value, label }) => {
-      const isString = typeof value === "string";
-      const text = isString ? `"${value}"` : value.toString();
-      const color = isString ? tokenColors.STRING : tokenColors.NUMBER;
-      return {
-        text,
-        description: label,
-        htmlContent: [{ value: text, color }],
-        fuzzySearchKey: value + label,
-      };
-    });
+    return dataSource
+      .getPossibleFieldValues(groupByField.toString().split(":")[0])
+      .map(({ value, label }) => {
+        const isString = typeof value === "string";
+        const text = isString ? `"${value}"` : value.toString();
+        const color = isString ? tokenColors.STRING : tokenColors.NUMBER;
+        return {
+          text,
+          description: label,
+          htmlContent: [{ value: text, color }],
+          fuzzySearchKey: value + label,
+        };
+      });
   },
   selectProposal: insertTokenAfterArgSeparator,
 });


### PR DESCRIPTION
The computation to autocomplete pivot group values was only supporting string-like group values. If a user were to write some random input, like a number, the code would crash.

Task: 3976271

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo