### PR TITLE
[FIX] pivot: preserve sorting on dimension reorder

### DIFF
--- a/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
+++ b/src/components/side_panel/pivot/pivot_layout_configurator/pivot_layout_configurator.ts
@@ -1,7 +1,7 @@
 import { Component, useRef } from "@odoo/owl";
 import { SpreadsheetChildEnv } from "../../../..";
 import { isDefined } from "../../../../helpers";
-import { AGGREGATORS, isDateField, parseDimension } from "../../../../helpers/pivot/pivot_helpers";
+import { AGGREGATORS, isDateField } from "../../../../helpers/pivot/pivot_helpers";
 import { PivotRuntimeDefinition } from "../../../../helpers/pivot/pivot_runtime_definition";
 import {
   Aggregator,
@@ -63,6 +63,7 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
       "__rows_title__",
       ...rows.map((row) => row.nameWithGranularity),
     ];
+    const allDimensions = columns.concat(rows);
     const offset = 1; // column title
     const draggableItems = draggableIds.map((id, index) => ({
       id,
@@ -85,8 +86,20 @@ export class PivotLayoutConfigurator extends Component<Props, SpreadsheetChildEn
         const columns = draggedItems.slice(0, draggedItems.indexOf("__rows_title__"));
         const rows = draggedItems.slice(draggedItems.indexOf("__rows_title__") + 1);
         this.props.onDimensionsUpdated({
-          columns: columns.map(parseDimension),
-          rows: rows.map(parseDimension),
+          columns: columns
+            .map((nameWithGranularity) =>
+              allDimensions.find(
+                (dimension) => dimension.nameWithGranularity === nameWithGranularity
+              )
+            )
+            .filter(isDefined),
+          rows: rows
+            .map((nameWithGranularity) =>
+              allDimensions.find(
+                (dimension) => dimension.nameWithGranularity === nameWithGranularity
+              )
+            )
+            .filter(isDefined),
         });
       },
     });

--- a/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
+++ b/tests/pivots/spreadsheet_pivot/spreadsheet_pivot_side_panel.test.ts
@@ -2,8 +2,9 @@ import { Model, SpreadsheetChildEnv } from "../../../src";
 import { toZone } from "../../../src/helpers";
 import { SpreadsheetPivot } from "../../../src/helpers/pivot/spreadsheet_pivot/spreadsheet_pivot";
 import { setCellContent } from "../../test_helpers/commands_helpers";
-import { click } from "../../test_helpers/dom_helper";
+import { click, dragElement, setInputValueAndTrigger } from "../../test_helpers/dom_helper";
 import { mountSpreadsheet, nextTick } from "../../test_helpers/helpers";
+import { mockGetBoundingClientRect } from "../../test_helpers/mock_helpers";
 import { addPivot, updatePivot } from "../../test_helpers/pivot_helpers";
 
 describe("Spreadsheet pivot side panel", () => {
@@ -157,6 +158,38 @@ describe("Spreadsheet pivot side panel", () => {
     expect(model.getters.getPivotCoreDefinition("3").measures).toEqual([
       { name: "amount", aggregator: "sum" },
       { name: "person", aggregator: "count" },
+    ]);
+  });
+
+  test("should preserve the sorting of the dimension after ordering is changed", async () => {
+    mockGetBoundingClientRect({
+      /**
+       * 'pt-1' is the class of the main div of the pivot dimension
+       */
+      "pt-1": () => ({
+        height: 10,
+        y: 0,
+      }),
+      "o-section-title": () => ({
+        height: 10,
+        y: 10,
+      }),
+      "pivot-dimensions": () => ({
+        height: 40,
+        y: 0,
+      }),
+    });
+    await click(fixture.querySelector(".add-dimension")!);
+    await click(fixture.querySelectorAll(".o-autocomplete-value")[0]);
+    await setInputValueAndTrigger(fixture.querySelector(".pivot-dimension select"), "desc");
+    await click(fixture.querySelector(".sp_apply_update")!);
+    expect(model.getters.getPivotCoreDefinition("1").columns).toEqual([
+      { name: "Amount", order: "desc" },
+    ]);
+    await dragElement(fixture.querySelector(".pivot-dimension")!, { x: 0, y: 30 }, undefined, true);
+    await click(fixture.querySelector(".sp_apply_update")!);
+    expect(model.getters.getPivotCoreDefinition("1").rows).toEqual([
+      { name: "Amount", order: "desc" },
     ]);
   });
 });


### PR DESCRIPTION
Steps to reproduce:
- Create a spreadsheet pivot, add some fields
- Re-order the fields with drag & drop => Every field is now "Unsorted' (or "ascending" for date fields)

When reordering dimensions in the pivot side panel, the sorting order of the pivot was being reset. This commit fixes the issue by preserving the sorting order when reordering dimensions.

Task: 4050440

## Description:

description of this task, what is implemented and why it is implemented that way.

Task: : [TASK_ID](https://www.odoo.com/web#id=TASK_ID&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)

## review checklist

- [ ] feature is organized in plugin, or UI components
- [ ] support of duplicate sheet (deep copy)
- [ ] in model/core: ranges are Range object, and can be adapted (adaptRanges)
- [ ] in model/UI: ranges are strings (to show the user)
- [ ] undo-able commands (uses this.history.update)
- [ ] multiuser-able commands (has inverse commands and transformations where needed)
- [ ] new/updated/removed commands are documented
- [ ] exportable in excel
- [ ] translations (\_t("qmsdf %s", abc))
- [ ] unit tested
- [ ] clean commented code
- [ ] track breaking changes
- [ ] doc is rebuild (npm run doc)
- [ ] status is correct in Odoo