### PR TITLE
[IMP] charts: improve `stacked` checkbox label

### DIFF
--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.ts
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.ts
@@ -1,12 +1,7 @@
-import { _t } from "../../../../translation";
 import { GenericChartConfigPanel } from "../building_blocks/generic_side_panel/config_panel";
 
 export class BarConfigPanel extends GenericChartConfigPanel {
   static template = "o-spreadsheet-BarConfigPanel";
-
-  get stackedLabel(): string {
-    return _t("Stacked barchart");
-  }
 
   onUpdateStacked(stacked: boolean) {
     this.props.updateChart(this.props.figureId, {

--- a/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
+++ b/src/components/side_panel/chart/bar_chart/bar_chart_config_panel.xml
@@ -4,7 +4,7 @@
       <Section class="'pt-0'">
         <Checkbox
           name="'stacked'"
-          label="stackedLabel"
+          label="chartTerms.StackedBarChart"
           value="props.definition.stacked"
           onChange.bind="onUpdateStacked"
         />

--- a/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
+++ b/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
@@ -53,6 +53,8 @@ export class GenericChartConfigPanel extends Component<Props, SpreadsheetChildEn
   private dataSeriesRanges: CustomizedDataSet[] = [];
   private labelRange: string | undefined;
 
+  protected chartTerms = ChartTerms;
+
   setup() {
     this.dataSeriesRanges = this.props.definition.dataSets;
     this.labelRange = this.props.definition.labelRange;
@@ -84,7 +86,7 @@ export class GenericChartConfigPanel extends Component<Props, SpreadsheetChildEn
     return [
       {
         name: "aggregated",
-        label: _t("Aggregate"),
+        label: this.chartTerms.AggregatedChart,
         value: this.props.definition.aggregated ?? false,
         onChange: this.onUpdateAggregated.bind(this),
       },

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.ts
@@ -1,6 +1,5 @@
 import { LineChart } from "../../../../helpers/figures/charts";
 import { canChartParseLabels } from "../../../../helpers/figures/charts/chart_common_line_scatter";
-import { _t } from "../../../../translation";
 import { LineChartDefinition } from "../../../../types/chart";
 import { GenericChartConfigPanel } from "../building_blocks/generic_side_panel/config_panel";
 
@@ -15,21 +14,13 @@ export class LineConfigPanel extends GenericChartConfigPanel {
     return false;
   }
 
-  get stackedLabel(): string {
-    return _t("Stacked linechart");
-  }
-
-  get cumulativeLabel(): string {
-    return _t("Cumulative data");
-  }
-
   getLabelRangeOptions() {
     const options = super.getLabelRangeOptions();
     if (this.canTreatLabelsAsText) {
       options.push({
         name: "labelsAsText",
         value: (this.props.definition as LineChartDefinition).labelsAsText,
-        label: _t("Treat labels as text"),
+        label: this.chartTerms.TreatLabelsAsText,
         onChange: this.onUpdateLabelsAsText.bind(this),
       });
     }

--- a/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
+++ b/src/components/side_panel/chart/line_chart/line_chart_config_panel.xml
@@ -4,13 +4,13 @@
       <Section class="'pt-0'">
         <Checkbox
           name="'stacked'"
-          label="stackedLabel"
+          label="chartTerms.StackedLineChart"
           value="props.definition.stacked"
           onChange.bind="onUpdateStacked"
         />
         <Checkbox
           name="'cumulative'"
-          label="cumulativeLabel"
+          label="chartTerms.CumulativeData"
           value="props.definition.cumulative"
           onChange.bind="onUpdateCumulative"
         />

--- a/src/components/side_panel/chart/scatter_chart/scatter_chart_config_panel.ts
+++ b/src/components/side_panel/chart/scatter_chart/scatter_chart_config_panel.ts
@@ -1,6 +1,5 @@
 import { canChartParseLabels } from "../../../../helpers/figures/charts/chart_common_line_scatter";
 import { ScatterChart } from "../../../../helpers/figures/charts/scatter_chart";
-import { _t } from "../../../../translation";
 import { LineChartDefinition } from "../../../../types/chart";
 import { GenericChartConfigPanel } from "../building_blocks/generic_side_panel/config_panel";
 
@@ -27,7 +26,7 @@ export class ScatterConfigPanel extends GenericChartConfigPanel {
       options.push({
         name: "labelsAsText",
         value: (this.props.definition as LineChartDefinition).labelsAsText,
-        label: _t("Treat labels as text"),
+        label: this.chartTerms.TreatLabelsAsText,
         onChange: this.onUpdateLabelsAsText.bind(this),
       });
     }

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -50,6 +50,11 @@ export const CellIsOperators = {
 export const ChartTerms = {
   Series: _t("Series"),
   BackgroundColor: _t("Background color"),
+  StackedBarChart: _t("Stacked bar chart"),
+  StackedLineChart: _t("Stacked line chart"),
+  CumulativeData: _t("Cumulative data"),
+  TreatLabelsAsText: _t("Treat labels as text"),
+  AggregatedChart: _t("Aggregate"),
   Errors: {
     Unexpected: _t("The chart definition is invalid for an unknown reason"),
     // BASIC CHART ERRORS (LINE | BAR | PIE)

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { PivotDimensionOrder } from "./components/side_panel/pivot/pivot_layout_
 import { PivotLayoutConfigurator } from "./components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator";
 import { PivotSidePanelStore } from "./components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store";
 import { SidePanelStore } from "./components/side_panel/side_panel/side_panel_store";
+import { ChartTerms } from "./components/translations_terms";
 import { ValidationMessages } from "./components/validation_messages/validation_messages";
 import {
   BOTTOMBAR_HEIGHT,
@@ -413,6 +414,7 @@ export const constants = {
   DEFAULT_LOCALE,
   HIGHLIGHT_COLOR,
   PIVOT_TABLE_CONFIG,
+  ChartTerms,
 };
 
 export { PivotRuntimeDefinition } from "./helpers/pivot/pivot_runtime_definition";


### PR DESCRIPTION
## Description

Change the checkbox label of stacked charts from `stacked linechart` to `stacked line chart` in the chart configuration panel. Same for bar charts.

Also moved some translations to the `ChartTerms` constant, so they can be re-used in other side panels (and in Odoo).

Task: : [3978443](https://www.odoo.com/web#id=3978443&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo