### PR TITLE
[FIX] pivot: correctly define default measure aggregator

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -4,6 +4,7 @@ import { isDefined } from "../../../../helpers";
 import { AGGREGATORS, isDateField, parseDimension } from "../../../../helpers/pivot/pivot_helpers";
 import { PivotRuntimeDefinition } from "../../../../helpers/pivot/pivot_runtime_definition";
 import {
+  Aggregator,
   Granularity,
   PivotCoreDefinition,
   PivotCoreDimension,
@@ -174,8 +175,15 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
   addMeasureDimension(fieldName: string) {
     const { measures }: { measures: PivotCoreMeasure[] } = this.props.definition;
     this.props.onDimensionsUpdated({
-      measures: measures.concat([{ name: fieldName }]),
+      measures: measures.concat([
+        { name: fieldName, aggregator: this.getDefaultMeasureAggregator(fieldName) },
+      ]),
     });
+  }
+
+  private getDefaultMeasureAggregator(fieldName: string): Aggregator | string {
+    const field = this.props.unusedMeasureFields.find((f) => f.name === fieldName);
+    return field?.aggregator ? field.aggregator : "count";
   }
 
   updateAggregator(updatedMeasure: PivotMeasure, aggregator: string) {

--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.xml
@@ -53,7 +53,7 @@
         </div>
       </t>
       <div
-        class="fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title">
+        class="fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title o-pivot-measure">
         Measures
         <AddDimensionButton
           onFieldPicked.bind="addMeasureDimension"

--- a/src/helpers/pivot/pivot_runtime_definition.ts
+++ b/src/helpers/pivot/pivot_runtime_definition.ts
@@ -51,7 +51,7 @@ function createMeasure(fields: PivotFields, measure: PivotCoreMeasure): PivotMea
     name === "__count"
       ? { name: "__count", string: _t("Count"), type: "integer", aggregator: "sum" }
       : fields[name];
-  const aggregator = measure.aggregator || field?.aggregator;
+  const aggregator = measure.aggregator;
   return {
     nameWithAggregator: name + (aggregator ? `:${aggregator}` : ""),
     /**

--- a/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
+++ b/src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot.ts
@@ -221,7 +221,7 @@ export class SpreadsheetPivot implements Pivot<SpreadsheetPivotRuntimeDefinition
       .map((value) => value[measure])
       .filter((cell) => cell && cell.type !== CellValueType.empty)
       .filter(isDefined);
-    const aggregator = this.getMeasure(measure).aggregator || "count";
+    const aggregator = this.getMeasure(measure).aggregator;
     const operator = AGGREGATORS_FN[aggregator];
     if (!operator) {
       throw new Error(`Aggregator ${aggregator} does not exist`);

--- a/src/types/pivot.ts
+++ b/src/types/pivot.ts
@@ -33,7 +33,7 @@ export interface PivotCoreDimension {
 
 export interface PivotCoreMeasure {
   name: string;
-  aggregator?: Aggregator | string;
+  aggregator: Aggregator | string;
 }
 
 export interface CommonPivotCoreDefinition {

--- a/tests/pivots/pivot_data.ts
+++ b/tests/pivots/pivot_data.ts
@@ -580,6 +580,7 @@ export const pivotModelData = function (xc: string) {
         measures: [
           {
             name: "__count",
+            aggregator: "sum",
           },
         ],
         name: "My pivot",

--- a/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
+++ b/tests/pivots/spreadsheet_pivot/__snapshots__/spreadsheet_pivot_side_panel.test.ts.snap
@@ -136,7 +136,7 @@ exports[`Spreadsheet pivot side panel It should correctly be displayed 1`] = `
           
           
           <div
-            class="fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title"
+            class="fw-bold pt-4 pb-1 d-flex flex-row justify-content-between align-items-center o-section-title o-pivot-measure"
           >
              Measures 
             <span

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot.test.ts
@@ -385,7 +385,7 @@ describe("Spreadsheet Pivot", () => {
   test("Measure count as a correct label", () => {
     const model = createModelWithPivot("A1:I5");
     updatePivot(model, "1", {
-      measures: [{ name: "__count" }],
+      measures: [{ name: "__count", aggregator: "sum" }],
     });
     setCellContent(model, "A26", `=pivot(1)`);
     expect(getCellContent(model, "B27")).toEqual("Count");
@@ -479,7 +479,7 @@ describe("Spreadsheet Pivot", () => {
     const model = createModelFromGrid(grid);
     addPivot(model, "A1:A3", {
       columns: [{ name: "Date", granularity: "month_number" }],
-      measures: [{ name: "__count" }],
+      measures: [{ name: "__count", aggregator: "sum" }],
     });
     expect(getEvaluatedGrid(model, "B4:E4")).toEqual([["March", "(Undefined)", "Total", ""]]);
   });

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -134,4 +134,29 @@ describe("Spreadsheet pivot side panel", () => {
     await click(fixture.querySelector(".fa-undo")!);
     expect(fixture.querySelectorAll(".pivot-dimension")).toHaveLength(0);
   });
+
+  test("Measures have the correct default aggregator", async () => {
+    setCellContent(model, "A1", "amount");
+    setCellContent(model, "A2", "10");
+    setCellContent(model, "B1", "person");
+    setCellContent(model, "B2", "Alice");
+    addPivot(model, "A1:B2", {}, "3");
+    env.openSidePanel("PivotSidePanel", { pivotId: "3" });
+    await nextTick();
+
+    await click(fixture.querySelector(".o-pivot-measure .add-dimension")!);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[0]);
+    await click(fixture.querySelector(".sp_apply_update")!);
+    expect(model.getters.getPivotCoreDefinition("3").measures).toEqual([
+      { name: "amount", aggregator: "sum" },
+    ]);
+
+    await click(fixture.querySelector(".o-pivot-measure .add-dimension")!);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[1]);
+    await click(fixture.querySelector(".sp_apply_update")!);
+    expect(model.getters.getPivotCoreDefinition("3").measures).toEqual([
+      { name: "amount", aggregator: "sum" },
+      { name: "person", aggregator: "count" },
+    ]);
+  });
 });


### PR DESCRIPTION
## Description

Measure aggregator are undefined by default when inserting a measure in a pivot. This leads to a strange state with a "dynamic" aggregator, if the field change from a integer to string field, the aggregator will automatically switch from `sum` to `count`.

This commit fixes this issue by defining a default aggregator when inserting a measure from the side panel.

Task: : [4052502](https://www.odoo.com/web#id=4052502&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo