### PR TITLE
[FIX] pivot: cannot use pivot formula inside its range

### DIFF
--- a/src/functions/helper_lookup.ts
+++ b/src/functions/helper_lookup.ts
@@ -1,4 +1,4 @@
-import { toZone, zoneToXc } from "../helpers";
+import { isZoneInside, toZone, zoneToXc } from "../helpers";
 import { _t } from "../translation";
 import { CellPosition, EvalContext, Getters, UID } from "../types";
 import { EvaluationError, InvalidReferenceError } from "../types/errors";
@@ -49,6 +49,11 @@ export function addPivotDependencies(
   const originCellXC = evalContext.__originCellXC?.();
   if (originCellXC) {
     const cellZone = toZone(originCellXC);
+    if (originSheetId === sheetId && isZoneInside(cellZone, zone)) {
+      throw new EvaluationError(
+        `Function [[FUNCTION_NAME]] cannot be used in its range data (${zoneToXc(zone)}).`
+      );
+    }
     originPosition = {
       sheetId: originSheetId,
       col: cellZone.left,

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -446,6 +446,14 @@ describe("Spreadsheet Pivot", () => {
     expect(getEvaluatedGrid(model, "B26:F26")).toEqual([["5", "9", "14", "Total", ""]]);
   });
 
+  test("Cannot use PIVOT function inside its range", () => {
+    const model = createModelWithPivot("A1:I5");
+    setCellContent(model, "B3", `=PIVOT("1")`);
+    expect(getCellError(model, "B3")).toBe(
+      "Function PIVOT cannot be used in its range data (A1:I5)."
+    );
+  });
+
   describe("Pivot reevaluation", () => {
     test("Pivot fields reevaluation", () => {
       const model = new Model({


### PR DESCRIPTION
Before this commit, a pivot formula was allowed to be used inside its range. This is now disallowed.

Task: 3986479

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo