### PR TITLE
[FIX] CF: Ignore errors thrown during CF evaluation

### DIFF
--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -479,7 +479,7 @@ describe("conditional format", () => {
     });
   });
 
-  test.skip("multiple conditional formats using stopIfTrue flag", () => {
+  test("multiple conditional formats using stopIfTrue flag", () => {
     setCellContent(model, "A1", "2");
 
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
@@ -1650,6 +1650,29 @@ describe("conditional formats types", () => {
       });
       expect(result).toBeCancelledBecause(CommandResult.FirstArgMissing);
     });
+
+    test.each(["=$c:$2", "=suùù("])(
+      "Invalid formula ('%s') as CF value are ignored during CF evaluation",
+      (formula: string) => {
+        setCellContent(model, "A1", "5");
+        model.dispatch("ADD_CONDITIONAL_FORMAT", {
+          cf: {
+            rule: {
+              type: "CellIsRule",
+              operator: "NotEqual",
+              values: [formula],
+              style: { fillColor: "#ff0f0f" },
+            },
+            id: "11",
+          },
+          ranges: toRangesData(sheetId, "A1"),
+          sheetId,
+        });
+        expect(model.getters.getCellComputedStyle(model.getters.getActivePosition())).toMatchObject(
+          {}
+        );
+      }
+    );
   });
   test.each([
     ["Between", ["1"]],


### PR DESCRIPTION
How to reproduce:
- Add a CF of type "single color"
- Input an invalid formula as its value
- save the CF

-> the whole grid crashes

Historically, the CF evaluation was wrapped in a try-catch statement and it was removed https://github.com/odoo/o-spreadsheet/pull/3380 as it seemed unnecessary. Unfortunately, since there is no check on the formula validity when we create the CF, the call to `compile` can crash.

A future improvement (targetting master) will align the behaviour of "cellIsRule" with the other CF type ("ColorScaleRule" and "IconSetRule") and catch invalid formulas in the `allowDispatch`.

Task: 4036921

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo