### PR TITLE
[REV] chart: avoid useless chart updates

### DIFF
--- a/src/components/figures/chart/chartJs/chartjs.ts
+++ b/src/components/figures/chart/chartJs/chartjs.ts
@@ -1,6 +1,6 @@
 import { Component, onMounted, useEffect, useRef } from "@odoo/owl";
 import type { Chart, ChartConfiguration } from "chart.js";
-import { deepCopy, deepEquals } from "../../../../helpers";
+import { deepCopy } from "../../../../helpers";
 import { Figure, SpreadsheetChildEnv } from "../../../../types";
 import { ChartJSRuntime } from "../../../../types/chart/chart";
 import { GaugeChartConfiguration, GaugeChartOptions } from "../../../../types/chart/gauge_chart";
@@ -14,7 +14,6 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
 
   private canvas = useRef("graphContainer");
   private chart?: Chart;
-  private currentRuntime!: ChartJSRuntime;
 
   get background(): string {
     return this.chartRuntime.background;
@@ -35,17 +34,13 @@ export class ChartJsComponent extends Component<Props, SpreadsheetChildEnv> {
   setup() {
     onMounted(() => {
       const runtime = this.chartRuntime;
-      this.currentRuntime = runtime;
       // Note: chartJS modify the runtime in place, so it's important to give it a copy
       this.createChart(deepCopy(runtime.chartJsConfig));
     });
-    useEffect(() => {
-      const runtime = this.chartRuntime;
-      if (!deepEquals(runtime, this.currentRuntime, "ignoreFunctions")) {
-        this.currentRuntime = runtime;
-        this.updateChartJs(deepCopy(runtime));
-      }
-    });
+    useEffect(
+      () => this.updateChartJs(deepCopy(this.chartRuntime)),
+      () => [this.chartRuntime]
+    );
   }
 
   private createChart(chartData: ChartConfiguration | GaugeChartConfiguration) {

--- a/src/helpers/misc.ts
+++ b/src/helpers/misc.ts
@@ -355,7 +355,7 @@ export function getAddHeaderStartIndex(position: "before" | "after", base: numbe
 /**
  * Compares two objects.
  */
-export function deepEquals(o1: any, o2: any, ignoreFunctions?: "ignoreFunctions"): boolean {
+export function deepEquals(o1: any, o2: any): boolean {
   if (o1 === o2) return true;
   if ((o1 && !o2) || (o2 && !o1)) return false;
   if (typeof o1 !== typeof o2) return false;
@@ -369,14 +369,10 @@ export function deepEquals(o1: any, o2: any, ignoreFunctions?: "ignoreFunctions"
   }
 
   for (const key in o1) {
-    const typeOfO1Key = typeof o1[key];
-    if (typeOfO1Key !== typeof o2[key]) return false;
-    if (typeOfO1Key === "object") {
-      if (!deepEquals(o1[key], o2[key], ignoreFunctions)) return false;
+    if (typeof o1[key] !== typeof o2[key]) return false;
+    if (typeof o1[key] === "object") {
+      if (!deepEquals(o1[key], o2[key])) return false;
     } else {
-      if (ignoreFunctions && typeOfO1Key === "function") {
-        continue;
-      }
       if (o1[key] !== o2[key]) return false;
     }
   }

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -14,6 +14,7 @@ import {
   paste,
   selectCell,
   setCellContent,
+  setCellFormat,
   setStyle,
   updateChart,
 } from "../../test_helpers/commands_helpers";
@@ -1139,13 +1140,13 @@ describe("charts", () => {
     expect(getCellContent(model, "D6")).toEqual("");
   });
 
-  test("Chart is not re-rendered if its runtime do not change", async () => {
+  test("Chart is re-rendered if it's label format change", async () => {
     const updateChart = jest.spyOn((window as any).Chart.prototype, "update");
     createTestChart("basicChart");
     await nextTick();
-    setCellContent(model, "C3", "value");
+    setCellFormat(model, "B2", "#.##0.00");
     await nextTick();
-    expect(updateChart).not.toHaveBeenCalled();
+    expect(updateChart).toHaveBeenCalled();
   });
 });
 

--- a/tests/helpers/misc_helpers.test.ts
+++ b/tests/helpers/misc_helpers.test.ts
@@ -246,19 +246,6 @@ test.each([
   expect(deepEquals(o2, o1)).toEqual(expectedResult);
 });
 
-test("deepEquals with argument ignoring functions", () => {
-  const o1 = { a: 1, b: () => 2, c: 2 };
-  const o2 = { a: 1, b: () => 2, c: 2 };
-  const o3 = { a: 1, b: () => 2, c: 3 };
-  const o4 = { a: 2, b: () => 2, c: 2 };
-  expect(deepEquals(o1, o2)).toEqual(false);
-  expect(deepEquals(o1, o2, "ignoreFunctions")).toEqual(true);
-  expect(deepEquals(o1, o3)).toEqual(false);
-  expect(deepEquals(o1, o3, "ignoreFunctions")).toEqual(false);
-  expect(deepEquals(o1, o4)).toEqual(false);
-  expect(deepEquals(o1, o4, "ignoreFunctions")).toEqual(false);
-});
-
 describe("isConsecutive", () => {
   test("consecutive", () => {
     expect(isConsecutive([2, 3, 1])).toBeTruthy();


### PR DESCRIPTION
## Description

This reverts commit 6eb43533d.

It turns out that checking the deep equality of runtime while ignoring functions is not a good fix to avoid useless chart updates. The problem is that some runtime changes apply only to the callbacks (eg. changing the dataset format only change the ticks callback).

The only real alternative would be to add the variables that are used in the callbacks to the runtime, so the deepEquals would work. But this is very error prone: we'll 100% forget to add a variable at some point.

So we will accept the useless updates for now, until we see a real performance issue.

Task: : [4029016](https://www.odoo.com/web#id=4029016&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo