### PR TITLE
[FIX] ChartTitle: traceback when chart title is undefined

### DIFF
--- a/src/components/side_panel/chart/building_blocks/title/title.ts
+++ b/src/components/side_panel/chart/building_blocks/title/title.ts
@@ -32,7 +32,7 @@ css/* scss */ `
 `;
 
 interface Props {
-  title: string;
+  title?: string;
   updateTitle: (title: string) => void;
   name?: string;
   toggleItalic?: () => void;
@@ -50,7 +50,7 @@ export class ChartTitle extends Component<Props, SpreadsheetChildEnv> {
   static template = "o-spreadsheet.ChartTitle";
   static components = { Section, ColorPickerWidget };
   static props = {
-    title: String,
+    title: { type: String, optional: true },
     updateTitle: Function,
     name: { type: String, optional: true },
     toggleItalic: { type: Function, optional: true },
@@ -58,6 +58,9 @@ export class ChartTitle extends Component<Props, SpreadsheetChildEnv> {
     updateAlignment: { type: Function, optional: true },
     updateColor: { type: Function, optional: true },
     style: { type: Object, optional: true },
+  };
+  static defaultProps = {
+    title: "",
   };
   openedEl: HTMLElement | null = null;
 

--- a/tests/side_panels/building_blocks/title.test.ts
+++ b/tests/side_panels/building_blocks/title.test.ts
@@ -18,6 +18,16 @@ describe("Chart title", () => {
     expect(fixture).toMatchSnapshot();
   });
 
+  test("Can render a chart title component with default title prop if not provided", async () => {
+    await mountChartTitle({
+      updateTitle: () => {},
+      style: {},
+    });
+
+    const input = fixture.querySelector("input")!;
+    expect(input.value).toBe("");
+  });
+
   test("Update is called when title is changed, not on input", async () => {
     const updateTitle = jest.fn();
     await mountChartTitle({


### PR DESCRIPTION
## Description:

With my recent PR#4476, creating a chart from scratch via the top menu item results in the chart title being undefined. This causes a traceback in the side panel since the ChartTitle component expects the title prop to be a string.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo