### PR TITLE
[IMP] tables: add test for header inserted next to table

### DIFF
--- a/tests/table/tables_plugin.test.ts
+++ b/tests/table/tables_plugin.test.ts
@@ -337,6 +337,28 @@ describe("Table plugin", () => {
       setCellContent(model, "A4", "Something");
       expect(zoneToXc(model.getters.getTables(sheetId)[0].range.zone)).toEqual("A1:B3");
     });
+
+    test("Table zone is not expanded when inserting a col/row next to it", () => {
+      // Note: this is more a limitation of our current behaviour of `adaptRanges` than a feature
+      // In fact, this seems bugged when drag & drop a column of a table to the left of the table,
+      // we expect the table to include this column but it does not.
+      // But changing this behaviour would either require tables to not use `Range`, or to have a
+      // complete overhaul of the way ranges work, which will probably break some spreadsheets and
+      // does not seems worth it ATM.
+      createTable(model, "B2:C3");
+
+      addColumns(model, "before", "B", 1);
+      expect(zoneToXc(model.getters.getTables(sheetId)[0].range.zone)).toEqual("C2:D3");
+
+      addColumns(model, "after", "D", 1);
+      expect(zoneToXc(model.getters.getTables(sheetId)[0].range.zone)).toEqual("C2:D3");
+
+      addRows(model, "before", 1, 1);
+      expect(zoneToXc(model.getters.getTables(sheetId)[0].range.zone)).toEqual("C3:D4");
+
+      addRows(model, "after", 3, 1);
+      expect(zoneToXc(model.getters.getTables(sheetId)[0].range.zone)).toEqual("C3:D4");
+    });
   });
 
   describe("Grid manipulation", () => {


### PR DESCRIPTION
This commit adds a test that checks that a table is not expanded when inserting a header next to it.

This is more a limitation of our current behaviour of `adaptRanges` than a feature. In fact, this seems bugged when drag & drop a column of a table to the left of the table, we expect the table to include this column but it does not.

But changing this behaviour would either require tables to not use `Range`, or to have a complete overhaul of the way ranges work, which will probably break some spreadsheets and does not seems worth it ATM.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo