### PR TITLE
[FIX] charts: fix scorecard chard design

### DIFF
--- a/src/components/figures/chart/scorecard/chart_scorecard.ts
+++ b/src/components/figures/chart/scorecard/chart_scorecard.ts
@@ -1,6 +1,7 @@
 import { Component, useEffect, useRef } from "@odoo/owl";
 import { drawScoreChart } from "../../../../helpers/figures/charts/scorecard_chart";
 import { getScorecardConfiguration } from "../../../../helpers/figures/charts/scorecard_chart_config_builder";
+import { _t } from "../../../../translation";
 import { Figure, SpreadsheetChildEnv } from "../../../../types";
 import { ScorecardChartRuntime } from "../../../../types/chart/scorecard_chart";
 
@@ -17,6 +18,12 @@ export class ScorecardChart extends Component<Props, SpreadsheetChildEnv> {
 
   get runtime(): ScorecardChartRuntime {
     return this.env.model.getters.getChartRuntime(this.props.figure.id) as ScorecardChartRuntime;
+  }
+
+  get title(): string {
+    const title = this.env.model.getters.getChartDefinition(this.props.figure.id).title.text ?? "";
+    // chart titles are extracted from .json files and they are translated at runtime here
+    return _t(title);
   }
 
   setup() {

--- a/src/components/figures/chart/scorecard/chart_scorecard.xml
+++ b/src/components/figures/chart/scorecard/chart_scorecard.xml
@@ -1,5 +1,5 @@
 <templates>
   <t t-name="o-spreadsheet-ScorecardChart">
-    <canvas class="o-figure-canvas w-100 h-100" t-ref="chartContainer"/>
+    <canvas class="o-figure-canvas w-100 h-100" t-ref="chartContainer" t-att-title="title"/>
   </t>
 </templates>

--- a/src/helpers/figures/charts/scorecard_chart.ts
+++ b/src/helpers/figures/charts/scorecard_chart.ts
@@ -1,5 +1,6 @@
 import { transformZone } from "../../../collaborative/ot/ot_helpers";
 import {
+  DEFAULT_CHART_PADDING,
   DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
   DEFAULT_SCORECARD_BASELINE_COLOR_UP,
   DEFAULT_SCORECARD_BASELINE_MODE,
@@ -294,6 +295,7 @@ export class ScorecardChart extends AbstractChart {
 export function drawScoreChart(structure: ScorecardChartConfig, canvas: HTMLCanvasElement) {
   const ctx = canvas.getContext("2d")!;
   canvas.width = structure.canvas.width;
+  const availableWidth = canvas.width - DEFAULT_CHART_PADDING;
   canvas.height = structure.canvas.height;
 
   ctx.fillStyle = structure.canvas.backgroundColor;
@@ -305,7 +307,7 @@ export function drawScoreChart(structure: ScorecardChartConfig, canvas: HTMLCanv
     const baseline = ctx.textBaseline;
     ctx.textBaseline = "middle";
     ctx.fillText(
-      clipTextWithEllipsis(ctx, structure.title.text, canvas.width - structure.title.position.x),
+      clipTextWithEllipsis(ctx, structure.title.text, availableWidth - structure.title.position.x),
       structure.title.position.x,
       structure.title.position.y
     );
@@ -452,6 +454,7 @@ export function createScorecardChartRuntime(
   return {
     title: {
       ...chart.title,
+      // chart titles are extracted from .json files and they are translated at runtime here
       text: _t(chart.title.text ?? ""),
     },
     keyValue: formattedKeyValue,
@@ -465,7 +468,9 @@ export function createScorecardChartRuntime(
       chart.baselineColorDown
     ),
     baselineDescr:
-      chart.baselineMode !== "progress" && chart.baselineDescr ? _t(chart.baselineDescr) : "",
+      chart.baselineMode !== "progress" && chart.baselineDescr
+        ? _t(chart.baselineDescr) // descriptions are extracted from .json files and they are translated at runtime here
+        : "",
     fontColor,
     background,
     baselineStyle:

--- a/src/helpers/figures/charts/scorecard_chart_config_builder.ts
+++ b/src/helpers/figures/charts/scorecard_chart_config_builder.ts
@@ -1,5 +1,5 @@
 import { Color } from "chart.js";
-import { DEFAULT_CHART_FONT_SIZE, DEFAULT_CHART_PADDING } from "../../../constants";
+import { DEFAULT_CHART_FONT_SIZE } from "../../../constants";
 import { DOMDimension, Pixel, PixelPosition, Style } from "../../../types";
 import { BaselineArrowDirection, ScorecardChartRuntime } from "../../../types/chart";
 import { relativeLuminance } from "../../color";
@@ -15,7 +15,7 @@ import {
 const KEY_BOX_HEIGHT_RATIO = 0.8;
 
 /* Padding at the border of the chart */
-const CHART_PADDING = DEFAULT_CHART_PADDING;
+const CHART_PADDING = 10;
 const BOTTOM_PADDING_RATIO = 0.05;
 
 /**
@@ -236,6 +236,7 @@ class ScorecardChartConfigBuilder {
           x: (this.width - keyWidth) / 2,
           y:
             this.height * (0.5 - BOTTOM_PADDING_RATIO * 2) +
+            CHART_PADDING / 2 +
             (titleHeight + keyHeight / (this.baseline || this.baselineDescr ? 2 : 1.2)) / 2,
         },
       };
@@ -300,6 +301,7 @@ class ScorecardChartConfigBuilder {
     const widthFont = getFontSizeMatchingWidth(maxLineWidth, 600, (fontSize: number) =>
       keyValueElement.getElementWidth(fontSize, this.context, this)
     );
+
     const keyFontSize = Math.min(heightFont, widthFont);
     let baselineValueFontSize = Math.floor(keyFontSize * 0.5);
 
@@ -318,7 +320,10 @@ class ScorecardChartConfigBuilder {
     );
 
     let isBaselineSplit = false;
-    if (baselineDescrFontSize < baselineValueFontSize / 2.5) {
+    if (
+      baselineDescrFontSize < baselineValueFontSize / 2.5 &&
+      this.baselineDescr.trim().includes(" ")
+    ) {
       isBaselineSplit = true;
       baselineDescrFontSize = Math.floor(baselineValueFontSize / 2.5);
       for (const line of splitTextInTwoLines(this.baselineDescr)) {
@@ -387,7 +392,7 @@ class ScorecardChartConfigBuilder {
   /** Get the height of the chart minus all the vertical paddings */
   private getDrawableHeight(): number {
     const verticalPadding = CHART_PADDING + this.height * BOTTOM_PADDING_RATIO;
-    let availableHeight = this.height - 2 * verticalPadding;
+    let availableHeight = this.height - verticalPadding;
     availableHeight -= this.title ? DEFAULT_CHART_FONT_SIZE * LINE_HEIGHT : 0;
     return availableHeight;
   }

--- a/src/helpers/text_helper.ts
+++ b/src/helpers/text_helper.ts
@@ -286,7 +286,7 @@ export function clipTextWithEllipsis(
     return text;
   }
   const ellipsis = "…";
-  const ellipsisWidth = computeCachedTextWidth(ctx, text);
+  const ellipsisWidth = computeCachedTextWidth(ctx, ellipsis);
   if (width <= ellipsisWidth) {
     return text;
   }


### PR DESCRIPTION
## Task Description

Since the refactoring of the chart design customization, the padding and title size have been uniformized for all chart. In the dashboards, as we have very small scorecard, it doesn't look really good now. This task fix this design issue, as well as fixing the ellipsis mechanism of the scorecard title.

## Related Task

Task: : [3964015](https://www.odoo.com/web#id=3964015&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo