### PR TITLE
[IMP] charts: add trending line

### DIFF
--- a/src/components/side_panel/chart/chart_with_axis/design_panel.xml
+++ b/src/components/side_panel/chart/chart_with_axis/design_panel.xml
@@ -71,6 +71,53 @@
               t-on-change="(ev) => this.updateDataSeriesLabel(ev)"
             />
           </Section>
+          <Section class="'pt-0 px-0 o-show-trend-line'" t-if="!props.definition.horizontal">
+            <t t-set="showTrendLineLabel">Show trend line</t>
+            <t t-set="trend" t-value="getTrendLineConfiguration()"/>
+            <t t-set="trendType" t-value="getTrendType(trend)"/>
+            <Checkbox
+              name="'showTrendLine'"
+              label="showTrendLineLabel"
+              value="trend !== undefined and trend.display"
+              onChange.bind="toggleDataTrend"
+            />
+            <div t-if="trend !== undefined and trend.display">
+              <div class="d-flex py-1">
+                <div class="w-100 pe-1">
+                  <span class="o-section-title">Type</span>
+                  <select class="o-input trend-type-selector" t-on-change="this.onChangeTrendType">
+                    <option value="linear" t-att-selected="trendType === 'linear'">Linear</option>
+                    <option value="exponential" t-att-selected="trendType === 'exponential'">
+                      Exponential
+                    </option>
+                    <option value="polynomial" t-att-selected="trendType === 'polynomial'">
+                      Polynomial
+                    </option>
+                    <option value="logarithmic" t-att-selected="trendType === 'logarithmic'">
+                      Logarithmic
+                    </option>
+                  </select>
+                </div>
+                <div class="w-50" t-if="trendType === 'polynomial'">
+                  <span class="o-section-title">Degree</span>
+                  <input
+                    t-att-value="trend.order"
+                    type="number"
+                    class="w-100 o-input o-number-input trend-order-input"
+                    t-on-change="this.onChangePolynomialDegree"
+                    min="1"
+                  />
+                </div>
+              </div>
+              <div class="d-flex align-items-center">
+                <span class="o-section-title mb-0 pe-2">Trend line color</span>
+                <RoundColorPicker
+                  currentColor="getTrendLineColor()"
+                  onColorPicked.bind="updateTrendLineColor"
+                />
+              </div>
+            </div>
+          </Section>
         </Section>
       </t>
     </SidePanelCollapsible>

--- a/src/functions/helper_statistical.ts
+++ b/src/functions/helper_statistical.ts
@@ -1,7 +1,16 @@
-import { isNumber, parseDateTime } from "../helpers";
+import { isNumber, parseDateTime, range } from "../helpers";
 import { _t } from "../translation";
-import { Arg, Locale, isMatrix } from "../types";
-import { assert, assertNotZero, isEvaluationError, reduceAny, reduceNumbers } from "./helpers";
+import { Arg, Locale, Matrix, isMatrix } from "../types";
+import { EvaluationError } from "../types/errors";
+import { invertMatrix, multiplyMatrices } from "./helper_matrices";
+import {
+  assert,
+  assertNotZero,
+  isEvaluationError,
+  reduceAny,
+  reduceNumbers,
+  transposeMatrix,
+} from "./helpers";
 
 export function assertSameNumberOfElements(...args: any[][]) {
   const dims = args[0].length;
@@ -69,4 +78,190 @@ export function max(values: Arg[], locale: Locale) {
 export function min(values: Arg[], locale: Locale): number {
   const result = reduceNumbers(values, (acc, a) => (a < acc ? a : acc), Infinity, locale);
   return result === Infinity ? 0 : result;
+}
+
+function prepareDataForRegression(X: Matrix<number>, Y: Matrix<number>, newX: Matrix<number>) {
+  const _X = X[0].length ? X : [range(1, Y.flat().length + 1)];
+  const nVar = _X.length;
+  let _newX = newX[0].length ? newX : _X;
+  _newX = _newX.length === nVar ? transposeMatrix(_newX) : _newX;
+  return { _X, _newX };
+}
+
+/*
+ * This function performs a linear regression on the data set. It returns an array with two elements.
+ * The first element is the slope, and the second element is the intercept.
+ * The linear regression line is: y = slope*x + intercept
+ * The function use the least squares method to find the best fit for the data set :
+ * see https://www.mathsisfun.com/data/least-squares-regression.html
+ *     https://www.statology.org/standard-error-of-estimate/
+ *     https://agronomy4future.org/?p=16670
+ *     https://vitalflux.com/interpreting-f-statistics-in-linear-regression-formula-examples/
+ *     https://web.ist.utl.pt/~ist11038/compute/errtheory/,regression/regrthroughorigin.pdf
+ */
+
+export function fullLinearRegression(
+  X: Matrix<number>,
+  Y: Matrix<number>,
+  computeIntercept = true,
+  verbose: boolean = false
+) {
+  const y = Y.flat();
+  const n = y.length;
+  let { _X } = prepareDataForRegression(X, Y, [[]]);
+  _X = _X.length === n ? transposeMatrix(_X) : _X.slice();
+  assertSameNumberOfElements(_X[0], y);
+  const nVar = _X.length;
+  const nDeg = n - nVar - (computeIntercept ? 1 : 0);
+  const yMatrix = [y];
+  const xMatrix: Matrix<number> = transposeMatrix(_X.reverse());
+  let avgX: number[] = [];
+  for (let i = 0; i < nVar; i++) {
+    avgX.push(0);
+    if (computeIntercept) {
+      for (const xij of _X[i]) {
+        avgX[i] += xij;
+      }
+      avgX[i] /= n;
+    }
+  }
+  let avgY = 0;
+  if (computeIntercept) {
+    for (const yi of y) {
+      avgY += yi;
+    }
+    avgY /= n;
+  }
+  const redX: Matrix<number> = xMatrix.map((row) => row.map((value, i) => value - avgX[i]));
+  if (computeIntercept) {
+    xMatrix.forEach((row) => row.push(1));
+  }
+  const coeffs = getLMSCoefficients(xMatrix, yMatrix);
+  if (!computeIntercept) {
+    coeffs.push([0]);
+  }
+  if (!verbose) {
+    return coeffs;
+  }
+  const dot1 = multiplyMatrices(redX, transposeMatrix(redX));
+  const { inverted: dotInv } = invertMatrix(dot1);
+  if (dotInv === undefined) {
+    throw new EvaluationError(_t("Matrix is not invertible"));
+  }
+  let SSE = 0,
+    SSR = 0;
+  for (let i = 0; i < n; i++) {
+    const yi = y[i] - avgY;
+    let temp = 0;
+    for (let j = 0; j < nVar; j++) {
+      const xi = redX[i][j];
+      temp += xi * coeffs[j][0];
+    }
+    const ei = yi - temp;
+    SSE += ei * ei;
+    SSR += temp * temp;
+  }
+  const RMSE = Math.sqrt(SSE / nDeg);
+  const r2 = SSR / (SSR + SSE);
+  const f_stat = SSR / nVar / (SSE / nDeg);
+  const deltaCoeffs: number[] = [];
+  for (let i = 0; i < nVar; i++) {
+    deltaCoeffs.push(RMSE * Math.sqrt(dotInv[i][i]));
+  }
+  if (computeIntercept) {
+    const dot2 = multiplyMatrices(dotInv, [avgX]);
+    const dot3 = multiplyMatrices(transposeMatrix([avgX]), dot2);
+    deltaCoeffs.push(RMSE * Math.sqrt(dot3[0][0] + 1 / y.length));
+  }
+  const returned: (number | string)[][] = [
+    [coeffs[0][0], deltaCoeffs[0], r2, f_stat, SSR],
+    [coeffs[1][0], deltaCoeffs[1], RMSE, nDeg, SSE],
+  ];
+  for (let i = 2; i < nVar; i++) {
+    returned.push([coeffs[i][0], deltaCoeffs[i], "", "", ""]);
+  }
+  if (computeIntercept) {
+    returned.push([coeffs[nVar][0], deltaCoeffs[nVar], "", "", ""]);
+  } else {
+    returned.push([0, "", "", "", ""]);
+  }
+  return returned;
+}
+
+/*
+  This function performs a polynomial regression on the data set. It returns the coefficients of
+  the polynomial function that best fits the data set.
+  The polynomial function is: y = c0 + c1*x + c2*x^2 + ... + cn*x^n, where n is the order (degree)
+  of the polynomial. The returned coefficients are then in the form: [c0, c1, c2, ..., cn]
+  The function is based on the method of least squares :
+  see: https://mathworld.wolfram.com/LeastSquaresFittingPolynomial.html
+*/
+export function polynomialRegression(
+  flatY: number[],
+  flatX: number[],
+  order: number,
+  intercept: boolean
+): Matrix<number> {
+  assertSameNumberOfElements(flatX, flatY);
+  assert(
+    () => order >= 1,
+    _t("Function [[FUNCTION_NAME]] A regression of order less than 1 cannot be possible.")
+  );
+
+  const yMatrix = [flatY];
+  const xMatrix: Matrix<number> = flatX.map((x) =>
+    range(0, order).map((i) => Math.pow(x, order - i))
+  );
+  if (intercept) {
+    xMatrix.forEach((row) => row.push(1));
+  }
+
+  const coeffs = getLMSCoefficients(xMatrix, yMatrix);
+  if (!intercept) {
+    coeffs.push([0]);
+  }
+  return coeffs;
+}
+
+function getLMSCoefficients(xMatrix: Matrix<number>, yMatrix: Matrix<number>): Matrix<number> {
+  const xMatrixT = transposeMatrix(xMatrix);
+  const dot1 = multiplyMatrices(xMatrix, xMatrixT);
+  const { inverted: dotInv } = invertMatrix(dot1);
+  if (dotInv === undefined) {
+    throw new EvaluationError(_t("Matrix is not invertible"));
+  }
+  const dot2 = multiplyMatrices(xMatrix, yMatrix);
+  return transposeMatrix(multiplyMatrices(dotInv, dot2));
+}
+
+export function evaluatePolynomial(coeffs: number[], x: number, order: number): number {
+  return coeffs.reduce((acc, coeff, i) => acc + coeff * Math.pow(x, order - i), 0);
+}
+
+export function expM(M: Matrix<number>): Matrix<number> {
+  return M.map((col) => col.map((cell) => Math.exp(cell)));
+}
+
+export function logM(M: Matrix<number>): Matrix<number> {
+  return M.map((col) => col.map((cell) => Math.log(cell)));
+}
+
+export function predictLinearValues(
+  Y: Matrix<number>,
+  X: Matrix<number>,
+  newX: Matrix<number>,
+  computeIntercept: boolean
+): Matrix<number> {
+  const { _X, _newX } = prepareDataForRegression(X, Y, newX);
+  const coeffs = fullLinearRegression(_X, Y, computeIntercept, false);
+  const nVar = coeffs.length - 1;
+  const newY = _newX.map((col) => {
+    let value = 0;
+    for (let i = 0; i < nVar; i++) {
+      value += (coeffs[i][0] as number) * col[nVar - i - 1];
+    }
+    value += coeffs[nVar][0] as number;
+    return [value];
+  });
+  return newY.length === newX.length ? newY : transposeMatrix(newY);
 }

--- a/src/functions/module_statistical.ts
+++ b/src/functions/module_statistical.ts
@@ -1,4 +1,3 @@
-import { range } from "../helpers";
 import { percentile } from "../helpers/index";
 import { _t } from "../translation";
 import {
@@ -14,14 +13,19 @@ import {
 import { CellErrorType, EvaluationError, NotAvailableError } from "../types/errors";
 import { arg } from "./arguments";
 import { assertSameDimensions } from "./helper_assert";
-import { invertMatrix, multiplyMatrices } from "./helper_matrices";
 import {
   assertSameNumberOfElements,
   average,
   countAny,
   countNumbers,
+  evaluatePolynomial,
+  expM,
+  fullLinearRegression,
+  logM,
   max,
   min,
+  polynomialRegression,
+  predictLinearValues,
 } from "./helper_statistical";
 import {
   assert,
@@ -35,7 +39,6 @@ import {
   toMatrix,
   toNumber,
   toNumberMatrix,
-  transposeMatrix,
   visitAny,
   visitMatchingRanges,
   visitNumbers,
@@ -171,192 +174,6 @@ function centile(
   }
 
   return percentile(sortedArray, _percent, isInclusive);
-}
-
-function prepareDataForRegression(X: Matrix<number>, Y: Matrix<number>, newX: Matrix<number>) {
-  const _X = X[0].length ? X : [range(1, Y.flat().length + 1)];
-  const nVar = _X.length;
-  let _newX = newX[0].length ? newX : _X;
-  _newX = _newX.length === nVar ? transposeMatrix(_newX) : _newX;
-  return { _X, _newX };
-}
-
-/*
- * This function performs a linear regression on the data set. It returns an array with two elements.
- * The first element is the slope, and the second element is the intercept.
- * The linear regression line is: y = slope*x + intercept
- * The function use the least squares method to find the best fit for the data set :
- * see https://www.mathsisfun.com/data/least-squares-regression.html
- *     https://www.statology.org/standard-error-of-estimate/
- *     https://agronomy4future.org/?p=16670
- *     https://vitalflux.com/interpreting-f-statistics-in-linear-regression-formula-examples/
- *     https://web.ist.utl.pt/~ist11038/compute/errtheory/,regression/regrthroughorigin.pdf
- */
-
-function fullLinearRegression(
-  X: Matrix<number>,
-  Y: Matrix<number>,
-  computeIntercept = true,
-  verbose: boolean = false
-) {
-  const y = Y.flat();
-  const n = y.length;
-  let { _X } = prepareDataForRegression(X, Y, [[]]);
-  _X = _X.length === n ? transposeMatrix(_X) : _X.slice();
-  assertSameNumberOfElements(_X[0], y);
-  const nVar = _X.length;
-  const nDeg = n - nVar - (computeIntercept ? 1 : 0);
-  const yMatrix = [y];
-  const xMatrix: Matrix<number> = transposeMatrix(_X.reverse());
-  let avgX: number[] = [];
-  for (let i = 0; i < nVar; i++) {
-    avgX.push(0);
-    if (computeIntercept) {
-      for (const xij of _X[i]) {
-        avgX[i] += xij;
-      }
-      avgX[i] /= n;
-    }
-  }
-  let avgY = 0;
-  if (computeIntercept) {
-    for (const yi of y) {
-      avgY += yi;
-    }
-    avgY /= n;
-  }
-  const redX: Matrix<number> = xMatrix.map((row) => row.map((value, i) => value - avgX[i]));
-  if (computeIntercept) {
-    xMatrix.forEach((row) => row.push(1));
-  }
-  const coeffs = getLMSCoefficients(xMatrix, yMatrix);
-  if (!computeIntercept) {
-    coeffs.push([0]);
-  }
-  if (!verbose) {
-    return coeffs;
-  }
-  const dot1 = multiplyMatrices(redX, transposeMatrix(redX));
-  const { inverted: dotInv } = invertMatrix(dot1);
-  if (dotInv === undefined) {
-    throw new EvaluationError(_t("Matrix is not invertible"));
-  }
-  let SSE = 0,
-    SSR = 0;
-  for (let i = 0; i < n; i++) {
-    const yi = y[i] - avgY;
-    let temp = 0;
-    for (let j = 0; j < nVar; j++) {
-      const xi = redX[i][j];
-      temp += xi * coeffs[j][0];
-    }
-    const ei = yi - temp;
-    SSE += ei * ei;
-    SSR += temp * temp;
-  }
-  const RMSE = Math.sqrt(SSE / nDeg);
-  const r2 = SSR / (SSR + SSE);
-  const f_stat = SSR / nVar / (SSE / nDeg);
-  const deltaCoeffs: number[] = [];
-  for (let i = 0; i < nVar; i++) {
-    deltaCoeffs.push(RMSE * Math.sqrt(dotInv[i][i]));
-  }
-  if (computeIntercept) {
-    const dot2 = multiplyMatrices(dotInv, [avgX]);
-    const dot3 = multiplyMatrices(transposeMatrix([avgX]), dot2);
-    deltaCoeffs.push(RMSE * Math.sqrt(dot3[0][0] + 1 / y.length));
-  }
-  const returned: (number | string)[][] = [
-    [coeffs[0][0], deltaCoeffs[0], r2, f_stat, SSR],
-    [coeffs[1][0], deltaCoeffs[1], RMSE, nDeg, SSE],
-  ];
-  for (let i = 2; i < nVar; i++) {
-    returned.push([coeffs[i][0], deltaCoeffs[i], "", "", ""]);
-  }
-  if (computeIntercept) {
-    returned.push([coeffs[nVar][0], deltaCoeffs[nVar], "", "", ""]);
-  } else {
-    returned.push([0, "", "", "", ""]);
-  }
-  return returned;
-}
-
-/*
-  This function performs a polynomial regression on the data set. It returns the coefficients of
-  the polynomial function that best fits the data set.
-  The polynomial function is: y = c0 + c1*x + c2*x^2 + ... + cn*x^n, where n is the order (degree)
-  of the polynomial. The returned coefficients are then in the form: [c0, c1, c2, ..., cn]
-  The function is based on the method of least squares :
-  see: https://mathworld.wolfram.com/LeastSquaresFittingPolynomial.html
-*/
-function polynomialRegression(
-  flatY: number[],
-  flatX: number[],
-  order: number,
-  intercept: boolean
-): Matrix<number> {
-  assertSameNumberOfElements(flatX, flatY);
-  assert(
-    () => order >= 1,
-    _t("Function [[FUNCTION_NAME]] A regression of order less than 1 cannot be possible.")
-  );
-
-  const yMatrix = [flatY];
-  const xMatrix: Matrix<number> = flatX.map((x) =>
-    range(0, order).map((i) => Math.pow(x, order - i))
-  );
-  if (intercept) {
-    xMatrix.forEach((row) => row.push(1));
-  }
-
-  const coeffs = getLMSCoefficients(xMatrix, yMatrix);
-  if (!intercept) {
-    coeffs.push([0]);
-  }
-  return coeffs;
-}
-
-function getLMSCoefficients(xMatrix: Matrix<number>, yMatrix: Matrix<number>): Matrix<number> {
-  const xMatrixT = transposeMatrix(xMatrix);
-  const dot1 = multiplyMatrices(xMatrix, xMatrixT);
-  const { inverted: dotInv } = invertMatrix(dot1);
-  if (dotInv === undefined) {
-    throw new EvaluationError(_t("Matrix is not invertible"));
-  }
-  const dot2 = multiplyMatrices(xMatrix, yMatrix);
-  return transposeMatrix(multiplyMatrices(dotInv, dot2));
-}
-
-function evaluatePolynomial(coeffs: number[], x: number, order: number): number {
-  return coeffs.reduce((acc, coeff, i) => acc + coeff * Math.pow(x, order - i), 0);
-}
-
-function expM(M: Matrix<number>): Matrix<number> {
-  return M.map((col) => col.map((cell) => Math.exp(cell)));
-}
-
-function logM(M: Matrix<number>): Matrix<number> {
-  return M.map((col) => col.map((cell) => Math.log(cell)));
-}
-
-function predictLinearValues(
-  Y: Matrix<number>,
-  X: Matrix<number>,
-  newX: Matrix<number>,
-  computeIntercept: boolean
-): Matrix<number> {
-  const { _X, _newX } = prepareDataForRegression(X, Y, newX);
-  const coeffs = fullLinearRegression(_X, Y, computeIntercept, false);
-  const nVar = coeffs.length - 1;
-  const newY = _newX.map((col) => {
-    let value = 0;
-    for (let i = 0; i < nVar; i++) {
-      value += (coeffs[i][0] as number) * col[nVar - i - 1];
-    }
-    value += coeffs[nVar][0] as number;
-    return [value];
-  });
-  return newY.length === newX.length ? newY : transposeMatrix(newY);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/helpers/figures/charts/scatter_chart.ts
+++ b/src/helpers/figures/charts/scatter_chart.ts
@@ -1,6 +1,5 @@
 import { ChartDataset } from "chart.js";
 import { BACKGROUND_CHART_COLOR } from "../../../constants";
-import { toNumber } from "../../../functions/helpers";
 import {
   AddColumnsRowsCommand,
   ApplyRangeChange,
@@ -25,8 +24,6 @@ import { LegendPosition } from "../../../types/chart/common_chart";
 import { ScatterChartDefinition, ScatterChartRuntime } from "../../../types/chart/scatter_chart";
 import { Validator } from "../../../types/validator";
 import { toXlsxHexColor } from "../../../xlsx/helpers/colors";
-import { formatValue } from "../../format";
-import { isNumber } from "../../numbers";
 import { createValidRange } from "../../range";
 import { AbstractChart } from "./abstract_chart";
 import {
@@ -216,32 +213,12 @@ export function createScatterChartRuntime(
   chart: ScatterChart,
   getters: Getters
 ): ScatterChartRuntime {
-  const { chartJsConfig, background, dataSetsValues, dataSetFormat, labelValues, labelFormat } =
-    createLineOrScatterChartRuntime(chart, getters);
+  const { chartJsConfig, background } = createLineOrScatterChartRuntime(chart, getters);
   // use chartJS line chart and disable the lines instead of chartJS scatter chart. This is because the scatter chart
   // have less options than the line chart (it only works with linear labels)
   chartJsConfig.type = "line";
-
-  const configOptions = chartJsConfig.options!;
-  const locale = getters.getLocale();
-
-  configOptions.plugins!.tooltip!.callbacks!.title = () => "";
-  configOptions.plugins!.tooltip!.callbacks!.label = (tooltipItem) => {
-    const dataSetPoint = dataSetsValues[tooltipItem.datasetIndex!].data![tooltipItem.dataIndex!];
-    let label: string | number = tooltipItem.label || labelValues.values[tooltipItem.dataIndex!];
-    if (isNumber(label, locale)) {
-      label = toNumber(label, locale);
-    }
-    const formattedX = formatValue(label, { locale, format: labelFormat });
-    const formattedY = formatValue(dataSetPoint, { locale, format: dataSetFormat });
-    const dataSetTitle = tooltipItem.dataset.label;
-    return formattedX
-      ? `${dataSetTitle}: (${formattedX}, ${formattedY})`
-      : `${dataSetTitle}: ${formattedY}`;
-  };
-
   for (const dataSet of chartJsConfig.data!.datasets!) {
-    (dataSet as ChartDataset<"line">).showLine = false;
+    (dataSet as ChartDataset<"line">).showLine = "showLine" in dataSet ? dataSet.showLine : false;
   }
 
   return { chartJsConfig, background };

--- a/src/types/chart/chart.ts
+++ b/src/types/chart/chart.ts
@@ -85,7 +85,18 @@ export interface TitleDesign {
   readonly color?: Color;
 }
 
-export type CustomizedDataSet = { readonly dataRange: string } & DatasetDesign;
+export type TrendType = "polynomial" | "exponential" | "logarithmic";
+export interface TrendConfiguration {
+  type?: TrendType;
+  order?: number;
+  color?: Color;
+  display?: boolean;
+}
+
+export type CustomizedDataSet = {
+  readonly dataRange: string;
+  readonly trend?: TrendConfiguration;
+} & DatasetDesign;
 
 export type AxisType = "category" | "linear" | "time";
 


### PR DESCRIPTION
## Task Description

This task aims to add the ability to add a trending line per data serie in a chart 'with axis' (line, bar, scatter, combo). We have now 4 types of trending line (polynomial, exponential, linear and logarithmic) and the ability to edit the color of the line and the order of the polynomial.

## Related Task

- Task: [3997500](https://www.odoo.com/web#id=3997500&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo