### PR TITLE
[IMP] top_bar: allow to change the order of the top bar components

### DIFF
--- a/src/components/top_bar/top_bar.ts
+++ b/src/components/top_bar/top_bar.ts
@@ -181,7 +181,7 @@ export class TopBar extends Component<Props, SpreadsheetChildEnv> {
 
   get topbarComponents() {
     return topbarComponentRegistry
-      .getAll()
+      .getAllOrdered()
       .filter((item) => !item.isVisible || item.isVisible(this.env));
   }
 

--- a/src/components/top_bar/top_bar.xml
+++ b/src/components/top_bar/top_bar.xml
@@ -20,8 +20,8 @@
             </div>
           </t>
         </div>
-        <div class="o-topbar-topright d-flex justify-content-end">
-          <div t-foreach="topbarComponents" t-as="comp" t-key="comp.id">
+        <div class="o-topbar-topright d-flex justify-content-end align-items-center">
+          <div t-foreach="topbarComponents" t-as="comp" t-key="comp.id" class="px-1">
             <t t-component="comp.component"/>
           </div>
         </div>

--- a/src/registries/topbar_component_registry.ts
+++ b/src/registries/topbar_component_registry.ts
@@ -10,6 +10,7 @@ export interface TopbarComponent {
   id: UID;
   component: any;
   isVisible?: (env: SpreadsheetChildEnv) => boolean;
+  sequence: number;
 }
 
 class TopBarComponentRegistry extends Registry<TopbarComponent> {
@@ -19,6 +20,10 @@ class TopBarComponentRegistry extends Registry<TopbarComponent> {
   add(name: string, value: Omit<TopbarComponent, "id">) {
     const component: TopbarComponent = { ...value, id: this.uuidGenerator.uuidv4() };
     return super.add(name, component);
+  }
+
+  getAllOrdered(): TopbarComponent[] {
+    return this.getAll().sort((a, b) => a.sequence - b.sequence);
   }
 }
 

--- a/tests/__snapshots__/top_bar_component.test.ts.snap
+++ b/tests/__snapshots__/top_bar_component.test.ts.snap
@@ -54,7 +54,7 @@ exports[`TopBar component can set cell format 1`] = `
           
         </div>
         <div
-          class="o-topbar-topright d-flex justify-content-end"
+          class="o-topbar-topright d-flex justify-content-end align-items-center"
         >
           
         </div>
@@ -1017,7 +1017,7 @@ exports[`TopBar component simple rendering 1`] = `
       
     </div>
     <div
-      class="o-topbar-topright d-flex justify-content-end"
+      class="o-topbar-topright d-flex justify-content-end align-items-center"
     >
       
     </div>

--- a/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
+++ b/tests/spreadsheet/__snapshots__/spreadsheet_component.test.ts.snap
@@ -55,7 +55,7 @@ exports[`Simple Spreadsheet Component simple rendering snapshot 1`] = `
         
       </div>
       <div
-        class="o-topbar-topright d-flex justify-content-end"
+        class="o-topbar-topright d-flex justify-content-end align-items-center"
       >
         
       </div>

--- a/tests/top_bar_component.test.ts
+++ b/tests/top_bar_component.test.ts
@@ -516,7 +516,7 @@ describe("TopBar component", () => {
 
   test("Can add a custom component to topbar", async () => {
     const compDefinitions = Object.assign({}, topbarComponentRegistry.content);
-    topbarComponentRegistry.add("1", { component: Comp });
+    topbarComponentRegistry.add("1", { component: Comp, sequence: 1 });
     await mountParent();
     expect(fixture.querySelectorAll(".o-topbar-test")).toHaveLength(1);
     topbarComponentRegistry.content = compDefinitions;
@@ -530,8 +530,9 @@ describe("TopBar component", () => {
       isVisible: () => {
         return comp1Visibility;
       },
+      sequence: 1,
     });
-    topbarComponentRegistry.add("second", { component: Comp2 });
+    topbarComponentRegistry.add("second", { component: Comp2, sequence: 2 });
     const { parent } = await mountParent();
     expect(fixture.querySelectorAll(".o-topbar-test1")).toHaveLength(0);
     expect(fixture.querySelectorAll(".o-topbar-test2")).toHaveLength(1);
@@ -641,10 +642,12 @@ test("Can show/hide a TopBarComponent based on condition", async () => {
   topbarComponentRegistry.add("1", {
     component: Comp1,
     isVisible: (env) => true,
+    sequence: 1,
   });
   topbarComponentRegistry.add("2", {
     component: Comp2,
     isVisible: (env) => false,
+    sequence: 2,
   });
   await mountParent();
   expect(fixture.querySelectorAll(".o-topbar-test1")).toHaveLength(1);


### PR DESCRIPTION
Task: 4000864

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo