### PR TITLE
[IMP] copy: Spreaded pivot gives fixed fomula on paste

### DIFF
--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -2,6 +2,7 @@ import { CommandResult } from "..";
 import { canonicalizeNumberValue } from "../formulas/formula_locale";
 import { deepEquals, formatValue } from "../helpers";
 import { getPasteZones } from "../helpers/clipboard/clipboard_helpers";
+import { makePivotFormulaFromPivotCell } from "../helpers/pivot/pivot_helpers";
 import {
   CellPosition,
   ClipboardCell,
@@ -47,28 +48,45 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
 
     const { clippedZones, rowsIndexes, columnsIndexes } = data;
     const clippedCells: ClipboardCell[][] = [];
-
+    const isCopyingOneCell = rowsIndexes.length == 1 && columnsIndexes.length == 1;
     for (let row of rowsIndexes) {
       let cellsInRow: ClipboardCell[] = [];
       for (let col of columnsIndexes) {
         const position = { col, row, sheetId };
-        const spreader = this.getters.getArrayFormulaSpreadingOn(position);
         let cell = this.getters.getCell(position);
         const evaluatedCell = this.getters.getEvaluatedCell(position);
-        if (spreader && !deepEquals(spreader, position)) {
-          const isSpreaderCopied =
-            rowsIndexes.includes(spreader.row) && columnsIndexes.includes(spreader.col);
-          const content = isSpreaderCopied
-            ? ""
-            : formatValue(evaluatedCell.value, { locale: this.getters.getLocale() });
-          cell = {
-            id: cell?.id || "",
-            style: cell?.style,
-            format: evaluatedCell.format,
-            content,
-            isFormula: false,
-            parsedValue: evaluatedCell.value,
-          };
+        const pivotId = this.getters.getPivotIdFromPosition(position);
+        const spreader = this.getters.getArrayFormulaSpreadingOn(position);
+        if (pivotId) {
+          if (!deepEquals(spreader, position) || !isCopyingOneCell) {
+            const pivotCell = this.getters.getPivotCellFromPosition(position);
+            const formulaPivotId = this.getters.getPivotFormulaId(pivotId);
+            const pivotFormula = makePivotFormulaFromPivotCell(formulaPivotId, pivotCell);
+            cell = {
+              id: cell?.id || "",
+              style: cell?.style,
+              format: evaluatedCell.format,
+              content: pivotFormula,
+              isFormula: false,
+              parsedValue: evaluatedCell.value,
+            };
+          }
+        } else {
+          if (spreader && !deepEquals(spreader, position)) {
+            const isSpreaderCopied =
+              rowsIndexes.includes(spreader.row) && columnsIndexes.includes(spreader.col);
+            const content = isSpreaderCopied
+              ? ""
+              : formatValue(evaluatedCell.value, { locale: this.getters.getLocale() });
+            cell = {
+              id: cell?.id || "",
+              style: cell?.style,
+              format: evaluatedCell.format,
+              content,
+              isFormula: false,
+              parsedValue: evaluatedCell.value,
+            };
+          }
         }
         cellsInRow.push({
           cell,


### PR DESCRIPTION
When copying a/some cells that belong to a spreaded pivot, the intention of the user is usually to have THAT value pasted somewhere else, that means it needs to be fixed on the dimentions that constitutes the value.
This commits converts the pivot formulas from the copied cells into fixed pivot formulas.

Task: [3965047](https://www.odoo.com/web#id=3965047&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo