### PR TITLE
[IMP] locale: add warning

### DIFF
--- a/src/components/side_panel/settings/settings_panel.xml
+++ b/src/components/side_panel/settings/settings_panel.xml
@@ -27,6 +27,12 @@
             <span t-esc="dateTimeFormatPreview"/>
           </div>
         </div>
+        <div class="alert alert-primary d-flex align-items-center mt-2" role="alert">
+          <div class="o-icon">
+            <i class="fa fa-info"/>
+          </div>
+          <div>This setting affects all users.</div>
+        </div>
       </Section>
     </div>
   </t>


### PR DESCRIPTION
Changing the spreadsheet locale affects all users but users might not realize that.

In an international company (such as Odoo), french speaking users might change the locale to FR (thinking it's only for themselves), even though it should probably be kept to English.

This task adds a small info warning.

Task: 3989485

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo