### PR TITLE
[IMP] Tests: drop ts-jest in favor of swc-node/jest 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@prettier/plugin-xml": "^2.2.0",
         "@rollup/plugin-node-resolve": "^15.2.0",
         "@rollup/plugin-terser": "^0.4.3",
+        "@swc/jest": "^0.2.36",
         "@types/jest": "^27.0.1",
         "@types/node": "^13.13.23",
         "@types/rbush": "^3.0.3",
@@ -48,7 +49,6 @@
         "rollup": "^3.28.0",
         "rollup-plugin-dts": "^5.3.1",
         "rollup-plugin-typescript2": "^0.35.0",
-        "ts-jest": "^29.1.0",
         "typedoc": "0.25.12",
         "typedoc-plugin-markdown": "3.17.1",
         "typescript": "^5.4.3",
@@ -782,6 +782,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/create-cache-key-function": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+      "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.6.1",
       "dev": true,
@@ -980,7 +992,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.0",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1141,11 +1155,13 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.6.1",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -1397,6 +1413,282 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@swc/core": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.7.tgz",
+      "integrity": "sha512-BBzORL9qWz5hZqAZ83yn+WNaD54RH5eludjqIOboolFOK/Pw+2l00/H77H4CEBJnzCIBQszsyqtITmrn4evp0g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.9"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.6.7",
+        "@swc/core-darwin-x64": "1.6.7",
+        "@swc/core-linux-arm-gnueabihf": "1.6.7",
+        "@swc/core-linux-arm64-gnu": "1.6.7",
+        "@swc/core-linux-arm64-musl": "1.6.7",
+        "@swc/core-linux-x64-gnu": "1.6.7",
+        "@swc/core-linux-x64-musl": "1.6.7",
+        "@swc/core-win32-arm64-msvc": "1.6.7",
+        "@swc/core-win32-ia32-msvc": "1.6.7",
+        "@swc/core-win32-x64-msvc": "1.6.7"
+      },
+      "peerDependencies": {
+        "@swc/helpers": "*"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.7.tgz",
+      "integrity": "sha512-sNb+ghP2OhZyUjS7E5Mf3PqSvoXJ5gY6GBaH2qp8WQxx9VL7ozC4HVo6vkeFJBN5cmYqUCLnhrM3HU4W+7yMSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.7.tgz",
+      "integrity": "sha512-LQwYm/ATYN5fYSYVPMfComPiFo5i8jh75h1ASvNWhXtS+/+k1dq1zXTJWZRuojd5NXgW3bb6mJtJ2evwYIgYbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.7.tgz",
+      "integrity": "sha512-kEDzVhNci38LX3kdY99t68P2CDf+2QFDk5LawVamXH0iN5DRAO/+wjOhxL8KOHa6wQVqKEt5WrhD+Rrvk/34Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.7.tgz",
+      "integrity": "sha512-SyOBUGfl31xLGpIJ/Jd6GKHtkfZyHBXSwFlK7FmPN//MBQLtTBm4ZaWTnWnGo4aRsJwQdXWDKPyqlMBtnIl1nQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.7.tgz",
+      "integrity": "sha512-1fOAXkDFbRfItEdMZPxT3du1QWYhgToa4YsnqTujjE8EqJW8K27hIcHRIkVuzp7PNhq8nLBg0JpJM4g27EWD7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.7.tgz",
+      "integrity": "sha512-Gp7uCwPsNO5ATxbyvfTyeNCHUGD9oA+xKMm43G1tWCy+l07gLqWMKp7DIr3L3qPD05TfAVo3OuiOn2abpzOFbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.7.tgz",
+      "integrity": "sha512-QeruGBZJ15tadqEMQ77ixT/CYGk20MtlS8wmvJiV+Wsb8gPW5LgCjtupzcLLnoQzDG54JGNCeeZ0l/T8NYsOvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.7.tgz",
+      "integrity": "sha512-ouRqgSnT95lTCiU/6kJRNS5b1o+p8I/V9jxtL21WUj/JOVhsFmBErqQ0MZyCu514noWiR5BIqOrZXR8C1Knx6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.7.tgz",
+      "integrity": "sha512-eZAP/EmJ0IcfgAx6B4/SpSjq3aT8gr0ooktfMqw/w0/5lnNrbMl2v+2kvxcneNcF7bp8VNcYZnoHlsP+LvmVbA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.7.tgz",
+      "integrity": "sha512-QOdE+7GQg1UQPS6p0KxzJOh/8GLbJ5zI1vqKArCCB0unFqUfKIjYb2TaH0geEBy3w9qtXxe3ZW6hzxtZSS9lDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
+      "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@swc/jest": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.36.tgz",
+      "integrity": "sha512-8X80dp81ugxs4a11z1ka43FPhP+/e+mJNXJSxiNYk8gIX/jPBtY4gQTrKu/KIoco8bzKuPI5lUxjfLiGsfvnlw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/create-cache-key-function": "^29.7.0",
+        "@swc/counter": "^0.1.3",
+        "jsonc-parser": "^3.2.0"
+      },
+      "engines": {
+        "npm": ">= 7.0.0"
+      },
+      "peerDependencies": {
+        "@swc/core": "*"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.9.tgz",
+      "integrity": "sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -2214,17 +2506,6 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/bser": {
       "version": "2.1.1",
       "dev": true,
@@ -2736,7 +3017,9 @@
       "license": "MIT"
     },
     "node_modules/colorette": {
-      "version": "2.0.16",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2990,7 +3273,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.3",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7524,11 +7809,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/log-update": {
       "version": "4.0.0",
       "dev": true,
@@ -7680,11 +7960,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -10286,62 +10561,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/ts-jest": {
-      "version": "29.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^29.0.0",
-        "json5": "^2.2.3",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "^7.5.3",
-        "yargs-parser": "^21.0.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
-        "typescript": ">=4.3 <6"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.5.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "npm-run-all build:js build:bundleJs \"build:bundleXml -- --outDir build\"",
     "doc": "typedoc",
     "precommit": "npm run prettier && npm run doc",
-    "test": "jest",
+    "test": "tsc --noEmit --project tsconfig.jest.json && jest",
     "test:watch": "jest --watch",
     "prettier": "prettier . --write",
     "check-formatting": "prettier . --check",
@@ -59,6 +59,7 @@
     "@prettier/plugin-xml": "^2.2.0",
     "@rollup/plugin-node-resolve": "^15.2.0",
     "@rollup/plugin-terser": "^0.4.3",
+    "@swc/jest": "^0.2.36",
     "@types/jest": "^27.0.1",
     "@types/node": "^13.13.23",
     "@types/rbush": "^3.0.3",
@@ -89,7 +90,6 @@
     "rollup": "^3.28.0",
     "rollup-plugin-dts": "^5.3.1",
     "rollup-plugin-typescript2": "^0.35.0",
-    "ts-jest": "^29.1.0",
     "typedoc": "0.25.12",
     "typedoc-plugin-markdown": "3.17.1",
     "typescript": "^5.4.3",
@@ -114,10 +114,7 @@
     ],
     "transform": {
       "^.+\\.ts?$": [
-        "ts-jest",
-        {
-          "tsconfig": "tsconfig.jest.json"
-        }
+        "@swc/jest"
       ]
     },
     "verbose": false,

--- a/src/clipboard_handlers/cell_clipboard.ts
+++ b/src/clipboard_handlers/cell_clipboard.ts
@@ -1,4 +1,3 @@
-import { CommandResult } from "..";
 import { canonicalizeNumberValue } from "../formulas/formula_locale";
 import { deepEquals, formatValue } from "../helpers";
 import { getPasteZones } from "../helpers/clipboard/clipboard_helpers";
@@ -9,6 +8,7 @@ import {
   ClipboardCellData,
   ClipboardOptions,
   ClipboardPasteTarget,
+  CommandResult,
   HeaderIndex,
   UID,
   Zone,

--- a/src/components/helpers/draw_grid_hook.ts
+++ b/src/components/helpers/draw_grid_hook.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "@odoo/owl";
-import { Model } from "../..";
 import { CANVAS_SHIFT } from "../../constants";
+import { Model } from "../../model";
 import { useStore } from "../../store_engine";
 import { GridRenderer } from "../../stores/grid_renderer_store";
 import { RendererStore } from "../../stores/renderer_store";

--- a/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
+++ b/src/components/side_panel/conditional_formatting/cf_editor/cf_editor.ts
@@ -1,14 +1,15 @@
 import { Component, useExternalListener, useState } from "@odoo/owl";
-import { CancelledReason, CommandResult } from "../../../..";
 import { DEFAULT_COLOR_SCALE_MIDPOINT_COLOR } from "../../../../constants";
 import { colorNumberString, rangeReference } from "../../../../helpers";
 import { canonicalizeCFRule } from "../../../../helpers/locale";
 import { cycleFixedReference } from "../../../../helpers/reference_type";
 import {
+  CancelledReason,
   CellIsRule,
   Color,
   ColorScaleRule,
   ColorScaleThreshold,
+  CommandResult,
   ConditionalFormat,
   ConditionalFormatRule,
   IconSetRule,

--- a/src/components/side_panel/pivot/editable_name/editable_name.ts
+++ b/src/components/side_panel/pivot/editable_name/editable_name.ts
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { Component, useState } from "@odoo/owl";
-import { SpreadsheetChildEnv } from "../../../..";
+import { SpreadsheetChildEnv } from "../../../../types";
 
 interface Props {
   name: string;

--- a/src/components/side_panel/pivot/pivot_defer_update/pivot_defer_update.ts
+++ b/src/components/side_panel/pivot/pivot_defer_update/pivot_defer_update.ts
@@ -1,6 +1,6 @@
 import { Component } from "@odoo/owl";
-import { SpreadsheetChildEnv } from "../../../..";
 import { _t } from "../../../../translation";
+import { SpreadsheetChildEnv } from "../../../../types";
 import { css } from "../../../helpers/css";
 import { Checkbox } from "../../components/checkbox/checkbox";
 import { Section } from "../../components/section/section";

--- a/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/add_dimension_button/add_dimension_button.ts
@@ -1,9 +1,9 @@
 import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
-import { SpreadsheetChildEnv } from "../../../../..";
 import { COMPOSER_ASSISTANT_COLOR } from "../../../../../constants";
 import { fuzzyLookup } from "../../../../../helpers";
 import { AutoCompleteProposal, AutoCompleteProvider } from "../../../../../registries";
 import { Store, useLocalStore } from "../../../../../store_engine";
+import { SpreadsheetChildEnv } from "../../../../../types";
 import { PivotField } from "../../../../../types/pivot";
 import { TextValueProvider } from "../../../../composer/autocomplete_dropdown/autocomplete_dropdown";
 import { AutoCompleteStore } from "../../../../composer/autocomplete_dropdown/autocomplete_dropdown_store";

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension/pivot_dimension.ts
@@ -1,5 +1,5 @@
 import { Component } from "@odoo/owl";
-import { SpreadsheetChildEnv } from "../../../../..";
+import { SpreadsheetChildEnv } from "../../../../../types";
 import { css } from "../../../../helpers";
 
 interface Props {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_granularity/pivot_dimension_granularity.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_granularity/pivot_dimension_granularity.ts
@@ -1,6 +1,6 @@
 import { Component } from "@odoo/owl";
-import { SpreadsheetChildEnv } from "../../../../..";
 import { ALL_PERIODS } from "../../../../../helpers/pivot/pivot_helpers";
+import { SpreadsheetChildEnv } from "../../../../../types";
 import { PivotDimension } from "../../../../../types/pivot";
 
 interface Props {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_dimension_order/pivot_dimension_order.ts
@@ -1,5 +1,5 @@
 import { Component } from "@odoo/owl";
-import { SpreadsheetChildEnv } from "../../../../..";
+import { SpreadsheetChildEnv } from "../../../../../types";
 import { PivotDimension } from "../../../../../types/pivot";
 
 interface Props {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -1,8 +1,8 @@
 import { Component, useRef } from "@odoo/owl";
-import { SpreadsheetChildEnv } from "../../../..";
 import { isDefined } from "../../../../helpers";
 import { AGGREGATORS, isDateField, parseDimension } from "../../../../helpers/pivot/pivot_helpers";
 import { PivotRuntimeDefinition } from "../../../../helpers/pivot/pivot_runtime_definition";
+import { SpreadsheetChildEnv } from "../../../../types";
 import {
   Granularity,
   PivotCoreDefinition,

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_side_panel.ts
@@ -1,6 +1,6 @@
 import { Component } from "@odoo/owl";
-import { SpreadsheetChildEnv, UID } from "../../../..";
 import { pivotSidePanelRegistry } from "../../../../helpers/pivot/pivot_side_panel_registry";
+import { SpreadsheetChildEnv, UID } from "../../../../types";
 import { Section } from "../../components/section/section";
 import { PivotLayoutConfigurator } from "../pivot_layout_configurator/pivot_layout_configurator";
 

--- a/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
+++ b/src/components/side_panel/pivot/pivot_side_panel/pivot_spreadsheet_side_panel/pivot_spreadsheet_side_panel.ts
@@ -1,10 +1,9 @@
 import { Component, useState } from "@odoo/owl";
-import { SpreadsheetChildEnv } from "../../../../..";
 import { splitReference, toZone } from "../../../../../helpers";
 import { SpreadsheetPivotRuntimeDefinition } from "../../../../../helpers/pivot/spreadsheet_pivot/runtime_definition_spreadsheet_pivot";
 import { SpreadsheetPivot } from "../../../../../helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
 import { Store, useLocalStore } from "../../../../../store_engine";
-import { UID } from "../../../../../types";
+import { SpreadsheetChildEnv, UID } from "../../../../../types";
 import { SpreadsheetPivotCoreDefinition } from "../../../../../types/pivot";
 import { SelectionInput } from "../../../../selection_input/selection_input";
 import { Checkbox } from "../../../components/checkbox/checkbox";

--- a/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
+++ b/src/components/side_panel/pivot/pivot_title_section/pivot_title_section.ts
@@ -1,6 +1,6 @@
 import { Component } from "@odoo/owl";
-import { SpreadsheetChildEnv, UID } from "../../../..";
 import { _t } from "../../../../translation";
+import { SpreadsheetChildEnv, UID } from "../../../../types";
 import { CogWheelMenu } from "../../components/cog_wheel_menu/cog_wheel_menu";
 import { Section } from "../../components/section/section";
 import { EditableName } from "../editable_name/editable_name";

--- a/src/helpers/ui/cut_interactive.ts
+++ b/src/helpers/ui/cut_interactive.ts
@@ -1,6 +1,5 @@
-import { CommandResult } from "../..";
 import { _t } from "../../translation";
-import { SpreadsheetChildEnv } from "../../types";
+import { CommandResult, SpreadsheetChildEnv } from "../../types";
 
 export function interactiveCut(env: SpreadsheetChildEnv) {
   const result = env.model.dispatch("CUT");

--- a/src/helpers/ui/paste_interactive.ts
+++ b/src/helpers/ui/paste_interactive.ts
@@ -1,6 +1,11 @@
-import { CommandResult, DispatchResult } from "../..";
 import { _t } from "../../translation";
-import { ClipboardPasteOptions, SpreadsheetChildEnv, Zone } from "../../types";
+import {
+  ClipboardPasteOptions,
+  CommandResult,
+  DispatchResult,
+  SpreadsheetChildEnv,
+  Zone,
+} from "../../types";
 
 export const PasteInteractiveContent = {
   wrongPasteSelection: _t("This operation is not allowed with multiple selections."),

--- a/src/helpers/ui/split_to_columns_interactive.ts
+++ b/src/helpers/ui/split_to_columns_interactive.ts
@@ -1,6 +1,5 @@
-import { CommandResult } from "../..";
 import { _t } from "../../translation";
-import { SpreadsheetChildEnv } from "../../types";
+import { CommandResult, SpreadsheetChildEnv } from "../../types";
 import { DispatchResult } from "./../../types/commands";
 
 export const SplitToColumnsInteractiveContent = {

--- a/src/helpers/ui/toggle_group_interactive.ts
+++ b/src/helpers/ui/toggle_group_interactive.ts
@@ -1,6 +1,5 @@
-import { CommandResult } from "../..";
 import { _t } from "../../translation";
-import { Dimension, HeaderIndex, SpreadsheetChildEnv, UID } from "../../types";
+import { CommandResult, Dimension, HeaderIndex, SpreadsheetChildEnv, UID } from "../../types";
 
 export const ToggleGroupInteractiveContent = {
   CannotHideAllRows: _t("Cannot hide all the rows of a sheet."),

--- a/src/registries/menus/number_format_menu_registry.ts
+++ b/src/registries/menus/number_format_menu_registry.ts
@@ -1,9 +1,8 @@
-import { SpreadsheetChildEnv } from "../..";
 import { ActionSpec, createActions } from "../../actions/action";
 import * as ACTION_FORMAT from "../../actions/format_actions";
 import { isDateTimeFormat, memoize } from "../../helpers";
 import { _t } from "../../translation";
-import { Format } from "../../types";
+import { Format, SpreadsheetChildEnv } from "../../types";
 import { Registry } from "../registry";
 
 export const numberFormatMenuRegistry = new Registry<ACTION_FORMAT.NumberFormatActionSpec>();


### PR DESCRIPTION
## Description:

SWC (speedy web compiler) is an rust-based faster alternative to the
traditional typescript transpiler `tsc`. SInce it does not support
typechecking, we cannot only rely on it in order to generate our
declaration files our build our library. We can however leverage the
already existing integration with jest, expecially the package
`@swc-node/jest` that works as an alternative to  `js-test`.

In order to preserve the typechecking of the test files, we alter the
`test` command to first run a simple typecheck with `tsc` and then run
the test suite with `@swc-node/jest` as a TS transpiler.

Some pros:
- Better execution time for the whole test suite
- running a standalone test way faster
- a pre-step of typecheck takes less time than currently beacause jest
  will keep running every test file and will not stop its execution
  because of a single file in error

Benchmark
---------

Running command `npm run test -- -w 50%` -  11178 tests:

Before:  131 secondes
After:   82 secondes (17 of typecheck + 68 of actual tests transpiled
and run

On Runbot

Before: 250 secondes
After:  122 secondes

Task: : [4049142](https://www.odoo.com/web#id=4049142&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo