### PR TITLE
[REF] evaluation: rename left over FPayload

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -272,10 +272,13 @@ function hasStringValue(obj: unknown): obj is { value: string } {
   );
 }
 
-function replaceFunctionNamePlaceholder(fPayload: FunctionResultObject, functionName: string) {
+function replaceFunctionNamePlaceholder(
+  functionResult: FunctionResultObject,
+  functionName: string
+) {
   // for performance reasons: change in place and only if needed
-  if (fPayload.message?.includes("[[FUNCTION_NAME]]")) {
-    fPayload.message = fPayload.message.replace("[[FUNCTION_NAME]]", functionName);
+  if (functionResult.message?.includes("[[FUNCTION_NAME]]")) {
+    functionResult.message = functionResult.message.replace("[[FUNCTION_NAME]]", functionName);
   }
 }
 

--- a/src/helpers/cells/cell_evaluation.ts
+++ b/src/helpers/cells/cell_evaluation.ts
@@ -27,8 +27,8 @@ export function evaluateLiteral(
 ): EvaluatedCell {
   const value =
     localeFormat.format === PLAIN_TEXT_FORMAT ? literalCell.content : literalCell.parsedValue;
-  const fPayload = { value, format: localeFormat.format };
-  return createEvaluatedCell(fPayload, localeFormat.locale);
+  const functionResult = { value, format: localeFormat.format };
+  return createEvaluatedCell(functionResult, localeFormat.locale);
 }
 
 export function parseLiteral(content: string, locale: Locale): CellValue {
@@ -52,17 +52,17 @@ export function parseLiteral(content: string, locale: Locale): CellValue {
 }
 
 export function createEvaluatedCell(
-  fPayload: FunctionResultObject,
+  functionResult: FunctionResultObject,
   locale: Locale = DEFAULT_LOCALE,
   cell?: Cell
 ): EvaluatedCell {
-  const link = detectLink(fPayload.value);
+  const link = detectLink(functionResult.value);
   if (!link) {
-    return _createEvaluatedCell(fPayload, locale, cell);
+    return _createEvaluatedCell(functionResult, locale, cell);
   }
   const value = parseLiteral(link.label, locale);
   const format =
-    fPayload.format ||
+    functionResult.format ||
     (typeof value === "number"
       ? detectDateFormat(link.label, locale) || detectNumberFormat(link.label)
       : undefined);
@@ -77,11 +77,11 @@ export function createEvaluatedCell(
 }
 
 function _createEvaluatedCell(
-  fPayload: FunctionResultObject,
+  functionResult: FunctionResultObject,
   locale: Locale,
   cell?: Cell
 ): EvaluatedCell {
-  let { value, format, message } = fPayload;
+  let { value, format, message } = functionResult;
   format = cell?.format || format;
 
   const formattedValue = formatValue(value, { format, locale });

--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -545,12 +545,12 @@ function forEachSpreadPositionInMatrix(
  * rather than appearing empty. This indicates that the
  * cell is the result of a non-empty content.
  */
-function nullValueToZeroValue(fPayload: FunctionResultObject): FunctionResultObject {
-  if (fPayload.value === null || fPayload.value === undefined) {
-    // 'fPayload.value === undefined' is supposed to never happen, it's a safety net for javascript use
-    return { ...fPayload, value: 0 };
+function nullValueToZeroValue(functionResult: FunctionResultObject): FunctionResultObject {
+  if (functionResult.value === null || functionResult.value === undefined) {
+    // 'functionResult.value === undefined' is supposed to never happen, it's a safety net for javascript use
+    return { ...functionResult, value: 0 };
   }
-  return fPayload;
+  return functionResult;
 }
 
 export function updateEvalContextAndExecute(

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -1275,8 +1275,8 @@ describe("Spreadsheet Pivot", () => {
 });
 
 describe("Spreadsheet arguments parsing", () => {
-  function toFPayload(args: CellValue[]): FunctionResultObject[] {
-    return args.map((value) => ({ value } as FunctionResultObject));
+  function toFunctionResultObject(args: CellValue[]): FunctionResultObject[] {
+    return args.map((value) => ({ value }));
   }
 
   test("Date arguments are correctly parsed", () => {
@@ -1293,14 +1293,14 @@ describe("Spreadsheet arguments parsing", () => {
       measures: [{ name: "Price", aggregator: "sum" }],
     });
     const pivot = model.getters.getPivot(model.getters.getPivotIds()[0]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Date:year", 2024]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Date:year", 2024]))).toEqual([
       {
         field: "Date:year",
         value: 2024,
         type: "date",
       },
     ]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Date:year", "2024"]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Date:year", "2024"]))).toEqual([
       {
         field: "Date:year",
         value: 2024,
@@ -1308,9 +1308,9 @@ describe("Spreadsheet arguments parsing", () => {
       },
     ]);
     expect(() =>
-      pivot.parseArgsToPivotDomain(toFPayload(["Date:year", "This is a string"]))
+      pivot.parseArgsToPivotDomain(toFunctionResultObject(["Date:year", "This is a string"]))
     ).toThrow();
-    expect(() => pivot.parseArgsToPivotDomain(toFPayload(["Date", 2024]))).toThrow();
+    expect(() => pivot.parseArgsToPivotDomain(toFunctionResultObject(["Date", 2024]))).toThrow();
   });
 
   test("Number arguments are correctly parsed", () => {
@@ -1327,14 +1327,14 @@ describe("Spreadsheet arguments parsing", () => {
       measures: [{ name: "Price", aggregator: "sum" }],
     });
     const pivot = model.getters.getPivot(model.getters.getPivotIds()[0]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Amount", 1]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Amount", 1]))).toEqual([
       {
         field: "Amount",
         value: 1,
         type: "integer",
       },
     ]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Amount", "1"]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Amount", "1"]))).toEqual([
       {
         field: "Amount",
         value: 1,
@@ -1342,7 +1342,7 @@ describe("Spreadsheet arguments parsing", () => {
       },
     ]);
     expect(() =>
-      pivot.parseArgsToPivotDomain(toFPayload(["Amount", "This is a string"]))
+      pivot.parseArgsToPivotDomain(toFunctionResultObject(["Amount", "This is a string"]))
     ).toThrow();
   });
 
@@ -1360,14 +1360,14 @@ describe("Spreadsheet arguments parsing", () => {
       measures: [{ name: "Price", aggregator: "sum" }],
     });
     const pivot = model.getters.getPivot(model.getters.getPivotIds()[0]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Active", true]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Active", true]))).toEqual([
       {
         field: "Active",
         value: true,
         type: "boolean",
       },
     ]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Active", "true"]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Active", "true"]))).toEqual([
       {
         field: "Active",
         value: true,
@@ -1375,7 +1375,7 @@ describe("Spreadsheet arguments parsing", () => {
       },
     ]);
     expect(() =>
-      pivot.parseArgsToPivotDomain(toFPayload(["Active", "This is a string"]))
+      pivot.parseArgsToPivotDomain(toFunctionResultObject(["Active", "This is a string"]))
     ).toThrow();
   });
 
@@ -1393,28 +1393,28 @@ describe("Spreadsheet arguments parsing", () => {
       measures: [{ name: "Price", aggregator: "sum" }],
     });
     const pivot = model.getters.getPivot(model.getters.getPivotIds()[0]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Name", true]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Name", true]))).toEqual([
       {
         field: "Name",
         value: "TRUE",
         type: "char",
       },
     ]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Name", "Hello"]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Name", "Hello"]))).toEqual([
       {
         field: "Name",
         value: "Hello",
         type: "char",
       },
     ]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Name", 1]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Name", 1]))).toEqual([
       {
         field: "Name",
         value: "1",
         type: "char",
       },
     ]);
-    expect(pivot.parseArgsToPivotDomain(toFPayload(["Name", "01/01/2024"]))).toEqual([
+    expect(pivot.parseArgsToPivotDomain(toFunctionResultObject(["Name", "01/01/2024"]))).toEqual([
       {
         field: "Name",
         value: "01/01/2024",


### PR DESCRIPTION

## Description:

Commit 330cfbf7650d renamed `FPayload` to `FunctionResultObject `but left a few variables named after the old name.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo