### PR TITLE
[IMP] pivot: add menu item to fix formulas

### DIFF
--- a/src/helpers/pivot/pivot_menu_items.ts
+++ b/src/helpers/pivot/pivot_menu_items.ts
@@ -15,3 +15,38 @@ export const pivotProperties: ActionSpec = {
   },
   icon: "o-spreadsheet-Icon.PIVOT",
 };
+
+export const FIX_FORMULAS: ActionSpec = {
+  name: _t("Convert to individual formulas"),
+  execute(env) {
+    const position = env.model.getters.getActivePosition();
+    const cell = env.model.getters.getCorrespondingFormulaCell(position);
+    const pivotId = env.model.getters.getPivotIdFromPosition(position);
+    if (!cell || !pivotId) {
+      return;
+    }
+    const { sheetId, col, row } = env.model.getters.getCellPosition(cell.id);
+    const pivot = env.model.getters.getPivot(pivotId);
+    pivot.init();
+    if (!pivot.isValid()) {
+      return;
+    }
+    env.model.dispatch("INSERT_PIVOT", {
+      sheetId,
+      col,
+      row,
+      pivotId,
+      table: pivot.getTableStructure().export(),
+    });
+  },
+  isVisible: (env) => {
+    const position = env.model.getters.getActivePosition();
+    const pivotId = env.model.getters.getPivotIdFromPosition(position);
+    if (!pivotId) {
+      return false;
+    }
+    const pivot = env.model.getters.getPivot(pivotId);
+    return pivot.isValid() && env.model.getters.isSpillPivotFormula(position);
+  },
+  icon: "o-spreadsheet-Icon.PIVOT",
+};

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -33,6 +33,7 @@ export class PivotUIPlugin extends UIPlugin {
     "getPivotDomainArgsFromPosition",
     "isPivotUnused",
     "areDomainArgsFieldsValid",
+    "isSpillPivotFormula",
   ] as const;
 
   private pivots: Record<UID, Pivot> = {};
@@ -118,6 +119,15 @@ export class PivotUIPlugin extends UIPlugin {
       }
     }
     return undefined;
+  }
+
+  isSpillPivotFormula(position: CellPosition) {
+    const cell = this.getters.getCorrespondingFormulaCell(position);
+    if (cell && cell.isFormula) {
+      const pivotFunction = this.getFirstPivotFunction(cell.compiledFormula.tokens);
+      return pivotFunction?.functionName === "PIVOT";
+    }
+    return false;
   }
 
   getFirstPivotFunction(tokens: Token[]) {

--- a/src/registries/menus/cell_menu_registry.ts
+++ b/src/registries/menus/cell_menu_registry.ts
@@ -106,6 +106,10 @@ cellMenuRegistry
     sequence: 150,
     separator: true,
   })
+  .add("pivot_fix_formulas", {
+    ...ACTIONS_PIVOT.FIX_FORMULAS,
+    sequence: 155,
+  })
   .add("pivot_properties", {
     ...ACTIONS_PIVOT.pivotProperties,
     sequence: 160,

--- a/tests/pivots/pivot_menu_items.test.ts
+++ b/tests/pivots/pivot_menu_items.test.ts
@@ -1,7 +1,8 @@
 import { Model, SpreadsheetChildEnv } from "../../src";
 import { cellMenuRegistry } from "../../src/registries";
 import { selectCell, setCellContent } from "../test_helpers/commands_helpers";
-import { makeTestEnv } from "../test_helpers/helpers";
+import { getCellText, getEvaluatedGrid } from "../test_helpers/getters_helpers";
+import { createModelFromGrid, makeTestEnv } from "../test_helpers/helpers";
 import { addPivot } from "../test_helpers/pivot_helpers";
 
 describe("Pivot menu items", () => {
@@ -60,5 +61,113 @@ describe("Pivot menu items", () => {
     const openSidePanel = jest.spyOn(env, "openSidePanel");
     cellMenuRegistry.get("pivot_properties").execute!(env);
     expect(openSidePanel).toHaveBeenCalledWith("PivotSidePanel", { pivotId: "1" });
+  });
+
+  test("It should fix formula when clicking on pivot_fix_formulas", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Product",  C1: "Quantity", D1: "Amount", E1: "Date",
+      A2: "Alice",    B2: "Jambon",   C2: "2",        D2: "10",     E2: "2/4/2023",
+      A3: "Bob",      B3: "Poulet",   C3: "3",        D3: "20",     E3: "1/1/2024",
+      A4: "Charlie",  B4: "Jambon",   C4: "1",        D4: "5",      E4: "1/4/2024",
+      A5: "Alice",    B5: "Tabouret", C5: "5",        D5: "50",     E5: "5/5/2024",
+      A6: "Bob",      B6: "Tabouret", C6: "4",        D6: "40",     E6: "12/31/2024",
+      A8: "=PIVOT(1)",
+    };
+    const model = createModelFromGrid(grid);
+    const env = makeTestEnv({ model });
+    addPivot(model, "A1:E6", {
+      columns: [{ name: "Customer", order: "asc" }],
+      rows: [{ name: "Date", order: "asc", granularity: "month_number" }],
+      measures: [{ name: "Amount", aggregator: "sum" }],
+    });
+    // Zone of the pivot is from A8 to E14
+    selectCell(model, "B8");
+    cellMenuRegistry.get("pivot_fix_formulas").execute!(env);
+
+    // prettier-ignore
+    expect(getEvaluatedGrid(model, "A8:E14")).toEqual([
+      ["",         "Alice",  "Bob",    "Charlie", "Total"],
+      ["",         "Amount", "Amount", "Amount",  "Amount"],
+      ["January",  "",       "20",     "5",       "25"],
+      ["February", "10",     "",       "",        "10"],
+      ["May",      "50",     "",       "",        "50"],
+      ["December", "",       "40",     "",        "40"],
+      ["Total",    "60",     "60",     "5",       "125"],
+    ]);
+
+    model.dispatch("SET_FORMULA_VISIBILITY", { show: true });
+    expect(getEvaluatedGrid(model, "A8:E14")).toEqual([
+      [
+        "",
+        `=PIVOT.HEADER(1,"Customer","Alice")`,
+        `=PIVOT.HEADER(1,"Customer","Bob")`,
+        `=PIVOT.HEADER(1,"Customer","Charlie")`,
+        "=PIVOT.HEADER(1)",
+      ],
+      [
+        "",
+        `=PIVOT.HEADER(1,"Customer","Alice","measure","Amount")`,
+        `=PIVOT.HEADER(1,"Customer","Bob","measure","Amount")`,
+        `=PIVOT.HEADER(1,"Customer","Charlie","measure","Amount")`,
+        `=PIVOT.HEADER(1,"measure","Amount")`,
+      ],
+      [
+        `=PIVOT.HEADER(1,"Date:month_number",1)`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",1,"Customer","Alice")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",1,"Customer","Bob")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",1,"Customer","Charlie")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",1)`,
+      ],
+      [
+        `=PIVOT.HEADER(1,"Date:month_number",2)`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",2,"Customer","Alice")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",2,"Customer","Bob")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",2,"Customer","Charlie")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",2)`,
+      ],
+      [
+        `=PIVOT.HEADER(1,"Date:month_number",5)`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",5,"Customer","Alice")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",5,"Customer","Bob")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",5,"Customer","Charlie")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",5)`,
+      ],
+      [
+        `=PIVOT.HEADER(1,"Date:month_number",12)`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",12,"Customer","Alice")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",12,"Customer","Bob")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",12,"Customer","Charlie")`,
+        `=PIVOT.VALUE(1,"Amount","Date:month_number",12)`,
+      ],
+      [
+        `=PIVOT.HEADER(1)`,
+        `=PIVOT.VALUE(1,"Amount","Customer","Alice")`,
+        `=PIVOT.VALUE(1,"Amount","Customer","Bob")`,
+        `=PIVOT.VALUE(1,"Amount","Customer","Charlie")`,
+        `=PIVOT.VALUE(1,"Amount")`,
+      ],
+    ]);
+  });
+
+  test("It should not fix formula when the pivot is not valid", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice",    B2: "10",
+      A3: "Bob",      B3: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ name: "Invalid" }],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+    const env = makeTestEnv({ model });
+    const pivot = model.getters.getPivot("1")!;
+    expect(pivot.isValid()).toBe(false);
+    selectCell(model, "C1");
+    cellMenuRegistry.get("pivot_fix_formulas").execute!(env);
+    expect(getCellText(model, "C1")).toBe("=PIVOT(1)");
   });
 });

--- a/tests/pivots/pivot_plugin.test.ts
+++ b/tests/pivots/pivot_plugin.test.ts
@@ -1,0 +1,31 @@
+import { setCellContent } from "../test_helpers/commands_helpers";
+import { createModelFromGrid, toCellPosition } from "../test_helpers/helpers";
+import { addPivot } from "../test_helpers/pivot_helpers";
+
+describe("Pivot plugin", () => {
+  test("isSpillPivotFormula", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "=PIVOT(1)",
+      A2: "Alice",    B2: "10",
+      A3: "Bob",      B3: "30",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ name: "Customer" }],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+
+    const sheetId = model.getters.getActiveSheetId();
+    const isSpillPivotFormula = (xc: string) =>
+      model.getters.isSpillPivotFormula(toCellPosition(sheetId, xc));
+    expect(isSpillPivotFormula("A1")).toBe(false); //Dataset
+    expect(isSpillPivotFormula("C1")).toBe(true); // PIVOT Formula
+    expect(isSpillPivotFormula("D2")).toBe(true); // Spill result
+    setCellContent(model, "G1", "=PIVOT.VALUE(1)");
+    expect(isSpillPivotFormula("G1")).toBe(false);
+    setCellContent(model, "G1", "=PIVOT.HEADER(1)");
+    expect(isSpillPivotFormula("G1")).toBe(false);
+  });
+});

--- a/tests/test_helpers/debug_helpers.ts
+++ b/tests/test_helpers/debug_helpers.ts
@@ -1,8 +1,10 @@
 import { Model } from "../../src";
-import { concat } from "../../src/helpers";
+import { concat, zoneToXc } from "../../src/helpers";
 import { Branch } from "../../src/history/branch";
 import { Tree } from "../../src/history/tree";
 import { UID } from "../../src/types";
+import { getEvaluatedGrid } from "./getters_helpers";
+import { toCellPosition } from "./helpers";
 
 interface Data {
   _commands?: any[];
@@ -69,4 +71,17 @@ export function getDebugInfo(tree: Tree) {
 export function printDebugModel(model: Model) {
   // @ts-ignore
   console.log(getDebugInfo(model["session"]["revisions"]["tree"]));
+}
+
+/**
+ * Display the result of a PIVOT formula (the spill one)
+ */
+export function printPivot(model: Model, xc: string) {
+  const sheetId = model.getters.getActiveSheetId();
+  const position = toCellPosition(sheetId, xc);
+  const zone = model.getters.getSpreadZone(position);
+  if (!zone) {
+    throw new Error("No zone found");
+  }
+  console.table(getEvaluatedGrid(model, zoneToXc(zone)));
 }


### PR DESCRIPTION
With this commit, a user can easily fix formulas of its pivot. Fixing a formula is simply replacing the =PIVOT formula with a formula by cell.

Task: 3987157

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo