### PR TITLE
[REF] pivot: do not create table in INSERT_PIVOT command

### DIFF
--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -1,17 +1,8 @@
-import { PIVOT_TABLE_CONFIG } from "../../constants";
 import { deepCopy, deepEquals, isDefined } from "../../helpers";
 import { getMaxObjectId, makePivotFormula } from "../../helpers/pivot/pivot_helpers";
 import { SpreadsheetPivotTable } from "../../helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot";
 import { _t } from "../../translation";
-import {
-  CellPosition,
-  CommandResult,
-  CoreCommand,
-  CreateTableCommand,
-  Position,
-  UID,
-  WorkbookData,
-} from "../../types";
+import { CellPosition, CommandResult, CoreCommand, Position, UID, WorkbookData } from "../../types";
 import { PivotCoreDefinition, PivotTableCell } from "../../types/pivot";
 import { CorePlugin } from "../core_plugin";
 
@@ -183,22 +174,6 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
         };
         this.addPivotFormula(cellPosition, formulaId, pivotCell);
       }
-    }
-    const pivotZone = {
-      top: position.row,
-      bottom: position.row + pivotCells[0].length - 1,
-      left: position.col,
-      right: position.col + pivotCells.length - 1,
-    };
-    const numberOfHeaders = table.columns.length - 1;
-    const cmdContent: Omit<CreateTableCommand, "type"> = {
-      sheetId: position.sheetId,
-      ranges: [this.getters.getRangeDataFromZone(position.sheetId, pivotZone)],
-      config: { ...PIVOT_TABLE_CONFIG, numberOfHeaders },
-      tableType: "static",
-    };
-    if (this.canDispatch("CREATE_TABLE", cmdContent).isSuccessful) {
-      this.dispatch("CREATE_TABLE", cmdContent);
     }
   }
 


### PR DESCRIPTION
Creating a table on a pivot should not be part of the INSERT_PIVOT plugin, it should be handled by the caller if needed. INSERT_PIVOT should simply be "Insert the formula of this pivot at this location".

Task: 3987435

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo