### PR TITLE
[FIX] pivot: do not allow date dimension without granularity

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -2524,7 +2524,7 @@ export const demoData = {
     1: {
       type: "SPREADSHEET",
       columns: [{ name: "Stage" }],
-      rows: [{ name: "Created on", order: "asc" }],
+      rows: [{ name: "Created on", granularity: "month_number", order: "asc" }],
       measures: [{ name: "Expected Revenue", aggregator: "count" }],
       name: "My pivot",
       dataSet: { sheetId: "pivot", zone: { top: 0, bottom: 21, left: 0, right: 8 } },

--- a/src/helpers/pivot/pivot_runtime_definition.ts
+++ b/src/helpers/pivot/pivot_runtime_definition.ts
@@ -79,8 +79,7 @@ function createMeasure(fields: PivotFields, measure: PivotCoreMeasure): PivotMea
 function createPivotDimension(fields: PivotFields, dimension: PivotCoreDimension): PivotDimension {
   const field = fields[dimension.name];
   const type = field?.type ?? "integer";
-  const granularity =
-    field && isDateField(field) ? dimension.granularity ?? "month_number" : undefined;
+  const granularity = field && isDateField(field) ? dimension.granularity : undefined;
 
   return {
     /**

--- a/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
@@ -4,8 +4,8 @@ import { PivotDimension } from "../../../types/pivot";
 import { FieldValue } from "./data_entry_spreadsheet_pivot";
 
 export function createDate(dimension: PivotDimension, value: FieldValue["value"], locale: Locale) {
-  const granularity = dimension.granularity || "month_number";
-  if (!(granularity in MAP_VALUE_DIMENSION_DATE)) {
+  const granularity = dimension.granularity;
+  if (!granularity || !(granularity in MAP_VALUE_DIMENSION_DATE)) {
     throw new Error(`Unknown date granularity: ${granularity}`);
   }
   if (value === null) {

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -172,7 +172,7 @@ describe("Spreadsheet Pivot", () => {
     ]);
 
     updatePivot(model, "1", {
-      columns: [{ name: "Created on", order: "asc" }],
+      columns: [{ name: "Created on", granularity: "month_number", order: "asc" }],
     });
     expect(getEvaluatedGrid(model, "B26:F26")).toEqual([
       ["February", "March", "April", "Total", ""],
@@ -218,7 +218,7 @@ describe("Spreadsheet Pivot", () => {
     ]);
 
     updatePivot(model, "1", {
-      rows: [{ name: "Created on", order: "asc" }],
+      rows: [{ name: "Created on", granularity: "month_number", order: "asc" }],
     });
     expect(getEvaluatedGrid(model, "A28:A32")).toEqual([
       ["February"],


### PR DESCRIPTION
When a date dimension is used in a pivot view, the granularity must be specified. Before this commit, it automatically defaulted to 'month_number'. With the experience of the odoo pivot, it's not a good idea to have a default granularity, as it's not easily migrable. In addition, supported a date dimension without granularity leads to lots of "if-else" in the code to handle this.

So, we prefer to avoid this situation and raise an error when a date dimension is used without a granularity.

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo