### PR TITLE
[IMP] FindAndReplace: default search scope to activeSheet

### DIFF
--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -22,7 +22,7 @@
           </div>
         </div>
         <select
-          class="o-input o-type-selector o-type-range-selector mt-3 mb-3"
+          class="o-input o-type-range-selector mt-3 mb-3"
           t-on-change="changeSearchScope"
           t-att-value="searchOptions.searchScope">
           <option value="allSheets">All sheets</option>

--- a/src/components/side_panel/find_and_replace/find_and_replace.xml
+++ b/src/components/side_panel/find_and_replace/find_and_replace.xml
@@ -23,7 +23,8 @@
         </div>
         <select
           class="o-input o-type-selector o-type-range-selector mt-3 mb-3"
-          t-on-change="changeSearchScope">
+          t-on-change="changeSearchScope"
+          t-att-value="searchOptions.searchScope">
           <option value="allSheets">All sheets</option>
           <option value="activeSheet">Current sheet</option>
           <option value="specificRange">Specific range</option>

--- a/src/components/side_panel/find_and_replace/find_and_replace_store.ts
+++ b/src/components/side_panel/find_and_replace/find_and_replace_store.ts
@@ -42,7 +42,7 @@ export class FindAndReplaceStore extends SpreadsheetStore implements HighlightPr
     matchCase: false,
     exactMatch: false,
     searchFormulas: false,
-    searchScope: "allSheets",
+    searchScope: "activeSheet",
     specificRange: undefined,
   };
 

--- a/tests/find_and_replace/find_and_replace_store.test.ts
+++ b/tests/find_and_replace/find_and_replace_store.test.ts
@@ -88,11 +88,22 @@ describe("basic search", () => {
     expect(store.selectedMatchIndex).toStrictEqual(0);
   });
 
+  test("default search scope is set to activeSheet", () => {
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "test");
+    createSheet(model, { sheetId: "sh2", activate: true });
+    setCellContent(model, "A1", "test");
+    setCellContent(model, "A2", "test");
+    updateSearch(model, "test");
+    expect(store.searchMatches).toEqual([match("sh2", "A1"), match("sh2", "A2")]);
+    expect(store.selectedMatchIndex).toStrictEqual(0);
+  });
+
   test("simple search for search scope allSheet", () => {
     setCellContent(model, "A2", "test");
     createSheet(model, { sheetId: "sh2" });
     setCellContent(model, "A2", "test", "sh2");
-    updateSearch(model, "test");
+    updateSearch(model, "test", { searchScope: "allSheets" });
     expect(store.selectedMatchIndex).toStrictEqual(0);
     expect(store.searchMatches).toEqual([match(sheetId1, "A2"), match("sh2", "A2")]);
   });
@@ -140,7 +151,7 @@ describe("basic search", () => {
     createSheet(model, { sheetId: sheetId2 });
     setCellContent(model, "A1", "=111", sheetId2);
 
-    updateSearch(model, "hello");
+    updateSearch(model, "hello", { searchScope: "allSheets" });
     store.selectNextMatch();
     expect(store.selectedMatchIndex).toStrictEqual(1);
     expect(store.searchMatches).toStrictEqual([match(sheetId1, "A1"), match(sheetId1, "A2")]);
@@ -222,7 +233,7 @@ describe("basic search", () => {
     createSheet(model, { sheetId: sheetId2 });
     setCellContent(model, "A2", "=111", sheetId2);
     activateSheet(model, sheetId2);
-    updateSearch(model, "1");
+    updateSearch(model, "1", { searchScope: "allSheets" });
     expect(getActivePosition(model)).toBe("A2");
     expect(store.selectedMatchIndex).toStrictEqual(2);
     expect(store.searchMatches).toStrictEqual([
@@ -388,7 +399,7 @@ test("replace don't replace value resulting from array formula", () => {
 
 test("Only change sheet on search related command", () => {
   setCellContent(model, "A1", "hello");
-  updateSearch(model, "hello");
+  updateSearch(model, "hello", { searchScope: "allSheets" });
   createSheet(model, { sheetId: "sh2", activate: true });
   expect(store.searchMatches).toHaveLength(1);
   expect(store.selectedMatchIndex).toStrictEqual(0);
@@ -517,7 +528,7 @@ describe("next/previous cycle", () => {
     createSheet(model, { sheetId: "s2" });
     setCellContent(model, "A1", "1", "s2");
     setCellContent(model, "Z26", "1", "s2");
-    updateSearch(model, "1");
+    updateSearch(model, "1", { searchScope: "allSheets" });
     expect(model.getters.getActiveSheetId()).toBe(sheetId1);
     expect(getActivePosition(model)).toBe("A1");
     store.selectPreviousMatch();

--- a/tests/find_and_replace/find_replace_side_panel_component.test.ts
+++ b/tests/find_and_replace/find_replace_side_panel_component.test.ts
@@ -34,7 +34,8 @@ const selectors = {
     ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-checkbox:nth-child(3) input",
   checkBoxReplaceFormulas:
     ".o-sidePanel .o-find-and-replace .o-section:nth-child(3) .o-far-item:nth-child(3) input",
-  searchRangeSelection: ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-type-selector",
+  searchRangeSelection:
+    ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-type-range-selector",
   searchRange: ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-selection-input input",
   resetSearchRange: ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-selection-ko",
   confirmSearchRange: ".o-sidePanel .o-find-and-replace .o-section:nth-child(1) .o-selection-ok",


### PR DESCRIPTION
## Description:

- The search operation will now default to the active sheet when the user opens the find and replace panel.

Task: : [3996599](https://www.odoo.com/web#id=3996599&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo