### PR TITLE
[FIX] locale: handle undefined thousands separator

### DIFF
--- a/src/components/side_panel/settings/settings_panel.ts
+++ b/src/components/side_panel/settings/settings_panel.ts
@@ -31,7 +31,13 @@ export class SettingsPanel extends Component<Props, SpreadsheetChildEnv> {
 
   private async loadLocales() {
     this.loadedLocales = (await this.env.loadLocales())
-      .filter(isValidLocale)
+      .filter((locale) => {
+        const isValid = isValidLocale(locale);
+        if (!isValid) {
+          console.warn(`Invalid locale: ${locale["code"]} ${locale}`);
+        }
+        return isValid;
+      })
       .sort((a, b) => a.name.localeCompare(b.name));
   }
 

--- a/src/helpers/locale.ts
+++ b/src/helpers/locale.ts
@@ -15,23 +15,24 @@ import { isNumber } from "./numbers";
 
 export function isValidLocale(locale: any): locale is Locale {
   if (
-    !(
-      locale &&
-      typeof locale === "object" &&
-      typeof locale.name === "string" &&
-      typeof locale.code === "string" &&
-      typeof locale.thousandsSeparator === "string" &&
-      typeof locale.decimalSeparator === "string" &&
-      typeof locale.dateFormat === "string" &&
-      typeof locale.timeFormat === "string" &&
-      typeof locale.formulaArgSeparator === "string"
-    )
+    !locale ||
+    typeof locale !== "object" ||
+    !(!locale.thousandsSeparator || typeof locale.thousandsSeparator === "string")
   ) {
     return false;
   }
 
-  if (!Object.values(locale).every((v) => v)) {
-    return false;
+  for (const property of [
+    "code",
+    "name",
+    "decimalSeparator",
+    "dateFormat",
+    "timeFormat",
+    "formulaArgSeparator",
+  ]) {
+    if (!locale[property] || typeof locale[property] !== "string") {
+      return false;
+    }
   }
 
   if (locale.formulaArgSeparator === locale.decimalSeparator) {
@@ -158,7 +159,10 @@ export function canonicalizeNumberLiteral(content: string, locale: Locale): stri
   if (locale.decimalSeparator === "." || !isNumber(content, locale)) {
     return content;
   }
-  return content.replace(locale.thousandsSeparator, "").replace(locale.decimalSeparator, ".");
+  if (locale.thousandsSeparator) {
+    content = content.replaceAll(locale.thousandsSeparator, "");
+  }
+  return content.replace(locale.decimalSeparator, ".");
 }
 
 /**

--- a/src/helpers/numbers.ts
+++ b/src/helpers/numbers.ts
@@ -20,7 +20,7 @@ export const getFormulaNumberRegex = memoize(function getFormulaNumberRegex(
 
 const getNumberRegex = memoize(function getNumberRegex(locale: Locale) {
   const decimalSeparator = escapeRegExp(locale.decimalSeparator);
-  const thousandsSeparator = escapeRegExp(locale.thousandsSeparator);
+  const thousandsSeparator = escapeRegExp(locale.thousandsSeparator || "");
 
   const pIntegerAndDecimals = `(\\d+(${thousandsSeparator}\\d{3,})*(${decimalSeparator}\\d*)?)`; // pattern that match integer number with or without decimal digits
   const pOnlyDecimals = `(${decimalSeparator}\\d+)`; // pattern that match only expression with decimal digits
@@ -54,7 +54,7 @@ export function isNumber(value: string | undefined, locale: Locale): boolean {
 }
 
 const getInvaluableSymbolsRegexp = memoize(function getInvaluableSymbolsRegexp(locale: Locale) {
-  return new RegExp(`[\$€${escapeRegExp(locale.thousandsSeparator)}]`, "g");
+  return new RegExp(`[\$€${escapeRegExp(locale.thousandsSeparator || "")}]`, "g");
 });
 /**
  * Convert a string into a number. It assumes that the string actually represents

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -5,7 +5,7 @@ export type LocaleCode = string & Alias;
 export interface Locale {
   name: string;
   code: LocaleCode;
-  thousandsSeparator: string;
+  thousandsSeparator?: string;
   decimalSeparator: string;
   dateFormat: string;
   timeFormat: string;

--- a/tests/functions/helper.test.ts
+++ b/tests/functions/helper.test.ts
@@ -306,13 +306,14 @@ describe("Function helpers", () => {
 describe("Locale helpers", () => {
   test("isValidLocale", () => {
     const locale = DEFAULT_LOCALE;
+    expect(isValidLocale({ ...locale, thousandsSeparator: undefined })).toBe(true);
 
     expect(isValidLocale(locale)).toBe(true);
 
     // Missing values
     expect(isValidLocale("en_US")).toBe(false);
     expect(isValidLocale({})).toBe(false);
-    expect(isValidLocale({ ...locale, thousandsSeparator: undefined })).toBe(false);
+    expect(isValidLocale({ ...locale, thousandsSeparator: undefined })).toBe(true);
     expect(isValidLocale({ ...locale, decimalSeparator: undefined })).toBe(false);
     expect(isValidLocale({ ...locale, dateFormat: undefined })).toBe(false);
     expect(isValidLocale({ ...locale, timeFormat: undefined })).toBe(false);
@@ -320,13 +321,15 @@ describe("Locale helpers", () => {
     expect(isValidLocale({ ...locale, code: undefined })).toBe(false);
     expect(isValidLocale({ ...locale, name: undefined })).toBe(false);
 
-    expect(isValidLocale({ ...locale, thousandsSeparator: "" })).toBe(false);
+    expect(isValidLocale({ ...locale, thousandsSeparator: "" })).toBe(true);
     expect(isValidLocale({ ...locale, decimalSeparator: "" })).toBe(false);
     expect(isValidLocale({ ...locale, dateFormat: "" })).toBe(false);
     expect(isValidLocale({ ...locale, timeFormat: "" })).toBe(false);
     expect(isValidLocale({ ...locale, formulaArgSeparator: "" })).toBe(false);
     expect(isValidLocale({ ...locale, code: "" })).toBe(false);
     expect(isValidLocale({ ...locale, name: "" })).toBe(false);
+
+    expect(isValidLocale({ ...locale, thousandsSeparator: 56 })).toBe(false);
 
     // Invalid formats
     expect(isValidLocale({ ...locale, dateFormat: "hey" })).toBe(false);

--- a/tests/helpers/locale_helpers.test.ts
+++ b/tests/helpers/locale_helpers.test.ts
@@ -10,7 +10,7 @@ import {
   ConditionalFormattingOperatorValues,
   IconSetRule,
 } from "../../src/types";
-import { FR_LOCALE } from "../test_helpers/constants";
+import { FR_LOCALE } from "./../test_helpers/constants";
 
 describe("Locale helpers", () => {
   describe("canonicalize content", () => {
@@ -18,6 +18,7 @@ describe("Locale helpers", () => {
       expect(canonicalizeContent("1", FR_LOCALE)).toBe("1");
       expect(canonicalizeContent("1,1", FR_LOCALE)).toBe("1.1");
       expect(canonicalizeContent("1 000,1", FR_LOCALE)).toBe("1000.1");
+      expect(canonicalizeContent("1 000 000,1", FR_LOCALE)).toBe("1000000.1");
       expect(canonicalizeContent("1.000,1", { ...FR_LOCALE, thousandsSeparator: "." })).toBe(
         "1000.1"
       );
@@ -28,6 +29,10 @@ describe("Locale helpers", () => {
       expect(canonicalizeContent("01/10/2022", FR_LOCALE)).toBe("10/1/2022");
       expect(canonicalizeContent("01/10/2022 10:00:00", FR_LOCALE)).toBe("10/1/2022 10:00:00 AM");
       expect(canonicalizeContent("01-10-2022", FR_LOCALE)).toBe("10/1/2022");
+
+      expect(
+        canonicalizeContent("1000000,1", { ...FR_LOCALE, thousandsSeparator: undefined })
+      ).toBe("1000000.1");
     });
 
     test("Non-number literals aren't canonicalize", () => {


### PR DESCRIPTION
## Description

This commit adds the handling of undefined thousands separator in the locales.

Also fix a bug where we couldn't canonicalize a number with multiple thousands separators.

Also add a warning in the console when an invalid locale is filtered from the side panel.

Task: : 0
## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo