### PR TITLE
[FIX] model: mark default translations as loaded

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -18,13 +18,8 @@ const {
   onError,
 } = owl;
 
-const { Spreadsheet, Model, setTranslationMethod } = o_spreadsheet;
+const { Spreadsheet, Model } = o_spreadsheet;
 const { topbarMenuRegistry } = o_spreadsheet.registries;
-
-setTranslationMethod(
-  (str, ...values) => str,
-  () => true
-);
 
 const uuidGenerator = new o_spreadsheet.helpers.UuidGenerator();
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -26,7 +26,7 @@ import {
   SelectionStreamProcessorImpl,
 } from "./selection_stream/selection_stream_processor";
 import { StateObserver } from "./state_observer";
-import { _t } from "./translation";
+import { _t, setDefaultTranslationMethod } from "./translation";
 import { StateUpdateMessage, TransportService } from "./types/collaborative/transport_service";
 import { CommandTypes } from "./types/commands";
 import { FileStore } from "./types/files";
@@ -192,6 +192,7 @@ export class Model extends EventBus<any> implements CommandDispatcher {
     verboseImport = true
   ) {
     super();
+    setDefaultTranslationMethod();
 
     stateUpdateMessages = repairInitialMessages(data, stateUpdateMessages);
 

--- a/tests/helpers/translation_helpers.test.ts
+++ b/tests/helpers/translation_helpers.test.ts
@@ -1,6 +1,13 @@
 import { _t, setTranslationMethod } from "../../src/translation";
 
 describe("Translations", () => {
+  beforeEach(() => {
+    setTranslationMethod(
+      (str, ...values) => str,
+      () => true
+    );
+  });
+
   test("placeholders in string translation are replaced with their given value", () => {
     expect(_t("Hello %s", "World")).toBe("Hello World");
   });

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -3,7 +3,6 @@
  */
 import { App } from "@odoo/owl";
 import { setDefaultSheetViewSize } from "../../src/constants";
-import { setTranslationMethod } from "../../src/translation";
 import { getCompiledTemplates } from "../../tools/owl_templates/compile_templates.cjs";
 import "./canvas.mock";
 import "./jest_extend";
@@ -19,10 +18,6 @@ function registerOwlTemplates() {
 beforeAll(() => {
   registerOwlTemplates();
   setDefaultSheetViewSize(1000);
-  setTranslationMethod(
-    (str, ...values) => str,
-    () => true
-  );
   Object.defineProperty(Element.prototype, "innerText", {
     get: function () {
       return this.textContent;


### PR DESCRIPTION
## Description

Currently the default translations function is marked as not loaded. That means that if no custom translation method is set, the translations will never be marked as loaded, and charts will crash because we try to deepCopy LazyTranslatedString.

However we can't mark the default translations as loaded by default, because otherwise top-level translations would always be translated before we can set the translation method.

The solution is to mark the default translations as loaded only when starting the model.

Task: : [3999116](https://www.odoo.com/web#id=3999116&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo