### PR TITLE
[FIX] functions: COUNTIF does not handle dates

### DIFF
--- a/src/functions/helpers.ts
+++ b/src/functions/helpers.ts
@@ -1,5 +1,5 @@
 // HELPERS
-import { memoize } from "../helpers";
+import { isDateTime, memoize } from "../helpers";
 import { DateTime, numberToJsDate, parseDateTime } from "../helpers/dates";
 import { isNumber, parseNumber } from "../helpers/numbers";
 import { _lt } from "../translation";
@@ -335,7 +335,7 @@ function getPredicate(descr: string, isQuery: boolean): Predicate {
     }
   }
 
-  if (isNumber(operand)) {
+  if (isNumber(operand) || isDateTime(operand)) {
     operand = toNumber(operand);
   } else if (operand === "TRUE" || operand === "FALSE") {
     operand = toBoolean(operand);

--- a/tests/functions/module_math.test.ts
+++ b/tests/functions/module_math.test.ts
@@ -815,6 +815,21 @@ describe("COUNTIF formula", () => {
     expect(gridResult.A2).toBe(0);
     expect(gridResult.A3).toBe(0);
   });
+
+  test("COUNTIF with date predicate", () => {
+    const grid = {
+      A1: "01/01/2024",
+      A2: "01/02/2024",
+      B1: '=COUNTIF(A1, "<01/02/2024")',
+      B2: '=COUNTIF(A2, "<01/02/2024")',
+      B3: '=COUNTIF(A2, "<=01/02/2024")',
+    };
+    expect(evaluateGrid(grid)).toMatchObject({
+      B1: 1,
+      B2: 0,
+      B3: 1,
+    });
+  });
 });
 
 describe("COUNTIFS formula", () => {


### PR DESCRIPTION
## Description

Dates predicates (eg. "<01/01/2024") were not handled in the COUNTIF function and its variants.

Related ticket: 4042962

Task: : [4045506](https://www.odoo.com/web#id=4045506&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo