### PR TITLE
[IMP] charts: make all series editable at once

### DIFF
--- a/src/components/side_panel/chart/building_blocks/general_design/general_design_editor.xml
+++ b/src/components/side_panel/chart/building_blocks/general_design/general_design_editor.xml
@@ -3,11 +3,14 @@
     <t t-set="chart_title">Chart title</t>
     <SidePanelCollapsible collapsedAtInit="false" title.translate="General">
       <t t-set-slot="content">
-        <Section class="'o-chart-background-color pt-0 pb-0'" title.translate="Background color">
-          <RoundColorPicker
-            currentColor="props.definition.background"
-            onColorPicked.bind="updateBackgroundColor"
-          />
+        <Section class="'o-chart-background-color pt-0 pb-0'">
+          <div class="d-flex align-items-center">
+            <span class="o-section-title mb-0 pe-2">Background color</span>
+            <RoundColorPicker
+              currentColor="props.definition.background"
+              onColorPicked.bind="updateBackgroundColor"
+            />
+          </div>
         </Section>
         <ChartTitle
           title="title.text"

--- a/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
+++ b/src/components/side_panel/chart/building_blocks/generic_side_panel/config_panel.ts
@@ -113,7 +113,16 @@ export class GenericChartConfigPanel extends Component<Props, SpreadsheetChildEn
    * button "confirm" is clicked
    */
   onDataSeriesRangesChanged(ranges: string[]) {
+    let yAxisId: string | undefined = undefined;
+    if (this.dataSeriesRanges.length) {
+      if (this.dataSeriesRanges.every((ds) => ds.yAxisId === "y")) {
+        yAxisId = "y";
+      } else if (this.dataSeriesRanges.every((ds) => ds.yAxisId === "y1")) {
+        yAxisId = "y1";
+      }
+    }
     this.dataSeriesRanges = ranges.map((dataRange, i) => ({
+      yAxisId,
       ...this.dataSeriesRanges?.[i],
       dataRange,
     }));

--- a/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.xml
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_design_editor.xml
@@ -2,7 +2,7 @@
   <t t-name="o-spreadsheet-SeriesDesignEditor">
     <SidePanelCollapsible collapsedAtInit="true" title.translate="Data Series">
       <t t-set-slot="content">
-        <Section class="'pt-0 pb-0'">
+        <Section class="'pt-0'">
           <select
             class="o-input data-series-selector"
             t-model="state.label"
@@ -10,12 +10,12 @@
             <t t-foreach="getDataSeries()" t-as="serie" t-key="serie_index">
               <option
                 t-att-value="serie"
-                t-att-selected="state.index === serie_index"
+                t-att-selected="serie_index === (state.index === 'all' ? 0 : state.index)"
                 t-esc="serie"
               />
             </t>
           </select>
-          <Section class="'px-0'">
+          <Section class="'px-0'" t-if="state.index !== 'all'">
             <div class="d-flex align-items-center">
               <span class="o-section-title mb-0 pe-2">Series color</span>
               <RoundColorPicker
@@ -24,7 +24,10 @@
               />
             </div>
           </Section>
-          <Section class="'pt-0 px-0'" title.translate="Series name">
+          <Section
+            class="'pt-0 pb-0 px-0'"
+            title.translate="Series name"
+            t-if="state.index !== 'all'">
             <input
               class="o-input o-serie-label-editor"
               type="text"

--- a/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.xml
+++ b/src/components/side_panel/chart/building_blocks/series_design/series_with_axis_design_editor.xml
@@ -1,6 +1,6 @@
 <templates>
   <t t-name="o-spreadsheet-SeriesWithAxisDesignEditor">
-    <SeriesDesignEditor t-props="props">
+    <SeriesDesignEditor t-props="props" canEditAllSeries="!props.definition.horizontal">
       <t t-set-slot="data-series-extension" t-slot-scope="scope">
         <t t-set="index" t-value="scope.index"/>
         <t t-slot="general-extension" index="index"/>
@@ -18,7 +18,7 @@
           </Section>
           <Section
             class="'pt-0 px-0 o-show-trend-line'"
-            t-if="!props.definition.horizontal"
+            t-if="!props.definition.horizontal and index !== 'all'"
             title.translate="Trend line">
             <t t-set="showTrendLineLabel">Show trend line</t>
             <t t-set="trend" t-value="getTrendLineConfiguration(index)"/>

--- a/src/helpers/figures/charts/chart_common.ts
+++ b/src/helpers/figures/charts/chart_common.ts
@@ -18,6 +18,7 @@ import {
   Zone,
 } from "../../../types";
 import {
+  AxisDesign,
   ChartAxisFormats,
   ChartWithDataSetDefinition,
   CustomizedDataSet,
@@ -385,6 +386,34 @@ export function getChartPositionAtCenterOfViewport(
     x: x + scrollX + Math.max(0, (width - chartSize.width) / 2),
     y: y + scrollY + Math.max(0, (height - chartSize.height) / 2),
   }; // Position at the center of the scrollable viewport
+}
+
+export function getChartAxisTitleRuntime(design?: AxisDesign):
+  | {
+      display: boolean;
+      text: string;
+      color?: string;
+      font: {
+        style: "italic" | "normal";
+        weight: "bold" | "normal";
+      };
+      align: "start" | "center" | "end";
+    }
+  | undefined {
+  if (design?.title?.text) {
+    const { text, color, align, italic, bold } = design.title;
+    return {
+      display: true,
+      text,
+      color,
+      font: {
+        style: italic ? "italic" : "normal",
+        weight: bold ? "bold" : "normal",
+      },
+      align: align === "left" ? "start" : align === "right" ? "end" : "center",
+    };
+  }
+  return;
 }
 
 export function getDefinedAxis(definition: GenericDefinition<ChartWithDataSetDefinition>): {

--- a/tests/figures/chart/charts_component.test.ts
+++ b/tests/figures/chart/charts_component.test.ts
@@ -545,6 +545,7 @@ describe("charts", () => {
     );
     await mountChartSidePanel();
     await openChartDesignSidePanel(model, env, fixture, chartId);
+    await setInputValueAndTrigger(".data-series-selector", "serie_1");
 
     let color_menu = fixture.querySelectorAll(".o-round-color-picker-button")[1];
 
@@ -588,7 +589,32 @@ describe("charts", () => {
     createChart(
       model,
       {
-        dataSets: [{ dataRange: "C1:C4" }],
+        dataSets: [{ dataRange: "C1:C4", label: "serie_1" }],
+        labelRange: "A2:A4",
+        type: "line",
+      },
+      chartId
+    );
+    await mountChartSidePanel();
+    await openChartDesignSidePanel(model, env, fixture, chartId);
+    await setInputValueAndTrigger(".data-series-selector", "serie_1");
+    await click(fixture, ".o-vertical-axis-selection input[value=right]");
+
+    //@ts-ignore
+    expect(model.getters.getChartDefinition(chartId).dataSets).toEqual([
+      {
+        dataRange: "C1:C4",
+        yAxisId: "y1",
+        label: "serie_1",
+      },
+    ]);
+  });
+
+  test("can edit all chart data series vertical axis at once", async () => {
+    createChart(
+      model,
+      {
+        dataSets: [{ dataRange: "B1:B4" }, { dataRange: "C1:C4" }],
         labelRange: "A2:A4",
         type: "line",
       },
@@ -601,6 +627,10 @@ describe("charts", () => {
     //@ts-ignore
     expect(model.getters.getChartDefinition(chartId).dataSets).toEqual([
       {
+        dataRange: "B1:B4",
+        yAxisId: "y1",
+      },
+      {
         dataRange: "C1:C4",
         yAxisId: "y1",
       },
@@ -611,7 +641,7 @@ describe("charts", () => {
     createChart(
       model,
       {
-        dataSets: [{ dataRange: "C1:C4" }],
+        dataSets: [{ dataRange: "C1:C4", label: "serie_1" }],
         labelRange: "A2:A4",
         type: "line",
       },
@@ -619,6 +649,7 @@ describe("charts", () => {
     );
     await mountChartSidePanel();
     await openChartDesignSidePanel(model, env, fixture, chartId);
+    await setInputValueAndTrigger(".data-series-selector", "serie_1");
     setInputValueAndTrigger(".o-serie-label-editor", "coucou");
 
     //@ts-ignore
@@ -940,12 +971,48 @@ describe("charts", () => {
     await simulateClick(".o-data-series .o-selection-ok");
     expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
       { dataRange: "B1:B4", yAxisId: "y" },
-      { dataRange: "C1:C4" },
+      { dataRange: "C1:C4", yAxisId: "y" },
     ]);
     const remove = document.querySelectorAll(".o-data-series .o-remove-selection")[1];
     await simulateClick(remove);
     expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
       { dataRange: "B1:B4", yAxisId: "y" },
+    ]);
+  });
+
+  test("New range added to the chart will have the same axisId as existing ranges", async () => {
+    createTestChart("basicChart");
+    updateChart(model, chartId, { dataSets: [{ dataRange: "B1:B4", yAxisId: "y1" }] });
+    await mountChartSidePanel();
+
+    await simulateClick(".o-data-series .o-add-selection");
+    const element = document.querySelectorAll(".o-data-series input")[1];
+    await setInputValueAndTrigger(element, "C1:C4");
+    await simulateClick(".o-data-series .o-selection-ok");
+    expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
+      { dataRange: "B1:B4", yAxisId: "y1" },
+      { dataRange: "C1:C4", yAxisId: "y1" },
+    ]);
+  });
+
+  test("Vertical axis is not added if differents axis are used when adding new range", async () => {
+    createTestChart("basicChart");
+    updateChart(model, chartId, {
+      dataSets: [
+        { dataRange: "B1:B4", yAxisId: "y" },
+        { dataRange: "C1:C4", yAxisId: "y1" },
+      ],
+    });
+    await mountChartSidePanel();
+
+    await simulateClick(".o-data-series .o-add-selection");
+    const element = document.querySelectorAll(".o-data-series input")[2];
+    await setInputValueAndTrigger(element, "D1:D4");
+    await simulateClick(".o-data-series .o-selection-ok");
+    expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
+      { dataRange: "B1:B4", yAxisId: "y" },
+      { dataRange: "C1:C4", yAxisId: "y1" },
+      { dataRange: "D1:D4" },
     ]);
   });
 
@@ -959,8 +1026,8 @@ describe("charts", () => {
     await simulateClick(".o-data-series .o-selection-ok");
     expect((model.getters.getChartDefinition(chartId) as BarChartDefinition).dataSets).toEqual([
       { dataRange: "B1:B4", yAxisId: "y" },
-      { dataRange: "C1:C4" },
-      { dataRange: "D1:D4" },
+      { dataRange: "C1:C4", yAxisId: "y" },
+      { dataRange: "D1:D4", yAxisId: "y" },
     ]);
     expect(fixture.querySelectorAll(".o-selection-input input").length).toEqual(4);
     expect(
@@ -1618,7 +1685,7 @@ describe("charts", () => {
         createChart(
           model,
           {
-            dataSets: [{ dataRange: "B1:B4" }],
+            dataSets: [{ dataRange: "B1:B4", label: "serie_1" }],
             labelRange: "A1:A4",
             type,
             dataSetsHaveTitle: false,
@@ -1628,6 +1695,7 @@ describe("charts", () => {
         );
         await mountChartSidePanel(chartId);
         await openChartDesignSidePanel(model, env, fixture, chartId);
+        await setInputValueAndTrigger(".data-series-selector", "serie_1");
 
         const checkbox = document.querySelector("input[name='showTrendLine']") as HTMLInputElement;
         expect(checkbox.checked).toBe(false);
@@ -1663,7 +1731,11 @@ describe("charts", () => {
           model,
           {
             dataSets: [
-              { dataRange: "B1:B4", trend: { type: "polynomial", order: 3, display: true } },
+              {
+                dataRange: "B1:B4",
+                label: "serie_1",
+                trend: { type: "polynomial", order: 3, display: true },
+              },
             ],
             labelRange: "A1:A4",
             type,
@@ -1674,6 +1746,7 @@ describe("charts", () => {
         );
         await mountChartSidePanel(chartId);
         await openChartDesignSidePanel(model, env, fixture, chartId);
+        await setInputValueAndTrigger(".data-series-selector", "serie_1");
 
         let definition = model.getters.getChartDefinition(chartId) as ChartWithDataSetDefinition;
         expect(definition.dataSets[0].trend).toEqual({
@@ -1702,7 +1775,11 @@ describe("charts", () => {
           model,
           {
             dataSets: [
-              { dataRange: "B1:B4", trend: { type: "polynomial", order: 3, display: true } },
+              {
+                dataRange: "B1:B4",
+                label: "serie_1",
+                trend: { type: "polynomial", order: 3, display: true },
+              },
             ],
             labelRange: "A1:A4",
             type,
@@ -1713,6 +1790,7 @@ describe("charts", () => {
         );
         await mountChartSidePanel(chartId);
         await openChartDesignSidePanel(model, env, fixture, chartId);
+        await setInputValueAndTrigger(".data-series-selector", "serie_1");
 
         let definition = model.getters.getChartDefinition(chartId) as ChartWithDataSetDefinition;
         expect(definition.dataSets[0].trend).toEqual({
@@ -1736,6 +1814,7 @@ describe("charts", () => {
             dataSets: [
               {
                 dataRange: "B1:B4",
+                label: "serie_1",
                 trend: { type: "trailingMovingAverage", window: 2, display: true },
               },
             ],
@@ -1748,6 +1827,7 @@ describe("charts", () => {
         );
         await mountChartSidePanel(chartId);
         await openChartDesignSidePanel(model, env, fixture, chartId);
+        await setInputValueAndTrigger(".data-series-selector", "serie_1");
 
         let definition = model.getters.getChartDefinition(chartId) as ChartWithDataSetDefinition;
         expect(definition.dataSets[0].trend).toEqual({
@@ -1770,7 +1850,11 @@ describe("charts", () => {
           model,
           {
             dataSets: [
-              { dataRange: "B1:B5", trend: { type: "polynomial", order: 3, display: true } },
+              {
+                dataRange: "B1:B5",
+                label: "serie_1",
+                trend: { type: "polynomial", order: 3, display: true },
+              },
             ],
             labelRange: "A1:A5",
             type,
@@ -1781,6 +1865,7 @@ describe("charts", () => {
         );
         await mountChartSidePanel(chartId);
         await openChartDesignSidePanel(model, env, fixture, chartId);
+        await setInputValueAndTrigger(".data-series-selector", "serie_1");
 
         const selectElement = fixture.querySelector(".trend-order-input") as HTMLSelectElement;
         const optionValues = [...selectElement.options].map((o) => o.value);
@@ -1797,6 +1882,7 @@ describe("charts", () => {
             dataSets: [
               {
                 dataRange: "B1:B4",
+                label: "serie_1",
                 trend: { type: "polynomial", order: 3, display: true },
                 backgroundColor: "#ff0000",
               },
@@ -1810,6 +1896,7 @@ describe("charts", () => {
         );
         await mountChartSidePanel(chartId);
         await openChartDesignSidePanel(model, env, fixture, chartId);
+        await setInputValueAndTrigger(".data-series-selector", "serie_1");
 
         let runtime = model.getters.getChartRuntime(chartId) as BarChartRuntime;
         expect(runtime.chartJsConfig.data.datasets[1].borderColor).toBe("#FF8080");

--- a/tests/figures/chart/combo_chart_component.test.ts
+++ b/tests/figures/chart/combo_chart_component.test.ts
@@ -3,7 +3,7 @@ import { ChartPanel } from "../../../src/components/side_panel/chart/main_chart_
 import { SpreadsheetChildEnv } from "../../../src/types";
 import { openChartDesignSidePanel } from "../../test_helpers/chart_helpers";
 import { createChart } from "../../test_helpers/commands_helpers";
-import { click } from "../../test_helpers/dom_helper";
+import { click, setInputValueAndTrigger } from "../../test_helpers/dom_helper";
 import { mountComponentWithPortalTarget } from "../../test_helpers/helpers";
 
 async function mountChartSidePanel(figureId = chartId) {
@@ -53,7 +53,10 @@ describe("combo charts", () => {
     createChart(
       model,
       {
-        dataSets: [{ dataRange: "B1:B4" }, { dataRange: "C1:C4", type: "bar" }],
+        dataSets: [
+          { dataRange: "B1:B4", label: "serie_1" },
+          { dataRange: "C1:C4", type: "bar" },
+        ],
         labelRange: "A2:A4",
         type: "combo",
       },
@@ -61,10 +64,12 @@ describe("combo charts", () => {
     );
     await mountChartSidePanel();
     await openChartDesignSidePanel(model, env, fixture, chartId);
+    await setInputValueAndTrigger(".data-series-selector", "serie_1");
     await click(fixture, ".o-series-type-selection input[value=bar]");
     //@ts-ignore
     expect(model.getters.getChartDefinition(chartId).dataSets[0]).toEqual({
       dataRange: "B1:B4",
+      label: "serie_1",
       type: "bar",
     });
 
@@ -72,6 +77,7 @@ describe("combo charts", () => {
     //@ts-ignore
     expect(model.getters.getChartDefinition(chartId).dataSets[0]).toEqual({
       dataRange: "B1:B4",
+      label: "serie_1",
       type: "line",
     });
   });


### PR DESCRIPTION
## Task Description

This commit aims to let the user edit some parameters of the data series once for all series (like the vertical axis) to avoid having to set it one by one.

## Related Task

- Task: 3972623


## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo