### PR TITLE
[REM] ChartTitle: removed the default chart title

### DIFF
--- a/src/helpers/figures/charts/chart_factory.ts
+++ b/src/helpers/figures/charts/chart_factory.ts
@@ -5,7 +5,6 @@ import {
 } from "../../../constants";
 import { isEvaluationError } from "../../../functions/helpers";
 import { chartRegistry } from "../../../registries/chart_types";
-import { _t } from "../../../translation";
 import {
   AddColumnsRowsCommand,
   CellValueType,
@@ -133,7 +132,7 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
   if (getZoneArea(zone) === 1 && topLeftCell?.content) {
     return {
       type: "scorecard",
-      title: { text: "" },
+      title: {},
       background: topLeftCell.style?.fillColor || undefined,
       keyValue: zoneToXc(zone),
       baselineMode: DEFAULT_SCORECARD_BASELINE_MODE,
@@ -142,7 +141,6 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
     };
   }
 
-  let title = "";
   const cellsInFirstRow = getters.getEvaluatedCellsInZone(sheetId, {
     ...dataSetZone,
     bottom: dataSetZone.top,
@@ -150,18 +148,6 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
   const dataSetsHaveTitle = !!cellsInFirstRow.find(
     (cell) => cell.type !== CellValueType.empty && cell.type !== CellValueType.number
   );
-
-  if (dataSetsHaveTitle) {
-    const texts = cellsInFirstRow
-      .filter((cell) => cell.type !== CellValueType.error && cell.type !== CellValueType.empty)
-      .map((cell) => cell.formattedValue);
-
-    const lastElement = texts.splice(-1)[0];
-    title = texts.join(", ");
-    if (lastElement) {
-      title += (title ? " " + _t("and") + " " : "") + lastElement;
-    }
-  }
 
   let labelRangeXc: string | undefined;
   if (!singleColumn) {
@@ -176,7 +162,7 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
   const labelRange = labelRangeXc ? getters.getRangeFromSheetXC(sheetId, labelRangeXc) : undefined;
   if (canChartParseLabels(labelRange, getters)) {
     return {
-      title: { text: title },
+      title: {},
       dataSets,
       labelsAsText: false,
       stacked: false,
@@ -194,7 +180,7 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
     getData(getters, _dataSets[0]).every((e) => typeof e === "string" && !isEvaluationError(e))
   ) {
     return {
-      title: { text: "" },
+      title: {},
       dataSets: [{ dataRange }],
       aggregated: true,
       labelRange: dataRange,
@@ -204,7 +190,7 @@ export function getSmartChartDefinition(zone: Zone, getters: Getters): ChartDefi
     };
   }
   return {
-    title: { text: title },
+    title: {},
     dataSets,
     labelRange: labelRangeXc,
     type: "bar",

--- a/tests/figures/chart/menu_item_insert_chart.test.ts
+++ b/tests/figures/chart/menu_item_insert_chart.test.ts
@@ -116,7 +116,7 @@ describe("Insert chart menu item", () => {
         legendPosition: "none",
         stacked: false,
         aggregated: false,
-        title: { text: expect.any(String) },
+        title: {},
         type: "bar",
       },
     };
@@ -369,45 +369,6 @@ describe("Insert chart menu item", () => {
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
   });
 
-  test("Chart title should be set by default if dataset have any", () => {
-    setSelection(model, ["B1:C4"]);
-    insertChart();
-    const payload = { ...defaultPayload };
-    payload.definition.dataSets = [{ dataRange: "C1:C4", yAxisId: "y" }];
-    payload.definition.legendPosition = "none";
-    payload.definition.title = { text: "" };
-    payload.definition.dataSetsHaveTitle = false;
-    payload.definition.labelRange = "B1:B4";
-    expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
-  });
-  test("Chart title should only generate string and numerical values", async () => {
-    setSelection(model, ["C1:G4"]);
-    insertChart();
-    const payload = { ...defaultPayload };
-    payload.definition.dataSets = [{ dataRange: "D1:G4", yAxisId: "y" }];
-    payload.definition.legendPosition = "top";
-    payload.definition.title = { text: "Title1 and 3" };
-    payload.definition.dataSetsHaveTitle = true;
-    payload.definition.labelRange = "C1:C4";
-    payload.definition.type = "line";
-    payload.definition.cumulative = false;
-    payload.definition.labelsAsText = false;
-    expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
-  });
-  test("Chart title should only append and prefix to last title", () => {
-    setSelection(model, ["C1:H4"]);
-    insertChart();
-    const payload = { ...defaultPayload };
-    payload.definition.dataSets = [{ dataRange: "D1:H4", yAxisId: "y" }];
-    payload.definition.legendPosition = "top";
-    payload.definition.title = { text: "Title1, 3 and Title2" };
-    payload.definition.dataSetsHaveTitle = true;
-    payload.definition.labelRange = "C1:C4";
-    payload.definition.type = "line";
-    payload.definition.cumulative = false;
-    payload.definition.labelsAsText = false;
-    expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);
-  });
   test("[Case 1] Chart is inserted with proper legend position", () => {
     setSelection(model, ["A1:B5"]);
     insertChart();
@@ -439,7 +400,7 @@ describe("Insert chart menu item", () => {
     const payload = { ...defaultPayload };
     payload.definition = {
       keyValue: "K5",
-      title: { text: expect.any(String) },
+      title: {},
       type: "scorecard",
       baselineColorDown: DEFAULT_SCORECARD_BASELINE_COLOR_DOWN,
       baselineColorUp: DEFAULT_SCORECARD_BASELINE_COLOR_UP,
@@ -527,7 +488,7 @@ describe("Insert chart menu item", () => {
         legendPosition: "top",
         type: "pie",
         dataSetsHaveTitle: false,
-        title: { text: "" },
+        title: {},
       },
     };
     expect(dispatchSpy).toHaveBeenCalledWith("CREATE_CHART", payload);


### PR DESCRIPTION
## Description:

This PR eliminates the logic that provided a default title to charts created via the menu item.

Task: : [3924665](https://www.odoo.com/web#id=3924665&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo