### PR TITLE
[REM] pivot: remove year support

### DIFF
--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel_store.ts
@@ -193,7 +193,8 @@ export class PivotSidePanelStore extends SpreadsheetStore {
     for (const dimension of columnsWithGranularity.concat(rowsWithGranularity)) {
       const fieldType = fields[dimension.name]?.type;
       if ((fieldType === "date" || fieldType === "datetime") && !dimension.granularity) {
-        const granularity = unusedGranularities[dimension.name]?.values().next().value || "year";
+        const granularity =
+          unusedGranularities[dimension.name]?.values().next().value || "month_number";
         unusedGranularities[dimension.name]?.delete(granularity);
         dimension.granularity = granularity;
       }

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -102,10 +102,9 @@ export function getMaxObjectId(o: object) {
 }
 
 export const ALL_PERIODS = {
-  year: _t("Year"),
-  quarter: _t("Quarter"),
-  month: _t("Month"),
-  week: _t("Week"),
+  quarter: _t("Quarter & Year"),
+  month: _t("Month & Year"),
+  week: _t("Week & Year"),
   day: _t("Day"),
   year_number: _t("Year"),
   quarter_number: _t("Quarter"),

--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -255,7 +255,6 @@ pivotTimeAdapterRegistry
   .add("week", nullHandlerDecorator(weekAdapter))
   .add("month", nullHandlerDecorator(monthAdapter))
   .add("quarter", nullHandlerDecorator(quarterAdapter))
-  .add("year", nullHandlerDecorator(yearAdapter))
   .add("day_of_month", nullHandlerDecorator(dayOfMonthAdapter))
   .add("iso_week_number", nullHandlerDecorator(isoWeekNumberAdapter))
   .add("month_number", nullHandlerDecorator(monthNumberAdapter))

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -18,7 +18,6 @@ export type Granularity =
   | "week"
   | "month"
   | "quarter"
-  | "year"
   | "day_of_month"
   | "iso_week_number"
   | "month_number"

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -55,12 +55,6 @@ describe("toNormalizedPivotValue", () => {
       expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
       expect(toNormalizedPivotValue(dimension, false)).toBe(false);
       // year
-      dimension.granularity = "year";
-      expect(toNormalizedPivotValue(dimension, "2020")).toBe(2020);
-      expect(toNormalizedPivotValue(dimension, 2020)).toBe(2020);
-      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
-      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
-
       dimension.granularity = "year_number";
       expect(toNormalizedPivotValue(dimension, "2020")).toBe(2020);
       expect(toNormalizedPivotValue(dimension, 2020)).toBe(2020);
@@ -225,9 +219,6 @@ describe("ToFunctionValue", () => {
     dimension.granularity = "month";
     expect(toFunctionPivotValue("11/2020", dimension)).toBe(`"11/2020"`);
     // year
-    dimension.granularity = "year";
-    expect(toFunctionPivotValue("2020", dimension)).toBe("2020");
-
     dimension.granularity = "year_number";
     expect(toFunctionPivotValue("2020", dimension)).toBe("2020");
 


### PR DESCRIPTION
This commit removes the support for the year granularity in the pivot as `year_number` is available. `year` was only used in odoo and its support will be removed.

Task: 3899604

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo