### PR TITLE
[FIX] grid_overlay: A1 is hovered by default

### DIFF
--- a/src/components/grid_overlay/grid_overlay.ts
+++ b/src/components/grid_overlay/grid_overlay.ts
@@ -22,11 +22,14 @@ function useCellHovered(
     row: undefined,
   };
   const { Date } = window;
-  let x = 0;
-  let y = 0;
+  let x: number | undefined = undefined;
+  let y: number | undefined = undefined;
   let lastMoved = 0;
 
   function getPosition(): Position {
+    if (x === undefined || y === undefined) {
+      return { col: -1, row: -1 };
+    }
     const col = env.model.getters.getColIndex(x);
     const row = env.model.getters.getRowIndex(y);
     return { col, row };

--- a/tests/components/grid.test.ts
+++ b/tests/components/grid.test.ts
@@ -674,6 +674,13 @@ describe("Grid component", () => {
       expect(getHorizontalScroll()).toBe(1500);
     });
 
+    test("A1 is not set as hovered by default when opening the spreadsheet without mouse events", async () => {
+      setCellContent(model, "A1", "=1/0");
+      jest.advanceTimersByTime(400);
+      await nextTick();
+      expect(fixture.querySelector(".o-error-tooltip")).toBeNull();
+    });
+
     test("Scrolling the grid remove hover popover", async () => {
       setCellContent(model, "A10", "=1/0");
       await hoverCell(model, "A10", 400);


### PR DESCRIPTION
## Description

The cell A1 is set as hovered by default when opening the spreadsheet, even if the use didn't actually hover it.

Task: : [4042621](https://www.odoo.com/web#id=4042621&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo