### PR TITLE
[FIX] data: update version to 17

### DIFF
--- a/demo/data.js
+++ b/demo/data.js
@@ -6,7 +6,7 @@
  */
 
 export const demoData = {
-  version: 16,
+  version: 17,
   sheets: [
     {
       id: "sh1",

--- a/src/migrations/data.ts
+++ b/src/migrations/data.ts
@@ -28,7 +28,7 @@ import { normalizeV9 } from "./legacy_tools";
  * a breaking change is made in the way the state is handled, and an upgrade
  * function should be defined
  */
-export const CURRENT_VERSION = 16;
+export const CURRENT_VERSION = 17;
 const INITIAL_SHEET_ID = "Sheet1";
 
 /**

--- a/src/xlsx/xlsx_reader.ts
+++ b/src/xlsx/xlsx_reader.ts
@@ -26,7 +26,7 @@ import { getXLSXFilesOfType } from "./helpers/xlsx_helper";
 import { XLSXImportWarningManager } from "./helpers/xlsx_parser_error_manager";
 import { escapeTagNamespaces, parseXML } from "./helpers/xml_helpers";
 
-const EXCEL_IMPORT_VERSION = 16;
+const EXCEL_IMPORT_VERSION = 17;
 
 export class XlsxReader {
   warningManager: XLSXImportWarningManager;

--- a/tests/model/__snapshots__/model.test.ts.snap
+++ b/tests/model/__snapshots__/model.test.ts.snap
@@ -54,6 +54,6 @@ exports[`Model export formula with unbound zone stays unbound 1`] = `
   ],
   "styles": {},
   "uniqueFigureIds": true,
-  "version": 16,
+  "version": 17,
 }
 `;


### PR DESCRIPTION
## Description

Since https://github.com/odoo/o-spreadsheet/pull/3893 the current data version is 17, but the CURRENT_VERSION is still set to 16, as well as the EXCEL_IMPORT_VERSION, meaning the chart migration is never applied. This PR aims to fix this behavior.

- Related Task: N./A.
