### PR TITLE
[FIX] collaborative: snapshot only when no pending changes

### DIFF
--- a/src/collaborative/session.ts
+++ b/src/collaborative/session.ts
@@ -176,6 +176,9 @@ export class Session extends EventBus<CollaborativeEvent> {
    * Send a snapshot of the spreadsheet to the collaboration server
    */
   snapshot(data: WorkbookData) {
+    if (this.pendingMessages.length !== 0) {
+      return;
+    }
     const snapshotId = this.uuidGenerator.uuidv4();
     this.transportService.sendMessage({
       type: "SNAPSHOT",


### PR DESCRIPTION
Since 7bcff34394, we snapshot the spreadsheet when the user leaves the spreadsheet and there is no other connected users.

However, if the user updates the spreadsheet (which sends a revision to the server) and leaves immediatly without waiting for the server's response, the snapshot is made even though it's completely useless. It won't be accepted because it's not sent with the correct last (accepted) server revision id.

The correct server revision id to send would be the one from the first sent revision, but we don't know yet if it's accepted by the server or not.

Task: 0

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo