### PR TITLE
[IMP] CF: Capture invalid formula for cellIsRule

### DIFF
--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -394,11 +394,14 @@ export class ConditionalFormattingEditor extends Component<Props, SpreadsheetChi
    ****************************************************************************/
 
   get isValue1Invalid(): boolean {
-    return !!this.state.errors?.includes(CommandResult.FirstArgMissing);
+    return (
+      this.state.errors.includes(CommandResult.FirstArgMissing) ||
+      this.state.errors.includes(CommandResult.ValueCellIsInvalidFormula)
+    );
   }
 
   get isValue2Invalid(): boolean {
-    return !!this.state.errors?.includes(CommandResult.SecondArgMissing);
+    return this.state.errors.includes(CommandResult.SecondArgMissing);
   }
 
   toggleStyle(tool: string) {

--- a/src/components/translations_terms.ts
+++ b/src/components/translations_terms.ts
@@ -24,6 +24,9 @@ export const CfTerms = {
     [CommandResult.ValueUpperInvalidFormula]: _t("Invalid upper inflection point formula"),
     [CommandResult.ValueLowerInvalidFormula]: _t("Invalid lower inflection point formula"),
     [CommandResult.EmptyRange]: _t("A range needs to be defined"),
+    [CommandResult.ValueCellIsInvalidFormula]: _t(
+      "At least one of the provided values is an invalid formula"
+    ),
     Unexpected: _t("The rule is invalid for an unknown reason"),
   },
   ColorScale: _t("Color scale"),

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -342,7 +342,8 @@ export class ConditionalFormatPlugin
             "LessThanOrEqual",
             "NotContains",
           ]),
-          this.checkOperatorArgsNumber(0, ["IsEmpty", "IsNotEmpty"])
+          this.checkOperatorArgsNumber(0, ["IsEmpty", "IsNotEmpty"]),
+          this.checkCFValues
         );
       case "ColorScaleRule": {
         return this.checkValidations(
@@ -510,6 +511,17 @@ export class ConditionalFormatPlugin
       stringToNumber(minValue) >= stringToNumber(midValue)
     ) {
       return CommandResult.MinBiggerThanMid;
+    }
+    return CommandResult.Success;
+  }
+
+  private checkCFValues(rule: CellIsRule) {
+    for (const value of rule.values) {
+      if (!value.startsWith("=")) continue;
+      const compiledFormula = compile(value || "");
+      if (compiledFormula.isBadExpression) {
+        return CommandResult.ValueCellIsInvalidFormula;
+      }
     }
     return CommandResult.Success;
   }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1271,6 +1271,7 @@ export const enum CommandResult {
   InvalidTableResize = "InvalidTableResize",
   PivotIdNotFound = "PivotIdNotFound",
   EmptyName = "EmptyName",
+  ValueCellIsInvalidFormula = "ValueCellIsInvalidFormula",
 }
 
 export interface CommandHandler<T> {

--- a/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_panel_component.test.ts
@@ -1017,6 +1017,17 @@ describe("UI of conditional formats", () => {
     expect(errorMessages()).toEqual(["The second argument is missing. Please provide a value"]);
   });
 
+  test("single color with an invalid formula as value", async () => {
+    await click(fixture, selectors.buttonAdd);
+    setInputValueAndTrigger(selectors.ruleEditor.range, "A1:A3");
+    await setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "GreaterThan");
+    expect(fixture.querySelector(".o-invalid")).toBeNull();
+    await editStandaloneComposer(selectors.ruleEditor.editor.valueInput, "=suùù(");
+    await click(fixture, selectors.buttonSave);
+    expect(fixture.querySelector(".o-invalid")).not.toBeNull();
+    expect(errorMessages()).toEqual(["At least one of the provided values is an invalid formula"]);
+  });
+
   test("changing rule type resets errors", async () => {
     await click(fixture, selectors.buttonAdd);
     setInputValueAndTrigger(selectors.ruleEditor.editor.operatorInput, "GreaterThan");

--- a/tests/conditional_formatting/conditional_formatting_plugin.test.ts
+++ b/tests/conditional_formatting/conditional_formatting_plugin.test.ts
@@ -505,7 +505,7 @@ describe("conditional format", () => {
     });
   });
 
-  test.skip("multiple conditional formats using stopIfTrue flag", () => {
+  test("multiple conditional formats using stopIfTrue flag", () => {
     setCellContent(model, "A1", "2");
 
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
@@ -675,7 +675,7 @@ describe("conditional format", () => {
     });
   });
 
-  test("cannot send invalid arguments to conditional format rules command", () => {
+  test("cannot send invalid arguments to *move* conditional format rules command", () => {
     model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: createEqualCF("1", { fillColor: "#FF0000" }, "idRule1"),
       ranges: toRangesData(sheetId, "A1"),
@@ -1676,6 +1676,26 @@ describe("conditional formats types", () => {
       });
       expect(result).toBeCancelledBecause(CommandResult.FirstArgMissing);
     });
+
+    test.each(["=$c:$2", "=suùù("])(
+      "Invalid formula ('%s') cannot be set as CF value",
+      (formula: string) => {
+        const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
+          cf: {
+            rule: {
+              type: "CellIsRule",
+              operator: "GreaterThan",
+              values: [formula],
+              style: { fillColor: "#ff0f0f" },
+            },
+            id: "11",
+          },
+          ranges: toRangesData(sheetId, "A1"),
+          sheetId,
+        });
+        expect(result).toBeCancelledBecause(CommandResult.ValueCellIsInvalidFormula);
+      }
+    );
   });
   test.each([
     ["Between", ["1"]],
@@ -1683,7 +1703,7 @@ describe("conditional formats types", () => {
     ["NotBetween", ["1"]],
     ["NotBetween", ["1", ""]],
   ])("%s operator with missing second argument %s", (operator: string, values: string[]) => {
-    let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
+    const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: {
         rule: {
           type: "CellIsRule",
@@ -1702,7 +1722,7 @@ describe("conditional formats types", () => {
     ["Between", ["", ""]],
     ["NotBetween", ["", ""]],
   ])("%s operator with both arguments missing %s", (operator: string, values: string[]) => {
-    let result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
+    const result = model.dispatch("ADD_CONDITIONAL_FORMAT", {
       cf: {
         rule: {
           type: "CellIsRule",


### PR DESCRIPTION
A user could input an invalid formula in for "cellIsRule" type of conditional formats. Up until recently, this did not pause any problem because the evaluation of cf was wrapped in a try catch and we would simply ignore the faulty formulas.
Unfortunately, following
https://github.com/odoo/o-spreadsheet/pull/3380, the try/catch was removed and the faulty CF would throw an error during its evaluation.

This commit reinstates the try-catch in case another part of the evaluation could throw in the future so that the end user would not see their spreadsheet chrash entirely and become unable to use it themselves.

It also adds a new condition to the CF allow dispatch to capture invalid formula in order to warn the user during the CF edition in the same way we already handle invalid formulas for colorScale and Iconset rules.

Task: 4036921

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo