### PR TITLE
[IMP] tests: add typing for window

### DIFF
--- a/tests/__mocks__/content_editable_helper.ts
+++ b/tests/__mocks__/content_editable_helper.ts
@@ -106,7 +106,6 @@ export class ContentEditableHelper {
   private attachEventHandlers() {
     if (this.el === null) return;
     this.el.addEventListener("keydown", (ev: KeyboardEvent) => this.onKeyDown(this.el!, ev));
-    // @ts-ignore
     this.el.addEventListener("focus", (ev: FocusEvent) => (window.mockContentHelper = this));
   }
 

--- a/tests/composer/autocomplete_dropdown_component.test.ts
+++ b/tests/composer/autocomplete_dropdown_component.test.ts
@@ -39,7 +39,6 @@ async function typeInComposer(text: string, fromScratch: boolean = true) {
     parent.startComposition();
   }
   const composerEl = await typeInComposerHelper("div.o-composer", text, false);
-  // @ts-ignore
   cehMock = window.mockContentHelper;
   return composerEl;
 }

--- a/tests/composer/composer_component.test.ts
+++ b/tests/composer/composer_component.test.ts
@@ -56,7 +56,6 @@ let composerStore: Store<ComposerStore>;
 async function startComposition(text?: string): Promise<HTMLDivElement> {
   parent.startComposition(text);
   await nextTick();
-  // @ts-ignore
   cehMock = window.mockContentHelper;
   return fixture.querySelector("div.o-composer")! as HTMLDivElement;
 }
@@ -66,7 +65,6 @@ async function typeInComposer(text: string, fromScratch: boolean = true) {
     parent.startComposition();
   }
   const composerEl = await typeInComposerHelper("div.o-composer", text, false);
-  // @ts-ignore
   cehMock = window.mockContentHelper;
   return composerEl;
 }

--- a/tests/composer/composer_integration_component.test.ts
+++ b/tests/composer/composer_integration_component.test.ts
@@ -62,21 +62,18 @@ let composerStore: Store<ComposerStore>;
 
 async function startComposition(key?: string) {
   const composerEl = await startGridComposition(key);
-  // @ts-ignore
   cehMock = window.mockContentHelper;
   return composerEl;
 }
 
 async function typeInComposerGrid(text: string, fromScratch: boolean = true) {
   const composerEl = await typeInComposerGridHelper(text, fromScratch);
-  // @ts-ignore
   cehMock = window.mockContentHelper;
   return composerEl;
 }
 
 async function typeInComposerTopBar(text: string, fromScratch: boolean = true) {
   const composerEl = await typeInComposerTopBarHelper(text, fromScratch);
-  // @ts-ignore
   cehMock = window.mockContentHelper;
   return composerEl;
 }

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -4,10 +4,19 @@
 import { App } from "@odoo/owl";
 import { setDefaultSheetViewSize } from "../../src/constants";
 import { getCompiledTemplates } from "../../tools/owl_templates/compile_templates.cjs";
+import { ContentEditableHelper } from "../__mocks__/content_editable_helper";
 import "./canvas.mock";
 import "./jest_extend";
 import "./polyfill";
 import "./resize_observer.mock";
+import { Resizers } from "./resize_observer.mock";
+
+declare global {
+  interface Window {
+    mockContentHelper: ContentEditableHelper;
+    resizers: Resizers;
+  }
+}
 
 function registerOwlTemplates() {
   const templates = getCompiledTemplates();
@@ -55,8 +64,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  //@ts-ignore
-  global.resizers.removeAll();
+  window.resizers.removeAll();
   executeCleanups();
 });
 

--- a/tests/setup/resize_observer.mock.ts
+++ b/tests/setup/resize_observer.mock.ts
@@ -4,24 +4,21 @@ class MockResizeObserver {
     this.cb = cb;
   }
   observe() {
-    //@ts-ignore
-    global.resizers.add(this);
+    window.resizers.add(this);
     Promise.resolve().then(() => this.cb());
   }
 
   unobserve() {
-    //@ts-ignore
-    global.resizers.remove(this);
+    window.resizers.remove(this);
   }
 
   disconnect() {
-    //@ts-ignore
-    global.resizers.remove(this);
+    window.resizers.remove(this);
   }
 }
-global.ResizeObserver = MockResizeObserver;
+window.ResizeObserver = MockResizeObserver;
 
-class Resizers {
+export class Resizers {
   private resizers: Set<MockResizeObserver> = new Set();
 
   add(resizeObserver: MockResizeObserver) {
@@ -41,5 +38,4 @@ class Resizers {
   }
 }
 
-//@ts-ignore
-global.resizers = new Resizers();
+window.resizers = new Resizers();

--- a/tests/spreadsheet/side_panel_component.test.ts
+++ b/tests/spreadsheet/side_panel_component.test.ts
@@ -341,7 +341,6 @@ describe("Side Panel", () => {
 
       spreadsheetWidth = 600;
       await nextTick();
-      // @ts-ignore - trigger resize observers
       window.resizers.resize();
       expect(store.panelSize).toBe(600 - MIN_SHEET_VIEW_WIDTH);
     });

--- a/tests/test_helpers/helpers.ts
+++ b/tests/test_helpers/helpers.ts
@@ -628,8 +628,7 @@ export async function typeInComposerHelper(selector: string, text: string, fromS
   }
 
   (composerEl as HTMLElement).focus();
-  // @ts-ignore
-  const cehMock = window.mockContentHelper as ContentEditableHelper;
+  const cehMock = window.mockContentHelper;
   composerEl.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "" }));
   await nextTick();
   cehMock.insertText(text);


### PR DESCRIPTION
We added things to the `window` global variable in the tests, but we didn't add them to the typing. This commit adds the missing typing, allowing us to remove a bunch of `@ts-ignore`.

Task: : [4037352](https://www.odoo.com/web#id=4037352&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo