### PR TITLE
[FIX] tests: remove toLocaleString from test

### DIFF
--- a/tests/figures/chart/scorecard_chart_component.test.ts
+++ b/tests/figures/chart/scorecard_chart_component.test.ts
@@ -19,9 +19,11 @@ import {
   setFormat,
   setStyle,
   updateChart,
+  updateLocale,
 } from "../../test_helpers/commands_helpers";
 import { getCellContent } from "../../test_helpers/getters_helpers";
 import { toRangesData } from "../../test_helpers/helpers";
+import { FR_LOCALE } from "./../../test_helpers/constants";
 
 let model: Model;
 let chartId: string;
@@ -290,11 +292,22 @@ describe("Scorecard charts computation", () => {
     expect(chartDesign.key?.text).toEqual("200%");
   });
 
+  test("Baseline is displayed with the spreadsheet locale", () => {
+    setCellContent(model, "C1", "=B2");
+    createScorecardChart(model, { keyValue: "A3", baseline: "C1" }, chartId);
+    let chartDesign = getChartDesign(model, chartId, sheetId);
+    expect(chartDesign.baseline?.text).toEqual("0.12");
+
+    updateLocale(model, FR_LOCALE);
+    chartDesign = getChartDesign(model, chartId, sheetId);
+    expect(chartDesign.baseline?.text).toEqual("0,12");
+  });
+
   test("Baseline is displayed with the cell evaluated format", () => {
     setCellContent(model, "C1", "=B2");
     createScorecardChart(model, { keyValue: "A3", baseline: "C1" }, chartId);
     let chartDesign = getChartDesign(model, chartId, sheetId);
-    expect(chartDesign.baseline?.text).toEqual((0.12).toLocaleString());
+    expect(chartDesign.baseline?.text).toEqual("0.12");
 
     setFormat(model, "B2", "[$$]#,##0.00");
     chartDesign = getChartDesign(model, chartId, sheetId);
@@ -305,7 +318,7 @@ describe("Scorecard charts computation", () => {
     setCellContent(model, "C1", "=B2");
     createScorecardChart(model, { keyValue: "A3", baseline: "B2" }, chartId);
     const chartDesign = getChartDesign(model, chartId, sheetId);
-    expect(chartDesign.baseline?.text).toEqual((0.12).toLocaleString());
+    expect(chartDesign.baseline?.text).toEqual("0.12");
     expect(getCellContent(model, "A3")).toEqual("2.1234");
   });
 


### PR DESCRIPTION
Since 17.3, the baseline of scorecards is correctly formatted with the spreadsheet's locale instead of using `toLocaleString()`.

The tests were still testing with `toLocaleString()`, causing them to fail in a french locale.

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo