### PR TITLE
[REM] chart: remove unused code

### DIFF
--- a/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
+++ b/src/components/side_panel/chart/gauge_chart_panel/gauge_chart_design_panel.ts
@@ -96,16 +96,6 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     );
   }
 
-  updateBackgroundColor(color: Color) {
-    this.props.updateChart(this.props.figureId, {
-      background: color,
-    });
-  }
-
-  updateTitle(content: string) {
-    this.props.updateChart(this.props.figureId, { title: { text: content } });
-  }
-
   isRangeMinInvalid() {
     return !!(
       this.state.sectionRuleDispatchResult?.isCancelledBecause(CommandResult.EmptyGaugeRangeMin) ||
@@ -171,9 +161,5 @@ export class GaugeChartDesignPanel extends Component<Props, SpreadsheetChildEnv>
     this.state.sectionRuleDispatchResult = this.props.canUpdateChart(this.props.figureId, {
       sectionRule,
     });
-  }
-
-  get backgroundColorTitle() {
-    return ChartTerms.BackgroundColor;
   }
 }

--- a/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
+++ b/src/components/side_panel/chart/scorecard_chart_panel/scorecard_chart_design_panel.ts
@@ -2,7 +2,6 @@ import { Component } from "@odoo/owl";
 import { _t } from "../../../../translation";
 import { ScorecardChartDefinition } from "../../../../types/chart/scorecard_chart";
 import { Color, DispatchResult, SpreadsheetChildEnv, UID } from "../../../../types/index";
-import { ChartTerms } from "../../../translations_terms";
 import { Checkbox } from "../../components/checkbox/checkbox";
 import { SidePanelCollapsible } from "../../components/collapsible/side_panel_collapsible";
 import { RoundColorPicker } from "../../components/round_color_picker/round_color_picker";
@@ -44,10 +43,6 @@ export class ScorecardChartDesignPanel extends Component<Props, SpreadsheetChild
     return _t("Humanize numbers");
   }
 
-  updateTitle(content: string) {
-    this.props.updateChart(this.props.figureId, { title: { text: content } });
-  }
-
   updateHumanizeNumbers(humanize: boolean) {
     this.props.updateChart(this.props.figureId, { humanize });
   }
@@ -72,9 +67,5 @@ export class ScorecardChartDesignPanel extends Component<Props, SpreadsheetChild
         this.props.updateChart(this.props.figureId, { baselineColorUp: color });
         break;
     }
-  }
-
-  get backgroundColorTitle() {
-    return ChartTerms.BackgroundColor;
   }
 }


### PR DESCRIPTION
## Description:

- remove unused code in gauge_chart_design_panel.ts and scorecard_chart_design_panel.ts

Task: 0

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo