### PR TITLE
[IMP] sheetview: lazily re-compute viewports on freeze rows

### DIFF
--- a/src/plugins/ui_stateful/sheetview.ts
+++ b/src/plugins/ui_stateful/sheetview.ts
@@ -207,8 +207,11 @@ export class SheetViewPlugin extends UIPlugin {
       }
       case "REMOVE_FILTER_TABLE":
       case "UPDATE_FILTER":
-        this.sheetsWithDirtyViewports.add(cmd.sheetId);
-        break;
+      case "UNFREEZE_ROWS":
+      case "UNFREEZE_COLUMNS":
+      case "FREEZE_COLUMNS":
+      case "FREEZE_ROWS":
+      case "UNFREEZE_COLUMNS_ROWS":
       case "REMOVE_COLUMNS_ROWS":
       case "RESIZE_COLUMNS_ROWS":
       case "HIDE_COLUMNS_ROWS":
@@ -221,11 +224,9 @@ export class SheetViewPlugin extends UIPlugin {
       case "FOLD_HEADER_GROUPS_IN_ZONE":
       case "UNFOLD_HEADER_GROUPS_IN_ZONE":
       case "UNFOLD_ALL_HEADER_GROUPS":
-      case "FOLD_ALL_HEADER_GROUPS": {
-        const sheetId = "sheetId" in cmd ? cmd.sheetId : this.getters.getActiveSheetId();
-        this.sheetsWithDirtyViewports.add(sheetId);
+      case "FOLD_ALL_HEADER_GROUPS":
+        this.sheetsWithDirtyViewports.add(cmd.sheetId);
         break;
-      }
       case "UPDATE_CELL":
         // update cell content or format can change hidden rows because of data filters
         if ("content" in cmd || "format" in cmd || cmd.style?.fontSize !== undefined) {
@@ -240,13 +241,6 @@ export class SheetViewPlugin extends UIPlugin {
         break;
       case "ACTIVATE_SHEET":
         this.sheetsWithDirtyViewports.add(cmd.sheetIdTo);
-        break;
-      case "UNFREEZE_ROWS":
-      case "UNFREEZE_COLUMNS":
-      case "FREEZE_COLUMNS":
-      case "FREEZE_ROWS":
-      case "UNFREEZE_COLUMNS_ROWS":
-        this.resetViewports(this.getters.getActiveSheetId());
         break;
       case "DELETE_SHEET":
         this.sheetsWithDirtyViewports.delete(cmd.sheetId);


### PR DESCRIPTION
## Description

Currently the viewports are immediately recomputed when receiving a FREEZE_ROW command. That means that it's impossible to batch a FREEZE_ROW command with an UPDATE_CELL command, for example, as the header positions are unavailable until the finalize after an UPDATE_CELL command.

Task: : [3600662](https://www.odoo.com/web#id=3600662&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo