### PR TITLE
[FIX] evaluation: spill blocked array formula

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -267,7 +267,6 @@ export class Evaluator {
     if (!this.blockedArrayFormulas.has(position)) {
       this.invalidateSpreading(position);
     }
-    this.spreadingRelations.removeNode(position);
 
     const cell = this.getters.getCell(position);
     if (cell === undefined) {
@@ -325,6 +324,8 @@ export class Evaluator {
 
     const nbColumns = formulaReturn.length;
     const nbRows = formulaReturn[0].length;
+
+    this.spreadingRelations.removeNode(formulaPosition);
 
     forEachSpreadPositionInMatrix(nbColumns, nbRows, this.updateSpreadRelation(formulaPosition));
     this.assertNoMergedCellsInSpreadZone(formulaPosition, formulaReturn);

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -124,6 +124,16 @@ describe("evaluate formulas that return an array", () => {
     expect((getEvaluatedCell(model, "A2") as ErrorCell).message).toBe("Function GETERR failed");
   });
 
+  test("delete blocking content spills the result", () => {
+    setCellContent(model, "A1", "=MFILL(3,3, 42)");
+    setCellContent(model, "A2", "coucou");
+    expect(getEvaluatedCell(model, "A1").value).toBe("#SPILL!");
+
+    addColumns(model, "before", "A", 1); // this forces a full re-evaluation
+    deleteContent(model, ["B2"]);
+    expect(getEvaluatedCell(model, "B1").value).toBe(42);
+  });
+
   describe("spread matrix with format", () => {
     test("can spread matrix of values with matrix of format", () => {
       functionRegistry.add("MATRIX.2.2", {


### PR DESCRIPTION
## Description:

Steps to reproduce

1. in A1, set =TRANSPOSE(B1:D1)
2. in A3, set any content
3. select column A and "Insert column left"
4. delete the content which is now in B3

=> A1 is still blocked.

What happens:
After step (2), everything is fine. The spreading relations are correct in `this.spreadingRelations`. When adding the new column however: this forces a full evaluation (cell are evaluated in order: A1, then A3). A1 is evaluated first, it's blocked but `this.spreadingRelations` knows its result should spill on A2 and A3. Next A3 is evaluated, which removes it from this.spreadingRelations

When the content in A3 is later deleted, the relation between A3 and A1 is gone and A1 is not re-evaluated.

Bug introduced by https://github.com/odoo/o-spreadsheet/commit/53ac0317f68ee6db696784a038ae3ee2223b732c

Task: : [3986897](https://www.odoo.com/web#id=3986897&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo