### PR TITLE
[IMP] pivot: normalize values

### DIFF
--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -2,7 +2,7 @@ import { CommandResult } from "..";
 import { canonicalizeNumberValue } from "../formulas/formula_locale";
 import { deepEquals, formatValue } from "../helpers";
 import { getPasteZones } from "../helpers/clipboard/clipboard_helpers";
-import { makePivotFormulaFromPivotCell } from "../helpers/pivot/pivot_helpers";
+import { createPivotFormula } from "../helpers/pivot/pivot_helpers";
 import {
   CellPosition,
   ClipboardCell,
@@ -50,7 +50,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
           if (!deepEquals(spreader, position) || !isCopyingOneCell) {
             const pivotCell = this.getters.getPivotCellFromPosition(position);
             const formulaPivotId = this.getters.getPivotFormulaId(pivotId);
-            const pivotFormula = makePivotFormulaFromPivotCell(formulaPivotId, pivotCell);
+            const pivotFormula = createPivotFormula(formulaPivotId, pivotCell);
             cell = {
               id: cell?.id || "",
               style: cell?.style,

--- a/src/components/composer/composer/composer_store.ts
+++ b/src/components/composer/composer/composer_store.ts
@@ -24,7 +24,7 @@ import {
   getDateTimeFormat,
   localizeFormula,
 } from "../../../helpers/locale";
-import { makePivotFormulaFromPivotCell } from "../../../helpers/pivot/pivot_helpers";
+import { createPivotFormula } from "../../../helpers/pivot/pivot_helpers";
 import { cycleFixedReference } from "../../../helpers/reference_type";
 import {
   AutoCompleteProvider,
@@ -646,7 +646,7 @@ export class ComposerStore extends SpreadsheetStore {
       const cell = this.getters.getCell(position);
       if (pivotId && pivotCell.type !== "EMPTY" && !cell?.isFormula) {
         const formulaPivotId = this.getters.getPivotFormulaId(pivotId);
-        const formula = makePivotFormulaFromPivotCell(formulaPivotId, pivotCell);
+        const formula = createPivotFormula(formulaPivotId, pivotCell);
         return formula.slice(1); // strip leading =
       }
     }

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -32,11 +32,7 @@ export class PivotSidePanelStore extends SpreadsheetStore {
   }
 
   get fields() {
-    const fields = this.pivot.getFields();
-    if (!fields) {
-      throw new Error("Fields not found");
-    }
-    return fields;
+    return this.pivot.getFields();
   }
 
   get pivot() {

--- a/src/functions/helper_lookup.ts
+++ b/src/functions/helper_lookup.ts
@@ -1,6 +1,6 @@
 import { toZone, zoneToXc } from "../helpers";
 import { _t } from "../translation";
-import { CellPosition, EvalContext, Getters, UID } from "../types";
+import { CellPosition, EvalContext, FPayload, Getters, Maybe, UID } from "../types";
 import { EvaluationError, InvalidReferenceError } from "../types/errors";
 import { PivotCoreDefinition } from "../types/pivot";
 
@@ -29,7 +29,7 @@ export function assertMeasureExist(pivotId: UID, measure: string, getters: Gette
   }
 }
 
-export function assertDomainLength(domain: string[]) {
+export function assertDomainLength(domain: Maybe<FPayload>[]) {
   if (domain.length % 2 !== 0) {
     throw new EvaluationError(_t("Function PIVOT takes an even number of arguments."));
   }

--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -1,4 +1,4 @@
-import { EvaluatedCell } from "../../../types";
+import { CellValue, EvaluatedCell } from "../../../types";
 import { PivotDimension, PivotTableColumn, PivotTableRow } from "../../../types/pivot";
 import { SpreadsheetPivotRuntimeDefinition } from "./runtime_definition_spreadsheet_pivot";
 import { SpreadsheetPivotTable } from "./table_spreadsheet_pivot";
@@ -10,7 +10,7 @@ export type DataEntry = Record<FieldName, FieldValue | undefined>;
 export type DataEntries = DataEntry[];
 
 interface ColumnsNode {
-  value: string;
+  value: CellValue;
   field: string;
   children: ColumnsTree;
   width: number;
@@ -38,7 +38,14 @@ export function dataEntriesToSpreadsheetPivotTable(
   });
 
   const measureNames = definition.measures.map((m) => m.name);
-  return new SpreadsheetPivotTable(cols, rows, measureNames);
+  const fieldsType: Record<string, string> = {};
+  for (const columns of definition.columns) {
+    fieldsType[columns.name] = columns.type;
+  }
+  for (const row of definition.rows) {
+    fieldsType[row.name] = row.type;
+  }
+  return new SpreadsheetPivotTable(cols, rows, measureNames, fieldsType);
 }
 
 // -----------------------------------------------------------------------------
@@ -54,7 +61,7 @@ function dataEntriesToRows(
   index: number,
   rows: PivotDimension[],
   fields: string[],
-  values: string[]
+  values: CellValue[]
 ): PivotTableRow[] {
   if (index >= rows.length) {
     return [];
@@ -138,7 +145,7 @@ function columnsTreeToColumns(
 
   const headers: PivotTableColumn[][] = new Array(height).fill(0).map(() => []);
 
-  function generateTreeHeaders(tree: ColumnsTree, rowIndex: number, val: string[]) {
+  function generateTreeHeaders(tree: ColumnsTree, rowIndex: number, val: CellValue[]) {
     const row = headers[rowIndex];
     for (const node of tree) {
       const localVal = val.concat([node.value]);

--- a/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
@@ -1,47 +1,48 @@
 import { toJsDate, toNumber } from "../../../functions/helpers";
-import { Locale } from "../../../types";
+import { CellValue, Locale } from "../../../types";
 import { PivotDimension } from "../../../types/pivot";
 import { toNormalizedPivotValue } from "../pivot_helpers";
-import { FieldValue } from "./data_entry_spreadsheet_pivot";
 
-export function createDate(dimension: PivotDimension, value: FieldValue["value"], locale: Locale) {
+const NULL_SYMBOL = Symbol("NULL");
+
+export function createDate(dimension: PivotDimension, value: CellValue, locale: Locale): CellValue {
   const granularity = dimension.granularity;
   if (!granularity || !(granularity in MAP_VALUE_DIMENSION_DATE)) {
     throw new Error(`Unknown date granularity: ${granularity}`);
   }
-  if (value === null) {
-    return null;
-  }
+  const keyInMap = typeof value === "number" || typeof value === "string" ? value : NULL_SYMBOL;
   if (!MAP_VALUE_DIMENSION_DATE[granularity].set.has(value)) {
     MAP_VALUE_DIMENSION_DATE[granularity].set.add(value);
-    const date = toJsDate(value, locale);
-    let number: FieldValue["value"] = 0;
-    switch (granularity) {
-      case "year_number":
-        number = date.getFullYear();
-        break;
-      case "quarter_number":
-        number = Math.floor(date.getMonth() / 3) + 1;
-        break;
-      case "month_number":
-        number = date.getMonth() + 1;
-        break;
-      case "iso_week_number":
-        number = date.getIsoWeek();
-        break;
-      case "day_of_month":
-        number = date.getDate();
-        break;
-      case "day":
-        number = Math.floor(toNumber(value, locale));
-        break;
+    let number: CellValue = null;
+    if (typeof value === "number" || typeof value === "string") {
+      const date = toJsDate(value, locale);
+      switch (granularity) {
+        case "year_number":
+          number = date.getFullYear();
+          break;
+        case "quarter_number":
+          number = Math.floor(date.getMonth() / 3) + 1;
+          break;
+        case "month_number":
+          number = date.getMonth() + 1;
+          break;
+        case "iso_week_number":
+          number = date.getIsoWeek();
+          break;
+        case "day_of_month":
+          number = date.getDate();
+          break;
+        case "day":
+          number = Math.floor(toNumber(value, locale));
+          break;
+      }
     }
-    MAP_VALUE_DIMENSION_DATE[granularity].values[`${value}`] = toNormalizedPivotValue(
+    MAP_VALUE_DIMENSION_DATE[granularity].values[keyInMap] = toNormalizedPivotValue(
       dimension,
       number
     );
   }
-  return MAP_VALUE_DIMENSION_DATE[granularity].values[`${value}`];
+  return MAP_VALUE_DIMENSION_DATE[granularity].values[keyInMap];
 }
 
 /**
@@ -76,30 +77,30 @@ export function createDate(dimension: PivotDimension, value: FieldValue["value"]
  */
 const MAP_VALUE_DIMENSION_DATE: Record<
   string,
-  { set: Set<FieldValue["value"]>; values: Record<string, FieldValue["value"]> }
+  { set: Set<CellValue>; values: Record<string | number | symbol, CellValue> }
 > = {
   year_number: {
-    set: new Set<FieldValue["value"]>(),
+    set: new Set<CellValue>(),
     values: {},
   },
   quarter_number: {
-    set: new Set<FieldValue["value"]>(),
+    set: new Set<CellValue>(),
     values: {},
   },
   month_number: {
-    set: new Set<FieldValue["value"]>(),
+    set: new Set<CellValue>(),
     values: {},
   },
   iso_week_number: {
-    set: new Set<FieldValue["value"]>(),
+    set: new Set<CellValue>(),
     values: {},
   },
   day_of_month: {
-    set: new Set<FieldValue["value"]>(),
+    set: new Set<CellValue>(),
     values: {},
   },
   day: {
-    set: new Set<FieldValue["value"]>(),
+    set: new Set<CellValue>(),
     values: {},
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,14 +115,14 @@ import {
 import { supportedPivotPositionalFormulaRegistry } from "./helpers/pivot/pivot_positional_formula_registry";
 
 import {
-  flatPivotDomain,
+  areDomainArgsFieldsValid,
+  createPivotFormula,
   getMaxObjectId,
   isDateField,
-  makePivotFormula,
   parseDimension,
   pivotNormalizationValueRegistry,
+  pivotToFunctionValueRegistry,
   toNormalizedPivotValue,
-  toPivotDomain,
 } from "./helpers/pivot/pivot_helpers";
 import { getPivotHighlights } from "./helpers/pivot/pivot_highlight";
 import { pivotRegistry } from "./helpers/pivot/pivot_registry";
@@ -275,6 +275,7 @@ export const registries = {
   pivotSidePanelRegistry,
   pivotNormalizationValueRegistry,
   supportedPivotPositionalFormulaRegistry,
+  pivotToFunctionValueRegistry,
 };
 export const helpers = {
   arg,
@@ -320,7 +321,6 @@ export const helpers = {
   expandZoneOnInsertion,
   reduceZoneOnDeletion,
   unquote,
-  makePivotFormula,
   getMaxObjectId,
   getFunctionsFromTokens,
   getFirstPivotFunction,
@@ -332,10 +332,10 @@ export const helpers = {
   insertTokenAfterLeftParenthesis,
   mergeContiguousZones,
   getPivotHighlights,
-  toPivotDomain,
-  flatPivotDomain,
   pivotTimeAdapter,
   UNDO_REDO_PIVOT_COMMANDS,
+  createPivotFormula,
+  areDomainArgsFieldsValid,
 };
 
 export const links = {

--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -1,5 +1,5 @@
 import { deepCopy, deepEquals } from "../../helpers";
-import { getMaxObjectId, makePivotFormulaFromPivotCell } from "../../helpers/pivot/pivot_helpers";
+import { createPivotFormula, getMaxObjectId } from "../../helpers/pivot/pivot_helpers";
 import { SpreadsheetPivotTable } from "../../helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot";
 import { _t } from "../../translation";
 import { CellPosition, CommandResult, CoreCommand, Position, UID, WorkbookData } from "../../types";
@@ -74,8 +74,8 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
       case "INSERT_PIVOT": {
         const { sheetId, col, row, pivotId, table } = cmd;
         const position = { sheetId, col, row };
-        const { cols, rows, measures } = table;
-        const spTable = new SpreadsheetPivotTable(cols, rows, measures);
+        const { cols, rows, measures, fieldsType } = table;
+        const spTable = new SpreadsheetPivotTable(cols, rows, measures, fieldsType || {});
         const formulaId = this.getPivotFormulaId(pivotId);
         this.insertPivot(position, formulaId, spTable);
         break;
@@ -171,7 +171,7 @@ export class PivotCorePlugin extends CorePlugin<CoreState> implements CoreState 
           sheetId: position.sheetId,
           col: position.col + col,
           row: position.row + row,
-          content: makePivotFormulaFromPivotCell(formulaId, pivotCell),
+          content: createPivotFormula(formulaId, pivotCell),
         });
       }
     }

--- a/src/registries/auto_completes/pivot_auto_complete.ts
+++ b/src/registries/auto_completes/pivot_auto_complete.ts
@@ -66,9 +66,6 @@ autoCompleteProviders.add("pivot_measures", {
     const pivot = this.getters.getPivot(pivotId);
     pivot.init();
     const fields = pivot.getFields();
-    if (!fields) {
-      return [];
-    }
     const definition = this.getters.getPivotCoreDefinition(pivotId);
 
     return definition.measures
@@ -112,9 +109,6 @@ autoCompleteProviders.add("pivot_group_fields", {
     const pivot = this.getters.getPivot(pivotId);
     pivot.init();
     const fields = pivot.getFields();
-    if (!fields) {
-      return;
-    }
     const { columns, rows } = pivot.definition;
 
     let args = functionContext.args;

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -1,7 +1,6 @@
 import { CellValue } from "./cells";
-import { Format } from "./format";
 import { Locale } from "./locale";
-import { UID, Zone } from "./misc";
+import { FPayload, UID, Zone } from "./misc";
 
 export type Aggregator =
   | "array_agg"
@@ -86,14 +85,14 @@ export interface PivotDimension extends PivotCoreDimension {
 
 export interface PivotTableColumn {
   fields: string[];
-  values: string[];
+  values: CellValue[];
   width: number;
   offset: number;
 }
 
 export interface PivotTableRow {
   fields: string[];
-  values: string[];
+  values: CellValue[];
   indent: number;
 }
 
@@ -101,6 +100,7 @@ export interface PivotTableData {
   cols: PivotTableColumn[][];
   rows: PivotTableRow[];
   measures: string[];
+  fieldsType?: Record<string, string | undefined>; // TODO Make it mandatory when JSON migration is available
 }
 
 export interface PivotHeaderCell {
@@ -130,16 +130,22 @@ export type PivotTableCell =
   | PivotValueCell
   | PivotEmptyCell;
 
+export interface PivotTimeAdapterNotNull<T> {
+  normalizeFunctionValue: (value: Exclude<CellValue, null>) => T;
+  toValueAndFormat: (normalizedValue: T, locale?: Locale) => FPayload;
+  toFunctionValue: (normalizedValue: T) => string;
+}
+
 export interface PivotTimeAdapter<T> {
-  normalizeFunctionValue: (value: string) => T;
-  formatValue: (normalizedValue: T, locale?: Locale) => string;
-  getFormat: (locale?: Locale) => Format | undefined;
-  toCellValue: (normalizedValue: T) => CellValue;
+  normalizeFunctionValue: (value: CellValue) => T | null;
+  toValueAndFormat: (normalizedValue: T, locale?: Locale) => FPayload;
+  toFunctionValue: (normalizedValue: T) => string;
 }
 
 export interface PivotNode {
   field: string;
-  value: string | number | boolean;
+  type: string;
+  value: CellValue;
 }
 
 export type PivotDomain = PivotNode[];

--- a/src/types/pivot_runtime.ts
+++ b/src/types/pivot_runtime.ts
@@ -1,6 +1,6 @@
 import { PivotRuntimeDefinition } from "../helpers/pivot/pivot_runtime_definition";
 import { SpreadsheetPivotTable } from "../helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot";
-import { FPayload } from "./misc";
+import { FPayload, Maybe } from "./misc";
 import {
   PivotCoreDefinition,
   PivotDimension,
@@ -19,13 +19,16 @@ export interface Pivot<T = PivotRuntimeDefinition> {
   isValid(): boolean;
 
   getTableStructure(): SpreadsheetPivotTable;
-  getFields(): PivotFields | undefined;
+  getFields(): PivotFields;
 
   getPivotHeaderValueAndFormat(domain: PivotDomain): FPayload;
   getPivotCellValueAndFormat(measure: string, domain: PivotDomain): FPayload;
   getPivotMeasureValue(measure: string, domain: PivotDomain): FPayload;
 
   getMeasure: (name: string) => PivotMeasure;
+
+  parseArgsToPivotDomain(args: Maybe<FPayload>[]): PivotDomain;
+  areDomainArgsFieldsValid(args: Maybe<FPayload>[]): boolean;
 
   assertIsValid({ throwOnError }: { throwOnError: boolean }): FPayload | undefined;
   getPossibleFieldValues(

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -1,4 +1,7 @@
-import { toNormalizedPivotValue } from "../../src/helpers/pivot/pivot_helpers";
+import {
+  toFunctionPivotValue,
+  toNormalizedPivotValue,
+} from "../../src/helpers/pivot/pivot_helpers";
 
 describe("toNormalizedPivotValue", () => {
   test("parse values of char field", () => {
@@ -27,11 +30,11 @@ describe("toNormalizedPivotValue", () => {
         granularity: "day",
       };
       // day
-      expect(toNormalizedPivotValue(dimension, "1/11/2020")).toBe("01/11/2020");
-      expect(toNormalizedPivotValue(dimension, "01/11/2020")).toBe("01/11/2020");
-      expect(toNormalizedPivotValue(dimension, "11/2020")).toBe("11/01/2020");
-      expect(toNormalizedPivotValue(dimension, "1")).toBe("12/31/1899");
-      expect(toNormalizedPivotValue(dimension, 1)).toBe("12/31/1899");
+      expect(toNormalizedPivotValue(dimension, "1/11/2020")).toBe(43841);
+      expect(toNormalizedPivotValue(dimension, "01/11/2020")).toBe(43841);
+      expect(toNormalizedPivotValue(dimension, "11/2020")).toBe(44136);
+      expect(toNormalizedPivotValue(dimension, "1")).toBe(1);
+      expect(toNormalizedPivotValue(dimension, 1)).toBe(1);
       expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
       expect(toNormalizedPivotValue(dimension, false)).toBe(false);
       // week
@@ -181,5 +184,73 @@ describe("toNormalizedPivotValue", () => {
     expect(() => toNormalizedPivotValue(dimension, "1")).toThrow();
     expect(() => toNormalizedPivotValue(dimension, 1)).toThrow();
     expect(() => toNormalizedPivotValue(dimension, "won")).toThrow();
+  });
+});
+
+describe("ToFunctionValue", () => {
+  test("Format values of char field", () => {
+    const dimension = { type: "char" };
+    expect(toFunctionPivotValue("won", dimension)).toBe(`"won"`);
+    expect(toFunctionPivotValue("1", dimension)).toBe(`"1"`);
+    expect(toFunctionPivotValue(1, dimension)).toBe(`"1"`);
+    expect(toFunctionPivotValue("11/2020", dimension)).toBe(`"11/2020"`);
+    expect(toFunctionPivotValue("2020", dimension)).toBe(`"2020"`);
+    expect(toFunctionPivotValue("01/11/2020", dimension)).toBe(`"01/11/2020"`);
+    expect(toFunctionPivotValue("false", dimension)).toBe(`"false"`);
+    expect(toFunctionPivotValue(false, dimension)).toBe(`"FALSE"`);
+    expect(toFunctionPivotValue("true", dimension)).toBe(`"true"`);
+  });
+
+  test("Format values of number field", () => {
+    const dimension = { type: "integer" };
+    expect(() => toFunctionPivotValue("won", dimension)).toThrow();
+    expect(toFunctionPivotValue("1", dimension)).toBe("1");
+    expect(toFunctionPivotValue(1, dimension)).toBe("1");
+    expect(toFunctionPivotValue("11/2020", dimension)).toBe("44136");
+    expect(toFunctionPivotValue("2020", dimension)).toBe("2020");
+    expect(toFunctionPivotValue("01/11/2020", dimension)).toBe("43841");
+    expect(() => toFunctionPivotValue("false", dimension)).toThrow();
+    expect(toFunctionPivotValue(false, dimension)).toBe("0");
+    expect(() => toFunctionPivotValue("true", dimension)).toThrow();
+  });
+
+  test.each(["date", "datetime"])("Format values of %s fields", (type: string) => {
+    const dimension = { type, granularity: "day" };
+    // day
+    expect(toFunctionPivotValue("1/11/2020", dimension)).toBe(`"01/11/2020"`);
+    // week
+    dimension.granularity = "week";
+    expect(toFunctionPivotValue("11/2020", dimension)).toBe(`"11/2020"`);
+    // month
+    dimension.granularity = "month";
+    expect(toFunctionPivotValue("11/2020", dimension)).toBe(`"11/2020"`);
+    // year
+    dimension.granularity = "year";
+    expect(toFunctionPivotValue("2020", dimension)).toBe("2020");
+
+    dimension.granularity = "year_number";
+    expect(toFunctionPivotValue("2020", dimension)).toBe("2020");
+
+    dimension.granularity = "day_of_month";
+    expect(toFunctionPivotValue(1, dimension)).toBe("1");
+
+    dimension.granularity = "iso_week_number";
+    expect(toFunctionPivotValue(1, dimension)).toBe("1");
+
+    dimension.granularity = "month_number";
+    expect(toFunctionPivotValue(1, dimension)).toBe("1");
+
+    dimension.granularity = "quarter_number";
+    expect(toFunctionPivotValue(1, dimension)).toBe("1");
+  });
+
+  test("Format values of boolean field", () => {
+    const dimension = {
+      type: "boolean",
+    };
+    expect(toFunctionPivotValue("false", dimension)).toBe("FALSE");
+    expect(toFunctionPivotValue(false, dimension)).toBe("FALSE");
+    expect(toFunctionPivotValue("true", dimension)).toBe("TRUE");
+    expect(toFunctionPivotValue(true, dimension)).toBe("TRUE");
   });
 });

--- a/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
@@ -29,7 +29,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(4);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(14);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(5);
-    expect(createDate(DAY_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe("04/05/2024");
+    expect(createDate(DAY_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(d05_april_2024);
 
     const d04_may_2024 = 45_416;
     expect(createDate(YEAR_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(2024);
@@ -37,7 +37,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(MONTH_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(5);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(18);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(4);
-    expect(createDate(DAY_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe("05/04/2024");
+    expect(createDate(DAY_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(d04_may_2024);
 
     const d01_january_2019 = 43_466;
     expect(createDate(YEAR_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(2019);
@@ -45,7 +45,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(MONTH_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
-    expect(createDate(DAY_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe("01/01/2019");
+    expect(createDate(DAY_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(d01_january_2019);
   });
 
   test("createDate with datetime values", () => {
@@ -56,7 +56,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(4);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(14);
     expect(createDate(DAY_OF_MONTH_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(5);
-    expect(createDate(DAY_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe("04/05/2024");
+    expect(createDate(DAY_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(45_387);
   });
 
   test("createDate with null values", () => {

--- a/tests/test_helpers/constants.ts
+++ b/tests/test_helpers/constants.ts
@@ -421,7 +421,7 @@ export const TEST_COMMANDS: CommandMapping = {
     sheetId: "sheetId",
     col: 0,
     row: 0,
-    table: new SpreadsheetPivotTable([[]], [], []).export(),
+    table: new SpreadsheetPivotTable([[]], [], [], {}).export(),
   },
   REMOVE_PIVOT: {
     type: "REMOVE_PIVOT",


### PR DESCRIPTION
Before this commit, all values of a pivot (e.g. each arguments, each
values available for a field, etc.) were all stringified before being
used. This was done in order to be able to compare them easily during
the introduction of pivots.
Of course, this is not optimal as it implies a lot of useless conversion
(e.g to compare the year 2024 to the value 2024 in the function, we
stringified the two values, which was not efficient at all).

Here are some examples of the process, before this commit:

To filter the DataEntries based on a PivotNode (an pair field-value):
- Stringify the result of `toNormalizedPivotValue` (this function
  already parse the value to a CellValue)
- Stringify the each value of the field in the DataEntries.
- Compare them

From PIVOT.HEADER or PIVOT.VALUE formulas:
- Call `toString` on each arguments
- Filter the DataEntries based on the arguments for each node (see above)
- For a date time => Re-normalize the value in order to use the
  `PivotTimeAdapter` to get the format and value to return (as FPayload)

From PIVOT formula:
- Values to construct the SpreadsheetPivotTable are stringified
- Filter the DataEntries based on the arguments for each node (see above)
- For a date time => Re-normalize the value in order to use the
  `PivotTimeAdapter` to get the format and value to return (as FPayload)

Now, the values are directly in the right type (boolean, string or
number), based on the type of the field. It is done either in the
construction of the SpreadsheetPivotTable (the values from the cells are
directly in the right type => nothing to do) or in the PIVOT.HEADER or
PIVOT.VALUE formulas (by calling `toNormalizedPivotValue` on each
arguments).

So, the processes listed above are now:

To filter the DataEntries based on a PivotNode (an pair field-value):
- Compare the value to each value in the DataEntry. We now compare
  boolean with boolean, string with string and number with number.

From PIVOT.HEADER or PIVOT.VALUE formulas:
- Normalize each arguments, `toString` for the field, and
  `toNormalizedPivotValue` for the value
- Filter the DataEntries based on the arguments for each node (see above)
- Return the value, directly in the correct type.

From PIVOT formula:
- Values to construct the SpreadsheetPivotTable are not converted
- Filter the DataEntries based on the arguments for each node (see above)
- Return the value, directly in the correct type.

In addition, the type of the normalized value for date with granularity
`day` is now number instead of string. It reduced by 83% the time to
load a pivot with 5k rows grouped by a date field on granularity `day`.

To be able to support the positional arguments for the Odoo pivot, the
parsing of the domain is now done in the pivot itself. The validation
of the domain is also done in the pivot.A nice thing is that we can get
rid of the mention of `#` in `areDomainArgsFieldsValid` !.

This commit also removes some useless methods in the `PivotTimeAdapter`.

Task: 3991743