### PR TITLE
[FIX] parser: `parse` should handle unbounded references

### DIFF
--- a/src/formulas/parser.ts
+++ b/src/formulas/parser.ts
@@ -3,7 +3,8 @@ import { parseNumber, removeStringQuotes } from "../helpers/index";
 import { _lt } from "../translation";
 import { InvalidReferenceError } from "../types/errors";
 import { UnknownFunctionError } from "./../types/errors";
-import { Token, tokenize } from "./tokenizer";
+import { rangeTokenize } from "./range_tokenizer";
+import { Token } from "./tokenizer";
 
 const functionRegex = /[a-zA-Z0-9\_]+(\.[a-zA-Z0-9\_]+)*/;
 
@@ -235,7 +236,7 @@ function parseExpression(tokens: Token[], bp: number): AST {
  * Parse an expression (as a string) into an AST.
  */
 export function parse(str: string): AST {
-  return parseTokens(tokenize(str));
+  return parseTokens(rangeTokenize(str));
 }
 
 export function parseTokens(tokens: Token[]): AST {

--- a/tests/formulas/parser.test.ts
+++ b/tests/formulas/parser.test.ts
@@ -234,6 +234,7 @@ describe("Converting AST to string", () => {
     expect(astToFormula(parse("'Sheet 1'!A10"))).toBe("'Sheet 1'!A10");
     expect(astToFormula(parse("'Sheet 1'!A10:A11"))).toBe("'Sheet 1'!A10:A11");
     expect(astToFormula(parse("SUM(A1,A2)"))).toBe("SUM(A1,A2)");
+    expect(astToFormula(parse("'Sheet 1'!A:B"))).toBe("'Sheet 1'!A:B");
   });
   test("Convert strings", () => {
     expect(astToFormula(parse('"R"'))).toBe('"R"');


### PR DESCRIPTION
The function parse could not handle unbounded references as it relied on `tokenize` and not `rangeTokenize` which is required.

Task: 4010920

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo