### PR TITLE
[REF] renderer: allow to extend cell icons

### DIFF
--- a/src/components/icons/icons.ts
+++ b/src/components/icons/icons.ts
@@ -1,4 +1,6 @@
 import { ICON_EDGE_LENGTH } from "../../constants";
+import { iconsOnCellRegistry } from "../../registries/icons_on_cell_registry";
+import { ImageSrc } from "../../types/image";
 import { css } from "../helpers";
 
 css/* scss */ `
@@ -51,50 +53,48 @@ const YELLOW_DOT =
 const RED_DOT =
   '<svg class="o-cf-icon red-dot" width="10" height="10" focusable="false" viewBox="0 0 512 512"><path fill="#E06666" d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z"></path></svg>';
 
-function loadIconImage(svg) {
+function getIconSrc(svg: string): ImageSrc {
   /** We have to add xmlns, as it's not added by owl in the canvas */
   svg = `<svg xmlns="http://www.w3.org/2000/svg" ${svg.slice(4)}`;
-  const image = new Image();
-  image.src = "data:image/svg+xml; charset=utf8, " + encodeURIComponent(svg);
-  return image;
+  return "data:image/svg+xml; charset=utf8, " + encodeURIComponent(svg);
 }
 
 export const ICONS = {
   arrowGood: {
     template: "ARROW_UP",
-    img: loadIconImage(ARROW_UP),
+    img: getIconSrc(ARROW_UP),
   },
   arrowNeutral: {
     template: "ARROW_RIGHT",
-    img: loadIconImage(ARROW_RIGHT),
+    img: getIconSrc(ARROW_RIGHT),
   },
   arrowBad: {
     template: "ARROW_DOWN",
-    img: loadIconImage(ARROW_DOWN),
+    img: getIconSrc(ARROW_DOWN),
   },
   smileyGood: {
     template: "SMILE",
-    img: loadIconImage(SMILE),
+    img: getIconSrc(SMILE),
   },
   smileyNeutral: {
     template: "MEH",
-    img: loadIconImage(MEH),
+    img: getIconSrc(MEH),
   },
   smileyBad: {
     template: "FROWN",
-    img: loadIconImage(FROWN),
+    img: getIconSrc(FROWN),
   },
   dotGood: {
     template: "GREEN_DOT",
-    img: loadIconImage(GREEN_DOT),
+    img: getIconSrc(GREEN_DOT),
   },
   dotNeutral: {
     template: "YELLOW_DOT",
-    img: loadIconImage(YELLOW_DOT),
+    img: getIconSrc(YELLOW_DOT),
   },
   dotBad: {
     template: "RED_DOT",
-    img: loadIconImage(RED_DOT),
+    img: getIconSrc(RED_DOT),
   },
 };
 
@@ -115,3 +115,10 @@ export const ICON_SETS = {
     bad: "dotBad",
   },
 };
+
+iconsOnCellRegistry.add("conditional_formatting", (getters, position) => {
+  const icon = getters.getConditionalIcon(position);
+  if (icon) {
+    return ICONS[icon].img;
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ import {
 } from "./plugins/index";
 import { UNDO_REDO_PIVOT_COMMANDS } from "./plugins/ui_core_views/pivot_ui";
 import { clickableCellRegistry } from "./registries/cell_clickable_registry";
+import { iconsOnCellRegistry } from "./registries/icons_on_cell_registry";
 import {
   autoCompleteProviders,
   autofillModifiersRegistry,
@@ -249,6 +250,7 @@ export const registries = {
   linkMenuRegistry,
   functionRegistry,
   featurePluginRegistry,
+  iconsOnCellRegistry,
   statefulUIPluginRegistry,
   coreViewsPluginRegistry,
   corePluginRegistry,

--- a/src/plugins/ui_feature/ui_sheet.ts
+++ b/src/plugins/ui_feature/ui_sheet.ts
@@ -9,7 +9,9 @@ import {
   splitTextToWidth,
 } from "../../helpers/index";
 import { localizeFormula } from "../../helpers/locale";
+import { iconsOnCellRegistry } from "../../registries/icons_on_cell_registry";
 import { CellValueType, Command, CommandResult, LocalCommand, UID } from "../../types";
+import { ImageSrc } from "../../types/image";
 import { CellPosition, HeaderIndex, Pixel, Style, Zone } from "../../types/misc";
 import { UIPlugin } from "../ui_plugin";
 
@@ -17,6 +19,7 @@ export class SheetUIPlugin extends UIPlugin {
   static getters = [
     "doesCellHaveGridIcon",
     "getCellWidth",
+    "getCellIconSrc",
     "getTextWidth",
     "getCellText",
     "getCellMultiLineText",
@@ -78,7 +81,7 @@ export class SheetUIPlugin extends UIPlugin {
       );
     }
 
-    const icon = this.getters.getConditionalIcon(position);
+    const icon = this.getters.getCellIconSrc(position);
     if (icon) {
       contentWidth += computeIconWidth(style);
     }
@@ -98,6 +101,17 @@ export class SheetUIPlugin extends UIPlugin {
     }
 
     return contentWidth;
+  }
+
+  getCellIconSrc(position: CellPosition): ImageSrc | undefined {
+    const callbacks = iconsOnCellRegistry.getAll();
+    for (const callback of callbacks) {
+      const imageSrc = callback(this.getters, position);
+      if (imageSrc) {
+        return imageSrc;
+      }
+    }
+    return undefined;
   }
 
   getTextWidth(text: string, style: Style): Pixel {

--- a/src/registries/icons_on_cell_registry.ts
+++ b/src/registries/icons_on_cell_registry.ts
@@ -1,0 +1,10 @@
+import { CellPosition, Getters } from "../types";
+import { ImageSrc } from "../types/image";
+import { Registry } from "./registry";
+
+type ImageSrcCallback = (getters: Getters, position: CellPosition) => ImageSrc | undefined;
+
+/**
+ * Registry to draw icons on cells
+ */
+export const iconsOnCellRegistry = new Registry<ImageSrcCallback>();

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -1,6 +1,11 @@
 import { FigureSize } from "./figure";
 import { XLSXFigureSize } from "./xlsx";
 
+/**
+ * Image source given to <img src="..."/>
+ */
+export type ImageSrc = string;
+
 export interface Image {
   path: string;
   size: FigureSize;


### PR DESCRIPTION
## Description:

Allow to extend cell icons from outside the lib with a registry.

Task: : [3761590](https://www.odoo.com/web#id=3761590&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo