### PR TITLE
[FIX] highlights: `useHighlights` should observe its provider highlights

### DIFF
--- a/src/components/helpers/highlight_hook.ts
+++ b/src/components/helpers/highlight_hook.ts
@@ -1,4 +1,5 @@
 import { onMounted, useEffect } from "@odoo/owl";
+import { deepEquals } from "../../helpers";
 import { useLocalStore, useStoreProvider } from "../../store_engine";
 import { HighlightProvider, HighlightStore } from "../../stores/highlight_store";
 import { Ref } from "../../types";
@@ -6,24 +7,27 @@ import { useHoveredElement } from "./listener_hook";
 
 export function useHighlightsOnHover(ref: Ref<HTMLElement>, highlightProvider: HighlightProvider) {
   const hoverState = useHoveredElement(ref);
-  const stores = useStoreProvider();
-
   useHighlights({
     get highlights() {
       return hoverState.hovered ? highlightProvider.highlights : [];
     },
   });
-  useEffect(
-    () => {
-      stores.trigger("store-updated");
-    },
-    () => [hoverState.hovered]
-  );
 }
 
 export function useHighlights(highlightProvider: HighlightProvider) {
+  const stores = useStoreProvider();
   const store = useLocalStore(HighlightStore);
   onMounted(() => {
     store.register(highlightProvider);
   });
+  let currentHighlights = highlightProvider.highlights;
+  useEffect(
+    (highlights) => {
+      if (!deepEquals(highlights, currentHighlights)) {
+        currentHighlights = highlights;
+        stores.trigger("store-updated");
+      }
+    },
+    () => [highlightProvider.highlights]
+  );
 }


### PR DESCRIPTION
Following the removal of the reactivity from the stores[^1], the hook `usehighlights` would not properly trigger a rerendering when its provider highlights changed.

This commit updates the hook to observe its provider highlights.

Task: 4004548

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo