### PR TITLE
[FIX] components: add missing static props

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -325,13 +325,14 @@ Demo.template = xml/* xml */ `
   </div>
 `;
 Demo.components = { Spreadsheet };
+Demo.props = {};
 
 // Setup code
 async function setup() {
   const templates = await (await fetch("../build/o_spreadsheet.xml")).text();
   start = Date.now();
 
-  const rootApp = new owl.App(Demo, { dev: true });
+  const rootApp = new owl.App(Demo, { dev: true, warnIfNoStaticProps: true });
   rootApp.addTemplates(templates);
   rootApp.mount(document.body);
 }

--- a/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.ts
+++ b/src/components/side_panel/chart/building_blocks/axis_design/axis_design_editor.ts
@@ -28,10 +28,9 @@ interface Props {
 
 export class AxisDesignEditor extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-AxisDesignEditor";
-  static components = {
-    Section,
-    ChartTitle,
-  };
+  static components = { Section, ChartTitle };
+  static props = { figureId: String, definition: Object, updateChart: Function, axesList: Array };
+
   state = useState({ currentAxis: "x" });
 
   get axisTitleStyle(): TitleDesign {

--- a/src/components/side_panel/chart/chart_with_axis/design_panel.ts
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.ts
@@ -33,6 +33,13 @@ export class ChartWithAxisDesignPanel extends Component<Props, SpreadsheetChildE
     AxisDesignEditor,
     RoundColorPicker,
   };
+  static props = {
+    figureId: String,
+    definition: Object,
+    canUpdateChart: Function,
+    updateChart: Function,
+  };
+
   private state = useState({ index: 0 });
 
   get axesList(): AxisDefinition[] {

--- a/src/components/side_panel/remove_duplicates/remove_duplicates.ts
+++ b/src/components/side_panel/remove_duplicates/remove_duplicates.ts
@@ -25,6 +25,7 @@ interface RemoveDuplicatesState {
 export class RemoveDuplicatesPanel extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet-RemoveDuplicatesPanel";
   static components = { ValidationMessages, Section, Checkbox };
+  static props = { onCloseSidePanel: Function };
 
   state: RemoveDuplicatesState = useState({
     hasHeader: false,

--- a/tests/autofill/autofill_component.test.ts
+++ b/tests/autofill/autofill_component.test.ts
@@ -207,6 +207,7 @@ describe("Autofill component", () => {
       static template = xml/* xml */ `
         <div class="custom_tooltip" t-esc="props.content"/>
       `;
+      static props = { content: String };
     }
     expect(fixture.querySelector(".o-autofill-nextvalue")).toBeNull();
     model.getters.getAutofillTooltip = jest.fn(() => {

--- a/tests/figures/figure_component.test.ts
+++ b/tests/figures/figure_component.test.ts
@@ -9,8 +9,9 @@ import {
   SELECTION_BORDER_COLOR,
 } from "../../src/constants";
 import { figureRegistry } from "../../src/registries";
-import { CreateFigureCommand, Figure, Pixel, SpreadsheetChildEnv, UID } from "../../src/types";
+import { CreateFigureCommand, Pixel, SpreadsheetChildEnv, UID } from "../../src/types";
 
+import { FigureComponent } from "../../src/components/figures/figure/figure";
 import {
   activateSheet,
   addColumns,
@@ -96,11 +97,9 @@ const TEMPLATE = xml/* xml */ `
   </div>
 `;
 
-interface Props {
-  figure: Figure;
-}
-class TextFigure extends Component<Props, SpreadsheetChildEnv> {
+class TextFigure extends Component<FigureComponent["props"], SpreadsheetChildEnv> {
   static template = TEMPLATE;
+  static props = FigureComponent.props;
 }
 
 mockChart();

--- a/tests/grid/grid_cell_icon_component.test.ts
+++ b/tests/grid/grid_cell_icon_component.test.ts
@@ -14,13 +14,18 @@ import { SpreadsheetChildEnv, UID } from "../../src/types";
 import { merge, resizeColumns, resizeRows, setStyle } from "../test_helpers/commands_helpers";
 import { getStylePropertyInPx, mountComponent } from "../test_helpers/helpers";
 
-class ParentComponent extends Component<{}, SpreadsheetChildEnv> {
+class ParentComponent extends Component<GridCellIconProps, SpreadsheetChildEnv> {
   static components = { GridCellIcon };
   static template = xml/* xml */ `
     <GridCellIcon t-props="this.props">
       <div class="my-icon"></div>
     </GridCellIcon>
   `;
+  static props = {
+    cellPosition: Object,
+    horizontalAlign: { type: String, optional: true },
+    verticalAlign: { type: String, optional: true },
+  };
 }
 
 describe("Grid cell icon component", () => {

--- a/tests/grid/grid_drag_and_drop_component.test.ts
+++ b/tests/grid/grid_drag_and_drop_component.test.ts
@@ -43,6 +43,7 @@ let selectedRow: number | undefined = undefined;
 
 class FakeGridComponent extends Component<Props, SpreadsheetChildEnv> {
   static template = TEMPLATE;
+  static props = { model: Object };
 
   setup() {
     useSubEnv({

--- a/tests/grid/highlight_component.test.ts
+++ b/tests/grid/highlight_component.test.ts
@@ -132,6 +132,7 @@ class Parent extends Component<Props> {
   static template = xml/*xml*/ `
     <Highlight zone="props.zone" color="props.color"/>
   `;
+  static props = { ...Highlight.props, model: Object };
   setup() {
     spyDispatch = jest.spyOn(model, "dispatch");
     spyHandleEvent = jest.fn();

--- a/tests/helpers/css_helpers.test.ts
+++ b/tests/helpers/css_helpers.test.ts
@@ -31,6 +31,7 @@ describe("styles and component", () => {
 
     class App extends Component {
       static template = xml`<div class="app">text</div>`;
+      static props = {};
     }
 
     expect(document.head.innerHTML).toBe(`<style component=\"${name}\">.app {
@@ -56,6 +57,7 @@ describe("styles and component", () => {
     `;
     class App extends Component {
       static template = xml`<div class="app">text</div>`;
+      static props = {};
     }
     class SubApp extends App {}
 

--- a/tests/menus/context_menu_component.test.ts
+++ b/tests/menus/context_menu_component.test.ts
@@ -200,6 +200,7 @@ class ContextMenuParent extends Component {
     </div>
   `;
   static components = { Menu };
+  static props = { x: Number, y: Number, width: Number, height: Number, config: Object };
   menus!: Action[];
   position!: { x: number; y: number; width: number; height: number };
   onClose!: () => void;

--- a/tests/popover/popover_component.test.ts
+++ b/tests/popover/popover_component.test.ts
@@ -28,6 +28,7 @@ async function mountTestPopover(args: MountPopoverArgs) {
         </div>
   `;
     static components = { Popover };
+    static props = { model: Object };
 
     setup() {
       const env: any = {

--- a/tests/selection_input/selection_input_component.test.ts
+++ b/tests/selection_input/selection_input_component.test.ts
@@ -65,6 +65,7 @@ class Parent extends Component<any> {
     />
   `;
   static components = { SelectionInput };
+  static props = { model: Object, config: Object };
   model!: Model;
   initialRanges: string[] | undefined;
   hasSingleRange: boolean | undefined;
@@ -104,6 +105,7 @@ class MultiParent extends Component<any> {
     </div>
   `;
   static components = { SelectionInput };
+  static props = { model: Object };
 
   setup() {
     useSubEnv({

--- a/tests/side_panels/building_blocks/__snapshots__/data_series.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/data_series.test.ts.snap
@@ -3,53 +3,49 @@
 exports[`Data Series Can render a data series component 1`] = `
 <div>
   <div
-    class="container"
+    class="o-section o-data-series"
   >
     <div
-      class="o-section o-data-series"
+      class="o-section-title"
+    >
+      Data series
+    </div>
+    
+    <div
+      class="o-selection"
     >
       <div
-        class="o-section-title"
+        class="o-selection-input d-flex flex-row"
       >
-        Data series
+        <div
+          class="position-relative w-100"
+        >
+          <input
+            class="w-100 o-required"
+            spellcheck="false"
+            style="color: #000;"
+            type="text"
+          />
+          
+        </div>
+        
       </div>
+      
       
       <div
-        class="o-selection"
+        class="o-selection-input d-flex flex-row"
       >
-        <div
-          class="o-selection-input d-flex flex-row"
+        <button
+          class="o-btn-action bg-transparent fw-bold o-add-selection"
         >
-          <div
-            class="position-relative w-100"
-          >
-            <input
-              class="w-100 o-required"
-              spellcheck="false"
-              style="color: #000;"
-              type="text"
-            />
-            
-          </div>
-          
-        </div>
+           Add range 
+        </button>
         
         
-        <div
-          class="o-selection-input d-flex flex-row"
-        >
-          <button
-            class="o-btn-action bg-transparent fw-bold o-add-selection"
-          >
-             Add range 
-          </button>
-          
-          
-          
-        </div>
+        
       </div>
-      
     </div>
+    
   </div>
 </div>
 `;

--- a/tests/side_panels/building_blocks/__snapshots__/error_section.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/error_section.test.ts.snap
@@ -3,45 +3,41 @@
 exports[`Chart error section Can render a chart error section component 1`] = `
 <div>
   <div
-    class="container"
+    class="o-section"
   >
+    
     <div
-      class="o-section"
+      class="d-flex align-items-center o-side-panel-error o-validation-error text-danger"
     >
-      
       <div
-        class="d-flex align-items-center o-side-panel-error o-validation-error text-danger"
+        class="o-icon fa-small"
       >
-        <div
-          class="o-icon fa-small"
-        >
-          <i
-            class="fa fa-exclamation-triangle"
-          />
-        </div>
-        
-        <span>
-          error_1
-        </span>
-      </div>
-      <div
-        class="d-flex align-items-center o-side-panel-error o-validation-error text-danger"
-      >
-        <div
-          class="o-icon fa-small"
-        >
-          <i
-            class="fa fa-exclamation-triangle"
-          />
-        </div>
-        
-        <span>
-          error_2
-        </span>
+        <i
+          class="fa fa-exclamation-triangle"
+        />
       </div>
       
-      
+      <span>
+        error_1
+      </span>
     </div>
+    <div
+      class="d-flex align-items-center o-side-panel-error o-validation-error text-danger"
+    >
+      <div
+        class="o-icon fa-small"
+      >
+        <i
+          class="fa fa-exclamation-triangle"
+        />
+      </div>
+      
+      <span>
+        error_2
+      </span>
+    </div>
+    
+    
   </div>
 </div>
 `;

--- a/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/label_range.test.ts.snap
@@ -3,60 +3,56 @@
 exports[`Label range Can add options to the label range component 1`] = `
 <div>
   <div
-    class="container"
+    class="o-section o-data-labels"
   >
     <div
-      class="o-section o-data-labels"
+      class="o-section-title"
+    >
+      Categories / Labels
+    </div>
+    
+    <div
+      class="o-selection"
     >
       <div
-        class="o-section-title"
+        class="o-selection-input d-flex flex-row"
       >
-        Categories / Labels
+        <div
+          class="position-relative w-100"
+        >
+          <input
+            class="w-100 o-optional"
+            spellcheck="false"
+            style="color: #000;"
+            type="text"
+          />
+          
+        </div>
+        
       </div>
+      
       
       <div
-        class="o-selection"
+        class="o-selection-input d-flex flex-row"
       >
-        <div
-          class="o-selection-input d-flex flex-row"
-        >
-          <div
-            class="position-relative w-100"
-          >
-            <input
-              class="w-100 o-optional"
-              spellcheck="false"
-              style="color: #000;"
-              type="text"
-            />
-            
-          </div>
-          
-        </div>
         
         
-        <div
-          class="o-selection-input d-flex flex-row"
-        >
-          
-          
-          
-        </div>
+        
       </div>
-      <label
-        class="o-checkbox"
-      >
-        <input
-          class="align-middle"
-          name="my_option"
-          type="checkbox"
-        />
-        My option
-        
-      </label>
-      
-      
     </div>
+    <label
+      class="o-checkbox"
+    >
+      <input
+        class="align-middle"
+        name="my_option"
+        type="checkbox"
+      />
+      My option
+      
+    </label>
+    
+    
   </div>
 </div>
 `;
@@ -64,49 +60,45 @@ exports[`Label range Can add options to the label range component 1`] = `
 exports[`Label range Can render a label range component 1`] = `
 <div>
   <div
-    class="container"
+    class="o-section o-data-labels"
   >
     <div
-      class="o-section o-data-labels"
+      class="o-section-title"
+    >
+      Categories / Labels
+    </div>
+    
+    <div
+      class="o-selection"
     >
       <div
-        class="o-section-title"
+        class="o-selection-input d-flex flex-row"
       >
-        Categories / Labels
+        <div
+          class="position-relative w-100"
+        >
+          <input
+            class="w-100 o-optional"
+            spellcheck="false"
+            style="color: #000;"
+            type="text"
+          />
+          
+        </div>
+        
       </div>
+      
       
       <div
-        class="o-selection"
+        class="o-selection-input d-flex flex-row"
       >
-        <div
-          class="o-selection-input d-flex flex-row"
-        >
-          <div
-            class="position-relative w-100"
-          >
-            <input
-              class="w-100 o-optional"
-              spellcheck="false"
-              style="color: #000;"
-              type="text"
-            />
-            
-          </div>
-          
-        </div>
         
         
-        <div
-          class="o-selection-input d-flex flex-row"
-        >
-          
-          
-          
-        </div>
+        
       </div>
-      
-      
     </div>
+    
+    
   </div>
 </div>
 `;

--- a/tests/side_panels/building_blocks/__snapshots__/title.test.ts.snap
+++ b/tests/side_panels/building_blocks/__snapshots__/title.test.ts.snap
@@ -6,118 +6,114 @@ exports[`Chart title Can render a chart title component 1`] = `
     class="o-spreadsheet"
   >
     <div
-      class="container"
+      class="o-section o-chart-title pb-0"
     >
       <div
-        class="o-section o-chart-title pb-0"
+        class="o-section-title"
       >
-        <div
-          class="o-section-title"
-        >
-          
-          Title
-        </div>
         
-        <input
-          class="o-input o-optional"
-          placeholder="Add a title"
-          type="text"
-        />
+        Title
+      </div>
+      
+      <input
+        class="o-input o-optional"
+        placeholder="Add a title"
+        type="text"
+      />
+      <div
+        class="o-section pt-0 px-0"
+      >
+        
         <div
-          class="o-section pt-0 px-0"
+          class="o-chart-title-designer position-relative d-flex align-items-center"
         >
+          <span
+            class="o-menu-item-button o-hoverable-button"
+            title="Bold"
+          >
+            <span>
+              <svg
+                class="o-icon"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M13.5 6.5C13.5 4.57 11.93 3 10 3H4.5v12h6.25c1.79 0 3.25-1.46 3.25-3.25 0-1.3-.77-2.41-1.87-2.93.83-.58 1.37-1.44 1.37-2.32M9.5 5c.83 0 1.5.67 1.5 1.5S10.33 8 9.5 8h-2V5h2m-2 8v-3H10c.83 0 1.5.67 1.5 1.5S10.83 13 10 13H7.5"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="o-menu-item-button o-hoverable-button"
+            title="Italic"
+          >
+            <span>
+              <svg
+                class="o-icon"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7 3v2h2.58l-3.66 8H3v2h8v-2H8.42l3.66-8H15V3"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="o-menu-item-button o-hoverable-button"
+            title="Horizontal alignment"
+          >
+            <span>
+              
+              
+              <svg
+                class="o-icon align-left"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 16h10v-2H2v2M12 6H2v2h10V6M2 2v2h14V2H2m0 10h14v-2H2v2"
+                  fill="currentColor"
+                />
+              </svg>
+              
+            </span>
+            <div
+              class="o-icon fa-small"
+            >
+              <i
+                class="fa fa-caret-down"
+              />
+            </div>
+            
+          </span>
           
           <div
-            class="o-chart-title-designer position-relative d-flex align-items-center"
+            class="o-color-picker-widget"
           >
             <span
-              class="o-menu-item-button o-hoverable-button"
-              title="Bold"
-            >
-              <span>
-                <svg
-                  class="o-icon"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13.5 6.5C13.5 4.57 11.93 3 10 3H4.5v12h6.25c1.79 0 3.25-1.46 3.25-3.25 0-1.3-.77-2.41-1.87-2.93.83-.58 1.37-1.44 1.37-2.32M9.5 5c.83 0 1.5.67 1.5 1.5S10.33 8 9.5 8h-2V5h2m-2 8v-3H10c.83 0 1.5.67 1.5 1.5S10.83 13 10 13H7.5"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              class="o-menu-item-button o-hoverable-button"
-              title="Italic"
-            >
-              <span>
-                <svg
-                  class="o-icon"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M7 3v2h2.58l-3.66 8H3v2h8v-2H8.42l3.66-8H15V3"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-            </span>
-            <span
-              class="o-menu-item-button o-hoverable-button"
-              title="Horizontal alignment"
-            >
-              <span>
-                
-                
-                <svg
-                  class="o-icon align-left"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M2 16h10v-2H2v2M12 6H2v2h10V6M2 2v2h14V2H2m0 10h14v-2H2v2"
-                    fill="currentColor"
-                  />
-                </svg>
-                
-              </span>
-              <div
-                class="o-icon fa-small"
-              >
-                <i
-                  class="fa fa-caret-down"
-                />
-              </div>
-              
-            </span>
-            
-            <div
-              class="o-color-picker-widget"
+              class="o-color-picker-button o-hoverable-button o-menu-item-button"
             >
               <span
-                class="o-color-picker-button o-hoverable-button o-menu-item-button"
+                style="border-bottom-style: hidden"
               >
-                <span
-                  style="border-bottom-style: hidden"
+                <svg
+                  class="o-icon"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <svg
-                    class="o-icon"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 1H8L3.5 13h2l1.12-3h4.75l1.12 3h2L10 1ZM7.38 8 9 3.67 10.62 8H7.38"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </span>
+                  <path
+                    d="M10 1H8L3.5 13h2l1.12-3h4.75l1.12 3h2L10 1ZM7.38 8 9 3.67 10.62 8H7.38"
+                    fill="currentColor"
+                  />
+                </svg>
               </span>
-              
-            </div>
+            </span>
             
           </div>
           
         </div>
         
       </div>
+      
     </div>
   </div>
 </div>

--- a/tests/side_panels/building_blocks/data_series.test.ts
+++ b/tests/side_panels/building_blocks/data_series.test.ts
@@ -1,23 +1,10 @@
-import { Component, xml } from "@odoo/owl";
 import { ChartDataSeries } from "../../../src/components/side_panel/chart/building_blocks/data_series/data_series";
-import { SpreadsheetChildEnv } from "../../../src/types";
 import { mountComponent } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-type Props = ChartDataSeries["props"];
-
-class Container extends Component<Props, SpreadsheetChildEnv> {
-  static template = xml/* xml */ `
-    <div class="container">
-      <ChartDataSeries t-props="props"/>
-    </div>
-  `;
-  static components = { ChartDataSeries };
-}
-
-async function mountDataSeries(props: Props) {
-  ({ fixture } = await mountComponent(Container, { props }));
+async function mountDataSeries(props: ChartDataSeries["props"]) {
+  ({ fixture } = await mountComponent(ChartDataSeries, { props }));
 }
 
 describe("Data Series", () => {

--- a/tests/side_panels/building_blocks/error_section.test.ts
+++ b/tests/side_panels/building_blocks/error_section.test.ts
@@ -1,23 +1,10 @@
-import { Component, xml } from "@odoo/owl";
 import { ChartErrorSection } from "../../../src/components/side_panel/chart/building_blocks/error_section/error_section";
-import { SpreadsheetChildEnv } from "../../../src/types";
 import { mountComponent } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-type Props = ChartErrorSection["props"];
-
-class Container extends Component<Props, SpreadsheetChildEnv> {
-  static template = xml/* xml */ `
-    <div class="container">
-      <ChartErrorSection t-props="props"/>
-    </div>
-  `;
-  static components = { ChartErrorSection };
-}
-
-async function mountChartErrorSection(props: Props) {
-  ({ fixture } = await mountComponent(Container, { props }));
+async function mountChartErrorSection(props: ChartErrorSection["props"]) {
+  ({ fixture } = await mountComponent(ChartErrorSection, { props }));
 }
 
 describe("Chart error section", () => {

--- a/tests/side_panels/building_blocks/label_range.test.ts
+++ b/tests/side_panels/building_blocks/label_range.test.ts
@@ -1,23 +1,10 @@
-import { Component, xml } from "@odoo/owl";
 import { ChartLabelRange } from "../../../src/components/side_panel/chart/building_blocks/label_range/label_range";
-import { SpreadsheetChildEnv } from "../../../src/types";
 import { mountComponent } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-type Props = ChartLabelRange["props"];
-
-class Container extends Component<Props, SpreadsheetChildEnv> {
-  static template = xml/* xml */ `
-    <div class="container">
-      <ChartLabelRange t-props="props"/>
-    </div>
-  `;
-  static components = { ChartLabelRange };
-}
-
-async function mountLabelRange(props: Props) {
-  ({ fixture } = await mountComponent(Container, { props }));
+async function mountLabelRange(props: ChartLabelRange["props"]) {
+  ({ fixture } = await mountComponent(ChartLabelRange, { props }));
 }
 
 describe("Label range", () => {

--- a/tests/side_panels/building_blocks/title.test.ts
+++ b/tests/side_panels/building_blocks/title.test.ts
@@ -1,24 +1,11 @@
-import { Component, xml } from "@odoo/owl";
 import { ChartTitle } from "../../../src/components/side_panel/chart/building_blocks/title/title";
-import { SpreadsheetChildEnv } from "../../../src/types";
 import { click, setInputValueAndTrigger } from "../../test_helpers/dom_helper";
 import { mountComponentWithPortalTarget } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-type Props = ChartTitle["props"];
-
-class Container extends Component<Props, SpreadsheetChildEnv> {
-  static template = xml/* xml */ `
-    <div class="container">
-      <ChartTitle t-props="props"/>
-    </div>
-  `;
-  static components = { ChartTitle };
-}
-
-async function mountChartTitle(props: Props) {
-  ({ fixture } = await mountComponentWithPortalTarget(Container, { props }));
+async function mountChartTitle(props: ChartTitle["props"]) {
+  ({ fixture } = await mountComponentWithPortalTarget(ChartTitle, { props }));
 }
 
 describe("Chart title", () => {

--- a/tests/side_panels/components/__snapshots__/checkbox.test.ts.snap
+++ b/tests/side_panels/components/__snapshots__/checkbox.test.ts.snap
@@ -2,18 +2,14 @@
 
 exports[`Checkbox Can render a checkbox 1`] = `
 <div>
-  <div
-    class="container"
+  <label
+    class="o-checkbox"
   >
-    <label
-      class="o-checkbox"
-    >
-      <input
-        class="align-middle"
-        type="checkbox"
-      />
-      
-    </label>
-  </div>
+    <input
+      class="align-middle"
+      type="checkbox"
+    />
+    
+  </label>
 </div>
 `;

--- a/tests/side_panels/components/checkbox.test.ts
+++ b/tests/side_panels/components/checkbox.test.ts
@@ -1,24 +1,11 @@
-import { Component, xml } from "@odoo/owl";
 import { Checkbox } from "../../../src/components/side_panel/components/checkbox/checkbox";
-import { SpreadsheetChildEnv } from "../../../src/types";
 import { click } from "../../test_helpers/dom_helper";
 import { mountComponent } from "../../test_helpers/helpers";
 
 let fixture: HTMLElement;
 
-type Props = Checkbox["props"];
-
-class CheckboxContainer extends Component<Props, SpreadsheetChildEnv> {
-  static template = xml/* xml */ `
-    <div class="container">
-      <Checkbox t-props="props"/>
-    </div>
-  `;
-  static components = { Checkbox };
-}
-
-async function mountCheckbox(props: Props) {
-  ({ fixture } = await mountComponent(CheckboxContainer, { props }));
+async function mountCheckbox(props: Checkbox["props"]) {
+  ({ fixture } = await mountComponent(Checkbox, { props }));
 }
 
 describe("Checkbox", () => {

--- a/tests/side_panels/components/section.test.ts
+++ b/tests/side_panels/components/section.test.ts
@@ -18,6 +18,7 @@ describe("Section", () => {
     </div>
   `;
       static components = { Section };
+      static props = { class: String };
     }
     const props = { class: "my-class" };
     ({ fixture } = await mountComponent(SectionContainer, { props }));
@@ -35,6 +36,7 @@ describe("Section", () => {
     </div>
   `;
       static components = { Section };
+      static props = { class: String };
     }
     const props = { class: "my-class" };
     ({ fixture } = await mountComponent(SectionContainer, { props }));

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -16,6 +16,11 @@ class Body extends Component<any, any> {
       <div class="props_body" t-if="props.text"><t t-esc="props.text"/></div>
       <input type="text" class="input" t-if="props.input" />
     </div>`;
+  static props = {
+    text: { type: String, optional: true },
+    input: { type: Boolean, optional: true },
+    onCloseSidePanel: Function,
+  };
 }
 
 class Body2 extends Component<any, any> {
@@ -24,6 +29,7 @@ class Body2 extends Component<any, any> {
       <div class="main_body_2">Hello</div>
       <div class="props_body_2" t-if="props.field"><t t-esc="props.field"/></div>
     </div>`;
+  static props = { field: { type: String, optional: true }, onCloseSidePanel: Function };
 }
 
 class BodyWithoutProps extends Component<any, any> {
@@ -31,6 +37,7 @@ class BodyWithoutProps extends Component<any, any> {
     <div>
       <div class="main_body_3">Hello</div>
     </div>`;
+  static props = { onCloseSidePanel: Function };
 }
 
 beforeEach(async () => {

--- a/tests/table/table_dropdown_button_component.test.ts
+++ b/tests/table/table_dropdown_button_component.test.ts
@@ -20,6 +20,7 @@ class Parent extends Component<{}, SpreadsheetChildEnv> {
     <SidePanel />
   </div>
   `;
+  static props = {};
 }
 
 beforeEach(async () => {

--- a/tests/table/table_style_editor_panel_component.test.ts
+++ b/tests/table/table_style_editor_panel_component.test.ts
@@ -1,4 +1,3 @@
-import { Component, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import { SidePanel } from "../../src/components/side_panel/side_panel/side_panel";
 import { TableStyleEditorPanelProps } from "../../src/components/side_panel/table_style_editor_panel/table_style_editor_panel";
@@ -6,24 +5,14 @@ import { buildTableStyle } from "../../src/helpers/table_presets";
 import { SpreadsheetChildEnv, TableStyle } from "../../src/types";
 import { createTableStyle } from "../test_helpers/commands_helpers";
 import { click, setInputValueAndTrigger } from "../test_helpers/dom_helper";
-import { mountComponent, nextTick } from "../test_helpers/helpers";
+import { mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
 
 let model: Model;
 let fixture: HTMLElement;
 let env: SpreadsheetChildEnv;
 
-class Parent extends Component<{}, SpreadsheetChildEnv> {
-  static components = { SidePanel };
-  static template = xml/*xml*/ `
-    <!-- Portal target -->
-    <div class="o-spreadsheet">
-      <SidePanel />
-    </div>
-    `;
-}
-
 async function mountPanel(partialProps: Partial<TableStyleEditorPanelProps> = {}) {
-  ({ fixture, env } = await mountComponent(Parent, { model }));
+  ({ fixture, env } = await mountComponentWithPortalTarget(SidePanel, { model }));
   const props = { onCloseSidePanel: () => {}, ...partialProps };
   env.openSidePanel("TableStyleEditorPanel", { ...props });
   await nextTick();

--- a/tests/table/table_styles_popover_component.test.ts
+++ b/tests/table/table_styles_popover_component.test.ts
@@ -1,28 +1,16 @@
-import { Component, xml } from "@odoo/owl";
 import { Model } from "../../src";
 import {
   TableStylesPopover,
   TableStylesPopoverProps,
 } from "../../src/components/tables/table_styles_popover/table_styles_popover";
 import { DEFAULT_TABLE_CONFIG } from "../../src/helpers/table_presets";
-import { SpreadsheetChildEnv } from "../../src/types";
 import { createTableStyle } from "../test_helpers/commands_helpers";
 import { click, triggerMouseEvent } from "../test_helpers/dom_helper";
-import { mountComponent, nextTick } from "../test_helpers/helpers";
+import { mountComponentWithPortalTarget, nextTick } from "../test_helpers/helpers";
 
 let model: Model;
 let fixture: HTMLElement;
 let openSidePanel: jest.Mock;
-
-class Parent extends Component<TableStylesPopoverProps, SpreadsheetChildEnv> {
-  static components = { TableStylesPopover };
-  static template = xml/*xml*/ `
-    <!-- Portal target -->
-    <div class="o-spreadsheet">
-      <TableStylesPopover t-props="props" />
-    </div>
-    `;
-}
 
 async function mountPopover(partialProps: Partial<TableStylesPopoverProps> = {}) {
   const props: TableStylesPopoverProps = {
@@ -38,7 +26,7 @@ async function mountPopover(partialProps: Partial<TableStylesPopoverProps> = {})
   };
   openSidePanel = jest.fn();
   const env = { openSidePanel };
-  ({ fixture } = await mountComponent(Parent, { model, props, env }));
+  ({ fixture } = await mountComponentWithPortalTarget(TableStylesPopover, { model, props, env }));
   await nextTick();
 }
 

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -111,6 +111,7 @@ export function addTestPlugin(
 const realTimeSetTimeout = window.setTimeout.bind(window);
 class Root extends Component {
   static template = xml`<div/>`;
+  static props = {};
 }
 const Scheduler = new App(Root).scheduler.constructor as unknown as { requestAnimationFrame: any };
 
@@ -228,6 +229,7 @@ class ParentWithPortalTarget<Props extends ComponentProps> extends Component<
       <t t-component="props.childComponent" t-props="props.childProps"/>
     </div>
   `;
+  static props = { "*": Object };
 }
 
 interface MountComponentArgs<Props extends ComponentProps> {
@@ -265,7 +267,13 @@ export async function mountComponent<Props extends { [key: string]: any }>(
   model.drawLayer = () => {};
   const env = makeTestEnv({ ...optionalArgs.env, model: model });
   const props = optionalArgs.props || ({} as Props);
-  const app = new App(component, { props, env, test: true, translateFn: _t });
+  const app = new App(component, {
+    props,
+    env,
+    test: true,
+    translateFn: _t,
+    warnIfNoStaticProps: true,
+  });
   const fixture = optionalArgs?.fixture || makeTestFixture();
   const parent = await app.mount(fixture);
 
@@ -839,6 +847,7 @@ export class ComposerWrapper extends Component<ComposerWrapperProps, Spreadsheet
   static template = xml/*xml*/ `
     <Composer t-props="composerProps"/>
   `;
+  static props = { composerProps: Object, focusComposer: String };
   state = useState({ focusComposer: <ComposerFocusType>"inactive" });
   composerStore!: Store<ComposerStore>;
   setup() {

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -62,11 +62,24 @@ class Parent extends Component<any, SpreadsheetChildEnv> {
     </div>
   `;
   static components = { TopBar };
+  static props = {};
 
   get gridHeight(): Pixel {
     const { height } = this.env.model.getters.getSheetViewDimension();
     return height;
   }
+}
+
+class Comp extends Component {
+  static template = xml`<div class="o-topbar-test">Test</div>`;
+  static props = {};
+}
+
+class Comp1 extends Comp {
+  static template = xml`<div class="o-topbar-test1">Test1</div>`;
+}
+class Comp2 extends Comp {
+  static template = xml`<div class="o-topbar-test2">Test2</div>`;
 }
 
 async function mountParent(
@@ -503,9 +516,6 @@ describe("TopBar component", () => {
 
   test("Can add a custom component to topbar", async () => {
     const compDefinitions = Object.assign({}, topbarComponentRegistry.content);
-    class Comp extends Component {
-      static template = xml`<div class="o-topbar-test">Test</div>`;
-    }
     topbarComponentRegistry.add("1", { component: Comp });
     await mountParent();
     expect(fixture.querySelectorAll(".o-topbar-test")).toHaveLength(1);
@@ -514,12 +524,6 @@ describe("TopBar component", () => {
 
   test("Can add multiple components to topbar with different visibilities", async () => {
     const compDefinitions = Object.assign({}, topbarComponentRegistry.content);
-    class Comp1 extends Component {
-      static template = xml`<div class="o-topbar-test1">Test1</div>`;
-    }
-    class Comp2 extends Component {
-      static template = xml`<div class="o-topbar-test2">Test2</div>`;
-    }
     let comp1Visibility = false;
     topbarComponentRegistry.add("first", {
       component: Comp1,
@@ -634,12 +638,6 @@ describe("TopBar component", () => {
 
 test("Can show/hide a TopBarComponent based on condition", async () => {
   const compDefinitions = Object.assign({}, topbarComponentRegistry.content);
-  class Comp1 extends Component {
-    static template = xml`<div class="o-topbar-test1">Test1</div>`;
-  }
-  class Comp2 extends Component {
-    static template = xml`<div class="o-topbar-test2">Test2</div>`;
-  }
   topbarComponentRegistry.add("1", {
     component: Comp1,
     isVisible: (env) => true,


### PR DESCRIPTION
## Description

Some components were missing their static props declaration.

Enable the setting `warnIfNoStaticProps` when mounting the app in demo and `mountSpreadsheet` in the tests.

I didn't activate the setting for every `mountComponent` because that means that we have to correctly declare the props of every random component that we create for the tests. But that means that tests can still pass if a component is only testes when mounted in standalone.

Task: : [3984200](https://www.odoo.com/web#id=3984200&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo