### PR TITLE
[FIX] spreadsheet: correctly get pivot id from position

### DIFF
--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -109,7 +109,10 @@ export class PivotUIPlugin extends UIPlugin {
   getPivotIdFromPosition(position: CellPosition) {
     const cell = this.getters.getCorrespondingFormulaCell(position);
     if (cell && cell.isFormula) {
-      const pivotFunction = this.getFirstPivotFunction(cell.compiledFormula.tokens);
+      const pivotFunction = this.getFirstPivotFunction(
+        position.sheetId,
+        cell.compiledFormula.tokens
+      );
       if (pivotFunction) {
         const pivotId = pivotFunction.args[0]?.toString();
         return pivotId && this.getters.getPivotId(pivotId);
@@ -118,7 +121,7 @@ export class PivotUIPlugin extends UIPlugin {
     return undefined;
   }
 
-  getFirstPivotFunction(tokens: Token[]) {
+  getFirstPivotFunction(sheetId: UID, tokens: Token[]) {
     const pivotFunction = getFirstPivotFunction(tokens);
     if (!pivotFunction) {
       return undefined;
@@ -135,7 +138,7 @@ export class PivotUIPlugin extends UIPlugin {
         return argAst.value;
       }
       const argsString = astToFormula(argAst);
-      return this.getters.evaluateFormula(this.getters.getActiveSheetId(), argsString);
+      return this.getters.evaluateFormula(sheetId, argsString);
     });
     return { functionName, args: evaluatedArgs };
   }
@@ -159,7 +162,10 @@ export class PivotUIPlugin extends UIPlugin {
       return undefined;
     }
     const mainPosition = this.getters.getCellPosition(cell.id);
-    const result = this.getters.getFirstPivotFunction(cell.compiledFormula.tokens);
+    const result = this.getters.getFirstPivotFunction(
+      position.sheetId,
+      cell.compiledFormula.tokens
+    );
     if (!result) {
       return undefined;
     }


### PR DESCRIPTION
Steps to reproduce in 17.0:

There's no way to reproduce the issue in 17.0 because the faulty getter in only called on positions in the active sheet (pivot autofill, global filter auto-matching)

Steps to reproduce in saas-17.1:

- insert a pivot in a blank spreadsheet
- delete all pivot formulas
- insert a new sheet
- in the new sheet:
	- in A1: type "1"
	- in A2: =ODOO.PIVOT(A1)
- activate the first sheet again
- Open the Data menu => the pivot 1 is marked as being unused, even though it's used in the second
   sheet

Task: 3859472
X-original-commit: https://github.com/odoo/odoo/commit/0f9161ebc3589678fea5a0b242b00c01b8df2725

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo