### PR TITLE
[REM] pivots: remove unused time adapter

### DIFF
--- a/src/helpers/pivot/pivot_time_adapter.ts
+++ b/src/helpers/pivot/pivot_time_adapter.ts
@@ -1,4 +1,4 @@
-import { toNumber, toString } from "../../functions/helpers";
+import { toNumber } from "../../functions/helpers";
 import { Registry } from "../../registries/registry";
 import { _t } from "../../translation";
 import { CellValue, DEFAULT_LOCALE } from "../../types";
@@ -78,25 +78,6 @@ const dayOfMonthAdapter: PivotTimeAdapterNotNull<number> = {
 };
 
 /**
- * Normalized value: "2/2023" for week 2 of 2023
- */
-const weekAdapter: PivotTimeAdapterNotNull<string> = {
-  normalizeFunctionValue(value) {
-    const [week, year] = toString(value).split("/");
-    return `${Number(week)}/${Number(year)}`;
-  },
-  toValueAndFormat(normalizedValue, locale) {
-    const [week, year] = normalizedValue.split("/");
-    return {
-      value: _t("W%(week)s %(year)s", { week, year }),
-    };
-  },
-  toFunctionValue(normalizedValue) {
-    return `"${normalizedValue}"`;
-  },
-};
-
-/**
  * normalizes iso week number
  */
 const isoWeekNumberAdapter: PivotTimeAdapterNotNull<number> = {
@@ -121,26 +102,6 @@ const isoWeekNumberAdapter: PivotTimeAdapterNotNull<number> = {
 };
 
 /**
- * normalized month value is a string formatted as "MM/yyyy" (luxon format)
- * e.g. "01/2020" for January 2020
- */
-const monthAdapter: PivotTimeAdapterNotNull<string> = {
-  normalizeFunctionValue(value) {
-    const date = toNumber(value, DEFAULT_LOCALE);
-    return formatValue(date, { locale: DEFAULT_LOCALE, format: "mm/yyyy" });
-  },
-  toValueAndFormat(normalizedValue) {
-    return {
-      value: toNumber(normalizedValue, DEFAULT_LOCALE),
-      format: "mmmm yyyy",
-    };
-  },
-  toFunctionValue(normalizedValue) {
-    return `"${normalizedValue}"`;
-  },
-};
-
-/**
  * normalizes month number
  */
 const monthNumberAdapter: PivotTimeAdapterNotNull<number> = {
@@ -161,26 +122,6 @@ const monthNumberAdapter: PivotTimeAdapterNotNull<number> = {
   },
   toFunctionValue(normalizedValue) {
     return `${normalizedValue}`;
-  },
-};
-
-/**
- * normalized quarter value is "quarter/year"
- * e.g. "1/2020" for Q1 2020
- */
-const quarterAdapter: PivotTimeAdapterNotNull<string> = {
-  normalizeFunctionValue(value) {
-    const [quarter, year] = toString(value).split("/");
-    return `${quarter}/${year}`;
-  },
-  toValueAndFormat(normalizedValue) {
-    const [quarter, year] = normalizedValue.split("/");
-    return {
-      value: _t("Q%(quarter)s %(year)s", { quarter, year }),
-    };
-  },
-  toFunctionValue(normalizedValue) {
-    return `"${normalizedValue}"`;
   },
 };
 
@@ -252,9 +193,6 @@ function nullHandlerDecorator<T>(adapter: PivotTimeAdapterNotNull<T>): PivotTime
 
 pivotTimeAdapterRegistry
   .add("day", nullHandlerDecorator(dayAdapter))
-  .add("week", nullHandlerDecorator(weekAdapter))
-  .add("month", nullHandlerDecorator(monthAdapter))
-  .add("quarter", nullHandlerDecorator(quarterAdapter))
   .add("year", nullHandlerDecorator(yearAdapter))
   .add("day_of_month", nullHandlerDecorator(dayOfMonthAdapter))
   .add("iso_week_number", nullHandlerDecorator(isoWeekNumberAdapter))

--- a/tests/pivots/pivot_helpers.test.ts
+++ b/tests/pivots/pivot_helpers.test.ts
@@ -37,23 +37,7 @@ describe("toNormalizedPivotValue", () => {
       expect(toNormalizedPivotValue(dimension, 1)).toBe(1);
       expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
       expect(toNormalizedPivotValue(dimension, false)).toBe(false);
-      // week
-      dimension.granularity = "week";
-      expect(toNormalizedPivotValue(dimension, "11/2020")).toBe("11/2020");
-      expect(toNormalizedPivotValue(dimension, "1/2020")).toBe("1/2020");
-      expect(toNormalizedPivotValue(dimension, "01/2020")).toBe("1/2020");
-      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
-      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
-      // month
-      dimension.granularity = "month";
-      expect(toNormalizedPivotValue(dimension, "11/2020")).toBe("11/2020");
-      expect(toNormalizedPivotValue(dimension, "1/2020")).toBe("01/2020");
-      expect(toNormalizedPivotValue(dimension, "01/2020")).toBe("01/2020");
-      expect(toNormalizedPivotValue(dimension, "2/11/2020")).toBe("02/2020");
-      expect(toNormalizedPivotValue(dimension, "2/1/2020")).toBe("02/2020");
-      expect(toNormalizedPivotValue(dimension, 1)).toBe("12/1899");
-      expect(toNormalizedPivotValue(dimension, "false")).toBe(false);
-      expect(toNormalizedPivotValue(dimension, false)).toBe(false);
+
       // year
       dimension.granularity = "year";
       expect(toNormalizedPivotValue(dimension, "2020")).toBe(2020);
@@ -122,11 +106,6 @@ describe("toNormalizedPivotValue", () => {
       expect(() => toNormalizedPivotValue(dimension, 5)).toThrow(
         "5 is not a valid quarter (it should be a number between 1 and 4)"
       );
-
-      dimension.granularity = "month";
-      expect(() => toNormalizedPivotValue(dimension, "true")).toThrow();
-      expect(() => toNormalizedPivotValue(dimension, true)).toThrow();
-      expect(() => toNormalizedPivotValue(dimension, "won")).toThrow();
     }
   });
 
@@ -218,12 +197,6 @@ describe("ToFunctionValue", () => {
     const dimension = { type, granularity: "day" };
     // day
     expect(toFunctionPivotValue("1/11/2020", dimension)).toBe(`"01/11/2020"`);
-    // week
-    dimension.granularity = "week";
-    expect(toFunctionPivotValue("11/2020", dimension)).toBe(`"11/2020"`);
-    // month
-    dimension.granularity = "month";
-    expect(toFunctionPivotValue("11/2020", dimension)).toBe(`"11/2020"`);
     // year
     dimension.granularity = "year";
     expect(toFunctionPivotValue("2020", dimension)).toBe("2020");


### PR DESCRIPTION


## Description:

Those 3 adapters are only used in odoo.
They are therefore moved to odoo which allows to have the code and tests at a single place.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo