### PR TITLE
[FIX] Evaluator: merge cells in spill zone

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -417,9 +417,9 @@ export class Evaluator {
   ) {
     const mergedCells = this.getters.getMergesInZone(sheetId, {
       top: row,
-      bottom: row + matrixResult.length,
+      bottom: row + matrixResult[0].length - 1,
       left: col,
-      right: col + matrixResult[0].length,
+      right: col + matrixResult.length - 1,
     });
 
     if (mergedCells.length === 0) {

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -935,5 +935,19 @@ describe("evaluate formulas that return an array", () => {
       expect(getEvaluatedCell(model, "B1").value).toBe(42);
       expect(getEvaluatedCell(model, "B2").value).toBe(42);
     });
+
+    test("correctly checks for merges in the specified zone", () => {
+      setCellContent(model, "A1", "=MFILL(1, 2, 42)");
+      merge(model, "B1:B2");
+
+      expect(getEvaluatedCell(model, "A1").value).toBe(42);
+      expect(getEvaluatedCell(model, "A2").value).toBe(42);
+
+      setCellContent(model, "F6", "=MFILL(2, 1, 42)");
+      merge(model, "F7:G7");
+
+      expect(getEvaluatedCell(model, "F6").value).toBe(42);
+      expect(getEvaluatedCell(model, "G6").value).toBe(42);
+    });
   });
 });


### PR DESCRIPTION
# Description:

PR#https://github.com/odoo/o-spreadsheet/pull/4205 introduced a #SPILL error when array formulas attempted to spread into merged cells. However, an incorrect logic in retrieving merged cells for specific range caused inconsistent behavior.

This PR corrects the logic to accurately retrieve merged cells within the specified range.

Task: : [4043638](https://www.odoo.com/odoo/project/2328/tasks/4043638?cids=2)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo