### PR TITLE
[FIX] chart: cumulative not working for linear charts

### DIFF
--- a/src/helpers/charts/line_chart.ts
+++ b/src/helpers/charts/line_chart.ts
@@ -372,15 +372,6 @@ function createLineChartRuntime(chart: LineChart, getters: Getters): LineChartRu
 
   const colors = new ChartColors();
   for (let [index, { label, data }] of dataSetsValues.entries()) {
-    if (["linear", "time"].includes(axisType)) {
-      // Replace empty string labels by undefined to make sure chartJS doesn't decide that "" is the same as 0
-      data = data.map((y, index) => ({ x: labels[index] || undefined, y }));
-    }
-    const color = colors.next();
-    let backgroundRGBA = colorToRGBA(color);
-    if (chart.stacked) {
-      backgroundRGBA.a = LINE_FILL_TRANSPARENCY;
-    }
     if (chart.cumulative) {
       let accumulator = 0;
       data = data.map((value) => {
@@ -390,6 +381,16 @@ function createLineChartRuntime(chart: LineChart, getters: Getters): LineChartRu
         }
         return value;
       });
+    }
+
+    if (["linear", "time"].includes(axisType)) {
+      // Replace empty string labels by undefined to make sure chartJS doesn't decide that "" is the same as 0
+      data = data.map((y, index) => ({ x: labels[index] || undefined, y }));
+    }
+    const color = colors.next();
+    let backgroundRGBA = colorToRGBA(color);
+    if (chart.stacked) {
+      backgroundRGBA.a = LINE_FILL_TRANSPARENCY;
     }
 
     const backgroundColor = rgbaToHex(backgroundRGBA);

--- a/tests/plugins/chart/basic_chart.test.ts
+++ b/tests/plugins/chart/basic_chart.test.ts
@@ -27,6 +27,7 @@ import {
   updateChart,
 } from "../../test_helpers/commands_helpers";
 import { getPlugin, nextTick, target } from "../../test_helpers/helpers";
+
 jest.mock("../../../src/helpers/uuid", () => require("../../__mocks__/uuid"));
 
 let model: Model;
@@ -1779,6 +1780,30 @@ describe("Cumulative Data line chart", () => {
       .data!.datasets![0].data;
 
     expect(updatedChartData).toEqual(expectedCumulativeData);
+  });
+
+  test("Cumulative data with linear chart", () => {
+    setCellContent(model, "A1", "1");
+    setCellContent(model, "A2", "2");
+    setCellContent(model, "B1", "10");
+    setCellContent(model, "B2", "20");
+    createChart(
+      model,
+      {
+        dataSets: ["B1:B2"],
+        dataSetsHaveTitle: false,
+        labelRange: "A1:A2",
+        type: "line",
+        cumulative: true,
+      },
+      "chartId"
+    );
+
+    const runtime = model.getters.getChartRuntime("chartId") as LineChartRuntime;
+    expect(runtime.chartJsConfig.data!.datasets![0].data).toEqual([
+      { x: "1", y: 10 },
+      { x: "2", y: 30 },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Description

The `cumulative` chart option was not working for line charts with a linear/time axis.

This was because the data in the linear charts
runtime was an array of objects `{x, y}` rather than an array of numbers, and this wasn't properly handled in the cumulative computations.

Task: : [4028957](https://www.odoo.com/web#id=4028957&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo