### PR TITLE
[REM] pivot: remove granularity year_number

### DIFF
--- a/demo/pivot.js
+++ b/demo/pivot.js
@@ -111,7 +111,7 @@ export function makePivotDataset(rowsNumber = 10_000) {
         rows: [
           {
             name: "Created on",
-            granularity: "year_number",
+            granularity: "year",
             order: "asc",
           },
         ],

--- a/src/helpers/pivot/pivot_helpers.ts
+++ b/src/helpers/pivot/pivot_helpers.ts
@@ -134,7 +134,6 @@ export const ALL_PERIODS = {
   month: _t("Month"),
   week: _t("Week"),
   day: _t("Day"),
-  year_number: _t("Year"),
   quarter_number: _t("Quarter"),
   month_number: _t("Month"),
   iso_week_number: _t("Week"),

--- a/src/helpers/pivot/pivot_registry.ts
+++ b/src/helpers/pivot/pivot_registry.ts
@@ -43,7 +43,7 @@ pivotRegistry.add("SPREADSHEET", {
   externalData: false,
   onIterationEndEvaluation: (pivot: SpreadsheetPivot) => pivot.markAsDirtyForEvaluation(),
   granularities: [
-    "year_number",
+    "year",
     "quarter_number",
     "month_number",
     "iso_week_number",

--- a/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/date_spreadsheet_pivot.ts
@@ -16,7 +16,7 @@ export function createDate(dimension: PivotDimension, value: FieldValue["value"]
     const date = toJsDate(value, locale);
     let number: FieldValue["value"] = 0;
     switch (granularity) {
-      case "year_number":
+      case "year":
         number = date.getFullYear();
         break;
       case "quarter_number":
@@ -44,7 +44,7 @@ export function createDate(dimension: PivotDimension, value: FieldValue["value"]
  * This map is used to cache the different values of a pivot date value
  * 43_831 -> 01/01/2012
  * Example: {
- *   year_number: {
+ *   year: {
  *     set: { 43_831 },
  *     values: { '43_831': 2012 }
  *   },
@@ -74,7 +74,7 @@ const MAP_VALUE_DIMENSION_DATE: Record<
   string,
   { set: Set<FieldValue["value"]>; values: Record<string, FieldValue["value"]> }
 > = {
-  year_number: {
+  year: {
     set: new Set<FieldValue["value"]>(),
     values: {},
   },

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -23,8 +23,7 @@ export type Granularity =
   | "day_of_month"
   | "iso_week_number"
   | "month_number"
-  | "quarter_number"
-  | "year_number";
+  | "quarter_number";
 
 export interface PivotCoreDimension {
   name: string;

--- a/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/date_spreadsheet_pivot.test.ts
@@ -13,7 +13,7 @@ function createPivotDimension(granularity: string): PivotDimension {
   };
 }
 
-const YEAR_NUMBER_DIMENSION = createPivotDimension("year_number");
+const YEAR_DIMENSION = createPivotDimension("year");
 const QUARTER_NUMBER_DIMENSION = createPivotDimension("quarter_number");
 const MONTH_NUMBER_DIMENSION = createPivotDimension("month_number");
 const ISO_WEEK_NUMBER_DIMENSION = createPivotDimension("iso_week_number");
@@ -24,7 +24,7 @@ describe("Date Spreadsheet Pivot", () => {
   test("createDate with date values", () => {
     const d05_april_2024 = 45_387;
 
-    expect(createDate(YEAR_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(2024);
+    expect(createDate(YEAR_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(2024);
     expect(createDate(QUARTER_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(2);
     expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(3);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(14);
@@ -32,7 +32,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(DAY_DIMENSION, d05_april_2024, DEFAULT_LOCALE)).toBe(d05_april_2024);
 
     const d04_may_2024 = 45_416;
-    expect(createDate(YEAR_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(2024);
+    expect(createDate(YEAR_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(2024);
     expect(createDate(QUARTER_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(2);
     expect(createDate(MONTH_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(4);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(18);
@@ -40,7 +40,7 @@ describe("Date Spreadsheet Pivot", () => {
     expect(createDate(DAY_DIMENSION, d04_may_2024, DEFAULT_LOCALE)).toBe(d04_may_2024);
 
     const d01_january_2019 = 43_466;
-    expect(createDate(YEAR_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(2019);
+    expect(createDate(YEAR_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(2019);
     expect(createDate(QUARTER_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
     expect(createDate(MONTH_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(0);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d01_january_2019, DEFAULT_LOCALE)).toBe(1);
@@ -51,7 +51,7 @@ describe("Date Spreadsheet Pivot", () => {
   test("createDate with datetime values", () => {
     const d05_april_2024_15h = 45_387.13;
 
-    expect(createDate(YEAR_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(2024);
+    expect(createDate(YEAR_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(2024);
     expect(createDate(QUARTER_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(2);
     expect(createDate(MONTH_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(3);
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, d05_april_2024_15h, DEFAULT_LOCALE)).toBe(14);
@@ -62,7 +62,7 @@ describe("Date Spreadsheet Pivot", () => {
   });
 
   test("createDate with null values", () => {
-    expect(createDate(YEAR_NUMBER_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
+    expect(createDate(YEAR_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
     expect(createDate(QUARTER_NUMBER_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
     expect(createDate(MONTH_NUMBER_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();
     expect(createDate(ISO_WEEK_NUMBER_DIMENSION, null, DEFAULT_LOCALE)).toBeNull();

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -189,7 +189,7 @@ describe("Spreadsheet Pivot", () => {
     expect(getEvaluatedGrid(model, "B26:E26")).toEqual([["3", "2", "Total", ""]]);
 
     updatePivot(model, "1", {
-      columns: [{ name: "Created on", order: "asc", granularity: "year_number" }],
+      columns: [{ name: "Created on", order: "asc", granularity: "year" }],
     });
     expect(getEvaluatedGrid(model, "B26:D26")).toEqual([["2024", "Total", ""]]);
   });
@@ -239,7 +239,7 @@ describe("Spreadsheet Pivot", () => {
     expect(getEvaluatedGrid(model, "A28:A31")).toEqual([["3"], ["2"], ["Total"], [""]]);
 
     updatePivot(model, "1", {
-      rows: [{ name: "Created on", order: "asc", granularity: "year_number" }],
+      rows: [{ name: "Created on", order: "asc", granularity: "year" }],
     });
     expect(getEvaluatedGrid(model, "A28:A30")).toEqual([["2024"], ["Total"], [""]]);
   });


### PR DESCRIPTION
This commit removes the granularity year_number from the pivot. One can use the granularity year instead, it's more concise and will be consistent with Odoo.

Part of task: 3899604

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo