### PR TITLE
[IMP] pivot_time_adapter: store number and avoid useless conversion

### DIFF
--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -37,21 +37,19 @@ export function pivotTimeAdapter(granularity: Granularity): PivotTimeAdapter<Cel
  * - "MM/dd/yyyy" (luxon format)
  * - "mm/dd/yyyy" (spreadsheet format)
  **/
-const dayAdapter: PivotTimeAdapter<string> = {
+const dayAdapter: PivotTimeAdapter<number> = {
   normalizeFunctionValue(value) {
-    const date = toNumber(value, DEFAULT_LOCALE);
-    return formatValue(date, { locale: DEFAULT_LOCALE, format: "mm/dd/yyyy" });
+    return toNumber(value, DEFAULT_LOCALE);
   },
   getFormat(locale) {
     return (locale ?? DEFAULT_LOCALE).dateFormat;
   },
   formatValue(normalizedValue, locale) {
     locale = locale ?? DEFAULT_LOCALE;
-    const value = toNumber(normalizedValue, DEFAULT_LOCALE);
-    return formatValue(value, { locale, format: this.getFormat(locale) });
+    return formatValue(normalizedValue, { locale, format: this.getFormat(locale) });
   },
   toCellValue(normalizedValue) {
-    return toNumber(normalizedValue, DEFAULT_LOCALE);
+    return normalizedValue;
   },
 };
 
@@ -73,11 +71,10 @@ const dayOfMonthAdapter: PivotTimeAdapter<number> = {
   },
   formatValue(normalizedValue, locale) {
     locale = locale ?? DEFAULT_LOCALE;
-    const value = toNumber(normalizedValue, DEFAULT_LOCALE);
-    return formatValue(value, { locale, format: this.getFormat(locale) });
+    return formatValue(normalizedValue, { locale, format: this.getFormat(locale) });
   },
   toCellValue(normalizedValue) {
-    return toNumber(normalizedValue, DEFAULT_LOCALE);
+    return normalizedValue;
   },
 };
 
@@ -119,11 +116,10 @@ const isoWeekNumberAdapter: PivotTimeAdapter<number> = {
   },
   formatValue(normalizedValue, locale) {
     locale = locale ?? DEFAULT_LOCALE;
-    const value = toNumber(normalizedValue, DEFAULT_LOCALE);
-    return formatValue(value, { locale, format: this.getFormat(locale) });
+    return formatValue(normalizedValue, { locale, format: this.getFormat(locale) });
   },
   toCellValue(normalizedValue) {
-    return toNumber(normalizedValue, DEFAULT_LOCALE);
+    return normalizedValue;
   },
 };
 
@@ -167,8 +163,7 @@ const monthNumberAdapter: PivotTimeAdapter<number> = {
   },
   formatValue(normalizedValue, locale) {
     locale = locale ?? DEFAULT_LOCALE;
-    const value = toNumber(normalizedValue, DEFAULT_LOCALE);
-    return formatValue(value, { locale, format: this.getFormat(locale) });
+    return formatValue(normalizedValue, { locale, format: this.getFormat(locale) });
   },
   toCellValue(normalizedValue) {
     return MONTHS[toNumber(normalizedValue, DEFAULT_LOCALE) - 1].toString();
@@ -214,11 +209,10 @@ const quarterNumberAdapter: PivotTimeAdapter<number> = {
   },
   formatValue(normalizedValue, locale) {
     locale = locale ?? DEFAULT_LOCALE;
-    const value = toNumber(normalizedValue, DEFAULT_LOCALE);
-    return formatValue(value, { locale, format: this.getFormat(locale) });
+    return formatValue(normalizedValue, { locale, format: this.getFormat(locale) });
   },
   toCellValue(normalizedValue) {
-    return toNumber(normalizedValue, DEFAULT_LOCALE);
+    return normalizedValue;
   },
 };
 
@@ -234,7 +228,7 @@ const yearAdapter: PivotTimeAdapter<number> = {
     return formatValue(normalizedValue, { locale, format: "0" });
   },
   toCellValue(normalizedValue) {
-    return toNumber(normalizedValue, DEFAULT_LOCALE);
+    return normalizedValue;
   },
 };
 

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -27,11 +27,11 @@ describe("toNormalizedPivotValue", () => {
         granularity: "day",
       };
       // day
-      expect(toNormalizedPivotValue(dimension, "1/11/2020")).toBe("01/11/2020");
-      expect(toNormalizedPivotValue(dimension, "01/11/2020")).toBe("01/11/2020");
-      expect(toNormalizedPivotValue(dimension, "11/2020")).toBe("11/01/2020");
-      expect(toNormalizedPivotValue(dimension, "1")).toBe("12/31/1899");
-      expect(toNormalizedPivotValue(dimension, 1)).toBe("12/31/1899");
+      expect(toNormalizedPivotValue(dimension, "1/11/2020")).toBe(43_841);
+      expect(toNormalizedPivotValue(dimension, "01/11/2020")).toBe(43_841);
+      expect(toNormalizedPivotValue(dimension, "11/2020")).toBe(44_136);
+      expect(toNormalizedPivotValue(dimension, "1")).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 1)).toBe(1);
       expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
       expect(toNormalizedPivotValue(dimension, false)).toBe(false);
       // week

--- a/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
@@ -29,7 +29,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(4);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(14);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(5);
-    expect(createDate(DAY_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe("04/05/2024");
+    expect(createDate(DAY_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(45_387);
 
     const d04_may_2024 = 45_416;
     expect(createDate(YEAR_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(2024);
@@ -37,7 +37,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(MONTH_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(5);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(18);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(4);
-    expect(createDate(DAY_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe("05/04/2024");
+    expect(createDate(DAY_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(45_416);
 
     const d01_january_2019 = 43_466;
     expect(createDate(YEAR_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(2019);
@@ -45,7 +45,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(MONTH_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
-    expect(createDate(DAY_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe("01/01/2019");
+    expect(createDate(DAY_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(43_466);
   });
 
   test("createDate with datetime values", () => {
@@ -56,7 +56,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(4);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(14);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(5);
-    expect(createDate(DAY_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe("04/05/2024");
+    expect(createDate(DAY_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(45_387);
   });
 
   test("createDate throw with unknown granularity", () => {


### PR DESCRIPTION
With this commit, the normalized value stored for a date with a granularity of "day" is now a number instead of a string. This number is the number of the date as stored in the spreadsheet.

This commit also simplify other adapters that handled numbers, as they made some useless conversion.

In the pivot of the demo page (makePivotDataset) with 5k lines grouped by date:day, the time for the evaluations drops from ± 75s to ± 15s.

Task: 3989580

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo