### PR TITLE
[FIX] Figure: Fix container size in presence of frozen panes

### DIFF
--- a/src/components/figures/figure_container/figure_container.ts
+++ b/src/components/figures/figure_container/figure_container.ts
@@ -166,7 +166,7 @@ export class FiguresContainer extends Component<Props, SpreadsheetChildEnv> {
   }
 
   private getContainerStyle(container: ContainerType): string {
-    const { width: viewWidth, height: viewHeight } = this.env.model.getters.getMainViewportRect();
+    const { width: viewWidth, height: viewHeight } = this.env.model.getters.getSheetViewDimension();
     const { x: viewportX, y: viewportY } = this.env.model.getters.getMainViewportCoordinates();
 
     const left = ["bottomRight", "topRight"].includes(container) ? viewportX : 0;

--- a/tests/components/figure.test.ts
+++ b/tests/components/figure.test.ts
@@ -118,7 +118,6 @@ describe("figures", () => {
     expect(fixture.querySelector(".o-figure")).toBeNull();
     expect(document.activeElement).toBe(fixture.querySelector(".o-grid div.o-composer"));
   });
-
   test("deleting a figure doesn't delete selection", async () => {
     createFigure(model);
     setCellContent(model, "A1", "content");
@@ -497,5 +496,44 @@ describe("figures", () => {
     triggerMouseEvent(".o-figure", "mousedown", 0, 0);
     await nextTick();
     expect(fixture.querySelector(".o-figure")?.classList.contains("o-dragging")).toBeFalsy();
+  });
+
+  test("Figure container is properly computed based on the sheetView size", async () => {
+    createFigure(model, { id: "topLeft" }); // topLeft
+    createFigure(model, { id: "topRight", x: 4 * DEFAULT_CELL_WIDTH }); // topRight
+    createFigure(model, { id: "bottomLeft", y: 4 * DEFAULT_CELL_HEIGHT }); // bottomLeft
+    createFigure(model, {
+      id: "bottomRight",
+      x: 4 * DEFAULT_CELL_WIDTH,
+      y: 4 * DEFAULT_CELL_HEIGHT,
+    }); // bottomRight
+    freezeRows(model, 2);
+    freezeColumns(model, 2);
+    const { width, height } = model.getters.getSheetViewDimension();
+    await nextTick();
+
+    const topLeftContainerStyle = (
+      fixture.querySelector("[data-id='topLeftContainer']") as HTMLDivElement
+    ).style;
+    expect(topLeftContainerStyle.width).toEqual(`${width}px`);
+    expect(topLeftContainerStyle.height).toEqual(`${height}px`);
+
+    const topRightContainerStyle = (
+      fixture.querySelector("[data-id='topRightContainer']") as HTMLDivElement
+    ).style;
+    expect(topRightContainerStyle.width).toEqual(`${width - 2 * DEFAULT_CELL_WIDTH}px`);
+    expect(topRightContainerStyle.height).toEqual(`${height}px`);
+
+    const bottomLeftContainerStyle = (
+      fixture.querySelector("[data-id='bottomLeftContainer']") as HTMLDivElement
+    ).style;
+    expect(bottomLeftContainerStyle.width).toEqual(`${width}px`);
+    expect(bottomLeftContainerStyle.height).toEqual(`${height - 2 * DEFAULT_CELL_HEIGHT}px`);
+
+    const bottomRightContainerStyle = (
+      fixture.querySelector("[data-id='bottomRightContainer']") as HTMLDivElement
+    ).style;
+    expect(bottomRightContainerStyle.width).toEqual(`${width - 2 * DEFAULT_CELL_WIDTH}px`);
+    expect(bottomRightContainerStyle.height).toEqual(`${height - 2 * DEFAULT_CELL_HEIGHT}px`);
   });
 });


### PR DESCRIPTION
The container size was computed based on the mainviewport theoretical size where it should have been using the SheetView dimension.

Task: 3976086

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo