### PR TITLE
[FIX] pivot: support empty date

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
@@ -8,6 +8,9 @@ export function createDate(dimension: PivotDimension, value: FieldValue["value"]
   if (!(granularity in MAP_VALUE_DIMENSION_DATE)) {
     throw new Error(`Unknown date granularity: ${granularity}`);
   }
+  if (value === null) {
+    return null;
+  }
   if (!MAP_VALUE_DIMENSION_DATE[granularity].set.has(value)) {
     MAP_VALUE_DIMENSION_DATE[granularity].set.add(value);
     const date = toJsDate(value, locale);

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -188,7 +188,8 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
     if (!finalCell) {
       return { value: "" };
     }
-    if (finalCell.value === null) {
+    // Value can be null but stringified (e.g. an empty date, as for now every date is stringified)
+    if (finalCell.value === null || finalCell.value === `${null}`) {
       return { value: _t("(Undefined)") };
     }
     if (dimension.type === "date") {

--- a/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
@@ -61,6 +61,15 @@ describe("Date Spreadsheet Pivot", () => {
     );
   });
 
+  test("createDate with null values", () => {
+    expect(createDate(YEAR_NUMBER_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
+    expect(createDate(QUARTER_NUMBER_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
+    expect(createDate(MONTH_NUMBER_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
+    expect(createDate(ISO_WEEK_NUMBER_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
+    expect(createDate(DAY_OF_MONTH_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
+    expect(createDate(DAY_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
+  });
+
   test("createDate throw with unknown granularity", () => {
     const unknownGranularity = "unknown_granularity";
     expect(() => createDate(createPivotDimension(unknownGranularity), 0, DEFAULT_LOCALE)).toThrow(

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -469,6 +469,21 @@ describe("Spreadsheet Pivot", () => {
     });
   });
 
+  test("Date dimensions should support empty cells", () => {
+    const grid = {
+      A1: "Date",
+      A2: "",
+      A3: "2024-03-01",
+      A4: "=pivot(1)",
+    };
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:A3", {
+      columns: [{ name: "Date", granularity: "month_number" }],
+      measures: [{ name: "__count" }],
+    });
+    expect(getEvaluatedGrid(model, "B4:E4")).toEqual([["March", "(Undefined)", "Total", ""]]);
+  });
+
   describe("Pivot reevaluation", () => {
     test("Pivot fields reevaluation", () => {
       const model = new Model({


### PR DESCRIPTION
Steps to reproduce:
- Open the demo sheet with the pivot
- Remove random date value => December appears

Task: 3989717

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo