### PR TITLE
[FIX] evaluation: correctly resets the `spreadingRelations`

### DIFF
--- a/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluator.ts
@@ -275,6 +275,10 @@ export class Evaluator {
       this.invalidateSpreading(position);
     }
 
+    if (this.spreadingRelations.isArrayFormula(position)) {
+      this.spreadingRelations.removeNode(position);
+    }
+
     const cell = this.getters.getCell(position);
     if (cell === undefined) {
       return EMPTY_CELL;
@@ -287,6 +291,7 @@ export class Evaluator {
         return ERROR_CYCLE_CELL;
       }
       this.cellsBeingComputed.add(cellId);
+
       return cell.isFormula
         ? this.computeFormulaCell(position.sheetId, cell)
         : evaluateLiteral(cell, localeFormat);
@@ -332,8 +337,6 @@ export class Evaluator {
 
     const nbColumns = formulaReturn.length;
     const nbRows = formulaReturn[0].length;
-
-    this.spreadingRelations.removeNode(formulaPosition);
 
     forEachSpreadPositionInMatrix(nbColumns, nbRows, this.updateSpreadRelation(formulaPosition));
     this.assertNoMergedCellsInSpreadZone(formulaPosition, formulaReturn);

--- a/tests/evaluation/evaluation_formula_array.test.ts
+++ b/tests/evaluation/evaluation_formula_array.test.ts
@@ -912,6 +912,13 @@ describe("evaluate formulas that return an array", () => {
       setCellContent(model, "H1", "2");
       expect(model.getters.getSpreadZone({ sheetId, col: 0, row: 0 })).toEqual(toZone("A1:B2"));
     });
+
+    test("getSpreadZone is updated after changing the cell content to a scalar value", () => {
+      setCellContent(model, "A1", "=MFILL(2,2,42)");
+      expect(model.getters.getSpreadZone({ sheetId, col: 0, row: 0 })).toEqual(toZone("A1:B2"));
+      setCellContent(model, "A1", "5");
+      expect(model.getters.getSpreadZone({ sheetId, col: 0, row: 0 })).not.toBeDefined();
+    });
   });
 
   describe("result array can collides with merged cells", () => {


### PR DESCRIPTION
## Task Description

When updating the content of a cell, the `spreadingRelations` isn't reset if we clear the cell or put a scalar content in a cell where there was an array before. This causes an issue where the highlight of the array formula is still present event after deleting the content of the cell.

## Related Task

Task: [4014088](https://www.odoo.com/web#id=4014088&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo