### PR TITLE
[REF] compiler: compile no longer throws any errors

### DIFF
--- a/src/formulas/compiler.ts
+++ b/src/formulas/compiler.ts
@@ -58,6 +58,21 @@ export function compile(formula: string): CompiledFormula {
 }
 
 export function compileTokens(tokens: Token[]): CompiledFormula {
+  try {
+    return compileTokensOrThrow(tokens);
+  } catch (error) {
+    return {
+      tokens,
+      dependencies: [],
+      execute: function () {
+        return error;
+      },
+      isBadExpression: true,
+    };
+  }
+}
+
+function compileTokensOrThrow(tokens: Token[]): CompiledFormula {
   const { dependencies, constantValues } = formulaArguments(tokens);
   const cacheKey = compilationCacheKey(tokens, dependencies, constantValues);
   if (!functionCache[cacheKey]) {
@@ -194,6 +209,7 @@ export function compileTokens(tokens: Token[]): CompiledFormula {
     dependencies,
     constantValues,
     tokens,
+    isBadExpression: false,
   };
   return compiledFormula;
 }

--- a/src/plugins/core/cell.ts
+++ b/src/plugins/core/cell.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_STYLE } from "../../constants";
-import { Token, compile, tokenize } from "../../formulas";
+import { Token, compile } from "../../formulas";
 import { isEvaluationError, toString } from "../../functions/helpers";
 import { deepEquals, isExcelCompatible, recomputeZones } from "../../helpers";
 import { parseLiteral } from "../../helpers/cells";
@@ -557,11 +557,7 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
     if (!content.startsWith("=")) {
       return this.createLiteralCell(id, content, format, style);
     }
-    try {
-      return this.createFormulaCell(id, content, format, style, sheetId);
-    } catch (error) {
-      return this.createErrorFormula(id, content, format, style, error);
-    }
+    return this.createFormulaCell(id, content, format, style, sheetId);
   }
 
   private createLiteralCell(
@@ -639,29 +635,6 @@ export class CellPlugin extends CorePlugin<CoreState> implements CoreState {
       sheetId,
       this.getters.getRangeString
     );
-  }
-
-  private createErrorFormula(
-    id: UID,
-    content: string,
-    format: Format | undefined,
-    style: Style | undefined,
-    error: Error
-  ): FormulaCell {
-    return {
-      id,
-      content,
-      style,
-      format,
-      isFormula: true,
-      compiledFormula: {
-        tokens: tokenize(content),
-        dependencies: [],
-        execute: function () {
-          throw error;
-        },
-      },
-    };
   }
 
   private checkCellOutOfSheet(cmd: PositionDependentCommand): CommandResult {

--- a/src/plugins/core/conditional_format.ts
+++ b/src/plugins/core/conditional_format.ts
@@ -427,9 +427,8 @@ export class ConditionalFormatPlugin
     thresholdName: string
   ) {
     if (threshold.type !== "formula") return CommandResult.Success;
-    try {
-      compile(threshold.value || "");
-    } catch (error) {
+    const compiledFormula = compile(threshold.value || "");
+    if (compiledFormula.isBadExpression) {
       switch (thresholdName) {
         case "min":
           return CommandResult.MinInvalidFormula;

--- a/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
+++ b/src/plugins/ui_core_views/cell_evaluation/evaluation_plugin.ts
@@ -1,5 +1,4 @@
-import { compileTokens } from "../../../formulas/compiler";
-import { isExportableToExcel, Token } from "../../../formulas/index";
+import { isExportableToExcel } from "../../../formulas/index";
 import { getItemId, positions, toXC } from "../../../helpers/index";
 import { CellErrorType } from "../../../types/errors";
 import {
@@ -13,11 +12,11 @@ import {
   Format,
   FormattedValue,
   FormulaCell,
-  invalidateDependenciesCommands,
   Matrix,
   Range,
   UID,
   Zone,
+  invalidateDependenciesCommands,
 } from "../../../types/index";
 import { FormulaCellWithDependencies } from "../../core";
 import { UIPlugin, UIPluginConfig } from "../../ui_plugin";
@@ -346,7 +345,7 @@ export class EvaluationPlugin extends UIPlugin {
     const cell = this.getters.getCell(position);
 
     if (cell && cell.isFormula) {
-      return isBadExpression(cell.compiledFormula.tokens) ? undefined : cell;
+      return cell.compiledFormula.isBadExpression ? undefined : cell;
     } else if (cell && cell.content) {
       return undefined;
     }
@@ -363,14 +362,5 @@ export class EvaluationPlugin extends UIPlugin {
       return spreadingFormulaCell;
     }
     return undefined;
-  }
-}
-
-function isBadExpression(tokens: Token[]): boolean {
-  try {
-    compileTokens(tokens);
-    return false;
-  } catch (error) {
-    return true;
   }
 }

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -180,6 +180,7 @@ export interface CompiledFormula {
   execute: FormulaToExecute;
   tokens: Token[];
   dependencies: string[];
+  isBadExpression: boolean;
 }
 
 export interface RangeCompiledFormula extends Omit<CompiledFormula, "dependencies"> {

--- a/tests/evaluation/compiler.test.ts
+++ b/tests/evaluation/compiler.test.ts
@@ -24,7 +24,7 @@ describe("expression compiler", () => {
   });
 
   test("simple values that throw error", () => {
-    expect(() => compiledBaseFunction(`='abc'`)).toThrowError();
+    expect(compiledBaseFunction(`='abc'`).isBadExpression).toBe(true);
   });
 
   test.each(["=1 + 3", "=2 * 3", "=2 - 3", "=2 / 3", "=-3", "=(3 + 1) * (-1 + 4)"])(
@@ -79,7 +79,7 @@ describe("expression compiler", () => {
   });
 
   test("cannot compile some invalid formulas", () => {
-    expect(() => compiledBaseFunction("=qsdf")).toThrow();
+    expect(compiledBaseFunction("=qsdf").isBadExpression).toBe(true);
   });
 });
 
@@ -100,10 +100,10 @@ describe("compile functions", () => {
           { name: "arg2", description: "", type: ["ANY"] },
         ],
       });
-      expect(() => compiledBaseFunction("=ANYFUNCTION()")).toThrow();
-      expect(() => compiledBaseFunction("=ANYFUNCTION(1)")).toThrow();
-      expect(() => compiledBaseFunction("=ANYFUNCTION(1,2)")).not.toThrow();
-      expect(() => compiledBaseFunction("=ANYFUNCTION(1,2,3)")).toThrow();
+      expect(compiledBaseFunction("=ANYFUNCTION()").isBadExpression).toBe(true);
+      expect(compiledBaseFunction("=ANYFUNCTION(1)").isBadExpression).toBe(true);
+      expect(compiledBaseFunction("=ANYFUNCTION(1,2)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=ANYFUNCTION(1,2,3)").isBadExpression).toBe(true);
       restoreDefaultFunctions();
     });
 
@@ -118,9 +118,9 @@ describe("compile functions", () => {
           { name: "arg2", description: "", type: ["ANY"], optional: true },
         ],
       });
-      expect(() => compiledBaseFunction("=OPTIONAL(1)")).not.toThrow();
-      expect(() => compiledBaseFunction("=OPTIONAL(1,2)")).not.toThrow();
-      expect(() => compiledBaseFunction("=OPTIONAL(1,2,3)")).toThrow();
+      expect(compiledBaseFunction("=OPTIONAL(1)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=OPTIONAL(1,2)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=OPTIONAL(1,2,3)").isBadExpression).toBe(true);
       restoreDefaultFunctions();
     });
 
@@ -135,9 +135,9 @@ describe("compile functions", () => {
           { name: "arg2", description: "", type: ["ANY"], default: true, defaultValue: 42 },
         ],
       });
-      expect(() => compiledBaseFunction("=USEDEFAULTARG(1)")).not.toThrow();
-      expect(() => compiledBaseFunction("=USEDEFAULTARG(1,2)")).not.toThrow();
-      expect(() => compiledBaseFunction("=USEDEFAULTARG(1,2,3)")).toThrow();
+      expect(compiledBaseFunction("=USEDEFAULTARG(1)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=USEDEFAULTARG(1,2)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=USEDEFAULTARG(1,2,3)").isBadExpression).toBe(true);
       restoreDefaultFunctions();
     });
 
@@ -152,9 +152,9 @@ describe("compile functions", () => {
           { name: "arg2", description: "", type: ["ANY"], optional: true, repeating: true },
         ],
       });
-      expect(() => compiledBaseFunction("=REPEATABLE(1)")).not.toThrow();
-      expect(() => compiledBaseFunction("=REPEATABLE(1,2)")).not.toThrow();
-      expect(() => compiledBaseFunction("=REPEATABLE(1,2,3,4,5,6)")).not.toThrow();
+      expect(compiledBaseFunction("=REPEATABLE(1)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=REPEATABLE(1,2)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=REPEATABLE(1,2,3,4,5,6)").isBadExpression).toBe(false);
       restoreDefaultFunctions();
     });
 
@@ -170,10 +170,10 @@ describe("compile functions", () => {
           { name: "arg3", description: "", type: ["ANY"], optional: true, repeating: true },
         ],
       });
-      expect(() => compiledBaseFunction("=REPEATABLES(1, 2)")).toThrow();
-      expect(() => compiledBaseFunction("=REPEATABLES(1, 2, 3)")).not.toThrow();
-      expect(() => compiledBaseFunction("=REPEATABLES(1, 2, 3, 4)")).toThrow();
-      expect(() => compiledBaseFunction("=REPEATABLES(1, 2, 3, 4, 5)")).not.toThrow();
+      expect(compiledBaseFunction("=REPEATABLES(1, 2)").isBadExpression).toBe(true);
+      expect(compiledBaseFunction("=REPEATABLES(1, 2, 3)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=REPEATABLES(1, 2, 3, 4)").isBadExpression).toBe(true);
+      expect(compiledBaseFunction("=REPEATABLES(1, 2, 3, 4, 5)").isBadExpression).toBe(false);
       restoreDefaultFunctions();
     });
   });
@@ -249,20 +249,20 @@ describe("compile functions", () => {
     );
 
     test("throw error if parameter isn't cell/range reference", () => {
-      expect(() => compiledBaseFunction("=USEMETAARG(X8)")).not.toThrow();
-      expect(() => compiledBaseFunction("=USEMETAARG($X$8)")).not.toThrow();
-      expect(() => compiledBaseFunction("=USEMETAARG(Sheet42!X8)")).not.toThrow();
-      expect(() => compiledBaseFunction("=USEMETAARG('Sheet 42'!X8)")).not.toThrow();
+      expect(compiledBaseFunction("=USEMETAARG(X8)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=USEMETAARG($X$8)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=USEMETAARG(Sheet42!X8)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=USEMETAARG('Sheet 42'!X8)").isBadExpression).toBe(false);
 
-      expect(() => compiledBaseFunction("=USEMETAARG(D3:Z9)")).not.toThrow();
-      expect(() => compiledBaseFunction("=USEMETAARG($D$3:$Z$9)")).not.toThrow();
-      expect(() => compiledBaseFunction("=USEMETAARG(Sheet42!$D$3:$Z$9)")).not.toThrow();
-      expect(() => compiledBaseFunction("=USEMETAARG('Sheet 42'!D3:Z9)")).not.toThrow();
+      expect(compiledBaseFunction("=USEMETAARG(D3:Z9)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=USEMETAARG($D$3:$Z$9)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=USEMETAARG(Sheet42!$D$3:$Z$9)").isBadExpression).toBe(false);
+      expect(compiledBaseFunction("=USEMETAARG('Sheet 42'!D3:Z9)").isBadExpression).toBe(false);
 
-      expect(() => compiledBaseFunction('=USEMETAARG("kikou")')).toThrowError();
-      expect(() => compiledBaseFunction('=USEMETAARG("")')).toThrowError();
-      expect(() => compiledBaseFunction("=USEMETAARG(TRUE)")).toThrowError();
-      expect(() => compiledBaseFunction("=USEMETAARG(SUM(1,2,3))")).toThrowError();
+      expect(compiledBaseFunction('=USEMETAARG("kikou")').isBadExpression).toBe(true);
+      expect(compiledBaseFunction('=USEMETAARG("")').isBadExpression).toBe(true);
+      expect(compiledBaseFunction("=USEMETAARG(TRUE)").isBadExpression).toBe(true);
+      expect(compiledBaseFunction("=USEMETAARG(SUM(1,2,3))").isBadExpression).toBe(true);
     });
 
     test("do not care about the value of the cell / range passed as a reference", () => {


### PR DESCRIPTION
## Description:

Currently `compile` and `compileTokens` can throw errors if there's a syntax error in the formula.

It's a regular source of errors and traceback because it's easy to forget to try/catch.

Even if the developper doesn't forget, the try/catch pattern is repeated at every call site.

With this commit, compile can no longer throw any errors. It always returns a valid compiled formula. In case of a syntax error, the `execute` returns the compilation error at the evaluation time. Errors in `execute` are expected and handled in the evaluation.


Task: : [4049824](https://www.odoo.com/web#id=4049824&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo