### PR TITLE
[MOV] pivot: move pivot table file

### DIFF
--- a/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/data_entry_spreadsheet_pivot.ts
@@ -1,7 +1,7 @@
 import { CellValue, EvaluatedCell } from "../../../types";
 import { PivotDimension, PivotTableColumn, PivotTableRow } from "../../../types/pivot";
+import { SpreadsheetPivotTable } from "../table_spreadsheet_pivot";
 import { SpreadsheetPivotRuntimeDefinition } from "./runtime_definition_spreadsheet_pivot";
-import { SpreadsheetPivotTable } from "./table_spreadsheet_pivot";
 
 export type FieldName = string;
 export type FieldValue = Pick<EvaluatedCell, "type" | "format" | "value">;

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -35,6 +35,7 @@ import {
 } from "../pivot_helpers";
 import { PivotParams } from "../pivot_registry";
 import { pivotTimeAdapter } from "../pivot_time_adapter";
+import { SpreadsheetPivotTable } from "../table_spreadsheet_pivot";
 import {
   DataEntries,
   DataEntry,
@@ -43,7 +44,6 @@ import {
 } from "./data_entry_spreadsheet_pivot";
 import { createDate } from "./date_spreadsheet_pivot";
 import { SpreadsheetPivotRuntimeDefinition } from "./runtime_definition_spreadsheet_pivot";
-import { SpreadsheetPivotTable } from "./table_spreadsheet_pivot";
 
 interface SpreadsheetPivotParams extends PivotParams {
   definition: SpreadsheetPivotCoreDefinition;

--- a/src/helpers/pivot/table_spreadsheet_pivot.ts
+++ b/src/helpers/pivot/table_spreadsheet_pivot.ts
@@ -1,5 +1,5 @@
-import { PivotDomain, PivotTableCell, PivotTableColumn, PivotTableRow } from "../../../types/pivot";
-import { parseDimension, toNormalizedPivotValue } from "../pivot_helpers";
+import { PivotDomain, PivotTableCell, PivotTableColumn, PivotTableRow } from "../../types/pivot";
+import { parseDimension, toNormalizedPivotValue } from "./pivot_helpers";
 
 /**
  * Class used to ease the construction of a pivot table.

--- a/src/index.ts
+++ b/src/index.ts
@@ -432,7 +432,7 @@ export const constants = {
 };
 
 export { PivotRuntimeDefinition } from "./helpers/pivot/pivot_runtime_definition";
-export { SpreadsheetPivotTable } from "./helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot";
+export { SpreadsheetPivotTable } from "./helpers/pivot/table_spreadsheet_pivot";
 
 export type { EnrichedToken } from "./formulas/composer_tokenizer";
 export type { AST, ASTFuncall } from "./formulas/parser";

--- a/src/plugins/core/pivot.ts
+++ b/src/plugins/core/pivot.ts
@@ -1,6 +1,6 @@
 import { deepCopy, deepEquals } from "../../helpers";
 import { createPivotFormula, getMaxObjectId } from "../../helpers/pivot/pivot_helpers";
-import { SpreadsheetPivotTable } from "../../helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot";
+import { SpreadsheetPivotTable } from "../../helpers/pivot/table_spreadsheet_pivot";
 import { _t } from "../../translation";
 import { CellPosition, CommandResult, CoreCommand, Position, UID, WorkbookData } from "../../types";
 import { PivotCoreDefinition } from "../../types/pivot";

--- a/src/plugins/ui_core_views/pivot_ui.ts
+++ b/src/plugins/ui_core_views/pivot_ui.ts
@@ -5,7 +5,7 @@ import {
   getNumberOfPivotFunctions,
 } from "../../helpers/pivot/pivot_composer_helpers";
 import { pivotRegistry } from "../../helpers/pivot/pivot_registry";
-import { EMPTY_PIVOT_CELL } from "../../helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot";
+import { EMPTY_PIVOT_CELL } from "../../helpers/pivot/table_spreadsheet_pivot";
 import {
   AddPivotCommand,
   CellPosition,

--- a/src/plugins/ui_feature/insert_pivot.ts
+++ b/src/plugins/ui_feature/insert_pivot.ts
@@ -1,5 +1,5 @@
 import { PIVOT_TABLE_CONFIG } from "../../constants";
-import { SpreadsheetPivotTable } from "../../helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot";
+import { SpreadsheetPivotTable } from "../../helpers/pivot/table_spreadsheet_pivot";
 import { getZoneArea } from "../../helpers/zones";
 import { _t } from "../../translation";
 import { HeaderIndex, PivotTableData, UID } from "../../types";

--- a/src/types/pivot_runtime.ts
+++ b/src/types/pivot_runtime.ts
@@ -1,5 +1,5 @@
 import { PivotRuntimeDefinition } from "../helpers/pivot/pivot_runtime_definition";
-import { SpreadsheetPivotTable } from "../helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot";
+import { SpreadsheetPivotTable } from "../helpers/pivot/table_spreadsheet_pivot";
 import { FunctionResultObject, Maybe } from "./misc";
 import {
   PivotCoreDefinition,


### PR DESCRIPTION
This commit moves file
`src/helpers/pivot/spreadsheet_pivot/table_spreadsheet_pivot.ts` out of `spreadsheet_pivot` which is where all spreadsheet pivot specific things go.

`SpreadsheetPivotTable` is common for all types of pivots (spreadsheet or odoo)

Task: 0

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo