### PR TITLE
[FIX] clipboard: Fixed pivot formula keep their reference

### DIFF
--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -47,7 +47,7 @@ export class CellClipboardHandler extends AbstractCellClipboardHandler<
         const pivotId = this.getters.getPivotIdFromPosition(position);
         const spreader = this.getters.getArrayFormulaSpreadingOn(position);
         if (pivotId) {
-          if (!deepEquals(spreader, position) || !isCopyingOneCell) {
+          if (spreader && (!deepEquals(spreader, position) || !isCopyingOneCell)) {
             const pivotCell = this.getters.getPivotCellFromPosition(position);
             const formulaPivotId = this.getters.getPivotFormulaId(pivotId);
             const pivotFormula = createPivotFormula(formulaPivotId, pivotCell);

--- a/tests/clipboard/clipboard_plugin.test.ts
+++ b/tests/clipboard/clipboard_plugin.test.ts
@@ -2011,6 +2011,25 @@ describe("clipboard", () => {
     paste(model, "G4");
     expect(getCell(model, "G4")!.content).toBe("=PIVOT(1)");
   });
+
+  test("fixed pivot formulas are copied like standard cells", () => {
+    // prettier-ignore
+    const grid = {
+      A1: "Customer", B1: "Price", C1: "1",
+      A2: "Alice",    B2: "10",    C2: '=PIVOT.VALUE(C1,"Price","Customer","Bob")',
+      A3: "Bob",      B3: "30"
+    };
+
+    const model = createModelFromGrid(grid);
+    addPivot(model, "A1:B3", {
+      columns: [],
+      rows: [{ name: "Customer" }],
+      measures: [{ name: "Price", aggregator: "sum" }],
+    });
+    copy(model, "C2");
+    paste(model, "G4");
+    expect(getCell(model, "G4")!.content).toBe('=PIVOT.VALUE(G3,"Price","Customer","Bob")');
+  });
 });
 
 describe("clipboard: pasting outside of sheet", () => {


### PR DESCRIPTION
The recent addition to copy the fixed pivot formulas of a spilled pivot introduced a bug where the clipboard would recompute the full pivot fixed formula even when we would copy the cell, which would resolve the references instead of keep it "as is".

How to reproduce:
- insert a pivot in a spreadsheet
- replace any argument by a reference to a cell with the value (see screenshot below)
- copy paste the cell => the reference is replaces with the value

Task: 4023453

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo