### PR TITLE
[FIX] charts: truncate labels by default

### DIFF
--- a/src/helpers/figures/charts/chart_ui_common.ts
+++ b/src/helpers/figures/charts/chart_ui_common.ts
@@ -100,7 +100,7 @@ export function getDefaultChartJsRuntime(
   chart: AbstractChart,
   labels: string[],
   fontColor: Color,
-  { format, locale, truncateLabels }: LocaleFormat & { truncateLabels?: boolean }
+  { format, locale, truncateLabels = true }: LocaleFormat & { truncateLabels?: boolean }
 ): Required<ChartConfiguration> {
   const options: ChartOptions = {
     // https://www.chartjs.org/docs/latest/general/responsive.html

--- a/tests/figures/chart/chart_plugin.test.ts
+++ b/tests/figures/chart/chart_plugin.test.ts
@@ -2004,6 +2004,30 @@ describe("Linear/Time charts", () => {
     expect(chart.data!.datasets![0].data![0]).toEqual({ y: 10, x: formattedValue });
   });
 
+  test.each(["bar", "line", "pie"] as const)("long labels are truncated in %s chart", (type) => {
+    setCellContent(model, "A2", "This is a very long label that should be truncated");
+    setCellContent(model, "B1", "First dataset");
+    setCellContent(model, "B2", "10");
+
+    createChart(
+      model,
+      {
+        type,
+        dataSets: ["B1:B2"],
+        labelRange: "A2",
+        labelsAsText: false,
+        dataSetsHaveTitle: true,
+      },
+      chartId
+    );
+
+    const chart = (model.getters.getChartRuntime(chartId) as BarChartRuntime).chartJsConfig;
+
+    expect(chart.data!.labels![0]).toEqual("This is a very long …");
+    expect((chart.data!.labels![0] as string).length).toBe(MAX_CHAR_LABEL + 1); // +1 for the ellipsis
+    expect(chart.data!.datasets![0].data![0]).toEqual(10);
+  });
+
   test("linear chart: label 0 isn't set to undefined", () => {
     setCellContent(model, "B2", "0");
     setCellContent(model, "B3", "1");


### PR DESCRIPTION
# Description

This PR ensures that labels are truncated by default in charts. The truncation can be disabled by passing the `truncate` option to the chart configuration.

Task: : [3958962](https://www.odoo.com/odoo/project/2328/tasks/3958962?cids=2)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo