### PR TITLE
[IMP] icons: add unhide col/row icons

### DIFF
--- a/src/actions/view_actions.ts
+++ b/src/actions/view_actions.ts
@@ -37,6 +37,7 @@ export const unhideCols: ActionSpec = {
     const currentCols = env.model.getters.getElementsFromSelection("COL");
     return currentCols.some((col) => hiddenCols.includes(col));
   },
+  icon: "o-spreadsheet-Icon.UNHIDE_COL",
 };
 
 export const unhideAllCols: ActionSpec = {
@@ -51,6 +52,7 @@ export const unhideAllCols: ActionSpec = {
   },
   isVisible: (env: SpreadsheetChildEnv) =>
     env.model.getters.getHiddenColsGroups(env.model.getters.getActiveSheetId()).length > 0,
+  icon: "o-spreadsheet-Icon.UNHIDE_COL",
 };
 
 export const hideRows: ActionSpec = {
@@ -84,6 +86,7 @@ export const unhideRows: ActionSpec = {
     const currentRows = env.model.getters.getElementsFromSelection("ROW");
     return currentRows.some((col) => hiddenRows.includes(col));
   },
+  icon: "o-spreadsheet-Icon.UNHIDE_ROW",
 };
 
 export const unhideAllRows: ActionSpec = {
@@ -98,6 +101,7 @@ export const unhideAllRows: ActionSpec = {
   },
   isVisible: (env: SpreadsheetChildEnv) =>
     env.model.getters.getHiddenRowsGroups(env.model.getters.getActiveSheetId()).length > 0,
+  icon: "o-spreadsheet-Icon.UNHIDE_ROW",
 };
 
 export const unFreezePane: ActionSpec = {

--- a/src/components/icons/icons.xml
+++ b/src/components/icons/icons.xml
@@ -130,11 +130,27 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.UNHIDE_ROW">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M17.5 16a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2A1.5 1.5 0 0 1 2 .5h14A1.5 1.5 0 0 1 17.5 2zH16v-3.5H2V16h14V2H2v3.5h14"
+      />
+    </svg>
+  </t>
   <t t-name="o-spreadsheet-Icon.HIDE_COL">
     <svg class="o-icon">
       <path
         fill="currentColor"
         d="M16 .5A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2A1.5 1.5 0 0 1 2 .5h14V2h-3.5v14H16V2H7v14h4V2H2v14h3.5V2M6 1l5 4v2L6 3m0 2 5 4v2L6 7m0 2 5 4v2l-5-4"
+      />
+    </svg>
+  </t>
+  <t t-name="o-spreadsheet-Icon.UNHIDE_COL">
+    <svg class="o-icon">
+      <path
+        fill="currentColor"
+        d="M16 .5A1.5 1.5 0 0 1 17.5 2v14a1.5 1.5 0 0 1-1.5 1.5H2A1.5 1.5 0 0 1 .5 16V2A1.5 1.5 0 0 1 2 .5h14V2h-3.5v14H16V2H2V16h3.5V2"
       />
     </svg>
   </t>


### PR DESCRIPTION
## Taks Description

This task add icons for the Unhide Column(s) and Unhide Row(s) menu items

## Related Task

- Task: [3863473](https://www.odoo.com/odoo/project/2328/tasks/3863473?cids=1)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo