### PR TITLE
[FIX] pivot: fix simplistic style of pivot field in error

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
@@ -19,6 +19,14 @@ css/* scss */ `
     .pivot-dim-operator-label {
       min-width: 120px;
     }
+
+    &.pivot-dimension-invalid {
+      background-color: #ffdddd;
+      border-color: red !important;
+      select {
+        background-color: #ffdddd;
+      }
+    }
   }
 `;
 

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.xml
@@ -2,11 +2,14 @@
   <t t-name="o-spreadsheet-PivotDimension">
     <div
       class="border py-1 px-2 d-flex flex-column shadow-sm pivot-dimension"
-      t-att-class="{'bg-danger': !props.dimension.isValid}">
-      <div class="d-flex flex-row justify-content-between align-items-center">
+      t-att-class="{'pivot-dimension-invalid': !props.dimension.isValid}">
+      <div class="d-flex flex-row  align-items-center">
+        <span class="text-danger me-1" t-if="!props.dimension.isValid">
+          <t t-call="o-spreadsheet-Icon.TRIANGLE_EXCLAMATION"/>
+        </span>
         <span class="fw-bold" t-esc="props.dimension.displayName"/>
         <i
-          class="btn fa fa-times pe-0"
+          class="btn fa fa-times pe-0 ms-auto"
           t-if="props.onRemoved"
           t-on-click="() => props.onRemoved(props.dimension)"
         />

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -234,4 +234,23 @@ describe("Spreadsheet pivot side panel", () => {
       { name: "Amount", order: "desc" },
     ]);
   });
+
+  test("Invalid pivot dimensions are displayed as such in the side panel", async () => {
+    setCellContent(model, "A1", "ValidDimension");
+    setCellContent(model, "A2", "10");
+    addPivot(model, "A1:A2", {
+      columns: [{ name: "ValidDimension" }],
+      rows: [{ name: "InvalidDimension" }],
+    });
+    env.openSidePanel("PivotSidePanel", { pivotId: "1" });
+    await nextTick();
+    const pivotDimensionEls = fixture.querySelectorAll<HTMLElement>(".pivot-dimension")!;
+    const validDimensionEl = pivotDimensionEls[0];
+    expect(validDimensionEl.classList).not.toContain("pivot-dimension-invalid");
+    expect(validDimensionEl.querySelector(".fa-exclamation-triangle")).toBe(null);
+
+    const invalidDimensionEl = pivotDimensionEls[1];
+    expect(invalidDimensionEl.classList).toContain("pivot-dimension-invalid");
+    expect(invalidDimensionEl.querySelector(".fa-exclamation-triangle")).not.toBe(null);
+  });
 });


### PR DESCRIPTION
## Description

Fields in error in the pivot side panel had a simple bg-red style, which isn't greate design-wise. This commit make them more pretty.

Task: : [4046068](https://www.odoo.com/web#id=4046068&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo